### PR TITLE
feat(loop): persist issue filters by workspace

### DIFF
--- a/packages/dmloop/src/api/__tests__/directory.test.ts
+++ b/packages/dmloop/src/api/__tests__/directory.test.ts
@@ -24,6 +24,7 @@ vi.mock("../http", () => ({
 import {
   ensureDirectory,
   invalidateDirectory,
+  listAssigneeCandidateState,
   listAssigneeCandidates,
   listProjectOptions,
 } from "../directory";
@@ -40,19 +41,30 @@ describe("directory", () => {
     vi.mocked(httpGet).mockReset();
   });
 
-  it("keeps display fallback data but rejects authoritative candidates when a candidate source fails", async () => {
+  it("keeps partial candidates but marks them non-authoritative when a candidate source fails", async () => {
     vi.mocked(httpGet).mockImplementation((path: string) => {
-      if (path === "/workspaces/ws-1/members") return Promise.reject(new Error("members failed"));
-      if (path === "/agents") return Promise.resolve([{ id: "a1", name: "Agent" }]);
+      if (path === "/workspaces/ws-1/members") return Promise.resolve([{ user_id: "m1", name: "Member" }]);
+      if (path === "/agents") return Promise.reject(new Error("agents failed"));
       if (path === "/squads") return Promise.resolve([{ id: "s1", name: "Squad" }]);
       if (path === "/projects") return Promise.resolve({ projects: [{ id: "p1", title: "Project" }] });
       return Promise.reject(new Error(`unexpected ${path}`));
     });
 
     const dir = await ensureDirectory();
-    expect(dir.agentName.get("a1")).toBe("Agent");
+    expect(dir.memberName.get("m1")).toBe("Member");
+    expect(dir.squadName.get("s1")).toBe("Squad");
     expect(dir.projectName.get("p1")).toBe("Project");
-    await expect(listAssigneeCandidates()).rejects.toThrow("Assignee directory failed");
+    await expect(listAssigneeCandidates()).resolves.toEqual([
+      { id: "m1", type: "member", name: "Member", octo_uid: null },
+      { id: "s1", type: "squad", name: "Squad" },
+    ]);
+    await expect(listAssigneeCandidateState()).resolves.toEqual({
+      candidates: [
+        { id: "m1", type: "member", name: "Member", octo_uid: null },
+        { id: "s1", type: "squad", name: "Squad" },
+      ],
+      succeeded: false,
+    });
     await expect(listProjectOptions()).resolves.toEqual([{ id: "p1", title: "Project" }]);
 
     const persisted = {
@@ -64,7 +76,7 @@ describe("directory", () => {
     const reconciled = reconcileIssueFilters(
       persisted,
       issueFilterOptionIds({
-        candidates: [],
+        candidates: (await listAssigneeCandidateState()).candidates,
         candidatesLoaded: true,
         candidatesSucceeded: false,
         projects: await listProjectOptions(),

--- a/packages/dmloop/src/api/__tests__/directory.test.ts
+++ b/packages/dmloop/src/api/__tests__/directory.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@octo/base", () => ({
+  WKApp: {
+    loginInfo: { token: "token" },
+    shared: {
+      currentSpaceId: "space-1",
+      avatarUser: vi.fn((uid: string) => `avatar:${uid}`),
+    },
+  },
+  SpaceService: {
+    shared: {
+      getAllMembers: vi.fn(() => Promise.resolve([])),
+    },
+  },
+}));
+
+vi.mock("../http", () => ({
+  currentWorkspaceId: vi.fn(() => "ws-1"),
+  currentWorkspaceSlug: vi.fn(() => "alpha"),
+  httpGet: vi.fn(),
+}));
+
+import {
+  ensureDirectory,
+  invalidateDirectory,
+  listAssigneeCandidates,
+  listProjectOptions,
+} from "../directory";
+import { httpGet } from "../http";
+import {
+  defaultIssueFilters,
+  issueFilterOptionIds,
+  reconcileIssueFilters,
+} from "../../ui/issueFilterPersistence";
+
+describe("directory", () => {
+  beforeEach(() => {
+    invalidateDirectory();
+    vi.mocked(httpGet).mockReset();
+  });
+
+  it("keeps display fallback data but rejects authoritative candidates when a candidate source fails", async () => {
+    vi.mocked(httpGet).mockImplementation((path: string) => {
+      if (path === "/workspaces/ws-1/members") return Promise.reject(new Error("members failed"));
+      if (path === "/agents") return Promise.resolve([{ id: "a1", name: "Agent" }]);
+      if (path === "/squads") return Promise.resolve([{ id: "s1", name: "Squad" }]);
+      if (path === "/projects") return Promise.resolve({ projects: [{ id: "p1", title: "Project" }] });
+      return Promise.reject(new Error(`unexpected ${path}`));
+    });
+
+    const dir = await ensureDirectory();
+    expect(dir.agentName.get("a1")).toBe("Agent");
+    expect(dir.projectName.get("p1")).toBe("Project");
+    await expect(listAssigneeCandidates()).rejects.toThrow("Assignee directory failed");
+    await expect(listProjectOptions()).resolves.toEqual([{ id: "p1", title: "Project" }]);
+
+    const persisted = {
+      ...defaultIssueFilters(),
+      assigneeIds: ["stored-assignee"],
+      creatorIds: ["stored-creator"],
+      projectIds: ["p1", "stale-project"],
+    };
+    const reconciled = reconcileIssueFilters(
+      persisted,
+      issueFilterOptionIds({
+        candidates: [],
+        candidatesLoaded: true,
+        candidatesSucceeded: false,
+        projects: await listProjectOptions(),
+        projectsLoaded: true,
+        projectsSucceeded: true,
+        labels: [],
+        labelsLoaded: false,
+        labelsSucceeded: false,
+      }),
+      false,
+    );
+    expect(reconciled.assigneeIds).toEqual(["stored-assignee"]);
+    expect(reconciled.creatorIds).toEqual(["stored-creator"]);
+    expect(reconciled.projectIds).toEqual(["p1"]);
+  });
+
+  it("rejects authoritative project options when the project source fails", async () => {
+    vi.mocked(httpGet).mockImplementation((path: string) => {
+      if (path === "/workspaces/ws-1/members") return Promise.resolve([{ user_id: "m1", name: "Member" }]);
+      if (path === "/agents") return Promise.resolve([]);
+      if (path === "/squads") return Promise.resolve([]);
+      if (path === "/projects") return Promise.reject(new Error("projects failed"));
+      return Promise.reject(new Error(`unexpected ${path}`));
+    });
+
+    await expect(listAssigneeCandidates()).resolves.toEqual([
+      { id: "m1", type: "member", name: "Member", octo_uid: null },
+    ]);
+    await expect(listProjectOptions()).rejects.toThrow("Project directory failed");
+  });
+});

--- a/packages/dmloop/src/api/directory.ts
+++ b/packages/dmloop/src/api/directory.ts
@@ -15,6 +15,8 @@ interface Directory {
   squadName: Map<string, string>;
   projectName: Map<string, string>;
   candidates: AssigneeCandidate[];
+  candidatesSucceeded: boolean;
+  projectsSucceeded: boolean;
 }
 
 let _cache: Directory | null = null;
@@ -29,26 +31,42 @@ async function build(): Promise<Directory> {
   const slug = currentWorkspaceSlug();
   const wsId = currentWorkspaceId();
   const [members, agents, squads, projectsResp] = await Promise.all([
-    wsId ? httpGet<Array<{ user_id: string; name: string; octo_uid?: string | null }>>(`/workspaces/${wsId}/members`).catch(() => []) : Promise.resolve([]),
+    wsId
+      ? settle(
+          httpGet<Array<{ user_id: string; name: string; octo_uid?: string | null }>>(
+            `/workspaces/${wsId}/members`,
+          ),
+          [],
+        )
+      : Promise.resolve({ value: [], succeeded: true }),
     // include_archived: resolve names for archived (soft-deleted) agents too, so issues/comments/
     // timeline referencing a deleted AI teammate show its name, not a raw id. Archived entries feed
     // the name map only; the assignee picker (candidates) stays active-only.
-    httpGet<Array<{ id: string; name: string; archived_at?: string | null }>>("/agents", { include_archived: true }).catch(() => []),
-    httpGet<Array<{ id: string; name: string }>>("/squads").catch(() => []),
-    httpGet<{ projects: Array<{ id: string; title: string }> }>("/projects").catch(() => ({ projects: [] })),
+    settle(
+      httpGet<Array<{ id: string; name: string; archived_at?: string | null }>>(
+        "/agents",
+        { include_archived: true },
+      ),
+      [],
+    ),
+    settle(httpGet<Array<{ id: string; name: string }>>("/squads"), []),
+    settle(
+      httpGet<{ projects: Array<{ id: string; title: string }> }>("/projects"),
+      { projects: [] },
+    ),
   ]);
   // Resolve member identity to octo names — but only pull the (potentially large)
   // space roster when at least one member is octo-bridged; a pure-native
   // workspace skips the roster fetch entirely.
   const octoName = new Map<string, string>();
-  if (members.some((m) => m.octo_uid)) {
+  if (members.value.some((m) => m.octo_uid)) {
     const roster = await SpaceService.shared.getAllMembers(WKApp.shared.currentSpaceId).catch(() => []);
     for (const s of roster) octoName.set(s.uid, s.name);
   }
   const memberName = new Map<string, string>();
   const memberOctoUid = new Map<string, string>();
   const candidates: AssigneeCandidate[] = [];
-  for (const m of members) {
+  for (const m of members.value) {
     // octo 身份优先：octo_uid 命中 space 名册取 octo 名字，否则回退后端显示名。
     const name = (m.octo_uid && octoName.get(m.octo_uid)) || m.name;
     memberName.set(m.user_id, name);
@@ -56,18 +74,40 @@ async function build(): Promise<Directory> {
     candidates.push({ id: m.user_id, type: "member", name, octo_uid: m.octo_uid ?? null });
   }
   const agentName = new Map<string, string>();
-  for (const a of agents) {
+  for (const a of agents.value) {
     agentName.set(a.id, a.name); // resolve names incl. archived (for display)
     if (!a.archived_at) candidates.push({ id: a.id, type: "agent", name: a.name }); // picker: active only
   }
   const squadName = new Map<string, string>();
-  for (const s of squads) {
+  for (const s of squads.value) {
     squadName.set(s.id, s.name);
     candidates.push({ id: s.id, type: "squad", name: s.name });
   }
   const projectName = new Map<string, string>();
-  for (const p of (projectsResp.projects ?? [])) projectName.set(p.id, p.title);
-  return { slug, memberName, memberOctoUid, agentName, squadName, projectName, candidates };
+  for (const p of (projectsResp.value.projects ?? [])) projectName.set(p.id, p.title);
+  return {
+    slug,
+    memberName,
+    memberOctoUid,
+    agentName,
+    squadName,
+    projectName,
+    candidates,
+    candidatesSucceeded:
+      members.succeeded && agents.succeeded && squads.succeeded,
+    projectsSucceeded: projectsResp.succeeded,
+  };
+}
+
+async function settle<T>(
+  promise: Promise<T>,
+  fallback: T,
+): Promise<{ value: T; succeeded: boolean }> {
+  try {
+    return { value: await promise, succeeded: true };
+  } catch {
+    return { value: fallback, succeeded: false };
+  }
 }
 
 export async function ensureDirectory(force = false): Promise<Directory> {
@@ -138,6 +178,7 @@ export function projectNameOf(
 
 export async function listAssigneeCandidates(): Promise<AssigneeCandidate[]> {
   const dir = await ensureDirectory();
+  if (!dir.candidatesSucceeded) throw new Error("Assignee directory failed");
   return dir.candidates;
 }
 
@@ -145,5 +186,6 @@ export async function listAssigneeCandidates(): Promise<AssigneeCandidate[]> {
 // listAssigneeCandidates 对称——调用方无需伸手进 Directory 内部结构。
 export async function listProjectOptions(): Promise<Array<{ id: string; title: string }>> {
   const dir = await ensureDirectory();
+  if (!dir.projectsSucceeded) throw new Error("Project directory failed");
   return [...dir.projectName].map(([id, title]) => ({ id, title }));
 }

--- a/packages/dmloop/src/api/directory.ts
+++ b/packages/dmloop/src/api/directory.ts
@@ -178,8 +178,18 @@ export function projectNameOf(
 
 export async function listAssigneeCandidates(): Promise<AssigneeCandidate[]> {
   const dir = await ensureDirectory();
-  if (!dir.candidatesSucceeded) throw new Error("Assignee directory failed");
   return dir.candidates;
+}
+
+export async function listAssigneeCandidateState(): Promise<{
+  candidates: AssigneeCandidate[];
+  succeeded: boolean;
+}> {
+  const dir = await ensureDirectory();
+  return {
+    candidates: dir.candidates,
+    succeeded: dir.candidatesSucceeded,
+  };
 }
 
 // 项目筛选下拉的选项，复用已缓存的 directory（不额外请求 /projects），与

--- a/packages/dmloop/src/api/issueApi.ts
+++ b/packages/dmloop/src/api/issueApi.ts
@@ -14,7 +14,13 @@ import type {
   CommentTriggerAgent,
 } from "./types";
 import { httpGet, httpPost, httpPut, httpDelete } from "./http";
-import { ensureDirectory, actorName, actorAvatar, listAssigneeCandidates as dirCandidates } from "./directory";
+import {
+  ensureDirectory,
+  actorName,
+  actorAvatar,
+  listAssigneeCandidates as dirCandidates,
+  listAssigneeCandidateState as dirCandidateState,
+} from "./directory";
 import { arrayFilterQuery } from "./issueFilterQuery";
 
 // enrich 的同步核心:调用方已拿到 directory 时复用,避免每组重复 ensureDirectory。
@@ -249,4 +255,11 @@ export function updateComment(commentId: string, content: string): Promise<Issue
 /* ---------- 指派候选 ---------- */
 export function listAssigneeCandidates(): Promise<AssigneeCandidate[]> {
   return dirCandidates();
+}
+
+export function listAssigneeCandidateState(): Promise<{
+  candidates: AssigneeCandidate[];
+  succeeded: boolean;
+}> {
+  return dirCandidateState();
 }

--- a/packages/dmloop/src/pages/IssuePage.tsx
+++ b/packages/dmloop/src/pages/IssuePage.tsx
@@ -38,6 +38,7 @@ import { pushFleetIssueDeepLink, replaceLoopRootPath } from "../issueDeepLink";
 import { readView, writeView } from "../ui/viewMode";
 import {
   defaultIssueFilters,
+  issueFilterOptionIds,
   issueFilterStorageKey,
   readIssueFilterState,
   reconcileIssueFilters,
@@ -132,11 +133,11 @@ export default function IssuePage({ defaultScope, defaultView, viewKey }: IssueP
     setLabelsSucceeded(false);
     listProjectOptions()
       .then((rows) => { if (alive) { setProjects(rows); setProjectsSucceeded(true); } })
-      .catch(() => { if (alive) { setProjects([]); setProjectsSucceeded(false); } })
+      .catch(() => { if (alive) setProjectsSucceeded(false); })
       .finally(() => { if (alive) setProjectsLoaded(true); });
     listLabels()
       .then((rows) => { if (alive) { setLabels(rows); setLabelsSucceeded(true); } })
-      .catch(() => { if (alive) { setLabels([]); setLabelsSucceeded(false); } })
+      .catch(() => { if (alive) setLabelsSucceeded(false); })
       .finally(() => { if (alive) setLabelsLoaded(true); });
     return () => { alive = false; };
   }, []);
@@ -146,13 +147,23 @@ export default function IssuePage({ defaultScope, defaultView, viewKey }: IssueP
   }, [f, filterStorageKey, isMyLoop, scope]);
 
   useEffect(() => {
-    const optionIds = {
-      assigneeIds: candsLoaded && candsSucceeded ? cands.map((c) => c.id) : undefined,
-      creatorIds: candsLoaded && candsSucceeded ? cands.filter((c) => c.type === "member").map((c) => c.id) : undefined,
-      projectIds: projectsLoaded && projectsSucceeded ? projects.map((p) => p.id) : undefined,
-      labelIds: labelsLoaded && labelsSucceeded ? labels.map((l) => l.id) : undefined,
-    };
-    setF((prev) => reconcileIssueFilters(prev, optionIds, isMyLoop));
+    setF((prev) =>
+      reconcileIssueFilters(
+        prev,
+        issueFilterOptionIds({
+          candidates: cands,
+          candidatesLoaded: candsLoaded,
+          candidatesSucceeded: candsSucceeded,
+          projects,
+          projectsLoaded,
+          projectsSucceeded,
+          labels,
+          labelsLoaded,
+          labelsSucceeded,
+        }),
+        isMyLoop,
+      ),
+    );
   }, [cands, candsLoaded, candsSucceeded, isMyLoop, labels, labelsLoaded, labelsSucceeded, projects, projectsLoaded, projectsSucceeded]);
 
   const reload = useCallback(() => {

--- a/packages/dmloop/src/pages/IssuePage.tsx
+++ b/packages/dmloop/src/pages/IssuePage.tsx
@@ -104,7 +104,11 @@ export default function IssuePage({ defaultScope, defaultView, viewKey }: IssueP
   // onVisibleChange —— 仅外部点击关闭,内部多字段交互保持面板打开。
   const [filterOpen, setFilterOpen] = useState(false);
   const [showOpen, setShowOpen] = useState(false);
-  const { candidates: cands, loaded: candsLoaded } = useAssigneeCandidateState();
+  const {
+    candidates: cands,
+    loaded: candsLoaded,
+    succeeded: candsSucceeded,
+  } = useAssigneeCandidateState();
   // 当前 octo 成员的后端 user_id(involves_user_id 需 UUID,非 octo uid)：
   // 复用订阅特性的身份解析——候选里 octo_uid===loginInfo.uid 的 member。未解析出则「与我相关」不可用。
   const myMemberId = useMemo(() => {
@@ -116,17 +120,23 @@ export default function IssuePage({ defaultScope, defaultView, viewKey }: IssueP
   const [labels, setLabels] = useState<IssueLabel[]>([]);
   const [projectsLoaded, setProjectsLoaded] = useState(false);
   const [labelsLoaded, setLabelsLoaded] = useState(false);
+  const [projectsSucceeded, setProjectsSucceeded] = useState(false);
+  const [labelsSucceeded, setLabelsSucceeded] = useState(false);
   const seq = useRef(0); // 请求序号：只应用最新一次的响应，防并发乱序覆盖
 
   useEffect(() => {
     let alive = true;
+    setProjectsLoaded(false);
+    setProjectsSucceeded(false);
+    setLabelsLoaded(false);
+    setLabelsSucceeded(false);
     listProjectOptions()
-      .then((rows) => { if (alive) setProjects(rows); })
-      .catch(() => { if (alive) setProjects([]); })
+      .then((rows) => { if (alive) { setProjects(rows); setProjectsSucceeded(true); } })
+      .catch(() => { if (alive) { setProjects([]); setProjectsSucceeded(false); } })
       .finally(() => { if (alive) setProjectsLoaded(true); });
     listLabels()
-      .then((rows) => { if (alive) setLabels(rows); })
-      .catch(() => { if (alive) setLabels([]); })
+      .then((rows) => { if (alive) { setLabels(rows); setLabelsSucceeded(true); } })
+      .catch(() => { if (alive) { setLabels([]); setLabelsSucceeded(false); } })
       .finally(() => { if (alive) setLabelsLoaded(true); });
     return () => { alive = false; };
   }, []);
@@ -137,13 +147,13 @@ export default function IssuePage({ defaultScope, defaultView, viewKey }: IssueP
 
   useEffect(() => {
     const optionIds = {
-      assigneeIds: candsLoaded ? cands.map((c) => c.id) : undefined,
-      creatorIds: candsLoaded ? cands.filter((c) => c.type === "member").map((c) => c.id) : undefined,
-      projectIds: projectsLoaded ? projects.map((p) => p.id) : undefined,
-      labelIds: labelsLoaded ? labels.map((l) => l.id) : undefined,
+      assigneeIds: candsLoaded && candsSucceeded ? cands.map((c) => c.id) : undefined,
+      creatorIds: candsLoaded && candsSucceeded ? cands.filter((c) => c.type === "member").map((c) => c.id) : undefined,
+      projectIds: projectsLoaded && projectsSucceeded ? projects.map((p) => p.id) : undefined,
+      labelIds: labelsLoaded && labelsSucceeded ? labels.map((l) => l.id) : undefined,
     };
     setF((prev) => reconcileIssueFilters(prev, optionIds, isMyLoop));
-  }, [cands, candsLoaded, isMyLoop, labels, labelsLoaded, projects, projectsLoaded]);
+  }, [cands, candsLoaded, candsSucceeded, isMyLoop, labels, labelsLoaded, labelsSucceeded, projects, projectsLoaded, projectsSucceeded]);
 
   const reload = useCallback(() => {
     const my = ++seq.current;

--- a/packages/dmloop/src/pages/IssuePage.tsx
+++ b/packages/dmloop/src/pages/IssuePage.tsx
@@ -27,7 +27,7 @@ import { listIssues, searchIssues, listGroupedIssues, listMyGroupedIssues, getAg
 import { groupIssuesByAssignee } from "../api/issueGrouping";
 import { listProjectOptions } from "../api/directory";
 import { listLabels } from "../api/labelApi";
-import { useAssigneeCandidates } from "../ui/useAssigneeCandidates";
+import { useAssigneeCandidateState } from "../ui/useAssigneeCandidates";
 import { ISSUE_STATUS_ORDER, PRIORITY_ORDER, isActiveRun } from "../ui/meta";
 import IssueBoard from "../panel/IssueBoard";
 import IssueGroupBoard from "../panel/IssueGroupBoard";
@@ -36,6 +36,14 @@ import IssueDetailPage from "../panel/IssueDetailPage";
 import CreateIssueModal from "../ui/CreateIssueModal";
 import { pushFleetIssueDeepLink, replaceLoopRootPath } from "../issueDeepLink";
 import { readView, writeView } from "../ui/viewMode";
+import {
+  defaultIssueFilters,
+  issueFilterStorageKey,
+  readIssueFilterState,
+  reconcileIssueFilters,
+  writeIssueFilterState,
+  type IssueFilters,
+} from "../ui/issueFilterPersistence";
 
 type ViewMode = "board" | "grouped" | "list";
 
@@ -49,19 +57,7 @@ function scopeToAssigneeTypes(scope: IssueScope): ("member" | "agent" | "squad")
 
 // 统一筛选:全维度数组多选 + 正交的「无负责人 / 无项目」布尔,同一套应用到看板/列表/分组
 // 三视图。keyword 走独立全文搜索端点,故与其它维度不并存于同一请求。
-interface Filters {
-  keyword: string;
-  statuses: IssueStatus[];
-  priorities: IssuePriority[];
-  assigneeIds: string[];
-  noAssignee: boolean;
-  creatorIds: string[];
-  projectIds: string[];
-  noProject: boolean;
-  labelIds: string[];
-  dateField: IssueDateField; // 时间范围筛选的列(created_at|updated_at)
-  dateRange?: Date[];        // [start, end];为空则不按时间筛选
-}
+type Filters = IssueFilters;
 
 const PAGE_SIZE = 50;
 
@@ -82,14 +78,24 @@ export default function IssuePage({ defaultScope, defaultView, viewKey }: IssueP
   // 「我的回路」= involves:只有分组视图能表达「指派/创建/关联」三路并集(listMyGroupedIssues 扇出),
   // 看板/列表无对应查询会退化成显示全工作区 → 该页锁死分组、不给切视图。
   const isMyLoop = defaultScope === "involves";
+  const workspaceSlug = currentWorkspaceSlug();
+  const filterStorageKey = issueFilterStorageKey(workspaceSlug, viewKey);
+  const [initialFilterState] = useState(() =>
+    readIssueFilterState(
+      localStorage,
+      filterStorageKey,
+      defaultScope ?? "all",
+      isMyLoop,
+    ),
+  );
   const [issues, setIssues] = useState<Issue[]>([]);
   const [groups, setGroups] = useState<IssueGroup[]>([]);
   const [running, setRunning] = useState<ReadonlySet<string>>(new Set());
   const [total, setTotal] = useState(0);
   const [loading, setLoading] = useState(true);
   const [view, setView] = useState<ViewMode>(() => isMyLoop ? "grouped" : (viewKey ? readView(viewKey, ["board", "grouped", "list"], defaultView ?? "board") : (defaultView ?? "board")));
-  const [scope, setScope] = useState<IssueScope>(defaultScope ?? "all");
-  const [f, setF] = useState<Filters>({ keyword: "", statuses: [], priorities: [], assigneeIds: [], noAssignee: false, creatorIds: [], projectIds: [], noProject: false, labelIds: [], dateField: "created_at" });
+  const [scope, setScope] = useState<IssueScope>(initialFilterState.scope);
+  const [f, setF] = useState<Filters>(initialFilterState.filters);
   const [page, setPage] = useState(0); // 0-based，仅列表视图分页
   // 「无负责人」仅在 scope=全部 时有效(与 assignee_types 组合恒空)。单一来源:发送/勾选态/计数共用,防漂移。
   const noAssigneeActive = scope === "all" && f.noAssignee;
@@ -98,7 +104,7 @@ export default function IssuePage({ defaultScope, defaultView, viewKey }: IssueP
   // onVisibleChange —— 仅外部点击关闭,内部多字段交互保持面板打开。
   const [filterOpen, setFilterOpen] = useState(false);
   const [showOpen, setShowOpen] = useState(false);
-  const cands = useAssigneeCandidates();
+  const { candidates: cands, loaded: candsLoaded } = useAssigneeCandidateState();
   // 当前 octo 成员的后端 user_id(involves_user_id 需 UUID,非 octo uid)：
   // 复用订阅特性的身份解析——候选里 octo_uid===loginInfo.uid 的 member。未解析出则「与我相关」不可用。
   const myMemberId = useMemo(() => {
@@ -108,12 +114,36 @@ export default function IssuePage({ defaultScope, defaultView, viewKey }: IssueP
   // 项目下拉复用 directory 已缓存的 /projects(避免重复请求);随 workspace 切换整页重挂而刷新。
   const [projects, setProjects] = useState<Array<{ id: string; title: string }>>([]);
   const [labels, setLabels] = useState<IssueLabel[]>([]);
+  const [projectsLoaded, setProjectsLoaded] = useState(false);
+  const [labelsLoaded, setLabelsLoaded] = useState(false);
   const seq = useRef(0); // 请求序号：只应用最新一次的响应，防并发乱序覆盖
 
   useEffect(() => {
-    listProjectOptions().then(setProjects).catch(() => {});
-    listLabels().then(setLabels).catch(() => {});
+    let alive = true;
+    listProjectOptions()
+      .then((rows) => { if (alive) setProjects(rows); })
+      .catch(() => { if (alive) setProjects([]); })
+      .finally(() => { if (alive) setProjectsLoaded(true); });
+    listLabels()
+      .then((rows) => { if (alive) setLabels(rows); })
+      .catch(() => { if (alive) setLabels([]); })
+      .finally(() => { if (alive) setLabelsLoaded(true); });
+    return () => { alive = false; };
   }, []);
+
+  useEffect(() => {
+    writeIssueFilterState(localStorage, filterStorageKey, { filters: f, scope }, isMyLoop);
+  }, [f, filterStorageKey, isMyLoop, scope]);
+
+  useEffect(() => {
+    const optionIds = {
+      assigneeIds: candsLoaded ? cands.map((c) => c.id) : undefined,
+      creatorIds: candsLoaded ? cands.filter((c) => c.type === "member").map((c) => c.id) : undefined,
+      projectIds: projectsLoaded ? projects.map((p) => p.id) : undefined,
+      labelIds: labelsLoaded ? labels.map((l) => l.id) : undefined,
+    };
+    setF((prev) => reconcileIssueFilters(prev, optionIds, isMyLoop));
+  }, [cands, candsLoaded, isMyLoop, labels, labelsLoaded, projects, projectsLoaded]);
 
   const reload = useCallback(() => {
     const my = ++seq.current;
@@ -308,8 +338,7 @@ export default function IssuePage({ defaultScope, defaultView, viewKey }: IssueP
 
   const clearFilters = () =>
     update({
-      keyword: "", statuses: [], priorities: [], assigneeIds: [], noAssignee: false,
-      creatorIds: [], projectIds: [], noProject: false, labelIds: [], dateRange: undefined,
+      ...defaultIssueFilters(),
     });
 
   // 一行多选筛选(标签 + Select multiple)。各维度只差 options / filter / maxTagCount,收进一个函数。

--- a/packages/dmloop/src/pages/IssuePage.tsx
+++ b/packages/dmloop/src/pages/IssuePage.tsx
@@ -12,7 +12,7 @@ import {
 import LoopButton from "../ui/LoopButton";
 import { Search, Plus, LayoutGrid, List as ListIcon, Users, ClipboardList, SlidersHorizontal, Filter } from "lucide-react";
 import { useI18n, WKApp } from "@octo/base";
-import { currentWorkspaceSlug } from "../api/http";
+import { currentWorkspaceId, currentWorkspaceSlug } from "../api/http";
 import type {
   Issue,
   IssueGroup,
@@ -80,7 +80,8 @@ export default function IssuePage({ defaultScope, defaultView, viewKey }: IssueP
   // 看板/列表无对应查询会退化成显示全工作区 → 该页锁死分组、不给切视图。
   const isMyLoop = defaultScope === "involves";
   const workspaceSlug = currentWorkspaceSlug();
-  const filterStorageKey = issueFilterStorageKey(workspaceSlug, viewKey);
+  const workspaceId = currentWorkspaceId();
+  const filterStorageKey = issueFilterStorageKey(workspaceSlug, viewKey, workspaceId);
   const [initialFilterState] = useState(() =>
     readIssueFilterState(
       localStorage,

--- a/packages/dmloop/src/ui/__tests__/issueFilterPersistence.test.ts
+++ b/packages/dmloop/src/ui/__tests__/issueFilterPersistence.test.ts
@@ -152,6 +152,35 @@ describe("issue filter persistence", () => {
     });
   });
 
+  it("preserves stored ids when option requests did not succeed", () => {
+    const filters = {
+      ...defaultIssueFilters(),
+      assigneeIds: ["a1"],
+      creatorIds: ["c1"],
+      projectIds: ["p1"],
+      labelIds: ["l1"],
+    };
+
+    expect(reconcileIssueFilters(filters, {}, false)).toBe(filters);
+  });
+
+  it("does not restore My Loop scope on the normal issue page", () => {
+    const storage = new MemoryStorage();
+    const key = "filters";
+    storage.setItem(
+      key,
+      JSON.stringify({
+        filters: { statuses: ["todo"] },
+        scope: "involves",
+      })
+    );
+
+    expect(readIssueFilterState(storage, key, "all", false)).toEqual({
+      filters: { ...defaultIssueFilters(), statuses: ["todo"] },
+      scope: "all",
+    });
+  });
+
   it("drops filters that do not apply to My Loop", () => {
     const storage = new MemoryStorage();
     const key = "filters";

--- a/packages/dmloop/src/ui/__tests__/issueFilterPersistence.test.ts
+++ b/packages/dmloop/src/ui/__tests__/issueFilterPersistence.test.ts
@@ -2,15 +2,15 @@ import { describe, expect, it } from "vitest";
 
 import {
   defaultIssueFilters,
+  type IssueFilterReader,
+  type IssueFilterWriter,
   issueFilterStorageKey,
   readIssueFilterState,
   reconcileIssueFilters,
   writeIssueFilterState,
 } from "../issueFilterPersistence";
 
-class MemoryStorage
-  implements Pick<Storage, "getItem" | "setItem" | "removeItem">
-{
+class MemoryStorage implements IssueFilterReader, IssueFilterWriter {
   private values = new Map<string, string>();
 
   getItem(key: string) {

--- a/packages/dmloop/src/ui/__tests__/issueFilterPersistence.test.ts
+++ b/packages/dmloop/src/ui/__tests__/issueFilterPersistence.test.ts
@@ -73,6 +73,31 @@ describe("issue filter persistence", () => {
     ]);
   });
 
+  it("round-trips a same-day date range", () => {
+    const storage = new MemoryStorage();
+    const key = issueFilterStorageKey("alpha", "loop.view.issue");
+    const sameDay = new Date("2026-07-01T00:00:00.000Z");
+
+    writeIssueFilterState(
+      storage,
+      key,
+      {
+        scope: "all",
+        filters: {
+          ...defaultIssueFilters(),
+          dateRange: [sameDay, sameDay],
+        },
+      },
+      false
+    );
+
+    const restored = readIssueFilterState(storage, key, "all", false);
+    expect(restored.filters.dateRange?.map((d) => d.toISOString())).toEqual([
+      "2026-07-01T00:00:00.000Z",
+      "2026-07-01T00:00:00.000Z",
+    ]);
+  });
+
   it("falls back on malformed or invalid storage data", () => {
     const storage = new MemoryStorage();
     const key = "filters";

--- a/packages/dmloop/src/ui/__tests__/issueFilterPersistence.test.ts
+++ b/packages/dmloop/src/ui/__tests__/issueFilterPersistence.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  defaultIssueFilters,
+  issueFilterStorageKey,
+  readIssueFilterState,
+  reconcileIssueFilters,
+  writeIssueFilterState,
+} from "../issueFilterPersistence";
+
+class MemoryStorage
+  implements Pick<Storage, "getItem" | "setItem" | "removeItem">
+{
+  private values = new Map<string, string>();
+
+  getItem(key: string) {
+    return this.values.get(key) ?? null;
+  }
+
+  setItem(key: string, value: string) {
+    this.values.set(key, value);
+  }
+
+  removeItem(key: string) {
+    this.values.delete(key);
+  }
+}
+
+describe("issue filter persistence", () => {
+  it("uses a workspace-scoped key", () => {
+    expect(issueFilterStorageKey("alpha", "loop.view.issue")).toBe(
+      "loop.issue.filters:loop.view.issue:alpha"
+    );
+    expect(issueFilterStorageKey("", "loop.view.issue")).toBeNull();
+    expect(issueFilterStorageKey("alpha")).toBeNull();
+  });
+
+  it("round-trips valid filters and scope", () => {
+    const storage = new MemoryStorage();
+    const key = issueFilterStorageKey("alpha", "loop.view.issue");
+    writeIssueFilterState(
+      storage,
+      key,
+      {
+        scope: "agents",
+        filters: {
+          ...defaultIssueFilters(),
+          keyword: "deploy",
+          statuses: ["todo"],
+          priorities: ["high"],
+          assigneeIds: ["a1"],
+          projectIds: ["p1"],
+          dateRange: [
+            new Date("2026-07-01T00:00:00.000Z"),
+            new Date("2026-07-02T00:00:00.000Z"),
+          ],
+        },
+      },
+      false
+    );
+
+    const restored = readIssueFilterState(storage, key, "all", false);
+    expect(restored.scope).toBe("agents");
+    expect(restored.filters.keyword).toBe("deploy");
+    expect(restored.filters.statuses).toEqual(["todo"]);
+    expect(restored.filters.priorities).toEqual(["high"]);
+    expect(restored.filters.assigneeIds).toEqual(["a1"]);
+    expect(restored.filters.projectIds).toEqual(["p1"]);
+    expect(restored.filters.dateRange?.map((d) => d.toISOString())).toEqual([
+      "2026-07-01T00:00:00.000Z",
+      "2026-07-02T00:00:00.000Z",
+    ]);
+  });
+
+  it("falls back on malformed or invalid storage data", () => {
+    const storage = new MemoryStorage();
+    const key = "filters";
+    storage.setItem(key, "{bad json");
+    expect(readIssueFilterState(storage, key, "members", false)).toEqual({
+      filters: defaultIssueFilters(),
+      scope: "members",
+    });
+
+    storage.setItem(
+      key,
+      JSON.stringify({
+        filters: {
+          statuses: ["todo", "missing"],
+          priorities: ["high", "missing"],
+          dateField: "bad",
+          dateRange: ["2026-07-02T00:00:00.000Z", "2026-07-01T00:00:00.000Z"],
+        },
+        scope: "bad",
+      })
+    );
+    expect(readIssueFilterState(storage, key, "all", false)).toEqual({
+      filters: {
+        ...defaultIssueFilters(),
+        statuses: ["todo"],
+        priorities: ["high"],
+      },
+      scope: "all",
+    });
+  });
+
+  it("removes the item when filters are cleared back to defaults", () => {
+    const storage = new MemoryStorage();
+    const key = "filters";
+    writeIssueFilterState(
+      storage,
+      key,
+      { filters: { ...defaultIssueFilters(), keyword: "x" }, scope: "all" },
+      false
+    );
+    expect(storage.getItem(key)).not.toBeNull();
+
+    writeIssueFilterState(
+      storage,
+      key,
+      { filters: defaultIssueFilters(), scope: "all" },
+      false
+    );
+    expect(storage.getItem(key)).toBeNull();
+  });
+
+  it("keeps only the intersection of persisted ids and current component options", () => {
+    const filters = {
+      ...defaultIssueFilters(),
+      assigneeIds: ["a1", "stale-a"],
+      creatorIds: ["c1", "stale-c"],
+      projectIds: ["p1", "stale-p"],
+      labelIds: ["l1", "stale-l"],
+    };
+
+    expect(
+      reconcileIssueFilters(
+        filters,
+        {
+          assigneeIds: ["a1"],
+          creatorIds: ["c1"],
+          projectIds: ["p1"],
+          labelIds: ["l1"],
+        },
+        false
+      )
+    ).toEqual({
+      ...filters,
+      assigneeIds: ["a1"],
+      creatorIds: ["c1"],
+      projectIds: ["p1"],
+      labelIds: ["l1"],
+    });
+  });
+
+  it("drops filters that do not apply to My Loop", () => {
+    const storage = new MemoryStorage();
+    const key = "filters";
+    storage.setItem(
+      key,
+      JSON.stringify({
+        filters: {
+          keyword: "ignored",
+          assigneeIds: ["a1"],
+          noAssignee: true,
+          creatorIds: ["c1"],
+          statuses: ["todo"],
+        },
+        scope: "agents",
+      })
+    );
+
+    const restored = readIssueFilterState(storage, key, "involves", true);
+    expect(restored).toEqual({
+      filters: { ...defaultIssueFilters(), statuses: ["todo"] },
+      scope: "involves",
+    });
+  });
+});

--- a/packages/dmloop/src/ui/__tests__/issueFilterPersistence.test.ts
+++ b/packages/dmloop/src/ui/__tests__/issueFilterPersistence.test.ts
@@ -123,6 +123,18 @@ describe("issue filter persistence", () => {
     ]);
   });
 
+  it("clears date range when defaults are merged over active filters", () => {
+    const active = {
+      ...defaultIssueFilters(),
+      dateRange: [
+        new Date("2026-07-01T00:00:00.000Z"),
+        new Date("2026-07-02T00:00:00.000Z"),
+      ],
+    };
+
+    expect({ ...active, ...defaultIssueFilters() }.dateRange).toBeUndefined();
+  });
+
   it("falls back on malformed or invalid storage data", () => {
     const storage = new MemoryStorage();
     const key = "filters";

--- a/packages/dmloop/src/ui/__tests__/issueFilterPersistence.test.ts
+++ b/packages/dmloop/src/ui/__tests__/issueFilterPersistence.test.ts
@@ -29,16 +29,41 @@ class MemoryStorage implements IssueFilterReader, IssueFilterWriter {
 
 describe("issue filter persistence", () => {
   it("uses a workspace-scoped key", () => {
-    expect(issueFilterStorageKey("alpha", "loop.view.issue")).toBe(
-      "loop.issue.filters:loop.view.issue:alpha"
+    expect(issueFilterStorageKey("alpha", "loop.view.issue", "ws-1")).toBe(
+      "loop.issue.filters:loop.view.issue:workspace:ws-1"
     );
-    expect(issueFilterStorageKey("", "loop.view.issue")).toBeNull();
+    expect(issueFilterStorageKey("", "loop.view.issue", "ws-1")).toBeNull();
+    expect(issueFilterStorageKey("alpha", "loop.view.issue")).toBeNull();
     expect(issueFilterStorageKey("alpha")).toBeNull();
+  });
+
+  it("does not collide when two spaces contain workspaces with the same slug", () => {
+    const storage = new MemoryStorage();
+    const spaceAKey = issueFilterStorageKey("shared-slug", "loop.view.issue", "ws-space-a");
+    const spaceBKey = issueFilterStorageKey("shared-slug", "loop.view.issue", "ws-space-b");
+
+    expect(spaceAKey).not.toBe(spaceBKey);
+
+    writeIssueFilterState(
+      storage,
+      spaceAKey,
+      { scope: "all", filters: { ...defaultIssueFilters(), keyword: "space-a" } },
+      false
+    );
+    writeIssueFilterState(
+      storage,
+      spaceBKey,
+      { scope: "all", filters: { ...defaultIssueFilters(), keyword: "space-b" } },
+      false
+    );
+
+    expect(readIssueFilterState(storage, spaceAKey, "all", false).filters.keyword).toBe("space-a");
+    expect(readIssueFilterState(storage, spaceBKey, "all", false).filters.keyword).toBe("space-b");
   });
 
   it("round-trips valid filters and scope", () => {
     const storage = new MemoryStorage();
-    const key = issueFilterStorageKey("alpha", "loop.view.issue");
+    const key = issueFilterStorageKey("alpha", "loop.view.issue", "ws-1");
     writeIssueFilterState(
       storage,
       key,
@@ -75,7 +100,7 @@ describe("issue filter persistence", () => {
 
   it("round-trips a same-day date range", () => {
     const storage = new MemoryStorage();
-    const key = issueFilterStorageKey("alpha", "loop.view.issue");
+    const key = issueFilterStorageKey("alpha", "loop.view.issue", "ws-1");
     const sameDay = new Date("2026-07-01T00:00:00.000Z");
 
     writeIssueFilterState(

--- a/packages/dmloop/src/ui/__tests__/issueFilterPersistence.test.ts
+++ b/packages/dmloop/src/ui/__tests__/issueFilterPersistence.test.ts
@@ -4,6 +4,7 @@ import {
   defaultIssueFilters,
   type IssueFilterReader,
   type IssueFilterWriter,
+  issueFilterOptionIds,
   issueFilterStorageKey,
   readIssueFilterState,
   reconcileIssueFilters,
@@ -162,6 +163,51 @@ describe("issue filter persistence", () => {
     };
 
     expect(reconcileIssueFilters(filters, {}, false)).toBe(filters);
+  });
+
+  it("does not turn completed failed option loads into empty authoritative lists", () => {
+    expect(
+      issueFilterOptionIds({
+        candidates: [],
+        candidatesLoaded: true,
+        candidatesSucceeded: false,
+        projects: [],
+        projectsLoaded: true,
+        projectsSucceeded: false,
+        labels: [],
+        labelsLoaded: true,
+        labelsSucceeded: false,
+      })
+    ).toEqual({
+      assigneeIds: undefined,
+      creatorIds: undefined,
+      projectIds: undefined,
+      labelIds: undefined,
+    });
+  });
+
+  it("builds authoritative option ids only after successful option loads", () => {
+    expect(
+      issueFilterOptionIds({
+        candidates: [
+          { id: "m1", type: "member", name: "M" },
+          { id: "a1", type: "agent", name: "A" },
+        ],
+        candidatesLoaded: true,
+        candidatesSucceeded: true,
+        projects: [{ id: "p1" }],
+        projectsLoaded: true,
+        projectsSucceeded: true,
+        labels: [{ id: "l1", name: "L", color: "#fff" }],
+        labelsLoaded: true,
+        labelsSucceeded: true,
+      })
+    ).toEqual({
+      assigneeIds: ["m1", "a1"],
+      creatorIds: ["m1"],
+      projectIds: ["p1"],
+      labelIds: ["l1"],
+    });
   });
 
   it("does not restore My Loop scope on the normal issue page", () => {

--- a/packages/dmloop/src/ui/issueFilterPersistence.ts
+++ b/packages/dmloop/src/ui/issueFilterPersistence.ts
@@ -84,10 +84,11 @@ export function defaultIssueFilters(): IssueFilters {
 
 export function issueFilterStorageKey(
   workspaceSlug: string,
-  viewKey?: string
+  viewKey?: string,
+  workspaceId?: string
 ): string | null {
-  if (!workspaceSlug || !viewKey) return null;
-  return `loop.issue.filters:${viewKey}:${workspaceSlug}`;
+  if (!workspaceSlug || !viewKey || !workspaceId) return null;
+  return `loop.issue.filters:${viewKey}:workspace:${workspaceId}`;
 }
 
 export function readIssueFilterState(

--- a/packages/dmloop/src/ui/issueFilterPersistence.ts
+++ b/packages/dmloop/src/ui/issueFilterPersistence.ts
@@ -32,6 +32,15 @@ export interface IssueFilterOptionIds {
   labelIds?: string[];
 }
 
+export interface IssueFilterReader {
+  getItem(key: string): string | null;
+}
+
+export interface IssueFilterWriter {
+  setItem(key: string, value: string): void;
+  removeItem(key: string): void;
+}
+
 const STATUSES: IssueStatus[] = [
   "backlog",
   "todo",
@@ -68,7 +77,7 @@ export function issueFilterStorageKey(
 }
 
 export function readIssueFilterState(
-  storage: Pick<Storage, "getItem">,
+  store: IssueFilterReader,
   key: string | null,
   fallbackScope: IssueScope,
   isMyLoop: boolean
@@ -76,7 +85,7 @@ export function readIssueFilterState(
   const fallback = { filters: defaultIssueFilters(), scope: fallbackScope };
   if (!key) return fallback;
   try {
-    const raw = storage.getItem(key);
+    const raw = store.getItem(key);
     if (!raw) return fallback;
     return normalizeState(JSON.parse(raw), fallbackScope, isMyLoop);
   } catch {
@@ -85,7 +94,7 @@ export function readIssueFilterState(
 }
 
 export function writeIssueFilterState(
-  storage: Pick<Storage, "setItem" | "removeItem">,
+  store: IssueFilterWriter,
   key: string | null,
   state: IssueFilterState,
   isMyLoop: boolean
@@ -94,10 +103,10 @@ export function writeIssueFilterState(
   const normalized = normalizeState(state, state.scope, isMyLoop);
   try {
     if (isDefaultState(normalized, isMyLoop)) {
-      storage.removeItem(key);
+      store.removeItem(key);
       return;
     }
-    storage.setItem(key, JSON.stringify(serializeState(normalized, isMyLoop)));
+    store.setItem(key, JSON.stringify(serializeState(normalized, isMyLoop)));
   } catch {
     /* ignore storage quota / privacy mode failures */
   }

--- a/packages/dmloop/src/ui/issueFilterPersistence.ts
+++ b/packages/dmloop/src/ui/issueFilterPersistence.ts
@@ -51,7 +51,7 @@ const STATUSES: IssueStatus[] = [
   "cancelled",
 ];
 const PRIORITIES: IssuePriority[] = ["urgent", "high", "medium", "low", "none"];
-const SCOPES: IssueScope[] = ["all", "members", "agents", "involves"];
+const ISSUE_PAGE_SCOPES: IssueScope[] = ["all", "members", "agents"];
 
 export function defaultIssueFilters(): IssueFilters {
   return {
@@ -162,7 +162,7 @@ function normalizeState(
   const scope =
     !isMyLoop &&
     typeof v.scope === "string" &&
-    SCOPES.includes(v.scope as IssueScope)
+    ISSUE_PAGE_SCOPES.includes(v.scope as IssueScope)
       ? (v.scope as IssueScope)
       : fallbackScope;
   return { filters, scope };

--- a/packages/dmloop/src/ui/issueFilterPersistence.ts
+++ b/packages/dmloop/src/ui/issueFilterPersistence.ts
@@ -1,0 +1,269 @@
+import type {
+  IssueDateField,
+  IssuePriority,
+  IssueScope,
+  IssueStatus,
+} from "../api/types";
+import { ISSUE_DATE_FIELDS } from "../api/types";
+
+export interface IssueFilters {
+  keyword: string;
+  statuses: IssueStatus[];
+  priorities: IssuePriority[];
+  assigneeIds: string[];
+  noAssignee: boolean;
+  creatorIds: string[];
+  projectIds: string[];
+  noProject: boolean;
+  labelIds: string[];
+  dateField: IssueDateField;
+  dateRange?: Date[];
+}
+
+export interface IssueFilterState {
+  filters: IssueFilters;
+  scope: IssueScope;
+}
+
+export interface IssueFilterOptionIds {
+  assigneeIds?: string[];
+  creatorIds?: string[];
+  projectIds?: string[];
+  labelIds?: string[];
+}
+
+const STATUSES: IssueStatus[] = [
+  "backlog",
+  "todo",
+  "in_progress",
+  "in_review",
+  "done",
+  "blocked",
+  "cancelled",
+];
+const PRIORITIES: IssuePriority[] = ["urgent", "high", "medium", "low", "none"];
+const SCOPES: IssueScope[] = ["all", "members", "agents", "involves"];
+
+export function defaultIssueFilters(): IssueFilters {
+  return {
+    keyword: "",
+    statuses: [],
+    priorities: [],
+    assigneeIds: [],
+    noAssignee: false,
+    creatorIds: [],
+    projectIds: [],
+    noProject: false,
+    labelIds: [],
+    dateField: "created_at",
+  };
+}
+
+export function issueFilterStorageKey(
+  workspaceSlug: string,
+  viewKey?: string
+): string | null {
+  if (!workspaceSlug || !viewKey) return null;
+  return `loop.issue.filters:${viewKey}:${workspaceSlug}`;
+}
+
+export function readIssueFilterState(
+  storage: Pick<Storage, "getItem">,
+  key: string | null,
+  fallbackScope: IssueScope,
+  isMyLoop: boolean
+): IssueFilterState {
+  const fallback = { filters: defaultIssueFilters(), scope: fallbackScope };
+  if (!key) return fallback;
+  try {
+    const raw = storage.getItem(key);
+    if (!raw) return fallback;
+    return normalizeState(JSON.parse(raw), fallbackScope, isMyLoop);
+  } catch {
+    return fallback;
+  }
+}
+
+export function writeIssueFilterState(
+  storage: Pick<Storage, "setItem" | "removeItem">,
+  key: string | null,
+  state: IssueFilterState,
+  isMyLoop: boolean
+): void {
+  if (!key) return;
+  const normalized = normalizeState(state, state.scope, isMyLoop);
+  try {
+    if (isDefaultState(normalized, isMyLoop)) {
+      storage.removeItem(key);
+      return;
+    }
+    storage.setItem(key, JSON.stringify(serializeState(normalized, isMyLoop)));
+  } catch {
+    /* ignore storage quota / privacy mode failures */
+  }
+}
+
+export function reconcileIssueFilters(
+  filters: IssueFilters,
+  options: IssueFilterOptionIds,
+  isMyLoop: boolean
+): IssueFilters {
+  const next: IssueFilters = {
+    ...filters,
+    assigneeIds: isMyLoop
+      ? []
+      : intersect(filters.assigneeIds, options.assigneeIds),
+    creatorIds: isMyLoop
+      ? []
+      : intersect(filters.creatorIds, options.creatorIds),
+    projectIds: intersect(filters.projectIds, options.projectIds),
+    labelIds: intersect(filters.labelIds, options.labelIds),
+  };
+  if (isMyLoop && (next.keyword || next.noAssignee)) {
+    next.keyword = "";
+    next.noAssignee = false;
+  }
+  return filtersEqual(filters, next) ? filters : next;
+}
+
+export function filtersEqual(a: IssueFilters, b: IssueFilters): boolean {
+  return (
+    a.keyword === b.keyword &&
+    a.noAssignee === b.noAssignee &&
+    a.noProject === b.noProject &&
+    a.dateField === b.dateField &&
+    arraysEqual(a.statuses, b.statuses) &&
+    arraysEqual(a.priorities, b.priorities) &&
+    arraysEqual(a.assigneeIds, b.assigneeIds) &&
+    arraysEqual(a.creatorIds, b.creatorIds) &&
+    arraysEqual(a.projectIds, b.projectIds) &&
+    arraysEqual(a.labelIds, b.labelIds) &&
+    datesEqual(a.dateRange, b.dateRange)
+  );
+}
+
+function normalizeState(
+  value: unknown,
+  fallbackScope: IssueScope,
+  isMyLoop: boolean
+): IssueFilterState {
+  const v = isRecord(value) ? value : {};
+  const rawFilters = isRecord(v.filters) ? v.filters : v;
+  const filters = normalizeFilters(rawFilters, isMyLoop);
+  const scope =
+    !isMyLoop &&
+    typeof v.scope === "string" &&
+    SCOPES.includes(v.scope as IssueScope)
+      ? (v.scope as IssueScope)
+      : fallbackScope;
+  return { filters, scope };
+}
+
+function normalizeFilters(
+  value: Record<string, unknown>,
+  isMyLoop: boolean
+): IssueFilters {
+  const defaults = defaultIssueFilters();
+  const dateRange = normalizeDateRange(value.dateRange);
+  return {
+    keyword: isMyLoop ? "" : stringValue(value.keyword),
+    statuses: enumList(value.statuses, STATUSES),
+    priorities: enumList(value.priorities, PRIORITIES),
+    assigneeIds: isMyLoop ? [] : stringList(value.assigneeIds),
+    noAssignee: isMyLoop ? false : value.noAssignee === true,
+    creatorIds: isMyLoop ? [] : stringList(value.creatorIds),
+    projectIds: stringList(value.projectIds),
+    noProject: value.noProject === true,
+    labelIds: stringList(value.labelIds),
+    dateField:
+      typeof value.dateField === "string" &&
+      (ISSUE_DATE_FIELDS as readonly string[]).includes(value.dateField)
+        ? (value.dateField as IssueDateField)
+        : defaults.dateField,
+    dateRange,
+  };
+}
+
+function serializeState(state: IssueFilterState, isMyLoop: boolean) {
+  const filters = state.filters;
+  return {
+    filters: {
+      keyword: isMyLoop ? "" : filters.keyword,
+      statuses: filters.statuses,
+      priorities: filters.priorities,
+      assigneeIds: isMyLoop ? [] : filters.assigneeIds,
+      noAssignee: isMyLoop ? false : filters.noAssignee,
+      creatorIds: isMyLoop ? [] : filters.creatorIds,
+      projectIds: filters.projectIds,
+      noProject: filters.noProject,
+      labelIds: filters.labelIds,
+      dateField: filters.dateField,
+      dateRange: filters.dateRange?.map((d) => d.toISOString()),
+    },
+    scope: isMyLoop ? undefined : state.scope,
+  };
+}
+
+function isDefaultState(state: IssueFilterState, isMyLoop: boolean): boolean {
+  const defaults = defaultIssueFilters();
+  const defaultScope = isMyLoop ? "involves" : "all";
+  return (
+    filtersEqual(state.filters, defaults) &&
+    (isMyLoop || state.scope === defaultScope)
+  );
+}
+
+function normalizeDateRange(value: unknown): Date[] | undefined {
+  if (!Array.isArray(value) || value.length !== 2) return undefined;
+  const start = toValidDate(value[0]);
+  const end = toValidDate(value[1]);
+  if (!start || !end || start.getTime() >= end.getTime()) return undefined;
+  return [start, end];
+}
+
+function toValidDate(value: unknown): Date | null {
+  if (typeof value !== "string" && !(value instanceof Date)) return null;
+  const date = new Date(value);
+  return Number.isFinite(date.getTime()) ? date : null;
+}
+
+function enumList<T extends string>(
+  value: unknown,
+  allowed: readonly T[]
+): T[] {
+  const allowedSet = new Set<string>(allowed);
+  return stringList(value).filter((v): v is T => allowedSet.has(v));
+}
+
+function stringList(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return Array.from(
+    new Set(
+      value.filter((v): v is string => typeof v === "string" && v.length > 0)
+    )
+  );
+}
+
+function stringValue(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function intersect(value: string[], allowed?: string[]): string[] {
+  if (!allowed) return value;
+  const allowedSet = new Set(allowed);
+  return value.filter((id) => allowedSet.has(id));
+}
+
+function arraysEqual(a: string[], b: string[]): boolean {
+  return a.length === b.length && a.every((v, i) => v === b[i]);
+}
+
+function datesEqual(a?: Date[], b?: Date[]): boolean {
+  if (!a && !b) return true;
+  if (!a || !b || a.length !== b.length) return false;
+  return a.every((date, i) => date.getTime() === b[i].getTime());
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}

--- a/packages/dmloop/src/ui/issueFilterPersistence.ts
+++ b/packages/dmloop/src/ui/issueFilterPersistence.ts
@@ -263,7 +263,7 @@ function normalizeDateRange(value: unknown): Date[] | undefined {
   if (!Array.isArray(value) || value.length !== 2) return undefined;
   const start = toValidDate(value[0]);
   const end = toValidDate(value[1]);
-  if (!start || !end || start.getTime() >= end.getTime()) return undefined;
+  if (!start || !end || start.getTime() > end.getTime()) return undefined;
   return [start, end];
 }
 

--- a/packages/dmloop/src/ui/issueFilterPersistence.ts
+++ b/packages/dmloop/src/ui/issueFilterPersistence.ts
@@ -1,5 +1,7 @@
 import type {
+  AssigneeCandidate,
   IssueDateField,
+  IssueLabel,
   IssuePriority,
   IssueScope,
   IssueStatus,
@@ -30,6 +32,18 @@ export interface IssueFilterOptionIds {
   creatorIds?: string[];
   projectIds?: string[];
   labelIds?: string[];
+}
+
+export interface IssueFilterOptionSource {
+  candidates: AssigneeCandidate[];
+  candidatesLoaded: boolean;
+  candidatesSucceeded: boolean;
+  projects: Array<{ id: string }>;
+  projectsLoaded: boolean;
+  projectsSucceeded: boolean;
+  labels: Pick<IssueLabel, "id">[];
+  labelsLoaded: boolean;
+  labelsSucceeded: boolean;
 }
 
 export interface IssueFilterReader {
@@ -133,6 +147,29 @@ export function reconcileIssueFilters(
     next.noAssignee = false;
   }
   return filtersEqual(filters, next) ? filters : next;
+}
+
+export function issueFilterOptionIds(
+  source: IssueFilterOptionSource
+): IssueFilterOptionIds {
+  return {
+    assigneeIds:
+      source.candidatesLoaded && source.candidatesSucceeded
+        ? source.candidates.map((c) => c.id)
+        : undefined,
+    creatorIds:
+      source.candidatesLoaded && source.candidatesSucceeded
+        ? source.candidates.filter((c) => c.type === "member").map((c) => c.id)
+        : undefined,
+    projectIds:
+      source.projectsLoaded && source.projectsSucceeded
+        ? source.projects.map((p) => p.id)
+        : undefined,
+    labelIds:
+      source.labelsLoaded && source.labelsSucceeded
+        ? source.labels.map((l) => l.id)
+        : undefined,
+  };
 }
 
 export function filtersEqual(a: IssueFilters, b: IssueFilters): boolean {

--- a/packages/dmloop/src/ui/issueFilterPersistence.ts
+++ b/packages/dmloop/src/ui/issueFilterPersistence.ts
@@ -79,6 +79,7 @@ export function defaultIssueFilters(): IssueFilters {
     noProject: false,
     labelIds: [],
     dateField: "created_at",
+    dateRange: undefined,
   };
 }
 

--- a/packages/dmloop/src/ui/useAssigneeCandidates.ts
+++ b/packages/dmloop/src/ui/useAssigneeCandidates.ts
@@ -5,23 +5,25 @@ import { listAssigneeCandidates } from "../api/issueApi";
 export interface AssigneeCandidateState {
   candidates: AssigneeCandidate[];
   loaded: boolean;
+  succeeded: boolean;
 }
 
 export function useAssigneeCandidateState(enabled = true): AssigneeCandidateState {
   const [state, setState] = useState<AssigneeCandidateState>({
     candidates: [],
     loaded: !enabled,
+    succeeded: !enabled,
   });
   useEffect(() => {
     let alive = true;
     if (!enabled) {
-      setState({ candidates: [], loaded: true });
+      setState({ candidates: [], loaded: true, succeeded: true });
       return () => { alive = false; };
     }
-    setState((prev) => ({ candidates: prev.candidates, loaded: false }));
+    setState((prev) => ({ candidates: prev.candidates, loaded: false, succeeded: false }));
     listAssigneeCandidates()
-      .then((candidates) => { if (alive) setState({ candidates, loaded: true }); })
-      .catch(() => { if (alive) setState({ candidates: [], loaded: true }); });
+      .then((candidates) => { if (alive) setState({ candidates, loaded: true, succeeded: true }); })
+      .catch(() => { if (alive) setState({ candidates: [], loaded: true, succeeded: false }); });
     return () => { alive = false; };
   }, [enabled]);
   return state;

--- a/packages/dmloop/src/ui/useAssigneeCandidates.ts
+++ b/packages/dmloop/src/ui/useAssigneeCandidates.ts
@@ -23,7 +23,15 @@ export function useAssigneeCandidateState(enabled = true): AssigneeCandidateStat
     setState((prev) => ({ candidates: prev.candidates, loaded: false, succeeded: false }));
     listAssigneeCandidates()
       .then((candidates) => { if (alive) setState({ candidates, loaded: true, succeeded: true }); })
-      .catch(() => { if (alive) setState({ candidates: [], loaded: true, succeeded: false }); });
+      .catch(() => {
+        if (alive) {
+          setState((prev) => ({
+            candidates: prev.candidates,
+            loaded: true,
+            succeeded: false,
+          }));
+        }
+      });
     return () => { alive = false; };
   }, [enabled]);
   return state;

--- a/packages/dmloop/src/ui/useAssigneeCandidates.ts
+++ b/packages/dmloop/src/ui/useAssigneeCandidates.ts
@@ -2,12 +2,32 @@ import { useEffect, useState } from "react";
 import type { AssigneeCandidate } from "../api/types";
 import { listAssigneeCandidates } from "../api/issueApi";
 
+export interface AssigneeCandidateState {
+  candidates: AssigneeCandidate[];
+  loaded: boolean;
+}
+
+export function useAssigneeCandidateState(enabled = true): AssigneeCandidateState {
+  const [state, setState] = useState<AssigneeCandidateState>({
+    candidates: [],
+    loaded: !enabled,
+  });
+  useEffect(() => {
+    let alive = true;
+    if (!enabled) {
+      setState({ candidates: [], loaded: true });
+      return () => { alive = false; };
+    }
+    setState((prev) => ({ candidates: prev.candidates, loaded: false }));
+    listAssigneeCandidates()
+      .then((candidates) => { if (alive) setState({ candidates, loaded: true }); })
+      .catch(() => { if (alive) setState({ candidates: [], loaded: true }); });
+    return () => { alive = false; };
+  }, [enabled]);
+  return state;
+}
+
 /** 加载 assignee 候选（member/agent/squad）。底层 directory 已做缓存，多处调用不重复拉网。 */
 export function useAssigneeCandidates(enabled = true): AssigneeCandidate[] {
-  const [cands, setCands] = useState<AssigneeCandidate[]>([]);
-  useEffect(() => {
-    if (!enabled) { setCands([]); return; }
-    listAssigneeCandidates().then(setCands).catch(() => setCands([]));
-  }, [enabled]);
-  return cands;
+  return useAssigneeCandidateState(enabled).candidates;
 }

--- a/packages/dmloop/src/ui/useAssigneeCandidates.ts
+++ b/packages/dmloop/src/ui/useAssigneeCandidates.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import type { AssigneeCandidate } from "../api/types";
-import { listAssigneeCandidates } from "../api/issueApi";
+import { listAssigneeCandidateState } from "../api/issueApi";
 
 export interface AssigneeCandidateState {
   candidates: AssigneeCandidate[];
@@ -21,8 +21,8 @@ export function useAssigneeCandidateState(enabled = true): AssigneeCandidateStat
       return () => { alive = false; };
     }
     setState((prev) => ({ candidates: prev.candidates, loaded: false, succeeded: false }));
-    listAssigneeCandidates()
-      .then((candidates) => { if (alive) setState({ candidates, loaded: true, succeeded: true }); })
+    listAssigneeCandidateState()
+      .then(({ candidates, succeeded }) => { if (alive) setState({ candidates, loaded: true, succeeded }); })
       .catch(() => {
         if (alive) {
           setState((prev) => ({


### PR DESCRIPTION
## Summary

- Persist Loop issue filters per workspace and restore them after refresh.
- Validate stored filter payloads before applying them to the page.
- Reconcile stored assignee, creator, project, and label IDs against current workspace options so stale values cannot crash the page.

## Changes

- Add a small filter persistence helper for storage key generation, read/write normalization, default cleanup, and option intersection.
- Wire `IssuePage` to restore, persist, clear, and reconcile filters by `workspaceSlug + viewKey`.
- Extend assignee candidate loading with a `loaded` flag while keeping the existing hook API.
- Add focused unit tests for workspace-scoped keys, malformed storage data, default cleanup, My Loop filtering, and stale option intersections.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm --filter @octo/loop test`
- `git diff --cached --check`

Known existing check gap:
- `pnpm --filter @octo/loop exec tsc --noEmit` fails on pre-existing dependency and cross-package type errors, including Semi Foundation lodash/prismjs declarations and existing `dmworkbase` React/NodeJS type issues.

Closes #1047
