### PR TITLE
fix(loop): adjust issue detail label layout for LOOP-87

### DIFF
--- a/packages/dmloop/src/panel/IssueDetailPage.tsx
+++ b/packages/dmloop/src/panel/IssueDetailPage.tsx
@@ -1337,7 +1337,7 @@ export default function IssueDetailPage({ issueId, onChanged, onClose, snapshot,
         }}
       />}
 
-      {/* 编辑属性弹窗：标签 / 父回路 / 开始/截止日期 / 阶段（侧栏保持只读，编辑走 ⋯ → 此弹窗） */}
+      {/* 编辑属性弹窗：父回路 / 开始/截止日期 / 阶段（标签直接在属性栏点击管理） */}
       {!readOnly && <Modal
         className="loop-modal"
         title={t("loop.menu.editProps")}
@@ -1347,10 +1347,6 @@ export default function IssueDetailPage({ issueId, onChanged, onClose, snapshot,
         width={460}
       >
         <div className="loop-fields">
-          <div className="loop-fields__row">
-            <div className="loop-fields__label">{t("loop.field.labels")}</div>
-            <LabelEditor issueId={issue.id} labels={issue.labels} onChanged={() => { syncIssue(reqRef.current); onChanged?.(); }} />
-          </div>
           <div className="loop-fields__row">
             <div className="loop-fields__label">{t("loop.field.parent")}</div>
             <Select

--- a/packages/dmloop/src/panel/IssueDetailPage.tsx
+++ b/packages/dmloop/src/panel/IssueDetailPage.tsx
@@ -72,6 +72,7 @@ import { listProjects } from "../api/projectApi";
 import { listRuns, rerunIssue, cancelTask } from "../api/runsApi";
 import AssigneePicker from "../ui/AssigneePicker";
 import LabelEditor from "../ui/LabelEditor";
+import LabelChips from "../ui/LabelChips";
 import { useRunConfirm } from "../ui/RunConfirmModal";
 import { useAssigneeCandidates } from "../ui/useAssigneeCandidates";
 import LoopMarkdown from "../ui/LoopMarkdown";
@@ -1233,6 +1234,21 @@ export default function IssueDetailPage({ issueId, onChanged, onClose, snapshot,
                       <ChevronDown size={12} className="loop-idp__prop-caret" />
                     </button>
                   </Dropdown>}
+                </div>
+                <div className="loop-idp__prop loop-idp__prop--inline loop-idp__prop--labels">
+                  <span className="loop-idp__prop-k">{t("loop.field.labels")}</span>
+                  {readOnly ? (
+                    <span className={`loop-idp__prop-v loop-idp__prop-labels${issue.labels?.length ? "" : " loop-idp__prop-v--muted"}`}>
+                      {issue.labels?.length ? <LabelChips labels={issue.labels} /> : t("loop.label.add")}
+                    </span>
+                  ) : (
+                    <LabelEditor
+                      issueId={issue.id}
+                      labels={issue.labels}
+                      className="loop-idp__label-editor"
+                      onChanged={() => { syncIssue(reqRef.current); onChanged?.(); }}
+                    />
+                  )}
                 </div>
               </div>
             )}

--- a/packages/dmloop/src/panel/issueDetail.css
+++ b/packages/dmloop/src/panel/issueDetail.css
@@ -512,16 +512,25 @@
 }
 .loop-idp__prop--inline {
   flex-direction: row;
-  align-items: center;
-  justify-content: space-between;
+  align-items: flex-start;
+  justify-content: flex-start;
+  gap: 10px;
 }
 .loop-idp__prop-k {
+  flex: 0 0 72px;
+  width: 72px;
+  padding-top: 4px;
   font-size: 12px;
   color: var(--semi-color-text-2, #8a8f99);
+  white-space: nowrap;
 }
 .loop-idp__prop-v {
+  flex: 1 1 auto;
+  min-width: 0;
   font-size: 13px;
   color: var(--semi-color-text-0, #1f2329);
+  text-align: left;
+  overflow-wrap: anywhere;
 }
 .loop-idp__prop-v--muted {
   color: var(--semi-color-text-2, #6b7075);
@@ -531,6 +540,7 @@
   display: inline-flex;
   align-items: center;
   gap: 6px;
+  min-width: 0;
   max-width: 170px;
   border: none;
   background: transparent;
@@ -563,8 +573,43 @@
   display: inline-flex;
   align-items: center;
   gap: 6px;
+  flex: 1 1 auto;
+  min-width: 0;
   font-size: 13px;
   color: var(--semi-color-text-0, #1f2329);
+}
+
+.loop-idp__prop--labels {
+  align-items: flex-start;
+}
+
+.loop-idp__label-editor,
+.loop-label-editor {
+  flex: 1 1 auto;
+  min-width: 0;
+  max-width: 100%;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  padding: 2px 0;
+  text-align: left;
+}
+
+.loop-idp__label-editor:hover .loop-label-chip,
+.loop-label-editor:hover .loop-label-editor__empty {
+  filter: brightness(0.98);
+}
+
+.loop-label-editor__empty {
+  display: inline-flex;
+  align-items: center;
+  min-height: 20px;
+  color: var(--semi-color-text-3, #b8bcc8);
+  font-size: 13px;
+}
+
+.loop-idp__prop-labels {
+  padding-top: 2px;
 }
 
 /* 执行日志：折叠开关 + run 列表 */

--- a/packages/dmloop/src/panel/issueDetail.css
+++ b/packages/dmloop/src/panel/issueDetail.css
@@ -514,12 +514,12 @@
   flex-direction: row;
   align-items: flex-start;
   justify-content: flex-start;
-  gap: 10px;
+  gap: var(--wk-sp-2, 8px);
 }
 .loop-idp__prop-k {
   flex: 0 0 72px;
   width: 72px;
-  padding-top: 4px;
+  padding-top: var(--wk-sp-1, 4px);
   font-size: 12px;
   color: var(--semi-color-text-2, #8a8f99);
   white-space: nowrap;
@@ -591,7 +591,7 @@
   border: none;
   background: transparent;
   cursor: pointer;
-  padding: 2px 0;
+  padding: var(--wk-sp-0-5, 2px) 0;
   text-align: left;
 }
 
@@ -609,7 +609,7 @@
 }
 
 .loop-idp__prop-labels {
-  padding-top: 2px;
+  padding-top: var(--wk-sp-0-5, 2px);
 }
 
 /* 执行日志：折叠开关 + run 列表 */

--- a/packages/dmloop/src/ui/LabelEditor.tsx
+++ b/packages/dmloop/src/ui/LabelEditor.tsx
@@ -12,10 +12,12 @@ export default function LabelEditor({
   issueId,
   labels,
   onChanged,
+  className,
 }: {
   issueId: string;
   labels?: IssueLabel[] | null;
   onChanged: () => void;
+  className?: string;
 }) {
   const { t } = useI18n();
   const [all, setAll] = useState<IssueLabel[]>([]);
@@ -81,10 +83,10 @@ export default function LabelEditor({
 
   // clickToHide 默认 false:勾选多个标签时下拉保持打开;每次打开重新拉全量标签。
   return (
-    <Dropdown trigger="click" position="bottomLeft" render={menu} onVisibleChange={(v) => v && loadAll()}>
-      <span style={{ cursor: "pointer", display: "inline-flex", alignItems: "center", gap: 4 }}>
-        {labels && labels.length > 0 ? <LabelChips labels={labels} /> : <span style={{ opacity: 0.5 }}>{t("loop.label.add")}</span>}
-      </span>
+    <Dropdown trigger="click" position="bottomRight" render={menu} onVisibleChange={(v) => v && loadAll()}>
+      <button type="button" className={`loop-label-editor${className ? ` ${className}` : ""}`}>
+        {labels && labels.length > 0 ? <LabelChips labels={labels} /> : <span className="loop-label-editor__empty">{t("loop.label.add")}</span>}
+      </button>
     </Dropdown>
   );
 }


### PR DESCRIPTION
## Goal

Fix LOOP-87 feedback for the issue detail property panel label layout.

## Changes

- Add labels to the issue detail property panel as a direct clickable label-menu trigger.
- Keep the property name column at a fixed width so long/many labels do not squeeze labels like Name/Status into a narrow column.
- Hide the standalone Add labels text once labels already exist; users click existing labels to manage them.
- Align the label dropdown to the right side of the trigger to avoid overflowing the right edge of the detail panel.

## Verification

- pnpm --filter @octo/web build
- git diff --check

Note: pnpm --filter @octo/loop exec tsc --noEmit still fails on existing workspace/third-party type errors outside this change, including Semi foundation and dmworkbase React/lodash typings.