### PR TITLE
feat(loop): add task label management

### DIFF
--- a/packages/dmloop/src/i18n/en-US.json
+++ b/packages/dmloop/src/i18n/en-US.json
@@ -155,6 +155,7 @@
     "creator": "Creator",
     "project": "Project",
     "label": "Label",
+    "tag": "Tag",
     "dateRange": "Date range",
     "noProject": "Incl. no project",
     "noAssignee": "Incl. no assignee"
@@ -464,7 +465,24 @@
   "label": {
     "add": "Add labels",
     "newPlaceholder": "New label",
-    "create": "Create label"
+    "create": "Create label",
+    "manage": "Manage labels...",
+    "manageTitle": "Workspace labels",
+    "selectPlaceholder": "Select tags",
+    "color": "Label color",
+    "empty": "No labels yet",
+    "edit": "Edit label",
+    "delete": "Delete label",
+    "remove": "Remove label {{name}}",
+    "deleteConfirm": "Delete this label?",
+    "deleteConfirmDesc": "The label will be removed from every task that uses it. This cannot be undone.",
+    "created": "Label created",
+    "updated": "Label updated",
+    "deleted": "Label deleted",
+    "createFailed": "Failed to create label",
+    "updateFailed": "Failed to update label",
+    "deleteFailed": "Failed to delete label",
+    "attachPartialFailed": "Task created, but {{count}} label(s) failed to attach"
   },
   "subscribe": {
     "label": "Subscribers",

--- a/packages/dmloop/src/i18n/zh-CN.json
+++ b/packages/dmloop/src/i18n/zh-CN.json
@@ -155,6 +155,7 @@
     "creator": "创建者",
     "project": "项目",
     "label": "标签",
+    "tag": "标签",
     "dateRange": "时间范围",
     "noProject": "含无项目",
     "noAssignee": "含无负责人"
@@ -464,7 +465,24 @@
   "label": {
     "add": "添加标签",
     "newPlaceholder": "新标签名",
-    "create": "创建标签"
+    "create": "创建标签",
+    "manage": "管理标签...",
+    "manageTitle": "工作区标签",
+    "selectPlaceholder": "选择标签",
+    "color": "标签颜色",
+    "empty": "还没有标签",
+    "edit": "编辑标签",
+    "delete": "删除标签",
+    "remove": "移除标签 {{name}}",
+    "deleteConfirm": "删除这个标签？",
+    "deleteConfirmDesc": "该标签会从所有使用中的任务上移除。此操作无法撤销。",
+    "created": "标签已创建",
+    "updated": "标签已更新",
+    "deleted": "标签已删除",
+    "createFailed": "创建标签失败",
+    "updateFailed": "更新标签失败",
+    "deleteFailed": "删除标签失败",
+    "attachPartialFailed": "任务已创建，但有 {{count}} 个标签绑定失败"
   },
   "subscribe": {
     "label": "订阅者",

--- a/packages/dmloop/src/pages/IssuePage.tsx
+++ b/packages/dmloop/src/pages/IssuePage.tsx
@@ -1,4 +1,10 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import {
   Input,
   Spin,
@@ -10,7 +16,16 @@ import {
   Toast,
 } from "@douyinfe/semi-ui";
 import LoopButton from "../ui/LoopButton";
-import { Search, Plus, LayoutGrid, List as ListIcon, Users, ClipboardList, SlidersHorizontal, Filter } from "lucide-react";
+import {
+  Search,
+  Plus,
+  LayoutGrid,
+  List as ListIcon,
+  Users,
+  ClipboardList,
+  SlidersHorizontal,
+  Filter,
+} from "lucide-react";
 import { useI18n, WKApp } from "@octo/base";
 import { currentWorkspaceId, currentWorkspaceSlug } from "../api/http";
 import type {
@@ -23,7 +38,13 @@ import type {
   IssueLabel,
 } from "../api/types";
 import { ISSUE_DATE_FIELDS } from "../api/types";
-import { listIssues, searchIssues, listGroupedIssues, listMyGroupedIssues, getAgentTaskSnapshot } from "../api/issueApi";
+import {
+  listIssues,
+  searchIssues,
+  listGroupedIssues,
+  listMyGroupedIssues,
+  getAgentTaskSnapshot,
+} from "../api/issueApi";
 import { groupIssuesByAssignee } from "../api/issueGrouping";
 import { listProjectOptions } from "../api/directory";
 import { listLabels } from "../api/labelApi";
@@ -34,6 +55,7 @@ import IssueGroupBoard from "../panel/IssueGroupBoard";
 import IssueList from "../panel/IssueList";
 import IssueDetailPage from "../panel/IssueDetailPage";
 import CreateIssueModal from "../ui/CreateIssueModal";
+import LabelChips from "../ui/LabelChips";
 import { pushFleetIssueDeepLink, replaceLoopRootPath } from "../issueDeepLink";
 import { readView, writeView } from "../ui/viewMode";
 import {
@@ -50,7 +72,9 @@ type ViewMode = "board" | "grouped" | "list";
 
 // scope pill → assignee_types 过滤(看板/列表/分组统一走后端 assignee_types)。
 // all / involves 不按类型收窄(involves 走用户关系并集,见 reload)。
-function scopeToAssigneeTypes(scope: IssueScope): ("member" | "agent" | "squad")[] | undefined {
+function scopeToAssigneeTypes(
+  scope: IssueScope
+): ("member" | "agent" | "squad")[] | undefined {
   if (scope === "members") return ["member"];
   if (scope === "agents") return ["agent", "squad"];
   return undefined;
@@ -64,7 +88,10 @@ const PAGE_SIZE = 50;
 
 // 筛选/显示字段都挂在工具栏 Dropdown 面板(z-index 1060)里,其弹层默认取 Semi 基准 1030 →
 // 会被面板本体盖在下面(选项看不见也点不到)。统一抬到面板之上。
-const FIELD_POPUP = { dropdownClassName: "loop-fields__dropdown", zIndex: 2000 } as const;
+const FIELD_POPUP = {
+  dropdownClassName: "loop-fields__dropdown",
+  zIndex: 2000,
+} as const;
 
 // 「我的回路」复用本页：defaultView="grouped" + defaultScope="involves" 即只看与我相关。
 interface IssuePageProps {
@@ -74,7 +101,11 @@ interface IssuePageProps {
   viewKey?: string;
 }
 
-export default function IssuePage({ defaultScope, defaultView, viewKey }: IssuePageProps = {}) {
+export default function IssuePage({
+  defaultScope,
+  defaultView,
+  viewKey,
+}: IssuePageProps = {}) {
   const { t } = useI18n();
   // 「我的回路」= involves:只有分组视图能表达「指派/创建/关联」三路并集(listMyGroupedIssues 扇出),
   // 看板/列表无对应查询会退化成显示全工作区 → 该页锁死分组、不给切视图。
@@ -115,10 +146,14 @@ export default function IssuePage({ defaultScope, defaultView, viewKey }: IssueP
   // 复用订阅特性的身份解析——候选里 octo_uid===loginInfo.uid 的 member。未解析出则「与我相关」不可用。
   const myMemberId = useMemo(() => {
     const uid = WKApp.loginInfo.uid;
-    return uid ? cands.find((c) => c.type === "member" && c.octo_uid === uid)?.id : undefined;
+    return uid
+      ? cands.find((c) => c.type === "member" && c.octo_uid === uid)?.id
+      : undefined;
   }, [cands]);
   // 项目下拉复用 directory 已缓存的 /projects(避免重复请求);随 workspace 切换整页重挂而刷新。
-  const [projects, setProjects] = useState<Array<{ id: string; title: string }>>([]);
+  const [projects, setProjects] = useState<
+    Array<{ id: string; title: string }>
+  >([]);
   const [labels, setLabels] = useState<IssueLabel[]>([]);
   const [projectsLoaded, setProjectsLoaded] = useState(false);
   const [labelsLoaded, setLabelsLoaded] = useState(false);
@@ -174,7 +209,9 @@ export default function IssuePage({ defaultScope, defaultView, viewKey }: IssueP
     // 且列表勾选态仍指向陈旧行,可能被批量删改误作用。seq 守卫:仅最新一次在途请求可清。
     const onErr = () => {
       if (my !== seq.current) return;
-      setIssues([]); setGroups([]); setTotal(0);
+      setIssues([]);
+      setGroups([]);
+      setTotal(0);
       Toast.error(t("loop.toast.loadFailed"));
     };
     // 时间范围:三参数须同时给且 start<end。onChange 已把 dateRange 归一为 undefined|[起,止]。
@@ -208,29 +245,48 @@ export default function IssuePage({ defaultScope, defaultView, viewKey }: IssueP
       // 独立语义(不吃 scope/其它筛选,上限 50),故与常规分组拉取分道;「我的回路」隐藏关键词、不入此路。
       if (gkw && !isMyLoop) {
         searchIssues(gkw, { limit: 50 })
-          .then(({ issues }) => { if (my === seq.current) setGroups(groupIssuesByAssignee(issues)); })
+          .then(({ issues }) => {
+            if (my === seq.current) setGroups(groupIssuesByAssignee(issues));
+          })
           .catch(onErr)
-          .finally(() => { if (my === seq.current) setLoading(false); });
+          .finally(() => {
+            if (my === seq.current) setLoading(false);
+          });
         return;
       }
       // 「与我相关」(仅「我的回路」页)= 指派给我 ∪ 我创建 ∪ 间接关联的并集扇出;需当前成员
       // 后端 id,未解析出则清空并等待(不回退成无 scope 全量)。myMemberId 在依赖里,解析后自动重取。
       if (scope === "involves") {
         if (!myMemberId) {
-          if (my === seq.current) { setGroups([]); setLoading(false); }
+          if (my === seq.current) {
+            setGroups([]);
+            setLoading(false);
+          }
           return;
         }
         listMyGroupedIssues(myMemberId, { ...common, limit: 100 })
-          .then((gs) => { if (my === seq.current) setGroups(gs); })
+          .then((gs) => {
+            if (my === seq.current) setGroups(gs);
+          })
           .catch(onErr)
-          .finally(() => { if (my === seq.current) setLoading(false); });
+          .finally(() => {
+            if (my === seq.current) setLoading(false);
+          });
         return;
       }
       // ponytail: 每组取后端上限 100；超量请用筛选。
-      listGroupedIssues({ ...common, assignee_types: scopeToAssigneeTypes(scope), limit: 100 })
-        .then((gs) => { if (my === seq.current) setGroups(gs); })
+      listGroupedIssues({
+        ...common,
+        assignee_types: scopeToAssigneeTypes(scope),
+        limit: 100,
+      })
+        .then((gs) => {
+          if (my === seq.current) setGroups(gs);
+        })
         .catch(onErr)
-        .finally(() => { if (my === seq.current) setLoading(false); });
+        .finally(() => {
+          if (my === seq.current) setLoading(false);
+        });
       return;
     }
 
@@ -238,7 +294,10 @@ export default function IssuePage({ defaultScope, defaultView, viewKey }: IssueP
     const kw = f.keyword.trim();
     // 有关键词 → 走全文搜索端点(独立语义:后端不吃其它筛选/排序、上限 50);否则常规筛选列表。
     const req = kw
-      ? searchIssues(kw, { limit: paged ? PAGE_SIZE : 50, offset: paged ? page * PAGE_SIZE : 0 })
+      ? searchIssues(kw, {
+          limit: paged ? PAGE_SIZE : 50,
+          offset: paged ? page * PAGE_SIZE : 0,
+        })
       : listIssues({
           ...common,
           assignee_types: scopeToAssigneeTypes(scope),
@@ -252,13 +311,18 @@ export default function IssuePage({ defaultScope, defaultView, viewKey }: IssueP
         // 删除/改状态使匹配数下降时，当前 page 可能越界（offset≥total）→ 钳到最后一页并重取。
         if (paged) {
           const maxPage = Math.max(0, Math.ceil(total / PAGE_SIZE) - 1);
-          if (page > maxPage) { setPage(maxPage); return; }
+          if (page > maxPage) {
+            setPage(maxPage);
+            return;
+          }
         }
         setIssues(issues);
         setTotal(total);
       })
       .catch(onErr)
-      .finally(() => { if (my === seq.current) setLoading(false); });
+      .finally(() => {
+        if (my === seq.current) setLoading(false);
+      });
   }, [f, view, page, scope, myMemberId, noAssigneeActive]);
 
   useEffect(reload, [reload]);
@@ -269,7 +333,16 @@ export default function IssuePage({ defaultScope, defaultView, viewKey }: IssueP
   const refreshRunning = useCallback(() => {
     const my = ++runSeq.current;
     getAgentTaskSnapshot()
-      .then((tasks) => { if (my === runSeq.current) setRunning(new Set(tasks.filter((tk) => isActiveRun(tk.status) && tk.issue_id).map((tk) => tk.issue_id))); })
+      .then((tasks) => {
+        if (my === runSeq.current)
+          setRunning(
+            new Set(
+              tasks
+                .filter((tk) => isActiveRun(tk.status) && tk.issue_id)
+                .map((tk) => tk.issue_id)
+            )
+          );
+      })
       .catch(() => {});
   }, []);
   // 挂载取一次 + 每 15s 轮询:无 WS 推送,agent 起停靠轮询让 running chip 最终收敛(而非只在本地 mutation 后)。
@@ -280,12 +353,17 @@ export default function IssuePage({ defaultScope, defaultView, viewKey }: IssueP
   }, [refreshRunning]);
 
   // 变更后刷新:既重取列表,又刷新运行中快照(指派/状态变更可能起/停 agent run)。
-  const onMutated = useCallback(() => { reload(); refreshRunning(); }, [reload, refreshRunning]);
+  const onMutated = useCallback(() => {
+    reload();
+    refreshRunning();
+  }, [reload, refreshRunning]);
   // 订阅 `wk:loop-issues-refresh` 重取列表:由 LoopPage 在「点击 loop 导航」与「新建回路成功」时补发,
   // 覆盖"已停在 issue tab(同 key 不重挂)"的场景。走 ref 读最新 onMutated:刷新须用当前筛选/视图,
   // 否则会用陈旧入参覆盖(reload 的 seq 守卫只防乱序)。
   const onMutatedRef = useRef(onMutated);
-  useEffect(() => { onMutatedRef.current = onMutated; }, [onMutated]);
+  useEffect(() => {
+    onMutatedRef.current = onMutated;
+  }, [onMutated]);
   useEffect(() => {
     const onRefresh = () => onMutatedRef.current();
     WKApp.mittBus.on("wk:loop-issues-refresh", onRefresh);
@@ -293,8 +371,16 @@ export default function IssuePage({ defaultScope, defaultView, viewKey }: IssueP
   }, []);
 
   // 改任一筛选/搜索都回到第一页，避免停在越界的 offset（此规则只此一处表达）。
-  const update = (p: Partial<Filters>) => { setF((prev) => ({ ...prev, ...p })); setPage(0); };
-  const switchView = (v: ViewMode) => { setView(v); setPage(0); if (viewKey) writeView(viewKey, v); setShowOpen(false); };
+  const update = (p: Partial<Filters>) => {
+    setF((prev) => ({ ...prev, ...p }));
+    setPage(0);
+  };
+  const switchView = (v: ViewMode) => {
+    setView(v);
+    setPage(0);
+    if (viewKey) writeView(viewKey, v);
+    setShowOpen(false);
+  };
 
   // 点击 Issue → 跳转独立详情页（push 到右主栏，返回可 pop）。
   // key=id:issueId 变化即整体重挂载 → 详情页所有异步状态从零开始,结构性杜绝跨 issue 陈旧写入
@@ -322,23 +408,35 @@ export default function IssuePage({ defaultScope, defaultView, viewKey }: IssueP
   // 新建回路 → 唤起统一建单弹窗(不再拉起独立 AI 页)。创建成功后刷新列表。
   const openNewLoop = () => setCreateOpen(true);
 
-  const isEmpty = view === "grouped" ? groups.every((g) => g.issues.length === 0) : total === 0;
+  const isEmpty =
+    view === "grouped"
+      ? groups.every((g) => g.issues.length === 0)
+      : total === 0;
 
   // 选项列表(多选共用,避免重复 map)。
   const statusOpts = ISSUE_STATUS_ORDER.map((s) => (
-    <Select.Option key={s} value={s}>{t(`loop.status.${s}`)}</Select.Option>
+    <Select.Option key={s} value={s}>
+      {t(`loop.status.${s}`)}
+    </Select.Option>
   ));
   const priorityOpts = PRIORITY_ORDER.map((p) => (
-    <Select.Option key={p} value={p}>{t(`loop.priority.${p}`)}</Select.Option>
+    <Select.Option key={p} value={p}>
+      {t(`loop.priority.${p}`)}
+    </Select.Option>
   ));
   const projectOpts = projects.map((p) => (
-    <Select.Option key={p.id} value={p.id}>{p.title}</Select.Option>
+    <Select.Option key={p.id} value={p.id}>
+      {p.title}
+    </Select.Option>
   ));
   const labelOpts = labels.map((l) => (
-    <Select.Option key={l.id} value={l.id}>{l.name}</Select.Option>
+    <Select.Option key={l.id} value={l.id}>
+      <LabelChips labels={[l]} />
+    </Select.Option>
   ));
 
-  const title = defaultScope === "involves" ? t("loop.nav.myloop") : t("loop.nav.issue");
+  const title =
+    defaultScope === "involves" ? t("loop.nav.myloop") : t("loop.nav.issue");
 
   // 关键词走全文搜索端点(独立语义,不吃其它筛选/排序)。搜索激活时禁用面板内其它筛选/scope,
   // 避免它们「看起来生效、实际被忽略」的误导。主看板三视图均支持;「我的回路」无关键词(搜索不吃 involves)。
@@ -355,8 +453,7 @@ export default function IssuePage({ defaultScope, defaultView, viewKey }: IssueP
         (f.creatorIds.length ? 1 : 0) +
         (f.projectIds.length || f.noProject ? 1 : 0) +
         (f.labelIds.length ? 1 : 0) +
-        (f.dateRange ? 1 : 0)) +
-    (!isMyLoop && f.keyword.trim() ? 1 : 0);
+        (f.dateRange ? 1 : 0)) + (!isMyLoop && f.keyword.trim() ? 1 : 0);
 
   const clearFilters = () =>
     update({
@@ -369,11 +466,22 @@ export default function IssuePage({ defaultScope, defaultView, viewKey }: IssueP
     value: string[],
     onChange: (v: string[]) => void,
     children: React.ReactNode,
-    opts?: { filter?: boolean; maxTagCount?: number },
+    opts?: { filter?: boolean; maxTagCount?: number }
   ) => (
     <div className="loop-fields__row">
       <div className="loop-fields__label">{label}</div>
-      <Select multiple value={value} onChange={(v) => onChange((v ?? []) as string[])} showClear filter={opts?.filter} disabled={searching} maxTagCount={opts?.maxTagCount ?? 1} {...FIELD_POPUP} style={{ width: "100%" }} placeholder={label}>
+      <Select
+        multiple
+        value={value}
+        onChange={(v) => onChange((v ?? []) as string[])}
+        showClear
+        filter={opts?.filter}
+        disabled={searching}
+        maxTagCount={opts?.maxTagCount ?? 1}
+        {...FIELD_POPUP}
+        style={{ width: "100%" }}
+        placeholder={label}
+      >
         {children}
       </Select>
     </div>
@@ -384,39 +492,143 @@ export default function IssuePage({ defaultScope, defaultView, viewKey }: IssueP
       <div className="loop-filter-panel__head">
         <span>{t("loop.action.filter")}</span>
         {activeFilters > 0 && (
-          <button type="button" className="loop-filter-panel__clear" onClick={clearFilters}>{t("loop.action.clearFilters")}</button>
+          <button
+            type="button"
+            className="loop-filter-panel__clear"
+            onClick={clearFilters}
+          >
+            {t("loop.action.clearFilters")}
+          </button>
         )}
       </div>
-      {filterSelect(t("loop.filter.status"), f.statuses, (v) => update({ statuses: v as IssueStatus[] }), statusOpts, { maxTagCount: 2 })}
-      {filterSelect(t("loop.filter.priority"), f.priorities, (v) => update({ priorities: v as IssuePriority[] }), priorityOpts, { maxTagCount: 2 })}
+      {filterSelect(
+        t("loop.filter.status"),
+        f.statuses,
+        (v) => update({ statuses: v as IssueStatus[] }),
+        statusOpts,
+        { maxTagCount: 2 }
+      )}
+      {filterSelect(
+        t("loop.filter.priority"),
+        f.priorities,
+        (v) => update({ priorities: v as IssuePriority[] }),
+        priorityOpts,
+        { maxTagCount: 2 }
+      )}
       {/* 「谁」类筛选(负责人/无负责人/创建者)在「我的回路」隐藏——该页本就锁定「与我相关」,
           按他人负责人/创建者筛与语义矛盾,且会污染并集扇出(见 listMyGroupedIssues)。 */}
-      {!isMyLoop && filterSelect(t("loop.filter.assignee"), f.assigneeIds, (v) => update({ assigneeIds: v }), cands.map((c) => (<Select.Option key={c.id} value={c.id}>{c.name}</Select.Option>)), { filter: true })}
+      {!isMyLoop &&
+        filterSelect(
+          t("loop.filter.assignee"),
+          f.assigneeIds,
+          (v) => update({ assigneeIds: v }),
+          cands.map((c) => (
+            <Select.Option key={c.id} value={c.id}>
+              {c.name}
+            </Select.Option>
+          )),
+          { filter: true }
+        )}
       {!isMyLoop && (
         <div className="loop-fields__row">
-          <Checkbox className="loop-nofilter" checked={noAssigneeActive} onChange={(e) => update({ noAssignee: !!e.target.checked })} disabled={searching || scope !== "all"}>{t("loop.filter.noAssignee")}</Checkbox>
+          <Checkbox
+            className="loop-nofilter"
+            checked={noAssigneeActive}
+            onChange={(e) => update({ noAssignee: !!e.target.checked })}
+            disabled={searching || scope !== "all"}
+          >
+            {t("loop.filter.noAssignee")}
+          </Checkbox>
         </div>
       )}
-      {!isMyLoop && filterSelect(t("loop.filter.creator"), f.creatorIds, (v) => update({ creatorIds: v }), cands.filter((c) => c.type === "member").map((c) => (<Select.Option key={c.id} value={c.id}>{c.name}</Select.Option>)), { filter: true })}
-      {projects.length > 0 && filterSelect(t("loop.filter.project"), f.projectIds, (v) => update({ projectIds: v }), projectOpts, { filter: true })}
+      {!isMyLoop &&
+        filterSelect(
+          t("loop.filter.creator"),
+          f.creatorIds,
+          (v) => update({ creatorIds: v }),
+          cands
+            .filter((c) => c.type === "member")
+            .map((c) => (
+              <Select.Option key={c.id} value={c.id}>
+                {c.name}
+              </Select.Option>
+            )),
+          { filter: true }
+        )}
+      {projects.length > 0 &&
+        filterSelect(
+          t("loop.filter.project"),
+          f.projectIds,
+          (v) => update({ projectIds: v }),
+          projectOpts,
+          { filter: true }
+        )}
       <div className="loop-fields__row">
-        <Checkbox className="loop-nofilter" checked={f.noProject} onChange={(e) => update({ noProject: !!e.target.checked })} disabled={searching}>{t("loop.filter.noProject")}</Checkbox>
+        <Checkbox
+          className="loop-nofilter"
+          checked={f.noProject}
+          onChange={(e) => update({ noProject: !!e.target.checked })}
+          disabled={searching}
+        >
+          {t("loop.filter.noProject")}
+        </Checkbox>
       </div>
-      {labels.length > 0 && filterSelect(t("loop.filter.label"), f.labelIds, (v) => update({ labelIds: v }), labelOpts, { filter: true })}
+      {labels.length > 0 &&
+        filterSelect(
+          t("loop.filter.tag"),
+          f.labelIds,
+          (v) => update({ labelIds: v }),
+          labelOpts,
+          { filter: true }
+        )}
       <div className="loop-fields__row">
         <div className="loop-fields__label">{t("loop.filter.dateRange")}</div>
         <div className="loop-fields__inline">
-          <Select value={f.dateField} onChange={(v) => update({ dateField: v as IssueDateField })} disabled={searching} {...FIELD_POPUP} style={{ width: 104 }}>
-            {ISSUE_DATE_FIELDS.map((d) => (<Select.Option key={d} value={d}>{t(`loop.dateField.${d}`)}</Select.Option>))}
+          <Select
+            value={f.dateField}
+            onChange={(v) => update({ dateField: v as IssueDateField })}
+            disabled={searching}
+            {...FIELD_POPUP}
+            style={{ width: 104 }}
+          >
+            {ISSUE_DATE_FIELDS.map((d) => (
+              <Select.Option key={d} value={d}>
+                {t(`loop.dateField.${d}`)}
+              </Select.Option>
+            ))}
           </Select>
-          <DatePicker type="dateRange" density="compact" disabled={searching} value={f.dateRange} onChange={(d) => update({ dateRange: Array.isArray(d) && d.length === 2 && d[0] && d[1] ? (d as Date[]) : undefined })} placeholder={t("loop.filter.dateRange")} zIndex={FIELD_POPUP.zIndex} style={{ flex: 1 }} />
+          <DatePicker
+            type="dateRange"
+            density="compact"
+            disabled={searching}
+            value={f.dateRange}
+            onChange={(d) =>
+              update({
+                dateRange:
+                  Array.isArray(d) && d.length === 2 && d[0] && d[1]
+                    ? (d as Date[])
+                    : undefined,
+              })
+            }
+            placeholder={t("loop.filter.dateRange")}
+            zIndex={FIELD_POPUP.zIndex}
+            style={{ flex: 1 }}
+          />
         </div>
       </div>
       {/* 关键词走全文搜索(平铺,分组视图前端按负责人再分组呈现)。「我的回路」不支持(搜索不吃 involves)。 */}
       {!isMyLoop && (
         <div className="loop-fields__row">
           <div className="loop-fields__label">{t("loop.search.issue")}</div>
-          <Input className="loop-search" prefix={<Search size={14} />} placeholder={t("loop.search.issue")} value={f.keyword} onChange={(v) => update({ keyword: v })} showClear style={{ width: "100%" }} />
+          <Input
+            className="loop-search"
+            prefix={<Search size={14} />}
+            placeholder={t("loop.search.issue")}
+            value={f.keyword}
+            onChange={(v) => update({ keyword: v })}
+            showClear
+            style={{ width: "100%" }}
+          />
         </div>
       )}
     </div>
@@ -424,13 +636,28 @@ export default function IssuePage({ defaultScope, defaultView, viewKey }: IssueP
 
   const showPanel = (
     <div className="loop-fields loop-show-panel">
-      <div className="loop-filter-panel__head"><span>{t("loop.action.show")}</span></div>
+      <div className="loop-filter-panel__head">
+        <span>{t("loop.action.show")}</span>
+      </div>
       <div className="loop-fields__row">
         <div className="loop-fields__label">{t("loop.view.board")}</div>
         <div className="loop-seg" role="tablist">
           {(["board", "grouped", "list"] as ViewMode[]).map((v) => (
-            <button key={v} type="button" role="tab" aria-selected={view === v} className={`loop-seg__btn${view === v ? " is-active" : ""}`} onClick={() => switchView(v)}>
-              {v === "board" ? <LayoutGrid size={14} /> : v === "grouped" ? <Users size={14} /> : <ListIcon size={14} />}
+            <button
+              key={v}
+              type="button"
+              role="tab"
+              aria-selected={view === v}
+              className={`loop-seg__btn${view === v ? " is-active" : ""}`}
+              onClick={() => switchView(v)}
+            >
+              {v === "board" ? (
+                <LayoutGrid size={14} />
+              ) : v === "grouped" ? (
+                <Users size={14} />
+              ) : (
+                <ListIcon size={14} />
+              )}
               {t(`loop.view.${v}`)}
             </button>
           ))}
@@ -462,8 +689,13 @@ export default function IssuePage({ defaultScope, defaultView, viewKey }: IssueP
                     role="tab"
                     aria-selected={active}
                     disabled={searching}
-                    className={`loop-agent-scope__btn${active ? " is-active" : ""}`}
-                    onClick={() => { setScope(s); setPage(0); }}
+                    className={`loop-agent-scope__btn${
+                      active ? " is-active" : ""
+                    }`}
+                    onClick={() => {
+                      setScope(s);
+                      setPage(0);
+                    }}
                   >
                     {t(`loop.scope.${s}`)}
                   </button>
@@ -472,16 +704,32 @@ export default function IssuePage({ defaultScope, defaultView, viewKey }: IssueP
             </div>
           )}
           <div className="loop-page__spacer" />
-          <Dropdown trigger="click" visible={filterOpen} onVisibleChange={setFilterOpen} position="bottomRight" render={filterPanel}>
-            <button className={`loop-toolbtn${activeFilters > 0 ? " is-on" : ""}`}>
+          <Dropdown
+            trigger="click"
+            visible={filterOpen}
+            onVisibleChange={setFilterOpen}
+            position="bottomRight"
+            render={filterPanel}
+          >
+            <button
+              className={`loop-toolbtn${activeFilters > 0 ? " is-on" : ""}`}
+            >
               <Filter size={14} />
               {t("loop.action.filter")}
-              {activeFilters > 0 && <span className="loop-toolbtn__badge">{activeFilters}</span>}
+              {activeFilters > 0 && (
+                <span className="loop-toolbtn__badge">{activeFilters}</span>
+              )}
             </button>
           </Dropdown>
           {/* 「我的回路」锁死分组视图,不给切视图/排序 → 隐藏「显示」入口。 */}
           {!isMyLoop && (
-            <Dropdown trigger="click" visible={showOpen} onVisibleChange={setShowOpen} position="bottomRight" render={showPanel}>
+            <Dropdown
+              trigger="click"
+              visible={showOpen}
+              onVisibleChange={setShowOpen}
+              position="bottomRight"
+              render={showPanel}
+            >
               <button className="loop-toolbtn">
                 <SlidersHorizontal size={14} />
                 {t("loop.action.show")}
@@ -502,21 +750,47 @@ export default function IssuePage({ defaultScope, defaultView, viewKey }: IssueP
         ) : isEmpty ? (
           <div className="loop-empty">
             <ClipboardList size={40} className="loop-empty__icon" />
-            <div className="loop-empty__title">{t("loop.empty.issueTitle")}</div>
+            <div className="loop-empty__title">
+              {t("loop.empty.issueTitle")}
+            </div>
             <div className="loop-empty__desc">{t("loop.empty.issueDesc")}</div>
-            <LoopButton icon={<Plus size={14} />} onClick={openNewLoop} style={{ marginTop: 12 }}>
+            <LoopButton
+              icon={<Plus size={14} />}
+              onClick={openNewLoop}
+              style={{ marginTop: 12 }}
+            >
               {t("loop.action.newIssue")}
             </LoopButton>
           </div>
         ) : view === "board" ? (
-          <IssueBoard issues={issues} onOpen={openDetail} onChanged={onMutated} running={running} />
+          <IssueBoard
+            issues={issues}
+            onOpen={openDetail}
+            onChanged={onMutated}
+            running={running}
+          />
         ) : view === "grouped" ? (
-          <IssueGroupBoard groups={groups} onOpen={openDetail} running={running} />
+          <IssueGroupBoard
+            groups={groups}
+            onOpen={openDetail}
+            running={running}
+          />
         ) : (
           <>
-            <IssueList issues={issues} onOpen={openDetail} onChanged={onMutated} running={running} />
+            <IssueList
+              issues={issues}
+              onOpen={openDetail}
+              onChanged={onMutated}
+              running={running}
+            />
             {total > PAGE_SIZE && (
-              <div style={{ display: "flex", justifyContent: "flex-end", padding: "12px 4px" }}>
+              <div
+                style={{
+                  display: "flex",
+                  justifyContent: "flex-end",
+                  padding: "12px 4px",
+                }}
+              >
                 <Pagination
                   total={total}
                   pageSize={PAGE_SIZE}
@@ -531,7 +805,11 @@ export default function IssuePage({ defaultScope, defaultView, viewKey }: IssueP
       <CreateIssueModal
         visible={createOpen}
         onClose={() => setCreateOpen(false)}
-        onCreated={() => { setCreateOpen(false); onMutated(); Toast.success(t("loop.toast.created")); }}
+        onCreated={() => {
+          setCreateOpen(false);
+          onMutated();
+          Toast.success(t("loop.toast.created"));
+        }}
       />
     </div>
   );

--- a/packages/dmloop/src/pages/IssuePage.tsx
+++ b/packages/dmloop/src/pages/IssuePage.tsx
@@ -430,7 +430,7 @@ export default function IssuePage({
     </Select.Option>
   ));
   const labelOpts = labels.map((l) => (
-    <Select.Option key={l.id} value={l.id}>
+    <Select.Option key={l.id} value={l.id} label={l.name}>
       <LabelChips labels={[l]} />
     </Select.Option>
   ));

--- a/packages/dmloop/src/pages/loop.css
+++ b/packages/dmloop/src/pages/loop.css
@@ -201,7 +201,8 @@
   font-size: 12.5px;
   font-weight: 600;
   cursor: pointer;
-  transition: border-color 120ms ease, background-color 120ms ease, color 120ms ease;
+  transition: border-color 120ms ease, background-color 120ms ease,
+    color 120ms ease;
 }
 
 .loop-toolbtn:hover {
@@ -313,10 +314,19 @@
 }
 
 /* ===== 新建回路弹窗（对齐 multica：面包屑 + 标题 + 描述 + 运行提示 + pill 工具栏 + 底栏） ===== */
-.loop-ci-modal .semi-modal-body { padding: 0; }
-.loop-ci-modal .semi-modal-content { padding: 0; border-radius: 12px; overflow: hidden; }
+.loop-ci-modal .semi-modal-body {
+  padding: 0;
+}
+.loop-ci-modal .semi-modal-content {
+  padding: 0;
+  border-radius: 12px;
+  overflow: hidden;
+}
 
-.loop-ci { display: flex; flex-direction: column; }
+.loop-ci {
+  display: flex;
+  flex-direction: column;
+}
 
 .loop-ci__head {
   display: flex;
@@ -332,8 +342,13 @@
   min-width: 0;
   font-size: 12px;
 }
-.loop-ci__crumb-ws { color: var(--semi-color-text-2, #8a8f99); }
-.loop-ci__crumb-sep { flex: none; color: var(--semi-color-text-3, #c9cdd4); }
+.loop-ci__crumb-ws {
+  color: var(--semi-color-text-2, #8a8f99);
+}
+.loop-ci__crumb-sep {
+  flex: none;
+  color: var(--semi-color-text-3, #c9cdd4);
+}
 .loop-ci__crumb-cur {
   color: var(--semi-color-text-1, #4e5969);
   font-weight: 500;
@@ -372,7 +387,10 @@
   font-weight: 600;
   font-family: inherit;
 }
-.loop-ci__title::placeholder { color: var(--semi-color-text-2, #a4a9b3); font-weight: 600; }
+.loop-ci__title::placeholder {
+  color: var(--semi-color-text-2, #a4a9b3);
+  font-weight: 600;
+}
 
 .loop-ci__desc {
   width: 100%;
@@ -389,7 +407,9 @@
   line-height: 1.6;
   font-family: inherit;
 }
-.loop-ci__desc::placeholder { color: var(--semi-color-text-2, #a4a9b3); }
+.loop-ci__desc::placeholder {
+  color: var(--semi-color-text-2, #a4a9b3);
+}
 
 .loop-ci__hint {
   display: flex;
@@ -419,7 +439,24 @@
   border-color: var(--semi-color-text-3, #c9cdd4);
 }
 
-.loop-ci__atts { display: flex; flex-wrap: wrap; gap: 6px; padding: 0 16px 6px; }
+.loop-ci__labels {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0 16px 8px;
+  color: var(--semi-color-text-2, #8a8f99);
+}
+
+.loop-ci__labels .semi-select {
+  min-height: 32px;
+}
+
+.loop-ci__atts {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  padding: 0 16px 6px;
+}
 .loop-ci__att {
   display: inline-flex;
   align-items: center;
@@ -432,7 +469,11 @@
   color: var(--semi-color-text-1, #4e5969);
   font-size: 12px;
 }
-.loop-ci__att span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.loop-ci__att span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 .loop-ci__att button {
   border: none;
   background: transparent;
@@ -442,7 +483,9 @@
   font-size: 14px;
   line-height: 1;
 }
-.loop-ci__att button:hover { color: var(--semi-color-danger, #f5222d); }
+.loop-ci__att button:hover {
+  color: var(--semi-color-danger, #f5222d);
+}
 
 .loop-ci__footer {
   display: flex;
@@ -467,7 +510,11 @@
   background: var(--semi-color-fill-0, #f5f6f8);
   color: var(--semi-color-text-0, #1c1f23);
 }
-.loop-ci__footer-right { display: flex; align-items: center; gap: 8px; }
+.loop-ci__footer-right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
 
 /* ===== 空状态引导 ===== */
 .loop-empty {
@@ -592,7 +639,8 @@
   align-items: center;
   gap: 5px;
   color: var(--semi-color-text-1, #4e5969);
-  transition: background-color 120ms ease, color 120ms ease, box-shadow 120ms ease;
+  transition: background-color 120ms ease, color 120ms ease,
+    box-shadow 120ms ease;
 }
 
 .loop-viewtoggle button:hover {
@@ -704,7 +752,13 @@
 }
 
 .loop-card__id {
-  font-family: var(--loop-mono-font, ui-monospace, SFMono-Regular, Menlo, monospace);
+  font-family: var(
+    --loop-mono-font,
+    ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    monospace
+  );
   font-size: 11.5px;
   color: var(--semi-color-text-3, #b8bcc8);
 }
@@ -788,7 +842,9 @@
   color: var(--semi-color-text-2, #8a8f99);
   transition: color 120ms ease;
 }
-.loop-agent-scope__btn:hover { color: var(--semi-color-text-0, #1c1f23); }
+.loop-agent-scope__btn:hover {
+  color: var(--semi-color-text-0, #1c1f23);
+}
 .loop-agent-scope__btn.is-active {
   color: var(--semi-color-text-0, #1c1f23);
   font-weight: 600;
@@ -813,10 +869,20 @@
   text-align: left;
   transition: background-color 120ms ease;
 }
-.loop-agent-row:hover { background: var(--semi-color-fill-0, #f5f6f8); }
+.loop-agent-row:hover {
+  background: var(--semi-color-fill-0, #f5f6f8);
+}
 
-.loop-agent-row__avatar { position: relative; flex: 0 0 auto; display: inline-flex; }
-.loop-agent-row__dot { position: absolute; right: -1px; bottom: -1px; }
+.loop-agent-row__avatar {
+  position: relative;
+  flex: 0 0 auto;
+  display: inline-flex;
+}
+.loop-agent-row__dot {
+  position: absolute;
+  right: -1px;
+  bottom: -1px;
+}
 
 /* Shared agent/member status dot — single source for color, shape, and motion.
    Status colors live in the --dot-* variables so the mention-avatar path
@@ -840,21 +906,37 @@
   background: var(--dot-offline);
   box-sizing: border-box;
 }
-.loop-status-dot[data-status="idle"] { background: var(--dot-idle); }
-.loop-status-dot[data-status="working"] { background: var(--dot-working); animation: loop-dot-pulse 1.6s ease-in-out infinite; }
-.loop-status-dot[data-status="error"] { background: var(--dot-error); }
-.loop-status-dot[data-status="unstable"] { background: var(--semi-color-warning, #d99e21); }
+.loop-status-dot[data-status="idle"] {
+  background: var(--dot-idle);
+}
+.loop-status-dot[data-status="working"] {
+  background: var(--dot-working);
+  animation: loop-dot-pulse 1.6s ease-in-out infinite;
+}
+.loop-status-dot[data-status="error"] {
+  background: var(--dot-error);
+}
+.loop-status-dot[data-status="unstable"] {
+  background: var(--semi-color-warning, #d99e21);
+}
 .loop-status-dot[data-status="offline"],
 .loop-status-dot[data-status="archived"] {
   background: var(--semi-color-bg-0, #fff);
   box-shadow: inset 0 0 0 1.5px var(--dot-offline);
 }
 @keyframes loop-dot-pulse {
-  0%, 100% { box-shadow: 0 0 0 0 rgba(47, 111, 237, 0.45); }
-  50% { box-shadow: 0 0 0 3px rgba(47, 111, 237, 0); }
+  0%,
+  100% {
+    box-shadow: 0 0 0 0 rgba(47, 111, 237, 0.45);
+  }
+  50% {
+    box-shadow: 0 0 0 3px rgba(47, 111, 237, 0);
+  }
 }
 @media (prefers-reduced-motion: reduce) {
-  .loop-status-dot[data-status="working"] { animation: none; }
+  .loop-status-dot[data-status="working"] {
+    animation: none;
+  }
 }
 
 .loop-agent-row__name {
@@ -888,12 +970,31 @@
   font-size: 12px;
 }
 
-.loop-agent-row__device { width: 160px; text-align: right; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.loop-agent-row__device {
+  width: 160px;
+  text-align: right;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 
-.loop-agent-row__owner { display: inline-flex; align-items: center; gap: 6px; width: 96px; }
-.loop-agent-row__ownername { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.loop-agent-row__owner {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  width: 96px;
+}
+.loop-agent-row__ownername {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 
-.loop-agent-row__time { width: 88px; text-align: right; white-space: nowrap; }
+.loop-agent-row__time {
+  width: 88px;
+  text-align: right;
+  white-space: nowrap;
+}
 
 .loop-agent-row__archive {
   flex: 0 0 auto;
@@ -901,7 +1002,10 @@
   pointer-events: none;
   transition: opacity 120ms ease;
 }
-.loop-agent-row:hover .loop-agent-row__archive { opacity: 1; pointer-events: auto; }
+.loop-agent-row:hover .loop-agent-row__archive {
+  opacity: 1;
+  pointer-events: auto;
+}
 
 /* 已归档：头像/文字置灰，恢复按钮常显 */
 .loop-agent-row.is-archived .loop-agent-row__avatar,
@@ -910,13 +1014,20 @@
   opacity: 0.55;
   filter: grayscale(1);
 }
-.loop-agent-row.is-archived .loop-agent-row__archive { opacity: 1; pointer-events: auto; }
-
-@media (max-width: 900px) {
-  .loop-agent-row__device { width: auto; max-width: 120px; }
-  .loop-agent-row__owner { display: none; }
+.loop-agent-row.is-archived .loop-agent-row__archive {
+  opacity: 1;
+  pointer-events: auto;
 }
 
+@media (max-width: 900px) {
+  .loop-agent-row__device {
+    width: auto;
+    max-width: 120px;
+  }
+  .loop-agent-row__owner {
+    display: none;
+  }
+}
 
 /* ===== Skill list ===== */
 .loop-skill-list {
@@ -1178,8 +1289,15 @@
   font-size: 12px;
   line-height: 18px;
 }
-.loop-abadge svg { color: var(--semi-color-text-2, #8a8f99); flex: 0 0 auto; }
-.loop-abadge__name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.loop-abadge svg {
+  color: var(--semi-color-text-2, #8a8f99);
+  flex: 0 0 auto;
+}
+.loop-abadge__name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 
 /* ===== 详情抽屉 ===== */
 .loop-detail {
@@ -1193,7 +1311,10 @@
   font-weight: 600;
   margin-bottom: 8px;
 }
-.loop-detail__section-optional { font-weight: 400; color: var(--semi-color-text-3, #b8bcc8); }
+.loop-detail__section-optional {
+  font-weight: 400;
+  color: var(--semi-color-text-3, #b8bcc8);
+}
 .loop-detail__section-hint {
   font-size: 12px;
   color: var(--semi-color-text-2, #6b7075);
@@ -1218,15 +1339,50 @@
 }
 
 /* 从运行时拷贝技能列表 */
-.loop-skill-rtlist { display: flex; flex-direction: column; gap: 6px; max-height: 260px; overflow: auto; border: 1px solid var(--semi-color-border,#e8e9eb); border-radius: 8px; padding: 8px; }
-.loop-skill-rtitem { display: flex; align-items: center; gap: 10px; padding: 6px 8px; border-radius: 6px; cursor: pointer; }
-.loop-skill-rtitem:hover { background: var(--semi-color-fill-0,#f5f6f8); }
-.loop-skill-rtitem__main { display: flex; flex-direction: column; min-width: 0; flex: 1; }
-.loop-skill-rtitem__main strong { font-size: 13px; }
-.loop-skill-rtitem__main small { font-size: 12px; color: var(--semi-color-text-2,#8590a6); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.loop-skill-rtlist {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  max-height: 260px;
+  overflow: auto;
+  border: 1px solid var(--semi-color-border, #e8e9eb);
+  border-radius: 8px;
+  padding: 8px;
+}
+.loop-skill-rtitem {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 8px;
+  border-radius: 6px;
+  cursor: pointer;
+}
+.loop-skill-rtitem:hover {
+  background: var(--semi-color-fill-0, #f5f6f8);
+}
+.loop-skill-rtitem__main {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  flex: 1;
+}
+.loop-skill-rtitem__main strong {
+  font-size: 13px;
+}
+.loop-skill-rtitem__main small {
+  font-size: 12px;
+  color: var(--semi-color-text-2, #8590a6);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 
 /* 设置页-成员邀请行 */
-.loop-settings-invite { display: flex; gap: 8px; align-items: center; }
+.loop-settings-invite {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
 
 /* ===== 新建 Skill 弹框：左表单 + 右预览 ===== */
 .loop-nsk__head-title {
@@ -1433,16 +1589,31 @@
 }
 
 @media (max-width: 720px) {
-  .loop-nsk { height: auto; }
-  .loop-nsk__body { flex-direction: column; }
+  .loop-nsk {
+    height: auto;
+  }
+  .loop-nsk__body {
+    flex-direction: column;
+  }
   .loop-nsk__form,
-  .loop-nsk__preview { width: 100%; }
-  .loop-nsk__preview { border-left: none; border-top: 1px solid var(--semi-color-border, #e8e9eb); }
+  .loop-nsk__preview {
+    width: 100%;
+  }
+  .loop-nsk__preview {
+    border-left: none;
+    border-top: 1px solid var(--semi-color-border, #e8e9eb);
+  }
 }
 
 /* ---------- running chip 旋转 ---------- */
-.loop-spin { animation: loop-spin 1s linear infinite; }
-@keyframes loop-spin { to { transform: rotate(360deg); } }
+.loop-spin {
+  animation: loop-spin 1s linear infinite;
+}
+@keyframes loop-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
 
 /* ---------- 按负责人分组板 ---------- */
 .loop-groupboard {
@@ -1474,7 +1645,9 @@
 }
 
 /* 分组板卡片非拖拽,光标用指针而非 grab。 */
-.loop-groupboard .loop-card { cursor: pointer; }
+.loop-groupboard .loop-card {
+  cursor: pointer;
+}
 
 /* ---------- 列表批量操作条 ---------- */
 .loop-batchbar {
@@ -1602,7 +1775,13 @@
 }
 
 .loop-list__id {
-  font-family: var(--loop-mono-font, ui-monospace, SFMono-Regular, Menlo, monospace);
+  font-family: var(
+    --loop-mono-font,
+    ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    monospace
+  );
   font-size: 11.5px;
   color: var(--semi-color-text-3, #b8bcc8);
   flex: 0 0 auto;
@@ -1622,8 +1801,12 @@
 }
 
 @media (max-width: 900px) {
-  .loop-list__project { display: none; }
-  .loop-list__title { max-width: 320px; }
+  .loop-list__project {
+    display: none;
+  }
+  .loop-list__title {
+    max-width: 320px;
+  }
 }
 
 /* ---------- 分组板 no-* 复选(含无负责人/无项目) ---------- */
@@ -1712,7 +1895,9 @@
   color: var(--semi-color-text-1, #4e5969);
   font-size: 12px;
 }
-.loop-project-list__cell--muted { color: var(--semi-color-text-2, #8a8f99); }
+.loop-project-list__cell--muted {
+  color: var(--semi-color-text-2, #8a8f99);
+}
 .loop-project-list__count {
   display: inline-flex;
   align-items: center;
@@ -1724,7 +1909,9 @@
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-.loop-project-list__time { white-space: nowrap; }
+.loop-project-list__time {
+  white-space: nowrap;
+}
 
 .loop-project-list__del {
   justify-self: end;
@@ -1757,12 +1944,30 @@
   color: var(--loop-tag-grey-fg, #5d626f);
   border-color: var(--loop-tag-grey-bd, #dddfe3);
 }
-.loop-pstatus--muted:hover { border-color: var(--semi-color-text-3, #c9cdd4); }
-.loop-pstatus--solid { color: #fff; }
-.loop-pstatus--solid:hover { opacity: 0.88; }
-.loop-pstatus__opt { display: inline-flex; align-items: center; gap: 8px; }
-.loop-pstatus__dot { width: 8px; height: 8px; border-radius: 999px; flex: none; }
-.loop-pstatus__check { margin-left: auto; color: var(--semi-color-text-2, #8a8f99); }
+.loop-pstatus--muted:hover {
+  border-color: var(--semi-color-text-3, #c9cdd4);
+}
+.loop-pstatus--solid {
+  color: #fff;
+}
+.loop-pstatus--solid:hover {
+  opacity: 0.88;
+}
+.loop-pstatus__opt {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+.loop-pstatus__dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+  flex: none;
+}
+.loop-pstatus__check {
+  margin-left: auto;
+  color: var(--semi-color-text-2, #8a8f99);
+}
 
 /* 项目优先级徽标：图标 + 文案的 ghost chip */
 .loop-pprio {
@@ -1781,7 +1986,9 @@
   cursor: pointer;
   transition: background-color 120ms ease;
 }
-.loop-pprio:hover { background: var(--semi-color-fill-0, #f5f6f8); }
+.loop-pprio:hover {
+  background: var(--semi-color-fill-0, #f5f6f8);
+}
 
 /* ===== 项目：卡片形态 ===== */
 .loop-project-cards {
@@ -1944,14 +2151,25 @@
   padding: 8px 10px;
   border-radius: 6px;
   background: var(--semi-color-fill-0, #f5f6f8);
-  font-family: var(--loop-mono-font, ui-monospace, SFMono-Regular, Menlo, monospace);
+  font-family: var(
+    --loop-mono-font,
+    ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    monospace
+  );
   font-size: 12px;
   white-space: nowrap;
 }
 
 /* ===== AI 小队列表 ===== */
-.loop-squad-toolbar { justify-content: flex-start; gap: 8px; }
-.loop-squad-toolbar__spacer { flex: 1; }
+.loop-squad-toolbar {
+  justify-content: flex-start;
+  gap: 8px;
+}
+.loop-squad-toolbar__spacer {
+  flex: 1;
+}
 
 /* 筛选 / 排序下拉 */
 .loop-squad-filter,
@@ -1961,8 +2179,16 @@
   overflow: auto;
   padding: 6px;
 }
-.loop-squad-filter__group { padding-bottom: 6px; margin-bottom: 6px; border-bottom: 1px solid var(--semi-color-border, rgba(0, 0, 0, 0.06)); }
-.loop-squad-filter__group:last-child { border-bottom: none; margin-bottom: 0; padding-bottom: 0; }
+.loop-squad-filter__group {
+  padding-bottom: 6px;
+  margin-bottom: 6px;
+  border-bottom: 1px solid var(--semi-color-border, rgba(0, 0, 0, 0.06));
+}
+.loop-squad-filter__group:last-child {
+  border-bottom: none;
+  margin-bottom: 0;
+  padding-bottom: 0;
+}
 .loop-squad-filter__label {
   font-size: 11px;
   font-weight: 600;
@@ -1971,7 +2197,11 @@
   text-transform: uppercase;
   letter-spacing: 0.3px;
 }
-.loop-squad-filter__empty { padding: 4px 8px; color: var(--semi-color-text-3, #b8bcc8); font-size: 12px; }
+.loop-squad-filter__empty {
+  padding: 4px 8px;
+  color: var(--semi-color-text-3, #b8bcc8);
+  font-size: 12px;
+}
 .loop-squad-filter__opt {
   display: flex;
   align-items: center;
@@ -1986,10 +2216,28 @@
   font-size: 13px;
   color: var(--semi-color-text-0, #1f2329);
 }
-.loop-squad-filter__opt:hover { background: var(--semi-color-fill-0, #f5f6f8); }
-.loop-squad-filter__check { width: 14px; flex: 0 0 auto; display: inline-flex; color: var(--semi-color-primary, #7c5cfc); }
-.loop-squad-filter__name { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.loop-squad-filter__count { flex: 0 0 auto; font-size: 11px; color: var(--semi-color-text-3, #b8bcc8); font-variant-numeric: tabular-nums; }
+.loop-squad-filter__opt:hover {
+  background: var(--semi-color-fill-0, #f5f6f8);
+}
+.loop-squad-filter__check {
+  width: 14px;
+  flex: 0 0 auto;
+  display: inline-flex;
+  color: var(--semi-color-primary, #7c5cfc);
+}
+.loop-squad-filter__name {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.loop-squad-filter__count {
+  flex: 0 0 auto;
+  font-size: 11px;
+  color: var(--semi-color-text-3, #b8bcc8);
+  font-variant-numeric: tabular-nums;
+}
 .loop-squad-filter__clear {
   width: 100%;
   margin-top: 4px;
@@ -2002,10 +2250,16 @@
   font-size: 12px;
   color: var(--semi-color-danger, #f5222d);
 }
-.loop-squad-filter__clear:hover { background: var(--semi-color-fill-0, #f5f6f8); }
+.loop-squad-filter__clear:hover {
+  background: var(--semi-color-fill-0, #f5f6f8);
+}
 
 /* 行 */
-.loop-squad-list { display: flex; flex-direction: column; gap: 2px; }
+.loop-squad-list {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
 .loop-squad-row {
   display: flex;
   align-items: center;
@@ -2016,7 +2270,9 @@
   cursor: pointer;
   transition: background-color 120ms ease;
 }
-.loop-squad-row:hover { background: var(--semi-color-fill-0, #f5f6f8); }
+.loop-squad-row:hover {
+  background: var(--semi-color-fill-0, #f5f6f8);
+}
 .loop-squad-row__name {
   flex: 0 0 auto;
   max-width: 220px;
@@ -2045,10 +2301,24 @@
   color: var(--semi-color-text-1, #555b61);
   font-size: 12px;
 }
-.loop-squad-row__leadername { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.loop-squad-row__stack { flex: 0 0 auto; display: inline-flex; align-items: center; }
-.loop-squad-row__stack > * { margin-left: -6px; box-shadow: 0 0 0 2px var(--semi-color-bg-0, #fff); border-radius: 999px; }
-.loop-squad-row__stack > *:first-child { margin-left: 0; }
+.loop-squad-row__leadername {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.loop-squad-row__stack {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+}
+.loop-squad-row__stack > * {
+  margin-left: -6px;
+  box-shadow: 0 0 0 2px var(--semi-color-bg-0, #fff);
+  border-radius: 999px;
+}
+.loop-squad-row__stack > *:first-child {
+  margin-left: 0;
+}
 .loop-squad-row__more {
   display: inline-flex;
   align-items: center;
@@ -2062,15 +2332,43 @@
   font-size: 11px;
   font-weight: 600;
 }
-.loop-squad-row__creator { flex: 0 0 auto; width: 120px; color: var(--semi-color-text-2, #6b7075); font-size: 12px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.loop-squad-row__time { flex: 0 0 auto; width: 88px; text-align: right; color: var(--semi-color-text-2, #6b7075); font-size: 12px; white-space: nowrap; }
-.loop-squad-row__del { flex: 0 0 auto; width: 28px; opacity: 0; pointer-events: none; transition: opacity 120ms ease; }
-.loop-squad-row:hover .loop-squad-row__del { opacity: 1; pointer-events: auto; }
+.loop-squad-row__creator {
+  flex: 0 0 auto;
+  width: 120px;
+  color: var(--semi-color-text-2, #6b7075);
+  font-size: 12px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.loop-squad-row__time {
+  flex: 0 0 auto;
+  width: 88px;
+  text-align: right;
+  color: var(--semi-color-text-2, #6b7075);
+  font-size: 12px;
+  white-space: nowrap;
+}
+.loop-squad-row__del {
+  flex: 0 0 auto;
+  width: 28px;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 120ms ease;
+}
+.loop-squad-row:hover .loop-squad-row__del {
+  opacity: 1;
+  pointer-events: auto;
+}
 
 @media (max-width: 900px) {
-  .loop-squad-row__desc { display: none; }
+  .loop-squad-row__desc {
+    display: none;
+  }
   .loop-squad-row__creator,
-  .loop-squad-row__time { display: none; }
+  .loop-squad-row__time {
+    display: none;
+  }
 }
 
 /* ===== AI 小队详情页（单栏身份区 + 成员/指引 tab；样式并入 loop.css 以规避新增 CSS 文件在运行中 Vite 的解析问题） ===== */
@@ -2082,7 +2380,12 @@
   background: var(--semi-color-bg-0, #fff);
   color: var(--semi-color-text-0, #1c1f23);
 }
-.loop-sqd__center { display: flex; align-items: center; justify-content: center; flex: 1; }
+.loop-sqd__center {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex: 1;
+}
 
 /* 顶部：面包屑 + 归档 */
 .loop-sqd__header {
@@ -2103,10 +2406,21 @@
   padding: 2px 4px;
   border-radius: 6px;
 }
-.loop-sqd__crumb:hover { background: var(--semi-color-fill-0, #f5f6f8); }
-.loop-sqd__crumb-sep { color: var(--semi-color-text-3, #b8bcc8); flex: 0 0 auto; }
-.loop-sqd__crumb-cur { font-size: 13px; font-weight: 700; color: var(--semi-color-text-0, #1f2329); }
-.loop-sqd__header-spacer { flex: 1; }
+.loop-sqd__crumb:hover {
+  background: var(--semi-color-fill-0, #f5f6f8);
+}
+.loop-sqd__crumb-sep {
+  color: var(--semi-color-text-3, #b8bcc8);
+  flex: 0 0 auto;
+}
+.loop-sqd__crumb-cur {
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--semi-color-text-0, #1f2329);
+}
+.loop-sqd__header-spacer {
+  flex: 1;
+}
 
 /* 主体 */
 .loop-sqd__body {
@@ -2120,7 +2434,11 @@
 }
 
 /* 身份区 */
-.loop-sqd__identity { display: flex; align-items: flex-start; gap: 14px; }
+.loop-sqd__identity {
+  display: flex;
+  align-items: flex-start;
+  gap: 14px;
+}
 .loop-sqd__avatar {
   flex: 0 0 auto;
   width: 52px;
@@ -2134,7 +2452,13 @@
   font-size: 22px;
   font-weight: 700;
 }
-.loop-sqd__idmain { min-width: 0; flex: 1; display: flex; flex-direction: column; gap: 4px; }
+.loop-sqd__idmain {
+  min-width: 0;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
 .loop-sqd__name {
   display: inline-flex;
   align-items: center;
@@ -2150,9 +2474,15 @@
   font-weight: 700;
   color: var(--semi-color-text-0, #1f2329);
 }
-.loop-sqd__name:hover { background: var(--semi-color-fill-0, #f5f6f8); }
-.loop-sqd__name-edit { color: transparent; }
-.loop-sqd__name:hover .loop-sqd__name-edit { color: var(--semi-color-text-3, #b8bcc8); }
+.loop-sqd__name:hover {
+  background: var(--semi-color-fill-0, #f5f6f8);
+}
+.loop-sqd__name-edit {
+  color: transparent;
+}
+.loop-sqd__name:hover .loop-sqd__name-edit {
+  color: var(--semi-color-text-3, #b8bcc8);
+}
 .loop-sqd__desc {
   display: inline-flex;
   align-items: flex-start;
@@ -2169,12 +2499,29 @@
   line-height: 1.5;
   color: var(--semi-color-text-1, #555b61);
 }
-.loop-sqd__desc:hover { background: var(--semi-color-fill-0, #f5f6f8); }
-.loop-sqd__desc-empty { color: var(--semi-color-text-3, #b8bcc8); font-style: italic; }
-.loop-sqd__desc-edit { flex: 0 0 auto; margin-top: 2px; color: transparent; }
-.loop-sqd__desc:hover .loop-sqd__desc-edit { color: var(--semi-color-text-3, #b8bcc8); }
+.loop-sqd__desc:hover {
+  background: var(--semi-color-fill-0, #f5f6f8);
+}
+.loop-sqd__desc-empty {
+  color: var(--semi-color-text-3, #b8bcc8);
+  font-style: italic;
+}
+.loop-sqd__desc-edit {
+  flex: 0 0 auto;
+  margin-top: 2px;
+  color: transparent;
+}
+.loop-sqd__desc:hover .loop-sqd__desc-edit {
+  color: var(--semi-color-text-3, #b8bcc8);
+}
 
-.loop-sqd__chips { display: flex; flex-wrap: wrap; align-items: center; gap: 8px; margin-top: 4px; }
+.loop-sqd__chips {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  margin-top: 4px;
+}
 .loop-sqd__chip {
   display: inline-flex;
   align-items: center;
@@ -2186,7 +2533,11 @@
   font-size: 12px;
   color: var(--semi-color-text-1, #555b61);
 }
-.loop-sqd__chip--plain { border: none; padding-left: 0; color: var(--semi-color-text-2, #6b7075); }
+.loop-sqd__chip--plain {
+  border: none;
+  padding-left: 0;
+  color: var(--semi-color-text-2, #6b7075);
+}
 
 /* tabs */
 .loop-sqd__tabs {
@@ -2214,12 +2565,36 @@
 }
 
 /* 成员 */
-.loop-sqd__members { display: flex; flex-direction: column; gap: 0; }
-.loop-sqd__members-head { display: flex; align-items: center; justify-content: space-between; padding-bottom: 10px; border-bottom: 1px solid var(--semi-color-border, #e8e9eb); }
-.loop-sqd__members-title { display: inline-flex; align-items: baseline; gap: 8px; font-size: 14px; font-weight: 700; color: var(--semi-color-text-0, #1f2329); }
-.loop-sqd__members-count { font-size: 12px; font-weight: 500; color: var(--semi-color-text-2, #6b7075); }
+.loop-sqd__members {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+.loop-sqd__members-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding-bottom: 10px;
+  border-bottom: 1px solid var(--semi-color-border, #e8e9eb);
+}
+.loop-sqd__members-title {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 8px;
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--semi-color-text-0, #1f2329);
+}
+.loop-sqd__members-count {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--semi-color-text-2, #6b7075);
+}
 
-.loop-sqd__memlist { display: flex; flex-direction: column; }
+.loop-sqd__memlist {
+  display: flex;
+  flex-direction: column;
+}
 .loop-sqd__mem {
   display: flex;
   align-items: center;
@@ -2227,20 +2602,48 @@
   padding: 10px 0;
   border-bottom: 1px solid var(--semi-color-fill-1, #eceef1);
 }
-.loop-sqd__mem:last-child { border-bottom: none; }
-.loop-sqd__mem:hover { background: var(--semi-color-fill-0, #f5f6f8); }
-.loop-sqd__mem-ava { position: relative; flex: 0 0 auto; display: inline-flex; }
-.loop-sqd__mem-dot { flex: 0 0 auto; }
+.loop-sqd__mem:last-child {
+  border-bottom: none;
+}
+.loop-sqd__mem:hover {
+  background: var(--semi-color-fill-0, #f5f6f8);
+}
+.loop-sqd__mem-ava {
+  position: relative;
+  flex: 0 0 auto;
+  display: inline-flex;
+}
+.loop-sqd__mem-dot {
+  flex: 0 0 auto;
+}
 .loop-sqd__mem-ava .loop-sqd__mem-dot {
   position: absolute;
   right: -1px;
   bottom: -1px;
 }
 
-.loop-sqd__mem-main { flex: 1; min-width: 0; }
-.loop-sqd__mem-line { display: flex; align-items: center; gap: 8px; }
-.loop-sqd__mem-name { font-size: 13px; font-weight: 600; color: var(--semi-color-text-0, #1f2329); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.loop-sqd__mem-type { font-size: 12px; color: var(--semi-color-text-3, #b8bcc8); flex: 0 0 auto; }
+.loop-sqd__mem-main {
+  flex: 1;
+  min-width: 0;
+}
+.loop-sqd__mem-line {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.loop-sqd__mem-name {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--semi-color-text-0, #1f2329);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.loop-sqd__mem-type {
+  font-size: 12px;
+  color: var(--semi-color-text-3, #b8bcc8);
+  flex: 0 0 auto;
+}
 /* 身份标签（领队 / 成员），置于右侧信息区 */
 .loop-sqd__mem-badge {
   display: inline-flex;
@@ -2267,11 +2670,28 @@
   color: var(--semi-color-text-2, #6b7075);
   text-align: left;
 }
-.loop-sqd__mem-role:hover { color: var(--semi-color-text-0, #1f2329); }
-.loop-sqd__mem-role-empty { font-style: italic; opacity: 0.6; }
+.loop-sqd__mem-role:hover {
+  color: var(--semi-color-text-0, #1f2329);
+}
+.loop-sqd__mem-role-empty {
+  font-style: italic;
+  opacity: 0.6;
+}
 
-.loop-sqd__mem-right { flex: 0 0 auto; display: flex; align-items: center; gap: 10px; }
-.loop-sqd__mem-status { display: inline-flex; align-items: center; gap: 6px; font-size: 12px; color: var(--semi-color-text-2, #6b7075); max-width: 320px; }
+.loop-sqd__mem-right {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.loop-sqd__mem-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--semi-color-text-2, #6b7075);
+  max-width: 320px;
+}
 .loop-sqd__mem-issue {
   display: inline-flex;
   align-items: center;
@@ -2284,19 +2704,62 @@
   color: var(--semi-color-text-2, #6b7075);
   font-size: 12px;
 }
-.loop-sqd__mem-issue:hover { color: var(--semi-color-primary, #7c5cfc); }
-.loop-sqd__mem-ident { font-family: var(--loop-mono-font, ui-monospace, SFMono-Regular, Menlo, monospace); font-size: 10px; text-transform: uppercase; flex: 0 0 auto; }
-.loop-sqd__mem-ititle { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }
-.loop-sqd__mem-more { flex: 0 0 auto; }
+.loop-sqd__mem-issue:hover {
+  color: var(--semi-color-primary, #7c5cfc);
+}
+.loop-sqd__mem-ident {
+  font-family: var(
+    --loop-mono-font,
+    ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    monospace
+  );
+  font-size: 10px;
+  text-transform: uppercase;
+  flex: 0 0 auto;
+}
+.loop-sqd__mem-ititle {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+.loop-sqd__mem-more {
+  flex: 0 0 auto;
+}
 /* 行操作收进右端 kebab「⋯」菜单（hover 显现）——单图标宽度一致，右侧天然对齐 */
-.loop-sqd__mem-kebab { flex: 0 0 auto; opacity: 0; transition: opacity 120ms ease; }
+.loop-sqd__mem-kebab {
+  flex: 0 0 auto;
+  opacity: 0;
+  transition: opacity 120ms ease;
+}
 .loop-sqd__mem:hover .loop-sqd__mem-kebab,
-.loop-sqd__mem:focus-within .loop-sqd__mem-kebab { opacity: 1; }
+.loop-sqd__mem:focus-within .loop-sqd__mem-kebab {
+  opacity: 1;
+}
 
 /* 指引 */
-.loop-sqd__instr { display: flex; flex-direction: column; gap: 10px; flex: 1; min-height: 0; }
-.loop-sqd__instr-head { display: flex; align-items: center; justify-content: space-between; gap: 12px; min-height: 28px; }
-.loop-sqd__instr-actions { display: inline-flex; align-items: center; gap: 12px; flex: 0 0 auto; }
+.loop-sqd__instr {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  flex: 1;
+  min-height: 0;
+}
+.loop-sqd__instr-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  min-height: 28px;
+}
+.loop-sqd__instr-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  flex: 0 0 auto;
+}
 .loop-sqd__editor {
   flex: 1;
   min-height: 280px;
@@ -2319,7 +2782,10 @@
   color: var(--semi-color-text-0, #1c1f23);
   background: var(--semi-color-bg-0, #fff);
 }
-.loop-sqd__unsaved { font-size: 12px; color: var(--semi-color-text-2, #6b7075); }
+.loop-sqd__unsaved {
+  font-size: 12px;
+  color: var(--semi-color-text-2, #6b7075);
+}
 
 /* ===== 侧栏分组标题（工作区） ===== */
 .loop-sidebar__group-label {

--- a/packages/dmloop/src/panel/IssueDetailPage.tsx
+++ b/packages/dmloop/src/panel/IssueDetailPage.tsx
@@ -1234,6 +1234,16 @@ export default function IssueDetailPage({ issueId, onChanged, onClose, snapshot,
                     </button>
                   </Dropdown>}
                 </div>
+                <div className="loop-idp__prop loop-idp__prop--inline">
+                  <span className="loop-idp__prop-k">{t("loop.field.labels")}</span>
+                  {readOnly ? (
+                    <span className="loop-idp__prop-v">
+                      {issue.labels?.length ? issue.labels.map((l) => l.name).join(", ") : "—"}
+                    </span>
+                  ) : (
+                    <LabelEditor issueId={issue.id} labels={issue.labels} onChanged={() => { syncIssue(reqRef.current); onChanged?.(); }} />
+                  )}
+                </div>
               </div>
             )}
           </section>
@@ -1331,10 +1341,6 @@ export default function IssueDetailPage({ issueId, onChanged, onClose, snapshot,
         width={460}
       >
         <div className="loop-fields">
-          <div className="loop-fields__row">
-            <div className="loop-fields__label">{t("loop.field.labels")}</div>
-            <LabelEditor issueId={issue.id} labels={issue.labels} onChanged={() => { syncIssue(reqRef.current); onChanged?.(); }} />
-          </div>
           <div className="loop-fields__row">
             <div className="loop-fields__label">{t("loop.field.parent")}</div>
             <Select

--- a/packages/dmloop/src/panel/IssueDetailPage.tsx
+++ b/packages/dmloop/src/panel/IssueDetailPage.tsx
@@ -72,6 +72,7 @@ import { listProjects } from "../api/projectApi";
 import { listRuns, rerunIssue, cancelTask } from "../api/runsApi";
 import AssigneePicker from "../ui/AssigneePicker";
 import LabelEditor from "../ui/LabelEditor";
+import LabelChips from "../ui/LabelChips";
 import { useRunConfirm } from "../ui/RunConfirmModal";
 import { useAssigneeCandidates } from "../ui/useAssigneeCandidates";
 import LoopMarkdown from "../ui/LoopMarkdown";
@@ -1234,14 +1235,19 @@ export default function IssueDetailPage({ issueId, onChanged, onClose, snapshot,
                     </button>
                   </Dropdown>}
                 </div>
-                <div className="loop-idp__prop loop-idp__prop--inline">
+                <div className="loop-idp__prop loop-idp__prop--inline loop-idp__prop--labels">
                   <span className="loop-idp__prop-k">{t("loop.field.labels")}</span>
                   {readOnly ? (
-                    <span className="loop-idp__prop-v">
-                      {issue.labels?.length ? issue.labels.map((l) => l.name).join(", ") : "—"}
+                    <span className={`loop-idp__prop-v loop-idp__prop-labels${issue.labels?.length ? "" : " loop-idp__prop-v--muted"}`}>
+                      {issue.labels?.length ? <LabelChips labels={issue.labels} /> : t("loop.label.add")}
                     </span>
                   ) : (
-                    <LabelEditor issueId={issue.id} labels={issue.labels} onChanged={() => { syncIssue(reqRef.current); onChanged?.(); }} />
+                    <LabelEditor
+                      issueId={issue.id}
+                      labels={issue.labels}
+                      className="loop-idp__label-editor"
+                      onChanged={() => { syncIssue(reqRef.current); onChanged?.(); }}
+                    />
                   )}
                 </div>
               </div>

--- a/packages/dmloop/src/panel/issueDetail.css
+++ b/packages/dmloop/src/panel/issueDetail.css
@@ -512,15 +512,24 @@
 }
 .loop-idp__prop--inline {
   flex-direction: row;
-  align-items: center;
-  justify-content: space-between;
+  align-items: flex-start;
+  justify-content: flex-start;
+  gap: var(--wk-sp-2, 8px);
 }
 .loop-idp__prop-k {
+  flex: 0 0 72px;
+  width: 72px;
+  padding-top: var(--wk-sp-1, 4px);
   font-size: 12px;
+  white-space: nowrap;
   color: var(--semi-color-text-2, #8a8f99);
 }
 .loop-idp__prop-v {
+  flex: 1 1 auto;
+  min-width: 0;
   font-size: 13px;
+  text-align: left;
+  overflow-wrap: anywhere;
   color: var(--semi-color-text-0, #1f2329);
 }
 .loop-idp__prop-v--muted {
@@ -563,8 +572,38 @@
   display: inline-flex;
   align-items: center;
   gap: 6px;
+  flex: 1 1 auto;
+  min-width: 0;
   font-size: 13px;
   color: var(--semi-color-text-0, #1f2329);
+}
+
+.loop-idp__prop--labels {
+  align-items: flex-start;
+}
+
+.loop-idp__label-editor {
+  flex: 1 1 auto;
+  min-width: 0;
+  max-width: 100%;
+  padding: var(--wk-sp-0-5, 2px) 0;
+  text-align: left;
+}
+
+.loop-idp__label-editor.loop-label-editor {
+  justify-content: flex-start;
+}
+
+.loop-idp__label-editor .loop-label-chipbutton {
+  justify-content: flex-start;
+}
+
+.loop-idp__label-editor .loop-label-chipbutton .loop-label-chips {
+  justify-content: flex-start;
+}
+
+.loop-idp__prop-labels {
+  padding-top: var(--wk-sp-0-5, 2px);
 }
 
 /* 执行日志：折叠开关 + run 列表 */

--- a/packages/dmloop/src/ui/CreateIssueModal.tsx
+++ b/packages/dmloop/src/ui/CreateIssueModal.tsx
@@ -1,16 +1,25 @@
 import React, { useEffect, useState } from "react";
-import { Modal, Toast, Avatar } from "@douyinfe/semi-ui";
-import { ChevronRight, X, Paperclip } from "lucide-react";
+import { Modal, Toast, Avatar, Select } from "@douyinfe/semi-ui";
+import { ChevronRight, X, Paperclip, Tag } from "lucide-react";
 import { useI18n } from "@octo/base";
-import type { IssueStatus, IssuePriority, AssigneeType } from "../api/types";
+import type {
+  IssueStatus,
+  IssuePriority,
+  AssigneeType,
+  IssueLabel,
+} from "../api/types";
 import { createIssue, listAssigneeCandidates } from "../api/issueApi";
 import { listProjectOptions } from "../api/directory";
 import { uploadAttachment } from "../api/attachmentApi";
+import { attachLabel, listLabels } from "../api/labelApi";
 import { currentWorkspaceName } from "../api/http";
 import AssigneePicker from "./AssigneePicker";
 import AutoGrowTextarea from "./AutoGrowTextarea";
+import LabelChips from "./LabelChips";
 import LoopButton from "./LoopButton";
-import LoopPropertyPill, { type LoopPropertyPillOption } from "./LoopPropertyPill";
+import LoopPropertyPill, {
+  type LoopPropertyPillOption,
+} from "./LoopPropertyPill";
 import {
   ISSUE_STATUS_ORDER,
   ISSUE_STATUS_ICON,
@@ -34,12 +43,24 @@ type LastAssignee = { id: string; type: AssigneeType; name: string };
 function readLastAssignee(): LastAssignee | null {
   try {
     const p = JSON.parse(sessionStorage.getItem(LAST_ASSIGNEE_KEY) ?? "null");
-    if (p && typeof p.id === "string" && typeof p.type === "string" && typeof p.name === "string") return p;
-  } catch { /* ignore */ }
+    if (
+      p &&
+      typeof p.id === "string" &&
+      typeof p.type === "string" &&
+      typeof p.name === "string"
+    )
+      return p;
+  } catch {
+    /* ignore */
+  }
   return null;
 }
 function writeLastAssignee(a: LastAssignee): void {
-  try { sessionStorage.setItem(LAST_ASSIGNEE_KEY, JSON.stringify(a)); } catch { /* ignore */ }
+  try {
+    sessionStorage.setItem(LAST_ASSIGNEE_KEY, JSON.stringify(a));
+  } catch {
+    /* ignore */
+  }
 }
 
 /**
@@ -48,14 +69,23 @@ function writeLastAssignee(a: LastAssignee): void {
  * 底栏(左附件 · 右取消/创建)。指派默认落到「我的第一个 AI队友」,并记忆上次选择。
  * 传 parentIssueId 时创建为子任务。
  */
-export default function CreateIssueModal({ visible, onClose, onCreated, parentIssueId }: CreateIssueModalProps) {
+export default function CreateIssueModal({
+  visible,
+  onClose,
+  onCreated,
+  parentIssueId,
+}: CreateIssueModalProps) {
   const { t } = useI18n();
   const [title, setTitle] = useState("");
   const [desc, setDesc] = useState("");
   const [status, setStatus] = useState<IssueStatus>("todo");
   const [priority, setPriority] = useState<IssuePriority>("none");
   const [projectId, setProjectId] = useState<string>("");
-  const [projects, setProjects] = useState<Array<{ id: string; title: string }>>([]);
+  const [projects, setProjects] = useState<
+    Array<{ id: string; title: string }>
+  >([]);
+  const [labels, setLabels] = useState<IssueLabel[]>([]);
+  const [labelIds, setLabelIds] = useState<string[]>([]);
   const [assigneeId, setAssigneeId] = useState<string | null>(null);
   const [assigneeType, setAssigneeType] = useState<AssigneeType | null>(null);
   const [assigneeName, setAssigneeName] = useState<string | null>(null);
@@ -64,10 +94,31 @@ export default function CreateIssueModal({ visible, onClose, onCreated, parentIs
 
   useEffect(() => {
     if (!visible) return;
-    setTitle(""); setDesc(""); setStatus("todo"); setPriority("none"); setProjectId(""); setPendingFiles([]);
-    setAssigneeId(null); setAssigneeType(null); setAssigneeName(null);
+    setTitle("");
+    setDesc("");
+    setStatus("todo");
+    setPriority("none");
+    setProjectId("");
+    setPendingFiles([]);
+    setLabelIds([]);
+    setAssigneeId(null);
+    setAssigneeType(null);
+    setAssigneeName(null);
     let alive = true;
-    listProjectOptions().then((ps) => { if (alive) setProjects(ps); }).catch(() => { if (alive) setProjects([]); });
+    listProjectOptions()
+      .then((ps) => {
+        if (alive) setProjects(ps);
+      })
+      .catch(() => {
+        if (alive) setProjects([]);
+      });
+    listLabels()
+      .then((rows) => {
+        if (alive) setLabels(rows);
+      })
+      .catch(() => {
+        if (alive) setLabels([]);
+      });
     // 默认指派:优先复用上次选择(若仍是有效候选),否则落到我的第一个 AI队友(agent)。
     listAssigneeCandidates()
       .then((cands) => {
@@ -75,10 +126,18 @@ export default function CreateIssueModal({ visible, onClose, onCreated, parentIs
         const last = readLastAssignee();
         const reuse = last ? cands.find((c) => c.id === last.id) : undefined;
         const pick = reuse ?? cands.find((c) => c.type === "agent") ?? null;
-        if (pick) { setAssigneeId(pick.id); setAssigneeType(pick.type); setAssigneeName(pick.name); }
+        if (pick) {
+          setAssigneeId(pick.id);
+          setAssigneeType(pick.type);
+          setAssigneeName(pick.name);
+        }
       })
-      .catch(() => { /* 无候选则保持未指派 */ });
-    return () => { alive = false; };
+      .catch(() => {
+        /* 无候选则保持未指派 */
+      });
+    return () => {
+      alive = false;
+    };
   }, [visible]);
 
   const isBot = assigneeType === "agent" || assigneeType === "squad";
@@ -88,7 +147,8 @@ export default function CreateIssueModal({ visible, onClose, onCreated, parentIs
     const arr = Array.from(files);
     setPendingFiles((p) => [...p, ...arr]);
   };
-  const removeFile = (idx: number) => setPendingFiles((p) => p.filter((_, i) => i !== idx));
+  const removeFile = (idx: number) =>
+    setPendingFiles((p) => p.filter((_, i) => i !== idx));
 
   const submit = async () => {
     if (!title.trim() || submitting) return;
@@ -100,12 +160,21 @@ export default function CreateIssueModal({ visible, onClose, onCreated, parentIs
         const ids: string[] = [];
         let failed = 0;
         for (const f of pendingFiles) {
-          try { ids.push((await uploadAttachment(f)).id); } catch { failed++; }
+          try {
+            ids.push((await uploadAttachment(f)).id);
+          } catch {
+            failed++;
+          }
         }
-        if (failed) { Toast.error(t("loop.attach.attachFailed", { values: { count: failed } })); return; }
+        if (failed) {
+          Toast.error(
+            t("loop.attach.attachFailed", { values: { count: failed } })
+          );
+          return;
+        }
         if (ids.length) attachmentIds = ids;
       }
-      await createIssue({
+      const issue = await createIssue({
         title: title.trim(),
         description: desc || undefined,
         status,
@@ -116,9 +185,28 @@ export default function CreateIssueModal({ visible, onClose, onCreated, parentIs
         parent_issue_id: parentIssueId,
         attachment_ids: attachmentIds,
       });
+      if (labelIds.length) {
+        const results = await Promise.all(
+          labelIds.map((labelId) =>
+            attachLabel(issue.id, labelId).then(
+              () => true,
+              () => false
+            )
+          )
+        );
+        const failed = results.filter((ok) => !ok).length;
+        if (failed)
+          Toast.error(
+            t("loop.label.attachPartialFailed", { values: { count: failed } })
+          );
+      }
       // 记忆本次 AI 队友选择(仅 agent/squad),下次 new loop 复用。
       if (isBot && assigneeId && assigneeType && assigneeName) {
-        writeLastAssignee({ id: assigneeId, type: assigneeType, name: assigneeName });
+        writeLastAssignee({
+          id: assigneeId,
+          type: assigneeType,
+          name: assigneeName,
+        });
       }
       onClose();
       onCreated?.();
@@ -127,14 +215,24 @@ export default function CreateIssueModal({ visible, onClose, onCreated, parentIs
     }
   };
 
-  const statusOptions: LoopPropertyPillOption<IssueStatus>[] = ISSUE_STATUS_ORDER.map((s) => {
-    const Icon = ISSUE_STATUS_ICON[s];
-    return { value: s, label: t(`loop.status.${s}`), icon: <Icon size={14} style={{ color: ISSUE_STATUS_HEX[s] }} /> };
-  });
-  const priorityOptions: LoopPropertyPillOption<IssuePriority>[] = PRIORITY_ORDER.map((p) => {
-    const Icon = PRIORITY_ICON[p];
-    return { value: p, label: t(`loop.priority.${p}`), icon: <Icon size={14} style={{ color: PRIORITY_HEX[p] }} /> };
-  });
+  const statusOptions: LoopPropertyPillOption<IssueStatus>[] =
+    ISSUE_STATUS_ORDER.map((s) => {
+      const Icon = ISSUE_STATUS_ICON[s];
+      return {
+        value: s,
+        label: t(`loop.status.${s}`),
+        icon: <Icon size={14} style={{ color: ISSUE_STATUS_HEX[s] }} />,
+      };
+    });
+  const priorityOptions: LoopPropertyPillOption<IssuePriority>[] =
+    PRIORITY_ORDER.map((p) => {
+      const Icon = PRIORITY_ICON[p];
+      return {
+        value: p,
+        label: t(`loop.priority.${p}`),
+        icon: <Icon size={14} style={{ color: PRIORITY_HEX[p] }} />,
+      };
+    });
   const projectOptions: LoopPropertyPillOption<string>[] = [
     { value: "", label: t("loop.field.noProject") },
     ...projects.map((p) => ({ value: p.id, label: p.title })),
@@ -161,9 +259,18 @@ export default function CreateIssueModal({ visible, onClose, onCreated, parentIs
                 <ChevronRight size={13} className="loop-ci__crumb-sep" />
               </>
             )}
-            <span className="loop-ci__crumb-cur">{parentIssueId ? t("loop.subIssue.create") : t("loop.action.newIssue")}</span>
+            <span className="loop-ci__crumb-cur">
+              {parentIssueId
+                ? t("loop.subIssue.create")
+                : t("loop.action.newIssue")}
+            </span>
           </div>
-          <button type="button" className="loop-ci__close" onClick={onClose} aria-label={t("loop.action.cancel")}>
+          <button
+            type="button"
+            className="loop-ci__close"
+            onClick={onClose}
+            aria-label={t("loop.action.cancel")}
+          >
             <X size={16} />
           </button>
         </div>
@@ -174,7 +281,9 @@ export default function CreateIssueModal({ visible, onClose, onCreated, parentIs
           value={title}
           onChange={(e) => setTitle(e.target.value)}
           placeholder={t("loop.field.titlePlaceholder")}
-          onKeyDown={(e) => { if (e.key === "Enter") submit(); }}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") submit();
+          }}
         />
         <AutoGrowTextarea
           className="loop-ci__desc"
@@ -185,21 +294,68 @@ export default function CreateIssueModal({ visible, onClose, onCreated, parentIs
 
         {isBot && assigneeName && (
           <div className="loop-ci__hint">
-            <Avatar size="extra-extra-small" color="light-blue">{assigneeName.slice(0, 1)}</Avatar>
-            <span>{t("loop.createIssue.runHint", { values: { name: assigneeName } })}</span>
+            <Avatar size="extra-extra-small" color="light-blue">
+              {assigneeName.slice(0, 1)}
+            </Avatar>
+            <span>
+              {t("loop.createIssue.runHint", {
+                values: { name: assigneeName },
+              })}
+            </span>
           </div>
         )}
 
         <div className="loop-ci__toolbar">
-          <LoopPropertyPill value={status} options={statusOptions} onChange={setStatus} ariaLabel={t("loop.field.status")} />
-          <LoopPropertyPill value={priority} options={priorityOptions} onChange={setPriority} ariaLabel={t("loop.field.priority")} />
+          <LoopPropertyPill
+            value={status}
+            options={statusOptions}
+            onChange={setStatus}
+            ariaLabel={t("loop.field.status")}
+          />
+          <LoopPropertyPill
+            value={priority}
+            options={priorityOptions}
+            onChange={setPriority}
+            ariaLabel={t("loop.field.priority")}
+          />
           <AssigneePicker
             value={assigneeId}
             valueName={assigneeName}
-            onChange={(id, type, name) => { setAssigneeId(id); setAssigneeType(type); setAssigneeName(name); }}
+            onChange={(id, type, name) => {
+              setAssigneeId(id);
+              setAssigneeType(type);
+              setAssigneeName(name);
+            }}
           />
-          <LoopPropertyPill value={projectId} options={projectOptions} onChange={setProjectId} ariaLabel={t("loop.field.project")} />
+          <LoopPropertyPill
+            value={projectId}
+            options={projectOptions}
+            onChange={setProjectId}
+            ariaLabel={t("loop.field.project")}
+          />
         </div>
+
+        {labels.length > 0 && (
+          <div className="loop-ci__labels">
+            <Tag size={14} />
+            <Select
+              multiple
+              filter
+              value={labelIds}
+              onChange={(v) => setLabelIds((v ?? []) as string[])}
+              dropdownClassName="loop-fields__dropdown"
+              placeholder={t("loop.label.selectPlaceholder")}
+              maxTagCount={2}
+              style={{ flex: 1 }}
+            >
+              {labels.map((label) => (
+                <Select.Option key={label.id} value={label.id}>
+                  <LabelChips labels={[label]} />
+                </Select.Option>
+              ))}
+            </Select>
+          </div>
+        )}
 
         {pendingFiles.length > 0 && (
           <div className="loop-ci__atts">
@@ -207,7 +363,13 @@ export default function CreateIssueModal({ visible, onClose, onCreated, parentIs
               <span key={i} className="loop-ci__att">
                 <Paperclip size={12} />
                 <span>{f.name}</span>
-                <button type="button" aria-label={t("loop.action.delete")} onClick={() => removeFile(i)}>×</button>
+                <button
+                  type="button"
+                  aria-label={t("loop.action.delete")}
+                  onClick={() => removeFile(i)}
+                >
+                  ×
+                </button>
               </span>
             ))}
           </div>
@@ -216,11 +378,28 @@ export default function CreateIssueModal({ visible, onClose, onCreated, parentIs
         <div className="loop-ci__footer">
           <label className="loop-ci__attach" aria-label={t("loop.attach.add")}>
             <Paperclip size={16} />
-            <input type="file" multiple hidden disabled={submitting} onChange={(e) => { addFiles(e.target.files); e.target.value = ""; }} />
+            <input
+              type="file"
+              multiple
+              hidden
+              disabled={submitting}
+              onChange={(e) => {
+                addFiles(e.target.files);
+                e.target.value = "";
+              }}
+            />
           </label>
           <div className="loop-ci__footer-right">
-            <LoopButton variant="ghost" onClick={onClose}>{t("loop.action.cancel")}</LoopButton>
-            <LoopButton loading={submitting} disabled={!title.trim()} onClick={submit}>{t("loop.action.create")}</LoopButton>
+            <LoopButton variant="ghost" onClick={onClose}>
+              {t("loop.action.cancel")}
+            </LoopButton>
+            <LoopButton
+              loading={submitting}
+              disabled={!title.trim()}
+              onClick={submit}
+            >
+              {t("loop.action.create")}
+            </LoopButton>
           </div>
         </div>
       </div>

--- a/packages/dmloop/src/ui/CreateIssueModal.tsx
+++ b/packages/dmloop/src/ui/CreateIssueModal.tsx
@@ -349,7 +349,7 @@ export default function CreateIssueModal({
               style={{ flex: 1 }}
             >
               {labels.map((label) => (
-                <Select.Option key={label.id} value={label.id}>
+                <Select.Option key={label.id} value={label.id} label={label.name}>
                   <LabelChips labels={[label]} />
                 </Select.Option>
               ))}

--- a/packages/dmloop/src/ui/LabelChips.tsx
+++ b/packages/dmloop/src/ui/LabelChips.tsx
@@ -9,19 +9,37 @@ import LoopTag from "./LoopTag";
  * 非法/非 #RRGGBB 颜色回退到中性灰（.loop-label-chip 的 --loop-chip-color 默认值）。
  * max 限制展示数量，其余折叠成「+N」（用于卡片这类空间有限处）。
  */
-export default function LabelChips({ labels, max }: { labels?: IssueLabel[] | null; max?: number }) {
+export default function LabelChips({
+  labels,
+  max,
+}: {
+  labels?: IssueLabel[] | null;
+  max?: number;
+}) {
   if (!labels || labels.length === 0) return null;
   const shown = max ? labels.slice(0, max) : labels;
   const rest = labels.length - shown.length;
   return (
-    <span style={{ display: "inline-flex", flexWrap: "wrap", gap: 4, alignItems: "center" }}>
+    <span
+      className="loop-label-chips"
+      style={{
+        display: "inline-flex",
+        flexWrap: "wrap",
+        gap: 4,
+        alignItems: "center",
+      }}
+    >
       {shown.map((l) => {
         const hex = /^#[0-9a-fA-F]{6}$/.test(l.color) ? l.color : undefined;
         return (
           <span
             key={l.id}
             className="loop-label-chip"
-            style={hex ? ({ "--loop-chip-color": hex } as React.CSSProperties) : undefined}
+            style={
+              hex
+                ? ({ "--loop-chip-color": hex } as React.CSSProperties)
+                : undefined
+            }
           >
             {l.name}
           </span>

--- a/packages/dmloop/src/ui/LabelColorPicker.tsx
+++ b/packages/dmloop/src/ui/LabelColorPicker.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import { Check } from "lucide-react";
+import { LABEL_PALETTE, normalizeLabelColor } from "./labelPalette";
+
+export default function LabelColorPicker({
+  value,
+  onChange,
+  ariaLabel,
+}: {
+  value: string;
+  onChange: (color: string) => void;
+  ariaLabel: string;
+}) {
+  const selected = normalizeLabelColor(value);
+  return (
+    <div className="loop-label-color" role="radiogroup" aria-label={ariaLabel}>
+      {LABEL_PALETTE.map((color) => {
+        const active = selected.toLowerCase() === color.toLowerCase();
+        return (
+          <button
+            key={color}
+            type="button"
+            role="radio"
+            aria-checked={active}
+            className={`loop-label-color__swatch${active ? " is-active" : ""}`}
+            style={{ "--loop-chip-color": color } as React.CSSProperties}
+            onClick={() => onChange(color)}
+            title={color}
+          >
+            {active && <Check size={12} strokeWidth={2.5} />}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/packages/dmloop/src/ui/LabelEditor.tsx
+++ b/packages/dmloop/src/ui/LabelEditor.tsx
@@ -1,9 +1,7 @@
 import React, { useState } from "react";
-import { Dropdown, Toast } from "@douyinfe/semi-ui";
-import { Check, Settings2, Tag, X } from "lucide-react";
+import { Tag } from "lucide-react";
 import { useI18n } from "@octo/base";
 import type { IssueLabel } from "../api/types";
-import { listLabels, attachLabel, detachLabel } from "../api/labelApi";
 import LabelChips from "./LabelChips";
 import LabelManagementModal from "./LabelManagementModal";
 
@@ -11,117 +9,45 @@ export default function LabelEditor({
   issueId,
   labels,
   onChanged,
+  className,
 }: {
   issueId: string;
   labels?: IssueLabel[] | null;
   onChanged: () => void;
+  className?: string;
 }) {
   const { t } = useI18n();
-  const [all, setAll] = useState<IssueLabel[]>([]);
-  const [busy, setBusy] = useState(false);
   const [manageOpen, setManageOpen] = useState(false);
-  const attached = new Set((labels ?? []).map((l) => l.id));
-
-  const loadAll = () =>
-    listLabels()
-      .then(setAll)
-      .catch(() => {});
-
-  const toggle = async (l: IssueLabel) => {
-    if (busy) return;
-    setBusy(true);
-    try {
-      if (attached.has(l.id)) await detachLabel(issueId, l.id);
-      else await attachLabel(issueId, l.id);
-      onChanged();
-    } catch (e) {
-      Toast.error((e as Error)?.message ?? t("loop.toast.saveFailed"));
-    } finally {
-      setBusy(false);
-    }
-  };
-
-  const detach = async (label: IssueLabel) => {
-    if (busy) return;
-    setBusy(true);
-    try {
-      await detachLabel(issueId, label.id);
-      onChanged();
-    } catch (e) {
-      Toast.error((e as Error)?.message ?? t("loop.toast.saveFailed"));
-    } finally {
-      setBusy(false);
-    }
-  };
-
-  const menu = (
-    <Dropdown.Menu>
-      {all.length === 0 && (
-        <Dropdown.Item disabled>{t("loop.label.empty")}</Dropdown.Item>
-      )}
-      {all.map((l) => {
-        const active = attached.has(l.id);
-        return (
-          <Dropdown.Item key={l.id} onClick={() => toggle(l)}>
-            <span className="loop-label-option">
-              <LabelChips labels={[l]} />
-              {active && <Check size={14} />}
-            </span>
-          </Dropdown.Item>
-        );
-      })}
-      <Dropdown.Divider />
-      <Dropdown.Item onClick={() => setManageOpen(true)}>
-        <span className="loop-label-option loop-label-option--manage">
-          <Settings2 size={14} />
-          {t("loop.label.manage")}
-        </span>
-      </Dropdown.Item>
-    </Dropdown.Menu>
-  );
+  const attachedLabels = labels ?? [];
 
   return (
     <>
-      <div className="loop-label-editor">
-        <div className="loop-label-editor__chips">
-          {(labels ?? []).map((label) => (
-            <span
-              key={label.id}
-              className="loop-label-removable"
-              style={
-                { "--loop-chip-color": label.color } as React.CSSProperties
-              }
-            >
-              <LabelChips labels={[label]} />
-              <button
-                type="button"
-                onClick={() => detach(label)}
-                aria-label={t("loop.label.remove", {
-                  values: { name: label.name },
-                })}
-              >
-                <X size={11} />
-              </button>
-            </span>
-          ))}
-        </div>
-        <Dropdown
-          trigger="click"
-          position="bottomLeft"
-          render={menu}
-          onVisibleChange={(v) => v && loadAll()}
-        >
-          <button type="button" className="loop-label-add">
+      <div className={`loop-label-editor${className ? ` ${className}` : ""}`}>
+        {attachedLabels.length > 0 ? (
+          <button
+            type="button"
+            className="loop-label-chipbutton"
+            onClick={() => setManageOpen(true)}
+          >
+            <LabelChips labels={attachedLabels} />
+          </button>
+        ) : (
+          <button
+            type="button"
+            className="loop-label-add"
+            onClick={() => setManageOpen(true)}
+          >
             <Tag size={13} />
             {t("loop.label.add")}
           </button>
-        </Dropdown>
+        )}
       </div>
       <LabelManagementModal
         visible={manageOpen}
         onClose={() => setManageOpen(false)}
-        onChanged={(next) => {
-          setAll(next);
+        issueId={issueId}
+        attachedLabelIds={attachedLabels.map((label) => label.id)}
+        onChanged={() => {
           onChanged();
         }}
       />

--- a/packages/dmloop/src/ui/LabelEditor.tsx
+++ b/packages/dmloop/src/ui/LabelEditor.tsx
@@ -1,13 +1,12 @@
 import React, { useState } from "react";
-import { Dropdown, Input, Button, Toast } from "@douyinfe/semi-ui";
-import { Check, Plus } from "lucide-react";
+import { Dropdown, Toast } from "@douyinfe/semi-ui";
+import { Check, Settings2, Tag, X } from "lucide-react";
 import { useI18n } from "@octo/base";
 import type { IssueLabel } from "../api/types";
-import { listLabels, createLabel, attachLabel, detachLabel } from "../api/labelApi";
+import { listLabels, attachLabel, detachLabel } from "../api/labelApi";
 import LabelChips from "./LabelChips";
+import LabelManagementModal from "./LabelManagementModal";
 
-// issue 标签编辑器:点开下拉列出工作区标签(勾选=挂/摘),底部内联建新标签并挂上。
-// UI 从简(默认色,取色器等留待 UI 定稿);核心是把挂/摘/建标签能力接上后端。
 export default function LabelEditor({
   issueId,
   labels,
@@ -20,10 +19,13 @@ export default function LabelEditor({
   const { t } = useI18n();
   const [all, setAll] = useState<IssueLabel[]>([]);
   const [busy, setBusy] = useState(false);
-  const [newName, setNewName] = useState("");
+  const [manageOpen, setManageOpen] = useState(false);
   const attached = new Set((labels ?? []).map((l) => l.id));
 
-  const loadAll = () => listLabels().then(setAll).catch(() => {});
+  const loadAll = () =>
+    listLabels()
+      .then(setAll)
+      .catch(() => {});
 
   const toggle = async (l: IssueLabel) => {
     if (busy) return;
@@ -39,15 +41,11 @@ export default function LabelEditor({
     }
   };
 
-  const create = async () => {
-    const name = newName.trim();
-    if (!name || busy) return;
+  const detach = async (label: IssueLabel) => {
+    if (busy) return;
     setBusy(true);
     try {
-      const label = await createLabel(name, "#8B5CF6"); // 默认紫,取色留待 UI 定稿
-      await attachLabel(issueId, label.id);
-      setNewName("");
-      await loadAll();
+      await detachLabel(issueId, label.id);
       onChanged();
     } catch (e) {
       Toast.error((e as Error)?.message ?? t("loop.toast.saveFailed"));
@@ -58,33 +56,75 @@ export default function LabelEditor({
 
   const menu = (
     <Dropdown.Menu>
-      {all.map((l) => (
-        <Dropdown.Item key={l.id} onClick={() => toggle(l)}>
-          <span style={{ flex: 1, marginRight: 8 }}>{l.name}</span>
-          {attached.has(l.id) && <Check size={14} />}
-        </Dropdown.Item>
-      ))}
+      {all.length === 0 && (
+        <Dropdown.Item disabled>{t("loop.label.empty")}</Dropdown.Item>
+      )}
+      {all.map((l) => {
+        const active = attached.has(l.id);
+        return (
+          <Dropdown.Item key={l.id} onClick={() => toggle(l)}>
+            <span className="loop-label-option">
+              <LabelChips labels={[l]} />
+              {active && <Check size={14} />}
+            </span>
+          </Dropdown.Item>
+        );
+      })}
       <Dropdown.Divider />
-      <div style={{ padding: "4px 8px", display: "flex", gap: 4 }} onClick={(e) => e.stopPropagation()}>
-        <Input
-          size="small"
-          value={newName}
-          onChange={setNewName}
-          placeholder={t("loop.label.newPlaceholder")}
-          onEnterPress={create}
-          style={{ width: 130 }}
-        />
-        <Button size="small" icon={<Plus size={14} />} onClick={create} loading={busy} aria-label={t("loop.label.create")} />
-      </div>
+      <Dropdown.Item onClick={() => setManageOpen(true)}>
+        <span className="loop-label-option loop-label-option--manage">
+          <Settings2 size={14} />
+          {t("loop.label.manage")}
+        </span>
+      </Dropdown.Item>
     </Dropdown.Menu>
   );
 
-  // clickToHide 默认 false:勾选多个标签时下拉保持打开;每次打开重新拉全量标签。
   return (
-    <Dropdown trigger="click" position="bottomLeft" render={menu} onVisibleChange={(v) => v && loadAll()}>
-      <span style={{ cursor: "pointer", display: "inline-flex", alignItems: "center", gap: 4 }}>
-        {labels && labels.length > 0 ? <LabelChips labels={labels} /> : <span style={{ opacity: 0.5 }}>{t("loop.label.add")}</span>}
-      </span>
-    </Dropdown>
+    <>
+      <div className="loop-label-editor">
+        <div className="loop-label-editor__chips">
+          {(labels ?? []).map((label) => (
+            <span
+              key={label.id}
+              className="loop-label-removable"
+              style={
+                { "--loop-chip-color": label.color } as React.CSSProperties
+              }
+            >
+              <LabelChips labels={[label]} />
+              <button
+                type="button"
+                onClick={() => detach(label)}
+                aria-label={t("loop.label.remove", {
+                  values: { name: label.name },
+                })}
+              >
+                <X size={11} />
+              </button>
+            </span>
+          ))}
+        </div>
+        <Dropdown
+          trigger="click"
+          position="bottomLeft"
+          render={menu}
+          onVisibleChange={(v) => v && loadAll()}
+        >
+          <button type="button" className="loop-label-add">
+            <Tag size={13} />
+            {t("loop.label.add")}
+          </button>
+        </Dropdown>
+      </div>
+      <LabelManagementModal
+        visible={manageOpen}
+        onClose={() => setManageOpen(false)}
+        onChanged={(next) => {
+          setAll(next);
+          onChanged();
+        }}
+      />
+    </>
   );
 }

--- a/packages/dmloop/src/ui/LabelEditor.tsx
+++ b/packages/dmloop/src/ui/LabelEditor.tsx
@@ -1,7 +1,9 @@
 import React, { useState } from "react";
-import { Tag } from "lucide-react";
+import { Dropdown, Toast } from "@douyinfe/semi-ui";
+import { Check, Settings2, Tag } from "lucide-react";
 import { useI18n } from "@octo/base";
 import type { IssueLabel } from "../api/types";
+import { attachLabel, detachLabel, listLabels } from "../api/labelApi";
 import LabelChips from "./LabelChips";
 import LabelManagementModal from "./LabelManagementModal";
 
@@ -17,31 +19,78 @@ export default function LabelEditor({
   className?: string;
 }) {
   const { t } = useI18n();
+  const [all, setAll] = useState<IssueLabel[]>([]);
+  const [busy, setBusy] = useState(false);
   const [manageOpen, setManageOpen] = useState(false);
   const attachedLabels = labels ?? [];
+  const attached = new Set(attachedLabels.map((label) => label.id));
+
+  const loadAll = () =>
+    listLabels()
+      .then(setAll)
+      .catch(() => {});
+
+  const toggle = async (label: IssueLabel) => {
+    if (busy) return;
+    setBusy(true);
+    try {
+      if (attached.has(label.id)) await detachLabel(issueId, label.id);
+      else await attachLabel(issueId, label.id);
+      onChanged();
+    } catch (e) {
+      Toast.error((e as Error)?.message ?? t("loop.toast.saveFailed"));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const menu = (
+    <Dropdown.Menu>
+      {all.length === 0 && (
+        <Dropdown.Item disabled>{t("loop.label.empty")}</Dropdown.Item>
+      )}
+      {all.map((label) => {
+        const active = attached.has(label.id);
+        return (
+          <Dropdown.Item key={label.id} onClick={() => toggle(label)}>
+            <span className="loop-label-option">
+              <LabelChips labels={[label]} />
+              {active && <Check size={14} />}
+            </span>
+          </Dropdown.Item>
+        );
+      })}
+      <Dropdown.Divider />
+      <Dropdown.Item onClick={() => setManageOpen(true)}>
+        <span className="loop-label-option loop-label-option--manage">
+          <Settings2 size={14} />
+          {t("loop.label.manage")}
+        </span>
+      </Dropdown.Item>
+    </Dropdown.Menu>
+  );
 
   return (
     <>
-      <div className={`loop-label-editor${className ? ` ${className}` : ""}`}>
-        {attachedLabels.length > 0 ? (
-          <button
-            type="button"
-            className="loop-label-chipbutton"
-            onClick={() => setManageOpen(true)}
-          >
-            <LabelChips labels={attachedLabels} />
-          </button>
-        ) : (
-          <button
-            type="button"
-            className="loop-label-add"
-            onClick={() => setManageOpen(true)}
-          >
-            <Tag size={13} />
-            {t("loop.label.add")}
-          </button>
-        )}
-      </div>
+      <Dropdown
+        trigger="click"
+        position="bottomRight"
+        render={menu}
+        onVisibleChange={(visible) => visible && loadAll()}
+      >
+        <div className={`loop-label-editor${className ? ` ${className}` : ""}`}>
+          {attachedLabels.length > 0 ? (
+            <button type="button" className="loop-label-chipbutton">
+              <LabelChips labels={attachedLabels} />
+            </button>
+          ) : (
+            <button type="button" className="loop-label-add">
+              <Tag size={13} />
+              {t("loop.label.add")}
+            </button>
+          )}
+        </div>
+      </Dropdown>
       <LabelManagementModal
         visible={manageOpen}
         onClose={() => setManageOpen(false)}

--- a/packages/dmloop/src/ui/LabelManagementModal.tsx
+++ b/packages/dmloop/src/ui/LabelManagementModal.tsx
@@ -1,0 +1,226 @@
+import React, { useEffect, useState } from "react";
+import { Button, Input, Modal, Popconfirm, Toast } from "@douyinfe/semi-ui";
+import { Edit3, Plus, Save, Trash2, X } from "lucide-react";
+import { useI18n } from "@octo/base";
+import type { IssueLabel } from "../api/types";
+import {
+  createLabel,
+  deleteLabel,
+  listLabels,
+  updateLabel,
+} from "../api/labelApi";
+import LabelChips from "./LabelChips";
+import LabelColorPicker from "./LabelColorPicker";
+import { DEFAULT_LABEL_COLOR, normalizeLabelColor } from "./labelPalette";
+
+export default function LabelManagementModal({
+  visible,
+  onClose,
+  onChanged,
+}: {
+  visible: boolean;
+  onClose: () => void;
+  onChanged?: (labels: IssueLabel[]) => void;
+}) {
+  const { t } = useI18n();
+  const [labels, setLabels] = useState<IssueLabel[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [name, setName] = useState("");
+  const [color, setColor] = useState<string>(DEFAULT_LABEL_COLOR);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editingName, setEditingName] = useState("");
+  const [editingColor, setEditingColor] = useState<string>(DEFAULT_LABEL_COLOR);
+
+  const reload = async () => {
+    setLoading(true);
+    try {
+      const rows = await listLabels();
+      setLabels(rows);
+      onChanged?.(rows);
+    } catch (e) {
+      Toast.error((e as Error)?.message ?? t("loop.toast.loadFailed"));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (!visible) return;
+    setName("");
+    setColor(DEFAULT_LABEL_COLOR);
+    setEditingId(null);
+    reload();
+  }, [visible]);
+
+  const create = async () => {
+    const trimmed = name.trim();
+    if (!trimmed || busy) return;
+    setBusy(true);
+    try {
+      await createLabel(trimmed, color);
+      setName("");
+      setColor(DEFAULT_LABEL_COLOR);
+      await reload();
+      Toast.success(t("loop.label.created"));
+    } catch (e) {
+      Toast.error((e as Error)?.message ?? t("loop.label.createFailed"));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const beginEdit = (label: IssueLabel) => {
+    setEditingId(label.id);
+    setEditingName(label.name);
+    setEditingColor(normalizeLabelColor(label.color));
+  };
+
+  const saveEdit = async () => {
+    if (!editingId || !editingName.trim() || busy) return;
+    setBusy(true);
+    try {
+      await updateLabel(editingId, {
+        name: editingName.trim(),
+        color: editingColor,
+      });
+      setEditingId(null);
+      await reload();
+      Toast.success(t("loop.label.updated"));
+    } catch (e) {
+      Toast.error((e as Error)?.message ?? t("loop.label.updateFailed"));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const remove = async (label: IssueLabel) => {
+    if (busy) return;
+    setBusy(true);
+    try {
+      await deleteLabel(label.id);
+      if (editingId === label.id) setEditingId(null);
+      await reload();
+      Toast.success(t("loop.label.deleted"));
+    } catch (e) {
+      Toast.error((e as Error)?.message ?? t("loop.label.deleteFailed"));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <Modal
+      className="loop-modal"
+      title={t("loop.label.manageTitle")}
+      visible={visible}
+      onCancel={onClose}
+      footer={null}
+      width={560}
+    >
+      <div className="loop-label-mgr">
+        <div className="loop-fields__row">
+          <div className="loop-fields__label">
+            {t("loop.label.newPlaceholder")}
+          </div>
+          <div className="loop-label-mgr__create">
+            <Input
+              value={name}
+              onChange={setName}
+              placeholder={t("loop.label.newPlaceholder")}
+              onEnterPress={create}
+              disabled={busy}
+            />
+            <Button
+              theme="solid"
+              icon={<Plus size={14} />}
+              onClick={create}
+              loading={busy}
+              disabled={!name.trim()}
+            >
+              {t("loop.label.create")}
+            </Button>
+          </div>
+          <LabelColorPicker
+            value={color}
+            onChange={setColor}
+            ariaLabel={t("loop.label.color")}
+          />
+        </div>
+
+        <div className="loop-label-mgr__list" aria-busy={loading}>
+          {labels.length === 0 && !loading ? (
+            <div className="loop-label-mgr__empty">{t("loop.label.empty")}</div>
+          ) : (
+            labels.map((label) => {
+              const editing = editingId === label.id;
+              return (
+                <div key={label.id} className="loop-label-mgr__row">
+                  {editing ? (
+                    <div className="loop-label-mgr__edit">
+                      <Input
+                        value={editingName}
+                        onChange={setEditingName}
+                        onEnterPress={saveEdit}
+                        disabled={busy}
+                      />
+                      <LabelColorPicker
+                        value={editingColor}
+                        onChange={setEditingColor}
+                        ariaLabel={t("loop.label.color")}
+                      />
+                    </div>
+                  ) : (
+                    <LabelChips labels={[label]} />
+                  )}
+                  <div className="loop-label-mgr__actions">
+                    {editing ? (
+                      <>
+                        <Button
+                          size="small"
+                          icon={<Save size={13} />}
+                          onClick={saveEdit}
+                          loading={busy}
+                          disabled={!editingName.trim()}
+                          aria-label={t("loop.action.save")}
+                        />
+                        <Button
+                          size="small"
+                          type="tertiary"
+                          icon={<X size={13} />}
+                          onClick={() => setEditingId(null)}
+                          aria-label={t("loop.action.cancel")}
+                        />
+                      </>
+                    ) : (
+                      <Button
+                        size="small"
+                        type="tertiary"
+                        icon={<Edit3 size={13} />}
+                        onClick={() => beginEdit(label)}
+                        aria-label={t("loop.label.edit")}
+                      />
+                    )}
+                    <Popconfirm
+                      title={t("loop.label.deleteConfirm")}
+                      content={t("loop.label.deleteConfirmDesc")}
+                      onConfirm={() => remove(label)}
+                    >
+                      <Button
+                        size="small"
+                        type="danger"
+                        theme="borderless"
+                        icon={<Trash2 size={13} />}
+                        aria-label={t("loop.label.delete")}
+                      />
+                    </Popconfirm>
+                  </div>
+                </div>
+              );
+            })
+          )}
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/packages/dmloop/src/ui/LabelManagementModal.tsx
+++ b/packages/dmloop/src/ui/LabelManagementModal.tsx
@@ -1,11 +1,13 @@
 import React, { useEffect, useState } from "react";
 import { Button, Input, Modal, Popconfirm, Toast } from "@douyinfe/semi-ui";
-import { Edit3, Plus, Save, Trash2, X } from "lucide-react";
+import { Check, Edit3, Plus, Save, Trash2, X } from "lucide-react";
 import { useI18n } from "@octo/base";
 import type { IssueLabel } from "../api/types";
 import {
   createLabel,
   deleteLabel,
+  attachLabel,
+  detachLabel,
   listLabels,
   updateLabel,
 } from "../api/labelApi";
@@ -17,10 +19,14 @@ export default function LabelManagementModal({
   visible,
   onClose,
   onChanged,
+  issueId,
+  attachedLabelIds,
 }: {
   visible: boolean;
   onClose: () => void;
   onChanged?: (labels: IssueLabel[]) => void;
+  issueId?: string;
+  attachedLabelIds?: string[];
 }) {
   const { t } = useI18n();
   const [labels, setLabels] = useState<IssueLabel[]>([]);
@@ -31,6 +37,8 @@ export default function LabelManagementModal({
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editingName, setEditingName] = useState("");
   const [editingColor, setEditingColor] = useState<string>(DEFAULT_LABEL_COLOR);
+  const [localAttachedIds, setLocalAttachedIds] = useState<string[]>([]);
+  const attached = new Set(localAttachedIds);
 
   const reload = async () => {
     setLoading(true);
@@ -50,8 +58,13 @@ export default function LabelManagementModal({
     setName("");
     setColor(DEFAULT_LABEL_COLOR);
     setEditingId(null);
+    setLocalAttachedIds(attachedLabelIds ?? []);
     reload();
   }, [visible]);
+
+  useEffect(() => {
+    if (visible) setLocalAttachedIds(attachedLabelIds ?? []);
+  }, [attachedLabelIds, visible]);
 
   const create = async () => {
     const trimmed = name.trim();
@@ -104,6 +117,25 @@ export default function LabelManagementModal({
       Toast.success(t("loop.label.deleted"));
     } catch (e) {
       Toast.error((e as Error)?.message ?? t("loop.label.deleteFailed"));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const toggleIssueLabel = async (label: IssueLabel) => {
+    if (!issueId || busy) return;
+    setBusy(true);
+    try {
+      if (attached.has(label.id)) {
+        await detachLabel(issueId, label.id);
+        setLocalAttachedIds((ids) => ids.filter((id) => id !== label.id));
+      } else {
+        await attachLabel(issueId, label.id);
+        setLocalAttachedIds((ids) => [...ids, label.id]);
+      }
+      onChanged?.(labels);
+    } catch (e) {
+      Toast.error((e as Error)?.message ?? t("loop.toast.saveFailed"));
     } finally {
       setBusy(false);
     }
@@ -171,7 +203,16 @@ export default function LabelManagementModal({
                       />
                     </div>
                   ) : (
-                    <LabelChips labels={[label]} />
+                    <button
+                      type="button"
+                      className={`loop-label-mgr__pick${
+                        attached.has(label.id) ? " is-active" : ""
+                      }`}
+                      onClick={() => toggleIssueLabel(label)}
+                    >
+                      <LabelChips labels={[label]} />
+                      {attached.has(label.id) && <Check size={14} />}
+                    </button>
                   )}
                   <div className="loop-label-mgr__actions">
                     {editing ? (

--- a/packages/dmloop/src/ui/LabelManagementModal.tsx
+++ b/packages/dmloop/src/ui/LabelManagementModal.tsx
@@ -40,12 +40,12 @@ export default function LabelManagementModal({
   const [localAttachedIds, setLocalAttachedIds] = useState<string[]>([]);
   const attached = new Set(localAttachedIds);
 
-  const reload = async () => {
+  const reload = async (notify = false) => {
     setLoading(true);
     try {
       const rows = await listLabels();
       setLabels(rows);
-      onChanged?.(rows);
+      if (notify) onChanged?.(rows);
     } catch (e) {
       Toast.error((e as Error)?.message ?? t("loop.toast.loadFailed"));
     } finally {
@@ -74,7 +74,7 @@ export default function LabelManagementModal({
       await createLabel(trimmed, color);
       setName("");
       setColor(DEFAULT_LABEL_COLOR);
-      await reload();
+      await reload(true);
       Toast.success(t("loop.label.created"));
     } catch (e) {
       Toast.error((e as Error)?.message ?? t("loop.label.createFailed"));
@@ -98,7 +98,7 @@ export default function LabelManagementModal({
         color: editingColor,
       });
       setEditingId(null);
-      await reload();
+      await reload(true);
       Toast.success(t("loop.label.updated"));
     } catch (e) {
       Toast.error((e as Error)?.message ?? t("loop.label.updateFailed"));
@@ -113,7 +113,7 @@ export default function LabelManagementModal({
     try {
       await deleteLabel(label.id);
       if (editingId === label.id) setEditingId(null);
-      await reload();
+      await reload(true);
       Toast.success(t("loop.label.deleted"));
     } catch (e) {
       Toast.error((e as Error)?.message ?? t("loop.label.deleteFailed"));

--- a/packages/dmloop/src/ui/__tests__/labelPalette.test.ts
+++ b/packages/dmloop/src/ui/__tests__/labelPalette.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_LABEL_COLOR,
+  LABEL_PALETTE,
+  normalizeLabelColor,
+} from "../labelPalette";
+
+describe("labelPalette", () => {
+  it("provides muted backend-safe hex colors", () => {
+    expect(LABEL_PALETTE).toHaveLength(10);
+    for (const color of LABEL_PALETTE) {
+      expect(color).toMatch(/^#[0-9A-F]{6}$/);
+    }
+  });
+
+  it("normalizes invalid colors to the default palette color", () => {
+    expect(DEFAULT_LABEL_COLOR).toBe("#6B7280");
+    expect(normalizeLabelColor("#657C9A")).toBe("#657C9A");
+    expect(normalizeLabelColor("657C9A")).toBe(DEFAULT_LABEL_COLOR);
+    expect(normalizeLabelColor("red")).toBe(DEFAULT_LABEL_COLOR);
+    expect(normalizeLabelColor(null)).toBe(DEFAULT_LABEL_COLOR);
+  });
+});

--- a/packages/dmloop/src/ui/labelPalette.ts
+++ b/packages/dmloop/src/ui/labelPalette.ts
@@ -1,0 +1,22 @@
+// Low-saturation label colors for long-lived task chips.
+// Keep values as strict #RRGGBB hex because the backend validates this shape.
+export const LABEL_PALETTE = [
+  "#6B7280",
+  "#7E6F8F",
+  "#8A6F78",
+  "#8B7A5E",
+  "#6F846B",
+  "#5E8078",
+  "#657C9A",
+  "#8D7467",
+  "#77806B",
+  "#7A778A",
+] as const;
+
+export const DEFAULT_LABEL_COLOR = LABEL_PALETTE[0];
+
+export function normalizeLabelColor(color?: string | null): string {
+  return /^#[0-9a-fA-F]{6}$/.test(color ?? "")
+    ? (color as string)
+    : DEFAULT_LABEL_COLOR;
+}

--- a/packages/dmloop/src/ui/loopControls.css
+++ b/packages/dmloop/src/ui/loopControls.css
@@ -130,21 +130,27 @@
 
 /* 触发器外观：白底 + 描边 + 圆角（白底修复了 Semi 默认灰 fill 与 loop 白底控件的冲突） */
 :is(.loop-page, .loop-sd, .loop-fields, .loop-modal, .loop-apd) .semi-select,
-:is(.loop-page, .loop-sd, .loop-fields, .loop-modal, .loop-apd) .semi-input-wrapper {
+:is(.loop-page, .loop-sd, .loop-fields, .loop-modal, .loop-apd)
+  .semi-input-wrapper {
   background: var(--semi-color-bg-0, #fff);
   border-radius: 8px;
   border-color: var(--semi-color-border, #e8e9eb);
   transition: border-color 120ms ease, box-shadow 120ms ease;
 }
 
-:is(.loop-page, .loop-sd, .loop-fields, .loop-modal, .loop-apd) .semi-select:hover,
-:is(.loop-page, .loop-sd, .loop-fields, .loop-modal, .loop-apd) .semi-input-wrapper:hover {
+:is(.loop-page, .loop-sd, .loop-fields, .loop-modal, .loop-apd)
+  .semi-select:hover,
+:is(.loop-page, .loop-sd, .loop-fields, .loop-modal, .loop-apd)
+  .semi-input-wrapper:hover {
   border-color: var(--semi-color-text-3, #c9cdd4);
 }
 
-:is(.loop-page, .loop-sd, .loop-fields, .loop-modal, .loop-apd) .semi-select-focus,
-:is(.loop-page, .loop-sd, .loop-fields, .loop-modal, .loop-apd) .semi-select-open,
-:is(.loop-page, .loop-sd, .loop-fields, .loop-modal, .loop-apd) .semi-input-wrapper-focus {
+:is(.loop-page, .loop-sd, .loop-fields, .loop-modal, .loop-apd)
+  .semi-select-focus,
+:is(.loop-page, .loop-sd, .loop-fields, .loop-modal, .loop-apd)
+  .semi-select-open,
+:is(.loop-page, .loop-sd, .loop-fields, .loop-modal, .loop-apd)
+  .semi-input-wrapper-focus {
   border-color: var(--semi-color-primary, #6a5cff) !important;
   box-shadow: 0 0 0 3px var(--semi-color-primary-light-default, #eef2ff);
 }
@@ -156,15 +162,19 @@
 
 /* 字号 / 行高 / placeholder 统一——让 Semi 控件手感与原生 .loop-field 一致 */
 :is(.loop-page, .loop-sd, .loop-fields, .loop-modal, .loop-apd) .semi-input,
-:is(.loop-page, .loop-sd, .loop-fields, .loop-modal, .loop-apd) .semi-select-selection {
+:is(.loop-page, .loop-sd, .loop-fields, .loop-modal, .loop-apd)
+  .semi-select-selection {
   font-size: 13px;
 }
-:is(.loop-page, .loop-sd, .loop-fields, .loop-modal, .loop-apd) textarea.semi-input-textarea {
+:is(.loop-page, .loop-sd, .loop-fields, .loop-modal, .loop-apd)
+  textarea.semi-input-textarea {
   font-size: 13px;
   line-height: 1.6;
 }
-:is(.loop-page, .loop-sd, .loop-fields, .loop-modal, .loop-apd) .semi-input::placeholder,
-:is(.loop-page, .loop-sd, .loop-fields, .loop-modal, .loop-apd) textarea.semi-input-textarea::placeholder {
+:is(.loop-page, .loop-sd, .loop-fields, .loop-modal, .loop-apd)
+  .semi-input::placeholder,
+:is(.loop-page, .loop-sd, .loop-fields, .loop-modal, .loop-apd)
+  textarea.semi-input-textarea::placeholder {
   color: var(--semi-color-text-2, #a4a9b3);
 }
 
@@ -210,7 +220,8 @@
   color: var(--semi-color-text-1, #4e5969);
   font-size: 13px;
   cursor: pointer;
-  transition: background-color 120ms ease, color 120ms ease, box-shadow 120ms ease;
+  transition: background-color 120ms ease, color 120ms ease,
+    box-shadow 120ms ease;
 }
 
 .loop-seg__btn:hover {
@@ -265,14 +276,30 @@
  * 命名 --loop-tag-* 为新增 token，非 Semi 覆盖；集中在此单一来源，改一处全站生效。
  * ========================================================================== */
 :root {
-  --loop-tag-grey-bg: #F1F2F4;   --loop-tag-grey-fg: #5D626F;   --loop-tag-grey-bd: #DDDFE3;
-  --loop-tag-blue-bg: #E4EAF2;   --loop-tag-blue-fg: #3E6598;   --loop-tag-blue-bd: #CDD7E4;
-  --loop-tag-green-bg: #E1EFE9;  --loop-tag-green-fg: #337154;  --loop-tag-green-bd: #CBE2D7;
-  --loop-tag-amber-bg: #F2ECDE;  --loop-tag-amber-fg: #896D34;  --loop-tag-amber-bd: #E7DDC5;
-  --loop-tag-orange-bg: #F4EAE1; --loop-tag-orange-fg: #9B653B; --loop-tag-orange-bd: #E9D8C9;
-  --loop-tag-red-bg: #F5E7E5;    --loop-tag-red-fg: #B14E43;    --loop-tag-red-bd: #ECD3D0;
-  --loop-tag-violet-bg: #ECE7F3; --loop-tag-violet-fg: #7B56B3; --loop-tag-violet-bd: #D9D1E6;
-  --loop-tag-purple-bg: #F0E7F3; --loop-tag-purple-fg: #9852AD; --loop-tag-purple-bd: #E1D1E6;
+  --loop-tag-grey-bg: #f1f2f4;
+  --loop-tag-grey-fg: #5d626f;
+  --loop-tag-grey-bd: #dddfe3;
+  --loop-tag-blue-bg: #e4eaf2;
+  --loop-tag-blue-fg: #3e6598;
+  --loop-tag-blue-bd: #cdd7e4;
+  --loop-tag-green-bg: #e1efe9;
+  --loop-tag-green-fg: #337154;
+  --loop-tag-green-bd: #cbe2d7;
+  --loop-tag-amber-bg: #f2ecde;
+  --loop-tag-amber-fg: #896d34;
+  --loop-tag-amber-bd: #e7ddc5;
+  --loop-tag-orange-bg: #f4eae1;
+  --loop-tag-orange-fg: #9b653b;
+  --loop-tag-orange-bd: #e9d8c9;
+  --loop-tag-red-bg: #f5e7e5;
+  --loop-tag-red-fg: #b14e43;
+  --loop-tag-red-bd: #ecd3d0;
+  --loop-tag-violet-bg: #ece7f3;
+  --loop-tag-violet-fg: #7b56b3;
+  --loop-tag-violet-bd: #d9d1e6;
+  --loop-tag-purple-bg: #f0e7f3;
+  --loop-tag-purple-fg: #9852ad;
+  --loop-tag-purple-bd: #e1d1e6;
 }
 
 /* 标签公共外形（语义标签 loop-tag 与用户色标签 loop-label-chip 共用，避免重复声明） */
@@ -290,27 +317,236 @@
   white-space: nowrap;
 }
 
-.loop-tag { border: 1px solid transparent; }
+.loop-tag {
+  border: 1px solid transparent;
+}
 
-.loop-tag--grey   { background: var(--loop-tag-grey-bg);   color: var(--loop-tag-grey-fg);   border-color: var(--loop-tag-grey-bd); }
-.loop-tag--blue   { background: var(--loop-tag-blue-bg);   color: var(--loop-tag-blue-fg);   border-color: var(--loop-tag-blue-bd); }
-.loop-tag--green  { background: var(--loop-tag-green-bg);  color: var(--loop-tag-green-fg);  border-color: var(--loop-tag-green-bd); }
-.loop-tag--amber  { background: var(--loop-tag-amber-bg);  color: var(--loop-tag-amber-fg);  border-color: var(--loop-tag-amber-bd); }
-.loop-tag--orange { background: var(--loop-tag-orange-bg); color: var(--loop-tag-orange-fg); border-color: var(--loop-tag-orange-bd); }
-.loop-tag--red    { background: var(--loop-tag-red-bg);    color: var(--loop-tag-red-fg);    border-color: var(--loop-tag-red-bd); }
-.loop-tag--violet { background: var(--loop-tag-violet-bg); color: var(--loop-tag-violet-fg); border-color: var(--loop-tag-violet-bd); }
-.loop-tag--purple { background: var(--loop-tag-purple-bg); color: var(--loop-tag-purple-fg); border-color: var(--loop-tag-purple-bd); }
+.loop-tag--grey {
+  background: var(--loop-tag-grey-bg);
+  color: var(--loop-tag-grey-fg);
+  border-color: var(--loop-tag-grey-bd);
+}
+.loop-tag--blue {
+  background: var(--loop-tag-blue-bg);
+  color: var(--loop-tag-blue-fg);
+  border-color: var(--loop-tag-blue-bd);
+}
+.loop-tag--green {
+  background: var(--loop-tag-green-bg);
+  color: var(--loop-tag-green-fg);
+  border-color: var(--loop-tag-green-bd);
+}
+.loop-tag--amber {
+  background: var(--loop-tag-amber-bg);
+  color: var(--loop-tag-amber-fg);
+  border-color: var(--loop-tag-amber-bd);
+}
+.loop-tag--orange {
+  background: var(--loop-tag-orange-bg);
+  color: var(--loop-tag-orange-fg);
+  border-color: var(--loop-tag-orange-bd);
+}
+.loop-tag--red {
+  background: var(--loop-tag-red-bg);
+  color: var(--loop-tag-red-fg);
+  border-color: var(--loop-tag-red-bd);
+}
+.loop-tag--violet {
+  background: var(--loop-tag-violet-bg);
+  color: var(--loop-tag-violet-fg);
+  border-color: var(--loop-tag-violet-bd);
+}
+.loop-tag--purple {
+  background: var(--loop-tag-purple-bg);
+  color: var(--loop-tag-purple-fg);
+  border-color: var(--loop-tag-purple-bd);
+}
 
 /* 任意后端色相的用户标签：把 hex 与白/黑混合拉出深度，避免 12% 透明度贴白底的塑料感。
  * --loop-chip-color 由 <LabelChips> 内联传入。每个属性先给中性灰 token 兜底：不支持
  * color-mix 的老引擎会丢弃整条 color-mix 声明、退回上一条，chip 仍成形而非裸样式。 */
 .loop-label-chip {
   background: var(--loop-tag-grey-bg);
-  background: color-mix(in oklch, var(--loop-chip-color, #8a8f99) 16%, var(--semi-color-bg-0, #fff));
+  background: color-mix(
+    in oklch,
+    var(--loop-chip-color, #8a8f99) 16%,
+    var(--semi-color-bg-0, #fff)
+  );
   border: 1px solid var(--loop-tag-grey-bd);
-  border: 1px solid color-mix(in oklch, var(--loop-chip-color, #8a8f99) 32%, var(--semi-color-bg-0, #fff));
+  border: 1px solid
+    color-mix(
+      in oklch,
+      var(--loop-chip-color, #8a8f99) 32%,
+      var(--semi-color-bg-0, #fff)
+    );
   color: var(--loop-tag-grey-fg);
   color: color-mix(in oklch, var(--loop-chip-color, #8a8f99) 74%, #14161a);
+}
+
+.loop-label-option {
+  display: inline-flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  width: 100%;
+  min-width: 160px;
+}
+
+.loop-label-option--manage {
+  justify-content: flex-start;
+  color: var(--semi-color-text-1, #4e5969);
+}
+
+.loop-label-editor {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+
+.loop-label-editor__chips {
+  display: inline-flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+}
+
+.loop-label-removable {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 6px;
+}
+
+.loop-label-removable button {
+  width: 18px;
+  height: 20px;
+  margin-left: -3px;
+  border: 1px solid
+    color-mix(
+      in oklch,
+      var(--loop-chip-color, #8a8f99) 32%,
+      var(--semi-color-bg-0, #fff)
+    );
+  border-left: none;
+  border-radius: 0 6px 6px 0;
+  background: color-mix(
+    in oklch,
+    var(--loop-chip-color, #8a8f99) 12%,
+    var(--semi-color-bg-0, #fff)
+  );
+  color: color-mix(in oklch, var(--loop-chip-color, #8a8f99) 70%, #14161a);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.loop-label-removable button:hover {
+  background: color-mix(
+    in oklch,
+    var(--loop-chip-color, #8a8f99) 22%,
+    var(--semi-color-bg-0, #fff)
+  );
+}
+
+.loop-label-add {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  height: 24px;
+  padding: 0 8px;
+  border: 1px dashed var(--semi-color-border, #e8e9eb);
+  border-radius: 6px;
+  background: transparent;
+  color: var(--semi-color-text-1, #4e5969);
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.loop-label-add:hover {
+  border-color: var(--semi-color-text-3, #c9cdd4);
+  background: var(--semi-color-fill-0, #f5f6f8);
+  color: var(--semi-color-text-0, #1c1f23);
+}
+
+.loop-label-color {
+  display: grid;
+  grid-template-columns: repeat(10, 24px);
+  gap: 6px;
+}
+
+.loop-label-color__swatch {
+  width: 24px;
+  height: 24px;
+  border: 1px solid
+    color-mix(in oklch, var(--loop-chip-color, #8a8f99) 44%, #fff);
+  border-radius: 6px;
+  background: color-mix(in oklch, var(--loop-chip-color, #8a8f99) 78%, #fff);
+  color: #fff;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.loop-label-color__swatch:hover,
+.loop-label-color__swatch.is-active {
+  box-shadow: 0 0 0 2px var(--semi-color-bg-0, #fff),
+    0 0 0 4px color-mix(in oklch, var(--loop-chip-color, #8a8f99) 42%, #fff);
+}
+
+.loop-label-mgr {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.loop-label-mgr__create {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 8px;
+}
+
+.loop-label-mgr__list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  max-height: 320px;
+  overflow: auto;
+}
+
+.loop-label-mgr__empty {
+  padding: 18px 12px;
+  border: 1px dashed var(--semi-color-border, #e8e9eb);
+  border-radius: 8px;
+  color: var(--semi-color-text-2, #8a8f99);
+  text-align: center;
+  font-size: 13px;
+}
+
+.loop-label-mgr__row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 10px;
+  min-height: 38px;
+  padding: 8px;
+  border: 1px solid var(--semi-color-border, #e8e9eb);
+  border-radius: 8px;
+}
+
+.loop-label-mgr__edit {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-width: 0;
+}
+
+.loop-label-mgr__actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
 }
 
 /* ==========================================================================
@@ -334,21 +570,38 @@
   white-space: nowrap;
   cursor: pointer;
   user-select: none;
-  transition: background-color 120ms ease, border-color 120ms ease, color 120ms ease, opacity 120ms ease;
+  transition: background-color 120ms ease, border-color 120ms ease,
+    color 120ms ease, opacity 120ms ease;
 }
 
-.loop-btn--sm { height: 28px; padding: 0 10px; font-size: 12px; gap: 4px; }
-.loop-btn--block { width: 100%; }
-.loop-btn--icon { width: 32px; padding: 0; }
-.loop-btn--icon.loop-btn--sm { width: 28px; }
+.loop-btn--sm {
+  height: 28px;
+  padding: 0 10px;
+  font-size: 12px;
+  gap: 4px;
+}
+.loop-btn--block {
+  width: 100%;
+}
+.loop-btn--icon {
+  width: 32px;
+  padding: 0;
+}
+.loop-btn--icon.loop-btn--sm {
+  width: 28px;
+}
 
 /* primary：品牌黑 + 同色系提亮/压深 */
 .loop-btn--primary {
-  background: var(--semi-color-primary, #1C1C23);
+  background: var(--semi-color-primary, #1c1c23);
   color: #fff;
 }
-.loop-btn--primary:hover:not(:disabled) { background: var(--semi-color-primary-hover, #2A2A33); }
-.loop-btn--primary:active:not(:disabled) { background: var(--semi-color-primary-active, #101014); }
+.loop-btn--primary:hover:not(:disabled) {
+  background: var(--semi-color-primary-hover, #2a2a33);
+}
+.loop-btn--primary:active:not(:disabled) {
+  background: var(--semi-color-primary-active, #101014);
+}
 
 /* secondary：白底描边（取消/次级操作） */
 .loop-btn--secondary {
@@ -360,19 +613,33 @@
   border-color: var(--semi-color-text-3, #c9cdd4);
   background: var(--semi-color-fill-0, #f7f8fa);
 }
-.loop-btn--secondary:active:not(:disabled) { background: var(--semi-color-fill-1, #f0f1f4); }
+.loop-btn--secondary:active:not(:disabled) {
+  background: var(--semi-color-fill-1, #f0f1f4);
+}
 
 /* ghost：无边框（工具栏/内联次级） */
-.loop-btn--ghost { background: transparent; color: var(--semi-color-text-1, #4e5969); }
+.loop-btn--ghost {
+  background: transparent;
+  color: var(--semi-color-text-1, #4e5969);
+}
 .loop-btn--ghost:hover:not(:disabled) {
   background: var(--semi-color-fill-0, #f5f6f8);
   color: var(--semi-color-text-0, #1c1f23);
 }
 
-.loop-btn:disabled { opacity: 0.45; cursor: not-allowed; }
+.loop-btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
 
-.loop-btn__spin { animation: loop-btn-spin 0.7s linear infinite; }
-@keyframes loop-btn-spin { to { transform: rotate(360deg); } }
+.loop-btn__spin {
+  animation: loop-btn-spin 0.7s linear infinite;
+}
+@keyframes loop-btn-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
 
 /* ==========================================================================
  * Loop 属性 pill（loop-pill）—— 对齐 multica 建单工具栏的圆角属性选择器
@@ -398,6 +665,11 @@
   background: var(--semi-color-fill-0, #f5f6f8);
   border-color: var(--semi-color-text-3, #c9cdd4);
 }
-.loop-pill__caret { color: var(--semi-color-text-2, #a4a9b3); }
-.loop-pill__opt { display: inline-flex; align-items: center; gap: 8px; }
-
+.loop-pill__caret {
+  color: var(--semi-color-text-2, #a4a9b3);
+}
+.loop-pill__opt {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}

--- a/packages/dmloop/src/ui/loopControls.css
+++ b/packages/dmloop/src/ui/loopControls.css
@@ -401,8 +401,10 @@
   display: flex;
   flex-wrap: wrap;
   align-items: center;
+  justify-content: flex-end;
   gap: 6px;
   min-width: 0;
+  max-width: 100%;
 }
 
 .loop-label-editor__chips {
@@ -416,6 +418,20 @@
   display: inline-flex;
   align-items: center;
   border-radius: 6px;
+}
+
+.loop-label-chipbutton {
+  display: inline-flex;
+  justify-content: flex-end;
+  max-width: 100%;
+  padding: 0;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+}
+
+.loop-label-chipbutton .loop-label-chips {
+  justify-content: flex-end;
 }
 
 .loop-label-removable button {
@@ -541,6 +557,23 @@
   flex-direction: column;
   gap: 8px;
   min-width: 0;
+}
+
+.loop-label-mgr__pick {
+  display: inline-flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  width: 100%;
+  min-width: 0;
+  padding: 0;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+}
+
+.loop-label-mgr__pick.is-active {
+  color: var(--semi-color-primary, #1c1c23);
 }
 
 .loop-label-mgr__actions {


### PR DESCRIPTION
## Goal

Add first-class Loop task label management across issue creation, issue detail, workspace label administration, and list filtering.

## Changes

- Add workspace label management with muted color palette support.
- Add label selection to the Loop issue creation flow.
- Add label display and management from the issue detail property area.
- Move issue label attach/detach into the label management dialog.
- Remove per-label close controls from detail chips and make existing labels clickable.
- Add multi-select label filtering to the Loop issue list.
- Stabilize issue detail property layout so long label sets do not squeeze property names.

## Verification

- `git diff --check`
- `pnpm --filter @octo/web build`

Closes #1052
