### PR TITLE
feat: improve chat image preview controls and styling

### DIFF
--- a/packages/dmworkbase/src/Messages/Image/__tests__/ImageContent.test.ts
+++ b/packages/dmworkbase/src/Messages/Image/__tests__/ImageContent.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import { describe, it, expect, vi } from 'vitest'
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import React from 'react'
 
 const mocks = vi.hoisted(() => ({
@@ -9,6 +9,7 @@ const mocks = vi.hoisted(() => ({
   toastSuccess: vi.fn(),
   toastWarning: vi.fn(),
   currentSlide: { src: 'https://cdn.example.com/photo.png' },
+  lightboxProps: undefined as any,
 }))
 
 vi.mock('wukongimjssdk', () => ({
@@ -28,7 +29,10 @@ vi.mock('wukongimjssdk', () => ({
 
 vi.mock('react', async () => await vi.importActual('react'))
 vi.mock('yet-another-react-lightbox', () => ({
-  default: () => null,
+  default: (props: any) => {
+    mocks.lightboxProps = props
+    return null
+  },
   isImageSlide: (slide: unknown) => !!slide,
   useLightboxState: () => ({ currentSlide: mocks.currentSlide }),
 }))
@@ -53,7 +57,7 @@ vi.mock('../../MessageCell', () => ({
   MessageCell: class {},
 }))
 
-import { ImageContent, ImagePreviewToolbar, getImageTransferState } from '../index'
+import { ImageContent, ImagePreviewLightbox, ImagePreviewToolbar, getImageTransferState } from '../index'
 import { MessageStatus, TaskStatus } from 'wukongimjssdk'
 
 describe('ImagePreviewToolbar', () => {
@@ -95,6 +99,35 @@ describe('ImagePreviewToolbar', () => {
       expect(onRotate).toHaveBeenCalled()
       expect(mocks.copyImageToClipboard).toHaveBeenCalledWith(mocks.currentSlide.src)
       expect(mocks.toastSuccess).toHaveBeenCalled()
+    })
+  })
+})
+
+describe('ImagePreviewLightbox', () => {
+  it('swaps image fit bounds for quarter-turn rotations', () => {
+    render(React.createElement(ImagePreviewLightbox, {
+      open: true,
+      close: vi.fn(),
+      slides: [{ src: 'https://cdn.example.com/landscape.png' }],
+    }))
+
+    expect(mocks.lightboxProps.carousel.imageProps.style).toEqual({
+      maxWidth: '100%',
+      maxHeight: '100%',
+    })
+
+    act(() => mocks.lightboxProps.render.buttonZoom({}).props.onRotate())
+
+    expect(mocks.lightboxProps.carousel.imageProps.style).toEqual({
+      maxWidth: '100cqh',
+      maxHeight: '100cqw',
+    })
+
+    act(() => mocks.lightboxProps.render.buttonZoom({}).props.onRotate())
+
+    expect(mocks.lightboxProps.carousel.imageProps.style).toEqual({
+      maxWidth: '100%',
+      maxHeight: '100%',
     })
   })
 })

--- a/packages/dmworkbase/src/Messages/Image/__tests__/ImageContent.test.ts
+++ b/packages/dmworkbase/src/Messages/Image/__tests__/ImageContent.test.ts
@@ -1,4 +1,15 @@
+// @vitest-environment jsdom
+
 import { describe, it, expect, vi } from 'vitest'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import React from 'react'
+
+const mocks = vi.hoisted(() => ({
+  copyImageToClipboard: vi.fn(),
+  toastSuccess: vi.fn(),
+  toastWarning: vi.fn(),
+  currentSlide: { src: 'https://cdn.example.com/photo.png' },
+}))
 
 vi.mock('wukongimjssdk', () => ({
   MediaMessageContent: class {
@@ -16,19 +27,77 @@ vi.mock('wukongimjssdk', () => ({
 }))
 
 vi.mock('react', async () => await vi.importActual('react'))
-vi.mock('yet-another-react-lightbox', () => ({ default: () => null }))
-vi.mock('yet-another-react-lightbox/plugins/download', () => ({ default: {} }))
+vi.mock('yet-another-react-lightbox', () => ({
+  default: () => null,
+  isImageSlide: (slide: unknown) => !!slide,
+  useLightboxState: () => ({ currentSlide: mocks.currentSlide }),
+}))
+vi.mock('yet-another-react-lightbox/plugins/zoom', () => ({ default: {} }))
 vi.mock('yet-another-react-lightbox/styles.css', () => ({}))
-vi.mock('@douyinfe/semi-ui', () => ({ Toast: { warning: vi.fn() } }))
+vi.mock('@douyinfe/semi-ui', () => ({ Toast: { success: mocks.toastSuccess, warning: mocks.toastWarning } }))
 vi.mock('../../../App', () => ({ default: {} }))
+vi.mock('../../../i18n', () => ({
+  t: (key: string) => ({
+    'base.filePreview.pdf.zoomOut': 'Zoom out',
+    'base.filePreview.pdf.actualSize': 'Actual size',
+    'base.filePreview.pdf.zoomIn': 'Zoom in',
+    'base.message.imagePreview.rotate': 'Rotate',
+    'base.module.contextMenus.copyImage': 'Copy image',
+    'base.module.contextMenus.copyImageSuccess': 'Image copied',
+  } as Record<string, string>)[key] || key,
+}))
 vi.mock('../../../Service/Const', () => ({ MessageContentTypeConst: { image: 3 } }))
+vi.mock('../../../Utils/clipboard', () => ({ copyImageToClipboard: mocks.copyImageToClipboard }))
 vi.mock('../../Base', () => ({ default: () => null }))
 vi.mock('../../MessageCell', () => ({
   MessageCell: class {},
 }))
 
-import { ImageContent, getImageTransferState } from '../index'
+import { ImageContent, ImagePreviewToolbar, getImageTransferState } from '../index'
 import { MessageStatus, TaskStatus } from 'wukongimjssdk'
+
+describe('ImagePreviewToolbar', () => {
+  it('provides the v2 preview actions and copies the visible image', async () => {
+    const zoomOut = vi.fn()
+    const zoomIn = vi.fn()
+    const changeZoom = vi.fn()
+    const onReset = vi.fn()
+    const onRotate = vi.fn()
+    mocks.copyImageToClipboard.mockResolvedValueOnce(undefined)
+    render(React.createElement(ImagePreviewToolbar, {
+      zoom: {
+        zoom: 1,
+        minZoom: 0.25,
+        maxZoom: 4,
+        offsetX: 0,
+        offsetY: 0,
+        disabled: false,
+        zoomIn,
+        zoomOut,
+        changeZoom,
+      },
+      onReset,
+      onRotate,
+    }))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Zoom out' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Actual size' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Zoom in' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Rotate' }))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy image' }))
+
+    await waitFor(() => {
+      expect(zoomOut).toHaveBeenCalled()
+      expect(zoomIn).toHaveBeenCalled()
+      expect(changeZoom).toHaveBeenCalledWith(1)
+      expect(onReset).toHaveBeenCalled()
+      expect(onRotate).toHaveBeenCalled()
+      expect(mocks.copyImageToClipboard).toHaveBeenCalledWith(mocks.currentSlide.src)
+      expect(mocks.toastSuccess).toHaveBeenCalled()
+    })
+  })
+})
 
 describe('ImageContent name field', () => {
   it('sets name from file.name in constructor', () => {

--- a/packages/dmworkbase/src/Messages/Image/index.css
+++ b/packages/dmworkbase/src/Messages/Image/index.css
@@ -1,0 +1,100 @@
+.wk-image-preview .yarl__container {
+  background-color: color-mix(in srgb, var(--wk-brand-primary) 58%, transparent);
+}
+
+.wk-image-preview .yarl__slide {
+  padding: var(--wk-sp-6) var(--wk-sp-6) 88px;
+}
+
+.wk-image-preview .yarl__slide_image {
+  rotate: var(--yarl__image_preview_rotation, 0deg);
+  transition: rotate var(--wk-dur-fast) ease;
+}
+
+.wk-image-preview .yarl__toolbar {
+  inset: 0;
+  padding: 0;
+  pointer-events: none;
+}
+
+.wk-image-preview .yarl__toolbar > * {
+  pointer-events: auto;
+}
+
+.wk-image-preview .yarl__toolbar > .yarl__button {
+  position: absolute;
+  top: var(--wk-sp-4);
+  right: var(--wk-sp-4);
+  display: flex;
+  width: 36px;
+  height: 36px;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border-radius: var(--wk-r-circle);
+  background: color-mix(in srgb, var(--wk-brand-primary) 78%, transparent);
+  color: var(--wk-color-white);
+  filter: none;
+}
+
+.wk-image-preview .yarl__toolbar > .yarl__button:hover {
+  background: var(--wk-brand-primary);
+}
+
+.wk-image-preview-toolbar {
+  position: absolute;
+  bottom: var(--wk-sp-4);
+  left: 50%;
+  display: flex;
+  height: 48px;
+  align-items: center;
+  gap: var(--wk-sp-1);
+  padding: var(--wk-sp-1) var(--wk-sp-2);
+  border-radius: var(--wk-r-md);
+  background: color-mix(in srgb, var(--wk-brand-primary) 94%, transparent);
+  box-shadow: var(--wk-shadow-lg);
+  color: var(--wk-color-white);
+  transform: translateX(-50%);
+}
+
+.wk-image-preview-toolbar button {
+  display: flex;
+  width: 36px;
+  height: 36px;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: 0;
+  border-radius: var(--wk-r-sm);
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+}
+
+.wk-image-preview-toolbar button:hover {
+  background: color-mix(in srgb, var(--wk-color-white) 15%, transparent);
+}
+
+.wk-image-preview-toolbar button:focus-visible {
+  outline: 2px solid var(--wk-color-white);
+  outline-offset: -2px;
+}
+
+.wk-image-preview-toolbar button:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+
+.wk-image-preview-toolbar .wk-image-preview-toolbar-reset {
+  width: auto;
+  min-width: 40px;
+  padding: 0 var(--wk-sp-2);
+  font: var(--wk-text-body-medium);
+}
+
+.wk-image-preview-toolbar-divider {
+  width: 1px;
+  height: 28px;
+  margin: 0 var(--wk-sp-1);
+  background: color-mix(in srgb, var(--wk-color-white) 25%, transparent);
+}

--- a/packages/dmworkbase/src/Messages/Image/index.css
+++ b/packages/dmworkbase/src/Messages/Image/index.css
@@ -3,6 +3,7 @@
 }
 
 .wk-image-preview .yarl__slide {
+  container-type: size;
   padding: var(--wk-sp-6) var(--wk-sp-6) 88px;
 }
 

--- a/packages/dmworkbase/src/Messages/Image/index.tsx
+++ b/packages/dmworkbase/src/Messages/Image/index.tsx
@@ -4,11 +4,14 @@ import WKApp from "../../App"
 import { MessageContentTypeConst } from "../../Service/Const"
 import MessageBase from "../Base"
 import { MessageCell } from "../MessageCell"
-import Lightbox from "yet-another-react-lightbox"
-import Download from "yet-another-react-lightbox/plugins/download"
+import Lightbox, { isImageSlide, useLightboxState } from "yet-another-react-lightbox"
+import type { Slide, ZoomRef } from "yet-another-react-lightbox"
+import Zoom from "yet-another-react-lightbox/plugins/zoom"
 import "yet-another-react-lightbox/styles.css"
+import { Copy, Download, RotateCw, X, ZoomIn, ZoomOut } from "lucide-react"
 import { Toast } from "@douyinfe/semi-ui"
 import { downloadFile } from "../../Utils/download"
+import { copyImageToClipboard } from "../../Utils/clipboard"
 import MessageRow from "../../ui/message/MessageRow"
 import SingleImage from "../../ui/message/ImageContent/SingleImage"
 import MultiImage from "../../ui/message/ImageContent/MultiImage"
@@ -16,8 +19,156 @@ import type { ImageTransferState } from "../../ui/message/ImageContent/SingleIma
 import { getImageMessageUI } from "../../bridge/message/useImageMessageUI"
 import { isMessageSelectable } from "../../Service/messageSelection"
 import { t } from "../../i18n"
+import "./index.css"
 
 const SMALL_FILE_THRESHOLD = 1024 * 1024 // 1MB 以下不显示进度覆盖层
+
+interface ImagePreviewToolbarProps {
+    zoom: ZoomRef
+    filename?: string
+    onReset: () => void
+    onRotate: () => void
+}
+
+export function ImagePreviewToolbar({ zoom, filename, onReset, onRotate }: ImagePreviewToolbarProps) {
+    const { currentSlide } = useLightboxState()
+    const [copying, setCopying] = React.useState(false)
+    const src = currentSlide && isImageSlide(currentSlide) ? currentSlide.src : ""
+
+    const handleCopy = async () => {
+        if (!src) return
+        setCopying(true)
+        try {
+            await copyImageToClipboard(src)
+            Toast.success(t("base.module.contextMenus.copyImageSuccess"))
+        } catch (error) {
+            Toast.warning(error instanceof Error ? error.message : t("base.module.contextMenus.copyFailed"))
+        } finally {
+            setCopying(false)
+        }
+    }
+
+    return (
+        <div className="wk-image-preview-toolbar">
+            <button
+                type="button"
+                aria-label={t("base.filePreview.pdf.zoomOut")}
+                title={t("base.filePreview.pdf.zoomOut")}
+                disabled={zoom.disabled || zoom.zoom <= zoom.minZoom}
+                onClick={zoom.zoomOut}
+            >
+                <ZoomOut size={19} />
+            </button>
+            <button
+                type="button"
+                className="wk-image-preview-toolbar-reset"
+                aria-label={t("base.filePreview.pdf.actualSize")}
+                title={t("base.filePreview.pdf.actualSize")}
+                onClick={() => {
+                    zoom.changeZoom(1)
+                    onReset()
+                }}
+            >
+                1:1
+            </button>
+            <button
+                type="button"
+                aria-label={t("base.filePreview.pdf.zoomIn")}
+                title={t("base.filePreview.pdf.zoomIn")}
+                disabled={zoom.disabled || zoom.zoom >= zoom.maxZoom}
+                onClick={zoom.zoomIn}
+            >
+                <ZoomIn size={19} />
+            </button>
+            <span className="wk-image-preview-toolbar-divider" />
+            <button
+                type="button"
+                aria-label={t("base.message.imagePreview.rotate")}
+                title={t("base.message.imagePreview.rotate")}
+                onClick={() => {
+                    zoom.changeZoom(1)
+                    onRotate()
+                }}
+            >
+                <RotateCw size={19} />
+            </button>
+            <span className="wk-image-preview-toolbar-divider" />
+            <button
+                type="button"
+                aria-label={t("base.module.contextMenus.copyImage")}
+                title={t("base.module.contextMenus.copyImage")}
+                disabled={!src || copying}
+                onClick={handleCopy}
+            >
+                <Copy size={19} />
+            </button>
+            <span className="wk-image-preview-toolbar-divider" />
+            <button
+                type="button"
+                aria-label={t("base.filePreview.download")}
+                title={t("base.filePreview.download")}
+                disabled={!src}
+                onClick={() => src && downloadFile(src, filename || "image.png")}
+            >
+                <Download size={19} />
+            </button>
+        </div>
+    )
+}
+
+interface ImagePreviewLightboxProps {
+    open: boolean
+    close: () => void
+    slides: readonly Slide[]
+    index?: number
+    filename?: string
+    isMulti?: boolean
+}
+
+function ImagePreviewLightbox({ open, close, slides, index, filename, isMulti }: ImagePreviewLightboxProps) {
+    const [rotation, setRotation] = React.useState(0)
+    const resetRotation = () => setRotation(0)
+
+    return (
+        <Lightbox
+            className="wk-image-preview"
+            open={open}
+            close={() => {
+                resetRotation()
+                close()
+            }}
+            slides={slides}
+            index={index}
+            plugins={[Zoom]}
+            labels={{
+                Close: t("base.common.close"),
+                "Zoom in": t("base.filePreview.pdf.zoomIn"),
+                "Zoom out": t("base.filePreview.pdf.zoomOut"),
+            }}
+            toolbar={{ buttons: ["zoom", "close"] }}
+            zoom={{ minZoom: 0.25, maxZoomPixelRatio: 4, zoomInMultiplier: 1.25, scrollToZoom: true }}
+            carousel={{ finite: true }}
+            controller={{ closeOnBackdropClick: true }}
+            on={{ entering: resetRotation, view: resetRotation }}
+            styles={{
+                root: { "--yarl__image_preview_rotation": `${rotation}deg` },
+            }}
+            render={{
+                buttonPrev: isMulti ? undefined : () => null,
+                buttonNext: isMulti ? undefined : () => null,
+                buttonZoom: (zoom) => (
+                    <ImagePreviewToolbar
+                        zoom={zoom}
+                        filename={filename}
+                        onReset={resetRotation}
+                        onRotate={() => setRotation(value => (value + 90) % 360)}
+                    />
+                ),
+                iconClose: () => <X size={22} />,
+            }}
+        />
+    )
+}
 
 
 export class ImageContent extends MediaMessageContent {
@@ -73,6 +224,7 @@ export class ImageContent extends MediaMessageContent {
 
 interface ImageCellState {
     showPreview: boolean
+    previewIndex: number
     uploadProgress: number
     uploadStatus: TaskStatus | null
 }
@@ -147,6 +299,7 @@ export class ImageCell extends MessageCell<any, ImageCellState> {
         super(props)
         this.state = {
             showPreview: false,
+            previewIndex: 0,
             uploadProgress: 0,
             uploadStatus: null,
         }
@@ -217,14 +370,16 @@ export class ImageCell extends MessageCell<any, ImageCellState> {
 
     render() {
         const { message, context } = this.props
-        const { showPreview, uploadProgress, uploadStatus } = this.state
+        const { showPreview, previewIndex, uploadProgress, uploadStatus } = this.state
         const content = message.content as ImageContent
 
         // 新 UI 实现
         const useNewUI = true
         if (useNewUI) {
             const uiProps = getImageMessageUI(message)
-            const hasRemoteUrl = !!(content.url || (content as any).remoteUrl)
+            const hasRemoteUrl = uiProps.isMulti
+                ? uiProps.images.some(image => !!image.src)
+                : !!(content.url || (content as any).remoteUrl)
             const fileSize = (content as any).file?.size ?? 0
             const transferState = getImageTransferState({
                 hasLocalFile: !!(content as any).file,
@@ -258,7 +413,9 @@ export class ImageCell extends MessageCell<any, ImageCellState> {
                                 images={uiProps.images}
                                 transferState={transferState}
                                 onImageClick={canOpenPreview ? (index) => {
-                                    // TODO: 多图预览
+                                    if (uiProps.images[index]?.src) {
+                                        this.setState({ showPreview: true, previewIndex: index })
+                                    }
                                 } : undefined}
                               />
                             : uiProps.singleImage
@@ -270,25 +427,16 @@ export class ImageCell extends MessageCell<any, ImageCellState> {
                                 : null
                         }
                     </MessageRow>
-                    <Lightbox
+                    <ImagePreviewLightbox
                         open={showPreview}
                         close={() => this.setState({ showPreview: false })}
+                        index={previewIndex}
                         slides={uiProps.isMulti
                             ? uiProps.images.map(img => ({ src: img.src, alt: '' }))
                             : [{ src: uiProps.singleImage?.src || '', alt: '' }]
                         }
-                        plugins={[Download]}
-                        download={{ download: ({ slide }) => {
-                            if (slide?.src) {
-                                downloadFile(slide.src, content.name || 'image.png')
-                            }
-                        }}}
-                        carousel={{ finite: true }}
-                        controller={{ closeOnBackdropClick: true }}
-                        render={{
-                            buttonPrev: uiProps.isMulti ? undefined : () => null,
-                            buttonNext: uiProps.isMulti ? undefined : () => null,
-                        }}
+                        filename={content.name}
+                        isMulti={uiProps.isMulti}
                     />
                 </>
             )
@@ -358,22 +506,11 @@ export class ImageCell extends MessageCell<any, ImageCellState> {
                     </div>
                 )}
             </div>
-            <Lightbox
+            <ImagePreviewLightbox
                 open={showPreview}
                 close={() => this.setState({ showPreview: false })}
                 slides={[{ src: imageURL, alt: '' }]}
-                plugins={[Download]}
-                download={{ download: ({ slide }) => {
-                    if (slide?.src) {
-                        downloadFile(slide.src, content.name || 'image.png')
-                    }
-                }}}
-                carousel={{ finite: true }}
-                controller={{ closeOnBackdropClick: true }}
-                render={{
-                    buttonPrev: () => null,
-                    buttonNext: () => null,
-                }}
+                filename={content.name}
             />
         </MessageBase>
     }

--- a/packages/dmworkbase/src/Messages/Image/index.tsx
+++ b/packages/dmworkbase/src/Messages/Image/index.tsx
@@ -125,7 +125,7 @@ interface ImagePreviewLightboxProps {
     isMulti?: boolean
 }
 
-function ImagePreviewLightbox({ open, close, slides, index, filename, isMulti }: ImagePreviewLightboxProps) {
+export function ImagePreviewLightbox({ open, close, slides, index, filename, isMulti }: ImagePreviewLightboxProps) {
     const [rotation, setRotation] = React.useState(0)
     const resetRotation = () => setRotation(0)
 
@@ -147,7 +147,15 @@ function ImagePreviewLightbox({ open, close, slides, index, filename, isMulti }:
             }}
             toolbar={{ buttons: ["zoom", "close"] }}
             zoom={{ minZoom: 0.25, maxZoomPixelRatio: 4, zoomInMultiplier: 1.25, scrollToZoom: true }}
-            carousel={{ finite: true }}
+            carousel={{
+                finite: true,
+                imageProps: {
+                    style: {
+                        maxWidth: rotation % 180 ? "100cqh" : "100%",
+                        maxHeight: rotation % 180 ? "100cqw" : "100%",
+                    },
+                },
+            }}
             controller={{ closeOnBackdropClick: true }}
             on={{ entering: resetRotation, view: resetRotation }}
             styles={{

--- a/packages/dmworkbase/src/i18n/locales/en-US.json
+++ b/packages/dmworkbase/src/i18n/locales/en-US.json
@@ -978,6 +978,7 @@
   "message.interactiveCard.inputTooLarge": "Submission is too large",
   "message.interactiveCard.copySuccess": "Copied",
   "message.interactiveCard.copyFailed": "Copy failed",
+  "message.imagePreview.rotate": "Rotate",
   "message.interactiveCard.copyTable": "Copy",
   "message.interactiveCard.denyDialog.title": "Deny document access request",
   "message.interactiveCard.denyDialog.descWithContext": "Once denied, {{actor}} will not get view access to \"{{title}}\".",

--- a/packages/dmworkbase/src/i18n/locales/zh-CN.json
+++ b/packages/dmworkbase/src/i18n/locales/zh-CN.json
@@ -978,6 +978,7 @@
   "message.interactiveCard.inputTooLarge": "提交内容过大",
   "message.interactiveCard.copySuccess": "已复制",
   "message.interactiveCard.copyFailed": "复制失败",
+  "message.imagePreview.rotate": "旋转",
   "message.interactiveCard.copyTable": "复制",
   "message.interactiveCard.denyDialog.title": "拒绝文档访问申请",
   "message.interactiveCard.denyDialog.descWithContext": "拒绝后，{{actor}} 将无法获得“{{title}}”的查看权限。",


### PR DESCRIPTION
## Summary

- replace the opaque black image preview background with a translucent backdrop that keeps the conversation visible
- move image actions to a bottom-centered toolbar with zoom out, 1:1 reset, zoom in, rotate, copy, and download controls
- preserve wheel zoom, drag, keyboard close, backdrop close, and multi-image navigation while opening the selected image correctly
- add localized rotate labels and focused toolbar interaction coverage

## Testing

- `pnpm --dir packages/dmworkbase exec vitest run src/Messages/Image/__tests__/ImageContent.test.ts`
- `pnpm i18n:check`
- `pnpm exec stylelint packages/dmworkbase/src/Messages/Image/index.css`
- `VITE_API_URL=http://127.0.0.1 pnpm --dir apps/web build`
- `git diff --check`

Closes #1055