### PR TITLE
fix(docs): complete SVG upload compatibility

### DIFF
--- a/packages/docs/src/attachments/api.test.ts
+++ b/packages/docs/src/attachments/api.test.ts
@@ -101,9 +101,9 @@ describe('attachment API — bare-relative docs paths (frontend-design §3.5)', 
 })
 
 describe('uploadImage — end-to-end flow yields attachId + signed src, never base64', () => {
-  it('sends SVG bytes to the dedicated validated endpoint (including empty browser MIME)', async () => {
+  it.each(['', 'image/svg'])('sends SVG bytes to the validated endpoint for browser MIME %j', async (type) => {
     api.responder = () => ({ data: { attachId: 'att_svg', url: 'https://assets.octo.example.com/x.svg' }, status: 200 })
-    const file = new File(['<svg/>'], 'diagram.svg', { type: '' })
+    const file = new File(['<svg/>'], 'diagram.svg', { type })
     const result = await uploadImage('d_1', file)
 
     expect(result).toEqual({ attachId: 'att_svg', src: 'https://assets.octo.example.com/x.svg' })
@@ -117,6 +117,7 @@ describe('uploadImage — end-to-end flow yields attachId + signed src, never ba
       'Content-Type': 'image/svg+xml',
       'X-File-Name': 'diagram.svg',
     })
+    api.calls.length = 0
   })
 
   it('does not route a non-SVG MIME to the SVG endpoint merely because the name ends in .svg', async () => {

--- a/packages/docs/src/attachments/api.ts
+++ b/packages/docs/src/attachments/api.ts
@@ -150,7 +150,8 @@ export async function uploadImage(docId: string, file: File): Promise<UploadedIm
   const declaredType = file.type.trim().toLowerCase()
   // Some platforms leave SVG's File.type empty; use the extension only in that
   // case. Never let a misleading .svg name override a non-SVG declared MIME.
-  const isSvg = declaredType === 'image/svg+xml' || (!declaredType && /\.svg$/i.test(file.name))
+  const isSvg = declaredType === 'image/svg+xml' || declaredType === 'image/svg'
+    || (!declaredType && /\.svg$/i.test(file.name))
   if (isSvg) {
     const { data } = await apiClient().post<{
       attachId: string

--- a/packages/docs/src/editor/imageUpload.test.ts
+++ b/packages/docs/src/editor/imageUpload.test.ts
@@ -6,11 +6,13 @@ describe('SVG image upload input', () => {
     const file = new File(['<svg/>'], 'diagram.svg', { type: 'image/svg+xml' })
     expect(imageMime(file)).toBe('image/svg+xml')
     expect(isUploadableImage(file)).toBe(true)
+    expect(IMAGE_FILE_ACCEPT.split(',')).toContain('image/svg')
     expect(IMAGE_FILE_ACCEPT.split(',')).toContain('image/svg+xml')
     expect(IMAGE_FILE_ACCEPT.split(',')).toContain('.svg')
   })
 
-  it('recognizes an SVG extension only when the browser leaves File.type empty', () => {
+  it('normalizes the legacy SVG MIME and uses the extension only for an empty MIME', () => {
+    expect(imageMime(new File(['<svg/>'], 'diagram.svg', { type: 'image/svg' }))).toBe('image/svg+xml')
     expect(imageMime(new File(['<svg/>'], 'diagram.SVG', { type: '' }))).toBe('image/svg+xml')
     expect(imageMime(new File(['x'], 'misleading.svg', { type: 'text/plain' }))).toBe('text/plain')
   })

--- a/packages/docs/src/editor/imageUpload.ts
+++ b/packages/docs/src/editor/imageUpload.ts
@@ -15,10 +15,11 @@ import { uploadImage, AttachmentRejectedError } from '../attachments/api.ts'
 /** Client-side guard before bothering the backend; the backend stays the final
  * authority and may still reject with a 400 (handled in uploadAndInsertImage). */
 export const MAX_IMAGE_BYTES = 10 * 1024 * 1024 // 10 MB
-export const IMAGE_FILE_ACCEPT = 'image/png,image/jpeg,image/gif,image/webp,image/bmp,image/svg+xml,.svg'
+export const IMAGE_FILE_ACCEPT = 'image/png,image/jpeg,image/gif,image/webp,image/bmp,image/svg,image/svg+xml,.svg'
 
 export function imageMime(file: File): string {
   const type = file.type.trim().toLowerCase()
+  if (type === 'image/svg') return 'image/svg+xml'
   if (type) return type
   return /\.svg$/i.test(file.name) ? 'image/svg+xml' : ''
 }

--- a/packages/docs/src/sheet/CollabSheet.ts
+++ b/packages/docs/src/sheet/CollabSheet.ts
@@ -16,7 +16,7 @@ import * as Y from 'yjs'
 import { HocuspocusProvider } from '@hocuspocus/provider'
 import { IndexeddbPersistence } from 'y-indexeddb'
 import { LocaleType, mergeLocales, ICommandService, CommandType, IContextService, FOCUSING_COMMON_DRAWINGS, IImageIoService } from '@univerjs/core'
-import { IMenuManagerService, RibbonInsertGroup, MenuItemType, IFontService } from '@univerjs/ui'
+import { IMenuManagerService, RibbonInsertGroup, MenuItemType, IFontService, ILocalFileService } from '@univerjs/ui'
 import { createUniver } from './createUniver.ts'
 import { sanitizeLinkHref } from '../editor/sanitize.ts'
 import { MathFormula, OCTO_MATH_FORMULA_KEY } from './floatDom/MathFormula.tsx'
@@ -51,6 +51,7 @@ import sheetsDrawingZhCN from '@univerjs/preset-sheets-drawing/locales/zh-CN'
 import '@univerjs/preset-sheets-drawing/lib/index.css'
 import { enableSheetSvgImages } from './sheetImageTypes.ts'
 import { SanitizedSheetImageIoService } from './sheetImageIoService.ts'
+import { SheetLocalFileService } from './sheetLocalFileService.ts'
 // Hyperlink (insert link) preset — OSS, same pattern as drawing. Hyperlinks live in the
 // SHEET_HYPER_LINK_PLUGIN resource (not cell data), so persistence/replication rides a dedicated
 // Yjs sync in binding.ts (fed the HyperLinkModel resolved from the injector below).
@@ -264,7 +265,10 @@ export class CollabSheet {
       // Override Univer's base64 image service only for this sheet instance. Raster images retain
       // the existing local path; SVG is uploaded, backend-sanitized, then downloaded from the
       // returned trusted attachment URL before it can enter shared Yjs state.
-      override: [[IImageIoService, { useValue: new SanitizedSheetImageIoService(opts.docId) }]],
+      override: [
+        [IImageIoService, { useValue: new SanitizedSheetImageIoService(opts.docId) }],
+        [ILocalFileService, { useClass: SheetLocalFileService }],
+      ],
       presets: [
         UniverSheetsCorePreset({
           container: opts.container,

--- a/packages/docs/src/sheet/sheetLocalFileService.test.ts
+++ b/packages/docs/src/sheet/sheetLocalFileService.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import { withSvgImageAccept } from './sheetLocalFileService.ts'
+
+describe('sheet image picker SVG support', () => {
+  it('adds the real .svg extension to Univer image picker options', () => {
+    expect(withSvgImageAccept({
+      multiple: true,
+      accept: '.png,.jpeg,.jpg,.gif,.bmp',
+    })).toEqual({
+      multiple: true,
+      accept: '.png,.jpeg,.jpg,.gif,.bmp,.svg',
+    })
+  })
+
+  it('does not change unrelated file pickers', () => {
+    expect(withSvgImageAccept({ accept: '.xlsx,.xls' })).toEqual({ accept: '.xlsx,.xls' })
+  })
+
+  it('does not duplicate an existing SVG extension', () => {
+    expect(withSvgImageAccept({ accept: '.png,.svg' })).toEqual({ accept: '.png,.svg' })
+  })
+})

--- a/packages/docs/src/sheet/sheetLocalFileService.ts
+++ b/packages/docs/src/sheet/sheetLocalFileService.ts
@@ -1,0 +1,24 @@
+import { DesktopLocalFileService, type IOpenFileOptions } from '@univerjs/ui'
+
+const RASTER_IMAGE_ACCEPT_RE = /(?:^|,)\s*\.(?:png|jpe?g|gif|bmp)(?:,|$)/i
+
+/**
+ * Univer's sheet drawing picker derives its accept list from a package-local
+ * allow-list. pnpm may install that package more than once, so mutating the
+ * app's imported copy does not reliably reach the picker. Intercept the actual
+ * file-open service instead and add the real SVG extension to image pickers.
+ */
+export class SheetLocalFileService extends DesktopLocalFileService {
+  override openFile(options?: IOpenFileOptions): Promise<File[]> {
+    return super.openFile(withSvgImageAccept(options))
+  }
+}
+
+export function withSvgImageAccept(options?: IOpenFileOptions): IOpenFileOptions | undefined {
+  const accept = options?.accept
+  if (!accept || !RASTER_IMAGE_ACCEPT_RE.test(accept)) return options
+
+  const values = accept.split(',').map((value) => value.trim()).filter(Boolean)
+  if (!values.some((value) => value.toLowerCase() === '.svg')) values.push('.svg')
+  return { ...options, accept: values.join(',') }
+}


### PR DESCRIPTION
## Summary
- normalize the legacy `image/svg` browser MIME to `image/svg+xml`
- route both SVG MIME variants through the dedicated sanitized upload endpoint
- fix Univer sheet image pickers by overriding the actual local-file service instead of relying only on a package-local mutable allow-list
- retain backend sanitation for sheet SVG images before they enter collaborative state

## Linked Spec
Fixes #1061

## How verified
- `pnpm --filter @octo/docs exec vitest run src/editor/imageUpload.test.ts src/attachments/api.test.ts src/sheet/sheetImageTypes.test.ts src/sheet/sheetImageIoService.test.ts src/sheet/sheetLocalFileService.test.ts`
- 5 test files passed, 24 tests passed
- targeted TypeScript check reports no errors in changed files

## Root cause
pnpm can install multiple `@univerjs/drawing` instances. Mutating the allow-list imported by the app did not necessarily mutate the instance used by Univer's sheet picker. The local-file override modifies the real picker options at the service boundary.

The existing backend sanitizer and security boundary remain unchanged.