### PR TITLE
feat(docs): unify document import and export

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,14 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: I18n check
         run: pnpm i18n:check
+      - name: Unified import/export unit tests
+        run: >-
+          pnpm --filter @octo/docs exec vitest run
+          src/editor/EditorShell.test.tsx
+          src/editor/fontFamilies.verify.test.ts
+          src/editor/importFlow.markdown.test.ts
+          src/pages/docsApi.export.test.ts
+          src/pages/docsApi.import.test.ts
       - name: Build
         run: pnpm build
       - name: Lint

--- a/packages/docs/src/editor/EditorShell.test.tsx
+++ b/packages/docs/src/editor/EditorShell.test.tsx
@@ -15,10 +15,25 @@ const fakeEditor = {
   getJSON: () => ({ type: 'doc', content: [] }),
   storage: { octoCommentHighlight: {} as { onActivate?: ((id: number) => void) | null } },
 }
+const fakeProvider = {
+  hasUnsyncedChanges: false,
+  listeners: new Map<string, Set<(...args: unknown[]) => void>>(),
+  on(event: string, fn: (...args: unknown[]) => void) {
+    const listeners = this.listeners.get(event) ?? new Set()
+    listeners.add(fn)
+    this.listeners.set(event, listeners)
+  },
+  off(event: string, fn: (...args: unknown[]) => void) {
+    this.listeners.get(event)?.delete(fn)
+  },
+  emit(event: string, ...args: unknown[]) {
+    for (const fn of this.listeners.get(event) ?? []) fn(...args)
+  },
+}
 
 vi.mock('../collab/useCollabEditor.ts', () => ({
   useCollabEditor: () => ({
-    instance: { editor: fakeEditor, provider: {} },
+    instance: { editor: fakeEditor, provider: fakeProvider },
     ready: true,
     role: 'admin',
     connState: 'connected',
@@ -26,11 +41,12 @@ vi.mock('../collab/useCollabEditor.ts', () => ({
   }),
 }))
 
-// Capture the markdown the handler serializes; the body content is irrelevant here.
-const exportSpy = vi.fn(async (..._args: unknown[]) => '# exported\n')
-vi.mock('../export/markdown.ts', () => ({
-  exportDocToMarkdown: (...args: unknown[]) => exportSpy(...args),
-}))
+// Capture calls to the single authoritative backend export endpoint.
+const exportSpy = vi.fn(async (..._args: unknown[]) => new ArrayBuffer(8))
+vi.mock('../pages/docsApi.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../pages/docsApi.ts')>()
+  return { ...actual, exportDocFile: (...args: unknown[]) => exportSpy(...args) }
+})
 
 // Stub the presentational children that take the live editor/provider — they are not under test.
 vi.mock('@tiptap/react', () => ({ EditorContent: () => null }))
@@ -79,6 +95,8 @@ beforeEach(() => {
   useMemberNamesMock.mockReset()
   useMemberNamesMock.mockReturnValue(new Map<string, string>())
   fakeEditor.storage.octoCommentHighlight = {}
+  fakeProvider.hasUnsyncedChanges = false
+  fakeProvider.listeners.clear()
   // jsdom has no object-URL impl; the export handler creates + revokes one.
   ;(URL as unknown as { createObjectURL: () => string }).createObjectURL = () => 'blob:mock'
   ;(URL as unknown as { revokeObjectURL: () => void }).revokeObjectURL = () => {}
@@ -135,13 +153,39 @@ describe('EditorShell — export filename uses the live title, not the stale pro
 
     // Export moved into the header ≡ "more" menu: open it, then trigger the export row.
     fireEvent.click(screen.getByTitle('docs.toolbar.more'))
+    fireEvent.click(screen.getByText('docs.toolbar.export'))
     fireEvent.click(screen.getByText('docs.toolbar.exportMarkdown'))
 
-    await waitFor(() => expect(exportSpy).toHaveBeenCalledTimes(1))
+    await waitFor(() => expect(exportSpy).toHaveBeenCalledWith('d_1', 'md'))
     await waitFor(() => expect(createdAnchors.length).toBeGreaterThan(0))
     const a = createdAnchors[createdAnchors.length - 1]
     expect(a.download).toBe('Live Title.md')
     expect(a.download).not.toBe('Stale Prop Title.md')
+  })
+
+  it('waits for pending collaboration updates before requesting a backend export', async () => {
+    fakeProvider.hasUnsyncedChanges = true
+    render(
+      <EditorShell
+        docId="d_1"
+        title="Pending Doc"
+        space="s_1"
+        folder="f_1"
+        doc="d_1"
+        uid="u_self"
+        user={{ id: 'u_self', name: 'Self' }}
+      />,
+    )
+
+    fireEvent.click(screen.getByTitle('docs.toolbar.more'))
+    fireEvent.click(screen.getByText('docs.toolbar.export'))
+    fireEvent.click(screen.getByText('docs.toolbar.exportMarkdown'))
+    await Promise.resolve()
+    expect(exportSpy).not.toHaveBeenCalled()
+
+    fakeProvider.hasUnsyncedChanges = false
+    fakeProvider.emit('unsyncedChanges', 0)
+    await waitFor(() => expect(exportSpy).toHaveBeenCalledWith('d_1', 'md'))
   })
 })
 
@@ -166,6 +210,7 @@ describe('EditorShell — header injection props (#512 AC-8)', () => {
     // The low-frequency controls now live behind the ≡ "more" menu, not as resident buttons.
     expect(screen.getByTitle('docs.toolbar.more')).toBeTruthy()
     fireEvent.click(screen.getByTitle('docs.toolbar.more'))
+    fireEvent.click(screen.getByText('docs.toolbar.export'))
     expect(screen.getByText('docs.toolbar.exportMarkdown')).toBeTruthy()
     expect(screen.getByText('docs.toolbar.history')).toBeTruthy()
   })
@@ -184,6 +229,7 @@ describe('EditorShell — header injection props (#512 AC-8)', () => {
     expect(screen.getByTitle('docs.list.back')).toBeTruthy()
     // ...and the built-in controls are still reachable via the ≡ menu (parity preserved).
     fireEvent.click(screen.getByTitle('docs.toolbar.more'))
+    fireEvent.click(screen.getByText('docs.toolbar.export'))
     expect(screen.getByText('docs.toolbar.exportMarkdown')).toBeTruthy()
   })
 })
@@ -207,6 +253,7 @@ describe('EditorShell — header "more" (≡) menu', () => {
     // Closed by default: no rows visible.
     expect(screen.queryByText('docs.toolbar.exportMarkdown')).toBeNull()
     fireEvent.click(screen.getByTitle('docs.toolbar.more'))
+    fireEvent.click(screen.getByText('docs.toolbar.export'))
 
     const historyRow = screen.getByText('docs.toolbar.history').closest('button')!
     const exportRow = screen.getByText('docs.toolbar.exportMarkdown').closest('button')!

--- a/packages/docs/src/editor/EditorShell.tsx
+++ b/packages/docs/src/editor/EditorShell.tsx
@@ -1,6 +1,6 @@
 import { EditorContent } from '@tiptap/react'
 import { useCollabEditor } from '../collab/useCollabEditor.ts'
-import type { CollabEditorOptions } from '../collab/createCollabEditor.ts'
+import type { CollabEditorOptions, ConnState } from '../collab/createCollabEditor.ts'
 import { canManage } from '../auth/roles.ts'
 import { Toolbar, EditorBubbleMenu, LinkBubbleMenu, MathBubbleMenu } from './Toolbar.tsx'
 import { TableContextMenu } from './TableControls.tsx'
@@ -15,8 +15,7 @@ import { useDocComments, useRefreshCommentsOnOpen } from '../comments/useDocComm
 import { useCommentHighlights } from '../comments/useCommentHighlights.ts'
 import { useDocDelete } from './useDocDelete.ts'
 import { useMemberNames } from '../members/useMemberNames.ts'
-import { exportDocToMarkdown, type MdNode } from '../export/markdown.ts'
-import { exportDocPdf } from '../pages/docsApi.ts'
+import { exportDocFile, type DocExportFormat } from '../pages/docsApi.ts'
 import { emojiGlyph } from './emoji.ts'
 import { colorFromId } from '../awareness/presence.ts'
 import { useEffect, useState, useRef, useCallback, type ReactNode } from 'react'
@@ -99,6 +98,50 @@ export interface EditorShellProps extends CollabEditorOptions {
  */
 export function exportDownloadName(title: string | null | undefined): string {
   return (title || t('docs.state.untitled')).trim() || 'document'
+}
+
+interface ExportSyncProvider {
+  hasUnsyncedChanges: boolean
+  on(event: string, fn: (...args: unknown[]) => void): void
+  off(event: string, fn: (...args: unknown[]) => void): void
+}
+
+const EXPORT_SYNC_TIMEOUT_MS = 10_000
+
+/** Wait until the server has acknowledged local Yjs updates before backend export. */
+export function waitForExportSync(
+  provider: ExportSyncProvider,
+  connState: ConnState | null,
+  timeoutMs = EXPORT_SYNC_TIMEOUT_MS,
+): Promise<void> {
+  if (connState !== 'connected') return Promise.reject(new Error('document_not_connected'))
+  if (!provider.hasUnsyncedChanges) return Promise.resolve()
+
+  return new Promise((resolve, reject) => {
+    let settled = false
+    const finish = (error?: Error) => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      provider.off('unsyncedChanges', onUnsynced)
+      provider.off('status', onStatus)
+      if (error) reject(error)
+      else resolve()
+    }
+    const onUnsynced = (count: unknown) => {
+      if (count === 0 || !provider.hasUnsyncedChanges) finish()
+    }
+    const onStatus = (event: unknown) => {
+      const status = (event as { status?: unknown } | null)?.status
+      if (status === 'disconnected') finish(new Error('document_disconnected'))
+    }
+    const timer = setTimeout(() => finish(new Error('document_sync_timeout')), timeoutMs)
+    provider.on('unsyncedChanges', onUnsynced)
+    provider.on('status', onStatus)
+    // Close the race where the acknowledgement lands between the initial check
+    // and listener registration.
+    if (!provider.hasUnsyncedChanges) finish()
+  })
 }
 
 /**
@@ -346,16 +389,16 @@ export function EditorShell(props: EditorShellProps) {
       }
       return
     }
+    // Atomic backend imports carry no PM stash; surface their small warning payload independently.
+    const warnings = consumeImportWarnings(docId)
+    if (warnings.length) setImportNotice(warnings.join(' '))
     if (!pmDoc) return
     try {
       ed.commands.setContent(pmDoc as never)
     } catch (err) {
       console.error('[docs] Import content injection failed:', err)
       setImportNotice(t('docs.toolbar.importCorrupt'))
-      return
     }
-    const warnings = consumeImportWarnings(docId)
-    if (warnings.length) setImportNotice(warnings.join(' '))
   }, [instance, ready, docId, t])
 
   // uid → display name for this space (#8): once resolved, push the real name into awareness so
@@ -469,93 +512,42 @@ export function EditorShell(props: EditorShellProps) {
   )
   const del = useDocDelete(docId, handleDeleted)
 
-  // Export-as-Markdown (batch 8, area C): serialize the live PM JSON to Markdown with freshly
-  // resolved signed asset URLs and trigger a browser download. Display-only — never mutates
-  // the doc; failures surface a small banner instead of crashing the editor.
+  // All downloadable document formats come from one authenticated backend
+  // endpoint. The backend reads the authoritative live Y.Doc; the browser does
+  // not serialize its potentially stale local editor snapshot.
   const [exporting, setExporting] = useState(false)
   const [exportError, setExportError] = useState<string | null>(null)
-  const onExportMarkdown = useCallback(async () => {
-    const ed = instance?.editor
-    if (!ed || exporting) return
+  const downloadExport = useCallback(async (format: DocExportFormat) => {
+    if (exporting) return
     setExporting(true)
     setExportError(null)
     try {
-      const md = await exportDocToMarkdown(docId, ed.getJSON() as unknown as MdNode, { emojiGlyph })
-      const blob = new Blob([md], { type: 'text/markdown;charset=utf-8' })
-      const url = URL.createObjectURL(blob)
+      if (!instance) throw new Error('document_not_ready')
+      await waitForExportSync(instance.provider, connState)
+      const bytes = await exportDocFile(docId, format)
+      const mime = format === 'md'
+        ? 'text/markdown;charset=utf-8'
+        : format === 'docx'
+          ? 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+          : 'application/pdf'
+      const url = URL.createObjectURL(new Blob([bytes], { type: mime }))
       const a = document.createElement('a')
       a.href = url
-      a.download = `${exportDownloadName(currentTitle)}.md`
-      document.body.appendChild(a)
-      a.click()
-      a.remove()
-      // Defer revoke so Safari/iOS can start the download for larger blobs
-      // (matches the PDF branch).
-      setTimeout(() => URL.revokeObjectURL(url), 5000)
-    } catch (err) {
-      console.error('[docs] Markdown export failed:', err)
-      setExportError(t('docs.toolbar.exportError'))
-    } finally {
-      setExporting(false)
-    }
-  }, [instance, docId, currentTitle, exporting])
-
-  const onExportDocx = useCallback(async () => {
-    const ed = instance?.editor
-    if (!ed || exporting) return
-    setExporting(true)
-    setExportError(null)
-    try {
-      // Lazy-load the DOCX exporter so `docx` + `mathjax-full` (multi-MB, DOCX-only)
-      // stay out of the eager editor bundle that loads on every document open.
-      const { exportDocToDocx } = await import('../export/docx/index.ts')
-      const blob = await exportDocToDocx(docId, ed.getJSON() as unknown as MdNode, { emojiGlyph })
-      const url = URL.createObjectURL(blob)
-      const a = document.createElement('a')
-      a.href = url
-      a.download = `${exportDownloadName(currentTitle)}.docx`
-      document.body.appendChild(a)
-      a.click()
-      a.remove()
-      // Defer revoke so Safari/iOS can start the download for larger blobs
-      // (matches the PDF branch).
-      setTimeout(() => URL.revokeObjectURL(url), 5000)
-    } catch (err) {
-      console.error('[docs] DOCX export failed:', err)
-      setExportError(t('docs.toolbar.exportError'))
-    } finally {
-      setExporting(false)
-    }
-  }, [instance, docId, currentTitle, exporting])
-
-  const onExportPdf = useCallback(async () => {
-    const ed = instance?.editor
-    if (!ed || exporting) return
-    setExporting(true)
-    setExportError(null)
-    try {
-      // Server-side PDF render via Typst (小吴's decision to go backend). The
-      // backend renders its own persisted copy of the doc with Typst, so the
-      // output has real CJK, rendered math, emoji, selectable text and smart
-      // pagination — one-click download with no print dialog. Returns the PDF
-      // bytes directly.
-      const bytes = await exportDocPdf(docId)
-      const blob = new Blob([bytes], { type: 'application/pdf' })
-      const url = URL.createObjectURL(blob)
-      const a = document.createElement('a')
-      a.href = url
-      a.download = `${exportDownloadName(currentTitle)}.pdf`
+      a.download = `${exportDownloadName(currentTitle)}.${format}`
       document.body.appendChild(a)
       a.click()
       a.remove()
       setTimeout(() => URL.revokeObjectURL(url), 5000)
     } catch (err) {
-      console.error('[docs] PDF export failed:', err)
+      console.error(`[docs] ${format.toUpperCase()} export failed:`, err)
       setExportError(t('docs.toolbar.exportError'))
     } finally {
       setExporting(false)
     }
-  }, [instance, docId, currentTitle, exporting])
+  }, [docId, currentTitle, exporting, instance, connState])
+  const onExportMarkdown = useCallback(() => void downloadExport('md'), [downloadExport])
+  const onExportDocx = useCallback(() => void downloadExport('docx'), [downloadExport])
+  const onExportPdf = useCallback(() => void downloadExport('pdf'), [downloadExport])
 
   const togglePanel = useCallback(
     (panel: Exclude<DrawerPanel, null>) => setActivePanel((cur) => (cur === panel ? null : panel)),

--- a/packages/docs/src/editor/fontFamilies.ts
+++ b/packages/docs/src/editor/fontFamilies.ts
@@ -23,6 +23,7 @@
  * time (zh-CN shows the Chinese face name, en-US the romanized family name).
  */
 export const FONT_FAMILIES = [
+  { labelKey: 'docs.toolbar.font.calibri', value: 'Calibri, Carlito, sans-serif' },
   { labelKey: 'docs.toolbar.font.timesNewRoman', value: '"Times New Roman", Times, serif' },
   { labelKey: 'docs.toolbar.font.tahoma', value: 'Tahoma, sans-serif' },
   { labelKey: 'docs.toolbar.font.verdana', value: 'Verdana, sans-serif' },

--- a/packages/docs/src/editor/fontFamilies.verify.test.ts
+++ b/packages/docs/src/editor/fontFamilies.verify.test.ts
@@ -31,6 +31,7 @@ describe('FONT_FAMILIES i18n refactor (XIN-936)', () => {
     expect(byKey['docs.toolbar.font.simsun']).toBe('SimSun, "宋体", serif')
     expect(byKey['docs.toolbar.font.simhei']).toBe('SimHei, "黑体", sans-serif')
     expect(byKey['docs.toolbar.font.kaiti']).toBe('KaiTi, "楷体", serif')
+    expect(byKey['docs.toolbar.font.calibri']).toBe('Calibri, Carlito, sans-serif')
   })
 
   it('resolves every labelKey in both zh-CN and en-US', () => {

--- a/packages/docs/src/editor/importFlow.markdown.test.ts
+++ b/packages/docs/src/editor/importFlow.markdown.test.ts
@@ -1,0 +1,134 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const createDoc = vi.fn()
+const deleteDoc = vi.fn()
+const importMarkdown = vi.fn()
+const importDocx = vi.fn()
+vi.mock('../pages/docsApi.ts', () => ({
+  createDoc: (...args: unknown[]) => createDoc(...args),
+  deleteDoc: (...args: unknown[]) => deleteDoc(...args),
+  importMarkdown: (...args: unknown[]) => importMarkdown(...args),
+  importDocx: (...args: unknown[]) => importDocx(...args),
+}))
+vi.mock('../attachments/api.ts', () => ({ copyAttachments: vi.fn(), ingestAttachments: vi.fn() }))
+
+import { consumeImportContent, consumeImportWarnings, runDocxImport, runMarkdownImport } from './importFlow.ts'
+
+function choose(input: HTMLInputElement, file: File): void {
+  Object.defineProperty(input, 'files', { configurable: true, value: [file] })
+  input.onchange?.(new Event('change'))
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  deleteDoc.mockResolvedValue(undefined)
+  sessionStorage.clear()
+  document.querySelectorAll('input[type=file]').forEach((input) => input.remove())
+})
+
+describe('runMarkdownImport backend flow', () => {
+  it('applies an oversized PM-shaped response without stashing content', async () => {
+    const events: string[] = []
+    createDoc.mockImplementation(async ({ title }: { title: string }) => {
+      events.push(`create:${title}`)
+      return { docId: 'd_new' }
+    })
+    importMarkdown.mockImplementation(async (docId: string, file: File) => {
+      events.push(`import:${docId}:${file.name}`)
+      return {
+        doc: { type: 'doc', content: Array.from({ length: 50_000 }, () => ({ type: 'paragraph' })) },
+        warnings: ['backend warning'],
+      }
+    })
+
+    const setItem = vi.spyOn(Storage.prototype, 'setItem')
+    const pending = runMarkdownImport('sp', 'folder')
+    choose(document.querySelector('input[type=file]')!, new File(['# Hello'], 'Hello.md', { type: 'text/markdown' }))
+    const result = await pending
+
+    expect(events).toEqual(['create:Hello', 'import:d_new:Hello.md'])
+    expect(result).toEqual({ docId: 'd_new', title: 'Hello', warnings: ['backend warning'] })
+    expect(consumeImportContent('d_new')).toBeNull()
+    expect(sessionStorage.getItem('octo-import-pm-d_new')).toBeNull()
+    expect(setItem.mock.calls.some(([key]) => key === 'octo-import-pm-d_new')).toBe(false)
+    expect(consumeImportWarnings('d_new')).toEqual(['backend warning'])
+  })
+
+  it('keeps concurrent picker file/title pairs race-safe', async () => {
+    createDoc.mockImplementation(async ({ title }: { title: string }) => ({ docId: `d_${title}` }))
+    importMarkdown.mockImplementation(async (docId: string) => ({
+      doc: { type: 'doc', content: [{ type: 'paragraph', attrs: { docId } }] }, warnings: [],
+    }))
+
+    const first = runMarkdownImport()
+    const second = runMarkdownImport()
+    const inputs = [...document.querySelectorAll<HTMLInputElement>('input[type=file]')]
+    choose(inputs[1]!, new File(['two'], 'Second.markdown'))
+    choose(inputs[0]!, new File(['one'], 'First.md'))
+
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      { docId: 'd_First', title: 'First', warnings: [] },
+      { docId: 'd_Second', title: 'Second', warnings: [] },
+    ])
+    expect(importMarkdown.mock.calls.map(([docId, file]) => [docId, (file as File).name])).toEqual([
+      ['d_Second', 'Second.markdown'],
+      ['d_First', 'First.md'],
+    ])
+  })
+
+  it('propagates apply failure and does not make content available for navigation', async () => {
+    createDoc.mockResolvedValue({ docId: 'd_failed' })
+    importMarkdown.mockRejectedValue(new Error('yjs_storage_failed'))
+
+    const pending = runMarkdownImport()
+    choose(document.querySelector('input[type=file]')!, new File(['large body'], 'Failed.md'))
+
+    await expect(pending).rejects.toThrow('yjs_storage_failed')
+    expect(deleteDoc).toHaveBeenCalledOnce()
+    expect(deleteDoc).toHaveBeenCalledWith('d_failed')
+    expect(sessionStorage.getItem('octo-import-pm-d_failed')).toBeNull()
+    expect(sessionStorage.getItem('octo-import-warn-d_failed')).toBeNull()
+  })
+
+  it('applies a large DOCX without stashing returned PM content and returns its id', async () => {
+    createDoc.mockResolvedValue({ docId: 'd_docx' })
+    importDocx.mockResolvedValue({
+      doc: { type: 'doc', content: Array.from({ length: 50_000 }, () => ({ type: 'paragraph' })) },
+      warnings: [],
+    })
+
+    const setItem = vi.spyOn(Storage.prototype, 'setItem')
+    const pending = runDocxImport()
+    choose(document.querySelector('input[type=file]')!, new File([new Uint8Array(2_000_000)], 'Large.docx'))
+
+    await expect(pending).resolves.toEqual({ docId: 'd_docx', title: 'Large', warnings: [] })
+    expect(sessionStorage.getItem('octo-import-pm-d_docx')).toBeNull()
+    expect(setItem.mock.calls.some(([key]) => key === 'octo-import-pm-d_docx')).toBe(false)
+  })
+
+  it('propagates DOCX apply/storage failure', async () => {
+    createDoc.mockResolvedValue({ docId: 'd_docx_failed' })
+    importDocx.mockRejectedValue(new Error('collab_write_failed'))
+
+    const pending = runDocxImport()
+    choose(document.querySelector('input[type=file]')!, new File(['zip'], 'Failed.docx'))
+
+    await expect(pending).rejects.toThrow('collab_write_failed')
+    expect(deleteDoc).toHaveBeenCalledOnce()
+    expect(deleteDoc).toHaveBeenCalledWith('d_docx_failed')
+    expect(sessionStorage.getItem('octo-import-pm-d_docx_failed')).toBeNull()
+  })
+
+  it('preserves the import error when cleanup also fails', async () => {
+    createDoc.mockResolvedValue({ docId: 'd_cleanup_failed' })
+    importMarkdown.mockRejectedValue(new Error('import_failed'))
+    deleteDoc.mockRejectedValue(new Error('cleanup_failed'))
+
+    const pending = runMarkdownImport()
+    choose(document.querySelector('input[type=file]')!, new File(['body'], 'Failed.md'))
+
+    await expect(pending).rejects.toThrow('import_failed')
+    expect(deleteDoc).toHaveBeenCalledWith('d_cleanup_failed')
+  })
+
+})

--- a/packages/docs/src/editor/importFlow.ts
+++ b/packages/docs/src/editor/importFlow.ts
@@ -1,18 +1,12 @@
-// Import flow: file picker → parse Markdown → create new doc → navigate → inject content.
-//
-// Design doc §5 (方案 A1 + B1): user picks a .md file, we parse it to PM JSON,
-// create a new empty doc via REST, stash the PM JSON in sessionStorage keyed by docId,
-// then navigate to the new doc. EditorShell picks up the stashed content on mount and
-// injects it via setContent once the editor is ready.
+// Import flow: file picker → create destination → atomically apply on backend → navigate.
+// The destination editor always loads authoritative content from its live Y.Doc.
 
-import { parseMarkdownToPmDoc } from '../import/markdown.ts'
-import { createDoc, importDocx } from '../pages/docsApi.ts'
+import { createDoc, deleteDoc, importDocx, importMarkdown } from '../pages/docsApi.ts'
 import {
   copyAttachments,
   ingestAttachments,
   type CopySourceRef,
 } from '../attachments/api.ts'
-import { emojiGlyph } from './emoji.ts'
 
 const IMPORT_KEY_PREFIX = 'octo-import-pm-'
 const IMPORT_WARN_PREFIX = 'octo-import-warn-'
@@ -134,8 +128,8 @@ export interface ImportResult {
 }
 
 /**
- * Run the full import flow: pick file → parse → create doc → stash content.
- * Caller navigates to result.docId after this resolves.
+ * Run the full import flow: pick file → create doc → atomically apply on backend.
+ * Caller navigates to result.docId only after this resolves.
  */
 /** Translator type threaded from the calling React component (has useTranslation). */
 type Translate = (key: string, opts?: { values?: Record<string, unknown> }) => string
@@ -173,7 +167,7 @@ export async function runMarkdownImport(
   t?: Translate,
 ): Promise<ImportResult> {
   // 1. File picker
-  const { text, fileName } = await pickMdFile(t)
+  const { file, fileName } = await pickMdFile(t)
 
   // 1b. Extension guard. `input.accept` is only a UI hint (the OS dialog still lets the user pick
   // "all files"), so reject anything that is not a Markdown file here — this import path is for
@@ -182,34 +176,32 @@ export async function runMarkdownImport(
     throw new Error(tr(t, 'docs.import.mdOnly'))
   }
 
-  // 2. Parse (emojiName resolves `:shortcode:` against the editor's bundled GitHub emoji set;
-  // unknown shortcodes stay literal text rather than becoming blank emoji nodes).
-  const parsed = parseMarkdownToPmDoc(text, { emojiName: emojiGlyph, t })
-
-  // 3. Determine title. Use the file name (matching the .docx import), so the sidebar label is
+  // 2. Determine title. Use the file name (matching the .docx import), so the sidebar label is
   // always the imported file's name rather than the document's first heading.
   const title = stripExtension(fileName) || 'Imported document'
 
-  // 4. Create new doc
+  // 3. Create the destination before import so the authenticated backend can authorize the write
+  // and scope any imported content to the exact destination doc.
   const created = await createDoc({ title, spaceId, folderId })
 
-  // 4b. Migrate imported images into the NEW doc. The parsed image nodes still point at the
-  // SOURCE doc's attachId + a short-lived signed URL. The editor resolves an image's URL with
-  // the CURRENT doc's id (getReadUrl(thisDoc, attachId)), so a foreign attachId never resolves
-  // and the image renders blank once the signed src expires. Re-upload each image under the new
-  // doc so it gets a doc-scoped attachId the editor can re-sign. Best-effort: an image that
-  // can't be fetched/re-uploaded degrades to a warning instead of blocking the whole import.
-  const migrateWarnings = await migrateImportedImages(created.docId, parsed.doc, t)
-
-  // 5. Stash content + warnings for EditorShell to pick up after navigation
-  stashImportContent(created.docId, parsed.doc)
-  stashImportWarnings(created.docId, [...parsed.warnings, ...migrateWarnings])
-
-  return {
-    docId: created.docId,
-    title,
-    warnings: [...parsed.warnings, ...migrateWarnings],
+  // 4. The backend is the authoritative Markdown parser used by web and CLI. It enforces the byte
+  // bound and strict UTF-8 at the client boundary too, then returns the same PM schema as DOCX.
+  // The apply header makes this call resolve only after the backend has committed the import to the
+  // live Y.Doc. Its response may intentionally omit the (potentially very large) parsed PM tree.
+  let warnings: string[]
+  try {
+    ;({ warnings = [] } = await importMarkdown(created.docId, file))
+  } catch (error) {
+    // Import failures must not leave the destination shell behind. Preserve the
+    // importer error even if best-effort cleanup also fails.
+    await deleteDoc(created.docId).catch(() => undefined)
+    throw error
   }
+
+  // Only small diagnostics cross navigation. The editor loads authoritative content from Y.Doc.
+  stashImportWarnings(created.docId, warnings)
+
+  return { docId: created.docId, title, warnings }
 }
 
 /**
@@ -397,12 +389,9 @@ function collectImageNodes(node: unknown, out: Array<Record<string, unknown>>): 
 }
 
 /**
- * Run the full .docx import flow: pick file → create an empty doc → POST the file
- * to the server-side importer → stash the returned ProseMirror JSON. Unlike the
- * Markdown flow (which parses client-side), docx parsing + image upload happen
- * on the server, so we must create the doc FIRST to get a docId that scopes the
- * uploaded image attachments. Caller navigates to result.docId after this
- * resolves; EditorShell drains the stash on mount.
+ * Run the full .docx import flow: pick file → create an empty doc → atomically apply the file
+ * on the backend. The doc is created first so imported attachments are scoped to its id. Caller
+ * navigates only after the authoritative Y.Doc write succeeds.
  */
 export async function runDocxImport(
   spaceId?: string,
@@ -416,11 +405,17 @@ export async function runDocxImport(
   const title = stripDocxExtension(fileName) || 'Imported document'
   const created = await createDoc({ title, spaceId, folderId })
 
-  // 3. Server parses the .docx to ProseMirror JSON and uploads embedded images.
-  const { doc, warnings } = await importDocx(created.docId, file)
+  // 3. Server parses and atomically applies the .docx to the live Y.Doc. The request rejects on any
+  // parse, storage, or collaboration-write failure, so callers never navigate to an empty doc.
+  let warnings: string[]
+  try {
+    ;({ warnings = [] } = await importDocx(created.docId, file))
+  } catch (error) {
+    await deleteDoc(created.docId).catch(() => undefined)
+    throw error
+  }
 
-  // 4. Stash content + warnings for EditorShell to pick up after navigation.
-  stashImportContent(created.docId, doc)
+  // 4. Only small diagnostics cross navigation; content is loaded from the authoritative Y.Doc.
   stashImportWarnings(created.docId, warnings)
 
   return {
@@ -433,7 +428,7 @@ export async function runDocxImport(
 // ── File picker ───────────────────────────────────────────────────────────────
 
 interface PickedFile {
-  text: string
+  file: File
   fileName: string
 }
 
@@ -453,11 +448,7 @@ function pickMdFile(t?: Translate): Promise<PickedFile> {
     input.onchange = () => {
       const file = input.files?.[0]
       if (!file) { reject(new Error(tr(t, 'docs.import.noFileChosen'))); cleanup(); return }
-      const fileName = file.name
-      const reader = new FileReader()
-      reader.onload = () => resolve({ text: reader.result as string, fileName })
-      reader.onerror = () => reject(new Error(tr(t, 'docs.import.fileReadFailed')))
-      reader.readAsText(file, 'UTF-8')
+      resolve({ file, fileName: file.name })
       cleanup()
     }
 

--- a/packages/docs/src/i18n/en-US.json
+++ b/packages/docs/src/i18n/en-US.json
@@ -123,6 +123,7 @@
       "simhei": "SimHei",
       "kaiti": "KaiTi",
       "arial": "Arial",
+      "calibri": "Calibri",
       "timesNewRoman": "Times New Roman",
       "georgia": "Georgia",
       "courierNew": "Courier New",

--- a/packages/docs/src/i18n/zh-CN.json
+++ b/packages/docs/src/i18n/zh-CN.json
@@ -123,6 +123,7 @@
       "simhei": "黑体",
       "kaiti": "楷体",
       "arial": "Arial",
+      "calibri": "Calibri",
       "timesNewRoman": "Times New Roman",
       "georgia": "Georgia",
       "courierNew": "Courier New",

--- a/packages/docs/src/pages/DocsHome.tsx
+++ b/packages/docs/src/pages/DocsHome.tsx
@@ -790,9 +790,8 @@ function DocsList({
     )
   }
 
-  // "从 Markdown 导入" → pick a .md file, parse it to a ProseMirror document client-side, create a
-  // NEW doc (title from the H1 / filename), stash the parsed content, then open it. Import never
-  // touches an existing doc — it always lands in its own new file, mirroring the Excel import flow.
+  // "从 Markdown 导入" → pick a .md file, create a NEW doc, then ask the backend to parse and
+  // atomically apply it to the live Y.Doc. Open only after that authoritative write succeeds.
   const onImportMarkdown = async () => {
     if (creating) return
     setCreating(true)
@@ -818,9 +817,8 @@ function DocsList({
   }
 
   // "从 Word 导入" → pick a .docx file, create a NEW doc, POST the file to the server-side
-  // importer (parses OOXML → ProseMirror JSON, uploads embedded images scoped to the new doc),
-  // stash the returned content, then open it. Like every import path, it lands in its own new
-  // file and never overwrites an existing doc.
+  // importer, which uploads embedded images and atomically applies content to the live Y.Doc.
+  // Open only after that write succeeds; the editor never receives PM content through storage.
   const onImportWord = async () => {
     if (creating) return
     setCreating(true)

--- a/packages/docs/src/pages/docsApi.export.test.ts
+++ b/packages/docs/src/pages/docsApi.export.test.ts
@@ -1,0 +1,22 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createMockWKApp } from '../octoweb/mock.ts'
+import { setWKApp } from '../octoweb/index.ts'
+import { exportDocFile } from './docsApi.ts'
+
+describe('authoritative backend document export route', () => {
+  const get = vi.fn(async () => ({ data: new ArrayBuffer(4), status: 200 }))
+  beforeEach(() => {
+    get.mockClear()
+    const wk = createMockWKApp()
+    wk.apiClient.get = get as typeof wk.apiClient.get
+    setWKApp(wk)
+  })
+
+  it.each(['md', 'docx', 'pdf'] as const)('requests %s from the unified live-Y.Doc endpoint', async (format) => {
+    await exportDocFile('d_1', format)
+    expect(get).toHaveBeenCalledWith(`/docs/d_1/export/file?format=${format}`, {
+      responseType: 'arraybuffer',
+      timeout: 120_000,
+    })
+  })
+})

--- a/packages/docs/src/pages/docsApi.import.test.ts
+++ b/packages/docs/src/pages/docsApi.import.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { createMockWKApp, type MockApiClient } from '../octoweb/mock.ts'
+import { setWKApp } from '../octoweb/index.ts'
+import { importDocx, importMarkdown, MAX_MARKDOWN_IMPORT_BYTES } from './docsApi.ts'
+
+let api: MockApiClient
+
+function upload(bytes: Uint8Array): Pick<File, 'size' | 'arrayBuffer'> {
+  return {
+    size: bytes.byteLength,
+    arrayBuffer: async () => Uint8Array.from(bytes).buffer,
+  }
+}
+
+beforeEach(() => {
+  const wk = createMockWKApp()
+  api = wk.apiClient
+  setWKApp(wk)
+})
+
+describe('authoritative backend Markdown import API', () => {
+  it('POSTs bounded UTF-8 bytes through the authenticated host client and returns PM warnings', async () => {
+    api.responder = () => ({
+      status: 200,
+      data: { doc: { type: 'doc', content: [{ type: 'paragraph' }] }, warnings: ['w1'] },
+    })
+    const bytes = new TextEncoder().encode('# 标题')
+    const result = await importMarkdown('d /1', upload(bytes))
+
+    expect(result.warnings).toEqual(['w1'])
+    const call = api.calls.at(-1)!
+    expect(call.method).toBe('post')
+    expect(call.url).toBe('/docs/d%20%2F1/import/markdown')
+    expect(Array.from(new Uint8Array(call.body as ArrayBuffer))).toEqual(Array.from(bytes))
+    expect(call.config).toEqual({
+      headers: {
+        'Content-Type': 'text/markdown; charset=utf-8',
+        'X-Octo-Import-Apply': 'true',
+      },
+      timeout: 120_000,
+    })
+  })
+
+  it('rejects empty, oversized, and invalid UTF-8 input before making a request', async () => {
+    await expect(importMarkdown('d1', upload(new Uint8Array()))).rejects.toThrow('empty_upload')
+    await expect(importMarkdown('d1', {
+      size: MAX_MARKDOWN_IMPORT_BYTES + 1,
+      arrayBuffer: async () => new ArrayBuffer(0),
+    })).rejects.toThrow('doc_too_large')
+    await expect(importMarkdown('d1', upload(new Uint8Array([0xc3, 0x28])))).rejects.toThrow('invalid_utf8')
+    expect(api.calls).toHaveLength(0)
+  })
+
+  it('propagates backend status and error body for UI error mapping', async () => {
+    api.responder = () => { throw { response: { status: 422, data: { error: 'import_failed' } } } }
+    await expect(importMarkdown('d1', upload(new TextEncoder().encode('x')))).rejects.toMatchObject({
+      response: { status: 422, data: { error: 'import_failed' } },
+    })
+  })
+
+  it('requests atomic backend apply for DOCX and accepts a response without doc', async () => {
+    api.responder = () => ({ status: 200, data: { warnings: ['degraded'] } })
+    const result = await importDocx('doc / 2', new File([new Uint8Array(2_000_000)], 'large.docx'))
+
+    expect(result).toEqual({ warnings: ['degraded'] })
+    const call = api.calls.at(-1)!
+    expect(call.url).toBe('/docs/doc%20%2F%202/import/docx')
+    expect(call.config).toEqual({
+      headers: {
+        'Content-Type': 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+        'X-Octo-Import-Apply': 'true',
+      },
+      timeout: 120_000,
+    })
+  })
+
+  it('propagates DOCX atomic apply failures', async () => {
+    api.responder = () => { throw new Error('storage_failed') }
+    await expect(importDocx('d1', new File(['zip'], 'x.docx'))).rejects.toThrow('storage_failed')
+  })
+
+})

--- a/packages/docs/src/pages/docsApi.ts
+++ b/packages/docs/src/pages/docsApi.ts
@@ -344,44 +344,68 @@ export async function deleteDoc(docId: string): Promise<void> {
   await apiClient().delete(`/docs/${docId}`)
 }
 
-/**
- * POST /api/v1/docs/{docId}/export/pdf — server-side (Typst) PDF render.
- * Returns the PDF bytes as an ArrayBuffer.
- *
- * Goes through the shared host apiClient with `responseType: 'arraybuffer'` so
- * the binary PDF body is not decoded as UTF-8 text (which would turn every
- * non-ASCII byte into U+FFFD and corrupt the file). Using the host client keeps
- * this on the same axios instance as the rest of the app, so the global request
- * interceptor (token + X-Space-Id) and `/api/v1/` baseURL apply — docs does not
- * depend on axios directly. A longer per-request timeout covers big documents
- * that the shared 20s default would otherwise cut off mid-success.
- */
-export async function exportDocPdf(docId: string): Promise<ArrayBuffer> {
-  const { data } = await apiClient().post<ArrayBuffer>(
-    `/docs/${docId}/export/pdf`,
-    undefined,
+/** Downloadable rich-document formats served from the authoritative live Y.Doc. */
+export type DocExportFormat = 'md' | 'docx' | 'pdf'
+
+/** GET the unified backend file export through the authenticated host client. */
+export async function exportDocFile(docId: string, format: DocExportFormat): Promise<ArrayBuffer> {
+  const { data } = await apiClient().get<ArrayBuffer>(
+    `/docs/${encodeURIComponent(docId)}/export/file?format=${format}`,
     { responseType: 'arraybuffer', timeout: 120_000 },
   )
   return data
 }
 
-/**
- * Parsed ProseMirror document + non-fatal warnings returned by the server-side
- * .docx import. `doc` is a ProseMirror `doc` JSON ready to inject via setContent;
- * `warnings` surface best-effort degradations (e.g. an image that failed to
- * upload was replaced by a file-attachment placeholder).
- */
-export interface DocxImportResult {
-  doc: unknown
+/** @deprecated Use exportDocFile(docId, 'pdf'). */
+export async function exportDocPdf(docId: string): Promise<ArrayBuffer> {
+  return exportDocFile(docId, 'pdf')
+}
+
+/** Atomic import result. `doc` remains optional for compatibility with parse-only responses. */
+export interface DocumentImportResult {
+  /** Omitted when the backend atomically applied the import to the live Y.Doc. */
+  doc?: unknown
   warnings: string[]
+}
+
+export type DocxImportResult = DocumentImportResult
+export const MAX_MARKDOWN_IMPORT_BYTES = 25 * 1024 * 1024
+
+/** Upload bounded, strict UTF-8 Markdown to the backend importer. */
+export async function importMarkdown(
+  docId: string,
+  file: Pick<File, 'size' | 'arrayBuffer'>,
+): Promise<DocumentImportResult> {
+  if (file.size === 0) throw new Error('empty_upload')
+  if (file.size > MAX_MARKDOWN_IMPORT_BYTES) throw new Error('doc_too_large')
+  const bytes = await file.arrayBuffer()
+  if (bytes.byteLength === 0) throw new Error('empty_upload')
+  if (bytes.byteLength > MAX_MARKDOWN_IMPORT_BYTES) throw new Error('doc_too_large')
+  try {
+    new TextDecoder('utf-8', { fatal: true }).decode(bytes)
+  } catch {
+    throw new Error('invalid_utf8')
+  }
+  const { data } = await apiClient().post<DocumentImportResult>(
+    `/docs/${encodeURIComponent(docId)}/import/markdown`,
+    bytes,
+    {
+      headers: {
+        'Content-Type': 'text/markdown; charset=utf-8',
+        'X-Octo-Import-Apply': 'true',
+      },
+      timeout: 120_000,
+    },
+  )
+  return data
 }
 
 /**
  * Import a .docx file into an (already created, empty) doc. The raw file bytes
  * are POSTed to the server-side importer, which parses the OOXML to ProseMirror
- * JSON, uploads embedded images as attachments scoped to `docId`, and returns
- * the document plus any degradation warnings. The caller injects `doc` into the
- * editor. Requires editor role on `docId` (import writes content).
+ * JSON, uploads embedded images as attachments scoped to `docId`, and atomically
+ * writes the live Y.Doc. The response may omit `doc`; callers load authoritative
+ * collaboration state. Requires editor role on `docId` (import writes content).
  *
  * Goes through the shared host apiClient so the global token / X-Space-Id
  * interceptor and `/api/v1/` baseURL apply. The docx content-type is set per
@@ -390,11 +414,12 @@ export interface DocxImportResult {
 export async function importDocx(docId: string, file: File): Promise<DocxImportResult> {
   const bytes = await file.arrayBuffer()
   const { data } = await apiClient().post<DocxImportResult>(
-    `/docs/${docId}/import/docx`,
+    `/docs/${encodeURIComponent(docId)}/import/docx`,
     bytes,
     {
       headers: {
         'Content-Type': 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+        'X-Octo-Import-Apply': 'true',
       },
       timeout: 120_000,
     },

--- a/packages/docs/src/sheet/CollabSheet.ts
+++ b/packages/docs/src/sheet/CollabSheet.ts
@@ -332,6 +332,7 @@ export class CollabSheet {
       // on macOS — cross-platform @font-face aliasing (for the ones we keep) is a follow-up.
       if (typeof fontSvc?.addFont === 'function') {
         const EXTRA_FONTS = [
+          { value: 'Calibri', label: 'Calibri', category: 'sans-serif' },
           { value: 'PingFang SC', label: t('docs.sheet.fontLabels.pingfang'), category: 'sans-serif' },
           { value: 'Hiragino Sans GB', label: t('docs.sheet.fontLabels.hiraginoSansGB'), category: 'sans-serif' },
           { value: 'STXihei', label: t('docs.sheet.fontLabels.stxihei'), category: 'sans-serif' },


### PR DESCRIPTION
## Summary

Connect rich-document import and download actions to the backend's unified, authoritative live-document pipelines.

## Related Issue

Fixes #1045

## Changes

- Route active Markdown import through `docsApi.importMarkdown`; keep DOCX on its backend importer.
- Route Markdown, DOCX, and PDF downloads through `docsApi.exportDocFile`, avoiding local editor JSON serialization.
- Preserve the current uncapped full-width editor route.
- Add Calibri to the Doc and Sheet font catalogs and locale labels.
- Add focused tests for backend import/export requests, import flow ordering/stashing, and editor download behavior.

## Architecture / Module Boundary

- Affected module(s): `@octo/docs` editor, docs API adapter, and Sheet font registration
- New or changed user-visible entry point: yes; existing Markdown import and MD/DOCX/PDF export actions now use backend pipelines
- Shared layer touched: service
- If shared code changed, impact scope: document import/export API calls within the Docs package only
- Duplicate entry point checked: yes

## Testing

- [x] Unit tests added/updated
- [ ] Manually verified
- `pnpm --filter @octo/docs exec vitest run src/pages/docsApi.export.test.ts src/pages/docsApi.import.test.ts src/editor/importFlow.markdown.test.ts src/editor/EditorShell.test.tsx src/editor/fontFamilies.verify.test.ts` — 5 files, 23 tests passed
- `pnpm i18n:check` — passed
- `pnpm --filter @octo/docs typecheck` — only two confirmed pristine-main baseline errors remain: `dmworkbase/src/i18n/format.ts:38` (`fractionalSecondDigits`) and `docs/src/members/sort.ts:26` (missing `grantedBy`)
- `git diff --check` — passed

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation (not applicable; no public documentation contract changed)
- [x] Ran `pnpm i18n:check` or confirmed the change does not affect UI copy
- [x] Confirmed the change follows module ownership and does not add duplicate user-visible entry points
- [x] Described impact scope when shared components, messages, bridge, or services are changed
- [x] Followed commit message conventions (Conventional Commits)
