### PR TITLE
fix(e2e): trust workspace in baseline workflows

### DIFF
--- a/.github/workflows/e2e-baseline-bootstrap.yml
+++ b/.github/workflows/e2e-baseline-bootstrap.yml
@@ -32,6 +32,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Trust workspace for git
+        shell: bash
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Prepare bootstrap branch
         shell: bash
         run: |

--- a/.github/workflows/e2e-baseline-update.yml
+++ b/.github/workflows/e2e-baseline-update.yml
@@ -48,6 +48,9 @@ jobs:
         with:
           ref: ${{ steps.pr.outputs.head_ref }}
           fetch-depth: 0
+      - name: Trust workspace for git
+        shell: bash
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## Summary
- Add `git config --global --add safe.directory "$GITHUB_WORKSPACE"` after checkout in baseline workflows.
- Fixes Git `dubious ownership` failures in the Playwright container before git fetch/switch/add/commit steps.

## Test Plan
- `pnpm -C . exec prettier --check .github/workflows/e2e-baseline-bootstrap.yml .github/workflows/e2e-baseline-update.yml`
- Parsed both workflow YAML files with PyYAML
- `git diff --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)