### PR TITLE
fix(channel-setting): polish group management controls

### DIFF
--- a/packages/dmworkbase/src/Components/GroupManagement/MemberPicker.css
+++ b/packages/dmworkbase/src/Components/GroupManagement/MemberPicker.css
@@ -14,7 +14,7 @@
   flex: 0 0 auto;
   align-items: center;
   gap: var(--wk-sp-2);
-  margin: var(--wk-sp-1) var(--wk-sp-4) var(--wk-sp-1);
+  margin: var(--wk-sp-3) var(--wk-sp-4) var(--wk-sp-2);
   padding: 0 var(--wk-sp-3);
   border: 1px solid var(--wk-border-subtle);
   border-radius: var(--wk-r-sm);

--- a/packages/dmworkbase/src/ui/channelSetting/GroupManagementView/index.css
+++ b/packages/dmworkbase/src/ui/channelSetting/GroupManagementView/index.css
@@ -242,8 +242,8 @@
 
 .wk-group-management-remove {
   display: inline-flex;
-  width: var(--wk-sp-7);
-  height: var(--wk-sp-7);
+  width: var(--wk-sp-6);
+  height: var(--wk-sp-6);
   flex: 0 0 auto;
   align-items: center;
   justify-content: center;
@@ -253,8 +253,33 @@
   background: transparent;
   color: var(--wk-text-tertiary);
   cursor: pointer;
+  line-height: 0;
   transition: background-color var(--wk-dur-fast) var(--wk-ease),
     color var(--wk-dur-fast) var(--wk-ease);
+}
+
+.wk-group-management-remove-icon {
+  position: relative;
+  display: inline-flex;
+  width: calc(var(--wk-sp-3) + var(--wk-sp-0-5));
+  height: calc(var(--wk-sp-3) + var(--wk-sp-0-5));
+  align-items: center;
+  justify-content: center;
+  border: 1px solid currentColor;
+  border-radius: var(--wk-r-full);
+  box-sizing: border-box;
+}
+
+.wk-group-management-remove-icon::after {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: var(--wk-sp-2);
+  height: 1px;
+  border-radius: var(--wk-r-full);
+  background: currentColor;
+  content: "";
+  transform: translate(-50%, -50%);
 }
 
 .wk-group-management-remove:hover,

--- a/packages/dmworkbase/src/ui/channelSetting/GroupManagementView/index.tsx
+++ b/packages/dmworkbase/src/ui/channelSetting/GroupManagementView/index.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { Switch } from "@douyinfe/semi-ui";
-import { Trash2 } from "lucide-react";
 import WKButton from "../../../Components/WKButton";
 import "./index.css";
 
@@ -103,7 +102,7 @@ function GroupManagementMemberRow({
           aria-label={`${labels.removeMember} ${labelText}`}
           title={labels.removeMember}
         >
-          <Trash2 size={15} aria-hidden="true" />
+          <span className="wk-group-management-remove-icon" aria-hidden="true" />
         </button>
       )}
     </li>


### PR DESCRIPTION
## Summary
- Replace the group management remove Trash icon with a V2-aligned circle-minus control.
- Keep the remove button at V2's 24px control size and center the inner line with CSS geometry.
- Add top spacing for the add-admin and add-Bot-admin member picker search field.

## Validation
- git diff --check
- pnpm exec vitest run packages/dmworkbase/src/Components/GroupManagement/__tests__/allowNoMention.test.ts packages/dmworkbase/src/bridge/channelSetting/__tests__/groupManagementActions.test.ts
- Browser geometry check on http://127.0.0.1:5175/: remove buttons are 24x24; icons are 14x14; button/icon centers aligned; line centered via 50% transform.
- Manual verification passed for the secondary picker search spacing.