### PR TITLE
feat: restore Agent summary mode switch entrypoint

### DIFF
--- a/packages/dmworksummary/src/index.css
+++ b/packages/dmworksummary/src/index.css
@@ -2049,6 +2049,41 @@
     margin-bottom: 16px;
 }
 
+/* Mode switch (normal/agent) */
+.summary-workbench-mode-switch {
+    margin-left: auto;
+    display: flex;
+    gap: 0;
+    background: var(--semi-color-fill-0);
+    border-radius: var(--semi-border-radius-full);
+    padding: 2px;
+    flex-shrink: 0;
+}
+
+.summary-workbench-mode-btn {
+    border: none;
+    background: transparent;
+    cursor: pointer;
+    font-family: inherit;
+    font-size: var(--semi-font-size-small);
+    font-weight: 600;
+    line-height: 20px;
+    padding: 4px 12px;
+    border-radius: var(--semi-border-radius-full);
+    color: var(--semi-color-text-2);
+    white-space: nowrap;
+    transition: background 0.15s, color 0.15s;
+}
+
+.summary-workbench-mode-btn--active {
+    background: var(--semi-color-bg-1);
+    color: var(--semi-color-text-0);
+}
+
+.summary-workbench-mode-btn:not(.summary-workbench-mode-btn--active):hover {
+    color: var(--semi-color-text-1);
+}
+
 .summary-workbench-header-emoji {
     font-size: 28px;
     line-height: 1;

--- a/packages/dmworksummary/src/pages/SummaryCreatePage.tsx
+++ b/packages/dmworksummary/src/pages/SummaryCreatePage.tsx
@@ -1031,6 +1031,22 @@ export default class SummaryCreatePage extends Component<SummaryCreatePageProps,
                 <div className="summary-workbench-header">
                     <span className="summary-workbench-header-emoji">🚀</span>
                     <span className="summary-workbench-title">{translate("summary.create.title")}</span>
+                    <div className="summary-workbench-mode-switch">
+                        <button
+                            type="button"
+                            className={`summary-workbench-mode-btn${mode === 'normal' ? ' summary-workbench-mode-btn--active' : ''}`}
+                            onClick={() => this.handleSelectMode('normal')}
+                        >
+                            {translate("summary.create.start")}
+                        </button>
+                        <button
+                            type="button"
+                            className={`summary-workbench-mode-btn${mode === 'agent' ? ' summary-workbench-mode-btn--active' : ''}`}
+                            onClick={() => this.handleSelectMode('agent')}
+                        >
+                            {translate("summary.create.agentStart")}
+                        </button>
+                    </div>
                 </div>
 
                 {/* Content card */}


### PR DESCRIPTION
## Problem

PR #1044 (Summary UI redesign) removed the `SplitButtonGroup` that allowed switching between Normal and Agent summary modes. This left Agent summary — a production feature (PR #992 by wanyiwang06) — completely inaccessible from the left sidebar summary entry point. The `AgentChatPanel` import, `handleSelectMode` method, and `mode: 'agent'` branch were left as dead code.

## Fix

- Add a segmented control (开始总结 / Agent 总结) in the create page header
- Active state uses Semi design tokens (`var(--semi-color-bg-1)`, `var(--semi-color-text-0)`)
- `handleSelectMode('normal'/'agent')` is now called from the new UI
- Agent mode renders `AgentChatPanel` with `selectedChannels={selectedChats}` (PR #992 agent context passing preserved)
- Normal mode shows textarea + templates + select chat/participants + start button

## Design

The segmented control fits the Figma design language better than the old `SplitButtonGroup` dropdown:
- Pill-shaped container with `var(--semi-color-fill-0)` background
- Active button: `var(--semi-color-bg-1)` background + `var(--semi-color-text-0)` text
- Non-active: transparent + `var(--semi-color-text-2)` text, hover → `var(--semi-color-text-1)`

## Files Changed

- `packages/dmworksummary/src/pages/SummaryCreatePage.tsx` — add mode switch JSX in header
- `packages/dmworksummary/src/index.css` — add mode switch CSS using Semi design tokens
