### PR TITLE
feat(mcp): add official publisher styling (LSC-24)

### DIFF
--- a/apps/web/e2e-kit/msw-handlers/mcp-official.ts
+++ b/apps/web/e2e-kit/msw-handlers/mcp-official.ts
@@ -1,0 +1,79 @@
+import { http, HttpResponse } from "msw";
+
+const API_BASE = "/market/api/v1";
+const REDACTED_CREATOR = "[redacted-admin]";
+
+function enabled(): boolean {
+  try {
+    return sessionStorage.getItem("__e2e_scenario") === "mcp-official";
+  } catch {
+    return false;
+  }
+}
+
+const officialListItem = {
+  mcp_id: "official-search",
+  name: "Official Search MCP",
+  slogan: "Platform-maintained web and news search.",
+  category: "search",
+  icon: "🔎",
+  tags: ["search", "official"],
+  tool_count: 6,
+  visibility: "system",
+  source: "system",
+  creator_name: REDACTED_CREATOR,
+  created_by_type: "human",
+  transport: "streamable-http",
+  match_reasons: [`creator:${REDACTED_CREATOR}`, "tool:web_search"],
+  updated_at: "2026-07-24T08:00:00Z",
+};
+
+const normalListItem = {
+  ...officialListItem,
+  mcp_id: "community-search",
+  name: "Community Search MCP",
+  slogan: "Community-maintained search integration.",
+  tags: ["search", "community"],
+  visibility: "public",
+  source: "space",
+  creator_name: "Alice",
+  match_reasons: ["creator:Alice", "tool:web_search"],
+};
+
+const detailFor = (item: typeof officialListItem) => ({
+  ...item,
+  quick_start: {
+    transport: "streamable-http",
+    server_name: item.name,
+    url: "https://example.test/mcp",
+  },
+  tools: [{ name: "web_search", description: "Search the web." }],
+  usage_examples: ["Search for the latest platform documentation."],
+  faqs: [],
+  notes: [],
+  created_at: "2026-07-20T08:00:00Z",
+});
+
+export const mcpOfficialHandlers = [
+  http.get("*/user/devices/:deviceId", () => {
+    if (!enabled()) return undefined;
+    return HttpResponse.json({});
+  }),
+  http.get(`*${API_BASE}/mcps`, () => {
+    if (!enabled()) return undefined;
+    return HttpResponse.json({
+      data: [officialListItem, normalListItem],
+      pagination: { total: 2, page: 1, page_size: 20 },
+    });
+  }),
+  http.get(`*${API_BASE}/mcp_categories`, () => {
+    if (!enabled()) return undefined;
+    return HttpResponse.json({ data: [{ key: "search", count: 2 }] });
+  }),
+  http.get(`*${API_BASE}/mcps/:id`, ({ params }) => {
+    if (!enabled()) return undefined;
+    const item =
+      params.id === officialListItem.mcp_id ? officialListItem : normalListItem;
+    return HttpResponse.json({ data: detailFor(item) });
+  }),
+];

--- a/apps/web/e2e-kit/tests/C37-mcp-official-publisher.spec.ts
+++ b/apps/web/e2e-kit/tests/C37-mcp-official-publisher.spec.ts
@@ -17,12 +17,16 @@ test("@C37 @mcp @integration official publisher renders from application API fix
   authedPage,
 }, testInfo) => {
   const consoleErrors: string[] = [];
+  const pageErrors: string[] = [];
   const networkFailures: string[] = [];
   const requests: Array<{ method: string; url: string }> = [];
   const responses: Array<{ url: string; status: number; visibility?: string }> =
     [];
   authedPage.on("console", (message) => {
     if (message.type() === "error") consoleErrors.push(message.text());
+  });
+  authedPage.on("pageerror", (error) => {
+    pageErrors.push(error.message);
   });
   authedPage.on("requestfailed", (request) => {
     if (request.url().includes(API_BASE)) {
@@ -118,6 +122,7 @@ test("@C37 @mcp @integration official publisher renders from application API fix
     true
   );
   expect(consoleErrors).toEqual([]);
+  expect(pageErrors).toEqual([]);
   expect(networkFailures).toEqual([]);
 
   await testInfo.attach("mcp-api-evidence.json", {
@@ -126,6 +131,24 @@ test("@C37 @mcp @integration official publisher renders from application API fix
         {
           fixtureType: "application-level API fixture",
           sensitiveFields: "creator_name redacted",
+          environment: {
+            browser: "Playwright Chromium",
+            viewportDesktop: "default Desktop Chrome",
+            viewportMobile: "390x844",
+            locale: "zh-CN",
+            themeModes: ["light", "dark"],
+          },
+          application: {
+            startCommand: "pnpm dev",
+            url: "http://localhost:3000/mcp-market/mcp?sid=e2etest",
+            listRoute: "/mcp-market/mcp",
+            detailRoute: "modal from /mcp-market/mcp via MCP card click",
+          },
+          runtimeSummary: {
+            consoleErrors,
+            pageErrors,
+            networkFailures,
+          },
           requests,
           responses,
         },

--- a/apps/web/e2e-kit/tests/C37-mcp-official-publisher.spec.ts
+++ b/apps/web/e2e-kit/tests/C37-mcp-official-publisher.spec.ts
@@ -1,0 +1,138 @@
+/* eslint-disable no-undef -- e2e code runs in Node */
+// @caseId C37-mcp-official-publisher
+
+import { test, expect } from "../fixtures-authed";
+import type { Page, TestInfo } from "@playwright/test";
+
+const API_BASE = "/market/api/v1";
+const REDACTED_CREATOR = "[redacted-admin]";
+
+async function screenshot(page: Page, testInfo: TestInfo, name: string) {
+  const path = testInfo.outputPath(name);
+  await page.screenshot({ path, fullPage: true });
+  await testInfo.attach(name, { path, contentType: "image/png" });
+}
+
+test("@C37 @mcp @integration official publisher renders from application API fixture", async ({
+  authedPage,
+}, testInfo) => {
+  const consoleErrors: string[] = [];
+  const networkFailures: string[] = [];
+  const requests: Array<{ method: string; url: string }> = [];
+  const responses: Array<{ url: string; status: number; visibility?: string }> =
+    [];
+  authedPage.on("console", (message) => {
+    if (message.type() === "error") consoleErrors.push(message.text());
+  });
+  authedPage.on("requestfailed", (request) => {
+    if (request.url().includes(API_BASE)) {
+      networkFailures.push(
+        `${request.method()} ${request.url()} ${
+          request.failure()?.errorText ?? ""
+        }`
+      );
+    }
+  });
+  authedPage.on("request", (request) => {
+    if (request.url().includes(API_BASE)) {
+      requests.push({ method: request.method(), url: request.url() });
+    }
+  });
+  authedPage.on("response", async (response) => {
+    if (!response.url().includes(API_BASE)) return;
+    const body = await response.json().catch(() => null);
+    const visibility = response.url().includes("/mcps/official-search")
+      ? body?.data?.visibility
+      : body?.data?.find?.(
+          (item: { visibility?: string }) => item.visibility === "system"
+        )?.visibility;
+    responses.push({
+      url: response.url(),
+      status: response.status(),
+      visibility,
+    });
+  });
+
+  await authedPage.addInitScript(() => {
+    sessionStorage.setItem("__e2e_scenario", "mcp-official");
+  });
+  await authedPage.goto("/mcp-market/mcp?sid=e2etest");
+
+  const officialCard = authedPage.locator(".wk-mcp-card", {
+    hasText: "Official Search MCP",
+  });
+  const normalCard = authedPage.locator(".wk-mcp-card", {
+    hasText: "Community Search MCP",
+  });
+  await expect(officialCard).toBeVisible();
+  await expect(normalCard).toBeVisible();
+  await expect(officialCard).toContainText("官方发布");
+  await expect(officialCard).not.toContainText(REDACTED_CREATOR);
+  await expect(normalCard).toContainText("Alice");
+  await expect(officialCard).toHaveClass(/wk-mcp-card--official/);
+  await expect(normalCard).not.toHaveClass(/wk-mcp-card--official/);
+  await screenshot(authedPage, testInfo, "mcp-list-light-full.png");
+
+  await officialCard.click();
+  const detailModal = authedPage.getByRole("dialog");
+  await expect(detailModal).toBeVisible();
+  await expect(detailModal).toContainText("Official Search MCP");
+  await expect(detailModal).toContainText("官方发布");
+  await expect(detailModal).not.toContainText(REDACTED_CREATOR);
+  await screenshot(authedPage, testInfo, "mcp-detail-light-full.png");
+
+  await authedPage
+    .getByRole("button", { name: "关闭" })
+    .click()
+    .catch(async () => {
+      await authedPage.keyboard.press("Escape");
+    });
+  await expect(detailModal).not.toBeVisible();
+
+  await normalCard.click();
+  await expect(detailModal).toBeVisible();
+  await expect(detailModal).toContainText("Community Search MCP");
+  await expect(detailModal).toContainText("Alice");
+  await expect(detailModal).not.toContainText("官方发布");
+  await screenshot(authedPage, testInfo, "mcp-normal-detail-light-full.png");
+  await authedPage.getByRole("button", { name: "关闭" }).click();
+  await expect(detailModal).not.toBeVisible();
+
+  await authedPage.evaluate(() =>
+    document.body.setAttribute("theme-mode", "dark")
+  );
+  await screenshot(authedPage, testInfo, "mcp-list-dark-full.png");
+
+  await authedPage.setViewportSize({ width: 390, height: 844 });
+  await expect(officialCard).toBeVisible();
+  await expect(normalCard).toBeVisible();
+  await screenshot(authedPage, testInfo, "mcp-list-mobile-dark-full.png");
+
+  expect(requests.some(({ url }) => url.includes(`${API_BASE}/mcps?`))).toBe(
+    true
+  );
+  expect(
+    requests.some(({ url }) => url.endsWith(`${API_BASE}/mcps/official-search`))
+  ).toBe(true);
+  expect(responses.some(({ visibility }) => visibility === "system")).toBe(
+    true
+  );
+  expect(consoleErrors).toEqual([]);
+  expect(networkFailures).toEqual([]);
+
+  await testInfo.attach("mcp-api-evidence.json", {
+    body: Buffer.from(
+      JSON.stringify(
+        {
+          fixtureType: "application-level API fixture",
+          sensitiveFields: "creator_name redacted",
+          requests,
+          responses,
+        },
+        null,
+        2
+      )
+    ),
+    contentType: "application/json",
+  });
+});

--- a/apps/web/src/mocks/handlers.ts
+++ b/apps/web/src/mocks/handlers.ts
@@ -4,5 +4,10 @@
 // 本文件 re-export 供 apps/web/src/mocks/browser.ts 消费.
 import { loopEmptyHandlers } from "../../e2e-kit/msw-handlers/loop-empty";
 import { chatBaselineHandlers } from "../../e2e-kit/msw-handlers/chat-baseline";
+import { mcpOfficialHandlers } from "../../e2e-kit/msw-handlers/mcp-official";
 
-export const handlers = [...loopEmptyHandlers, ...chatBaselineHandlers];
+export const handlers = [
+  ...mcpOfficialHandlers,
+  ...loopEmptyHandlers,
+  ...chatBaselineHandlers,
+];

--- a/packages/dmworkmcp/src/components/McpCard.stories.tsx
+++ b/packages/dmworkmcp/src/components/McpCard.stories.tsx
@@ -1,0 +1,73 @@
+import React from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { i18n } from "@octo/base";
+import McpCard from "./McpCard";
+import type { McpListItem } from "../types/mcp";
+import enUS from "../i18n/en-US.json";
+import zhCN from "../i18n/zh-CN.json";
+import "../index.css";
+
+i18n.registerNamespace("mcp", {
+  "zh-CN": zhCN,
+  "en-US": enUS,
+});
+i18n.setLocale("zh-CN", { notify: false, persist: false });
+
+const officialItem: McpListItem = {
+  id: "official-search",
+  name: "Search MCP",
+  slogan: "平台维护的搜索服务，提供稳定的网页与新闻检索能力。",
+  category: "search",
+  tags: ["搜索", "热门"],
+  toolCount: 6,
+  icon: "🔎",
+  visibility: "system",
+  source: "system",
+  creatorName: "Internal Admin",
+  matchReasons: ["creator:Internal Admin", "tool:web_search"],
+};
+
+const normalItem: McpListItem = {
+  ...officialItem,
+  id: "community-search",
+  name: "Community Search MCP",
+  visibility: "public",
+  source: "space",
+  creatorName: "Alice",
+  matchReasons: ["creator:Alice", "tool:web_search"],
+};
+
+const meta = {
+  title: "MCP/McpCard",
+  component: McpCard,
+  parameters: { layout: "centered" },
+  decorators: [
+    (Story) => (
+      <div style={{ width: 360 }}>
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    item: officialItem,
+    onClick: () => undefined,
+  },
+} satisfies Meta<typeof McpCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Official: Story = {};
+
+export const Normal: Story = {
+  args: { item: normalItem },
+};
+
+export const Comparison: Story = {
+  render: () => (
+    <div style={{ display: "grid", gap: 16, width: 360 }}>
+      <McpCard item={officialItem} onClick={() => undefined} />
+      <McpCard item={normalItem} onClick={() => undefined} />
+    </div>
+  ),
+};

--- a/packages/dmworkmcp/src/components/McpCard.tsx
+++ b/packages/dmworkmcp/src/components/McpCard.tsx
@@ -1,11 +1,12 @@
 import React from "react";
 import { Tooltip } from "@douyinfe/semi-ui";
 import { IconWrenchStroked } from "@douyinfe/semi-icons";
-import { Bot, Pencil, Trash2, UserRound } from "lucide-react";
+import { Bot, Pencil, ShieldCheck, Trash2, UserRound } from "lucide-react";
 import type { McpListItem } from "../types/mcp";
 import { t } from "@octo/base";
 import { IconGlyph } from "../utils/icon";
 import { getMcpAvatarColor, getMcpAvatarText } from "../utils/mcpAvatar";
+import { isOfficialMcp } from "../utils/publisher";
 
 interface McpCardProps {
   item: McpListItem;
@@ -38,9 +39,10 @@ export function parseMatchReason(reason: string): { key: string; value?: string 
  *  the card itself doesn't already show (tool / usage_example / creator) —
  *  matches on name / description / tag are visible in the card body and
  *  don't need their own chip. */
-export function MatchReasons({ reasons }: { reasons: string[] }) {
+export function MatchReasons({ reasons, hideCreator = false }: { reasons: string[]; hideCreator?: boolean }) {
   const revealing = reasons.filter((reason) => {
     const type = reason.split(":", 1)[0];
+    if (hideCreator && type === "creator") return false;
     return type === "tool" || type === "usage_example" || type === "creator";
   });
   if (!revealing.length) return null;
@@ -89,14 +91,15 @@ export function resolveOwner(item: McpListItem): { botName?: string; humanName?:
 const McpCard: React.FC<McpCardProps> = ({ item, onClick, onEdit, onDelete }) => {
   const visibleTags = item.tags.slice(0, CARD_TAG_LIMIT);
   const overflowTags = item.tags.slice(CARD_TAG_LIMIT);
-  const owner = resolveOwner(item);
+  const isOfficial = isOfficialMcp(item);
+  const owner = isOfficial ? null : resolveOwner(item);
   // `.trim()` gates the fallback avatar so a whitespace-only icon string
   // (paste artifact, backend quirk) doesn't slip past the truthiness check
   // and render an empty box via IconGlyph.
   const hasIcon = !!item.icon?.trim();
   return (
     <div
-      className="wk-mcp-card"
+      className={`wk-mcp-card${isOfficial ? " wk-mcp-card--official" : ""}`}
       role="button"
       tabIndex={0}
       onClick={() => onClick(item)}
@@ -133,7 +136,14 @@ const McpCard: React.FC<McpCardProps> = ({ item, onClick, onEdit, onDelete }) =>
               {item.name}
             </h3>
           </div>
-          {owner && (
+          {isOfficial ? (
+            <div className="wk-mcp-card__meta-row">
+              <span className="wk-mcp-card__owner wk-mcp-card__owner--official">
+                <ShieldCheck className="wk-mcp-card__owner-official-icon" size={13} aria-hidden="true" />
+                <span className="wk-mcp-card__owner-name">{t("mcp.card.officialPublisher")}</span>
+              </span>
+            </div>
+          ) : owner ? (
             <div className="wk-mcp-card__meta-row">
               {owner.botName && (
                 <span className="wk-mcp-card__owner" title={owner.botName}>
@@ -151,7 +161,7 @@ const McpCard: React.FC<McpCardProps> = ({ item, onClick, onEdit, onDelete }) =>
                 </span>
               )}
             </div>
-          )}
+          ) : null}
         </div>
       </div>
       <div className="wk-mcp-card__slogan">{item.slogan}</div>
@@ -182,7 +192,9 @@ const McpCard: React.FC<McpCardProps> = ({ item, onClick, onEdit, onDelete }) =>
           </Tooltip>
         )}
       </div>
-      {item.matchReasons?.length ? <MatchReasons reasons={item.matchReasons} /> : null}
+      {item.matchReasons?.length ? (
+        <MatchReasons reasons={item.matchReasons} hideCreator={isOfficial} />
+      ) : null}
       <div className="wk-mcp-card__footer">
         <div className="wk-mcp-card__stats">
           <span

--- a/packages/dmworkmcp/src/components/McpDetailModal.tsx
+++ b/packages/dmworkmcp/src/components/McpDetailModal.tsx
@@ -2,13 +2,14 @@ import React, { useEffect, useMemo, useState } from "react";
 import { WKModal, WKButton, t } from "@octo/base";
 import { Toast, Spin } from "@douyinfe/semi-ui";
 import { IconWrenchStroked } from "@douyinfe/semi-icons";
-import { Bot, UserRound } from "lucide-react";
+import { Bot, ShieldCheck, UserRound } from "lucide-react";
 import { deleteMcp, fetchMcpDetail } from "../api/mcpService";
 import { buildQuickStartTabs, TOKEN_PLACEHOLDER_RE } from "../api/quickStartTemplates";
 import type { McpDetail, McpQuickStart } from "../types/mcp";
 import { IconGlyph } from "../utils/icon";
 import { getMcpAvatarColor, getMcpAvatarText } from "../utils/mcpAvatar";
 import { resolveOwner } from "./McpCard";
+import { isOfficialMcp } from "../utils/publisher";
 
 interface McpDetailModalProps {
   /** The id of the MCP to show; null closes the modal. */
@@ -266,9 +267,17 @@ const McpDetailModal: React.FC<McpDetailModalProps> = ({
           )}
         </div>
         {(() => {
-          const owner = resolveOwner(detail);
+          const isOfficial = isOfficialMcp(detail);
+          const owner = isOfficial ? null : resolveOwner(detail);
           const parts: React.ReactNode[] = [];
-          if (owner?.botName) {
+          if (isOfficial) {
+            parts.push(
+              <span key="official" className="wk-mcp-detail__owner wk-mcp-detail__owner--official">
+                <ShieldCheck className="wk-mcp-card__owner-official-icon" size={13} aria-hidden="true" />
+                <span className="wk-mcp-card__owner-name">{t("mcp.card.officialPublisher")}</span>
+              </span>
+            );
+          } else if (owner?.botName) {
             parts.push(
               <span key="bot" className="wk-mcp-detail__owner" title={owner.botName}>
                 <Bot className="wk-mcp-card__owner-bot-icon" size={13} aria-hidden="true" />

--- a/packages/dmworkmcp/src/components/__tests__/McpOfficialPublisher.test.tsx
+++ b/packages/dmworkmcp/src/components/__tests__/McpOfficialPublisher.test.tsx
@@ -1,0 +1,132 @@
+// @vitest-environment jsdom
+import React from "react";
+import ReactDOM from "react-dom";
+import { act } from "react-dom/test-utils";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import McpCard from "../McpCard";
+import McpDetailModal from "../McpDetailModal";
+import type { McpDetail, McpListItem } from "../../types/mcp";
+
+const fetchMcpDetail = vi.fn();
+
+vi.mock("../../api/mcpService", () => ({
+  deleteMcp: vi.fn(),
+  fetchMcpDetail: (...args: unknown[]) => fetchMcpDetail(...args),
+}));
+vi.mock("../../api/quickStartTemplates", () => ({
+  buildQuickStartTabs: () => [],
+  TOKEN_PLACEHOLDER_RE: /$^/g,
+}));
+vi.mock("../../utils/icon", () => ({ IconGlyph: () => null }));
+vi.mock("@douyinfe/semi-ui", () => ({
+  Spin: () => null,
+  Toast: { success: vi.fn(), error: vi.fn() },
+  Tooltip: ({ children }: { children: React.ReactNode }) => children,
+}));
+vi.mock("@octo/base", () => ({
+  t: (key: string) => (key === "mcp.card.officialPublisher" ? "官方发布" : key),
+  WKButton: ({ children }: { children: React.ReactNode }) =>
+    React.createElement("button", null, children),
+  WKModal: ({
+    children,
+    header,
+  }: {
+    children: React.ReactNode;
+    header?: React.ReactNode;
+  }) => React.createElement("div", null, header, children),
+  wkConfirm: vi.fn(),
+}));
+
+let container: HTMLDivElement | null = null;
+
+afterEach(() => {
+  if (container) {
+    ReactDOM.unmountComponentAtNode(container);
+    container.remove();
+    container = null;
+  }
+  vi.clearAllMocks();
+});
+
+function render(element: React.ReactElement) {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  act(() => {
+    ReactDOM.render(element, container);
+  });
+  return container;
+}
+
+const baseItem: McpListItem = {
+  id: "mcp-1",
+  name: "Official MCP",
+  slogan: "Test MCP",
+  category: "dev",
+  tags: [],
+  toolCount: 1,
+  icon: "",
+  visibility: "system",
+  source: "system",
+  creatorName: "Internal Admin",
+  matchReasons: ["creator:Internal Admin", "tool:search"],
+};
+
+describe("official MCP publisher", () => {
+  it("shows official publisher on cards without leaking creator identity", () => {
+    const root = render(<McpCard item={baseItem} onClick={vi.fn()} />);
+
+    expect(root.querySelector(".wk-mcp-card--official")).not.toBeNull();
+    expect(root.textContent).toContain("官方发布");
+    expect(root.textContent).not.toContain("Internal Admin");
+    expect(root.textContent).toContain("search");
+  });
+
+  it("keeps normal publisher rendering for non-system MCPs", () => {
+    const root = render(
+      <McpCard
+        item={{ ...baseItem, visibility: "public", source: "system" }}
+        onClick={vi.fn()}
+      />
+    );
+
+    expect(root.querySelector(".wk-mcp-card--official")).toBeNull();
+    expect(root.textContent).toContain("Internal Admin");
+    expect(root.textContent).not.toContain("官方发布");
+  });
+
+  it("keeps card keyboard activation for official MCPs", () => {
+    const onClick = vi.fn();
+    const root = render(<McpCard item={baseItem} onClick={onClick} />);
+    const card = root.querySelector(".wk-mcp-card") as HTMLElement;
+
+    act(() => {
+      card.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Enter", bubbles: true })
+      );
+    });
+
+    expect(onClick).toHaveBeenCalledWith(baseItem);
+  });
+
+  it("shows the same official publisher in details", async () => {
+    const detail: McpDetail = {
+      ...baseItem,
+      quickStart: { transport: "streamable-http", serverName: "Official MCP" },
+      tools: [],
+      usageExamples: [],
+      faqs: [],
+      notes: [],
+    };
+    fetchMcpDetail.mockResolvedValue(detail);
+
+    let root!: HTMLElement;
+    await act(async () => {
+      root = render(<McpDetailModal mcpId="mcp-1" onClose={vi.fn()} />);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(root.textContent).toContain("官方发布");
+    expect(root.textContent).not.toContain("Internal Admin");
+  });
+});

--- a/packages/dmworkmcp/src/i18n/en-US.json
+++ b/packages/dmworkmcp/src/i18n/en-US.json
@@ -87,6 +87,7 @@
     "clear": "Clear"
   },
   "card": {
+    "officialPublisher": "Official publisher",
     "matchReason": {
       "name": "Matched name",
       "description": "Matched summary",

--- a/packages/dmworkmcp/src/i18n/zh-CN.json
+++ b/packages/dmworkmcp/src/i18n/zh-CN.json
@@ -87,6 +87,7 @@
     "clear": "清空"
   },
   "card": {
+    "officialPublisher": "官方发布",
     "matchReason": {
       "name": "命中名称",
       "description": "命中简介",

--- a/packages/dmworkmcp/src/index.css
+++ b/packages/dmworkmcp/src/index.css
@@ -560,7 +560,7 @@
   border-radius: var(--wk-r-full);
   background: var(--wk-bg-surface);
   color: var(--wk-text-secondary);
-  font: 400 var(--wk-text-size-sm)/1 var(--wk-font-sans);
+  font: 400 var(--wk-text-size-sm) / 1 var(--wk-font-sans);
   cursor: pointer;
   white-space: nowrap;
   transition: all var(--wk-dur-fast) var(--wk-ease);
@@ -649,6 +649,16 @@
   outline: none;
   border-color: var(--wk-border-strong);
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+}
+
+.wk-mcp-card--official {
+  border-color: var(--wk-ai-border);
+  background: var(--wk-ai-surface);
+}
+
+.wk-mcp-card--official:hover,
+.wk-mcp-card--official:focus-visible {
+  border-color: var(--wk-color-accent);
 }
 
 /* Row 1: icon + header column. Matches `.skill-market-card__top`. */
@@ -751,8 +761,14 @@
 }
 
 .wk-mcp-card__owner-bot-icon,
-.wk-mcp-card__owner-user-icon {
+.wk-mcp-card__owner-user-icon,
+.wk-mcp-card__owner-official-icon {
   flex: 0 0 auto;
+}
+
+.wk-mcp-card__owner--official,
+.wk-mcp-detail__owner--official {
+  color: var(--wk-text-accent);
 }
 
 .wk-mcp-card__meta-separator {
@@ -845,7 +861,8 @@
   color: #1f2937;
   border: 1px solid rgba(15, 23, 42, 0.06);
   border-radius: 8px;
-  box-shadow: 0 12px 32px rgba(15, 23, 42, 0.12), 0 2px 6px rgba(15, 23, 42, 0.06);
+  box-shadow: 0 12px 32px rgba(15, 23, 42, 0.12),
+    0 2px 6px rgba(15, 23, 42, 0.06);
 }
 
 /* Content already sits inside the wrapper's box; kill the redundant shadow

--- a/packages/dmworkmcp/src/types/mcp.ts
+++ b/packages/dmworkmcp/src/types/mcp.ts
@@ -90,7 +90,7 @@ export interface McpListItem {
    *  stays intact after a bot rename / delete. */
   createdByBotName?: string;
   transport?: McpTransport;
-  source?: "system" | "space" | "mine";
+  source?: McpSource;
   verificationStatus?: "verified" | "unverified" | "error";
   matchReasons?: string[];
   relevance?: number;
@@ -128,6 +128,8 @@ export interface McpDetail extends McpListItem {
  *  "import" is reserved for the Git-import path (#867). */
 export type McpCreatedByType = "human" | "bot" | "import";
 
+export type McpSource = "system" | "space" | "mine";
+
 /** A category filter option with its live count. */
 export interface McpCategory {
   key: string;
@@ -142,7 +144,7 @@ export interface ListMcpParams {
   categories?: string[];
   transports?: McpTransport[];
   visibilities?: McpVisibility[];
-  sources?: Array<"system" | "space" | "mine">;
+  sources?: McpSource[];
   verificationStatuses?: Array<"verified" | "unverified" | "error">;
   /** Provenance filter (mcp-v1.md §4.2; issue #894). Single-select today —
    *  the toolbar segmented control is one-of-three. Kept as a single value
@@ -241,7 +243,7 @@ export interface CreateMcpParams {
   notes?: string[];
 }
 
-export type McpVisibility = "public" | "private";
+export type McpVisibility = "public" | "private" | "system";
 
 /**
  * Payload for updating an existing MCP server entry (PATCH /mcps/{id}).

--- a/packages/dmworkmcp/src/utils/publisher.test.ts
+++ b/packages/dmworkmcp/src/utils/publisher.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+import { isOfficialMcp } from "./publisher";
+
+describe("isOfficialMcp", () => {
+  it("only treats visibility=system as official", () => {
+    expect(isOfficialMcp({ visibility: "system" })).toBe(true);
+    expect(isOfficialMcp({ visibility: "public" })).toBe(false);
+    expect(isOfficialMcp({ visibility: "private" })).toBe(false);
+    expect(isOfficialMcp({ visibility: undefined })).toBe(false);
+  });
+});

--- a/packages/dmworkmcp/src/utils/publisher.ts
+++ b/packages/dmworkmcp/src/utils/publisher.ts
@@ -1,0 +1,5 @@
+import type { McpListItem } from "../types/mcp";
+
+export function isOfficialMcp(item: Pick<McpListItem, "visibility">): boolean {
+  return item.visibility === "system";
+}


### PR DESCRIPTION
## Summary
- LSC-24: identify official MCPs only with `visibility === "system"`
- replace creator identity with a shield icon and localized “官方发布 / Official publisher” on list cards and details
- add subtle token-based official card styling and hide creator search match reasons for official MCPs
- preserve normal human/bot/import publisher rendering and fail closed for missing/unknown visibility
- add a reproducible full-app Playwright integration case using the repository MSW harness

## Verification
- `pnpm --filter @dmwork/mcp test` — 12 files, 134 tests passed
- `pnpm i18n:check` — passed
- `pnpm --filter @octo/web build` — passed
- `E2E_TARGET=local pnpm --filter @octo/web exec playwright test --config=e2e-kit/playwright.config.ts e2e-kit/tests/C37-mcp-official-publisher.spec.ts --project=chromium` — 1 passed

## Full-app Integration Evidence
Fixture type: **application-level API fixture** (repository MSW service worker), not real backend data.

- Commit: `45cc17b2`
- Start command: Playwright config webServer runs `pnpm dev`
- URL: `http://localhost:3000/mcp-market/mcp?sid=e2etest`
- Requests observed in Chromium:
  - `GET /market/api/v1/mcps?category=all&sort=updated&page_size=20&page=1`
  - `GET /market/api/v1/mcp_categories`
  - `GET /market/api/v1/mcps/official-search`
  - `GET /market/api/v1/mcps/community-search`
- Responses: HTTP 200; list and official detail contain `visibility: "system"`; `creator_name` is redacted in fixture evidence.
- UI coverage: full shell/NavRail/market sidebar, official + normal list cards, official + normal details, light/dark theme, 390px viewport.
- Console errors: 0; MCP network failures: 0.
- Screenshots and `mcp-api-evidence.json` are attached by Playwright and mirrored to the Octo issue comment.

Base: `upstream/main@8f8a19c2`
Head: `feat/LSC-24-mcp-official-publisher-v2@45cc17b2`
