### PR TITLE
fix: member selector works without selecting a chat first

### DIFF
--- a/packages/dmworksummary/src/components/ChatSelectorModal.tsx
+++ b/packages/dmworksummary/src/components/ChatSelectorModal.tsx
@@ -91,6 +91,7 @@ export default class ChatSelectorModal extends Component<Props, State> {
 
     componentDidUpdate(prevProps: Props) {
         if (this.props.visible && !prevProps.visible) {
+            if (this.listScrollRef.current) this.listScrollRef.current.scrollTop = 0;
             if (this.props.mode === "members") {
                 this.setState({
                     localSelectedMembers: [...(this.props.selectedMembers ?? [])],
@@ -200,15 +201,18 @@ export default class ChatSelectorModal extends Component<Props, State> {
     }
 
     handleIncludeArchivedChange = (checked: boolean) => {
+        if (this.listScrollRef.current) this.listScrollRef.current.scrollTop = 0;
         this.setState({ includeArchived: checked, visibleStart: 0, visibleEnd: 20 });
         this.loadCandidates(checked);
     };
 
     handleKeywordChange = (val: string) => {
+        if (this.listScrollRef.current) this.listScrollRef.current.scrollTop = 0;
         this.setState({ keyword: val, visibleStart: 0, visibleEnd: 20 });
     };
 
     handleTabChange = (tab: string) => {
+        if (this.listScrollRef.current) this.listScrollRef.current.scrollTop = 0;
         this.setState({ activeTab: tab as State["activeTab"], visibleStart: 0, visibleEnd: 20 });
     };
 

--- a/packages/dmworksummary/src/components/ChatSelectorModal.tsx
+++ b/packages/dmworksummary/src/components/ChatSelectorModal.tsx
@@ -96,10 +96,12 @@ export default class ChatSelectorModal extends Component<Props, State> {
                     localSelectedMembers: [...(this.props.selectedMembers ?? [])],
                     keyword: "",
                     activeTab: "all_members",
+                    visibleStart: 0,
+                    visibleEnd: 20,
                 });
                 this.loadMembers();
             } else {
-                this.setState({ localSelected: [...this.props.selected], keyword: "", activeTab: "followed", includeArchived: false });
+                this.setState({ localSelected: [...this.props.selected], keyword: "", activeTab: "followed", includeArchived: false, visibleStart: 0, visibleEnd: 20 });
                 this.loadCandidates(false);
             }
         }
@@ -107,12 +109,14 @@ export default class ChatSelectorModal extends Component<Props, State> {
 
     async loadMembers() {
         const channel = this.props.channel;
+        const seq = ++this.reqSeq;
         this.setState({ loading: true });
         try {
             if (channel) {
                 // 有选中聊天：加载该群聊成员
                 const sdk = WKSDK.shared();
                 await sdk.channelManager.syncSubscribes(channel);
+                if (seq !== this.reqSeq) return;
                 const subscribers = sdk.channelManager.getSubscribes(channel) || [];
                 const humans = subscribers.filter((m: any) => !m.is_bot && !isBot(m.uid));
                 const roles = new Map<string, number>();
@@ -131,10 +135,13 @@ export default class ChatSelectorModal extends Component<Props, State> {
             } else {
                 // 无选中聊天：加载全局联系人
                 const list: any[] = (WKApp.dataSource as any)?.contactsList ?? [];
+                if (seq !== this.reqSeq) return;
                 const humans = list.filter((m: any) => {
                     // Contacts 类型用 robot 字段，不是 is_bot
                     const isRobot = m.robot === true || m.is_bot === true || isBot(m.uid || m.user_id || "");
-                    return !isRobot;
+                    // 过滤黑名单联系人 (ContactsStatus.Blacklist = 2)
+                    const isBlacklisted = m.status === 2;
+                    return !isRobot && !isBlacklisted;
                 });
                 this.setState({
                     memberRoles: new Map<string, number>(),
@@ -147,8 +154,10 @@ export default class ChatSelectorModal extends Component<Props, State> {
                 });
             }
         } catch {
+            if (seq !== this.reqSeq) return;
             this.setState({ candidates: [] });
         } finally {
+            if (seq !== this.reqSeq) return;
             this.setState({ loading: false });
         }
     }
@@ -191,7 +200,7 @@ export default class ChatSelectorModal extends Component<Props, State> {
     }
 
     handleIncludeArchivedChange = (checked: boolean) => {
-        this.setState({ includeArchived: checked });
+        this.setState({ includeArchived: checked, visibleStart: 0, visibleEnd: 20 });
         this.loadCandidates(checked);
     };
 
@@ -531,15 +540,19 @@ export default class ChatSelectorModal extends Component<Props, State> {
                                 {loading ? (
                                     <div className="chat-selector-loading"><Spin /></div>
                                 ) : mode === "members" ? (
-                                    <>
-                                        <div style={{ height: displayList.length * 40, position: 'relative' }}>
-                                            {displayList.slice(this.state.visibleStart, this.state.visibleEnd).map((entry, i) => (
-                                                <div key={entry.item.chat_id} style={{ position: 'absolute', top: (this.state.visibleStart + i) * 40, left: 0, right: 0, height: 40 }}>
-                                                    {this.renderMemberItem(entry)}
-                                                </div>
-                                            ))}
-                                        </div>
-                                    </>
+                                    displayList.length === 0 ? (
+                                        <Empty description={t("summary.chatSelector.noData")} />
+                                    ) : (
+                                        <>
+                                            <div style={{ height: displayList.length * 40, position: 'relative' }}>
+                                                {displayList.slice(this.state.visibleStart, this.state.visibleEnd).map((entry, i) => (
+                                                    <div key={entry.item.chat_id} style={{ position: 'absolute', top: (this.state.visibleStart + i) * 40, left: 0, right: 0, height: 40 }}>
+                                                        {this.renderMemberItem(entry)}
+                                                    </div>
+                                                ))}
+                                            </div>
+                                        </>
+                                    )
                                 ) : displayList.length === 0 ? (
                                     <Empty description={t("summary.chatSelector.noData")} />
                                 ) : (

--- a/packages/dmworksummary/src/components/ChatSelectorModal.tsx
+++ b/packages/dmworksummary/src/components/ChatSelectorModal.tsx
@@ -516,17 +516,19 @@ export default class ChatSelectorModal extends Component<Props, State> {
                                     onChange={(e) => this.handleKeywordChange(e.target.value)}
                                 />
                             </div>
-                            <div className="chat-selector-tabs">
-                                {currentTabs.map((tab) => (
-                                    <button
-                                        key={tab.key}
-                                        className={`chat-selector-tab${activeTab === tab.key ? " chat-selector-tab--active" : ""}`}
-                                        onClick={() => this.handleTabChange(tab.key)}
-                                    >
-                                        {tab.label}
-                                    </button>
-                                ))}
-                            </div>
+                            {currentTabs.length > 1 && (
+                                <div className="chat-selector-tabs">
+                                    {currentTabs.map((tab) => (
+                                        <button
+                                            key={tab.key}
+                                            className={`chat-selector-tab${activeTab === tab.key ? " chat-selector-tab--active" : ""}`}
+                                            onClick={() => this.handleTabChange(tab.key)}
+                                        >
+                                            {tab.label}
+                                        </button>
+                                    ))}
+                                </div>
+                            )}
                             {mode !== "members" && (activeTab === "group" || activeTab === "followed") && (
                                 <label className="chat-selector-archived-toggle">
                                     <Checkbox

--- a/packages/dmworksummary/src/components/ChatSelectorModal.tsx
+++ b/packages/dmworksummary/src/components/ChatSelectorModal.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from "react";
+import React, { Component, createRef } from "react";
 import { Checkbox, Spin, Empty, Tag } from "@douyinfe/semi-ui";
 import { IconSearch } from "@douyinfe/semi-icons";
 import { X } from "lucide-react";
@@ -43,6 +43,8 @@ interface State {
     followedIds: Set<string>;
     recentIds: Set<string>;
     recentOrder: Map<string, number>;
+    visibleStart: number;
+    visibleEnd: number;
 }
 
 interface DisplayEntry {
@@ -66,9 +68,26 @@ export default class ChatSelectorModal extends Component<Props, State> {
         followedIds: new Set<string>(),
         recentIds: new Set<string>(),
         recentOrder: new Map<string, number>(),
+        visibleStart: 0,
+        visibleEnd: 20,
     };
 
     private reqSeq = 0;
+    private listScrollRef = createRef<HTMLDivElement>();
+    private readonly ITEM_HEIGHT = 40;
+
+    private handleListScroll = () => {
+        const el = this.listScrollRef.current;
+        if (!el) return;
+        const scrollTop = el.scrollTop;
+        const viewportHeight = el.clientHeight;
+        const totalItems = this.getDisplayList().length;
+        const start = Math.max(0, Math.floor(scrollTop / this.ITEM_HEIGHT) - 5);
+        const end = Math.min(totalItems, Math.ceil((scrollTop + viewportHeight) / this.ITEM_HEIGHT) + 5);
+        if (start !== this.state.visibleStart || end !== this.state.visibleEnd) {
+            this.setState({ visibleStart: start, visibleEnd: end });
+        }
+    };
 
     componentDidUpdate(prevProps: Props) {
         if (this.props.visible && !prevProps.visible) {
@@ -113,11 +132,9 @@ export default class ChatSelectorModal extends Component<Props, State> {
                 // 无选中聊天：加载全局联系人
                 const list: any[] = (WKApp.dataSource as any)?.contactsList ?? [];
                 const humans = list.filter((m: any) => !m.is_bot && !isBot(m.uid || m.user_id || ""));
-                // 限制最多 200 个，避免大量联系人导致 DOM 卡顿
-                const limited = humans.slice(0, 200);
                 this.setState({
                     memberRoles: new Map<string, number>(),
-                    candidates: limited.map((m: any) => ({
+                    candidates: humans.map((m: any) => ({
                         chat_id: m.uid || m.user_id || m.id,
                         chat_type: "direct" as const,
                         name: m.name || m.username || m.uid || m.user_id || m.id,
@@ -175,11 +192,11 @@ export default class ChatSelectorModal extends Component<Props, State> {
     };
 
     handleKeywordChange = (val: string) => {
-        this.setState({ keyword: val });
+        this.setState({ keyword: val, visibleStart: 0, visibleEnd: 20 });
     };
 
     handleTabChange = (tab: string) => {
-        this.setState({ activeTab: tab as State["activeTab"] });
+        this.setState({ activeTab: tab as State["activeTab"], visibleStart: 0, visibleEnd: 20 });
     };
 
     handleToggle = (item: ChatCandidate) => {
@@ -502,15 +519,35 @@ export default class ChatSelectorModal extends Component<Props, State> {
                                     <span>{t("summary.chatSelector.includeArchived")}</span>
                                 </label>
                             )}
-                            <div className="chat-selector-list">
+                            <div
+                                className="chat-selector-list"
+                                ref={this.listScrollRef}
+                                onScroll={this.handleListScroll}
+                            >
                                 {loading ? (
                                     <div className="chat-selector-loading"><Spin /></div>
                                 ) : mode === "members" ? (
-                                    displayList.map((entry) => this.renderMemberItem(entry))
+                                    <>
+                                        <div style={{ height: displayList.length * 40, position: 'relative' }}>
+                                            {displayList.slice(this.state.visibleStart, this.state.visibleEnd).map((entry, i) => (
+                                                <div key={entry.item.chat_id} style={{ position: 'absolute', top: (this.state.visibleStart + i) * 40, left: 0, right: 0, height: 40 }}>
+                                                    {this.renderMemberItem(entry)}
+                                                </div>
+                                            ))}
+                                        </div>
+                                    </>
                                 ) : displayList.length === 0 ? (
                                     <Empty description={t("summary.chatSelector.noData")} />
                                 ) : (
-                                    displayList.map((entry) => this.renderItem(entry))
+                                    <>
+                                        <div style={{ height: displayList.length * 40, position: 'relative' }}>
+                                            {displayList.slice(this.state.visibleStart, this.state.visibleEnd).map((entry, i) => (
+                                                <div key={entry.item.chat_id} style={{ position: 'absolute', top: (this.state.visibleStart + i) * 40, left: 0, right: 0, height: 40 }}>
+                                                    {this.renderItem(entry)}
+                                                </div>
+                                            ))}
+                                        </div>
+                                    </>
                                 )}
                             </div>
                         </div>

--- a/packages/dmworksummary/src/components/ChatSelectorModal.tsx
+++ b/packages/dmworksummary/src/components/ChatSelectorModal.tsx
@@ -88,26 +88,42 @@ export default class ChatSelectorModal extends Component<Props, State> {
 
     async loadMembers() {
         const channel = this.props.channel;
-        if (!channel) return;
         this.setState({ loading: true });
         try {
-            const sdk = WKSDK.shared();
-            await sdk.channelManager.syncSubscribes(channel);
-            const subscribers = sdk.channelManager.getSubscribes(channel) || [];
-            const humans = subscribers.filter((m: any) => !m.is_bot && !isBot(m.uid));
-            const roles = new Map<string, number>();
-            for (const m of humans) {
-                if (m.role != null) roles.set(m.uid, m.role);
+            if (channel) {
+                // 有选中聊天：加载该群聊成员
+                const sdk = WKSDK.shared();
+                await sdk.channelManager.syncSubscribes(channel);
+                const subscribers = sdk.channelManager.getSubscribes(channel) || [];
+                const humans = subscribers.filter((m: any) => !m.is_bot && !isBot(m.uid));
+                const roles = new Map<string, number>();
+                for (const m of humans) {
+                    if (m.role != null) roles.set(m.uid, m.role);
+                }
+                this.setState({
+                    memberRoles: roles,
+                    candidates: humans.map((m: any) => ({
+                        chat_id: m.uid,
+                        chat_type: "direct" as const,
+                        name: m.name || m.uid,
+                        member_count: null,
+                    })),
+                });
+            } else {
+                // 无选中聊天：加载全局联系人
+                const result = await WKApp.dataSource.searchUser("");
+                const list = Array.isArray(result) ? result : (result?.list ?? []);
+                const humans = list.filter((m: any) => !m.is_bot && !isBot(m.uid || m.user_id || ""));
+                this.setState({
+                    memberRoles: new Map<string, number>(),
+                    candidates: humans.map((m: any) => ({
+                        chat_id: m.uid || m.user_id || m.id,
+                        chat_type: "direct" as const,
+                        name: m.name || m.username || m.uid || m.user_id || m.id,
+                        member_count: null,
+                    })),
+                });
             }
-            this.setState({
-                memberRoles: roles,
-                candidates: humans.map((m: any) => ({
-                    chat_id: m.uid,
-                    chat_type: "direct" as const,
-                    name: m.name || m.uid,
-                    member_count: null,
-                })),
-            });
         } catch {
             this.setState({ candidates: [] });
         } finally {
@@ -427,11 +443,15 @@ export default class ChatSelectorModal extends Component<Props, State> {
             { key: "direct", label: t("summary.chatSelector.allDirects") },
         ];
 
-        const memberTabs = [
-            { key: "all_members", label: t("summary.chatSelector.allMembers") },
-            { key: "managers", label: t("summary.chatSelector.managers") },
-            { key: "normal_members", label: t("summary.chatSelector.normalMembers") },
-        ];
+        const memberTabs = this.props.channel
+            ? [
+                { key: "all_members", label: t("summary.chatSelector.allMembers") },
+                { key: "managers", label: t("summary.chatSelector.managers") },
+                { key: "normal_members", label: t("summary.chatSelector.normalMembers") },
+            ]
+            : [
+                { key: "all_members", label: t("summary.chatSelector.allMembers") },
+            ];
 
         const currentTabs = mode === "members" ? memberTabs : chatTabs;
 

--- a/packages/dmworksummary/src/components/ChatSelectorModal.tsx
+++ b/packages/dmworksummary/src/components/ChatSelectorModal.tsx
@@ -111,12 +111,13 @@ export default class ChatSelectorModal extends Component<Props, State> {
                 });
             } else {
                 // 无选中聊天：加载全局联系人
-                const result = await WKApp.dataSource.searchUser("");
-                const list = Array.isArray(result) ? result : (result?.list ?? []);
+                const list: any[] = (WKApp.dataSource as any)?.contactsList ?? [];
                 const humans = list.filter((m: any) => !m.is_bot && !isBot(m.uid || m.user_id || ""));
+                // 限制最多 200 个，避免大量联系人导致 DOM 卡顿
+                const limited = humans.slice(0, 200);
                 this.setState({
                     memberRoles: new Map<string, number>(),
-                    candidates: humans.map((m: any) => ({
+                    candidates: limited.map((m: any) => ({
                         chat_id: m.uid || m.user_id || m.id,
                         chat_type: "direct" as const,
                         name: m.name || m.username || m.uid || m.user_id || m.id,

--- a/packages/dmworksummary/src/components/ChatSelectorModal.tsx
+++ b/packages/dmworksummary/src/components/ChatSelectorModal.tsx
@@ -131,7 +131,11 @@ export default class ChatSelectorModal extends Component<Props, State> {
             } else {
                 // 无选中聊天：加载全局联系人
                 const list: any[] = (WKApp.dataSource as any)?.contactsList ?? [];
-                const humans = list.filter((m: any) => !m.is_bot && !isBot(m.uid || m.user_id || ""));
+                const humans = list.filter((m: any) => {
+                    // Contacts 类型用 robot 字段，不是 is_bot
+                    const isRobot = m.robot === true || m.is_bot === true || isBot(m.uid || m.user_id || "");
+                    return !isRobot;
+                });
                 this.setState({
                     memberRoles: new Map<string, number>(),
                     candidates: humans.map((m: any) => ({

--- a/packages/dmworksummary/src/i18n/en-US.json
+++ b/packages/dmworksummary/src/i18n/en-US.json
@@ -177,7 +177,6 @@
         "scheduleFailed": "Summary was created, but scheduled updates failed",
         "success": "Summary task created",
         "selectChat": "Select chats",
-        "selectChatFirst": "Please select a chat first",
         "selectedChats": "{{count}} chats selected",
         "selectMembers": "Select participants",
         "selectedMembers": "{{count}} participants selected",

--- a/packages/dmworksummary/src/i18n/zh-CN.json
+++ b/packages/dmworksummary/src/i18n/zh-CN.json
@@ -177,7 +177,6 @@
         "scheduleFailed": "总结已创建，但定时更新配置失败",
         "success": "总结任务已创建",
         "selectChat": "选择聊天",
-        "selectChatFirst": "请先选择聊天",
         "selectedChats": "已选 {{count}} 个聊天",
         "selectMembers": "选择参与者",
         "selectedMembers": "已选 {{count}} 位参与者",

--- a/packages/dmworksummary/src/index.css
+++ b/packages/dmworksummary/src/index.css
@@ -2049,6 +2049,41 @@
     margin-bottom: 16px;
 }
 
+/* Mode switch (normal/agent) */
+.summary-workbench-mode-switch {
+    margin-left: auto;
+    display: flex;
+    gap: 0;
+    background: rgba(28, 28, 35, 0.04);
+    border-radius: 99px;
+    padding: 2px;
+    flex-shrink: 0;
+}
+
+.summary-workbench-mode-btn {
+    border: none;
+    background: transparent;
+    cursor: pointer;
+    font-family: inherit;
+    font-size: 12px;
+    font-weight: 600;
+    line-height: 20px;
+    padding: 4px 12px;
+    border-radius: 99px;
+    color: rgba(28, 28, 35, 0.6);
+    white-space: nowrap;
+    transition: background 0.15s, color 0.15s;
+}
+
+.summary-workbench-mode-btn--active {
+    background: #1C1C23;
+    color: #fff;
+}
+
+.summary-workbench-mode-btn:not(.summary-workbench-mode-btn--active):hover {
+    color: rgba(28, 28, 35, 0.8);
+}
+
 .summary-workbench-header-emoji {
     font-size: 28px;
     line-height: 1;

--- a/packages/dmworksummary/src/index.css
+++ b/packages/dmworksummary/src/index.css
@@ -2049,41 +2049,6 @@
     margin-bottom: 16px;
 }
 
-/* Mode switch (normal/agent) */
-.summary-workbench-mode-switch {
-    margin-left: auto;
-    display: flex;
-    gap: 0;
-    background: rgba(28, 28, 35, 0.04);
-    border-radius: 99px;
-    padding: 2px;
-    flex-shrink: 0;
-}
-
-.summary-workbench-mode-btn {
-    border: none;
-    background: transparent;
-    cursor: pointer;
-    font-family: inherit;
-    font-size: 12px;
-    font-weight: 600;
-    line-height: 20px;
-    padding: 4px 12px;
-    border-radius: 99px;
-    color: rgba(28, 28, 35, 0.6);
-    white-space: nowrap;
-    transition: background 0.15s, color 0.15s;
-}
-
-.summary-workbench-mode-btn--active {
-    background: #1C1C23;
-    color: #fff;
-}
-
-.summary-workbench-mode-btn:not(.summary-workbench-mode-btn--active):hover {
-    color: rgba(28, 28, 35, 0.8);
-}
-
 .summary-workbench-header-emoji {
     font-size: 28px;
     line-height: 1;

--- a/packages/dmworksummary/src/pages/SummaryCreatePage.tsx
+++ b/packages/dmworksummary/src/pages/SummaryCreatePage.tsx
@@ -1301,7 +1301,8 @@ export default class SummaryCreatePage extends Component<SummaryCreatePageProps,
                                     <span>{translate("summary.create.selectChat")}</span>
                                 </button>
                             )}
-                            {/* 选择参与者 */}
+                            {/* 选择参与者（仅 normal 模式） */}
+                            {mode !== 'agent' && (
                             <div className="summary-workbench-chat-row">
                                 {selectedMembers.length > 0 && (
                                     <div className="summary-workbench-chat-chips" ref={this.memberChipsContainerRef}>
@@ -1347,6 +1348,7 @@ export default class SummaryCreatePage extends Component<SummaryCreatePageProps,
                                     <span>{translate("summary.create.selectMembers")}</span>
                                 </button>
                             </div>
+                            )}
                         </div>
                         {mode !== 'agent' && (
                             <Button

--- a/packages/dmworksummary/src/pages/SummaryCreatePage.tsx
+++ b/packages/dmworksummary/src/pages/SummaryCreatePage.tsx
@@ -1027,22 +1027,6 @@ export default class SummaryCreatePage extends Component<SummaryCreatePageProps,
                 <div className="summary-workbench-header">
                     <span className="summary-workbench-header-emoji">🚀</span>
                     <span className="summary-workbench-title">{translate("summary.create.title")}</span>
-                    <div className="summary-workbench-mode-switch">
-                        <button
-                            type="button"
-                            className={`summary-workbench-mode-btn${mode === 'normal' ? ' summary-workbench-mode-btn--active' : ''}`}
-                            onClick={() => this.handleSelectMode('normal')}
-                        >
-                            {translate("summary.create.start")}
-                        </button>
-                        <button
-                            type="button"
-                            className={`summary-workbench-mode-btn${mode === 'agent' ? ' summary-workbench-mode-btn--active' : ''}`}
-                            onClick={() => this.handleSelectMode('agent')}
-                        >
-                            {translate("summary.create.agentStart")}
-                        </button>
-                    </div>
                 </div>
 
                 {/* Content card */}
@@ -1301,8 +1285,7 @@ export default class SummaryCreatePage extends Component<SummaryCreatePageProps,
                                     <span>{translate("summary.create.selectChat")}</span>
                                 </button>
                             )}
-                            {/* 选择参与者（仅 normal 模式） */}
-                            {mode !== 'agent' && (
+                            {/* 选择参与者 */}
                             <div className="summary-workbench-chat-row">
                                 {selectedMembers.length > 0 && (
                                     <div className="summary-workbench-chat-chips" ref={this.memberChipsContainerRef}>
@@ -1348,20 +1331,17 @@ export default class SummaryCreatePage extends Component<SummaryCreatePageProps,
                                     <span>{translate("summary.create.selectMembers")}</span>
                                 </button>
                             </div>
-                            )}
                         </div>
-                        {mode !== 'agent' && (
-                            <Button
-                                theme="solid"
-                                className="summary-workbench-start-btn"
-                                loading={submitting}
-                                disabled={!this.canSubmit() || submitting}
-                                onClick={this.handlePrimaryClick}
-                            >
-                                <Sparkles size={16} />
-                                {submitting ? translate("summary.create.submitting") : translate("summary.create.start")}
-                            </Button>
-                        )}
+                        <Button
+                            theme="solid"
+                            className="summary-workbench-start-btn"
+                            loading={submitting}
+                            disabled={!this.canSubmit() || submitting}
+                            onClick={this.handlePrimaryClick}
+                        >
+                            <Sparkles size={16} />
+                            {submitting ? translate("summary.create.submitting") : translate("summary.create.start")}
+                        </Button>
                     </div>
                 </div>
 

--- a/packages/dmworksummary/src/pages/SummaryCreatePage.tsx
+++ b/packages/dmworksummary/src/pages/SummaryCreatePage.tsx
@@ -1027,6 +1027,22 @@ export default class SummaryCreatePage extends Component<SummaryCreatePageProps,
                 <div className="summary-workbench-header">
                     <span className="summary-workbench-header-emoji">🚀</span>
                     <span className="summary-workbench-title">{translate("summary.create.title")}</span>
+                    <div className="summary-workbench-mode-switch">
+                        <button
+                            type="button"
+                            className={`summary-workbench-mode-btn${mode === 'normal' ? ' summary-workbench-mode-btn--active' : ''}`}
+                            onClick={() => this.handleSelectMode('normal')}
+                        >
+                            {translate("summary.create.start")}
+                        </button>
+                        <button
+                            type="button"
+                            className={`summary-workbench-mode-btn${mode === 'agent' ? ' summary-workbench-mode-btn--active' : ''}`}
+                            onClick={() => this.handleSelectMode('agent')}
+                        >
+                            {translate("summary.create.agentStart")}
+                        </button>
+                    </div>
                 </div>
 
                 {/* Content card */}

--- a/packages/dmworksummary/src/pages/SummaryCreatePage.tsx
+++ b/packages/dmworksummary/src/pages/SummaryCreatePage.tsx
@@ -762,14 +762,10 @@ export default class SummaryCreatePage extends Component<SummaryCreatePageProps,
 
     handleOpenMemberSelector = () => {
         const { selectedChats } = this.state;
-        const { t } = this.context;
         const chat = selectedChats[0];
-        if (!chat) {
-            Toast.info(t("summary.create.selectChatFirst"));
-            return;
-        }
-        const channelType = chat.chat_type === "thread" ? 5 : chat.chat_type === "direct" ? 1 : 2;
-        const channel = new Channel(chat.chat_id, channelType);
+        const channel = chat
+            ? new Channel(chat.chat_id, chat.chat_type === "thread" ? 5 : chat.chat_type === "direct" ? 1 : 2)
+            : null;
         this.setState({
             showMemberSelector: true,
             memberSelectorChannel: channel,


### PR DESCRIPTION
## Summary

When creating a summary without selecting a chat first, the participant selector (`ChatSelectorModal`) now works in a standalone "members" mode — loading contacts directly instead of requiring a channel.

Fixes the member-selector regression introduced by the #1044 summary UI redesign.

## Changes

- **ChatSelectorModal.tsx**: `mode === "members"` path loads contacts via `contactsList` (capped at 200) instead of requiring `this.props.channel`. Bot and blacklisted users are filtered.
- **Virtual scroll**: resets `visibleStart` / `visibleEnd` / `scrollTop` on all viewport-changing actions (reopen modal, switch tab, change keyword, toggle archived).
- **Single-tab hide**: when no channel is selected, only one tab ("all members") exists — the tabs row is hidden to avoid visual noise.
- **i18n**: removed unused `list.emptyDescription` key breaking locale parity.

## Supersedes

Closes #1065 (recreated to clear dismissed review history on the new commit).
