### PR TITLE
fix(bot-manage): route mention-free search through backend q param (WS-115)

### DIFF
--- a/packages/dmworkbase/src/Components/BotManage/index.tsx
+++ b/packages/dmworkbase/src/Components/BotManage/index.tsx
@@ -165,6 +165,7 @@ class MentionFreeListContainer extends Component<MentionFreeListContainerProps> 
 
     componentWillUnmount(): void {
         if (this.unsubscribe) this.unsubscribe()
+        this.props.vm.dispose()
     }
 
     render(): ReactNode {
@@ -174,6 +175,7 @@ class MentionFreeListContainer extends Component<MentionFreeListContainerProps> 
             <MentionFreeListView
                 labels={labels}
                 loading={vm.loading}
+                searching={vm.searching}
                 backendMissing={vm.isBackendMissing}
                 loadError={vm.loadError}
                 searchKeyword={vm.searchKeyword}

--- a/packages/dmworkbase/src/Service/BotManageService.ts
+++ b/packages/dmworkbase/src/Service/BotManageService.ts
@@ -16,6 +16,8 @@ export interface ListBotGroupsRequest {
   robotId: string
   limit: number
   cursor?: string | null
+  /** 后端 g.name LIKE %q% 全库搜索关键字；空串 / 仅空白不下发。 */
+  q?: string
 }
 
 const BotManageService = {
@@ -25,6 +27,10 @@ const BotManageService = {
     }
     if (request.cursor) {
       param.cursor = request.cursor
+    }
+    const q = (request.q || "").trim()
+    if (q) {
+      param.q = q
     }
     return APIClient.shared.get(`robot/${request.robotId}/groups`, { param })
   },

--- a/packages/dmworkbase/src/Service/__tests__/BotManageService.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/BotManageService.test.ts
@@ -48,6 +48,25 @@ describe("BotManageService", () => {
     })
   })
 
+  it("listGroups trims q and omits it when blank/whitespace", async () => {
+    apiGet.mockResolvedValue({ list: [] })
+
+    await BotManageService.listGroups({ robotId: "bot1", limit: 30, q: "  hello  " })
+    expect(apiGet).toHaveBeenLastCalledWith("robot/bot1/groups", {
+      param: { limit: 30, q: "hello" },
+    })
+
+    await BotManageService.listGroups({ robotId: "bot1", limit: 30, q: "   " })
+    expect(apiGet).toHaveBeenLastCalledWith("robot/bot1/groups", {
+      param: { limit: 30 },
+    })
+
+    await BotManageService.listGroups({ robotId: "bot1", limit: 30, q: "" })
+    expect(apiGet).toHaveBeenLastCalledWith("robot/bot1/groups", {
+      param: { limit: 30 },
+    })
+  })
+
   it("enableMentionFree calls mention preference endpoint", async () => {
     apiPut.mockResolvedValueOnce(undefined)
 

--- a/packages/dmworkbase/src/bridge/profileDetail/BotManageVM.ts
+++ b/packages/dmworkbase/src/bridge/profileDetail/BotManageVM.ts
@@ -31,6 +31,9 @@ export type { BotGroupItem } from "../../Service/BotManageService"
 /** 单页拉取条数。与后端 groupsListDefaultLimit 对齐。 */
 const GROUPS_PAGE_LIMIT = 30
 
+/** 搜索输入防抖：避免逐字符打后端。UX 首选 250ms。 */
+const SEARCH_DEBOUNCE_MS = 250
+
 /**
  * MentionFreeVM —— L3「免@回答」群列表 ViewModel。
  *
@@ -40,7 +43,9 @@ const GROUPS_PAGE_LIMIT = 30
  *   - isBackendMissing=true → 「功能即将上线」
  *   - 否则渲染列表（分区：已开启免@置顶 + 其他群）+ 触底 loadMore
  *
- * 搜索为客户端过滤（issue：搜索=客户端过滤已加载项），不发后端 q 参数。
+ * 搜索走后端 q 参数（g.name LIKE %q%）：命中该 bot 的全部管理群，不受当前已滚动
+ * 加载到哪一页影响。输入经 debounce 后以 cursor=null 重新拉首屏；loadMore 沿用同一
+ * 关键字翻页。搜索期间用 searching 标志（而非 loading）避免全屏 spinner 盖住输入框。
  */
 export class MentionFreeVM extends ProviderListener {
     /** 当前管理的 bot uid（= robot_id）。可被上层 setRobotId 更新以支持复用实例。 */
@@ -49,6 +54,12 @@ export class MentionFreeVM extends ProviderListener {
     groups: BotGroupItem[] = []
     loading: boolean = false
     loadingMore: boolean = false
+    /**
+     * 搜索/切关键字触发的重拉进行中标志（区别于首屏 loading）。
+     * UI 用它显示轻量顶部条 spinner，不清空已有列表、不盖住搜索输入框——否则
+     * 用户每敲一个字符整个列表都闪成全屏 spinner，无法连续输入。
+     */
+    searching: boolean = false
     loadError: boolean = false
     isBackendMissing: boolean = false
     toggleFailed: boolean = false
@@ -58,8 +69,13 @@ export class MentionFreeVM extends ProviderListener {
     nextCursor: string | null = null
     hasMore: boolean = false
 
-    /** 客户端搜索关键字（按群名过滤已加载项）。 */
+    /** 客户端搜索关键字（回显输入框，实际过滤走后端 q 参数）。 */
     searchKeyword: string = ""
+
+    /** 已发到后端并生效的关键字（loadMore 翻页沿用同一 q）。 */
+    private activeQuery: string = ""
+    /** searchKeyword debounce 定时器句柄（浏览器 setTimeout 返回 number）。 */
+    private searchDebounceHandle: ReturnType<typeof setTimeout> | null = null
 
     /**
      * 单调递增的请求世代号（防串台核心，codex review P1）。
@@ -93,12 +109,15 @@ export class MentionFreeVM extends ProviderListener {
         if (this.robotId === robotId) return
         this.robotId = robotId
         this.generation++
+        this.clearSearchDebounce()
+        this.activeQuery = ""
         this.groups = []
         this.nextCursor = null
         this.hasMore = false
         this.searchKeyword = ""
         this.loading = false
         this.loadingMore = false
+        this.searching = false
         this.loadError = false
         this.isBackendMissing = false
         this.toggleFailed = false
@@ -108,40 +127,72 @@ export class MentionFreeVM extends ProviderListener {
 
     setSearchKeyword(kw: string): void {
         this.searchKeyword = kw
-        this.notifyListener()
+        this.notifyListener() // 立刻回显输入框
+        this.clearSearchDebounce()
+        // debounce：输入稳定 SEARCH_DEBOUNCE_MS 后才以 cursor=null 重拉首屏，
+        // 关键字空/仅空白则回到无 q 的全量首屏。
+        this.searchDebounceHandle = setTimeout(() => {
+            this.searchDebounceHandle = null
+            void this.loadGroups({ search: true })
+        }, SEARCH_DEBOUNCE_MS)
+    }
+
+    /** 清掉在飞的搜索 debounce 定时器（切 bot / 重新输入 / 组件卸载时调用）。 */
+    private clearSearchDebounce(): void {
+        if (this.searchDebounceHandle !== null) {
+            clearTimeout(this.searchDebounceHandle)
+            this.searchDebounceHandle = null
+        }
+    }
+
+    /** 组件卸载时调用：清 debounce，避免定时器在实例销毁后回调泄漏。 */
+    dispose(): void {
+        this.clearSearchDebounce()
     }
 
     /**
-     * 客户端过滤 + 分区后的可见列表：
-     *   - 先按 searchKeyword（群名，大小写不敏感）过滤已加载项；
-     *   - 再分区：已开启免@（no_mention=true）置顶，其它群在后；
+     * 分区后的可见列表：
+     *   - 已开启免@（no_mention=true）置顶，其它群在后；
      *   - 分区内保持后端返回的相对顺序（gm.id 升序，稳定）。
+     *
+     * 关键字过滤已下沉到后端（q 参数），这里不再做本地 name 二次过滤——否则会
+     * 对后端已过滤好的结果再过滤一遍，且在 debounce 未触发的中间态短暂闪空。
      */
     visibleGroups(): { enabled: BotGroupItem[]; others: BotGroupItem[] } {
-        const kw = this.searchKeyword.trim().toLowerCase()
-        const filtered = kw
-            ? this.groups.filter((g) => (g.name || "").toLowerCase().includes(kw))
-            : this.groups
-        const enabled = filtered.filter((g) => g.no_mention)
-        const others = filtered.filter((g) => !g.no_mention)
+        const enabled = this.groups.filter((g) => g.no_mention)
+        const others = this.groups.filter((g) => !g.no_mention)
         return { enabled, others }
     }
 
     /**
      * 拉首屏群列表（cursor 从头）。
      *
+     * @param opts.search 由 setSearchKeyword 的 debounce 触发时为 true：翻转 searching
+     *   而非 loading，避免全屏 spinner 盖住输入框、清空已有列表。首屏 / 重试 / 切 bot
+     *   走默认（loading）分支。
+     *
+     * 关键字：始终取当前 searchKeyword.trim() 作为后端 q，成功后记录到 activeQuery
+     * 供 loadMore 翻页沿用。
+     *
      * 防串台：捕获调用时的 generation，await 之后用 isStale() 比对，过期则整段丢弃
      * （仿 BotDetailModal.loadBotInfo:169，但用 gen 替代裸 uid 比较以防 ABA）。
      */
-    async loadGroups(): Promise<void> {
+    async loadGroups(opts: { search?: boolean } = {}): Promise<void> {
         const requestedUid = this.robotId
         if (!requestedUid) return
         // 自增 gen 让此前在飞的 loadGroups/loadMore（同一 bot 的重复触发）也作废，
         // 避免重试 / 兜底首拉与首次 didMount 撞车后旧响应盖新响应。
         const gen = ++this.generation
         const isStale = () => this.generation !== gen
+        const q = this.searchKeyword.trim()
+        const isSearch = !!opts.search
 
-        this.loading = true
+        if (isSearch) {
+            // 搜索：保留已有列表 + 输入框，只显示轻量进行中标志。
+            this.searching = true
+        } else {
+            this.loading = true
+        }
         this.loadingMore = false
         this.loadError = false
         this.isBackendMissing = false
@@ -152,17 +203,21 @@ export class MentionFreeVM extends ProviderListener {
             const res = await BotManageService.listGroups({
                 robotId: requestedUid,
                 limit: GROUPS_PAGE_LIMIT,
+                q: q || undefined,
             })
             if (isStale()) return
             const { list, nextCursor, hasMore } = parseGroupsResp(res)
             this.groups = list
             this.nextCursor = nextCursor
             this.hasMore = hasMore
+            // 成功后记录已生效关键字，供 loadMore 翻页沿用同一 q。
+            this.activeQuery = q
         } catch (e: any) {
             if (isStale()) return
             this.groups = []
             this.nextCursor = null
             this.hasMore = false
+            this.activeQuery = q
             if (e && typeof e === "object" && "status" in e && (e as any).status === 404) {
                 this.isBackendMissing = true
             } else {
@@ -171,6 +226,7 @@ export class MentionFreeVM extends ProviderListener {
         } finally {
             if (!isStale()) {
                 this.loading = false
+                this.searching = false
                 this.notifyListener()
             }
         }
@@ -183,7 +239,7 @@ export class MentionFreeVM extends ProviderListener {
      * 否则会把旧请求的下一页拼到新列表里。
      */
     async loadMore(): Promise<void> {
-        if (this.loading || this.loadingMore) return
+        if (this.loading || this.loadingMore || this.searching) return
         if (!this.hasMore || !this.nextCursor) return
 
         const requestedUid = this.robotId
@@ -199,6 +255,8 @@ export class MentionFreeVM extends ProviderListener {
                 robotId: requestedUid,
                 limit: GROUPS_PAGE_LIMIT,
                 cursor: requestedCursor,
+                // 翻页沿用首屏已生效的关键字，保证下一页与当前搜索结果同源。
+                q: this.activeQuery || undefined,
             })
             if (isStale()) return
             const { list, nextCursor, hasMore } = parseGroupsResp(res)

--- a/packages/dmworkbase/src/bridge/profileDetail/BotManageVM.ts
+++ b/packages/dmworkbase/src/bridge/profileDetail/BotManageVM.ts
@@ -145,9 +145,21 @@ export class MentionFreeVM extends ProviderListener {
         }
     }
 
-    /** 组件卸载时调用：清 debounce，避免定时器在实例销毁后回调泄漏。 */
+    /**
+     * 组件卸载时调用：取消未触发的搜索 debounce。
+     *
+     * 关键：若取消时还有一个未生效的关键字（用户在 debounce 窗口内输入后立刻
+     * 导航返回），把 searchKeyword 回滚到已生效的 activeQuery。否则 VM 被上层
+     * Provider 复用、容器重新挂载（L3 pop 后再 push）时，输入框会显示这个从未
+     * 打到后端的关键字，而列表还是 activeQuery 对应的旧结果，造成「输入框 ↔ 列表」
+     * 不一致（reviewer #1082）。activeQuery 始终对应当前 groups，故回滚后二者一致。
+     */
     dispose(): void {
+        const hadPendingKeyword = this.searchDebounceHandle !== null
         this.clearSearchDebounce()
+        if (hadPendingKeyword) {
+            this.searchKeyword = this.activeQuery
+        }
     }
 
     /**

--- a/packages/dmworkbase/src/bridge/profileDetail/__tests__/BotManageVM.test.ts
+++ b/packages/dmworkbase/src/bridge/profileDetail/__tests__/BotManageVM.test.ts
@@ -9,8 +9,9 @@
  *   5. loadMore 无 cursor / hasMore=false → 不发请求
  *   6. toggleMentionFree 开 → PUT mention_pref{no_mention:1}；关 → DELETE
  *   7. toggle 成功 → 局部更新 no_mention；失败 → 记录错误 + 本地不变（开关回弹）
- *   8. visibleGroups → 客户端按群名过滤 + 已开启置顶分区
+ *   8. visibleGroups → 已开启置顶分区（关键字过滤已下沉后端 q）
  *   9. 防串台：setRobotId 后旧请求 isStale 丢弃，不污染新 bot 列表
+ *  10. 搜索接后端 q：debounce 合并输入、清关键字重拉、切 bot 清 debounce（本 issue WS-115）
  *
  * 与 PersonaSettings/vm.test.ts 同款 mock 策略（vi.hoisted Service）。
  */
@@ -231,7 +232,7 @@ describe("MentionFreeVM.visibleGroups (client filter + partition)", () => {
         expect(others.map((g) => g.group_no)).toEqual(["g1", "g3"])
     })
 
-    it("filters by group name (case-insensitive substring)", async () => {
+    it("does NOT filter locally by name (filtering is delegated to backend q)", async () => {
         hoisted.get.mockResolvedValueOnce({
             list: [
                 grp({ group_no: "g1", name: "Engineering" }),
@@ -242,9 +243,10 @@ describe("MentionFreeVM.visibleGroups (client filter + partition)", () => {
         })
         const vm = new MentionFreeVM("bot1")
         await vm.loadGroups()
+        // 关键字只回显；实际过滤由后端 q 完成，本地列表保持后端返回原样。
         vm.setSearchKeyword("market")
         const { enabled, others } = vm.visibleGroups()
-        expect([...enabled, ...others].map((g) => g.group_no)).toEqual(["g2"])
+        expect([...enabled, ...others].map((g) => g.group_no)).toEqual(["g1", "g2"])
     })
 })
 
@@ -376,5 +378,104 @@ describe("MentionFreeVM 防串台 (requestedUid / isStale)", () => {
         })
         await vm.loadMore()
         expect(vm.groups.map((g) => g.group_no)).toEqual(["b1", "b2"])
+    })
+})
+
+describe("MentionFreeVM 搜索接后端 q (debounce, WS-115)", () => {
+    beforeEach(() => {
+        vi.useFakeTimers()
+    })
+    afterEach(() => {
+        vi.useRealTimers()
+    })
+
+    it("A: debounces rapid input into a single backend call carrying q, cursor empty", async () => {
+        // 首屏（构造后手动触发一次 loadGroups，模拟 didMount）
+        hoisted.get.mockResolvedValue({ list: [], next_cursor: null, has_more: false })
+        const vm = new MentionFreeVM("bot1")
+        await vm.loadGroups()
+        hoisted.get.mockClear()
+
+        // debounce 窗口内连续输入，只应触发 1 次后端拉取
+        vm.setSearchKeyword("a")
+        vi.advanceTimersByTime(100)
+        vm.setSearchKeyword("ab")
+        vi.advanceTimersByTime(100)
+        vm.setSearchKeyword("abc")
+        expect(hoisted.get).not.toHaveBeenCalled()
+
+        await vi.advanceTimersByTimeAsync(250)
+        expect(hoisted.get).toHaveBeenCalledTimes(1)
+        expect(hoisted.get).toHaveBeenCalledWith({
+            robotId: "bot1",
+            limit: 30,
+            q: "abc",
+        })
+        // 搜索走 searching 而非 loading（不盖列表）
+        expect(vm.searching).toBe(false) // resolve 后复位
+        expect(vm.searchKeyword).toBe("abc")
+    })
+
+    it("B: clearing the keyword re-fetches without q and resets activeQuery", async () => {
+        hoisted.get.mockResolvedValue({
+            list: [grp({ group_no: "g1", name: "Engineering" })],
+            next_cursor: "C2",
+            has_more: true,
+        })
+        const vm = new MentionFreeVM("bot1")
+        await vm.loadGroups()
+
+        vm.setSearchKeyword("abc")
+        await vi.advanceTimersByTimeAsync(250)
+        expect(hoisted.get).toHaveBeenLastCalledWith({ robotId: "bot1", limit: 30, q: "abc" })
+
+        // loadMore 在有 q 时沿用同一关键字
+        hoisted.get.mockClear()
+        await vm.loadMore()
+        expect(hoisted.get).toHaveBeenLastCalledWith({
+            robotId: "bot1",
+            limit: 30,
+            cursor: "C2",
+            q: "abc",
+        })
+
+        // 清空关键字 → 重拉且不带 q
+        hoisted.get.mockClear()
+        vm.setSearchKeyword("")
+        await vi.advanceTimersByTimeAsync(250)
+        expect(hoisted.get).toHaveBeenCalledTimes(1)
+        expect(hoisted.get).toHaveBeenLastCalledWith({ robotId: "bot1", limit: 30 })
+
+        // activeQuery 复位：清空后 loadMore 不再带 q
+        hoisted.get.mockClear()
+        await vm.loadMore()
+        expect(hoisted.get).toHaveBeenLastCalledWith({
+            robotId: "bot1",
+            limit: 30,
+            cursor: "C2",
+        })
+    })
+
+    it("C: switching bot mid-search clears the pending debounce (no call for the old robotId)", async () => {
+        hoisted.get.mockResolvedValue({ list: [], next_cursor: null, has_more: false })
+        const vm = new MentionFreeVM("botOld")
+        await vm.loadGroups()
+        hoisted.get.mockClear()
+
+        // 输入进行中（debounce 未触发）就切 bot
+        vm.setSearchKeyword("query")
+        vi.advanceTimersByTime(100)
+        vm.setRobotId("botNew") // 切 bot 自身触发一次 botNew 首屏拉取
+        await Promise.resolve()
+
+        // 记录切 bot 触发的调用，确认参数针对 botNew 且无残留 q
+        expect(hoisted.get).toHaveBeenCalledTimes(1)
+        expect(hoisted.get).toHaveBeenLastCalledWith({ robotId: "botNew", limit: 30 })
+
+        // 旧 debounce 必须已被清：继续推进时间不应再对 botOld 发请求
+        hoisted.get.mockClear()
+        await vi.advanceTimersByTimeAsync(500)
+        expect(hoisted.get).not.toHaveBeenCalled()
+        expect(vm.searchKeyword).toBe("")
     })
 })

--- a/packages/dmworkbase/src/bridge/profileDetail/__tests__/BotManageVM.test.ts
+++ b/packages/dmworkbase/src/bridge/profileDetail/__tests__/BotManageVM.test.ts
@@ -478,4 +478,45 @@ describe("MentionFreeVM 搜索接后端 q (debounce, WS-115)", () => {
         expect(hoisted.get).not.toHaveBeenCalled()
         expect(vm.searchKeyword).toBe("")
     })
+
+    it("D: unmount during the debounce window reverts searchKeyword to the applied query (back/reopen consistency)", async () => {
+        // reviewer #1082：在 debounce 窗口内输入后立刻导航返回，VM 被复用重新挂载时
+        // 输入框显示未生效关键字、列表却是旧结果。dispose 取消 debounce 时应回滚关键字。
+        hoisted.get.mockResolvedValue({
+            list: [grp({ group_no: "g1" }), grp({ group_no: "g2" })],
+            next_cursor: null,
+            has_more: false,
+        })
+        const vm = new MentionFreeVM("bot1")
+        await vm.loadGroups() // 首屏未过滤，activeQuery=""
+        hoisted.get.mockClear()
+
+        // 输入关键字（排定 debounce）后立刻卸载，debounce 尚未触发
+        vm.setSearchKeyword("query")
+        expect(vm.searchKeyword).toBe("query")
+        vm.dispose()
+
+        // 关键字回滚到已生效的空串；且从未对 "query" 发起后端拉取
+        expect(vm.searchKeyword).toBe("")
+        await vi.advanceTimersByTimeAsync(500)
+        expect(hoisted.get).not.toHaveBeenCalled()
+
+        // 复用同一 VM 重新挂载：输入框(searchKeyword="") 与列表(未过滤)一致
+        const { enabled, others } = vm.visibleGroups()
+        expect([...enabled, ...others].map((g) => g.group_no)).toEqual(["g1", "g2"])
+    })
+
+    it("D2: unmount with no pending debounce leaves the applied keyword untouched", async () => {
+        // 关键字已生效（debounce 已触发成功）后卸载：无待定定时器，不应回滚关键字。
+        hoisted.get.mockResolvedValue({ list: [], next_cursor: null, has_more: false })
+        const vm = new MentionFreeVM("bot1")
+        await vm.loadGroups()
+
+        vm.setSearchKeyword("abc")
+        await vi.advanceTimersByTimeAsync(250) // debounce 触发，activeQuery 变为 "abc"
+        expect(vm.searchKeyword).toBe("abc")
+
+        vm.dispose() // 无待定 debounce
+        expect(vm.searchKeyword).toBe("abc")
+    })
 })

--- a/packages/dmworkbase/src/ui/profileDetail/BotManageView/BotManageView.stories.tsx
+++ b/packages/dmworkbase/src/ui/profileDetail/BotManageView/BotManageView.stories.tsx
@@ -95,6 +95,7 @@ function MentionFreeStory(args: Partial<MentionFreeListViewProps>) {
       <MentionFreeListView
         labels={labels}
         loading={false}
+        searching={false}
         backendMissing={false}
         loadError={false}
         searchKeyword={searchKeyword}
@@ -168,6 +169,10 @@ export const NoSearchResult: StoryObj<typeof MentionFreeStory> = {
 
 export const LoadingMore: StoryObj<typeof MentionFreeStory> = {
   render: () => <MentionFreeStory loadingMore />,
+};
+
+export const Searching: StoryObj<typeof MentionFreeStory> = {
+  render: () => <MentionFreeStory searchKeyword="eng" searching />,
 };
 
 export const LongGroupName: StoryObj<typeof MentionFreeStory> = {

--- a/packages/dmworkbase/src/ui/profileDetail/BotManageView/index.css
+++ b/packages/dmworkbase/src/ui/profileDetail/BotManageView/index.css
@@ -118,6 +118,27 @@ button.wk-bot-manage-menu-row .wk-bot-manage-menu-right {
 .wk-bot-manage-search {
     padding: var(--wk-sp-3) var(--wk-sp-4) var(--wk-sp-2);
     flex-shrink: 0;
+    position: relative;
+}
+
+.wk-bot-manage-search-spinner {
+    position: absolute;
+    top: 50%;
+    right: calc(var(--wk-sp-4) + var(--wk-sp-3));
+    width: var(--wk-sp-4);
+    height: var(--wk-sp-4);
+    margin-top: calc(-1 * var(--wk-sp-2));
+    border: 2px solid var(--wk-border-subtle);
+    border-top-color: var(--wk-brand-primary);
+    border-radius: 50%;
+    animation: wk-bot-manage-spin 0.6s linear infinite;
+    pointer-events: none;
+}
+
+@keyframes wk-bot-manage-spin {
+    to {
+        transform: rotate(360deg);
+    }
 }
 
 .wk-bot-manage-search-input {

--- a/packages/dmworkbase/src/ui/profileDetail/BotManageView/index.css
+++ b/packages/dmworkbase/src/ui/profileDetail/BotManageView/index.css
@@ -145,7 +145,9 @@ button.wk-bot-manage-menu-row .wk-bot-manage-menu-right {
     width: 100%;
     box-sizing: border-box;
     height: calc(var(--wk-sp-8) + var(--wk-sp-0-5));
-    padding: 0 var(--wk-sp-3);
+    /* 右侧常驻预留搜索 spinner 的空间（spinner 内嵌偏移 sp-3 + 宽 sp-4 + 间隙 sp-2），
+       避免搜索时输入文字被 spinner 盖住、且布局不因 spinner 出现/消失而跳动。 */
+    padding: 0 calc(var(--wk-sp-3) + var(--wk-sp-4) + var(--wk-sp-2)) 0 var(--wk-sp-3);
     border-radius: var(--wk-r-md);
     border: 1px solid var(--wk-border-subtle);
     background: var(--wk-bg-surface);

--- a/packages/dmworkbase/src/ui/profileDetail/BotManageView/index.tsx
+++ b/packages/dmworkbase/src/ui/profileDetail/BotManageView/index.tsx
@@ -40,6 +40,7 @@ export interface BotManageViewProps {
 export interface MentionFreeListViewProps {
   labels: BotManageViewLabels;
   loading: boolean;
+  searching: boolean;
   backendMissing: boolean;
   loadError: boolean;
   searchKeyword: string;
@@ -136,6 +137,7 @@ function BotManageMenuItem({
 export function MentionFreeListView({
   labels,
   loading,
+  searching,
   backendMissing,
   loadError,
   searchKeyword,
@@ -204,6 +206,13 @@ export function MentionFreeListView({
           onChange={(e) => onSearchKeywordChange(e.target.value)}
           data-testid="bot-manage-mention-search"
         />
+        {searching && (
+          <span
+            className="wk-bot-manage-search-spinner"
+            data-testid="bot-manage-mention-searching"
+            aria-hidden="true"
+          />
+        )}
       </div>
       <div
         className="wk-bot-manage-list"
@@ -211,7 +220,7 @@ export function MentionFreeListView({
         onScroll={handleScroll}
         data-testid="bot-manage-mention-list"
       >
-        {isEmpty && (
+        {isEmpty && !searching && (
           <div className="wk-bot-manage-empty">
             {searchKeyword.trim() ? labels.noSearchResult : labels.empty}
           </div>


### PR DESCRIPTION
## 问题

Bot 管理 → 免@回答群列表，刚打开时搜索命中不了目标群，需要先拖滚动条加载出对应分页再搜同样关键字才行。根因是前端搜索走客户端过滤（只过滤已加载到内存的 `this.groups`），后端 `GET /v1/robot/:robot_id/groups?q=` 早已支持 `g.name LIKE %q%` 全库搜索但前端从未调用。

## 改动（仅前端，后端零改动）

- **Service**：`ListBotGroupsRequest` 新增可选 `q`，`listGroups` 把非空 `q.trim()` 下发到请求参数。
- **VM (`BotManageVM`)**：
  - `setSearchKeyword` 改为 debounce 250ms 后以 `cursor=null` + `q` 重新拉首屏；
  - `loadGroups`/`loadMore` 透传 `q`（翻页沿用首屏已生效的 `activeQuery`，保证下一页与当前搜索同源）；
  - `visibleGroups` 去掉本地二次 name 过滤（过滤已下沉后端，避免中间态闪空）；
  - 切 bot / 组件卸载时清 debounce 定时器，防串台 + 防定时器泄漏；
  - 搜索期间用独立 `searching` 标志而非 `loading`，避免每敲一个字符列表就闪成全屏 spinner。
- **View**：透出 `searching` 显示轻量顶部 spinner，不清空已有列表。

## 测试

`packages/dmworkbase/src/bridge/profileDetail/__tests__/BotManageVM.test.ts` 全绿（20 passed），新增 3 条：
- debounce 窗口内多次输入只触发 1 次带 `q` 的后端拉取，`cursor` 为空；
- 清空关键字重拉且不带 `q`，`activeQuery` 复位（loadMore 不再带 q）；
- 搜索输入过程中切 bot，旧 debounce 被清，不对旧 robotId 发请求。

Closes #1081
