### PR TITLE
refactor(forward-modal): split ForwardModal into hooks, logic, and ui modules

### DIFF
--- a/packages/dmworkbase/src/Components/ConversationSelect/index.tsx
+++ b/packages/dmworkbase/src/Components/ConversationSelect/index.tsx
@@ -8,14 +8,10 @@
  * 不传 → 行为与之前完全一致。
  */
 import React from "react"
-import { Channel, ChannelTypePerson } from "wukongimjssdk"
 import { ForwardModal } from "../ForwardModal/ForwardModal"
 import { useForwardModal } from "../ForwardModal/useForwardModal"
+import { useForwardTargetMemberCount } from "../ForwardModal/hooks"
 import type { ForwardFinished, ForwardGrantConfig, ForwardGrantRole } from "../ForwardModal/grant"
-import {
-  getCurrentImChannelSubscribers,
-  syncCurrentImChannelSubscribers,
-} from "../../im-runtime/currentChannelRuntime"
 
 export interface ConversationSelectGrant {
   canGrant: boolean
@@ -59,50 +55,9 @@ export default function ConversationSelect({
     grant ? { canGrant: grant.canGrant, defaultRole: grant.defaultRole } : undefined
   )
 
-  // "将授权给群当前 N 名成员" 提示：取真实群成员数，而非选中目标数。
-  // 与 host 侧 collectForwardUids 一致地把选中目标展开成去重 uid 快照
-  // （群 → syncSubscribes/getSubscribes 成员，个人 → 对端 uid），使提示数
-  // 与实际会被授权的成员数吻合；无群目标时不提示（个人转发不显示）。
-  const selectedKey = selectedIDs.join(",")
-  const [targetMemberCount, setTargetMemberCount] = React.useState<number | undefined>(undefined)
-
-  React.useEffect(() => {
-    const groups = selectedChannels.filter((ch) => ch.channelType !== ChannelTypePerson)
-    if (groups.length === 0) {
-      setTargetMemberCount(undefined)
-      return
-    }
-    const persons = selectedChannels.filter((ch) => ch.channelType === ChannelTypePerson)
-    // stale guard：选中项在异步 syncSubscribes 期间变化时，丢弃过期结果，
-    // 避免旧一批成员数覆盖当前选择的计数。
-    let cancelled = false
-    const compute = async () => {
-      const uids = new Set<string>()
-      for (const ch of persons) {
-        if (ch.channelID) uids.add(ch.channelID)
-      }
-      for (const ch of groups) {
-        try {
-          await syncCurrentImChannelSubscribers(ch)
-        } catch {
-          // best-effort：拉取失败时退回已缓存的成员快照。
-        }
-        if (cancelled) return
-        const subs = getCurrentImChannelSubscribers(ch) as { uid?: string }[]
-        for (const s of subs) {
-          if (s?.uid) uids.add(s.uid)
-        }
-      }
-      if (!cancelled) setTargetMemberCount(uids.size > 0 ? uids.size : undefined)
-    }
-    void compute()
-    return () => {
-      cancelled = true
-    }
-    // selectedKey 是 selectedIDs 的稳定字符串键（selectedChannels 每次渲染重建，
-    // 不能直接做依赖，否则会无限触发）。
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedKey])
+  // 授权区「将授权给群当前 N 名成员」提示：取真实群成员数（去重 uid），
+  // 无群目标时为 undefined（个人转发不显示）。
+  const targetMemberCount = useForwardTargetMemberCount(selectedIDs, selectedChannels)
 
   const grantConfig: ForwardGrantConfig | undefined = grant
     ? {

--- a/packages/dmworkbase/src/Components/ForwardModal/ForwardModal.tsx
+++ b/packages/dmworkbase/src/Components/ForwardModal/ForwardModal.tsx
@@ -1,16 +1,15 @@
-import React, { useCallback } from "react"
-import { Channel, ChannelTypeGroup, ChannelTypePerson } from "wukongimjssdk"
-import { X } from "lucide-react"
-import { IconSearchStroked } from "@douyinfe/semi-icons"
-import { Tag, Tabs, TabPane } from "@douyinfe/semi-ui"
-import Checkbox from "../Checkbox"
-import AiBadge from "../AiBadge"
-import WKAvatar from "../WKAvatar"
-import VisibilityTrigger from "../VisibilityTrigger"
+import React, { useMemo } from "react"
 import { useI18n } from "../../i18n"
-import { ChannelTypeCommunityTopic } from "../../Service/Const"
 import type { ChatSelectorTab } from "../ChatSelector/tabFilter"
 import type { ForwardGrantConfig } from "./grant"
+import {
+  Footer,
+  GrantArea,
+  ItemList,
+  SearchBar,
+  SelectedPanel,
+  TabsBar,
+} from "./ui"
 import "./ForwardModal.css"
 
 export interface ForwardItem {
@@ -51,148 +50,11 @@ export interface ForwardModalProps {
   grant?: ForwardGrantConfig
 }
 
-// ─── 授权区（opt-in，仅 grant 存在时渲染）─────────────────────────────
-
-function GrantArea({ grant }: { grant: ForwardGrantConfig }) {
-  const { t } = useI18n()
-  if (!grant.canGrant) {
-    return (
-      <div className="wk-fm-grant wk-fm-grant--disabled">
-        <span className="wk-fm-grant-lock">🔒</span>
-        <span className="wk-fm-grant-hint">
-          {grant.disabledReason ?? t("base.forwardModal.grant.disabledReason")}
-        </span>
-      </div>
-    )
-  }
-  return (
-    <div className="wk-fm-grant">
-      <div className="wk-fm-grant-row">
-        <label className="wk-fm-grant-switch">
-          <Checkbox checked={grant.enabled} onCheck={() => grant.onEnabledChange(!grant.enabled)} />
-          <span className="wk-fm-grant-label">{t("base.forwardModal.grant.enableLabel")}</span>
-        </label>
-        <select
-          className="wk-fm-grant-role"
-          value={grant.role}
-          disabled={!grant.enabled}
-          onChange={(e) => grant.onRoleChange(e.target.value as ForwardGrantConfig["role"])}
-        >
-          <option value="reader">{t("base.forwardModal.grant.roleReader")}</option>
-          <option value="writer">{t("base.forwardModal.grant.roleWriter")}</option>
-        </select>
-      </div>
-      {grant.enabled && typeof grant.targetMemberCount === "number" && grant.targetMemberCount > 0 && (
-        <div className="wk-fm-grant-members">
-          {t("base.forwardModal.grant.targetMembers", { values: { count: grant.targetMemberCount } })}
-        </div>
-      )}
-    </div>
-  )
-}
-
-// ─── 左列：可选列表项 ───────────────────────────────────────────
-
-interface ItemRowProps {
-  item: ForwardItem
-  selected: boolean
-  flat: boolean
-  showMeta: boolean
-  onToggle: (item: ForwardItem) => void
-}
-
-function getKindLabel(item: ForwardItem, t: ReturnType<typeof useI18n>["t"]): string {
-  if (item.isThread || item.channelType === ChannelTypeCommunityTopic) {
-    return t("base.forwardModal.kindThread")
-  }
-  if (item.channelType === ChannelTypePerson) {
-    return t("base.forwardModal.kindDirect")
-  }
-  return t("base.forwardModal.kindGroup")
-}
-
-function ItemRow({ item, selected, flat, showMeta, onToggle }: ItemRowProps) {
-  const { t } = useI18n()
-  const channel = new Channel(item.channelID, item.channelType)
-  const kindLabel = showMeta ? getKindLabel(item, t) : ""
-  const isExternalGroup = item.channelType === ChannelTypeGroup && item.isExternal
-  return (
-    <div
-      className={`wk-fm-item${!flat && item.parentChannelID ? " wk-fm-item--child" : ""}${flat ? " wk-fm-item--flat" : ""}${selected ? " wk-fm-item--selected" : ""}`}
-      onClick={() => onToggle(item)}
-    >
-      <Checkbox
-        checked={selected}
-        onCheck={() => {}}
-      />
-      <div className="wk-fm-avatar-wrap">
-        <WKAvatar channel={channel} lazy />
-      </div>
-      <div className="wk-fm-item-main">
-        <div className="wk-fm-item-title-row">
-          <span className="wk-fm-item-name">{item.displayName}</span>
-          {showMeta && item.isAI && <AiBadge size="small" />}
-        </div>
-      </div>
-      {showMeta && (
-        <div className="wk-fm-item-meta">
-          <span>{kindLabel}</span>
-          {isExternalGroup && (
-            <>
-              <span className="wk-fm-item-meta-separator">·</span>
-              <span>{t("base.forwardModal.external")}</span>
-            </>
-          )}
-        </div>
-      )}
-      {!showMeta && isExternalGroup && (
-        <Tag
-          size="small"
-          color="purple"
-          className="wk-conversationlist-item-external-tag"
-        >
-          {t("base.forwardModal.external")}
-        </Tag>
-      )}
-      {!showMeta && item.isAI && <AiBadge />}
-    </div>
-  )
-}
-
-// ─── 右列：已选列表项 ───────────────────────────────────────────
-
-interface SelectedRowProps {
-  item: ForwardItem
-  onRemove: (item: ForwardItem) => void
-}
-
-function SelectedRow({ item, onRemove }: SelectedRowProps) {
-  const { t } = useI18n()
-  const channel = new Channel(item.channelID, item.channelType)
-  return (
-    <div className="wk-fm-selected-item">
-      <div className="wk-fm-avatar-wrap">
-        {/* 右列已选列表项数量少且都在视口内，不启用 lazy 避免占位 SVG → 真实
-            图的视觉闪烁 */}
-        <WKAvatar channel={channel} />
-      </div>
-      <span className="wk-fm-item-name">{item.displayName}</span>
-      <button
-        className="wk-fm-remove-btn"
-        onClick={(e) => {
-          e.stopPropagation()
-          onRemove(item)
-        }}
-        aria-label={t("base.forwardModal.remove")}
-      >
-        <X size={14} strokeWidth={2} />
-      </button>
-    </div>
-  )
-}
-
-// ─── 主组件 ──────────────────────────────────────────────────────
-
+/**
+ * 转发弹窗 UI shell：Header + 左（搜索/Tabs/列表）+ 右（已选）+ 授权区（opt-in）+ Footer。
+ * 数据装配、过滤、选择、授权都在上层 useForwardModal / ConversationSelect 完成，
+ * 这里只做纯渲染与事件转发，便于后续 UI 升级。
+ */
 export function ForwardModal({
   title,
   items,
@@ -210,135 +72,47 @@ export function ForwardModal({
   grant,
 }: ForwardModalProps) {
   const { t } = useI18n()
-  const selectedSet = new Set(selectedIDs)
   const sourceForSelected = allItems ?? items
-  const selectedItems = sourceForSelected.filter((i) => selectedSet.has(i.channelID))
+  const selectedSet = useMemo(() => new Set(selectedIDs), [selectedIDs])
+  const selectedItems = useMemo(
+    () => sourceForSelected.filter((i) => selectedSet.has(i.channelID)),
+    [sourceForSelected, selectedSet],
+  )
   const modalTitle = title ?? t("base.forwardModal.title")
   const recentFlatList = activeTab === "recent"
 
-  const handleInputChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => {
-      onInputChange(e.target.value)
-    },
-    [onInputChange]
-  )
-
   return (
     <div className="wk-fm">
-      {/* Header */}
       <div className="wk-fm-header">
         <span className="wk-fm-title">{modalTitle}</span>
       </div>
 
-      {/* 内容区：左右两列 */}
       <div className="wk-fm-content">
-
-        {/* 左列：搜索 + 可选列表 */}
         <div className="wk-fm-left">
-          {/* 搜索框 */}
-          <div className="wk-fm-search">
-            <IconSearchStroked className="wk-fm-search-icon" />
-            <input
-              className="wk-fm-search-input"
-              placeholder={t("base.forwardModal.searchPlaceholder")}
-              type="text"
-              value={inputValue}
-              onChange={handleInputChange}
-            />
-          </div>
-
-          {/* 四 Tab：关注 / 最近 / 全部群聊 / 全部私聊（对齐智能纪要选择器） */}
-          <Tabs
-            activeKey={activeTab}
-            onChange={(key) => onTabChange(key as ChatSelectorTab)}
-            size="small"
-            className="wk-fm-tabs"
-          >
-            <TabPane tab={t("base.forwardModal.tabFollowed")} itemKey="followed" />
-            <TabPane tab={t("base.forwardModal.tabRecent")} itemKey="recent" />
-            <TabPane tab={t("base.forwardModal.tabAllGroups")} itemKey="group" />
-            <TabPane tab={t("base.forwardModal.tabAllDirects")} itemKey="direct" />
-          </Tabs>
-
-          {/* 可选列表 */}
-          <div className="wk-fm-list">
-            {loading ? (
-              <div className="wk-fm-empty">{t("base.forwardModal.loading")}</div>
-            ) : items.length === 0 ? (
-              <div className="wk-fm-empty">{t("base.forwardModal.noContacts")}</div>
-            ) : (
-              items.map((item) => {
-                const row = (
-                  <ItemRow
-                    item={item}
-                    selected={selectedSet.has(item.channelID)}
-                    flat={recentFlatList}
-                    showMeta={recentFlatList}
-                    onToggle={onToggleSelect}
-                  />
-                )
-                if (onItemVisible) {
-                  return (
-                    <VisibilityTrigger
-                      key={item.channelID}
-                      onVisible={() => onItemVisible(item)}
-                    >
-                      {row}
-                    </VisibilityTrigger>
-                  )
-                }
-                return <React.Fragment key={item.channelID}>{row}</React.Fragment>
-              })
-            )}
-          </div>
+          <SearchBar value={inputValue} onChange={onInputChange} />
+          <TabsBar activeTab={activeTab} onTabChange={onTabChange} />
+          <ItemList
+            items={items}
+            selectedSet={selectedSet}
+            loading={loading}
+            flat={recentFlatList}
+            showMeta={recentFlatList}
+            onToggleSelect={onToggleSelect}
+            onItemVisible={onItemVisible}
+          />
         </div>
 
-        {/* 分割线 */}
         <div className="wk-fm-divider" />
 
-        {/* 右列：已选列表 */}
         <div className="wk-fm-right">
-          {selectedItems.length === 0 ? (
-            <div className="wk-fm-empty wk-fm-empty--right">{t("base.forwardModal.noneSelected")}</div>
-          ) : (
-            <>
-              <div className="wk-fm-selected-title">
-                {t("base.forwardModal.selectedCount", { values: { count: selectedItems.length } })}
-              </div>
-              <div className="wk-fm-selected-list">
-                {selectedItems.map((item) => (
-                  <SelectedRow
-                    key={item.channelID}
-                    item={item}
-                    onRemove={onToggleSelect}
-                  />
-                ))}
-              </div>
-            </>
-          )}
+          <SelectedPanel selectedItems={selectedItems} onRemove={onToggleSelect} />
         </div>
       </div>
 
       {/* 授权区（opt-in）：仅当调用方传入 grant 时渲染，插在内容区与 Footer 之间。 */}
       {grant && <GrantArea grant={grant} />}
 
-      {/* Footer */}
-      <div className="wk-fm-footer">
-        {onCancel && (
-          <button className="wk-fm-btn wk-fm-btn--cancel" onClick={onCancel}>
-            {t("base.common.cancel")}
-          </button>
-        )}
-        <button
-          className="wk-fm-btn wk-fm-btn--confirm"
-          onClick={onConfirm}
-          disabled={selectedIDs.length === 0}
-        >
-          {selectedIDs.length > 0
-            ? t("base.forwardModal.confirmWithCount", { values: { count: selectedIDs.length } })
-            : t("base.forwardModal.confirm")}
-        </button>
-      </div>
+      <Footer selectedCount={selectedIDs.length} onConfirm={onConfirm} onCancel={onCancel} />
     </div>
   )
 }

--- a/packages/dmworkbase/src/Components/ForwardModal/__tests__/useForwardTargetMemberCount.test.tsx
+++ b/packages/dmworkbase/src/Components/ForwardModal/__tests__/useForwardTargetMemberCount.test.tsx
@@ -1,0 +1,266 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import React from "react"
+import ReactDOM from "react-dom"
+import { act } from "react-dom/test-utils"
+
+const hoisted = vi.hoisted(() => ({
+  subscribers: new Map<string, Array<{ uid?: string }>>(),
+  syncCurrentImChannelSubscribers: vi.fn(async () => undefined),
+}))
+
+vi.mock("wukongimjssdk", () => {
+  class Channel {
+    channelID: string
+    channelType: number
+
+    constructor(channelID: string, channelType: number) {
+      this.channelID = channelID
+      this.channelType = channelType
+    }
+  }
+
+  return {
+    Channel,
+    ChannelTypePerson: 1,
+  }
+})
+
+vi.mock("../../../im-runtime/currentChannelRuntime", () => ({
+  getCurrentImChannelSubscribers: (channel: { channelID: string }) =>
+    hoisted.subscribers.get(channel.channelID) ?? [],
+  syncCurrentImChannelSubscribers: hoisted.syncCurrentImChannelSubscribers,
+}))
+
+import { Channel } from "wukongimjssdk"
+import { useForwardTargetMemberCount } from "../hooks/useForwardTargetMemberCount"
+
+function Probe({
+  selectedIDs,
+  selectedChannels,
+  onValue,
+}: {
+  selectedIDs: string[]
+  selectedChannels: Channel[]
+  onValue: (value: number | undefined) => void
+}) {
+  const value = useForwardTargetMemberCount(selectedIDs, selectedChannels)
+  onValue(value)
+  return null
+}
+
+async function flushMicrotasks() {
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+describe("useForwardTargetMemberCount", () => {
+  beforeEach(() => {
+    hoisted.subscribers = new Map()
+    hoisted.syncCurrentImChannelSubscribers.mockReset()
+    hoisted.syncCurrentImChannelSubscribers.mockResolvedValue(undefined)
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ""
+  })
+
+  it("recomputes once a selected id gets resolved into a channel", async () => {
+    const container = document.createElement("div")
+    document.body.appendChild(container)
+    let latest: number | undefined
+
+    const person = new Channel("user-1", 1)
+    const group = new Channel("group-1", 2)
+    hoisted.subscribers.set("group-1", [{ uid: "user-1" }, { uid: "user-2" }])
+
+    await act(async () => {
+      ReactDOM.render(
+        <Probe
+          selectedIDs={["user-1", "group-1"]}
+          selectedChannels={[person]}
+          onValue={(value) => {
+            latest = value
+          }}
+        />,
+        container,
+      )
+      await flushMicrotasks()
+    })
+
+    expect(latest).toBeUndefined()
+
+    await act(async () => {
+      ReactDOM.render(
+        <Probe
+          selectedIDs={["user-1", "group-1"]}
+          selectedChannels={[person, group]}
+          onValue={(value) => {
+            latest = value
+          }}
+        />,
+        container,
+      )
+      await flushMicrotasks()
+    })
+
+    expect(hoisted.syncCurrentImChannelSubscribers).toHaveBeenCalledTimes(1)
+    expect(latest).toBe(2)
+
+    act(() => {
+      ReactDOM.unmountComponentAtNode(container)
+    })
+    container.remove()
+  })
+
+  it("dedupes a Person UID that also appears in a selected group's subscribers", async () => {
+    // 语义：Set<uid> 存放最终授权成员；Person 与其在群里的 uid 相同时只算一次。
+    const container = document.createElement("div")
+    document.body.appendChild(container)
+    let latest: number | undefined
+
+    const person = new Channel("user-1", 1)
+    const group = new Channel("group-1", 2)
+    // user-1 既是私聊对端，也是群成员 → 应去重为 2（user-1 + user-2），而非 3。
+    hoisted.subscribers.set("group-1", [{ uid: "user-1" }, { uid: "user-2" }])
+
+    await act(async () => {
+      ReactDOM.render(
+        <Probe
+          selectedIDs={["user-1", "group-1"]}
+          selectedChannels={[person, group]}
+          onValue={(v) => (latest = v)}
+        />,
+        container,
+      )
+      await flushMicrotasks()
+    })
+
+    expect(latest).toBe(2)
+
+    act(() => {
+      ReactDOM.unmountComponentAtNode(container)
+    })
+    container.remove()
+  })
+
+  it("falls back to cached subscribers when syncCurrentImChannelSubscribers rejects", async () => {
+    // 语义：sync 拉取失败时 try/catch 兜底，仍用 getCurrentImChannelSubscribers 缓存计算。
+    const container = document.createElement("div")
+    document.body.appendChild(container)
+    let latest: number | undefined
+
+    const group = new Channel("group-1", 2)
+    hoisted.subscribers.set("group-1", [{ uid: "u1" }, { uid: "u2" }, { uid: "u3" }])
+    hoisted.syncCurrentImChannelSubscribers.mockRejectedValue(new Error("net"))
+
+    await act(async () => {
+      ReactDOM.render(
+        <Probe
+          selectedIDs={["group-1"]}
+          selectedChannels={[group]}
+          onValue={(v) => (latest = v)}
+        />,
+        container,
+      )
+      await flushMicrotasks()
+    })
+
+    expect(latest).toBe(3)
+
+    act(() => {
+      ReactDOM.unmountComponentAtNode(container)
+    })
+    container.remove()
+  })
+
+  it("stale-guard: a slow sync from an outdated selection must not overwrite the new selection's count", async () => {
+    // 场景：先选 group-1（订阅数 5，sync 慢），随后切到 group-2（订阅数 2，sync 快）。
+    // 语义：group-1 的 sync 晚 resolve 时，cancelled 已置 true，不得把 count 覆写回 5。
+    const container = document.createElement("div")
+    document.body.appendChild(container)
+    let latest: number | undefined
+
+    const groupA = new Channel("group-A", 2)
+    const groupB = new Channel("group-B", 2)
+    hoisted.subscribers.set("group-A", Array.from({ length: 5 }, (_, i) => ({ uid: `a${i}` })))
+    hoisted.subscribers.set("group-B", [{ uid: "b1" }, { uid: "b2" }])
+
+    let resolveA: () => void = () => {}
+    const slowA = new Promise<void>((res) => { resolveA = res })
+    hoisted.syncCurrentImChannelSubscribers.mockImplementation(async (ch: any) => {
+      if (ch.channelID === "group-A") return slowA
+      return undefined
+    })
+
+    // 第一次渲染：选中 A（sync 挂起）。
+    await act(async () => {
+      ReactDOM.render(
+        <Probe
+          selectedIDs={["group-A"]}
+          selectedChannels={[groupA]}
+          onValue={(v) => (latest = v)}
+        />,
+        container,
+      )
+      await flushMicrotasks()
+    })
+
+    // 第二次渲染：切到 B。此举应触发 effect cleanup → cancelled=true。
+    await act(async () => {
+      ReactDOM.render(
+        <Probe
+          selectedIDs={["group-B"]}
+          selectedChannels={[groupB]}
+          onValue={(v) => (latest = v)}
+        />,
+        container,
+      )
+      await flushMicrotasks()
+    })
+
+    expect(latest).toBe(2)
+
+    // 让老 A 的 sync 姗姗来迟 resolve。cancelled 守卫必须让它无声消化。
+    await act(async () => {
+      resolveA()
+      await flushMicrotasks()
+      await flushMicrotasks()
+    })
+
+    // 关键回归：不得把 count 覆盖成 5。
+    expect(latest).toBe(2)
+
+    act(() => {
+      ReactDOM.unmountComponentAtNode(container)
+    })
+    container.remove()
+  })
+
+  it("returns undefined for a person-only selection (individual forwards do not show the hint)", async () => {
+    const container = document.createElement("div")
+    document.body.appendChild(container)
+    let latest: number | undefined
+
+    const person = new Channel("user-1", 1)
+
+    await act(async () => {
+      ReactDOM.render(
+        <Probe
+          selectedIDs={["user-1"]}
+          selectedChannels={[person]}
+          onValue={(v) => (latest = v)}
+        />,
+        container,
+      )
+      await flushMicrotasks()
+    })
+
+    expect(latest).toBeUndefined()
+
+    act(() => {
+      ReactDOM.unmountComponentAtNode(container)
+    })
+    container.remove()
+  })
+})

--- a/packages/dmworkbase/src/Components/ForwardModal/hooks/__tests__/useDebouncedKeyword.test.tsx
+++ b/packages/dmworkbase/src/Components/ForwardModal/hooks/__tests__/useDebouncedKeyword.test.tsx
@@ -1,0 +1,178 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import React from "react"
+import ReactDOM from "react-dom"
+import { act } from "react-dom/test-utils"
+
+import { useDebouncedKeyword } from "../useDebouncedKeyword"
+
+function Probe({
+  delayMs,
+  onValue,
+}: {
+  delayMs?: number
+  onValue: (value: ReturnType<typeof useDebouncedKeyword>) => void
+}) {
+  const value = useDebouncedKeyword(delayMs)
+  onValue(value)
+  return null
+}
+
+async function flushMicrotasks() {
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+describe("useDebouncedKeyword", () => {
+  let container: HTMLDivElement
+  let latest: ReturnType<typeof useDebouncedKeyword>
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    container = document.createElement("div")
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    act(() => {
+      ReactDOM.unmountComponentAtNode(container)
+    })
+    container.remove()
+  })
+
+  it("updates inputValue immediately but keyword only after delay", async () => {
+    act(() => {
+      ReactDOM.render(
+        <Probe onValue={(v) => (latest = v)} />,
+        container,
+      )
+    })
+
+    expect(latest.inputValue).toBe("")
+    expect(latest.keyword).toBe("")
+
+    act(() => {
+      latest.setInputValue("hel")
+    })
+    // inputValue 立即更新驱动 UI；keyword 尚未越过 debounce。
+    expect(latest.inputValue).toBe("hel")
+    expect(latest.keyword).toBe("")
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(299)
+    })
+    expect(latest.keyword).toBe("")
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1)
+    })
+    expect(latest.keyword).toBe("hel")
+  })
+
+  it("resets keyword AND clears the pending timer so a late setKeyword never fires", async () => {
+    act(() => {
+      ReactDOM.render(<Probe onValue={(v) => (latest = v)} />, container)
+    })
+
+    act(() => {
+      latest.setInputValue("stale")
+    })
+    expect(latest.inputValue).toBe("stale")
+
+    act(() => {
+      latest.reset()
+    })
+    expect(latest.inputValue).toBe("")
+    expect(latest.keyword).toBe("")
+
+    // 关键：reset 已 clearTimeout；后续推进时间不得让 "stale" 回填 keyword。
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000)
+    })
+    expect(latest.keyword).toBe("")
+    expect(latest.inputValue).toBe("")
+  })
+
+  it("honours a custom delayMs", async () => {
+    act(() => {
+      ReactDOM.render(
+        <Probe delayMs={50} onValue={(v) => (latest = v)} />,
+        container,
+      )
+    })
+
+    act(() => {
+      latest.setInputValue("fast")
+    })
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(50)
+    })
+    expect(latest.keyword).toBe("fast")
+  })
+
+  it("cleans up the pending timer on unmount so no late setKeyword hits an unmounted component", async () => {
+    let captured: ReturnType<typeof useDebouncedKeyword> | undefined
+    act(() => {
+      ReactDOM.render(
+        <Probe onValue={(v) => (captured = v)} />,
+        container,
+      )
+    })
+
+    act(() => {
+      captured!.setInputValue("in-flight")
+    })
+
+    // 卸载前推进不到 debounce 边界；卸载后再推过边界，若清理失败会触发 React 警告。
+    const warnSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+
+    act(() => {
+      ReactDOM.unmountComponentAtNode(container)
+    })
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000)
+    })
+
+    expect(warnSpy).not.toHaveBeenCalled()
+    warnSpy.mockRestore()
+    // 已卸载：无需再触碰 latest；container 由 afterEach 兜底清理。
+  })
+
+  it("only fires the latest keystroke when multiple setInputValue calls stack within the debounce window", async () => {
+    act(() => {
+      ReactDOM.render(<Probe onValue={(v) => (latest = v)} />, container)
+    })
+
+    act(() => {
+      latest.setInputValue("a")
+    })
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(100)
+    })
+    act(() => {
+      latest.setInputValue("ab")
+    })
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(100)
+    })
+    act(() => {
+      latest.setInputValue("abc")
+    })
+
+    // 300ms 从 "abc" 那次调用起计；此时距最新调用不到 300ms → keyword 仍空。
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(299)
+    })
+    expect(latest.keyword).toBe("")
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1)
+    })
+    // 只跳到最终值，中间的 "a" / "ab" 都被合并掉。
+    expect(latest.keyword).toBe("abc")
+  })
+
+  // node ping – silence unused
+  void flushMicrotasks
+})

--- a/packages/dmworkbase/src/Components/ForwardModal/hooks/__tests__/useForwardCandidates.test.tsx
+++ b/packages/dmworkbase/src/Components/ForwardModal/hooks/__tests__/useForwardCandidates.test.tsx
@@ -1,0 +1,360 @@
+// @vitest-environment jsdom
+/**
+ * useForwardCandidates 直接单测：聚焦上层 useForwardModal.test.tsx 未覆盖的两条路径 ——
+ *   1. loadGen 竞态守卫：老 load() 的 groupSaveList / searchFriends 晚 resolve 不得覆盖新 load() 的结果。
+ *   2. requestChannelInfoIfNeeded 去重：同一 channelID 只 fetchChannelInfo 一次；已缓存时不打接口。
+ *
+ * 其余行为（Space 切换清 extraGroups、orphan thread 归位、conversation-list-refreshed 重载、
+ * hasThreads O(N·M) 修复的功能等价）已在 useForwardModal.test.tsx 中通过组合层覆盖。
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import React from "react"
+import ReactDOM from "react-dom"
+import { act } from "react-dom/test-utils"
+
+const CT_GROUP = 2
+const CT_PERSON = 1
+const CT_COMMUNITY_TOPIC = 5
+
+const hoisted = vi.hoisted(() => ({
+  conversations: [] as any[],
+  getChannelInfo: vi.fn(() => undefined),
+  fetchChannelInfo: vi.fn(),
+  addListener: vi.fn(),
+  removeListener: vi.fn(),
+  groupSaveList: vi.fn(async () => [] as any[]),
+  searchFriends: vi.fn(async () => [] as any[]),
+  mittOn: vi.fn(),
+  mittOff: vi.fn(),
+  currentSpaceId: "" as string,
+  channelSpaceMap: new Map<string, string>(),
+  shouldSkip: vi.fn((_channel: any) => false),
+  channelListeners: [] as Array<(info: any) => void>,
+}))
+
+vi.mock("../../../../Service/Model", () => ({
+  ConversationWrap: class {
+    conversation: any
+    constructor(conversation: any) {
+      this.conversation = conversation
+    }
+    get channel() {
+      return this.conversation.channel
+    }
+    get channelInfo() {
+      return this.conversation.channelInfo
+    }
+    get timestamp() {
+      return this.conversation.timestamp ?? 0
+    }
+  },
+}))
+
+vi.mock("wukongimjssdk", () => {
+  class Channel {
+    channelID: string
+    channelType: number
+    constructor(channelID: string, channelType: number) {
+      this.channelID = channelID
+      this.channelType = channelType
+    }
+  }
+  const sdk = {
+    conversationManager: {
+      get conversations() {
+        return hoisted.conversations
+      },
+    },
+    channelManager: {
+      getChannelInfo: hoisted.getChannelInfo,
+      addListener: (fn: any) => {
+        hoisted.addListener(fn)
+        hoisted.channelListeners.push(fn)
+      },
+      removeListener: hoisted.removeListener,
+      fetchChannelInfo: hoisted.fetchChannelInfo,
+    },
+  }
+  return {
+    __esModule: true,
+    default: { shared: () => sdk },
+    WKSDK: { shared: () => sdk },
+    Channel,
+    ChannelInfo: class {},
+    ChannelTypeGroup: 2,
+    ChannelTypePerson: 1,
+  }
+})
+
+vi.mock("../../../../Service/SpaceService", () => ({
+  shouldSkipChannelForSpace: (channel: any) => hoisted.shouldSkip(channel),
+  shouldSkipPersonConversationForSpace: () => false,
+}))
+
+vi.mock("../../../../Utils/rateLimit", () => ({
+  debounce: (fn: any) => {
+    const wrapped = (...args: any[]) => fn(...args)
+    wrapped.cancel = () => {}
+    return wrapped
+  },
+}))
+
+vi.mock("../../../../App", () => ({
+  default: {
+    get shared() {
+      return {
+        get currentSpaceId() {
+          return hoisted.currentSpaceId
+        },
+        channelSpaceMap: hoisted.channelSpaceMap,
+      }
+    },
+    dataSource: {
+      channelDataSource: { groupSaveList: hoisted.groupSaveList },
+      commonDataSource: { searchFriends: hoisted.searchFriends },
+    },
+    mittBus: { on: hoisted.mittOn, off: hoisted.mittOff },
+  },
+}))
+
+import { useForwardCandidates } from "../useForwardCandidates"
+
+function Probe({
+  onValue,
+}: {
+  onValue: (value: ReturnType<typeof useForwardCandidates>) => void
+}) {
+  const value = useForwardCandidates()
+  onValue(value)
+  return null
+}
+
+async function flushMicrotasks() {
+  for (let i = 0; i < 20; i++) await Promise.resolve()
+}
+
+function resetHoisted() {
+  vi.clearAllMocks()
+  hoisted.conversations = []
+  hoisted.getChannelInfo.mockReturnValue(undefined)
+  hoisted.groupSaveList.mockResolvedValue([])
+  hoisted.searchFriends.mockResolvedValue([])
+  hoisted.shouldSkip.mockImplementation(() => false)
+  hoisted.currentSpaceId = ""
+  hoisted.channelSpaceMap = new Map()
+  hoisted.channelListeners = []
+}
+
+async function renderCandidates() {
+  const container = document.createElement("div")
+  document.body.appendChild(container)
+  let latest: ReturnType<typeof useForwardCandidates> | undefined
+  await act(async () => {
+    ReactDOM.render(<Probe onValue={(v) => (latest = v)} />, container)
+    await flushMicrotasks()
+  })
+  return {
+    get current() {
+      return latest!
+    },
+    unmount() {
+      act(() => {
+        ReactDOM.unmountComponentAtNode(container)
+      })
+      container.remove()
+    },
+  }
+}
+
+describe("useForwardCandidates — loadGen concurrency guard", () => {
+  beforeEach(() => {
+    resetHoisted()
+  })
+
+  it("drops results from a stale load() when a new load() supersedes it (extraGroups + friends)", async () => {
+    // 第一次 load()：groupSaveList 挂起，load 卡在这里不会走到 searchFriends。
+    // 这里只需要一个能"永不 resolve"的 groupSaveList 就能让老 load 的 gen 一直 pending。
+    let resolveOldGroups: (v: any) => void = () => {}
+    hoisted.groupSaveList.mockReturnValueOnce(
+      new Promise((res) => { resolveOldGroups = res }) as any,
+    )
+
+    const view = await renderCandidates()
+
+    // 第二次 load()：另一个 refresh 触发。用非挂起数据快速完成。
+    hoisted.groupSaveList.mockResolvedValueOnce([
+      {
+        channel: { channelID: "g-new", channelType: CT_GROUP },
+        orgData: { displayName: "New Group" },
+      },
+    ] as any)
+    hoisted.searchFriends.mockResolvedValueOnce([
+      { channel: { channelID: "d-new", channelType: CT_PERSON }, orgData: { displayName: "Bob" } },
+    ] as any)
+
+    // 用 mittBus 记录的 refresh handler 触发第二次 load()。
+    const refreshHandler = hoisted.mittOn.mock.calls.find(
+      (c) => c[0] === "conversation-list-refreshed",
+    )?.[1] as undefined | (() => void)
+    expect(refreshHandler).toBeDefined()
+
+    await act(async () => {
+      refreshHandler!()
+      await flushMicrotasks()
+    })
+
+    // 新 load() 的结果生效。
+    expect(view.current.conversationItems.map((i) => i.channelID)).toContain("g-new")
+    expect(view.current.friendItems.map((i) => i.channelID)).toContain("d-new")
+
+    // 老 load() 姗姗来迟：loadGen 守卫必须让它无声消化，不得把 g-old 拼进 state。
+    await act(async () => {
+      resolveOldGroups([
+        {
+          channel: { channelID: "g-old", channelType: CT_GROUP },
+          orgData: { displayName: "Old Group" },
+        },
+      ])
+      await flushMicrotasks()
+    })
+
+    const convIds = view.current.conversationItems.map((i) => i.channelID)
+    expect(convIds).not.toContain("g-old")
+    // 新数据仍在。
+    expect(convIds).toContain("g-new")
+    expect(view.current.friendItems.map((i) => i.channelID)).toContain("d-new")
+
+    view.unmount()
+  })
+})
+
+describe("useForwardCandidates — requestChannelInfoIfNeeded dedupe", () => {
+  beforeEach(() => {
+    resetHoisted()
+  })
+
+  it("calls fetchChannelInfo exactly once for the same channelID even when the visibility trigger fires repeatedly", async () => {
+    // getChannelInfo 恒返回 undefined → 每次都会走 fetch 分支（除非被 fetchedRef 去重拦住）。
+    hoisted.conversations = [
+      {
+        channel: { channelID: "g1", channelType: CT_GROUP },
+        channelInfo: { orgData: { displayName: "G1" }, top: false },
+        timestamp: 100,
+      },
+    ]
+
+    const view = await renderCandidates()
+
+    const item = view.current.conversationItems.find((i) => i.channelID === "g1")!
+    expect(item).toBeTruthy()
+
+    act(() => {
+      view.current.requestChannelInfoIfNeeded(item)
+      view.current.requestChannelInfoIfNeeded(item)
+      view.current.requestChannelInfoIfNeeded(item)
+    })
+    await act(async () => {
+      await flushMicrotasks()
+    })
+
+    expect(hoisted.fetchChannelInfo).toHaveBeenCalledTimes(1)
+
+    view.unmount()
+  })
+
+  it("does NOT call fetchChannelInfo when the local channelInfo cache already exists", async () => {
+    // getChannelInfo 返回一个已缓存 info → 短路，不发起请求。
+    hoisted.getChannelInfo.mockReturnValue({ orgData: { displayName: "cached" } } as any)
+    hoisted.conversations = [
+      {
+        channel: { channelID: "g-cached", channelType: CT_GROUP },
+        channelInfo: { orgData: { displayName: "G Cached" }, top: false },
+        timestamp: 100,
+      },
+    ]
+
+    const view = await renderCandidates()
+
+    const item = view.current.conversationItems.find((i) => i.channelID === "g-cached")!
+    act(() => {
+      view.current.requestChannelInfoIfNeeded(item)
+    })
+    await act(async () => {
+      await flushMicrotasks()
+    })
+
+    expect(hoisted.fetchChannelInfo).not.toHaveBeenCalled()
+
+    view.unmount()
+  })
+
+  it("ignores requests missing a channelID (defensive guard)", async () => {
+    const view = await renderCandidates()
+
+    act(() => {
+      view.current.requestChannelInfoIfNeeded({} as any)
+      view.current.requestChannelInfoIfNeeded({ channelID: "" } as any)
+    })
+    await act(async () => {
+      await flushMicrotasks()
+    })
+
+    expect(hoisted.fetchChannelInfo).not.toHaveBeenCalled()
+
+    view.unmount()
+  })
+})
+
+describe("useForwardCandidates — hasThreads O(1) via pre-aggregated parentGroupNo set", () => {
+  beforeEach(() => {
+    resetHoisted()
+  })
+
+  it("marks a group with a matching thread child as hasThreads=true (aggregated set hit)", async () => {
+    // 父群 + 子区（parentGroupNo 指向父群），两条都是本地会话。
+    hoisted.conversations = [
+      {
+        channel: { channelID: "g-parent", channelType: CT_GROUP },
+        channelInfo: { orgData: { displayName: "Parent" }, top: false },
+        timestamp: 100,
+      },
+      {
+        channel: { channelID: "t-child", channelType: CT_COMMUNITY_TOPIC },
+        channelInfo: {
+          orgData: { displayName: "Child", parentGroupNo: "g-parent" },
+          top: false,
+        },
+        timestamp: 90,
+      },
+    ]
+    // getCurrentImChannelInfo 需要返回子区的 orgData 以便 parentGroupNo 被收集。
+    hoisted.getChannelInfo.mockImplementation((ch: any) => {
+      if (ch.channelID === "t-child") {
+        return { orgData: { parentGroupNo: "g-parent" } }
+      }
+      return undefined
+    })
+
+    const view = await renderCandidates()
+    const parent = view.current.conversationItems.find((i) => i.channelID === "g-parent")
+    expect(parent?.hasThreads).toBe(true)
+
+    view.unmount()
+  })
+
+  it("marks a group without any thread children as hasThreads=false", async () => {
+    hoisted.conversations = [
+      {
+        channel: { channelID: "g-lonely", channelType: CT_GROUP },
+        channelInfo: { orgData: { displayName: "Lonely" }, top: false },
+        timestamp: 100,
+      },
+    ]
+
+    const view = await renderCandidates()
+    const lonely = view.current.conversationItems.find((i) => i.channelID === "g-lonely")
+    expect(lonely?.hasThreads).toBe(false)
+
+    view.unmount()
+  })
+})

--- a/packages/dmworkbase/src/Components/ForwardModal/hooks/__tests__/useForwardGrant.test.tsx
+++ b/packages/dmworkbase/src/Components/ForwardModal/hooks/__tests__/useForwardGrant.test.tsx
@@ -1,0 +1,101 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import React from "react"
+import ReactDOM from "react-dom"
+import { act } from "react-dom/test-utils"
+
+import {
+  useForwardGrant,
+  type UseForwardGrantOptions,
+  type UseForwardGrantResult,
+} from "../useForwardGrant"
+
+function Probe({
+  options,
+  onValue,
+}: {
+  options?: UseForwardGrantOptions
+  onValue: (value: UseForwardGrantResult) => void
+}) {
+  const value = useForwardGrant(options)
+  onValue(value)
+  return null
+}
+
+describe("useForwardGrant", () => {
+  let container: HTMLDivElement
+  let latest: UseForwardGrantResult
+
+  beforeEach(() => {
+    container = document.createElement("div")
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    act(() => {
+      ReactDOM.unmountComponentAtNode(container)
+    })
+    container.remove()
+  })
+
+  function render(options?: UseForwardGrantOptions) {
+    act(() => {
+      ReactDOM.render(
+        <Probe options={options} onValue={(v) => (latest = v)} />,
+        container,
+      )
+    })
+  }
+
+  it("defaults switch OFF and role to defaultRole", () => {
+    render({ canGrant: true })
+    expect(latest.grantEnabled).toBe(false)
+    expect(latest.grantRole).toBe("reader")
+  })
+
+  it("uses caller-provided defaultRole when specified", () => {
+    render({ canGrant: true, defaultRole: "writer" })
+    expect(latest.grantRole).toBe("writer")
+  })
+
+  it("resets role to defaultRole whenever the switch is turned back on (AC-4 / AC-15)", () => {
+    render({ canGrant: true, defaultRole: "reader" })
+
+    act(() => latest.setGrantEnabled(true))
+    act(() => latest.setGrantRole("writer"))
+    expect(latest.grantRole).toBe("writer")
+
+    act(() => latest.setGrantEnabled(false))
+    // 关掉后再打开：必须复位为 defaultRole，不得记忆上次更高级别。
+    act(() => latest.setGrantEnabled(true))
+    expect(latest.grantRole).toBe("reader")
+  })
+
+  it("readConfirmPayload returns undefined when options are absent (hook inactive)", () => {
+    render(undefined)
+    // 未激活即使强开也不产生 payload。
+    act(() => latest.setGrantEnabled(true))
+    expect(latest.readConfirmPayload()).toBeUndefined()
+  })
+
+  it("readConfirmPayload returns undefined when active but switch is OFF", () => {
+    render({ canGrant: true })
+    expect(latest.grantEnabled).toBe(false)
+    expect(latest.readConfirmPayload()).toBeUndefined()
+  })
+
+  it("readConfirmPayload returns { role } when active AND enabled", () => {
+    render({ canGrant: true, defaultRole: "reader" })
+    act(() => latest.setGrantEnabled(true))
+    act(() => latest.setGrantRole("writer"))
+    expect(latest.readConfirmPayload()).toEqual({ role: "writer" })
+  })
+
+  it("readConfirmPayload keeps a stable identity across renders (safe for stable confirm)", () => {
+    render({ canGrant: true })
+    const first = latest.readConfirmPayload
+    act(() => latest.setGrantEnabled(true))
+    const second = latest.readConfirmPayload
+    expect(second).toBe(first)
+  })
+})

--- a/packages/dmworkbase/src/Components/ForwardModal/hooks/__tests__/useForwardSearch.test.tsx
+++ b/packages/dmworkbase/src/Components/ForwardModal/hooks/__tests__/useForwardSearch.test.tsx
@@ -1,0 +1,210 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import React from "react"
+import ReactDOM from "react-dom"
+import { act } from "react-dom/test-utils"
+
+const hoisted = vi.hoisted(() => ({
+  currentSpaceId: "" as string,
+  searchChatCandidates: undefined as
+    | undefined
+    | ((params: any) => Promise<any>),
+}))
+
+vi.mock("wukongimjssdk", () => {
+  class Channel {
+    channelID: string
+    channelType: number
+    constructor(channelID: string, channelType: number) {
+      this.channelID = channelID
+      this.channelType = channelType
+    }
+  }
+  return { Channel, ChannelTypeGroup: 2, ChannelTypePerson: 1 }
+})
+
+vi.mock("../../../../App", () => ({
+  default: {
+    get shared() {
+      return {
+        get currentSpaceId() {
+          return hoisted.currentSpaceId
+        },
+      }
+    },
+    get searchChatCandidates() {
+      return hoisted.searchChatCandidates
+    },
+  },
+}))
+
+// 保持 candidateToForwardItem 的 getCachedChannelInfo 走注入默认（读运行时缓存桩），
+// 但我们直接 mock currentChannelRuntime 的 get 分支 → undefined，避免它触碰 SDK。
+vi.mock("../../../../im-runtime/currentChannelRuntime", () => ({
+  getCurrentImChannelInfo: () => undefined,
+}))
+
+vi.mock("../../../../Service/Thread", () => ({
+  parseThreadChannelId: () => null,
+}))
+
+import { Channel } from "wukongimjssdk"
+import { useForwardSearch } from "../useForwardSearch"
+
+function Probe({
+  keyword,
+  onCandidate,
+  onValue,
+}: {
+  keyword: string
+  onCandidate: (channelID: string, channel: Channel) => void
+  onValue: (value: ReturnType<typeof useForwardSearch>) => void
+}) {
+  const value = useForwardSearch(keyword, onCandidate)
+  onValue(value)
+  return null
+}
+
+async function flushMicrotasks() {
+  for (let i = 0; i < 4; i++) await Promise.resolve()
+}
+
+describe("useForwardSearch", () => {
+  let container: HTMLDivElement
+
+  beforeEach(() => {
+    hoisted.currentSpaceId = ""
+    hoisted.searchChatCandidates = undefined
+    container = document.createElement("div")
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    act(() => {
+      ReactDOM.unmountComponentAtNode(container)
+    })
+    container.remove()
+  })
+
+  it("clears results and skips call when keyword.length < 2", async () => {
+    const spy = vi.fn(async () => [{ chat_id: "g", chat_type: "group", name: "G" }])
+    hoisted.searchChatCandidates = spy
+
+    let latest: ReturnType<typeof useForwardSearch> | undefined
+    await act(async () => {
+      ReactDOM.render(
+        <Probe
+          keyword="a"
+          onCandidate={() => {}}
+          onValue={(v) => (latest = v)}
+        />,
+        container,
+      )
+      await flushMicrotasks()
+    })
+
+    expect(spy).not.toHaveBeenCalled()
+    expect(latest!.searchGroupItems).toEqual([])
+  })
+
+  it("clears results without throwing when searchChatCandidates is unregistered", async () => {
+    hoisted.searchChatCandidates = undefined
+
+    let latest: ReturnType<typeof useForwardSearch> | undefined
+    await act(async () => {
+      ReactDOM.render(
+        <Probe
+          keyword="engineering"
+          onCandidate={() => {}}
+          onValue={(v) => (latest = v)}
+        />,
+        container,
+      )
+      await flushMicrotasks()
+    })
+
+    expect(latest!.searchGroupItems).toEqual([])
+  })
+
+  it("drops a stale response when a newer keyword request supersedes it (reqId race guard)", async () => {
+    // 两次 keyword 变化：老请求延后 resolve 得比新请求晚，reqId 守卫必须丢弃老结果。
+    let resolveOld: (v: any) => void = () => {}
+    let resolveNew: (v: any) => void = () => {}
+    const oldResult = [{ chat_id: "old", chat_type: "group", name: "Old" }]
+    const newResult = [{ chat_id: "new", chat_type: "group", name: "New" }]
+
+    let callCount = 0
+    hoisted.searchChatCandidates = vi.fn(async () => {
+      callCount += 1
+      if (callCount === 1) return new Promise((res) => { resolveOld = res })
+      return new Promise((res) => { resolveNew = res })
+    }) as any
+
+    let latest: ReturnType<typeof useForwardSearch> | undefined
+    await act(async () => {
+      ReactDOM.render(
+        <Probe
+          keyword="old-word"
+          onCandidate={() => {}}
+          onValue={(v) => (latest = v)}
+        />,
+        container,
+      )
+      await flushMicrotasks()
+    })
+
+    // 触发第二次请求（更新 keyword）：老请求仍挂起。
+    await act(async () => {
+      ReactDOM.render(
+        <Probe
+          keyword="new-word"
+          onCandidate={() => {}}
+          onValue={(v) => (latest = v)}
+        />,
+        container,
+      )
+      await flushMicrotasks()
+    })
+
+    // 老请求晚于新请求 resolve：reqId !== requestRef.current → 丢弃。
+    await act(async () => {
+      resolveNew(newResult)
+      await flushMicrotasks()
+      resolveOld(oldResult)
+      await flushMicrotasks()
+    })
+
+    const ids = latest!.searchGroupItems.map((i) => i.channelID)
+    expect(ids).toEqual(["new"])
+    expect(ids).not.toContain("old")
+  })
+
+  it("registers each returned candidate via onCandidateChannel for the channelMap", async () => {
+    hoisted.searchChatCandidates = vi.fn(async () => [
+      { chat_id: "g1", chat_type: "group", name: "G1" },
+      { chat_id: "d1", chat_type: "direct", name: "Alice" },
+    ]) as any
+
+    const spy = vi.fn()
+    let latest: ReturnType<typeof useForwardSearch> | undefined
+    await act(async () => {
+      ReactDOM.render(
+        <Probe
+          keyword="foo"
+          onCandidate={spy}
+          onValue={(v) => (latest = v)}
+        />,
+        container,
+      )
+      await flushMicrotasks()
+    })
+
+    expect(spy).toHaveBeenCalledTimes(2)
+    expect(spy.mock.calls[0][0]).toBe("g1")
+    expect(spy.mock.calls[1][0]).toBe("d1")
+    // 命中类型正确传递到 Channel：direct → 1，group → 2。
+    expect(spy.mock.calls[0][1].channelType).toBe(2)
+    expect(spy.mock.calls[1][1].channelType).toBe(1)
+    expect(latest!.searchGroupItems.map((i) => i.channelID)).toEqual(["g1", "d1"])
+  })
+})

--- a/packages/dmworkbase/src/Components/ForwardModal/hooks/__tests__/useForwardSelection.test.tsx
+++ b/packages/dmworkbase/src/Components/ForwardModal/hooks/__tests__/useForwardSelection.test.tsx
@@ -1,0 +1,119 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import React from "react"
+import ReactDOM from "react-dom"
+import { act } from "react-dom/test-utils"
+
+vi.mock("wukongimjssdk", () => {
+  class Channel {
+    channelID: string
+    channelType: number
+    constructor(channelID: string, channelType: number) {
+      this.channelID = channelID
+      this.channelType = channelType
+    }
+  }
+  return { Channel, ChannelTypeGroup: 2, ChannelTypePerson: 1 }
+})
+
+import { Channel } from "wukongimjssdk"
+import {
+  useForwardSelection,
+  type UseForwardSelectionResult,
+} from "../useForwardSelection"
+
+function Probe({
+  channelMapRef,
+  onValue,
+}: {
+  channelMapRef: React.MutableRefObject<Map<string, Channel>>
+  onValue: (value: UseForwardSelectionResult) => void
+}) {
+  const value = useForwardSelection(channelMapRef)
+  onValue(value)
+  return null
+}
+
+function item(channelID: string, channelType = 2) {
+  return {
+    channelID,
+    channelType,
+    displayName: channelID,
+  } as any
+}
+
+describe("useForwardSelection", () => {
+  let container: HTMLDivElement
+  let channelMapRef: React.MutableRefObject<Map<string, Channel>>
+  let latest: UseForwardSelectionResult
+
+  beforeEach(() => {
+    container = document.createElement("div")
+    document.body.appendChild(container)
+    channelMapRef = {
+      current: new Map<string, Channel>([
+        ["g1", new Channel("g1", 2)],
+        ["g2", new Channel("g2", 2)],
+      ]),
+    }
+  })
+
+  afterEach(() => {
+    act(() => {
+      ReactDOM.unmountComponentAtNode(container)
+    })
+    container.remove()
+  })
+
+  function render() {
+    act(() => {
+      ReactDOM.render(
+        <Probe channelMapRef={channelMapRef} onValue={(v) => (latest = v)} />,
+        container,
+      )
+    })
+  }
+
+  it("adds an item to selectedIDs, then removes it on a second toggle (idempotent toggle)", () => {
+    render()
+    expect(latest.selectedIDs).toEqual([])
+
+    act(() => latest.toggleSelect(item("g1")))
+    expect(latest.selectedIDs).toEqual(["g1"])
+
+    act(() => latest.toggleSelect(item("g1")))
+    expect(latest.selectedIDs).toEqual([])
+  })
+
+  it("derives selectedChannels via channelMapRef and drops entries missing from the map", () => {
+    render()
+    act(() => latest.toggleSelect(item("g1")))
+    act(() => latest.toggleSelect(item("g-missing")))
+
+    expect(latest.selectedIDs).toEqual(["g1", "g-missing"])
+    // 兜底：channelMap 里没有的 id 走 filter(Boolean) 剔除，避免上层 confirm 拿到 undefined。
+    expect(latest.selectedChannels.map((ch) => ch.channelID)).toEqual(["g1"])
+  })
+
+  it("readSelectedChannels reads the latest snapshot without re-invoking the hook", () => {
+    render()
+    // 捕获最开始那一次的 read 函数引用（模拟稳定的 confirm() 闭包）。
+    const readAtStart = latest.readSelectedChannels
+    expect(readAtStart()).toEqual([])
+
+    act(() => latest.toggleSelect(item("g1")))
+    act(() => latest.toggleSelect(item("g2")))
+
+    // 关键：同一个 readSelectedChannels 引用能读到最新 selectedIDs（走 ref 快照）。
+    expect(readAtStart().map((ch) => ch.channelID)).toEqual(["g1", "g2"])
+  })
+
+  it("reset clears selectedIDs and readSelectedChannels returns empty afterwards", () => {
+    render()
+    act(() => latest.toggleSelect(item("g1")))
+    act(() => latest.reset())
+
+    expect(latest.selectedIDs).toEqual([])
+    expect(latest.readSelectedChannels()).toEqual([])
+  })
+})

--- a/packages/dmworkbase/src/Components/ForwardModal/hooks/__tests__/useSidebarScopes.test.tsx
+++ b/packages/dmworkbase/src/Components/ForwardModal/hooks/__tests__/useSidebarScopes.test.tsx
@@ -1,0 +1,160 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import React from "react"
+import ReactDOM from "react-dom"
+import { act } from "react-dom/test-utils"
+
+const hoisted = vi.hoisted(() => ({
+  deviceId: "" as string,
+  sidebarSync: vi.fn(async (_req: any) => ({
+    items: [] as any[],
+    version: 0,
+    follow_version: 0,
+  })),
+}))
+
+vi.mock("../../../../App", () => ({
+  default: {
+    get shared() {
+      return {
+        get deviceId() {
+          return hoisted.deviceId
+        },
+      }
+    },
+  },
+}))
+
+vi.mock("../../../../Service/SidebarService", () => ({
+  default: { sync: (...args: any[]) => hoisted.sidebarSync(...args) },
+  SidebarTargetType: { DM: 1, CHANNEL: 2, THREAD: 5 },
+}))
+
+import { useSidebarScopes } from "../useSidebarScopes"
+
+function Probe({
+  onValue,
+}: {
+  onValue: (value: ReturnType<typeof useSidebarScopes>) => void
+}) {
+  const value = useSidebarScopes()
+  onValue(value)
+  return null
+}
+
+async function flushMicrotasks() {
+  for (let i = 0; i < 4; i++) await Promise.resolve()
+}
+
+describe("useSidebarScopes", () => {
+  let container: HTMLDivElement
+
+  beforeEach(() => {
+    hoisted.deviceId = ""
+    hoisted.sidebarSync.mockReset()
+    hoisted.sidebarSync.mockResolvedValue({
+      items: [],
+      version: 0,
+      follow_version: 0,
+    })
+    container = document.createElement("div")
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    act(() => {
+      ReactDOM.unmountComponentAtNode(container)
+    })
+    container.remove()
+  })
+
+  it("short-circuits SidebarService.sync when deviceId is empty (validateSidebarRequest would reject)", async () => {
+    hoisted.deviceId = ""
+
+    let latest: ReturnType<typeof useSidebarScopes> | undefined
+    await act(async () => {
+      ReactDOM.render(<Probe onValue={(v) => (latest = v)} />, container)
+      await flushMicrotasks()
+    })
+
+    // 0 次调用：既不发 follow 也不发 recent。
+    expect(hoisted.sidebarSync).not.toHaveBeenCalled()
+    // 空集合退化：与既有 useForwardModal 行为一致。
+    expect(latest!.followedKeys.size).toBe(0)
+    expect(latest!.recentKeys.size).toBe(0)
+    expect(latest!.recentSortMeta.size).toBe(0)
+  })
+
+  it("issues one follow + one recent sync when deviceId is non-empty and merges results", async () => {
+    hoisted.deviceId = "dev-uuid"
+    hoisted.sidebarSync.mockImplementation(async (req: any) => {
+      if (req.tab === "follow") {
+        return {
+          items: [{ target_type: 2, target_id: "g1", is_followed: true }],
+          version: 0,
+          follow_version: 0,
+        }
+      }
+      return {
+        items: [
+          { target_type: 2, target_id: "g2", timestamp: 500, is_pinned: true },
+        ],
+        version: 0,
+        follow_version: 0,
+      }
+    })
+
+    let latest: ReturnType<typeof useSidebarScopes> | undefined
+    await act(async () => {
+      ReactDOM.render(<Probe onValue={(v) => (latest = v)} />, container)
+      await flushMicrotasks()
+    })
+
+    expect(hoisted.sidebarSync).toHaveBeenCalledTimes(2)
+    expect(latest!.followedKeys.has("2::g1")).toBe(true)
+    expect(latest!.recentKeys.has("2::g2")).toBe(true)
+    const meta = latest!.recentSortMeta.get("2::g2")
+    expect(meta?.timestamp).toBe(500)
+    expect(meta?.isPinned).toBe(true)
+  })
+
+  it("does not setState after unmount even if the sidebar sync resolves later (cancelled guard)", async () => {
+    hoisted.deviceId = "dev-uuid"
+    let resolveFollow: (v: any) => void = () => {}
+    let resolveRecent: (v: any) => void = () => {}
+    hoisted.sidebarSync.mockImplementation(
+      async (req: any) =>
+        new Promise((res) => {
+          if (req.tab === "follow") resolveFollow = res
+          else resolveRecent = res
+        }),
+    )
+
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+
+    let latest: ReturnType<typeof useSidebarScopes> | undefined
+    await act(async () => {
+      ReactDOM.render(<Probe onValue={(v) => (latest = v)} />, container)
+      await flushMicrotasks()
+    })
+    expect(latest!.recentKeys.size).toBe(0)
+
+    act(() => {
+      ReactDOM.unmountComponentAtNode(container)
+    })
+
+    // 卸载后 promise 才 resolve：cancelled=true 必须阻止 setState，否则触发 React warning。
+    await act(async () => {
+      resolveFollow({
+        items: [{ target_type: 2, target_id: "g-late", is_followed: true }],
+        version: 0,
+        follow_version: 0,
+      })
+      resolveRecent({ items: [], version: 0, follow_version: 0 })
+      await flushMicrotasks()
+    })
+
+    expect(errorSpy).not.toHaveBeenCalled()
+    errorSpy.mockRestore()
+  })
+})

--- a/packages/dmworkbase/src/Components/ForwardModal/hooks/index.ts
+++ b/packages/dmworkbase/src/Components/ForwardModal/hooks/index.ts
@@ -1,0 +1,20 @@
+export {
+  useDebouncedKeyword,
+  type UseDebouncedKeywordResult,
+} from "./useDebouncedKeyword"
+export { useSidebarScopes, type UseSidebarScopesResult } from "./useSidebarScopes"
+export { useForwardSearch, type UseForwardSearchResult } from "./useForwardSearch"
+export {
+  useForwardCandidates,
+  type UseForwardCandidatesResult,
+} from "./useForwardCandidates"
+export {
+  useForwardSelection,
+  type UseForwardSelectionResult,
+} from "./useForwardSelection"
+export {
+  useForwardGrant,
+  type UseForwardGrantOptions,
+  type UseForwardGrantResult,
+} from "./useForwardGrant"
+export { useForwardTargetMemberCount } from "./useForwardTargetMemberCount"

--- a/packages/dmworkbase/src/Components/ForwardModal/hooks/useDebouncedKeyword.ts
+++ b/packages/dmworkbase/src/Components/ForwardModal/hooks/useDebouncedKeyword.ts
@@ -1,0 +1,44 @@
+import { useCallback, useEffect, useRef, useState } from "react"
+
+/**
+ * 输入框防抖：`inputValue` 即时更新驱动 UI，`keyword` 经 delayMs 静默后才生效
+ * 触发下游过滤/搜索，避免每次按键都跑一遍关键字过滤 + 后端搜索接口。
+ *
+ * 默认 300ms，与既有 useForwardModal 行为一致。unmount 时清理定时器，
+ * 防止在已卸载组件上触发 setKeyword。resetKeyword() 供外部同步清空 input
+ * 与已生效 keyword（例如 confirm 后重置状态）。
+ */
+export interface UseDebouncedKeywordResult {
+  inputValue: string
+  keyword: string
+  setInputValue: (val: string) => void
+  reset: () => void
+}
+
+export function useDebouncedKeyword(delayMs = 300): UseDebouncedKeywordResult {
+  const [inputValue, setInputValueState] = useState("")
+  const [keyword, setKeyword] = useState("")
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const setInputValue = useCallback((val: string) => {
+    setInputValueState(val)
+    if (timerRef.current) clearTimeout(timerRef.current)
+    timerRef.current = setTimeout(() => {
+      setKeyword(val)
+    }, delayMs)
+  }, [delayMs])
+
+  const reset = useCallback(() => {
+    if (timerRef.current) clearTimeout(timerRef.current)
+    setInputValueState("")
+    setKeyword("")
+  }, [])
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current)
+    }
+  }, [])
+
+  return { inputValue, keyword, setInputValue, reset }
+}

--- a/packages/dmworkbase/src/Components/ForwardModal/hooks/useForwardCandidates.ts
+++ b/packages/dmworkbase/src/Components/ForwardModal/hooks/useForwardCandidates.ts
@@ -1,0 +1,313 @@
+import { useCallback, useEffect, useRef, useState } from "react"
+import {
+  Channel,
+  ChannelInfo,
+  ChannelInfoListener,
+  ChannelTypeGroup,
+} from "wukongimjssdk"
+import WKApp from "../../../App"
+import { ConversationWrap } from "../../../Service/Model"
+import { ChannelTypeCommunityTopic } from "../../../Service/Const"
+import {
+  shouldSkipChannelForSpace,
+  shouldSkipPersonConversationForSpace,
+} from "../../../Service/SpaceService"
+import { debounce } from "../../../Utils/rateLimit"
+import { filterArchivedThreads } from "../../ConversationListGrouped/archivedThreads"
+import {
+  addCurrentImChannelInfoListener,
+  fetchCurrentImChannelInfo,
+  getCurrentImChannelInfo,
+} from "../../../im-runtime/currentChannelRuntime"
+import { getCurrentImConversationsDirectly } from "../../../im-runtime/currentConversationRuntime"
+import type { ForwardItem } from "../ForwardModal"
+import {
+  channelInfoToForwardItem,
+  deriveForwardItemBase,
+  sortConversations,
+} from "../logic"
+
+/**
+ * 转发候选装配 hook：本地会话 + group/my 兜底群 + 好友。
+ *
+ * 隐藏在 rebuildConvItems 里的复杂度（Space 权威回种、子区归位、孤儿兜底、
+ * 归档子区过滤、双写竞态守卫）都收敛在这里。上层组合 hook 只关心三件事：
+ *   - `conversationItems` / `friendItems`：给 mergeForwardSources 用
+ *   - `channelMapRef`：给 confirm() 按 channelID 取 Channel 引用
+ *   - `requestChannelInfoIfNeeded`：ItemRow 进入视口时按需拉 channelInfo
+ *
+ * 副作用（订阅 channelInfo 监听、监听 `conversation-list-refreshed` 广播、
+ * 切 Space 时清空兜底群）在 hook 卸载时全部清理。
+ */
+export interface UseForwardCandidatesResult {
+  conversationItems: ForwardItem[]
+  friendItems: ForwardItem[]
+  loading: boolean
+  channelMapRef: React.MutableRefObject<Map<string, Channel>>
+  requestChannelInfoIfNeeded: (item: ForwardItem) => void
+}
+
+function conversationWrapToForwardItem(
+  wrap: ConversationWrap,
+  parentGroupNoSet: ReadonlySet<string>,
+  parentChannelID?: string,
+): ForwardItem {
+  const channelInfo = wrap.channelInfo
+  const isThread = wrap.channel.channelType === ChannelTypeCommunityTopic
+  // hasThreads: 判断该群聊下是否有子区。调用方预先聚合 parentGroupNoSet（O(M) 一次遍历），
+  // 这里 O(1) 命中即可；避免每个 wrap 都做 .some() 全表扫（旧实现 O(N·M) 卡顿）。
+  const hasThreads = !isThread && parentGroupNoSet.has(wrap.channel.channelID)
+  const base = deriveForwardItemBase(wrap.channel, channelInfo)
+  return {
+    ...base,
+    hasThreads,
+    parentChannelID,
+  }
+}
+
+export function useForwardCandidates(): UseForwardCandidatesResult {
+  const [conversationItems, setConversationItems] = useState<ForwardItem[]>([])
+  const [friendItems, setFriendItems] = useState<ForwardItem[]>([])
+  const [loading, setLoading] = useState(true)
+
+  // 存一份 channel 引用，用于 confirm 时返回
+  const channelMapRef = useRef<Map<string, Channel>>(new Map())
+
+  // 保存原始 wraps 引用，供 channelInfoListener 触发后重新构建
+  const wrapsRef = useRef<ConversationWrap[]>([])
+
+  // group/my 兜底群（recents 里缺席的群只在旁路返回，SDK 不建 conversation）。
+  // 由 load() 在 gen 守卫通过后写入，rebuildConvItems 每次执行都消费它并与
+  // recents 群合并，从而成为 conversationItems 的唯一写入路径，避免懒加载
+  // channelInfo 到达后 rebuild 全量覆盖把兜底群冲掉的双写竞态。
+  const extraGroupsRef = useRef<ChannelInfo[]>([])
+
+  // 懒加载：记录已发起 fetchChannelInfo 的 channelID，避免重复请求
+  const fetchedRef = useRef<Set<string>>(new Set())
+
+  // load() 可能并发(mount 自动触发 + conversation-list-refreshed 又触发一次)。
+  // 用一个单调递增的 generation,await 边界处比对,过期就丢弃 setState,
+  // 避免两次 setConversationItems(prev => [...prev, ...]) 重复 append 同一批群。
+  const loadGenRef = useRef(0)
+
+  /**
+   * 懒加载入口：列表项进入视口时调用。仅当本地 channelInfo 缺失且该 channel
+   * 未发起过请求时才调 fetchChannelInfo。去重避免 rebuildConvItems forceUpdate
+   * 之后重复打同一个接口。
+   */
+  const requestChannelInfoIfNeeded = useCallback((item: ForwardItem) => {
+    if (!item?.channelID) return
+    if (fetchedRef.current.has(item.channelID)) return
+    const ch = channelMapRef.current.get(item.channelID)
+      ?? new Channel(item.channelID, item.channelType)
+    if (getCurrentImChannelInfo(ch)) return
+    fetchedRef.current.add(item.channelID)
+    void fetchCurrentImChannelInfo(ch)
+  }, [])
+
+  const rebuildConvItems = useCallback(() => {
+    // 分离：群聊（非子区）和子区
+    const groupWraps: ConversationWrap[] = []
+    const threadWraps: ConversationWrap[] = []
+    const spaceId = WKApp.shared.currentSpaceId
+    // 已并入的群 ID（recents 群 + extraGroups 群），用于去重与子区挂回。
+    const seenGroupIDs = new Set<string>()
+    // 预聚合 parentGroupNo → 一次 O(M) 扫全部会话，给 hasThreads 做 O(1) 命中，
+    // 消除原实现 rebuild 里对每个 wrap 都 .some() 全表扫的 O(N·M) 热点。
+    const parentGroupNoSet = new Set<string>()
+    for (const conv of getCurrentImConversationsDirectly<ConversationWrap["conversation"]>()) {
+      if (conv.channel.channelType !== ChannelTypeCommunityTopic) continue
+      const parentGroupNoRaw = getCurrentImChannelInfo(conv.channel)?.orgData?.parentGroupNo
+      if (parentGroupNoRaw != null) parentGroupNoSet.add(String(parentGroupNoRaw))
+    }
+    for (const wrap of wrapsRef.current) {
+      channelMapRef.current.set(wrap.channel.channelID, wrap.channel)
+      if (wrap.channel.channelType === ChannelTypeCommunityTopic) {
+        threadWraps.push(wrap)
+      } else {
+        // recents 群：load() 入口的 shouldSkipChannelForSpace 已做权威 Space
+        // 把关（channelSpaceMap → channelInfo → fail-closed），此处不再二次过滤。
+        groupWraps.push(wrap)
+        if (wrap.channel.channelType === ChannelTypeGroup) {
+          seenGroupIDs.add(wrap.channel.channelID)
+        }
+      }
+    }
+
+    // group/my 兜底群：用群条目自带的权威 space_id（来自 group/my 行）按来源分流。
+    const extraGroupItems: ForwardItem[] = []
+    for (const groupInfo of extraGroupsRef.current) {
+      const channelID = groupInfo.channel.channelID
+      // 去重：仅当不在已并入的 recents 群集合时才并入（避免 React duplicate key）。
+      if (seenGroupIDs.has(channelID)) continue
+
+      if (spaceId) {
+        const groupSpaceId = groupInfo.orgData?.space_id
+        if (typeof groupSpaceId === "string") {
+          if (groupSpaceId === spaceId) {
+            // 权威命中：用 group/my 行自带的权威 space_id 回灌 channelSpaceMap
+            // （隐藏副作用：让后续 shouldSkipChannelForSpace 走缓存命中分支）。
+            // key 格式与 shouldSkipChannelForSpace 一致。
+            WKApp.shared.channelSpaceMap.set(`${channelID}_${ChannelTypeGroup}`, groupSpaceId)
+          } else if (groupSpaceId !== "") {
+            // 跨 Space：先用 group/my 行自带的权威 space_id 回种 channelSpaceMap
+            // （回种群真实归属，与 shouldSkipChannelForSpace 命中 channelInfo 时
+            // 无条件回填的语义一致），再交给 shouldSkipChannelForSpace 统一裁决
+            // （它内部含 source_space_id 外部成员豁免）。豁免逻辑只活在
+            // SpaceService，不在此复制。先回种再调用不会短路——缓存命中分支读到
+            // 回种的跨 Space 值后仍会执行 source_space_id 豁免检查。
+            WKApp.shared.channelSpaceMap.set(`${channelID}_${ChannelTypeGroup}`, groupSpaceId)
+            if (shouldSkipChannelForSpace(groupInfo.channel)) continue
+          }
+          // 空串 ""：group/my 已带 param.space_id 背书，保留但绝不回种缓存（空串污染）。
+        }
+        // groupSpaceId 字段缺失(undefined) 或为 null（typeof 非 "string"）
+        // → 末位 fail-open 保留，且不回种 channelSpaceMap。
+      }
+      // currentSpaceId 为空（无 Space 模式）→ 不做 Space 过滤，全保留。
+
+      channelMapRef.current.set(channelID, groupInfo.channel)
+      seenGroupIDs.add(channelID)
+      extraGroupItems.push(channelInfoToForwardItem(groupInfo))
+    }
+
+    // 转发目标永不包含已归档子区：复用侧栏的 fail-open helper
+    // （仅过滤明确 status=Archived 的子区，status 未知/未加载的子区保留）。
+    // 仅作用于子区来源，不触碰群聊/私聊。
+    const visibleThreadWraps = filterArchivedThreads(threadWraps)
+
+    // 按 parentGroupNo 建 Map
+    const threadsByParent = new Map<string, ConversationWrap[]>()
+    const orphanThreads: ConversationWrap[] = []
+    for (const tw of visibleThreadWraps) {
+      const parentGroupNoRaw = tw.channelInfo?.orgData?.parentGroupNo
+      const parentGroupNo = parentGroupNoRaw != null ? String(parentGroupNoRaw) : undefined
+      if (parentGroupNo) {
+        const list = threadsByParent.get(parentGroupNo) || []
+        list.push(tw)
+        threadsByParent.set(parentGroupNo, list)
+      } else {
+        orphanThreads.push(tw)
+      }
+    }
+
+    // 输出顺序：父群 → 其子区（紧跟） → 下一父群
+    const items: ForwardItem[] = []
+    for (const gw of groupWraps) {
+      items.push(conversationWrapToForwardItem(gw, parentGroupNoSet))
+      const children = threadsByParent.get(gw.channel.channelID) || []
+      for (const tw of children) {
+        items.push(conversationWrapToForwardItem(tw, parentGroupNoSet, gw.channel.channelID))
+      }
+      // 已挂回的子区从 Map 移除，避免后续兜底重复追加。
+      threadsByParent.delete(gw.channel.channelID)
+    }
+    // group/my 兜底群追加在 recents 群之后；其子区（仅来自 recents）挂回父群。
+    for (const item of extraGroupItems) {
+      items.push(item)
+      const children = threadsByParent.get(item.channelID) || []
+      for (const tw of children) {
+        items.push(conversationWrapToForwardItem(tw, parentGroupNoSet, item.channelID))
+      }
+      threadsByParent.delete(item.channelID)
+    }
+    // 兜底：有 parentGroupNo 但父群既不在 recents 也不在 group/my 的子区，
+    // 作为独立项追加到末尾（带 parentChannelID），避免父群确实缺席时被静默丢弃。
+    for (const [parentGroupNo, children] of threadsByParent) {
+      for (const tw of children) {
+        items.push(conversationWrapToForwardItem(tw, parentGroupNoSet, parentGroupNo))
+      }
+    }
+    // 找不到父群的孤儿子区（无 parentGroupNo）追加到末尾
+    for (const ow of orphanThreads) {
+      items.push(conversationWrapToForwardItem(ow, parentGroupNoSet))
+    }
+
+    setConversationItems(items)
+  }, [])
+
+  useEffect(() => {
+    async function load() {
+      const gen = ++loadGenRef.current
+      // 重入/切 Space 时先清空上一轮兜底群，避免第一帧 rebuild 用旧 Space 的
+      // group/my 兜底群产出（空串/字段缺失分支会 fail-open 让旧 Space 群闪现）。
+      // 代价仅冷启动第一帧不显示兜底群（本就冷状态，无损）。
+      extraGroupsRef.current = []
+      setLoading(true)
+      try {
+        // 最近会话：仅构造 wrap，不再对每个 conv 主动 fetchChannelInfo。
+        // channelInfo 由 ForwardModal 中每个 ItemRow 的 VisibilityTrigger 在
+        // 进入视口时按需拉取（去重 + debounce 合批 forceUpdate）。
+        const conversations = getCurrentImConversationsDirectly<ConversationWrap["conversation"]>()
+        const wraps: ConversationWrap[] = []
+        for (const conv of conversations) {
+          if (shouldSkipChannelForSpace(conv.channel)) continue
+          if (shouldSkipPersonConversationForSpace(conv)) continue
+          wraps.push(new ConversationWrap(conv))
+        }
+        wrapsRef.current = sortConversations(wraps)
+        rebuildConvItems()
+
+        // 补全：获取用户加入的全部群聊（已支持 space_id 过滤）。
+        // 不再直接 setConversationItems 第二次写入，而是存入 extraGroupsRef 并
+        // 触发一次 rebuildConvItems，让其与 recents 群合并产出，杜绝双写竞态。
+        const allGroups = await WKApp.dataSource.channelDataSource.groupSaveList()
+        if (gen !== loadGenRef.current) return // 有更新的 load 在跑,丢弃本次结果
+        extraGroupsRef.current = allGroups
+        rebuildConvItems()
+
+        // 好友
+        const friends = (await WKApp.dataSource.commonDataSource.searchFriends("")) ?? []
+        if (gen !== loadGenRef.current) return
+        // 按 channelID 去重：Space 模式下后端 space/{id}/members 可能返回同一
+        // uid 的多条记录（多角色等），不去重会触发 React duplicate key 警告。
+        const seen = new Set<string>()
+        const fItems: ForwardItem[] = []
+        for (const info of friends) {
+          const cid = info.channel.channelID
+          if (seen.has(cid)) continue
+          seen.add(cid)
+          channelMapRef.current.set(cid, info.channel)
+          fItems.push(channelInfoToForwardItem(info))
+        }
+        setFriendItems(fItems)
+      } finally {
+        // 仅最新 generation 收尾 loading,避免老 load 的 setLoading(false)
+        // 把更新的 load 标记成"已完成"。
+        if (gen === loadGenRef.current) setLoading(false)
+      }
+    }
+
+    // 订阅 channelInfo 更新，触发列表重渲（头像/名称补全）。
+    // 使用 debounce 合批，避免视口内多个懒加载请求集中返回时连续触发 rebuild。
+    const rebuildDebounced = debounce(() => rebuildConvItems(), 150)
+    const channelListener: ChannelInfoListener = (_channelInfo: ChannelInfo) => {
+      rebuildDebounced()
+    }
+    const unsubscribeChannelListener = addCurrentImChannelInfoListener(channelListener)
+
+    // 切 Space 后 conversationManager.conversations 会被先清空再回填,
+    // 如果 modal 在回填前打开,初次 load() 会读到空 cache（缺最近会话/子区）。
+    // 监听 ChatVM 的回填广播,触发后重新 load 一次,保证最终能拿到完整数据。
+    const onConversationListRefreshed = () => {
+      load()
+    }
+    WKApp.mittBus.on('conversation-list-refreshed', onConversationListRefreshed)
+
+    load()
+
+    return () => {
+      unsubscribeChannelListener()
+      WKApp.mittBus.off('conversation-list-refreshed', onConversationListRefreshed)
+      rebuildDebounced.cancel()
+    }
+  }, [rebuildConvItems])
+
+  return {
+    conversationItems,
+    friendItems,
+    loading,
+    channelMapRef,
+    requestChannelInfoIfNeeded,
+  }
+}

--- a/packages/dmworkbase/src/Components/ForwardModal/hooks/useForwardGrant.ts
+++ b/packages/dmworkbase/src/Components/ForwardModal/hooks/useForwardGrant.ts
@@ -1,0 +1,62 @@
+import { useCallback, useRef, useState } from "react"
+import type { ForwardGrant, ForwardGrantRole } from "../grant"
+
+/**
+ * 授权区（feature #511）状态。仅在调用方传入 grantOptions 时激活。
+ *
+ * 语义（对齐既有 useForwardModal 行为）：
+ *   - 开关默认关闭：需用户主动打开才走授权（AC-4 / AC-15）
+ *   - 打开开关时角色复位为 defaultRole（不记忆上次更高级别）
+ *   - `confirmPayload()` 供稳定的 confirm() 读取当前 grant 快照（active && enabled
+ *     时返回 { role }，否则 undefined），避免上层为读快照重造 confirm 引用。
+ */
+export interface UseForwardGrantOptions {
+  canGrant: boolean
+  defaultRole?: ForwardGrantRole
+}
+
+export interface UseForwardGrantResult {
+  grantEnabled: boolean
+  grantRole: ForwardGrantRole
+  setGrantEnabled: (v: boolean) => void
+  setGrantRole: (r: ForwardGrantRole) => void
+  /** 供 confirm() 读取当前授权快照：未激活或未开启时返回 undefined。 */
+  readConfirmPayload: () => ForwardGrant | undefined
+}
+
+export function useForwardGrant(options?: UseForwardGrantOptions): UseForwardGrantResult {
+  const active = !!options
+  const defaultRole = options?.defaultRole ?? "reader"
+
+  const [grantEnabled, setGrantEnabledState] = useState<boolean>(false)
+  const [grantRole, setGrantRole] = useState<ForwardGrantRole>(defaultRole)
+
+  // 重开开关时复位为 defaultRole（不记忆上次更高级别）→ AC-4 / AC-15。
+  const setGrantEnabled = useCallback(
+    (v: boolean) => {
+      setGrantEnabledState(v)
+      if (v) setGrantRole(defaultRole)
+    },
+    [defaultRole],
+  )
+
+  const stateRef = useRef<{ active: boolean; enabled: boolean; role: ForwardGrantRole }>({
+    active,
+    enabled: grantEnabled,
+    role: grantRole,
+  })
+  stateRef.current = { active, enabled: grantEnabled, role: grantRole }
+
+  const readConfirmPayload = useCallback((): ForwardGrant | undefined => {
+    const { active: a, enabled, role } = stateRef.current
+    return a && enabled ? { role } : undefined
+  }, [])
+
+  return {
+    grantEnabled,
+    grantRole,
+    setGrantEnabled,
+    setGrantRole,
+    readConfirmPayload,
+  }
+}

--- a/packages/dmworkbase/src/Components/ForwardModal/hooks/useForwardSearch.ts
+++ b/packages/dmworkbase/src/Components/ForwardModal/hooks/useForwardSearch.ts
@@ -1,0 +1,70 @@
+import { useEffect, useRef, useState } from "react"
+import { Channel } from "wukongimjssdk"
+import WKApp from "../../../App"
+import type { ForwardItem } from "../ForwardModal"
+import {
+  candidateToForwardItem,
+  type SearchChatCandidate,
+} from "../candidateToForwardItem"
+import { chatTypeToChannelType } from "../chatTypeToChannelType"
+
+/**
+ * 后端 `WKApp.searchChatCandidates` 搜索群/子区/后端全库联系人。keyword < 2 或
+ * 回调未注册时清空结果（复刻既有 useForwardModal 行为）。
+ *
+ * 副作用：每条候选构造 Channel 后回调 `onCandidateChannel`，让调用方把 Channel
+ * 引用登记到 channelMap，供 confirm() 按 channelID 取回。之所以做成回调而非
+ * 返回 Map：channelMap 由上层管理（跨来源共享：本地会话 / 好友 / 搜索候选），
+ * 这里只负责「搜到就登记」这一步。
+ *
+ * 竞态守卫：单调递增 reqId + await 后比对，过期请求直接丢弃。
+ */
+export interface UseForwardSearchResult {
+  searchGroupItems: ForwardItem[]
+}
+
+export function useForwardSearch(
+  keyword: string,
+  onCandidateChannel: (channelID: string, channel: Channel) => void,
+): UseForwardSearchResult {
+  const [searchGroupItems, setSearchGroupItems] = useState<ForwardItem[]>([])
+  const requestRef = useRef(0)
+  // 把 callback 收敛到 ref，避免上层每次 render 传入新引用触发 effect 重跑。
+  const onCandidateChannelRef = useRef(onCandidateChannel)
+  onCandidateChannelRef.current = onCandidateChannel
+
+  useEffect(() => {
+    if (keyword.length < 2) {
+      setSearchGroupItems([])
+      return
+    }
+    if (!WKApp.searchChatCandidates) {
+      setSearchGroupItems([])
+      return
+    }
+    const reqId = ++requestRef.current
+    const searchParams: Record<string, string> = { keyword }
+    const currentSpaceId = WKApp.shared.currentSpaceId
+    if (currentSpaceId) {
+      searchParams.space_id = currentSpaceId
+    }
+    WKApp.searchChatCandidates(searchParams)
+      .then((candidates: unknown) => {
+        if (reqId !== requestRef.current) return
+        const arr: SearchChatCandidate[] = Array.isArray(candidates)
+          ? (candidates as SearchChatCandidate[])
+          : []
+        const groups: ForwardItem[] = arr.map((c) => {
+          const ch = new Channel(c.chat_id, chatTypeToChannelType(c.chat_type))
+          onCandidateChannelRef.current(c.chat_id, ch)
+          return candidateToForwardItem(c)
+        })
+        setSearchGroupItems(groups)
+      })
+      .catch(() => {
+        if (reqId === requestRef.current) setSearchGroupItems([])
+      })
+  }, [keyword])
+
+  return { searchGroupItems }
+}

--- a/packages/dmworkbase/src/Components/ForwardModal/hooks/useForwardSelection.ts
+++ b/packages/dmworkbase/src/Components/ForwardModal/hooks/useForwardSelection.ts
@@ -1,0 +1,59 @@
+import { useCallback, useRef, useState } from "react"
+import type { Channel } from "wukongimjssdk"
+import type { ForwardItem } from "../ForwardModal"
+
+/**
+ * 选择态管理：selectedIDs / toggleSelect / selectedChannels。
+ *
+ * `channelMapRef` 由 candidates hook 持有（跨来源共享），此处只读拿 Channel 引用
+ * 用于导出 selectedChannels + confirm 的通道；不复制、不重复登记 Channel。
+ *
+ * `readSelectedChannels()` 用一个 ref 兜住最新的 selectedIDs，让上层的 confirm()
+ * 回调保持稳定引用（不因每次 toggleSelect 都重造函数）。
+ */
+export interface UseForwardSelectionResult {
+  selectedIDs: string[]
+  selectedChannels: Channel[]
+  toggleSelect: (item: ForwardItem) => void
+  /** 从最新 selectedIDs 计算 Channel 数组，供稳定的 confirm() 回调调用。 */
+  readSelectedChannels: () => Channel[]
+  reset: () => void
+}
+
+export function useForwardSelection(
+  channelMapRef: React.MutableRefObject<Map<string, Channel>>,
+): UseForwardSelectionResult {
+  const [selectedIDs, setSelectedIDs] = useState<string[]>([])
+  const selectedIDsRef = useRef<string[]>(selectedIDs)
+  selectedIDsRef.current = selectedIDs
+
+  const toggleSelect = useCallback((item: ForwardItem) => {
+    setSelectedIDs((prev: string[]) =>
+      prev.includes(item.channelID)
+        ? prev.filter((id: string) => id !== item.channelID)
+        : [...prev, item.channelID]
+    )
+  }, [])
+
+  const selectedChannels = selectedIDs
+    .map((id: string) => channelMapRef.current.get(id))
+    .filter(Boolean) as Channel[]
+
+  const readSelectedChannels = useCallback((): Channel[] => {
+    return selectedIDsRef.current
+      .map((id: string) => channelMapRef.current.get(id))
+      .filter(Boolean) as Channel[]
+  }, [channelMapRef])
+
+  const reset = useCallback(() => {
+    setSelectedIDs([])
+  }, [])
+
+  return {
+    selectedIDs,
+    selectedChannels,
+    toggleSelect,
+    readSelectedChannels,
+    reset,
+  }
+}

--- a/packages/dmworkbase/src/Components/ForwardModal/hooks/useForwardTargetMemberCount.ts
+++ b/packages/dmworkbase/src/Components/ForwardModal/hooks/useForwardTargetMemberCount.ts
@@ -1,0 +1,76 @@
+import { useEffect, useMemo, useState } from "react"
+import { Channel, ChannelTypePerson } from "wukongimjssdk"
+import type { ImSubscriberLike } from "../../../im-runtime/channelRuntime"
+import {
+  getCurrentImChannelSubscribers,
+  syncCurrentImChannelSubscribers,
+} from "../../../im-runtime/currentChannelRuntime"
+
+/**
+ * 授权区「将授权给群当前 N 名成员」提示的成员数。
+ *
+ * 语义：与 host 侧 collectForwardUids 一致地把选中目标展开成去重 uid 快照
+ * （群 → syncSubscribes/getSubscribes 成员，个人 → 对端 uid），使提示数与
+ * 实际会被授权的成员数吻合。无群目标时返回 undefined（个人转发不显示）。
+ *
+ * stale guard：选中项在异步 syncSubscribes 期间变化时，丢弃过期结果，
+ * 避免旧一批成员数覆盖当前选择的计数。
+ */
+export function useForwardTargetMemberCount(
+  selectedIDs: string[],
+  selectedChannels: Channel[],
+): number | undefined {
+  // 选择语义以 selectedIDs 为准；resolvedKey 用来感知 channelMap 补齐后的重算时机。
+  // useMemo 化避免每次渲染都执行 .join(',') 与 .map(...).join(',')。
+  const selectedKey = useMemo(() => selectedIDs.join(","), [selectedIDs])
+  const resolvedKey = useMemo(
+    () => selectedChannels.map((ch) => `${ch.channelID}:${ch.channelType}`).join(","),
+    [selectedChannels],
+  )
+  const [count, setCount] = useState<number | undefined>(undefined)
+
+  useEffect(() => {
+    // 选中项里仍有未登记到 channelMap 的目标时，不用部分 resolved channel
+    // 先算一个偏小快照；等待 channel 信息补齐后再计算完整成员数。
+    if (selectedChannels.length !== selectedIDs.length) {
+      setCount(undefined)
+      return
+    }
+
+    const groups = selectedChannels.filter((ch) => ch.channelType !== ChannelTypePerson)
+    if (groups.length === 0) {
+      setCount(undefined)
+      return
+    }
+    const persons = selectedChannels.filter((ch) => ch.channelType === ChannelTypePerson)
+    let cancelled = false
+    const compute = async () => {
+      const uids = new Set<string>()
+      for (const ch of persons) {
+        if (ch.channelID) uids.add(ch.channelID)
+      }
+      for (const ch of groups) {
+        try {
+          await syncCurrentImChannelSubscribers(ch)
+        } catch {
+          // best-effort：拉取失败时退回已缓存的成员快照。
+        }
+        if (cancelled) return
+        const subs = getCurrentImChannelSubscribers<Channel, ImSubscriberLike>(ch)
+        for (const s of subs) {
+          if (typeof s?.uid === "string" && s.uid) uids.add(s.uid)
+        }
+      }
+      if (!cancelled) setCount(uids.size > 0 ? uids.size : undefined)
+    }
+    void compute()
+    return () => {
+      cancelled = true
+    }
+    // selectedKey 承载「选中了哪些 id」的语义；resolvedKey 只用于感知这些 id 对应的
+    // Channel 何时补齐或类型变化，避免 selectedChannels 新数组引用导致重复触发。
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedKey, resolvedKey])
+
+  return count
+}

--- a/packages/dmworkbase/src/Components/ForwardModal/hooks/useSidebarScopes.ts
+++ b/packages/dmworkbase/src/Components/ForwardModal/hooks/useSidebarScopes.ts
@@ -1,0 +1,68 @@
+import { useEffect, useState } from "react"
+import WKApp from "../../../App"
+import SidebarService from "../../../Service/SidebarService"
+import type { RecentSortMeta } from "../logic"
+
+/**
+ * 「关注 / 最近」Tab 的作用域集合同步。
+ *
+ * 与智能纪要选择器一致，走 SidebarService follow/recent 同步。转发列表主体仍复用本地
+ * 会话 + group/my + 好友装配（保证零权限回归）；这里只提供 sidebar 返回的权威集合
+ * 作为「关注 / 最近」Tab 的过滤作用域 + 最近 Tab 的排序元信息。
+ *
+ * deviceId 为空时后端 validateSidebarRequest 必拒，跳过注定失败的请求，
+ * 关注/最近集合退化为空集（保持与既有 useForwardModal 行为一致）。
+ */
+export interface UseSidebarScopesResult {
+  followedKeys: Set<string>
+  recentKeys: Set<string>
+  recentSortMeta: Map<string, RecentSortMeta>
+}
+
+export function useSidebarScopes(): UseSidebarScopesResult {
+  const [followedKeys, setFollowedKeys] = useState<Set<string>>(new Set())
+  const [recentKeys, setRecentKeys] = useState<Set<string>>(new Set())
+  const [recentSortMeta, setRecentSortMeta] = useState<Map<string, RecentSortMeta>>(new Map())
+
+  useEffect(() => {
+    const deviceUuid = WKApp.shared.deviceId || ""
+    if (deviceUuid === "") {
+      setFollowedKeys(new Set())
+      setRecentKeys(new Set())
+      setRecentSortMeta(new Map())
+      return
+    }
+    let cancelled = false
+    Promise.all([
+      SidebarService.sync({ tab: "follow", device_uuid: deviceUuid }).catch(() => null),
+      SidebarService.sync({ tab: "recent", device_uuid: deviceUuid }).catch(() => null),
+    ])
+      .then(([followResp, recentResp]) => {
+        if (cancelled) return
+        const followed = new Set<string>()
+        for (const item of followResp?.items ?? []) {
+          if (item.is_followed) followed.add(`${item.target_type}::${item.target_id}`)
+        }
+
+        const recent = new Set<string>()
+        const sortMeta = new Map<string, RecentSortMeta>()
+        for (const item of recentResp?.items ?? []) {
+          const key = `${item.target_type}::${item.target_id}`
+          recent.add(key)
+          sortMeta.set(key, {
+            timestamp: item.timestamp ?? 0,
+            isPinned: item.is_pinned === true,
+          })
+        }
+
+        setFollowedKeys(followed)
+        setRecentKeys(recent)
+        setRecentSortMeta(sortMeta)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  return { followedKeys, recentKeys, recentSortMeta }
+}

--- a/packages/dmworkbase/src/Components/ForwardModal/logic/__tests__/channelInfoToForwardItem.test.ts
+++ b/packages/dmworkbase/src/Components/ForwardModal/logic/__tests__/channelInfoToForwardItem.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest"
+import { channelInfoToForwardItem } from "../channelInfoToForwardItem"
+
+const CT_PERSON = 1
+const CT_GROUP = 2
+const CT_COMMUNITY_TOPIC = 5
+
+function info(overrides: {
+  channelID?: string
+  channelType?: number
+  orgData?: Record<string, unknown>
+  top?: boolean
+} = {}) {
+  return {
+    channel: {
+      channelID: overrides.channelID ?? "g1",
+      channelType: overrides.channelType ?? CT_GROUP,
+    },
+    orgData: overrides.orgData ?? { displayName: "Group 1" },
+    top: overrides.top ?? false,
+  } as any
+}
+
+describe("channelInfoToForwardItem", () => {
+  it("copies channelID / channelType and prefers displayName", () => {
+    const item = channelInfoToForwardItem(info({ orgData: { displayName: "Engineering" } }))
+    expect(item.channelID).toBe("g1")
+    expect(item.channelType).toBe(CT_GROUP)
+    expect(item.displayName).toBe("Engineering")
+  })
+
+  it("falls back to channelID when displayName is empty", () => {
+    const item = channelInfoToForwardItem(info({ channelID: "g-fallback", orgData: { displayName: "" } }))
+    expect(item.displayName).toBe("g-fallback")
+  })
+
+  it("marks robot=1 as isAI", () => {
+    const item = channelInfoToForwardItem(info({ orgData: { displayName: "Bot", robot: 1 } }))
+    expect(item.isAI).toBe(true)
+  })
+
+  it("marks is_external_group=1 as isExternal only for groups", () => {
+    const groupItem = channelInfoToForwardItem(info({
+      channelType: CT_GROUP,
+      orgData: { displayName: "External", is_external_group: 1 },
+    }))
+    expect(groupItem.isExternal).toBe(true)
+
+    const personItem = channelInfoToForwardItem(info({
+      channelType: CT_PERSON,
+      orgData: { displayName: "Alice", is_external_group: 1 },
+    }))
+    expect(personItem.isExternal).toBe(false)
+  })
+
+  it("marks community-topic channelType as thread", () => {
+    const item = channelInfoToForwardItem(info({ channelType: CT_COMMUNITY_TOPIC }))
+    expect(item.isThread).toBe(true)
+  })
+
+  it("propagates top === true as isPinned", () => {
+    expect(channelInfoToForwardItem(info({ top: true })).isPinned).toBe(true)
+    expect(channelInfoToForwardItem(info({ top: false })).isPinned).toBe(false)
+  })
+})

--- a/packages/dmworkbase/src/Components/ForwardModal/logic/__tests__/forwardItemKey.test.ts
+++ b/packages/dmworkbase/src/Components/ForwardModal/logic/__tests__/forwardItemKey.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest"
+import { forwardItemKey, forwardItemKind, FORWARD_ITEM_ACCESSORS } from "../forwardItemKey"
+import type { ForwardItem } from "../../ForwardModal"
+
+const CT_PERSON = 1
+const CT_GROUP = 2
+const CT_COMMUNITY_TOPIC = 5
+
+function item(id: string, extra: Partial<ForwardItem> = {}): ForwardItem {
+  return {
+    channelID: id,
+    channelType: CT_GROUP,
+    displayName: id,
+    ...extra,
+  }
+}
+
+describe("forwardItemKey", () => {
+  it("produces `${type}::${id}` composite keys", () => {
+    expect(forwardItemKey(item("g1", { channelType: CT_GROUP }))).toBe("2::g1")
+    expect(forwardItemKey(item("d1", { channelType: CT_PERSON }))).toBe("1::d1")
+    expect(forwardItemKey(item("t1", { channelType: CT_COMMUNITY_TOPIC }))).toBe("5::t1")
+  })
+
+  it("distinguishes ids with the same string but different types", () => {
+    const a = item("dup", { channelType: CT_PERSON })
+    const b = item("dup", { channelType: CT_GROUP })
+    expect(forwardItemKey(a)).not.toBe(forwardItemKey(b))
+  })
+})
+
+describe("forwardItemKind", () => {
+  it("classifies persons as 'direct'", () => {
+    expect(forwardItemKind(item("d1", { channelType: CT_PERSON }))).toBe("direct")
+  })
+
+  it("classifies community-topic channelType as 'thread'", () => {
+    expect(forwardItemKind(item("t1", { channelType: CT_COMMUNITY_TOPIC }))).toBe("thread")
+  })
+
+  it("classifies items with explicit isThread flag as 'thread' even when channelType is group", () => {
+    expect(forwardItemKind(item("t1", { channelType: CT_GROUP, isThread: true }))).toBe("thread")
+  })
+
+  it("classifies everything else as 'group'", () => {
+    expect(forwardItemKind(item("g1", { channelType: CT_GROUP }))).toBe("group")
+  })
+})
+
+describe("FORWARD_ITEM_ACCESSORS", () => {
+  it("composes group-typed composite keys from a bare parent id", () => {
+    expect(FORWARD_ITEM_ACCESSORS.getGroupKeyFromId("g1")).toBe("2::g1")
+  })
+
+  it("exposes id / name / parentId / kind consistently", () => {
+    const t = item("t1", { channelType: CT_COMMUNITY_TOPIC, parentChannelID: "g1", displayName: "Standup" })
+    expect(FORWARD_ITEM_ACCESSORS.getId(t)).toBe("t1")
+    expect(FORWARD_ITEM_ACCESSORS.getName(t)).toBe("Standup")
+    expect(FORWARD_ITEM_ACCESSORS.getParentId(t)).toBe("g1")
+    expect(FORWARD_ITEM_ACCESSORS.getKind(t)).toBe("thread")
+    expect(FORWARD_ITEM_ACCESSORS.getKey(t)).toBe("5::t1")
+  })
+})

--- a/packages/dmworkbase/src/Components/ForwardModal/logic/__tests__/mergeForwardSources.test.ts
+++ b/packages/dmworkbase/src/Components/ForwardModal/logic/__tests__/mergeForwardSources.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest"
+import { mergeForwardSources } from "../mergeForwardSources"
+import type { ForwardItem } from "../../ForwardModal"
+
+const CT_GROUP = 2
+const CT_PERSON = 1
+
+function item(id: string, extra: Partial<ForwardItem> = {}): ForwardItem {
+  return {
+    channelID: id,
+    channelType: CT_GROUP,
+    displayName: id,
+    ...extra,
+  }
+}
+
+describe("mergeForwardSources", () => {
+  it("returns conversation items unchanged when the other sources are empty", () => {
+    const conv = [item("g1"), item("g2")]
+    const merged = mergeForwardSources(conv, [], [])
+    expect(merged.map((i) => i.channelID)).toEqual(["g1", "g2"])
+  })
+
+  it("appends friends that are not present in conversations", () => {
+    const conv = [item("g1")]
+    const friends = [
+      item("d1", { channelType: CT_PERSON }),
+      item("d2", { channelType: CT_PERSON }),
+    ]
+    const merged = mergeForwardSources(conv, friends, [])
+    expect(merged.map((i) => i.channelID)).toEqual(["g1", "d1", "d2"])
+  })
+
+  it("skips a friend whose channelID collides with a conversation entry (keeps the conversation)", () => {
+    const conv = [item("dup", { displayName: "Conv Version" })]
+    const friends = [item("dup", { channelType: CT_PERSON, displayName: "Friend Version" })]
+    const merged = mergeForwardSources(conv, friends, [])
+    expect(merged).toHaveLength(1)
+    expect(merged[0].displayName).toBe("Conv Version")
+  })
+
+  it("appends search groups that neither conversations nor friends already cover", () => {
+    const conv = [item("g1")]
+    const friends = [item("d1", { channelType: CT_PERSON })]
+    const search = [item("g-search"), item("d1", { channelType: CT_PERSON, displayName: "search-collision" })]
+    const merged = mergeForwardSources(conv, friends, search)
+    // d1 collision from search is dropped; g-search stays
+    expect(merged.map((i) => i.channelID)).toEqual(["g1", "d1", "g-search"])
+  })
+
+  it("does not mutate its inputs", () => {
+    const conv = [item("g1")]
+    const friends = [item("d1", { channelType: CT_PERSON })]
+    const search = [item("g2")]
+    mergeForwardSources(conv, friends, search)
+    expect(conv).toHaveLength(1)
+    expect(friends).toHaveLength(1)
+    expect(search).toHaveLength(1)
+  })
+})

--- a/packages/dmworkbase/src/Components/ForwardModal/logic/__tests__/sortConversations.test.ts
+++ b/packages/dmworkbase/src/Components/ForwardModal/logic/__tests__/sortConversations.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest"
+import { sortConversations } from "../sortConversations"
+
+function wrap(id: string, timestamp: number, top?: boolean) {
+  return {
+    id,
+    timestamp,
+    channelInfo: top === undefined ? undefined : { top },
+  }
+}
+
+describe("sortConversations", () => {
+  it("sorts by timestamp descending when nothing is pinned", () => {
+    const a = wrap("a", 100)
+    const b = wrap("b", 300)
+    const c = wrap("c", 200)
+    const sorted = sortConversations([a, b, c])
+    expect(sorted.map((w) => w.id)).toEqual(["b", "c", "a"])
+  })
+
+  it("places pinned wraps ahead of newer unpinned wraps", () => {
+    const newer = wrap("newer", 2_000, false)
+    const pinned = wrap("pinned", 1, true)
+    const sorted = sortConversations([newer, pinned])
+    expect(sorted.map((w) => w.id)).toEqual(["pinned", "newer"])
+  })
+
+  it("keeps timestamp-desc order among multiple pinned wraps", () => {
+    const p1 = wrap("p1", 100, true)
+    const p2 = wrap("p2", 300, true)
+    const sorted = sortConversations([p1, p2])
+    expect(sorted.map((w) => w.id)).toEqual(["p2", "p1"])
+  })
+
+  it("does not mutate the input array", () => {
+    const list = [wrap("a", 100), wrap("b", 200)]
+    sortConversations(list)
+    expect(list.map((w) => w.id)).toEqual(["a", "b"])
+  })
+
+  it("keeps a pinned wrap with timestamp=0 ahead of a far-future unpinned wrap", () => {
+    // 行为断言（避免自我重复常量）：真实毫秒时间戳里最极端的一档
+    // （2050 年初 ≈ 2.5e12），只要仍能被置顶加成压制，就锁定了「置顶恒赢」的语义。
+    const pinnedAtZero = wrap("pinned-0", 0, true)
+    const unpinnedFarFuture = wrap("future-unpinned", Date.UTC(2050, 0, 1), false)
+    const sorted = sortConversations([unpinnedFarFuture, pinnedAtZero])
+    expect(sorted.map((w) => w.id)).toEqual(["pinned-0", "future-unpinned"])
+  })
+
+  it("treats undefined channelInfo as not pinned", () => {
+    const noInfo = wrap("noInfo", 500)
+    const pinned = wrap("pinned", 100, true)
+    const sorted = sortConversations([noInfo, pinned])
+    expect(sorted.map((w) => w.id)).toEqual(["pinned", "noInfo"])
+  })
+})

--- a/packages/dmworkbase/src/Components/ForwardModal/logic/__tests__/sortRecentItems.test.ts
+++ b/packages/dmworkbase/src/Components/ForwardModal/logic/__tests__/sortRecentItems.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest"
+import { sortRecentItems, type RecentSortMeta } from "../sortRecentItems"
+import { forwardItemKey } from "../forwardItemKey"
+import type { ForwardItem } from "../../ForwardModal"
+
+const CT_GROUP = 2
+
+function item(id: string, extra: Partial<ForwardItem> = {}): ForwardItem {
+  return {
+    channelID: id,
+    channelType: CT_GROUP,
+    displayName: id,
+    ...extra,
+  }
+}
+
+function meta(entries: Array<[ForwardItem, RecentSortMeta]>): Map<string, RecentSortMeta> {
+  const m = new Map<string, RecentSortMeta>()
+  for (const [it, mt] of entries) m.set(forwardItemKey(it), mt)
+  return m
+}
+
+describe("sortRecentItems", () => {
+  it("returns items in timestamp-desc order when nothing is pinned", () => {
+    const a = item("a")
+    const b = item("b")
+    const c = item("c")
+    const sorted = sortRecentItems([a, b, c], meta([
+      [a, { timestamp: 100, isPinned: false }],
+      [b, { timestamp: 300, isPinned: false }],
+      [c, { timestamp: 200, isPinned: false }],
+    ]))
+    expect(sorted.map((i) => i.channelID)).toEqual(["b", "c", "a"])
+  })
+
+  it("places sidebar-pinned items ahead of newer unpinned items", () => {
+    const pinned = item("pinned")
+    const newer = item("newer")
+    const sorted = sortRecentItems([newer, pinned], meta([
+      [newer, { timestamp: 2_000_000_000_000, isPinned: false }],
+      [pinned, { timestamp: 0, isPinned: true }],
+    ]))
+    expect(sorted.map((i) => i.channelID)).toEqual(["pinned", "newer"])
+  })
+
+  it("treats local channelInfo.top as pinned even when the sidebar meta says otherwise", () => {
+    const localPinned = item("localTop", { isPinned: true })
+    const newer = item("newer")
+    const sorted = sortRecentItems([newer, localPinned], meta([
+      [newer, { timestamp: 2_000_000_000_000, isPinned: false }],
+      [localPinned, { timestamp: 0, isPinned: false }],
+    ]))
+    expect(sorted.map((i) => i.channelID)).toEqual(["localTop", "newer"])
+  })
+
+  it("falls back to timestamp 0 when meta is missing for an item", () => {
+    const withMeta = item("withMeta")
+    const noMeta = item("noMeta")
+    const sorted = sortRecentItems([noMeta, withMeta], meta([
+      [withMeta, { timestamp: 100, isPinned: false }],
+    ]))
+    expect(sorted.map((i) => i.channelID)).toEqual(["withMeta", "noMeta"])
+  })
+
+  it("does not mutate the input array", () => {
+    const a = item("a")
+    const b = item("b")
+    const input = [a, b]
+    sortRecentItems(input, meta([
+      [a, { timestamp: 100, isPinned: false }],
+      [b, { timestamp: 200, isPinned: false }],
+    ]))
+    expect(input.map((i) => i.channelID)).toEqual(["a", "b"])
+  })
+})

--- a/packages/dmworkbase/src/Components/ForwardModal/logic/channelInfoToForwardItem.ts
+++ b/packages/dmworkbase/src/Components/ForwardModal/logic/channelInfoToForwardItem.ts
@@ -1,0 +1,42 @@
+import { ChannelTypeGroup } from "wukongimjssdk"
+import type { Channel, ChannelInfo } from "wukongimjssdk"
+import { ChannelTypeCommunityTopic } from "../../../Service/Const"
+import type { ForwardItem } from "../ForwardModal"
+
+/**
+ * 把 (channel, channelInfo) 派生成 ForwardItem 的基础字段。纯函数，无隐藏副作用。
+ *
+ * 抽出以让 ChannelInfo 来源（好友 / group/my 兜底群）与 ConversationWrap 来源
+ * （最近会话）共享同一份 displayName 回退 / robot / isPinned / isThread / isExternal
+ * 语义，避免两处分叉（例如后续新增 badge / 修改外群语义时必须两处同改）。
+ *
+ * channelInfo 允许为空以适配 ConversationWrap 里 channelInfo 尚未加载的场景；
+ * 缺省时 displayName 回退到 channelID，其余可选字段全部为 false/undefined。
+ */
+export function deriveForwardItemBase(
+  channel: Channel,
+  channelInfo?: ChannelInfo,
+): ForwardItem {
+  const orgData = channelInfo?.orgData
+  return {
+    channelID: channel.channelID,
+    channelType: channel.channelType,
+    displayName: orgData?.displayName || channel.channelID,
+    isAI: orgData?.robot === 1,
+    isThread: channel.channelType === ChannelTypeCommunityTopic,
+    isPinned: channelInfo?.top === true,
+    isExternal:
+      channel.channelType === ChannelTypeGroup &&
+      orgData?.is_external_group === 1,
+  }
+}
+
+/**
+ * 把 ChannelInfo 映射成 ForwardItem。纯函数，无隐藏副作用。
+ *
+ * 抽出后便于单测 —— 用例只需构造一个 ChannelInfo 形状的对象即可覆盖显示名回退、
+ * robot 标记、外部群标记等分支，无需拉起整个 useForwardModal。
+ */
+export function channelInfoToForwardItem(channelInfo: ChannelInfo): ForwardItem {
+  return deriveForwardItemBase(channelInfo.channel, channelInfo)
+}

--- a/packages/dmworkbase/src/Components/ForwardModal/logic/forwardItemKey.ts
+++ b/packages/dmworkbase/src/Components/ForwardModal/logic/forwardItemKey.ts
@@ -1,0 +1,31 @@
+import { ChannelTypeGroup, ChannelTypePerson } from "wukongimjssdk"
+import { ChannelTypeCommunityTopic } from "../../../Service/Const"
+import type {
+  ChatKind,
+  ChatSelectorAccessors,
+} from "../../ChatSelector/tabFilter"
+import type { ForwardItem } from "../ForwardModal"
+
+// 复合 key：`${channelType}::${channelID}`，防跨类型 id 碰撞。channelType 取值
+// (个人=1 / 群=2 / 子区=5) 恰与 SidebarTargetType(DM/CHANNEL/THREAD) 一致，
+// 故转发本地 item 与 SidebarService 返回的关注/最近集合可直接对齐比较。
+export function forwardItemKey(item: ForwardItem): string {
+  return `${item.channelType}::${item.channelID}`
+}
+
+// 归类：个人→私聊，子区→thread，其余→群。供四 Tab 作用域过滤使用。
+export function forwardItemKind(item: ForwardItem): ChatKind {
+  if (item.channelType === ChannelTypePerson) return "direct"
+  if (item.isThread || item.channelType === ChannelTypeCommunityTopic) return "thread"
+  return "group"
+}
+
+export const FORWARD_ITEM_ACCESSORS: ChatSelectorAccessors<ForwardItem> = {
+  getId: (i) => i.channelID,
+  getName: (i) => i.displayName,
+  getKind: forwardItemKind,
+  getParentId: (i) => i.parentChannelID,
+  getKey: forwardItemKey,
+  // 父群恒为群聊，故以群类型（ChannelTypeGroup）构造复合 key，与 forwardItemKey 同构。
+  getGroupKeyFromId: (parentId) => `${ChannelTypeGroup}::${parentId}`,
+}

--- a/packages/dmworkbase/src/Components/ForwardModal/logic/index.ts
+++ b/packages/dmworkbase/src/Components/ForwardModal/logic/index.ts
@@ -1,0 +1,17 @@
+export {
+  channelInfoToForwardItem,
+  deriveForwardItemBase,
+} from "./channelInfoToForwardItem"
+export {
+  FORWARD_ITEM_ACCESSORS,
+  forwardItemKey,
+  forwardItemKind,
+} from "./forwardItemKey"
+export { mergeForwardSources } from "./mergeForwardSources"
+export {
+  PINNED_CONVERSATION_SCORE_BOOST,
+  sortConversations,
+} from "./sortConversations"
+export type { SortableConversation } from "./sortConversations"
+export { sortRecentItems } from "./sortRecentItems"
+export type { RecentSortMeta } from "./sortRecentItems"

--- a/packages/dmworkbase/src/Components/ForwardModal/logic/mergeForwardSources.ts
+++ b/packages/dmworkbase/src/Components/ForwardModal/logic/mergeForwardSources.ts
@@ -1,0 +1,24 @@
+import type { ForwardItem } from "../ForwardModal"
+
+/**
+ * 合并去重转发候选的三来源：本地会话 > 好友 > 后端搜索群组。纯函数。
+ *
+ * 优先级：conversationItems 在最前（保留其 displayName / 排序 / hasThreads
+ * 等本地元信息），friends 中已出现在会话里的跳过，搜索群组再排除掉前两者已
+ * 覆盖的 channelID，最后按 [conv, friend, search] 顺序拼接。
+ *
+ * 之所以以 channelID 而非复合 key 去重：三来源共存的仅群/私聊；父群与子区
+ * channelID 天然不同（子区 id 形如 `groupNo____shortId`），不存在跨类型碰撞。
+ */
+export function mergeForwardSources(
+  conversationItems: ForwardItem[],
+  friendItems: ForwardItem[],
+  searchGroupItems: ForwardItem[],
+): ForwardItem[] {
+  const convIDs = new Set(conversationItems.map((i) => i.channelID))
+  const uniqueFriends = friendItems.filter((f) => !convIDs.has(f.channelID))
+  const localIDs = new Set<string>(convIDs)
+  for (const f of uniqueFriends) localIDs.add(f.channelID)
+  const uniqueSearchGroups = searchGroupItems.filter((g) => !localIDs.has(g.channelID))
+  return [...conversationItems, ...uniqueFriends, ...uniqueSearchGroups]
+}

--- a/packages/dmworkbase/src/Components/ForwardModal/logic/sortConversations.ts
+++ b/packages/dmworkbase/src/Components/ForwardModal/logic/sortConversations.ts
@@ -1,0 +1,24 @@
+/**
+ * 会话置顶优先 + timestamp 倒序排序。纯函数，不感知 SDK。
+ *
+ * PINNED_CONVERSATION_SCORE_BOOST 用大数把置顶项抬到普通项之上，避免拿 timestamp
+ * 做减法时溢出 Number.MAX_SAFE_INTEGER。取 1e15：远大于任何合理毫秒时间戳
+ * （2050 年 1 月 1 日 ≈ 2.5e12），也远小于 Number.MAX_SAFE_INTEGER（≈ 9e15），
+ * 保证「置顶必赢」的偏序在下一个百年内稳定成立。
+ */
+export const PINNED_CONVERSATION_SCORE_BOOST = 1_000_000_000_000_000
+
+export interface SortableConversation {
+  timestamp: number
+  channelInfo?: { top?: boolean } | undefined
+}
+
+export function sortConversations<T extends SortableConversation>(wraps: T[]): T[] {
+  return [...wraps].sort((a, b) => {
+    let aScore = a.timestamp
+    let bScore = b.timestamp
+    if (a.channelInfo?.top) aScore += PINNED_CONVERSATION_SCORE_BOOST
+    if (b.channelInfo?.top) bScore += PINNED_CONVERSATION_SCORE_BOOST
+    return bScore - aScore
+  })
+}

--- a/packages/dmworkbase/src/Components/ForwardModal/logic/sortRecentItems.ts
+++ b/packages/dmworkbase/src/Components/ForwardModal/logic/sortRecentItems.ts
@@ -1,0 +1,29 @@
+import type { ForwardItem } from "../ForwardModal"
+import { forwardItemKey } from "./forwardItemKey"
+
+/** 最近 Tab 的排序元信息：来自 SidebarService recent 同步。 */
+export interface RecentSortMeta {
+  timestamp: number
+  isPinned: boolean
+}
+
+/**
+ * 「最近」Tab 排序：置顶优先，其余按 timestamp 倒序。纯函数，不修改入参。
+ *
+ * 置顶判断双源合并：SidebarService 标记的 is_pinned 与本地 channelInfo.top
+ * 二者任一为 true 即视为置顶（对齐既有 useForwardModal 行为）。
+ * 抽出后便于单测 —— 只需构造 items + meta Map 即可覆盖各分支。
+ */
+export function sortRecentItems(
+  items: ForwardItem[],
+  recentSortMeta: Map<string, RecentSortMeta>,
+): ForwardItem[] {
+  return [...items].sort((a, b) => {
+    const aMeta = recentSortMeta.get(forwardItemKey(a))
+    const bMeta = recentSortMeta.get(forwardItemKey(b))
+    const aPinned = aMeta?.isPinned === true || a.isPinned === true
+    const bPinned = bMeta?.isPinned === true || b.isPinned === true
+    if (aPinned !== bPinned) return aPinned ? -1 : 1
+    return (bMeta?.timestamp ?? 0) - (aMeta?.timestamp ?? 0)
+  })
+}

--- a/packages/dmworkbase/src/Components/ForwardModal/ui/Footer.tsx
+++ b/packages/dmworkbase/src/Components/ForwardModal/ui/Footer.tsx
@@ -1,0 +1,31 @@
+import React from "react"
+import { useI18n } from "../../../i18n"
+
+/** 底部按钮区：取消（可选）+ 确认（有选中时显示计数）。 */
+export interface FooterProps {
+  selectedCount: number
+  onConfirm: () => void
+  onCancel?: () => void
+}
+
+export function Footer({ selectedCount, onConfirm, onCancel }: FooterProps) {
+  const { t } = useI18n()
+  return (
+    <div className="wk-fm-footer">
+      {onCancel && (
+        <button className="wk-fm-btn wk-fm-btn--cancel" onClick={onCancel}>
+          {t("base.common.cancel")}
+        </button>
+      )}
+      <button
+        className="wk-fm-btn wk-fm-btn--confirm"
+        onClick={onConfirm}
+        disabled={selectedCount === 0}
+      >
+        {selectedCount > 0
+          ? t("base.forwardModal.confirmWithCount", { values: { count: selectedCount } })
+          : t("base.forwardModal.confirm")}
+      </button>
+    </div>
+  )
+}

--- a/packages/dmworkbase/src/Components/ForwardModal/ui/GrantArea.tsx
+++ b/packages/dmworkbase/src/Components/ForwardModal/ui/GrantArea.tsx
@@ -1,0 +1,46 @@
+import React from "react"
+import Checkbox from "../../Checkbox"
+import { useI18n } from "../../../i18n"
+import type { ForwardGrantConfig } from "../grant"
+
+/**
+ * 授权区（opt-in）。仅当 ForwardModal 的调用方显式传入 grant 配置时才渲染。
+ * canGrant=false 走灰化+提示分支；canGrant=true 走开关 + 角色下拉 + 目标人数提示分支。
+ */
+export function GrantArea({ grant }: { grant: ForwardGrantConfig }) {
+  const { t } = useI18n()
+  if (!grant.canGrant) {
+    return (
+      <div className="wk-fm-grant wk-fm-grant--disabled">
+        <span className="wk-fm-grant-lock">🔒</span>
+        <span className="wk-fm-grant-hint">
+          {grant.disabledReason ?? t("base.forwardModal.grant.disabledReason")}
+        </span>
+      </div>
+    )
+  }
+  return (
+    <div className="wk-fm-grant">
+      <div className="wk-fm-grant-row">
+        <label className="wk-fm-grant-switch">
+          <Checkbox checked={grant.enabled} onCheck={() => grant.onEnabledChange(!grant.enabled)} />
+          <span className="wk-fm-grant-label">{t("base.forwardModal.grant.enableLabel")}</span>
+        </label>
+        <select
+          className="wk-fm-grant-role"
+          value={grant.role}
+          disabled={!grant.enabled}
+          onChange={(e) => grant.onRoleChange(e.target.value as ForwardGrantConfig["role"])}
+        >
+          <option value="reader">{t("base.forwardModal.grant.roleReader")}</option>
+          <option value="writer">{t("base.forwardModal.grant.roleWriter")}</option>
+        </select>
+      </div>
+      {grant.enabled && typeof grant.targetMemberCount === "number" && grant.targetMemberCount > 0 && (
+        <div className="wk-fm-grant-members">
+          {t("base.forwardModal.grant.targetMembers", { values: { count: grant.targetMemberCount } })}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/packages/dmworkbase/src/Components/ForwardModal/ui/ItemList.tsx
+++ b/packages/dmworkbase/src/Components/ForwardModal/ui/ItemList.tsx
@@ -1,0 +1,65 @@
+import React from "react"
+import VisibilityTrigger from "../../VisibilityTrigger"
+import { useI18n } from "../../../i18n"
+import type { ForwardItem } from "../ForwardModal"
+import { ItemRow } from "./ItemRow"
+
+/**
+ * 可选列表。loading / 空态 / 正常渲染三态，正常渲染时逐项包 VisibilityTrigger 触发懒加载。
+ *
+ * `flat` 控制平铺/树形样式（最近 Tab 为平铺）。`onItemVisible` 为空时不裹 VisibilityTrigger，
+ * 走静态列表分支（供不需要 channelInfo 懒加载的场景使用，如 Storybook）。
+ */
+export interface ItemListProps {
+  items: ForwardItem[]
+  selectedSet: ReadonlySet<string>
+  loading: boolean
+  flat: boolean
+  showMeta: boolean
+  onToggleSelect: (item: ForwardItem) => void
+  onItemVisible?: (item: ForwardItem) => void
+}
+
+export function ItemList({
+  items,
+  selectedSet,
+  loading,
+  flat,
+  showMeta,
+  onToggleSelect,
+  onItemVisible,
+}: ItemListProps) {
+  const { t } = useI18n()
+  return (
+    <div className="wk-fm-list">
+      {loading ? (
+        <div className="wk-fm-empty">{t("base.forwardModal.loading")}</div>
+      ) : items.length === 0 ? (
+        <div className="wk-fm-empty">{t("base.forwardModal.noContacts")}</div>
+      ) : (
+        items.map((item) => {
+          const row = (
+            <ItemRow
+              item={item}
+              selected={selectedSet.has(item.channelID)}
+              flat={flat}
+              showMeta={showMeta}
+              onToggle={onToggleSelect}
+            />
+          )
+          if (onItemVisible) {
+            return (
+              <VisibilityTrigger
+                key={item.channelID}
+                onVisible={() => onItemVisible(item)}
+              >
+                {row}
+              </VisibilityTrigger>
+            )
+          }
+          return <React.Fragment key={item.channelID}>{row}</React.Fragment>
+        })
+      )}
+    </div>
+  )
+}

--- a/packages/dmworkbase/src/Components/ForwardModal/ui/ItemRow.tsx
+++ b/packages/dmworkbase/src/Components/ForwardModal/ui/ItemRow.tsx
@@ -1,0 +1,91 @@
+import React, { useMemo } from "react"
+import { Channel, ChannelTypeGroup, ChannelTypePerson } from "wukongimjssdk"
+import { Tag } from "@douyinfe/semi-ui"
+import Checkbox from "../../Checkbox"
+import AiBadge from "../../AiBadge"
+import WKAvatar from "../../WKAvatar"
+import { useI18n } from "../../../i18n"
+import { ChannelTypeCommunityTopic } from "../../../Service/Const"
+import type { ForwardItem } from "../ForwardModal"
+
+/**
+ * 左列列表项。三种视图模式：
+ *   - flat=true  平铺（最近 Tab）：无缩进、显示 kind/external 元信息文字
+ *   - flat=false 树形（关注/群/私聊 Tab）：子区带一级缩进、外部群/AI 用 Tag/Badge
+ *
+ * React.memo：500 行列表下,一次键入 / toggleSelect 会触发 ForwardModal 重渲；
+ * item / selected / flat / showMeta / onToggle 都不变时,memo 直接短路,免去
+ * 500 次子渲染 + Channel 构造 + WKAvatar 重渲。
+ */
+export interface ItemRowProps {
+  item: ForwardItem
+  selected: boolean
+  flat: boolean
+  showMeta: boolean
+  onToggle: (item: ForwardItem) => void
+}
+
+function getKindLabel(item: ForwardItem, t: ReturnType<typeof useI18n>["t"]): string {
+  if (item.isThread || item.channelType === ChannelTypeCommunityTopic) {
+    return t("base.forwardModal.kindThread")
+  }
+  if (item.channelType === ChannelTypePerson) {
+    return t("base.forwardModal.kindDirect")
+  }
+  return t("base.forwardModal.kindGroup")
+}
+
+function ItemRowInner({ item, selected, flat, showMeta, onToggle }: ItemRowProps) {
+  const { t } = useI18n()
+  // 只依赖 channelID / channelType 的 Channel 引用；同一 item 复用同一实例,
+  // 避免每次渲染都 new Channel(...) 让 WKAvatar 判断 prop 变化重渲。
+  const channel = useMemo(
+    () => new Channel(item.channelID, item.channelType),
+    [item.channelID, item.channelType],
+  )
+  const kindLabel = showMeta ? getKindLabel(item, t) : ""
+  const isExternalGroup = item.channelType === ChannelTypeGroup && item.isExternal
+  return (
+    <div
+      className={`wk-fm-item${!flat && item.parentChannelID ? " wk-fm-item--child" : ""}${flat ? " wk-fm-item--flat" : ""}${selected ? " wk-fm-item--selected" : ""}`}
+      onClick={() => onToggle(item)}
+    >
+      <Checkbox
+        checked={selected}
+        onCheck={() => {}}
+      />
+      <div className="wk-fm-avatar-wrap">
+        <WKAvatar channel={channel} lazy />
+      </div>
+      <div className="wk-fm-item-main">
+        <div className="wk-fm-item-title-row">
+          <span className="wk-fm-item-name">{item.displayName}</span>
+          {showMeta && item.isAI && <AiBadge size="small" />}
+        </div>
+      </div>
+      {showMeta && (
+        <div className="wk-fm-item-meta">
+          <span>{kindLabel}</span>
+          {isExternalGroup && (
+            <>
+              <span className="wk-fm-item-meta-separator">·</span>
+              <span>{t("base.forwardModal.external")}</span>
+            </>
+          )}
+        </div>
+      )}
+      {!showMeta && isExternalGroup && (
+        <Tag
+          size="small"
+          color="purple"
+          className="wk-conversationlist-item-external-tag"
+        >
+          {t("base.forwardModal.external")}
+        </Tag>
+      )}
+      {!showMeta && item.isAI && <AiBadge />}
+    </div>
+  )
+}
+
+export const ItemRow = React.memo(ItemRowInner)

--- a/packages/dmworkbase/src/Components/ForwardModal/ui/SearchBar.tsx
+++ b/packages/dmworkbase/src/Components/ForwardModal/ui/SearchBar.tsx
@@ -1,0 +1,32 @@
+import React, { useCallback } from "react"
+import { IconSearchStroked } from "@douyinfe/semi-icons"
+import { useI18n } from "../../../i18n"
+
+/** 顶部搜索输入：受控 value + change 回调。 */
+export interface SearchBarProps {
+  value: string
+  onChange: (val: string) => void
+  placeholder?: string
+}
+
+export function SearchBar({ value, onChange, placeholder }: SearchBarProps) {
+  const { t } = useI18n()
+  const handleInputChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      onChange(e.target.value)
+    },
+    [onChange],
+  )
+  return (
+    <div className="wk-fm-search">
+      <IconSearchStroked className="wk-fm-search-icon" />
+      <input
+        className="wk-fm-search-input"
+        placeholder={placeholder ?? t("base.forwardModal.searchPlaceholder")}
+        type="text"
+        value={value}
+        onChange={handleInputChange}
+      />
+    </div>
+  )
+}

--- a/packages/dmworkbase/src/Components/ForwardModal/ui/SelectedPanel.tsx
+++ b/packages/dmworkbase/src/Components/ForwardModal/ui/SelectedPanel.tsx
@@ -1,0 +1,33 @@
+import React from "react"
+import { useI18n } from "../../../i18n"
+import type { ForwardItem } from "../ForwardModal"
+import { SelectedRow } from "./SelectedRow"
+
+/** 右列已选列表。空态时展示提示；有选中时展示计数标题 + 逐行 SelectedRow。 */
+export interface SelectedPanelProps {
+  selectedItems: ForwardItem[]
+  onRemove: (item: ForwardItem) => void
+}
+
+export function SelectedPanel({ selectedItems, onRemove }: SelectedPanelProps) {
+  const { t } = useI18n()
+  if (selectedItems.length === 0) {
+    return (
+      <div className="wk-fm-empty wk-fm-empty--right">
+        {t("base.forwardModal.noneSelected")}
+      </div>
+    )
+  }
+  return (
+    <>
+      <div className="wk-fm-selected-title">
+        {t("base.forwardModal.selectedCount", { values: { count: selectedItems.length } })}
+      </div>
+      <div className="wk-fm-selected-list">
+        {selectedItems.map((item) => (
+          <SelectedRow key={item.channelID} item={item} onRemove={onRemove} />
+        ))}
+      </div>
+    </>
+  )
+}

--- a/packages/dmworkbase/src/Components/ForwardModal/ui/SelectedRow.tsx
+++ b/packages/dmworkbase/src/Components/ForwardModal/ui/SelectedRow.tsx
@@ -1,0 +1,37 @@
+import React from "react"
+import { Channel } from "wukongimjssdk"
+import { X } from "lucide-react"
+import WKAvatar from "../../WKAvatar"
+import { useI18n } from "../../../i18n"
+import type { ForwardItem } from "../ForwardModal"
+
+/** 右列已选列表项：头像 + 名称 + 移除按钮。 */
+export interface SelectedRowProps {
+  item: ForwardItem
+  onRemove: (item: ForwardItem) => void
+}
+
+export function SelectedRow({ item, onRemove }: SelectedRowProps) {
+  const { t } = useI18n()
+  const channel = new Channel(item.channelID, item.channelType)
+  return (
+    <div className="wk-fm-selected-item">
+      <div className="wk-fm-avatar-wrap">
+        {/* 右列已选列表项数量少且都在视口内，不启用 lazy 避免占位 SVG → 真实
+            图的视觉闪烁 */}
+        <WKAvatar channel={channel} />
+      </div>
+      <span className="wk-fm-item-name">{item.displayName}</span>
+      <button
+        className="wk-fm-remove-btn"
+        onClick={(e) => {
+          e.stopPropagation()
+          onRemove(item)
+        }}
+        aria-label={t("base.forwardModal.remove")}
+      >
+        <X size={14} strokeWidth={2} />
+      </button>
+    </div>
+  )
+}

--- a/packages/dmworkbase/src/Components/ForwardModal/ui/TabsBar.tsx
+++ b/packages/dmworkbase/src/Components/ForwardModal/ui/TabsBar.tsx
@@ -1,0 +1,27 @@
+import React from "react"
+import { Tabs, TabPane } from "@douyinfe/semi-ui"
+import { useI18n } from "../../../i18n"
+import type { ChatSelectorTab } from "../../ChatSelector/tabFilter"
+
+/** 四 Tab：关注 / 最近 / 全部群聊 / 全部私聊（对齐智能纪要选择器）。 */
+export interface TabsBarProps {
+  activeTab: ChatSelectorTab
+  onTabChange: (tab: ChatSelectorTab) => void
+}
+
+export function TabsBar({ activeTab, onTabChange }: TabsBarProps) {
+  const { t } = useI18n()
+  return (
+    <Tabs
+      activeKey={activeTab}
+      onChange={(key) => onTabChange(key as ChatSelectorTab)}
+      size="small"
+      className="wk-fm-tabs"
+    >
+      <TabPane tab={t("base.forwardModal.tabFollowed")} itemKey="followed" />
+      <TabPane tab={t("base.forwardModal.tabRecent")} itemKey="recent" />
+      <TabPane tab={t("base.forwardModal.tabAllGroups")} itemKey="group" />
+      <TabPane tab={t("base.forwardModal.tabAllDirects")} itemKey="direct" />
+    </Tabs>
+  )
+}

--- a/packages/dmworkbase/src/Components/ForwardModal/ui/index.ts
+++ b/packages/dmworkbase/src/Components/ForwardModal/ui/index.ts
@@ -1,0 +1,8 @@
+export { GrantArea } from "./GrantArea"
+export { ItemRow, type ItemRowProps } from "./ItemRow"
+export { SelectedRow, type SelectedRowProps } from "./SelectedRow"
+export { SearchBar, type SearchBarProps } from "./SearchBar"
+export { TabsBar, type TabsBarProps } from "./TabsBar"
+export { ItemList, type ItemListProps } from "./ItemList"
+export { SelectedPanel, type SelectedPanelProps } from "./SelectedPanel"
+export { Footer, type FooterProps } from "./Footer"

--- a/packages/dmworkbase/src/Components/ForwardModal/useForwardModal.ts
+++ b/packages/dmworkbase/src/Components/ForwardModal/useForwardModal.ts
@@ -1,106 +1,25 @@
-import { useState, useEffect, useCallback, useRef } from "react"
-import { Channel, ChannelInfo, ChannelInfoListener, ChannelTypeGroup, ChannelTypePerson } from "wukongimjssdk"
-import { ConversationWrap } from "../../Service/Model"
-import { ChannelTypeCommunityTopic } from "../../Service/Const"
-import { shouldSkipChannelForSpace, shouldSkipPersonConversationForSpace } from "../../Service/SpaceService"
-import { filterArchivedThreads } from "../ConversationListGrouped/archivedThreads"
-import { debounce } from "../../Utils/rateLimit"
-import WKApp from "../../App"
-import SidebarService from "../../Service/SidebarService"
-import { ForwardItem } from "./ForwardModal"
-import { candidateToForwardItem } from "./candidateToForwardItem"
-import { chatTypeToChannelType } from "./chatTypeToChannelType"
+import { useCallback, useMemo, useState } from "react"
+import type { Channel } from "wukongimjssdk"
+import type { ForwardItem } from "./ForwardModal"
 import {
   filterChatSelectorItems,
   type ChatSelectorTab,
-  type ChatSelectorAccessors,
-  type ChatKind,
 } from "../ChatSelector/tabFilter"
 import type { ForwardFinished, ForwardGrantRole } from "./grant"
 import {
-  addCurrentImChannelInfoListener,
-  fetchCurrentImChannelInfo,
-  getCurrentImChannelInfo,
-} from "../../im-runtime/currentChannelRuntime"
-import { getCurrentImConversationsDirectly } from "../../im-runtime/currentConversationRuntime"
-
-// 复合 key：${channelType}::${channelID}，防跨类型 id 碰撞。channelType 取值
-// (个人=1 / 群=2 / 子区=5) 恰与 SidebarTargetType(DM/CHANNEL/THREAD) 一致，
-// 故转发本地 item 与 SidebarService 返回的关注/最近集合可直接对齐比较。
-function forwardItemKey(item: ForwardItem): string {
-  return `${item.channelType}::${item.channelID}`
-}
-
-// 归类：个人→私聊，子区→thread，其余→群。供四 Tab 作用域过滤使用。
-function forwardItemKind(item: ForwardItem): ChatKind {
-  if (item.channelType === ChannelTypePerson) return "direct"
-  if (item.isThread || item.channelType === ChannelTypeCommunityTopic) return "thread"
-  return "group"
-}
-
-const FORWARD_ITEM_ACCESSORS: ChatSelectorAccessors<ForwardItem> = {
-  getId: (i) => i.channelID,
-  getName: (i) => i.displayName,
-  getKind: forwardItemKind,
-  getParentId: (i) => i.parentChannelID,
-  getKey: forwardItemKey,
-  // 父群恒为群聊，故以群类型（ChannelTypeGroup）构造复合 key，与 forwardItemKey 同构。
-  getGroupKeyFromId: (parentId) => `${ChannelTypeGroup}::${parentId}`,
-}
-
-const PINNED_CONVERSATION_SCORE_BOOST = 1_000_000_000_000
-
-interface RecentSortMeta {
-  timestamp: number
-  isPinned: boolean
-}
-
-function channelInfoToForwardItem(channelInfo: ChannelInfo): ForwardItem {
-  return {
-    channelID: channelInfo.channel.channelID,
-    channelType: channelInfo.channel.channelType,
-    displayName: channelInfo.orgData.displayName || channelInfo.channel.channelID,
-    isAI: channelInfo.orgData?.robot === 1,
-    isThread: channelInfo.channel.channelType === ChannelTypeCommunityTopic,
-    isPinned: channelInfo.top === true,
-    isExternal:
-      channelInfo.channel.channelType === ChannelTypeGroup &&
-      channelInfo.orgData?.is_external_group === 1,
-  }
-}
-
-function conversationWrapToForwardItem(wrap: ConversationWrap, parentChannelID?: string): ForwardItem {
-  const channelInfo = wrap.channelInfo
-  const isThread = wrap.channel.channelType === ChannelTypeCommunityTopic
-  // hasThreads: 判断该群聊下是否有子区（子区会出现在 conversations 里，其 orgData.parentGroupNo 指向父群）
-  const hasThreads = !isThread && getCurrentImConversationsDirectly<ConversationWrap["conversation"]>().some(
-    (c) => c.channel.channelType === ChannelTypeCommunityTopic
-      && (getCurrentImChannelInfo(c.channel)?.orgData?.parentGroupNo === wrap.channel.channelID)
-  )
-  return {
-    channelID: wrap.channel.channelID,
-    channelType: wrap.channel.channelType,
-    displayName: channelInfo?.orgData.displayName || wrap.channel.channelID,
-    isAI: channelInfo?.orgData?.robot === 1,
-    isThread,
-    isPinned: channelInfo?.top === true,
-    hasThreads: hasThreads ?? false,
-    parentChannelID,
-    isExternal:
-      wrap.channel.channelType === ChannelTypeGroup &&
-      channelInfo?.orgData?.is_external_group === 1,
-  }
-}
-
-function sortConversations(wraps: ConversationWrap[]): ConversationWrap[] {
-  return [...wraps].sort((a, b) => {
-    let aScore = a.timestamp
-    let bScore = b.timestamp
-    if (a.channelInfo?.top) aScore += PINNED_CONVERSATION_SCORE_BOOST
-    if (b.channelInfo?.top) bScore += PINNED_CONVERSATION_SCORE_BOOST
-    return bScore - aScore
-  })
-}
+  FORWARD_ITEM_ACCESSORS,
+  mergeForwardSources,
+  sortRecentItems,
+} from "./logic"
+import {
+  useDebouncedKeyword,
+  useForwardCandidates,
+  useForwardGrant,
+  useForwardSearch,
+  useForwardSelection,
+  useSidebarScopes,
+  type UseForwardGrantOptions,
+} from "./hooks"
 
 export interface UseForwardModalResult {
   /** 关键字过滤后的列表（用于渲染列表项） */
@@ -137,427 +56,98 @@ export interface UseForwardModalResult {
  * emits a `grant` second argument on confirm; when absent, confirm keeps the legacy
  * single-argument `onFinished(channels)` behaviour (既有转发路径零回归).
  */
-export interface UseForwardModalGrantOptions {
-  canGrant: boolean
-  defaultRole?: ForwardGrantRole
-}
+export type UseForwardModalGrantOptions = UseForwardGrantOptions
 
+/**
+ * 转发弹窗的组合层。数据/搜索/关注/选择/授权都拆到独立 hook；这里只做四件事：
+ *   1. 把候选来源合并成 allItems；
+ *   2. 按当前 Tab + keyword 过滤（复用与纪要选择器同一套 filterChatSelectorItems）；
+ *   3. 最近 Tab 再叠一层 sidebar 置顶 + timestamp 排序；
+ *   4. confirm 时从 selection + grant 两个 hook 读快照，透传给 onFinished。
+ */
 export function useForwardModal(
   onFinished?: ForwardFinished,
-  grantOptions?: UseForwardModalGrantOptions
+  grantOptions?: UseForwardModalGrantOptions,
 ): UseForwardModalResult {
-  const [conversationItems, setConversationItems] = useState<ForwardItem[]>([])
-  const [friendItems, setFriendItems] = useState<ForwardItem[]>([])
-  const [searchGroupItems, setSearchGroupItems] = useState<ForwardItem[]>([])
-  const [selectedIDs, setSelectedIDs] = useState<string[]>([])
-  const [inputValue, setInputValueState] = useState("")
-  const [keyword, setKeyword] = useState("")
-  const [loading, setLoading] = useState(true)
-  // 四 Tab：关注 / 最近 / 全部群聊 / 全部私聊（对齐智能纪要选择器）。默认「最近」。
+  // 四 Tab：关注 / 最近 / 全部群聊 / 全部私聊。默认「最近」。
   const [activeTab, setActiveTab] = useState<ChatSelectorTab>("recent")
-  // 关注集合（复合 key）：来自 SidebarService follow 同步，供「关注」Tab 过滤。
-  const [followedKeys, setFollowedKeys] = useState<Set<string>>(new Set())
-  // 最近集合与排序（复合 key）：来自 SidebarService recent 同步，供「最近」Tab 过滤与排序。
-  const [recentKeys, setRecentKeys] = useState<Set<string>>(new Set())
-  const [recentSortMeta, setRecentSortMeta] = useState<Map<string, RecentSortMeta>>(new Map())
-  // 授权区状态：开关默认关闭（不勾选，需用户主动打开才走授权），角色默认 reader。
-  // 仅在传入 grantOptions 时生效。
-  const grantActive = !!grantOptions
-  const [grantEnabled, setGrantEnabledState] = useState<boolean>(false)
-  const [grantRole, setGrantRole] = useState<ForwardGrantRole>(grantOptions?.defaultRole ?? "reader")
-  // 重开授权开关时复位为 reader（不记忆上次更高级别）→ AC-4 / AC-15。
-  const setGrantEnabled = useCallback((v: boolean) => {
-    setGrantEnabledState(v)
-    if (v) setGrantRole(grantOptions?.defaultRole ?? "reader")
-  }, [grantOptions?.defaultRole])
-  const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const searchRequestRef = useRef(0)
-  // load() 可能并发(mount 自动触发 + conversation-list-refreshed 又触发一次)。
-  // 用一个单调递增的 generation,await 边界处比对,过期就丢弃 setState,
-  // 避免两次 setConversationItems(prev => [...prev, ...]) 重复 append 同一批群。
-  const loadGenRef = useRef(0)
 
-  const setInputValue = useCallback((val: string) => {
-    setInputValueState(val)
-    if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current)
-    debounceTimerRef.current = setTimeout(() => {
-      setKeyword(val)
-    }, 300)
-  }, [])
+  // 输入框防抖：inputValue 即时更新驱动 UI，keyword 静默 300ms 才生效驱动过滤 + 搜索。
+  const { inputValue, keyword, setInputValue, reset: resetKeyword } = useDebouncedKeyword()
 
-  // unmount 时清理 debounce timer，防止在已卸载组件上触发 setState
-  useEffect(() => {
-    return () => {
-      if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current)
-    }
-  }, [])
+  // 关注/最近集合作用域：来自 SidebarService follow/recent 同步；deviceId 空时退化空集。
+  const { followedKeys, recentKeys, recentSortMeta } = useSidebarScopes()
 
-  // 存一份 channel 引用，用于 confirm 时返回
-  const channelMapRef = useRef<Map<string, Channel>>(new Map())
+  // 候选装配：最近会话 + group/my 兜底群 + 好友；持有 channelMapRef 供搜索/选择共享。
+  const {
+    conversationItems,
+    friendItems,
+    loading,
+    channelMapRef,
+    requestChannelInfoIfNeeded,
+  } = useForwardCandidates()
 
-  // 保存原始 wraps 引用，供 channelInfoListener 触发后重新构建
-  const wrapsRef = useRef<ConversationWrap[]>([])
+  // 后端搜索：keyword 驱动，命中候选把 Channel 登记到 channelMapRef。
+  const { searchGroupItems } = useForwardSearch(keyword, (channelID, channel) => {
+    channelMapRef.current.set(channelID, channel)
+  })
 
-  // group/my 兜底群（recents 里缺席的群只在旁路返回，SDK 不建 conversation）。
-  // 由 load() 在 gen 守卫通过后写入，rebuildConvItems 每次执行都消费它并与
-  // recents 群合并，从而成为 conversationItems 的唯一写入路径，避免懒加载
-  // channelInfo 到达后 rebuild 全量覆盖把兜底群冲掉的双写竞态。
-  const extraGroupsRef = useRef<ChannelInfo[]>([])
+  // 选择态：selectedIDs / toggle / selectedChannels（从 channelMapRef 派生）。
+  const {
+    selectedIDs,
+    selectedChannels,
+    toggleSelect,
+    readSelectedChannels,
+    reset: resetSelection,
+  } = useForwardSelection(channelMapRef)
 
-  // 懒加载：记录已发起 fetchChannelInfo 的 channelID，避免重复请求
-  const fetchedRef = useRef<Set<string>>(new Set())
-
-  /**
-   * 懒加载入口：列表项进入视口时调用。仅当本地 channelInfo 缺失且该 channel
-   * 未发起过请求时才调 fetchChannelInfo。去重避免 rebuildConvItems forceUpdate
-   * 之后重复打同一个接口。
-   */
-  const requestChannelInfoIfNeeded = useCallback((item: ForwardItem) => {
-    if (!item?.channelID) return
-    if (fetchedRef.current.has(item.channelID)) return
-    const ch = channelMapRef.current.get(item.channelID)
-      ?? new Channel(item.channelID, item.channelType)
-    if (getCurrentImChannelInfo(ch)) return
-    fetchedRef.current.add(item.channelID)
-    void fetchCurrentImChannelInfo(ch)
-  }, [])
-
-  const rebuildConvItems = useCallback(() => {
-    // 分离：群聊（非子区）和子区
-    const groupWraps: ConversationWrap[] = []
-    const threadWraps: ConversationWrap[] = []
-    const spaceId = WKApp.shared.currentSpaceId
-    // 已并入的群 ID（recents 群 + extraGroups 群），用于去重与子区挂回。
-    const seenGroupIDs = new Set<string>()
-    for (const wrap of wrapsRef.current) {
-      channelMapRef.current.set(wrap.channel.channelID, wrap.channel)
-      if (wrap.channel.channelType === ChannelTypeCommunityTopic) {
-        threadWraps.push(wrap)
-      } else {
-        // recents 群：load() 入口的 shouldSkipChannelForSpace 已做权威 Space
-        // 把关（channelSpaceMap → channelInfo → fail-closed），此处不再二次过滤。
-        groupWraps.push(wrap)
-        if (wrap.channel.channelType === ChannelTypeGroup) {
-          seenGroupIDs.add(wrap.channel.channelID)
-        }
-      }
-    }
-
-    // group/my 兜底群：用群条目自带的权威 space_id（来自 group/my 行）按来源分流。
-    const extraGroupItems: ForwardItem[] = []
-    for (const groupInfo of extraGroupsRef.current) {
-      const channelID = groupInfo.channel.channelID
-      // 去重：仅当不在已并入的 recents 群集合时才并入（避免 React duplicate key）。
-      if (seenGroupIDs.has(channelID)) continue
-
-      if (spaceId) {
-        const groupSpaceId = groupInfo.orgData?.space_id
-        if (typeof groupSpaceId === "string") {
-          if (groupSpaceId === spaceId) {
-            // 权威命中：用 group/my 行自带的权威 space_id 回灌 channelSpaceMap
-            // （隐藏副作用：让后续 shouldSkipChannelForSpace 走缓存命中分支）。
-            // key 格式与 shouldSkipChannelForSpace 一致。
-            WKApp.shared.channelSpaceMap.set(`${channelID}_${ChannelTypeGroup}`, groupSpaceId)
-          } else if (groupSpaceId !== "") {
-            // 跨 Space：先用 group/my 行自带的权威 space_id 回种 channelSpaceMap
-            // （回种群真实归属，与 shouldSkipChannelForSpace 命中 channelInfo 时
-            // 无条件回填的语义一致），再交给 shouldSkipChannelForSpace 统一裁决
-            // （它内部含 source_space_id 外部成员豁免）。豁免逻辑只活在
-            // SpaceService，不在此复制。先回种再调用不会短路——缓存命中分支读到
-            // 回种的跨 Space 值后仍会执行 source_space_id 豁免检查。
-            WKApp.shared.channelSpaceMap.set(`${channelID}_${ChannelTypeGroup}`, groupSpaceId)
-            if (shouldSkipChannelForSpace(groupInfo.channel)) continue
-          }
-          // 空串 ""：group/my 已带 param.space_id 背书，保留但绝不回种缓存（空串污染）。
-        }
-        // groupSpaceId 字段缺失(undefined) 或为 null（typeof 非 "string"）
-        // → 末位 fail-open 保留，且不回种 channelSpaceMap。
-      }
-      // currentSpaceId 为空（无 Space 模式）→ 不做 Space 过滤，全保留。
-
-      channelMapRef.current.set(channelID, groupInfo.channel)
-      seenGroupIDs.add(channelID)
-      extraGroupItems.push(channelInfoToForwardItem(groupInfo))
-    }
-
-    // 转发目标永不包含已归档子区：复用侧栏的 fail-open helper
-    // （仅过滤明确 status=Archived 的子区，status 未知/未加载的子区保留）。
-    // 仅作用于子区来源，不触碰群聊/私聊。
-    const visibleThreadWraps = filterArchivedThreads(threadWraps)
-
-    // 按 parentGroupNo 建 Map
-    const threadsByParent = new Map<string, ConversationWrap[]>()
-    const orphanThreads: ConversationWrap[] = []
-    for (const tw of visibleThreadWraps) {
-      const parentGroupNoRaw = tw.channelInfo?.orgData?.parentGroupNo
-      const parentGroupNo = parentGroupNoRaw != null ? String(parentGroupNoRaw) : undefined
-      if (parentGroupNo) {
-        const list = threadsByParent.get(parentGroupNo) || []
-        list.push(tw)
-        threadsByParent.set(parentGroupNo, list)
-      } else {
-        orphanThreads.push(tw)
-      }
-    }
-
-    // 输出顺序：父群 → 其子区（紧跟） → 下一父群
-    const items: ForwardItem[] = []
-    for (const gw of groupWraps) {
-      items.push(conversationWrapToForwardItem(gw))
-      const children = threadsByParent.get(gw.channel.channelID) || []
-      for (const tw of children) {
-        items.push(conversationWrapToForwardItem(tw, gw.channel.channelID))
-      }
-      // 已挂回的子区从 Map 移除，避免后续兜底重复追加。
-      threadsByParent.delete(gw.channel.channelID)
-    }
-    // group/my 兜底群追加在 recents 群之后；其子区（仅来自 recents）挂回父群。
-    for (const item of extraGroupItems) {
-      items.push(item)
-      const children = threadsByParent.get(item.channelID) || []
-      for (const tw of children) {
-        items.push(conversationWrapToForwardItem(tw, item.channelID))
-      }
-      threadsByParent.delete(item.channelID)
-    }
-    // 兜底：有 parentGroupNo 但父群既不在 recents 也不在 group/my 的子区，
-    // 作为独立项追加到末尾（带 parentChannelID），避免父群确实缺席时被静默丢弃。
-    for (const [parentGroupNo, children] of threadsByParent) {
-      for (const tw of children) {
-        items.push(conversationWrapToForwardItem(tw, parentGroupNo))
-      }
-    }
-    // 找不到父群的孤儿子区（无 parentGroupNo）追加到末尾
-    for (const ow of orphanThreads) {
-      items.push(conversationWrapToForwardItem(ow))
-    }
-
-    setConversationItems(items)
-  }, [])
-
-  useEffect(() => {
-    async function load() {
-      const gen = ++loadGenRef.current
-      // 重入/切 Space 时先清空上一轮兜底群，避免第一帧 rebuild 用旧 Space 的
-      // group/my 兜底群产出（空串/字段缺失分支会 fail-open 让旧 Space 群闪现）。
-      // 代价仅冷启动第一帧不显示兜底群（本就冷状态，无损）。
-      extraGroupsRef.current = []
-      setLoading(true)
-      try {
-        // 最近会话：仅构造 wrap，不再对每个 conv 主动 fetchChannelInfo。
-        // channelInfo 由 ForwardModal 中每个 ItemRow 的 VisibilityTrigger 在
-        // 进入视口时按需拉取（去重 + debounce 合批 forceUpdate）。
-        const conversations = getCurrentImConversationsDirectly<ConversationWrap["conversation"]>()
-        const wraps: ConversationWrap[] = []
-        for (const conv of conversations) {
-          if (shouldSkipChannelForSpace(conv.channel)) continue
-          if (shouldSkipPersonConversationForSpace(conv)) continue
-          wraps.push(new ConversationWrap(conv))
-        }
-        wrapsRef.current = sortConversations(wraps)
-        rebuildConvItems()
-
-        // 补全：获取用户加入的全部群聊（已支持 space_id 过滤）。
-        // 不再直接 setConversationItems 第二次写入，而是存入 extraGroupsRef 并
-        // 触发一次 rebuildConvItems，让其与 recents 群合并产出，杜绝双写竞态。
-        const allGroups = await WKApp.dataSource.channelDataSource.groupSaveList()
-        if (gen !== loadGenRef.current) return // 有更新的 load 在跑,丢弃本次结果
-        extraGroupsRef.current = allGroups
-        rebuildConvItems()
-
-        // 好友
-        const friends = (await WKApp.dataSource.commonDataSource.searchFriends("")) ?? []
-        if (gen !== loadGenRef.current) return
-        // 按 channelID 去重：Space 模式下后端 space/{id}/members 可能返回同一
-        // uid 的多条记录（多角色等），不去重会触发 React duplicate key 警告。
-        const seen = new Set<string>()
-        const fItems: ForwardItem[] = []
-        for (const info of friends) {
-          const cid = info.channel.channelID
-          if (seen.has(cid)) continue
-          seen.add(cid)
-          channelMapRef.current.set(cid, info.channel)
-          fItems.push(channelInfoToForwardItem(info))
-        }
-        setFriendItems(fItems)
-      } finally {
-        // 仅最新 generation 收尾 loading,避免老 load 的 setLoading(false)
-        // 把更新的 load 标记成"已完成"。
-        if (gen === loadGenRef.current) setLoading(false)
-      }
-    }
-
-    // 订阅 channelInfo 更新，触发列表重渲（头像/名称补全）。
-    // 使用 debounce 合批，避免视口内多个懒加载请求集中返回时连续触发 rebuild。
-    const rebuildDebounced = debounce(() => rebuildConvItems(), 150)
-    const channelListener: ChannelInfoListener = (_channelInfo: ChannelInfo) => {
-      rebuildDebounced()
-    }
-    const unsubscribeChannelListener = addCurrentImChannelInfoListener(channelListener)
-
-    // 切 Space 后 conversationManager.conversations 会被先清空再回填,
-    // 如果 modal 在回填前打开,初次 load() 会读到空 cache（缺最近会话/子区）。
-    // 监听 ChatVM 的回填广播,触发后重新 load 一次,保证最终能拿到完整数据。
-    const onConversationListRefreshed = () => {
-      load()
-    }
-    WKApp.mittBus.on('conversation-list-refreshed', onConversationListRefreshed)
-
-    load()
-
-    return () => {
-      unsubscribeChannelListener()
-      WKApp.mittBus.off('conversation-list-refreshed', onConversationListRefreshed)
-      rebuildDebounced.cancel()
-    }
-  }, [rebuildConvItems])
-
-  // 关注/最近集合同步：与智能纪要选择器一致，走 SidebarService follow/recent 同步。
-  // 数据源采用方案 (b)：转发列表主体仍复用本地会话 + group/my + 好友装配
-  // （保证零权限回归），「关注」/「最近」Tab 只用 sidebar 返回的权威集合作用域。
-  // deviceId 为空时后端 validateSidebarRequest 必拒，跳过注定失败的请求，
-  // 关注/最近集合退化为空集。
-  useEffect(() => {
-    const deviceUuid = WKApp.shared.deviceId || ""
-    if (deviceUuid === "") {
-      setFollowedKeys(new Set())
-      setRecentKeys(new Set())
-      setRecentSortMeta(new Map())
-      return
-    }
-    let cancelled = false
-    Promise.all([
-      SidebarService.sync({ tab: "follow", device_uuid: deviceUuid }).catch(() => null),
-      SidebarService.sync({ tab: "recent", device_uuid: deviceUuid }).catch(() => null),
-    ])
-      .then(([followResp, recentResp]) => {
-        if (cancelled) return
-        const followed = new Set<string>()
-        for (const item of followResp?.items ?? []) {
-          if (item.is_followed) followed.add(`${item.target_type}::${item.target_id}`)
-        }
-
-        const recent = new Set<string>()
-        const sortMeta = new Map<string, RecentSortMeta>()
-        for (const item of recentResp?.items ?? []) {
-          const key = `${item.target_type}::${item.target_id}`
-          recent.add(key)
-          sortMeta.set(key, {
-            timestamp: item.timestamp ?? 0,
-            isPinned: item.is_pinned === true,
-          })
-        }
-
-        setFollowedKeys(followed)
-        setRecentKeys(recent)
-        setRecentSortMeta(sortMeta)
-      })
-    return () => {
-      cancelled = true
-    }
-  }, [])
-
-
-  useEffect(() => {
-    if (keyword.length < 2) {
-      setSearchGroupItems([])
-      return
-    }
-    if (!WKApp.searchChatCandidates) {
-      setSearchGroupItems([])
-      return
-    }
-    const reqId = ++searchRequestRef.current
-    const searchParams: Record<string, string> = { keyword }
-    const currentSpaceId = WKApp.shared.currentSpaceId
-    if (currentSpaceId) {
-      searchParams.space_id = currentSpaceId
-    }
-    WKApp.searchChatCandidates(searchParams)
-      .then((candidates: any) => {
-        if (reqId !== searchRequestRef.current) return
-        const arr = Array.isArray(candidates) ? candidates : []
-        const groups: ForwardItem[] = arr.map((c: any) => {
-          // 保留 channelMapRef 副作用：confirm 时按 channelID 取回 Channel 引用。
-          const ch = new Channel(c.chat_id, chatTypeToChannelType(c.chat_type))
-          channelMapRef.current.set(c.chat_id, ch)
-          return candidateToForwardItem(c)
-        })
-        setSearchGroupItems(groups)
-      })
-      .catch(() => {
-        if (reqId === searchRequestRef.current) setSearchGroupItems([])
-      })
-  }, [keyword])
+  // 授权区：默认关闭，仅在 grantOptions 存在时激活；confirm 时读快照透传给 onFinished。
+  const {
+    grantEnabled,
+    grantRole,
+    setGrantEnabled,
+    setGrantRole,
+    readConfirmPayload: readGrantPayload,
+  } = useForwardGrant(grantOptions)
 
   // 合并去重：conversationItems 优先，friend 已在 conversation 里的跳过，搜索群组追加
-  const convIDs = new Set(conversationItems.map((i: ForwardItem) => i.channelID))
-  const uniqueFriends = friendItems.filter((f: ForwardItem) => !convIDs.has(f.channelID))
-  const localIDs = new Set([...convIDs, ...uniqueFriends.map((f) => f.channelID)])
-  const uniqueSearchGroups = searchGroupItems.filter((g: ForwardItem) => !localIDs.has(g.channelID))
-  const allItems = [...conversationItems, ...uniqueFriends, ...uniqueSearchGroups]
+  const allItems = useMemo(
+    () => mergeForwardSources(conversationItems, friendItems, searchGroupItems),
+    [conversationItems, friendItems, searchGroupItems],
+  )
 
   // 四 Tab 作用域 + 关键字过滤（方案 A：命中子区带出父群；命中父群不展开子区）。
   // 复用共享的 filterChatSelectorItems，保证与智能纪要选择器同一套过滤语义。
   // 注意：搜索时（keyword 非空）以搜索结果 uniqueSearchGroups 补充 allItems，
   // 这些后端候选未必落在 followed/recent 集合内，但「关注/最近」Tab 仍按
   // 集合过滤（搜后端全库群不应污染关注/最近作用域），与纪要行为一致。
-  const filteredBase = filterChatSelectorItems(
-    allItems,
-    { activeTab, keyword, followedKeys, recentKeys },
-    FORWARD_ITEM_ACCESSORS,
+  const filteredBase = useMemo(
+    () =>
+      filterChatSelectorItems(
+        allItems,
+        { activeTab, keyword, followedKeys, recentKeys },
+        FORWARD_ITEM_ACCESSORS,
+      ),
+    [allItems, activeTab, keyword, followedKeys, recentKeys],
   )
-  const filtered = activeTab === "recent"
-    ? [...filteredBase].sort((a, b) => {
-      const aMeta = recentSortMeta.get(forwardItemKey(a))
-      const bMeta = recentSortMeta.get(forwardItemKey(b))
-      const aPinned = aMeta?.isPinned === true || a.isPinned === true
-      const bPinned = bMeta?.isPinned === true || b.isPinned === true
-      if (aPinned !== bPinned) return aPinned ? -1 : 1
-      return (bMeta?.timestamp ?? 0) - (aMeta?.timestamp ?? 0)
-    })
-    : filteredBase
-
-  const toggleSelect = useCallback((item: ForwardItem) => {
-    setSelectedIDs((prev: string[]) =>
-      prev.includes(item.channelID)
-        ? prev.filter((id: string) => id !== item.channelID)
-        : [...prev, item.channelID]
-    )
-  }, [])
-
-  const selectedIDsRef = useRef<string[]>(selectedIDs)
-  selectedIDsRef.current = selectedIDs
-
-  // Keep the grant selection reachable from the stable confirm() callback without
-  // re-creating it on every toggle.
-  const grantRef = useRef<{ active: boolean; enabled: boolean; role: ForwardGrantRole }>({
-    active: grantActive,
-    enabled: grantEnabled,
-    role: grantRole,
-  })
-  grantRef.current = { active: grantActive, enabled: grantEnabled, role: grantRole }
-
-  const selectedChannels = selectedIDs
-    .map((id: string) => channelMapRef.current.get(id))
-    .filter(Boolean) as Channel[]
+  const filtered = useMemo(
+    () =>
+      activeTab === "recent" ? sortRecentItems(filteredBase, recentSortMeta) : filteredBase,
+    [activeTab, filteredBase, recentSortMeta],
+  )
 
   const confirm = useCallback(() => {
-    const channels = selectedIDsRef.current
-      .map((id: string) => channelMapRef.current.get(id))
-      .filter(Boolean) as Channel[]
+    const channels = readSelectedChannels()
     if (onFinished && channels.length > 0) {
-      const { active, enabled, role } = grantRef.current
-      onFinished(channels, active && enabled ? { role } : undefined)
+      onFinished(channels, readGrantPayload())
     }
-  }, [onFinished])
+  }, [onFinished, readSelectedChannels, readGrantPayload])
 
   const reset = useCallback(() => {
-    setSelectedIDs([])
-    setInputValueState("")
-    setKeyword("")
+    resetSelection()
+    resetKeyword()
     setActiveTab("recent")
-  }, [])
+  }, [resetSelection, resetKeyword])
 
   return {
     items: filtered,


### PR DESCRIPTION
## Summary
- 拆分臃肿的 `ForwardModal.tsx` 与 `useForwardModal.ts`，按职责划分为 `hooks/`、`logic/`、`ui/` 三层，单文件更聚焦、更易复用。
- 纯逻辑（排序、合并、key 生成、`channelInfo` 转换）下沉到 `logic/`，异步/状态副作用（候选加载、搜索、选择、授权、侧栏 scopes、防抖关键词、成员数）拆到独立 hooks。
- UI 组件（`SearchBar`、`TabsBar`、`ItemList`、`ItemRow`、`SelectedPanel`、`SelectedRow`、`Footer`、`GrantArea`）从主组件中提取，`ForwardModal.tsx` 只剩装配层。
- 为每个新拆出的 hook 与 logic 补齐 `__tests__`（vitest），确保重构行为等价。

## Test plan
- [ ] `cd apps/web && pnpm test -- ForwardModal`
- [ ] `pnpm lint`
- [ ] 手动回归：单聊/群聊/多选转发、搜索 + 防抖、授权提示、"最近"排序、@AI/@所有人 转发场景