### PR TITLE
feat(channel-setting): refresh information panels and member views

### DIFF
--- a/packages/dmworkbase/src/App.css
+++ b/packages/dmworkbase/src/App.css
@@ -12,7 +12,7 @@
     /* --wk-height-chat-search: 65px; */
     --wk-height-chat-search: 64px;
     --wk-height-chat-conversation-header: 48px;  /* Figma: 48px */
-    --wk-wdith-chat-channelsetting: 380px;
+    --wk-wdith-chat-channelsetting: 28rem;
     --wk-width-chat-search-panel: 480px;
     --wk-width-thread-panel: 380px;
     --wk-layer-transition: 300ms cubic-bezier(0.33,1,0.68,1);

--- a/packages/dmworkbase/src/Components/ChannelSetting/index.css
+++ b/packages/dmworkbase/src/Components/ChannelSetting/index.css
@@ -83,7 +83,143 @@
     width: 100%;
     height: 100%;
     overflow: auto;
-    padding-bottom: 40px;
+    padding: var(--wk-sp-2) 0 var(--wk-sp-4);
+    background: var(--wk-bg-surface);
+}
+
+/* 仅作用于 ChannelSetting，避免影响其他 Sections/ListItem 调用方。 */
+.wk-channelsetting-content > .wk-sections {
+    display: flex;
+    flex-direction: column;
+    gap: var(--wk-sp-2);
+}
+
+.wk-channelsetting-content .wk-section {
+    margin: 0 var(--wk-sp-4);
+    overflow: hidden;
+    background: var(--wk-bg-base);
+    border: 1px solid var(--wk-border-subtle);
+    border-radius: var(--wk-r-sm);
+}
+
+.wk-channelsetting-content .wk-section-title {
+    padding: var(--wk-sp-3) var(--wk-sp-4) var(--wk-sp-2);
+    color: var(--wk-text-tertiary);
+    font-size: var(--wk-text-size-sm);
+}
+
+.wk-channelsetting-content .wk-section-subtitle {
+    padding: var(--wk-sp-2) var(--wk-sp-4) var(--wk-sp-3);
+    color: var(--wk-text-tertiary);
+    font-size: var(--wk-text-size-sm);
+}
+
+.wk-channelsetting-content .wk-section-row + .wk-section-row {
+    border-top: 1px solid var(--wk-border-subtle);
+}
+
+.wk-channelsetting-content .wk-list-item {
+    min-height: calc(var(--wk-sp-10) + var(--wk-sp-2));
+    padding: var(--wk-sp-2) var(--wk-sp-4);
+    background: transparent;
+}
+
+.wk-channelsetting-content .wk-list-item:hover {
+    background: var(--wk-bg-hover);
+}
+
+.wk-channelsetting-content .wk-list-item-static:hover {
+    background: transparent;
+}
+
+.wk-channelsetting-content .wk-list-item-title {
+    color: var(--wk-text-primary);
+    font-size: var(--wk-text-size-md);
+}
+
+.wk-channelsetting-content .wk-list-item-subtitle {
+    min-width: 0;
+    margin-left: var(--wk-sp-4);
+    color: var(--wk-text-secondary);
+    font-size: var(--wk-text-size-base);
+}
+
+.wk-channelsetting-content .wk-list-item-subtitle-muliteline {
+    margin-top: var(--wk-sp-2);
+    color: var(--wk-text-secondary);
+    font-size: var(--wk-text-size-base);
+}
+
+.wk-channelsetting-content .wk-channelsetting-qrcode-icon {
+    width: var(--wk-sp-4);
+    height: var(--wk-sp-4);
+    color: var(--wk-text-tertiary);
+}
+
+.wk-channelsetting-content .wk-section:has(.wk-subscribers) {
+    padding: var(--wk-sp-4) var(--wk-sp-2) var(--wk-sp-3);
+}
+
+.wk-channelsetting-content .wk-section:has(.wk-subscribers) .wk-section-row {
+    border: 0;
+}
+
+.wk-channelsetting-content .wk-subscribers-content {
+    grid-template-columns: repeat(5, minmax(0, 1fr));
+    column-gap: var(--wk-sp-2);
+    row-gap: var(--wk-sp-4);
+    padding-inline: var(--wk-sp-2);
+}
+
+.wk-channelsetting-content .wk-subscribers-item {
+    min-height: 0;
+    gap: var(--wk-sp-1-5);
+}
+
+.wk-channelsetting-content .wk-subscribers-item img,
+.wk-channelsetting-content .wk-subscribers-item-avatar-wrap img,
+.wk-channelsetting-content .wk-subscribers-item-avatar-wrap {
+    width: var(--wk-sp-12);
+    height: var(--wk-sp-12);
+}
+
+.wk-channelsetting-content .wk-subscribers-item-name {
+    margin-top: 0;
+    color: var(--wk-text-secondary);
+    font-size: var(--wk-text-size-xs);
+    line-height: var(--wk-text-size-md);
+}
+
+.wk-channelsetting-content .wk-subscribers-item-role-badge {
+    right: auto;
+    bottom: calc(0px - var(--wk-sp-1));
+    left: 50%;
+    padding: var(--wk-sp-0-5) var(--wk-sp-1);
+    color: var(--wk-text-inverse);
+    font-size: var(--wk-text-size-badge);
+    border-radius: var(--wk-r-xs);
+    box-shadow: none;
+    transform: translateX(-50%);
+}
+
+.wk-channelsetting-content .wk-subscribers-item-role-badge-owner {
+    background: var(--wk-color-warning);
+}
+
+.wk-channelsetting-content .wk-subscribers-item-role-badge-manager {
+    background: var(--wk-text-primary);
+}
+
+.wk-channelsetting-content .wk-subscribers-more {
+    margin: var(--wk-sp-4) var(--wk-sp-2) 0;
+    padding: var(--wk-sp-2);
+    border-radius: var(--wk-r-sm);
+    color: var(--wk-text-primary);
+    font-size: var(--wk-text-size-sm);
+}
+
+.wk-channelsetting-content .wk-subscribers-more:hover {
+    background: var(--wk-bg-hover);
 }
 
 .wk-channelsetting-channel-info {
@@ -198,8 +334,12 @@
 
 .wk-route-content .wk-channelsetting-input-edit {
     box-sizing: border-box;
-    width: calc(100% - (2 * var(--wk-sp-2)));
-    margin: 0 var(--wk-sp-2);
+    width: calc(100% - (2 * var(--wk-sp-4)));
+    margin: var(--wk-sp-2) var(--wk-sp-4) 0;
+    overflow: hidden;
+    background: var(--wk-bg-base);
+    border: 1px solid var(--wk-border-subtle);
+    border-radius: var(--wk-r-sm);
 }
 
 .wk-channelmanage {

--- a/packages/dmworkbase/src/Components/Subscribers/index.tsx
+++ b/packages/dmworkbase/src/Components/Subscribers/index.tsx
@@ -54,12 +54,12 @@ export class Subscribers extends Component<SubscribersProps> {
         <div className="wk-subscribers-item-avatar-wrap">
           <img src={WKApp.shared.avatarUser(subscriber.uid)} alt=""></img>
           {subscriber.role === GroupRole.owner && (
-            <span className="wk-subscribers-item-role-badge">
+            <span className="wk-subscribers-item-role-badge wk-subscribers-item-role-badge-owner">
               {this.context.t("base.subscribers.role.owner")}
             </span>
           )}
           {subscriber.role === GroupRole.manager && (
-            <span className="wk-subscribers-item-role-badge">
+            <span className="wk-subscribers-item-role-badge wk-subscribers-item-role-badge-manager">
               {this.context.t("base.subscribers.role.manager")}
             </span>
           )}
@@ -157,12 +157,17 @@ export class Subscribers extends Component<SubscribersProps> {
                           )}
                         />,
                         new RouteContextConfig({
-                          title: this.context.t("base.subscribers.memberList"),
+                          title: this.context.t(
+                            "base.subscribers.memberListWithCount",
+                            { values: { count: vm.memberCount() } }
+                          ),
                         })
                       );
                     }}
                   >
-                    {this.context.t("base.subscribers.viewMore")}
+                    {this.context.t("base.subscribers.viewAll", {
+                      values: { count: vm.memberCount() },
+                    })}
                   </div>
                 ) : undefined}
               </div>

--- a/packages/dmworkbase/src/Components/Subscribers/list.css
+++ b/packages/dmworkbase/src/Components/Subscribers/list.css
@@ -4,19 +4,90 @@
     background-color: var(--wk-bg-surface);
     width: 100%;
     height: 100%;
-    overflow: scroll;
+    overflow-y: auto;
+    overflow-x: hidden;
+}
+
+/*
+ * 成员列表返回时保留 animationend，让 WKViewQueue 继续按原逻辑清理栈顶，
+ * 但取消可见位移，避免标题已切回父页而内容仍横向退场造成闪动。
+ * 不改变 RoutePage/WKViewQueue 的入栈、退栈与数据刷新逻辑。
+ */
+.wk-viewqueue-view-out:has(.wk-subscrierlist) {
+    background: var(--wk-bg-surface);
+    animation-name: wk-subscriber-list-exit;
+    animation-duration: var(--wk-dur-fast);
+    animation-timing-function: var(--wk-ease);
+}
+
+@keyframes wk-subscriber-list-exit {
+    from,
+    to {
+        transform: translate3d(0, 0, 0);
+    }
+}
+
+.wk-subscrierlist .wk-indextable-search-box {
+    height: auto;
+    margin: var(--wk-sp-2) var(--wk-sp-5);
+    padding: var(--wk-sp-1-5) var(--wk-sp-2);
+    align-items: center;
+    background: var(--wk-bg-base);
+    border: 1px solid var(--wk-border-subtle);
+    border-radius: var(--wk-r-sm);
+}
+
+.wk-subscrierlist .wk-indextable-search-icon {
+    margin-left: 0;
+    color: var(--wk-text-tertiary);
+}
+
+.wk-subscrierlist-search-icon {
+    width: var(--wk-sp-4);
+    height: var(--wk-sp-4);
+}
+
+.wk-subscrierlist .wk-indextable-search-input {
+    flex: 1;
+    max-width: none;
+    margin-left: var(--wk-sp-2);
+}
+
+.wk-subscrierlist .wk-indextable-search-input input {
+    width: 100%;
+    height: auto;
+    padding: 0;
+    color: var(--wk-text-primary);
+    font-size: var(--wk-text-size-md);
+    line-height: var(--wk-sp-5);
+}
+
+.wk-subscrierlist .wk-indextable-search-input input::placeholder {
+    color: var(--wk-text-tertiary);
 }
 
 .wk-subscrierlist-list-item {
     display: flex;
     align-items: center;
-    padding: 1rem;
+    gap: var(--wk-sp-3);
+    min-height: var(--wk-sp-12);
+    padding: var(--wk-sp-2) var(--wk-sp-5);
     cursor: pointer;
+    transition: background var(--wk-dur-fast) var(--wk-ease);
+}
+
+.wk-subscrierlist-list-item:hover {
+    background: var(--wk-bg-hover);
 }
 
 .wk-subscrierlist-item-avatar {
     position: relative;
     flex-shrink: 0;
+}
+
+.wk-subscrierlist-item-avatar .wk-avatar {
+    width: var(--wk-sp-8);
+    height: var(--wk-sp-8);
 }
 
 .wk-subscrierlist-item-online-badge {
@@ -26,13 +97,17 @@
 }
 
 .wk-subscrierlist-item-name {
-    margin-left: 1rem;
+    min-width: 0;
+    margin-left: 0;
     text-overflow: ellipsis;
     overflow: hidden;
     white-space: nowrap;
-    max-width: 10rem;
+    max-width: 16rem;
     display: flex;
     align-items: center;
+    gap: var(--wk-sp-1);
+    color: var(--wk-text-primary);
+    font-size: var(--wk-text-size-md);
 }
 
 .wk-subscrierlist-item-source {
@@ -57,13 +132,36 @@
 
 .wk-subscrierlist-item-content {
     display: flex;
+    min-width: 0;
     width: 100%;
-    justify-content: space-between;
+    align-items: center;
+    justify-content: flex-start;
+    gap: var(--wk-sp-1-5);
 }
 
 .wk-subscrierlist-item-desc {
-    font-size: 14px;
+    display: none;
+    flex-shrink: 0;
+    padding: var(--wk-sp-0-5) var(--wk-sp-1);
+    font-size: var(--wk-text-size-tiny);
+    font-weight: 600;
+    line-height: var(--wk-text-size-base);
+    border-radius: var(--wk-r-xs);
+}
+
+.wk-subscrierlist-item-desc-owner,
+.wk-subscrierlist-item-desc-manager {
+    display: inline-flex;
+}
+
+.wk-subscrierlist-item-desc-owner {
+    color: var(--wk-color-warning);
+    background: var(--wk-color-warning-bg);
+}
+
+.wk-subscrierlist-item-desc-manager {
     color: var(--wk-text-secondary);
+    background: var(--wk-bg-elevated);
 }
 
 .wk-subscrierlist-item-action {

--- a/packages/dmworkbase/src/Components/Subscribers/list.tsx
+++ b/packages/dmworkbase/src/Components/Subscribers/list.tsx
@@ -298,9 +298,7 @@ export class SubscriberList extends Component<
               >
                 <div className="wk-indextable-search-box">
                   <div className="wk-indextable-search-icon">
-                    <IconSearchStroked
-                      style={{ color: "#bbbfc4", fontSize: "20px" }}
-                    />
+                    <IconSearchStroked className="wk-subscrierlist-search-icon" />
                   </div>
                   <div className="wk-indextable-search-input">
                     <input
@@ -312,7 +310,6 @@ export class SubscriberList extends Component<
                       )}
                       ref={(rf) => {}}
                       type="text"
-                      style={{ fontSize: "17px" }}
                     />
                   </div>
                 </div>
@@ -393,7 +390,15 @@ export class SubscriberList extends Component<
                               </Tag>
                             )}
                           </div>
-                          <div className="wk-subscrierlist-item-desc">
+                          <div
+                            className={`wk-subscrierlist-item-desc${
+                              item.role === GroupRole.owner
+                                ? " wk-subscrierlist-item-desc-owner"
+                                : item.role === GroupRole.manager
+                                ? " wk-subscrierlist-item-desc-manager"
+                                : ""
+                            }`}
+                          >
                             {this.getRoleName(item)}
                           </div>
                         </div>

--- a/packages/dmworkbase/src/Components/Subscribers/vm.ts
+++ b/packages/dmworkbase/src/Components/Subscribers/vm.ts
@@ -71,4 +71,8 @@ export class SubscribersVM extends ProviderListener {
         let showMemberNum = this.shouldShowMemberNum()
         return this.subscribers.length>showMemberNum
     }
+
+    memberCount() {
+        return this.routeData.channelInfo?.orgData?.member_count || this.subscribers.length
+    }
 }

--- a/packages/dmworkbase/src/features/channelSetting/__tests__/channelSettingSections.test.ts
+++ b/packages/dmworkbase/src/features/channelSetting/__tests__/channelSettingSections.test.ts
@@ -5,6 +5,7 @@ import { ChannelTypeCommunityTopic } from "../../../Service/Const";
 import { ThreadStatus } from "../../../Service/Thread";
 import { GroupStatusDisband } from "../../../Utils/groupDisband";
 import { updateChannelSettingMyGroupNickname } from "../../../bridge/channelSetting/channelSettingActions";
+import { t } from "../../../i18n";
 import { buildChannelGroupInfoSection } from "../channelSettingGroupInfoSection";
 import {
   buildChannelDangerSection,
@@ -16,8 +17,27 @@ import {
   buildThreadActionsSection,
   buildThreadInfoSection,
   buildThreadMdSection,
+  buildThreadOverviewSection,
   buildThreadWebhookSection,
 } from "../channelSettingThreadSections";
+
+vi.mock("@douyinfe/semi-ui", () => ({
+  Button: vi.fn(),
+  Input: vi.fn(),
+  Switch: vi.fn(),
+  Tag: vi.fn(),
+  TextArea: vi.fn(),
+  Toast: {
+    error: vi.fn(),
+    warning: vi.fn(),
+  },
+}));
+
+vi.mock("@douyinfe/semi-icons", () => ({
+  IconAlertTriangle: vi.fn(),
+  IconLink: vi.fn(),
+  IconPlus: vi.fn(),
+}));
 
 vi.mock("../../../App", () => ({
   default: {
@@ -178,9 +198,7 @@ describe("channel setting section builders", () => {
     const inputEditPush = vi.fn();
     const section = buildMyGroupNicknameSection(context, inputEditPush);
 
-    section?.rows?.[0].properties.onClick();
-    const onFinish = inputEditPush.mock.calls[0][2];
-    await onFinish("Alice Updated");
+    await section?.rows?.[0].properties.onSave("Alice Updated");
 
     expect(updateChannelSettingMyGroupNickname).toHaveBeenCalledWith({
       channel: context.routeData().channel,
@@ -188,6 +206,29 @@ describe("channel setting section builders", () => {
     });
     expect(context.routeData().subscriberOfMe.remark).toBe("Alice Updated");
     expect(context.routeData().refresh).toHaveBeenCalled();
+  });
+
+  it("keeps a cleared group nickname empty instead of falling back to the member name", async () => {
+    const context = createContext();
+    const inputEditPush = vi.fn();
+    const section = buildMyGroupNicknameSection(context, inputEditPush);
+
+    await section?.rows?.[0].properties.onSave("");
+
+    expect(updateChannelSettingMyGroupNickname).toHaveBeenCalledWith({
+      channel: context.routeData().channel,
+      remark: "",
+    });
+    expect(context.routeData().subscriberOfMe.remark).toBe("");
+
+    const refreshedSection = buildMyGroupNicknameSection(
+      context,
+      inputEditPush
+    );
+    expect(refreshedSection?.rows?.[0].properties.value).toBe("");
+    expect(refreshedSection?.rows?.[0].properties.displayValue).toBe(
+      t("base.common.notSet")
+    );
   });
 
   it("builds danger rows only for active groups", () => {
@@ -245,6 +286,9 @@ describe("channel setting section builders", () => {
     );
     expect(buildThreadMdSection(context)?.rows).toHaveLength(1);
     expect(buildThreadWebhookSection(context)?.rows).toHaveLength(1);
+    expect(
+      buildThreadOverviewSection(context, inputEditPush)?.rows
+    ).toHaveLength(5);
     expect(buildThreadActionsSection(context)?.rows).toHaveLength(2);
   });
 
@@ -255,6 +299,9 @@ describe("channel setting section builders", () => {
     expect(buildThreadInfoSection(context, inputEditPush)).toBeUndefined();
     expect(buildThreadMdSection(context)).toBeUndefined();
     expect(buildThreadWebhookSection(context)).toBeUndefined();
+    expect(
+      buildThreadOverviewSection(context, inputEditPush)
+    ).toBeUndefined();
     expect(buildThreadActionsSection(context)).toBeUndefined();
   });
 });

--- a/packages/dmworkbase/src/features/channelSetting/__tests__/channelSettingSections.test.ts
+++ b/packages/dmworkbase/src/features/channelSetting/__tests__/channelSettingSections.test.ts
@@ -1,3 +1,4 @@
+import { Toast } from "@douyinfe/semi-ui";
 import { Channel, ChannelTypeGroup } from "wukongimjssdk";
 import { describe, expect, it, vi } from "vitest";
 
@@ -231,6 +232,21 @@ describe("channel setting section builders", () => {
     );
   });
 
+  it("keeps the group nickname unchanged and reports a failed save", async () => {
+    vi.mocked(updateChannelSettingMyGroupNickname).mockRejectedValueOnce({
+      msg: "Nickname save failed",
+    });
+    const context = createContext();
+    const section = buildMyGroupNicknameSection(context, vi.fn());
+
+    const saved = await section?.rows?.[0].properties.onSave("New nickname");
+
+    expect(saved).toBe(false);
+    expect(Toast.error).toHaveBeenCalledWith("Nickname save failed");
+    expect(context.routeData().subscriberOfMe.remark).toBe("Ali");
+    expect(context.routeData().refresh).not.toHaveBeenCalled();
+  });
+
   it("builds danger rows only for active groups", () => {
     const normal = buildChannelDangerSection(createContext());
     const disbanded = buildChannelDangerSection(
@@ -299,9 +315,7 @@ describe("channel setting section builders", () => {
     expect(buildThreadInfoSection(context, inputEditPush)).toBeUndefined();
     expect(buildThreadMdSection(context)).toBeUndefined();
     expect(buildThreadWebhookSection(context)).toBeUndefined();
-    expect(
-      buildThreadOverviewSection(context, inputEditPush)
-    ).toBeUndefined();
+    expect(buildThreadOverviewSection(context, inputEditPush)).toBeUndefined();
     expect(buildThreadActionsSection(context)).toBeUndefined();
   });
 });

--- a/packages/dmworkbase/src/features/channelSetting/channelSettingGroupManagementRows.tsx
+++ b/packages/dmworkbase/src/features/channelSetting/channelSettingGroupManagementRows.tsx
@@ -20,7 +20,10 @@ import {
   transferChannelSettingOwner,
 } from "../../bridge/channelSetting/channelSettingActions";
 import { I18nText, t } from "../../i18n";
-import { ChannelSettingInfoRow } from "../../ui/ChannelSettingRows";
+import {
+  ChannelSettingInfoRow,
+  ChannelSettingInlineEditRow,
+} from "../../ui/ChannelSettingRows";
 import { ChannelSettingInputEditPush } from "./types";
 import { createChannelSettingMemberSearch } from "./channelSettingMemberSearch";
 
@@ -120,7 +123,6 @@ function buildTransferOwnerRow(
 export function buildGroupManagementRows({
   context,
   data,
-  inputEditPush,
   disbanded,
 }: BuildGroupManagementRowsOptions): Row[] {
   const { channel, channelInfo } = data;
@@ -208,26 +210,20 @@ export function buildGroupManagementRows({
 
   rows.push(
     new Row({
-      cell: ChannelSettingInfoRow,
+      cell: ChannelSettingInlineEditRow,
       properties: {
         title: t("base.module.channelSettings.remark"),
-        value: channelInfo?.orgData?.remark,
-        onClick: () => {
-          inputEditPush(
-            context,
-            channelInfo?.orgData?.remark || "",
-            (value) =>
-              remarkChannelSetting({ channel, remark: value })
-                .then(() => data.refresh())
-                .catch((error) => {
-                  Toast.error(error?.msg);
-                  throw error;
-                }),
-            t("base.module.channelSettings.remarkPlaceholder"),
-            15,
-            true
-          );
-        },
+        value: channelInfo?.orgData?.remark || "",
+        placeholder: t("base.module.channelSettings.remarkPlaceholder"),
+        maxCount: 15,
+        allowEmpty: true,
+        onSave: (value: string) =>
+          remarkChannelSetting({ channel, remark: value })
+            .then(() => data.refresh())
+            .catch((error) => {
+              Toast.error(error?.msg);
+              throw error;
+            }),
       },
     })
   );

--- a/packages/dmworkbase/src/features/channelSetting/channelSettingGroupProfileRows.tsx
+++ b/packages/dmworkbase/src/features/channelSetting/channelSettingGroupProfileRows.tsx
@@ -1,4 +1,5 @@
 import { Tag, Toast } from "@douyinfe/semi-ui";
+import { QrCode } from "lucide-react";
 import React from "react";
 
 import WKApp from "../../App";
@@ -13,7 +14,7 @@ import { updateChannelSettingField } from "../../bridge/channelSetting/channelSe
 import { t } from "../../i18n";
 import {
   ChannelSettingIconRow,
-  ChannelSettingInfoRow,
+  ChannelSettingInlineEditRow,
 } from "../../ui/ChannelSettingRows";
 import { ChannelSettingInputEditPush } from "./types";
 
@@ -27,7 +28,6 @@ interface BuildGroupProfileRowsOptions {
 export function buildGroupProfileRows({
   context,
   data,
-  inputEditPush,
   disbanded,
 }: BuildGroupProfileRowsOptions): Row[] {
   if (disbanded) return [];
@@ -47,32 +47,31 @@ export function buildGroupProfileRows({
 
   return [
     new Row({
-      cell: ChannelSettingInfoRow,
+      cell: ChannelSettingInlineEditRow,
       properties: {
         title: t("base.module.channelSettings.groupName"),
-        value: groupName,
-        onClick: () => {
+        value: channelInfo?.title || "",
+        displayValue: groupName,
+        placeholder: t("base.module.channelSettings.groupNamePlaceholder"),
+        maxCount: GROUP_NAME_MAX_LENGTH,
+        onStartEdit: () => {
           if (!data.isManagerOrCreatorOfMe) {
             Toast.warning(
               t("base.module.channelSettings.groupNameOnlyManager")
             );
-            return;
+            return false;
           }
-          inputEditPush(
-            context,
-            channelInfo?.title || "",
-            (value) =>
-              updateChannelSettingField({
-                channel,
-                field: ChannelField.channelName,
-                value,
-              }).catch((error) => {
-                Toast.error(error.msg);
-              }),
-            t("base.module.channelSettings.groupNamePlaceholder"),
-            GROUP_NAME_MAX_LENGTH
-          );
+          return true;
         },
+        onSave: (value: string) =>
+          updateChannelSettingField({
+            channel,
+            field: ChannelField.channelName,
+            value,
+          }).catch((error) => {
+            Toast.error(error.msg);
+            return false;
+          }),
       },
     }),
     new Row({
@@ -105,13 +104,7 @@ export function buildGroupProfileRows({
       cell: ChannelSettingIconRow,
       properties: {
         title: t("base.module.channelSettings.groupQrCode"),
-        icon: (
-          <img
-            style={{ width: "24px", height: "24px" }}
-            src={require("../../assets/icon_qrcode.png")}
-            alt=""
-          />
-        ),
+        icon: <QrCode className="wk-channelsetting-qrcode-icon" aria-hidden />,
         onClick: () => {
           context.push(
             <ChannelQRCode channel={channel} />,
@@ -123,35 +116,32 @@ export function buildGroupProfileRows({
       },
     }),
     new Row({
-      cell: ChannelSettingInfoRow,
+      cell: ChannelSettingInlineEditRow,
       properties: {
         title: t("base.module.channelSettings.groupNotice"),
         value: channelInfo?.orgData?.notice,
         multiline: true,
-        onClick: () => {
+        placeholder: t("base.module.channelSettings.groupNotice"),
+        maxCount: 400,
+        allowEmpty: true,
+        onStartEdit: () => {
           if (!data.isManagerOrCreatorOfMe) {
             Toast.warning(
               t("base.module.channelSettings.groupNoticeOnlyManager")
             );
-            return;
+            return false;
           }
-          inputEditPush(
-            context,
-            channelInfo?.orgData?.notice || "",
-            (value) =>
-              updateChannelSettingField({
-                channel,
-                field: ChannelField.notice,
-                value,
-              }).catch((error) => {
-                Toast.error(error.msg);
-              }),
-            t("base.module.channelSettings.groupNotice"),
-            400,
-            true,
-            true
-          );
+          return true;
         },
+        onSave: (value: string) =>
+          updateChannelSettingField({
+            channel,
+            field: ChannelField.notice,
+            value,
+          }).catch((error) => {
+            Toast.error(error.msg);
+            return false;
+          }),
       },
     }),
   ];

--- a/packages/dmworkbase/src/features/channelSetting/channelSettingNicknameSection.tsx
+++ b/packages/dmworkbase/src/features/channelSetting/channelSettingNicknameSection.tsx
@@ -6,12 +6,12 @@ import { Row, Section } from "../../Service/Section";
 import { isGroupDisbanded } from "../../Utils/groupDisband";
 import { updateChannelSettingMyGroupNickname } from "../../bridge/channelSetting/channelSettingActions";
 import { t } from "../../i18n";
-import { ChannelSettingInfoRow } from "../../ui/ChannelSettingRows";
+import { ChannelSettingInlineEditRow } from "../../ui/ChannelSettingRows";
 import { ChannelSettingInputEditPush } from "./types";
 
 export function buildMyGroupNicknameSection(
   context: RouteContext<ChannelSettingRouteData>,
-  inputEditPush: ChannelSettingInputEditPush
+  _inputEditPush: ChannelSettingInputEditPush
 ) {
   const data = context.routeData() as ChannelSettingRouteData;
   if (
@@ -21,33 +21,30 @@ export function buildMyGroupNicknameSection(
     return undefined;
   }
 
-  const displayName = data.subscriberOfMe?.remark || data.subscriberOfMe?.name;
+  const groupNickname = data.subscriberOfMe?.remark ?? "";
 
   return new Section({
     rows: [
       new Row({
-        cell: ChannelSettingInfoRow,
+        cell: ChannelSettingInlineEditRow,
         properties: {
           title: t("base.module.channelSettings.myGroupNickname"),
-          value: displayName,
-          onClick: () => {
-            inputEditPush(
-              context,
-              displayName || "",
-              async (value: string) => {
-                await updateChannelSettingMyGroupNickname({
-                  channel: data.channel,
-                  remark: value,
-                });
-                if (data.subscriberOfMe) {
-                  data.subscriberOfMe.remark = value;
-                }
-                data.refresh();
-              },
-              t("base.module.channelSettings.myGroupNicknamePlaceholder"),
-              10,
-              true
-            );
+          value: groupNickname,
+          displayValue: groupNickname || t("base.common.notSet"),
+          placeholder: t(
+            "base.module.channelSettings.myGroupNicknamePlaceholder"
+          ),
+          maxCount: 10,
+          allowEmpty: true,
+          onSave: async (value: string) => {
+            await updateChannelSettingMyGroupNickname({
+              channel: data.channel,
+              remark: value,
+            });
+            if (data.subscriberOfMe) {
+              data.subscriberOfMe.remark = value;
+            }
+            data.refresh();
           },
         },
       }),

--- a/packages/dmworkbase/src/features/channelSetting/channelSettingNicknameSection.tsx
+++ b/packages/dmworkbase/src/features/channelSetting/channelSettingNicknameSection.tsx
@@ -1,3 +1,4 @@
+import { Toast } from "@douyinfe/semi-ui";
 import { ChannelTypeGroup } from "wukongimjssdk";
 
 import { ChannelSettingRouteData } from "../../Components/ChannelSetting/context";
@@ -37,10 +38,22 @@ export function buildMyGroupNicknameSection(
           maxCount: 10,
           allowEmpty: true,
           onSave: async (value: string) => {
-            await updateChannelSettingMyGroupNickname({
-              channel: data.channel,
-              remark: value,
-            });
+            try {
+              await updateChannelSettingMyGroupNickname({
+                channel: data.channel,
+                remark: value,
+              });
+            } catch (error) {
+              const message =
+                typeof error === "object" &&
+                error !== null &&
+                "msg" in error &&
+                typeof error.msg === "string"
+                  ? error.msg
+                  : t("base.module.channelSettings.saveFailedRetry");
+              Toast.error(message);
+              return false;
+            }
             if (data.subscriberOfMe) {
               data.subscriberOfMe.remark = value;
             }

--- a/packages/dmworkbase/src/features/channelSetting/channelSettingThreadActionsSection.tsx
+++ b/packages/dmworkbase/src/features/channelSetting/channelSettingThreadActionsSection.tsx
@@ -124,8 +124,5 @@ export function buildThreadActionsSection(
     })
   );
 
-  return new Section({
-    title: t("base.module.thread.management"),
-    rows,
-  });
+  return new Section({ rows });
 }

--- a/packages/dmworkbase/src/features/channelSetting/channelSettingThreadInfoSection.tsx
+++ b/packages/dmworkbase/src/features/channelSetting/channelSettingThreadInfoSection.tsx
@@ -17,12 +17,15 @@ import {
   getCurrentImChannelInfo,
 } from "../../im-runtime/currentChannelRuntime";
 import { t } from "../../i18n";
-import { ChannelSettingInfoRow } from "../../ui/ChannelSettingRows";
+import {
+  ChannelSettingInfoRow,
+  ChannelSettingInlineEditRow,
+} from "../../ui/ChannelSettingRows";
 import { ChannelSettingInputEditPush } from "./types";
 
 export function buildThreadInfoSection(
   context: RouteContext<ChannelSettingRouteData>,
-  inputEditPush: ChannelSettingInputEditPush
+  _inputEditPush: ChannelSettingInputEditPush
 ) {
   const data = context.routeData() as ChannelSettingRouteData;
   const { channel, channelInfo } = data;
@@ -49,37 +52,34 @@ export function buildThreadInfoSection(
       : "green";
   const rows: Row[] = [
     new Row({
-      cell: ChannelSettingInfoRow,
+      cell: ChannelSettingInlineEditRow,
       properties: {
         title: t("base.module.thread.name"),
-        value: threadName,
-        onClick: () => {
-          if (!threadInfo) return;
+        value: threadName || "",
+        placeholder: t("base.module.thread.name"),
+        maxCount: THREAD_NAME_MAX_LENGTH,
+        onStartEdit: () => {
+          if (!threadInfo) return false;
           if (!canEdit) {
             Toast.warning(t("base.module.thread.nameOnlyCreatorOrManager"));
-            return;
+            return false;
           }
-          inputEditPush(
-            context,
-            threadName || "",
-            async (value) => {
-              try {
-                await updateChannelSettingThreadName({
-                  channel,
-                  groupNo: threadInfo.groupNo,
-                  shortId: threadInfo.shortId,
-                  name: value,
-                });
-                data.refresh();
-              } catch (error: any) {
-                Toast.error(
-                  error?.msg || t("base.module.thread.saveFailedRetry")
-                );
-              }
-            },
-            t("base.module.thread.name"),
-            THREAD_NAME_MAX_LENGTH
-          );
+          return true;
+        },
+        onSave: async (value: string) => {
+          if (!threadInfo) return;
+          try {
+            await updateChannelSettingThreadName({
+              channel,
+              groupNo: threadInfo.groupNo,
+              shortId: threadInfo.shortId,
+              name: value,
+            });
+            data.refresh();
+          } catch (error: any) {
+            Toast.error(error?.msg || t("base.module.thread.saveFailedRetry"));
+            return false;
+          }
         },
       },
     }),

--- a/packages/dmworkbase/src/features/channelSetting/channelSettingThreadSections.ts
+++ b/packages/dmworkbase/src/features/channelSetting/channelSettingThreadSections.ts
@@ -1,4 +1,25 @@
+import { ChannelSettingRouteData } from "../../Components/ChannelSetting/context";
+import RouteContext from "../../Service/Context";
+import { Section } from "../../Service/Section";
+import { buildThreadInfoSection } from "./channelSettingThreadInfoSection";
+import { buildThreadMdSection } from "./channelSettingThreadMdSection";
+import { buildThreadWebhookSection } from "./channelSettingThreadWebhookSection";
+import { ChannelSettingInputEditPush } from "./types";
+
 export { buildThreadInfoSection } from "./channelSettingThreadInfoSection";
 export { buildThreadMdSection } from "./channelSettingThreadMdSection";
 export { buildThreadWebhookSection } from "./channelSettingThreadWebhookSection";
 export { buildThreadActionsSection } from "./channelSettingThreadActionsSection";
+
+export function buildThreadOverviewSection(
+  context: RouteContext<ChannelSettingRouteData>,
+  inputEditPush: ChannelSettingInputEditPush
+) {
+  const sections = [
+    buildThreadInfoSection(context, inputEditPush),
+    buildThreadMdSection(context),
+    buildThreadWebhookSection(context),
+  ];
+  const rows = sections.flatMap((section) => section?.rows || []);
+  return rows.length > 0 ? new Section({ rows }) : undefined;
+}

--- a/packages/dmworkbase/src/i18n/locales/en-US.json
+++ b/packages/dmworkbase/src/i18n/locales/en-US.json
@@ -1,6 +1,7 @@
 {
   "common.add": "Add",
   "common.cancel": "Cancel",
+  "common.clear": "Clear",
   "common.close": "Close",
   "common.done": "Done",
   "common.notSet": "Not set",

--- a/packages/dmworkbase/src/i18n/locales/en-US.json
+++ b/packages/dmworkbase/src/i18n/locales/en-US.json
@@ -1054,6 +1054,8 @@
   "subscribers.role.owner": "Owner",
   "subscribers.searchPlaceholder": "Search",
   "subscribers.viewMore": "View more group members",
+  "subscribers.viewAll": "View all {{count}} members",
+  "subscribers.memberListWithCount": "Members ({{count}})",
   "threadCreated.created": "Created a thread",
   "threadCreated.deleted": "This thread has been deleted.",
   "threadCreated.deletedOrMissing": "This thread has been deleted or does not exist.",

--- a/packages/dmworkbase/src/i18n/locales/en-US.json
+++ b/packages/dmworkbase/src/i18n/locales/en-US.json
@@ -671,6 +671,7 @@
   "module.channelSettings.remark": "Remark",
   "module.channelSettings.remarkPlaceholder": "Only you can see this group chat remark.",
   "module.channelSettings.removeMembers": "Remove group members",
+  "module.channelSettings.saveFailedRetry": "Failed to save. Please try again.",
   "module.channelSettings.saveToContacts": "Save to contacts",
   "module.channelSettings.transferOwner": "Transfer owner",
   "module.channelSettings.transferOwnerConfirm": "Transfer group ownership to {{name}}? You will become a regular member after the transfer.",

--- a/packages/dmworkbase/src/i18n/locales/zh-CN.json
+++ b/packages/dmworkbase/src/i18n/locales/zh-CN.json
@@ -1,6 +1,7 @@
 {
   "common.add": "添加",
   "common.cancel": "取消",
+  "common.clear": "清空",
   "common.close": "关闭",
   "common.done": "完成",
   "common.notSet": "未设置",

--- a/packages/dmworkbase/src/i18n/locales/zh-CN.json
+++ b/packages/dmworkbase/src/i18n/locales/zh-CN.json
@@ -671,6 +671,7 @@
   "module.channelSettings.remark": "备注",
   "module.channelSettings.remarkPlaceholder": "群聊的备注仅自己可见",
   "module.channelSettings.removeMembers": "删除群成员",
+  "module.channelSettings.saveFailedRetry": "保存失败，请重试",
   "module.channelSettings.saveToContacts": "保存到通讯录",
   "module.channelSettings.transferOwner": "转让群主",
   "module.channelSettings.transferOwnerConfirm": "确定将群主转让给 {{name}} 吗？转让后你将成为普通成员。",

--- a/packages/dmworkbase/src/i18n/locales/zh-CN.json
+++ b/packages/dmworkbase/src/i18n/locales/zh-CN.json
@@ -1054,6 +1054,8 @@
   "subscribers.role.owner": "群主",
   "subscribers.searchPlaceholder": "搜索",
   "subscribers.viewMore": "查看更多群成员",
+  "subscribers.viewAll": "查看全部 {{count}} 名成员",
+  "subscribers.memberListWithCount": "成员（{{count}}）",
   "threadCreated.created": "新建了子区",
   "threadCreated.deleted": "该子区已删除",
   "threadCreated.deletedOrMissing": "该子区已删除或不存在",

--- a/packages/dmworkbase/src/module.tsx
+++ b/packages/dmworkbase/src/module.tsx
@@ -155,9 +155,7 @@ import { buildChannelMembersSection } from "./features/channelSetting/channelSet
 import { buildChannelGroupInfoSection } from "./features/channelSetting/channelSettingGroupInfoSection";
 import {
   buildThreadActionsSection,
-  buildThreadInfoSection,
-  buildThreadMdSection,
-  buildThreadWebhookSection,
+  buildThreadOverviewSection,
 } from "./features/channelSetting/channelSettingThreadSections";
 
 /** execCommand 降级复制，用于 navigator.clipboard 不可用的场景 */
@@ -1663,40 +1661,17 @@ export default class BaseModule implements IModule {
       90000
     );
 
-    // 子区 (Thread) 设置项
+    // 子区信息行沿用各自既有 builder 和权限/点击逻辑，只在展示层合并为同一信息卡。
+    // 当前未注册的免打扰、查找聊天内容等入口不得因 UI 参考图而补回。
     WKApp.shared.channelSettingRegister(
-      "thread.base.info",
+      "thread.overview",
       (context) => {
-        return buildThreadInfoSection(
+        return buildThreadOverviewSection(
           context,
           this.channelSettingInputEditPush.bind(this)
         );
       },
       500
-    );
-
-    // 子区 GROUP.md 设置项
-    WKApp.shared.channelSettingRegister(
-      "thread.md.setting",
-      (context) => {
-        return buildThreadMdSection(context);
-      },
-      1000
-    );
-
-    // 子区入站 Webhook（入口 A：聊天信息 / 完整会话设置页）。与入口 B
-    // （ThreadPanel 右上角「…」菜单）完全同口径：复用群面板 ChannelWebhookPanel，
-    // 传【父群】channel + 子区 short_id，datasource 据此拼
-    // groups/{group}/threads/{short}/incoming-webhooks 做作用域隔离；
-    // isManager 锚【父群】角色（子区无独立角色矩阵，普通成员仍可管自己创建的）。
-    // 仅【活跃中】子区显示 —— 归档子区建 webhook 会被后端拒，避免无效入口，
-    // 与入口 B 的 status 门槛保持一致。
-    WKApp.shared.channelSettingRegister(
-      "thread.webhook",
-      (context) => {
-        return buildThreadWebhookSection(context);
-      },
-      2000
     );
 
     // 子区设置说明：

--- a/packages/dmworkbase/src/ui/ChannelSettingRows/ChannelSettingRows.stories.tsx
+++ b/packages/dmworkbase/src/ui/ChannelSettingRows/ChannelSettingRows.stories.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import {
   ChannelSettingActionRow,
   ChannelSettingIconRow,
+  ChannelSettingInlineEditRow,
   ChannelSettingInfoRow,
   ChannelSettingToggleRow,
 } from ".";
@@ -18,8 +19,15 @@ type Story = StoryObj;
 
 function Frame({ children }: { children: React.ReactNode }) {
   return (
-    <div style={{ width: "var(--wk-wdith-chat-channelsetting)" }}>
-      {children}
+    <div
+      className="wk-channelsetting-content"
+      style={{ width: "var(--wk-wdith-chat-channelsetting)", height: "auto" }}
+    >
+      <div className="wk-sections">
+        <div className="wk-section">
+          <div className="wk-channelsetting-section-rows">{children}</div>
+        </div>
+      </div>
     </div>
   );
 }
@@ -72,6 +80,39 @@ export const Actions: Story = {
         title="删除并退出"
         danger
         onClick={() => undefined}
+      />
+    </Frame>
+  ),
+};
+
+export const LongContent: Story = {
+  render: () => (
+    <Frame>
+      <ChannelSettingInfoRow
+        title="群聊名称"
+        value="这是一个用于检查超长群聊名称在加宽卡片中是否正确截断的项目讨论群"
+        onClick={() => undefined}
+      />
+      <ChannelSettingInfoRow
+        title="群公告"
+        value="这里展示一段较长的多行公告内容，用于验证换行、卡片内边距以及深色主题下的文字层级。"
+        multiline
+        onClick={() => undefined}
+      />
+    </Frame>
+  ),
+};
+
+export const InlineEditing: Story = {
+  render: () => (
+    <Frame>
+      <ChannelSettingInlineEditRow
+        title="备注"
+        value=""
+        placeholder="群聊的备注仅自己可见"
+        maxCount={15}
+        allowEmpty
+        onSave={async () => undefined}
       />
     </Frame>
   ),

--- a/packages/dmworkbase/src/ui/ChannelSettingRows/__tests__/ChannelSettingInlineEditRow.test.tsx
+++ b/packages/dmworkbase/src/ui/ChannelSettingRows/__tests__/ChannelSettingInlineEditRow.test.tsx
@@ -1,0 +1,73 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { ChannelSettingInlineEditRow } from "../index";
+
+vi.mock("@douyinfe/semi-icons", () => ({
+  IconClear: () => <span aria-hidden="true">x</span>,
+}));
+
+vi.mock("@douyinfe/semi-ui", () => ({
+  Button: ({ children, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button {...props}>{children}</button>
+  ),
+  Input: ({ suffix, onChange, ...props }: any) => (
+    <label>
+      <input
+        {...props}
+        onChange={(event) => onChange(event.currentTarget.value)}
+      />
+      {suffix}
+    </label>
+  ),
+  TextArea: ({ onChange, ...props }: any) => (
+    <textarea
+      {...props}
+      onChange={(event) => onChange(event.currentTarget.value)}
+    />
+  ),
+}));
+
+vi.mock("../../../Components/ListItem", () => ({
+  ListItem: ({ title, onClick }: any) => <button onClick={onClick}>{title}</button>,
+  ListItemButton: vi.fn(),
+  ListItemButtonType: { default: "default", warn: "warn" },
+  ListItemIcon: vi.fn(),
+  ListItemMuliteLine: vi.fn(),
+  ListItemSwitch: vi.fn(),
+}));
+
+vi.mock("../../../i18n", () => ({
+  t: (key: string) => key,
+}));
+
+describe("ChannelSettingInlineEditRow", () => {
+  it("clears an existing value and saves the empty nickname", async () => {
+    const onSave = vi.fn(() => Promise.resolve());
+
+    render(
+      <ChannelSettingInlineEditRow
+        title="My nickname"
+        value="Old nickname"
+        allowEmpty
+        onSave={onSave}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "My nickname" }));
+
+    const input = screen.getByDisplayValue("Old nickname") as HTMLInputElement;
+    fireEvent.mouseDown(
+      screen.getByRole("button", { name: "My nickname-base.common.clear" })
+    );
+
+    expect(input.value).toBe("");
+
+    const save = screen.getByRole("button", { name: "base.common.save" });
+    expect(save).toBeEnabled();
+    fireEvent.click(save);
+
+    expect(onSave).toHaveBeenCalledWith("");
+  });
+});

--- a/packages/dmworkbase/src/ui/ChannelSettingRows/__tests__/ChannelSettingInlineEditRow.test.tsx
+++ b/packages/dmworkbase/src/ui/ChannelSettingRows/__tests__/ChannelSettingInlineEditRow.test.tsx
@@ -9,7 +9,11 @@ vi.mock("@douyinfe/semi-icons", () => ({
 }));
 
 vi.mock("@douyinfe/semi-ui", () => ({
-  Button: ({ children, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+  Button: ({
+    children,
+    loading: _loading,
+    ...props
+  }: React.ButtonHTMLAttributes<HTMLButtonElement> & { loading?: boolean }) => (
     <button {...props}>{children}</button>
   ),
   Input: ({ suffix, onChange, ...props }: any) => (
@@ -30,7 +34,12 @@ vi.mock("@douyinfe/semi-ui", () => ({
 }));
 
 vi.mock("../../../Components/ListItem", () => ({
-  ListItem: ({ title, onClick }: any) => <button onClick={onClick}>{title}</button>,
+  ListItem: ({ title, subTitle, onClick }: any) => (
+    <button aria-label={title} onClick={onClick}>
+      {title}
+      <span>{subTitle}</span>
+    </button>
+  ),
   ListItemButton: vi.fn(),
   ListItemButtonType: { default: "default", warn: "warn" },
   ListItemIcon: vi.fn(),
@@ -90,6 +99,87 @@ describe("ChannelSettingInlineEditRow", () => {
 
     await waitFor(() => expect(onSave).toHaveBeenCalledWith("Unsaved draft"));
     expect(screen.getByDisplayValue("Unsaved draft")).toBe(input);
-    expect(screen.getByRole("button", { name: "base.common.cancel" })).toBeEnabled();
+    expect(
+      screen.getByRole("button", { name: "base.common.cancel" })
+    ).toBeEnabled();
+  });
+
+  it("keeps the draft open when saving rejects", async () => {
+    const onSave = vi.fn(() => Promise.reject(new Error("request failed")));
+
+    render(
+      <ChannelSettingInlineEditRow
+        title="Remark"
+        value="Old remark"
+        allowEmpty
+        onSave={onSave}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Remark" }));
+    fireEvent.change(screen.getByDisplayValue("Old remark"), {
+      target: { value: "Unsaved remark" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "base.common.save" }));
+
+    await waitFor(() => expect(onSave).toHaveBeenCalledWith("Unsaved remark"));
+    expect(screen.getByDisplayValue("Unsaved remark")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "base.common.cancel" })
+    ).toBeEnabled();
+  });
+
+  it("preserves an in-progress draft across external value updates", () => {
+    const onSave = vi.fn(() => Promise.resolve());
+    const { rerender } = render(
+      <ChannelSettingInlineEditRow
+        title="Group name"
+        value="Original name"
+        onSave={onSave}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Group name" }));
+    fireEvent.change(screen.getByDisplayValue("Original name"), {
+      target: { value: "Local draft" },
+    });
+
+    rerender(
+      <ChannelSettingInlineEditRow
+        title="Group name"
+        value="Remote name"
+        onSave={onSave}
+      />
+    );
+
+    expect(screen.getByDisplayValue("Local draft")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "base.common.cancel" }));
+    expect(screen.getByText("Remote name")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Group name" }));
+    expect(screen.getByDisplayValue("Remote name")).toBeInTheDocument();
+  });
+
+  it("keeps a successful save visible until the external value catches up", async () => {
+    const onSave = vi.fn(() => Promise.resolve());
+
+    render(
+      <ChannelSettingInlineEditRow
+        title="Group name"
+        value="Old name"
+        onSave={onSave}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Group name" }));
+    fireEvent.change(screen.getByDisplayValue("Old name"), {
+      target: { value: "Saved name" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "base.common.save" }));
+
+    await waitFor(() => expect(onSave).toHaveBeenCalledWith("Saved name"));
+    expect(screen.getByText("Saved name")).toBeInTheDocument();
+    expect(screen.queryByDisplayValue("Saved name")).not.toBeInTheDocument();
   });
 });

--- a/packages/dmworkbase/src/ui/ChannelSettingRows/__tests__/ChannelSettingInlineEditRow.test.tsx
+++ b/packages/dmworkbase/src/ui/ChannelSettingRows/__tests__/ChannelSettingInlineEditRow.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 import { ChannelSettingInlineEditRow } from "../index";
@@ -69,5 +69,27 @@ describe("ChannelSettingInlineEditRow", () => {
     fireEvent.click(save);
 
     expect(onSave).toHaveBeenCalledWith("");
+  });
+
+  it("keeps the draft open when saving fails", async () => {
+    const onSave = vi.fn(() => Promise.resolve(false));
+
+    render(
+      <ChannelSettingInlineEditRow
+        title="Group name"
+        value="Old name"
+        onSave={onSave}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Group name" }));
+
+    const input = screen.getByDisplayValue("Old name") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "Unsaved draft" } });
+    fireEvent.click(screen.getByRole("button", { name: "base.common.save" }));
+
+    await waitFor(() => expect(onSave).toHaveBeenCalledWith("Unsaved draft"));
+    expect(screen.getByDisplayValue("Unsaved draft")).toBe(input);
+    expect(screen.getByRole("button", { name: "base.common.cancel" })).toBeEnabled();
   });
 });

--- a/packages/dmworkbase/src/ui/ChannelSettingRows/__tests__/ChannelSettingInlineEditRow.test.tsx
+++ b/packages/dmworkbase/src/ui/ChannelSettingRows/__tests__/ChannelSettingInlineEditRow.test.tsx
@@ -25,11 +25,14 @@ vi.mock("@douyinfe/semi-ui", () => ({
       {suffix}
     </label>
   ),
-  TextArea: ({ onChange, ...props }: any) => (
-    <textarea
-      {...props}
-      onChange={(event) => onChange(event.currentTarget.value)}
-    />
+  TextArea: ({ onChange, onClear, showClear: _showClear, ...props }: any) => (
+    <label>
+      <textarea
+        {...props}
+        onChange={(event) => onChange(event.currentTarget.value)}
+      />
+      <button type="button" aria-label="textarea-clear" onClick={onClear} />
+    </label>
   ),
 }));
 
@@ -43,7 +46,12 @@ vi.mock("../../../Components/ListItem", () => ({
   ListItemButton: vi.fn(),
   ListItemButtonType: { default: "default", warn: "warn" },
   ListItemIcon: vi.fn(),
-  ListItemMuliteLine: vi.fn(),
+  ListItemMuliteLine: ({ title, subTitle, onClick }: any) => (
+    <button aria-label={title} onClick={onClick}>
+      {title}
+      <span>{subTitle}</span>
+    </button>
+  ),
   ListItemSwitch: vi.fn(),
 }));
 
@@ -181,5 +189,90 @@ describe("ChannelSettingInlineEditRow", () => {
     await waitFor(() => expect(onSave).toHaveBeenCalledWith("Saved name"));
     expect(screen.getByText("Saved name")).toBeInTheDocument();
     expect(screen.queryByDisplayValue("Saved name")).not.toBeInTheDocument();
+  });
+
+  it("does not enter edit mode when the start guard rejects editing", () => {
+    const onStartEdit = vi.fn(() => false);
+
+    render(
+      <ChannelSettingInlineEditRow
+        title="Group name"
+        value="Protected name"
+        onStartEdit={onStartEdit}
+        onSave={vi.fn(() => Promise.resolve())}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Group name" }));
+
+    expect(onStartEdit).toHaveBeenCalledOnce();
+    expect(
+      screen.queryByDisplayValue("Protected name")
+    ).not.toBeInTheDocument();
+  });
+
+  it("enters edit mode when the start guard returns void", () => {
+    const onStartEdit = vi.fn(() => undefined);
+
+    render(
+      <ChannelSettingInlineEditRow
+        title="Group name"
+        value="Editable name"
+        onStartEdit={onStartEdit}
+        onSave={vi.fn(() => Promise.resolve())}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Group name" }));
+
+    expect(onStartEdit).toHaveBeenCalledOnce();
+    expect(screen.getByDisplayValue("Editable name")).toBeInTheDocument();
+  });
+
+  it("disables saving for unchanged, empty, and over-limit values", () => {
+    render(
+      <ChannelSettingInlineEditRow
+        title="Group name"
+        value="Name"
+        maxCount={5}
+        onSave={vi.fn(() => Promise.resolve())}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Group name" }));
+    const input = screen.getByDisplayValue("Name");
+    const save = screen.getByRole("button", { name: "base.common.save" });
+
+    expect(save).toBeDisabled();
+
+    fireEvent.change(input, { target: { value: "" } });
+    expect(save).toBeDisabled();
+
+    fireEvent.change(input, { target: { value: "Too long" } });
+    expect(save).toBeDisabled();
+
+    fireEvent.change(input, { target: { value: "Valid" } });
+    expect(save).toBeEnabled();
+  });
+
+  it("clears a multiline draft and saves the empty value", async () => {
+    const onSave = vi.fn(() => Promise.resolve());
+
+    render(
+      <ChannelSettingInlineEditRow
+        title="Group notice"
+        value="Old notice"
+        multiline
+        allowEmpty
+        onSave={onSave}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Group notice" }));
+    fireEvent.click(screen.getByRole("button", { name: "textarea-clear" }));
+
+    expect(screen.getByDisplayValue("")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "base.common.save" }));
+    await waitFor(() => expect(onSave).toHaveBeenCalledWith(""));
   });
 });

--- a/packages/dmworkbase/src/ui/ChannelSettingRows/index.css
+++ b/packages/dmworkbase/src/ui/ChannelSettingRows/index.css
@@ -1,0 +1,36 @@
+.wk-channelsetting-inline-edit {
+  display: flex;
+  flex-direction: column;
+  gap: var(--wk-sp-2);
+  padding: var(--wk-sp-3) var(--wk-sp-4);
+  background: var(--wk-bg-base);
+}
+
+.wk-channelsetting-inline-edit-title {
+  color: var(--wk-text-primary);
+  font-size: var(--wk-text-size-md);
+}
+
+.wk-channelsetting-inline-edit .semi-input-wrapper,
+.wk-channelsetting-inline-edit .semi-input-textarea-wrapper {
+  background: var(--wk-bg-surface);
+  border-color: var(--wk-border-strong);
+  border-radius: var(--wk-r-sm);
+}
+
+.wk-channelsetting-inline-edit-footer {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: var(--wk-sp-2);
+}
+
+.wk-channelsetting-inline-edit-count {
+  margin-right: auto;
+  color: var(--wk-text-tertiary);
+  font-size: var(--wk-text-size-sm);
+}
+
+.wk-channelsetting-inline-edit-count-error {
+  color: var(--wk-color-error);
+}

--- a/packages/dmworkbase/src/ui/ChannelSettingRows/index.css
+++ b/packages/dmworkbase/src/ui/ChannelSettingRows/index.css
@@ -18,6 +18,16 @@
   border-radius: var(--wk-r-sm);
 }
 
+.wk-channelsetting-inline-edit-clear {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--wk-sp-1);
+  color: var(--wk-text-tertiary);
+  background: transparent;
+  border: 0;
+}
+
 .wk-channelsetting-inline-edit-footer {
   display: flex;
   align-items: center;

--- a/packages/dmworkbase/src/ui/ChannelSettingRows/index.tsx
+++ b/packages/dmworkbase/src/ui/ChannelSettingRows/index.tsx
@@ -210,8 +210,10 @@ export function ChannelSettingInlineEditRow({
             setSaving(true);
             try {
               const saved = await onSave(draft);
-              if (saved !== false) setCurrentValue(draft);
-              setEditing(false);
+              if (saved !== false) {
+                setCurrentValue(draft);
+                setEditing(false);
+              }
             } catch {
               // The bridge/container owns the user-facing error message.
             } finally {

--- a/packages/dmworkbase/src/ui/ChannelSettingRows/index.tsx
+++ b/packages/dmworkbase/src/ui/ChannelSettingRows/index.tsx
@@ -1,4 +1,5 @@
-import React from "react";
+import { Button, Input, TextArea } from "@douyinfe/semi-ui";
+import React, { useEffect, useState } from "react";
 
 import {
   ListItem,
@@ -9,6 +10,8 @@ import {
   ListItemSwitch,
   ListItemSwitchContext,
 } from "../../Components/ListItem";
+import { t } from "../../i18n";
+import "./index.css";
 
 export interface ChannelSettingInfoRowProps {
   title: string;
@@ -82,5 +85,121 @@ export function ChannelSettingActionRow({
       onClick={onClick}
       style={{}}
     />
+  );
+}
+
+export interface ChannelSettingInlineEditRowProps {
+  title: string;
+  value?: string;
+  displayValue?: React.ReactNode;
+  placeholder?: string;
+  maxCount?: number;
+  allowEmpty?: boolean;
+  multiline?: boolean;
+  onStartEdit?: () => boolean | void;
+  onSave: (value: string) => Promise<void | boolean>;
+}
+
+export function ChannelSettingInlineEditRow({
+  title,
+  value = "",
+  displayValue,
+  placeholder,
+  maxCount,
+  allowEmpty = false,
+  multiline = false,
+  onStartEdit,
+  onSave,
+}: ChannelSettingInlineEditRowProps) {
+  const [editing, setEditing] = useState(false);
+  const [currentValue, setCurrentValue] = useState(value);
+  const [draft, setDraft] = useState(value);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    setCurrentValue(value);
+    setDraft(value);
+  }, [value]);
+
+  const exceeded = maxCount !== undefined && draft.length > maxCount;
+  const emptyInvalid = !allowEmpty && draft.trim().length === 0;
+  const unchanged = draft === currentValue;
+  const saveDisabled = saving || exceeded || emptyInvalid || unchanged;
+
+  const startEdit = () => {
+    if (onStartEdit?.() === false) return;
+    setDraft(currentValue);
+    setEditing(true);
+  };
+
+  if (!editing) {
+    return (
+      <ChannelSettingInfoRow
+        title={title}
+        value={currentValue === value ? displayValue ?? value : currentValue}
+        multiline={multiline}
+        onClick={startEdit}
+      />
+    );
+  }
+
+  const inputProps = {
+    value: draft,
+    placeholder,
+    disabled: saving,
+    showClear: true,
+    onChange: (next: string) => setDraft(next),
+    onClear: () => setDraft(""),
+  };
+
+  return (
+    <div className="wk-channelsetting-inline-edit">
+      <div className="wk-channelsetting-inline-edit-title">{title}</div>
+      {multiline ? (
+        <TextArea {...inputProps} autosize={{ minRows: 2, maxRows: 6 }} />
+      ) : (
+        <Input {...inputProps} />
+      )}
+      <div className="wk-channelsetting-inline-edit-footer">
+        {maxCount !== undefined ? (
+          <span
+            className={`wk-channelsetting-inline-edit-count${
+              exceeded ? " wk-channelsetting-inline-edit-count-error" : ""
+            }`}
+          >
+            {draft.length} / {maxCount}
+          </span>
+        ) : null}
+        <Button
+          theme="borderless"
+          disabled={saving}
+          onClick={() => {
+            setDraft(currentValue);
+            setEditing(false);
+          }}
+        >
+          {t("base.common.cancel")}
+        </Button>
+        <Button
+          theme="solid"
+          loading={saving}
+          disabled={saveDisabled}
+          onClick={async () => {
+            setSaving(true);
+            try {
+              const saved = await onSave(draft);
+              if (saved !== false) setCurrentValue(draft);
+              setEditing(false);
+            } catch {
+              // The bridge/container owns the user-facing error message.
+            } finally {
+              setSaving(false);
+            }
+          }}
+        >
+          {t("base.common.save")}
+        </Button>
+      </div>
+    </div>
   );
 }

--- a/packages/dmworkbase/src/ui/ChannelSettingRows/index.tsx
+++ b/packages/dmworkbase/src/ui/ChannelSettingRows/index.tsx
@@ -1,4 +1,5 @@
 import { Button, Input, TextArea } from "@douyinfe/semi-ui";
+import { IconClear } from "@douyinfe/semi-icons";
 import React, { useEffect, useState } from "react";
 
 import {
@@ -147,18 +148,39 @@ export function ChannelSettingInlineEditRow({
     value: draft,
     placeholder,
     disabled: saving,
-    showClear: true,
     onChange: (next: string) => setDraft(next),
-    onClear: () => setDraft(""),
   };
 
   return (
     <div className="wk-channelsetting-inline-edit">
       <div className="wk-channelsetting-inline-edit-title">{title}</div>
       {multiline ? (
-        <TextArea {...inputProps} autosize={{ minRows: 2, maxRows: 6 }} />
+        <TextArea
+          {...inputProps}
+          showClear
+          onClear={() => setDraft("")}
+          autosize={{ minRows: 2, maxRows: 6 }}
+        />
       ) : (
-        <Input {...inputProps} />
+        <Input
+          {...inputProps}
+          suffix={
+            draft && !saving ? (
+              <button
+                type="button"
+                className="wk-channelsetting-inline-edit-clear"
+                aria-label={`${title}-${t("base.common.clear")}`}
+                onMouseDown={(event) => {
+                  event.preventDefault();
+                  event.stopPropagation();
+                  setDraft("");
+                }}
+              >
+                <IconClear />
+              </button>
+            ) : null
+          }
+        />
       )}
       <div className="wk-channelsetting-inline-edit-footer">
         {maxCount !== undefined ? (

--- a/packages/dmworkbase/src/ui/ChannelSettingRows/index.tsx
+++ b/packages/dmworkbase/src/ui/ChannelSettingRows/index.tsx
@@ -1,6 +1,6 @@
 import { Button, Input, TextArea } from "@douyinfe/semi-ui";
 import { IconClear } from "@douyinfe/semi-icons";
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 
 import {
   ListItem,
@@ -98,6 +98,7 @@ export interface ChannelSettingInlineEditRowProps {
   allowEmpty?: boolean;
   multiline?: boolean;
   onStartEdit?: () => boolean | void;
+  /** Resolve false or reject to keep the editor open with its current draft. */
   onSave: (value: string) => Promise<void | boolean>;
 }
 
@@ -116,10 +117,17 @@ export function ChannelSettingInlineEditRow({
   const [currentValue, setCurrentValue] = useState(value);
   const [draft, setDraft] = useState(value);
   const [saving, setSaving] = useState(false);
+  const editingRef = useRef(false);
+
+  useEffect(() => {
+    editingRef.current = editing;
+  }, [editing]);
 
   useEffect(() => {
     setCurrentValue(value);
-    setDraft(value);
+    if (!editingRef.current) {
+      setDraft(value);
+    }
   }, [value]);
 
   const exceeded = maxCount !== undefined && draft.length > maxCount;


### PR DESCRIPTION
## Summary

- align group and subzone information panels with the reviewed card-based layout and wider drawer while preserving existing entry points, permissions, and runtime actions
- move simple name, notice, remark, group-nickname, and subzone-name edits into reusable inline rows; keep group/subzone action semantics unchanged
- refine member grid and member-list presentation while preserving the existing Chinese/pinyin search, authoritative server search, and pagination behavior
- keep inline drafts intact when saves fail or external channel refreshes arrive during editing, and make the group-nickname clear action reliable on first edit

## Scope boundaries

- no changes to `bridge/channelSetting/*Actions`
- no changes to WKApp, WKSDK, datasource, Chat, Conversation, or Messages runtime paths
- no new subzone switches, hidden entries, or permission behavior
- no new pinyin-search capability; this PR only preserves and adapts the behavior already present at its merge base

## Validation

- focused `vitest`: 4 files, 34 tests passed
- inline-edit matrix: clear/save, successful save, `false` failure, rejected failure, external refresh while editing, and cancel-to-latest-value all passed
- `pnpm i18n:check`: passed
- `pnpm --dir apps/web build`: passed
- Prettier and `git diff --check`: passed
- full dmworkbase suite: 2,064/2,065 passed; one unrelated `ThreadPanel.archive` test timed out once under full-suite load and passed 16/16 when rerun in isolation
- Storybook static build: transformed 10,137 modules without component compilation errors, then exited with the existing low-level code 132 issue

## Manual acceptance

- group and subzone information cards, drawer width, member spacing, and member-list back navigation
- inline edit/save/cancel for group name, announcement, remark, group nickname, and subzone name
- failed saves keep the editor open and preserve the typed draft
- background channel refreshes do not overwrite a draft; Cancel shows the latest external value
- group nickname clear action works on first panel entry
- existing view-more and transfer-owner member search still supports Chinese and pinyin, including members outside a super-group first-page cache
- unchanged mute, pin, save, archive, leave, exit, and permission behavior
