### PR TITLE
feat(global-search): add cloud docs full-text search tab

### DIFF
--- a/packages/dmworkbase/src/App.tsx
+++ b/packages/dmworkbase/src/App.tsx
@@ -237,6 +237,7 @@ export class WKRemoteConfig {
   revokeSecond: number = 2 * 60; // 撤回时间
   threadOn: boolean = false; // 子区功能开关，默认关闭
   messagesSearchOn: boolean = false; // 会话内聊天记录搜索开关，默认关闭
+  docsSearchOn: boolean = false; // 云文档全文搜索开关，默认关闭；与 docsOn(模块入口)解耦，独立灰度
   disableUserCreateSpace: boolean = false; // 是否关闭普通用户创建 Space 入口
   /**
    * 自定义贴纸管理入口开关。后端字段 sticker_custom_enabled 为 true 时，前端展示
@@ -407,6 +408,7 @@ export class WKRemoteConfig {
       const previousMessageReaction = this.messageReaction;
       const previousStickerUploadLimits = this.stickerUploadLimits;
       const previousDocsOn = this.docsOn;
+      const previousDocsSearchOn = this.docsSearchOn;
       const previousDmloopOn = this.dmloopOn;
       const previousDmpersonalOn = this.dmpersonalOn;
       const previousDriveOn = this.driveOn;
@@ -427,6 +429,7 @@ export class WKRemoteConfig {
         result["sticker_upload_limits"]
       );
       this.docsOn = parseRemoteBool(result["docs_on"]);
+      this.docsSearchOn = parseRemoteBool(result["docs_search_on"]);
       this.dmloopOn = parseRemoteBool(result["dmloop_on"]);
       this.dmpersonalOn = parseRemoteBool(result["dmpersonal_on"]);
       this.driveOn = parseRemoteBool(result["drive_on"]);
@@ -446,6 +449,7 @@ export class WKRemoteConfig {
           this.stickerUploadLimits
         ) ||
         previousDocsOn !== this.docsOn ||
+        previousDocsSearchOn !== this.docsSearchOn ||
         previousDmloopOn !== this.dmloopOn ||
         previousDmpersonalOn !== this.dmpersonalOn ||
         previousDriveOn !== this.driveOn

--- a/packages/dmworkbase/src/Components/GlobalSearch/DocSearchPanel.tsx
+++ b/packages/dmworkbase/src/Components/GlobalSearch/DocSearchPanel.tsx
@@ -1,0 +1,198 @@
+import React, { useCallback, useMemo } from "react";
+import { useI18n } from "../../i18n";
+import type {
+  DocSearchItem,
+  GlobalSearchDataSource,
+} from "../../Service/SearchTypes";
+import useSearchPagination from "../../bridge/search/useSearchPagination";
+import "./doc-search-panel.css";
+
+const PAGE_SIZE = 20;
+
+interface DocSearchPanelProps {
+  keyword: string;
+  dataSource: GlobalSearchDataSource;
+  // Mounted alongside the other tab panels and toggled via display:none, so a
+  // hidden panel must not run/paginate its search. Gate on isActive (same
+  // reasoning as GlobalContentSearchPanel).
+  isActive?: boolean;
+  // Integration point: open the clicked cloud doc, then dismiss the search
+  // modal. Wired by the host (route/endpoint TBD). No-op default keeps P0
+  // self-contained without hardcoding an unverified route.
+  onOpenDoc?: (item: DocSearchItem) => void;
+}
+
+// Backend `highlight` may contain <em></em>. Render it into React text nodes
+// with an <em>-only allowlist: everything between/around the tags becomes a
+// plain React string (auto-escaped by React), and only the marked spans are
+// wrapped in <em>. This never uses dangerouslySetInnerHTML, so injected markup
+// in the fragment cannot execute.
+function renderHighlight(fragment: string): React.ReactNode {
+  const pattern = /<em>([\s\S]*?)<\/em>/gi;
+  const nodes: React.ReactNode[] = [];
+  let cursor = 0;
+  let match: RegExpExecArray | null;
+  let key = 0;
+  while ((match = pattern.exec(fragment))) {
+    if (match.index > cursor) {
+      nodes.push(fragment.slice(cursor, match.index));
+    }
+    nodes.push(<em key={key++}>{match[1]}</em>);
+    cursor = pattern.lastIndex;
+  }
+  if (cursor < fragment.length) nodes.push(fragment.slice(cursor));
+  return nodes.length > 0 ? nodes : fragment;
+}
+
+const DOC_TYPE_BADGE: Record<string, string> = {
+  doc: "DOC",
+  sheet: "XLS",
+  board: "BRD",
+};
+
+function formatUpdatedAt(ms: number, locale: string): string {
+  if (!ms) return "";
+  try {
+    return new Date(ms).toLocaleDateString(locale);
+  } catch {
+    return "";
+  }
+}
+
+const DocSearchPanel: React.FC<DocSearchPanelProps> = ({
+  keyword,
+  dataSource,
+  isActive = true,
+  onOpenDoc,
+}) => {
+  const { t, locale } = useI18n();
+  const trimmed = keyword.trim();
+  const canSearch = !!trimmed && isActive && !!dataSource.searchDocs;
+
+  // Reuse the shared cursor-paginator by encoding the 1-based page as the
+  // cursor string ("2", "3", ...). searchDocs is page-based; map both ways.
+  const searchPage = useCallback(
+    async (cursor?: string) => {
+      const page = cursor ? Number(cursor) || 1 : 1;
+      const res = await dataSource.searchDocs!({
+        keyword: trimmed,
+        page,
+        pageSize: PAGE_SIZE,
+      });
+      const loaded = page * PAGE_SIZE;
+      const hasMore = loaded < res.total;
+      return {
+        items: res.items,
+        hasMore,
+        nextCursor: hasMore ? String(page + 1) : undefined,
+      };
+    },
+    [dataSource, trimmed]
+  );
+
+  const {
+    contentRef,
+    error,
+    handleScroll,
+    loadNextPage,
+    loading,
+    loadingMore,
+    paginationError,
+    queryStarted,
+    response,
+  } = useSearchPagination<DocSearchItem>({
+    enabled: canSearch,
+    search: searchPage,
+    errorMessage: t("base.globalSearch.docs.searchFailed"),
+  });
+
+  const items = response.items;
+
+  const emptyState = useMemo(() => {
+    if (loading) {
+      return (
+        <div className="wk-doc-search__hint">
+          {t("base.globalSearch.docs.loading")}
+        </div>
+      );
+    }
+    if (error && items.length === 0) {
+      return <div className="wk-doc-search__hint">{error}</div>;
+    }
+    return (
+      <div className="wk-doc-search__empty">
+        {!trimmed
+          ? t("base.globalSearch.docs.emptyHint")
+          : queryStarted
+            ? t("base.globalSearch.docs.noResults")
+            : t("base.globalSearch.docs.emptyHint")}
+      </div>
+    );
+  }, [error, items.length, loading, queryStarted, t, trimmed]);
+
+  return (
+    <div className="wk-doc-search">
+      <div
+        className="wk-doc-search__list"
+        ref={contentRef}
+        onScroll={handleScroll}
+      >
+        {items.length === 0 ? (
+          emptyState
+        ) : (
+          <>
+            {items.map((item) => (
+              <button
+                type="button"
+                key={item.docId}
+                className="wk-doc-search__item"
+                onClick={() => onOpenDoc?.(item)}
+              >
+                <span
+                  className={`wk-doc-search__icon wk-doc-search__icon--${item.docType}`}
+                >
+                  {DOC_TYPE_BADGE[item.docType] ?? "DOC"}
+                </span>
+                <span className="wk-doc-search__meta">
+                  <span className="wk-doc-search__title">
+                    {item.title || item.docId}
+                  </span>
+                  {item.highlight && (
+                    <span className="wk-doc-search__snippet">
+                      {renderHighlight(item.highlight)}
+                    </span>
+                  )}
+                  <span className="wk-doc-search__sub">
+                    {formatUpdatedAt(item.updatedAt, locale)}
+                  </span>
+                </span>
+              </button>
+            ))}
+            {loadingMore && (
+              <div className="wk-doc-search__hint" role="status">
+                {t("base.globalSearch.docs.loading")}
+              </div>
+            )}
+            {paginationError && (
+              <div className="wk-doc-search__loadmore">
+                <span>{paginationError}</span>
+                <button type="button" onClick={() => loadNextPage(true)}>
+                  {t("base.globalSearch.docs.loadMore")}
+                </button>
+              </div>
+            )}
+            {!loadingMore && !paginationError && response.hasMore && (
+              <div className="wk-doc-search__loadmore">
+                <button type="button" onClick={() => loadNextPage(true)}>
+                  {t("base.globalSearch.docs.loadMore")}
+                </button>
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default DocSearchPanel;

--- a/packages/dmworkbase/src/Components/GlobalSearch/DocSearchPanel.tsx
+++ b/packages/dmworkbase/src/Components/GlobalSearch/DocSearchPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useRef, useEffect } from "react";
+import React, { useCallback, useMemo } from "react";
 import { useI18n } from "../../i18n";
 import type {
   DocSearchItem,
@@ -49,6 +49,7 @@ const DOC_TYPE_BADGE: Record<string, string> = {
   doc: "DOC",
   sheet: "XLS",
   board: "BRD",
+  html: "WEB",
 };
 
 function formatUpdatedAt(ms: number, locale: string): string {
@@ -70,24 +71,18 @@ const DocSearchPanel: React.FC<DocSearchPanelProps> = ({
   const trimmed = keyword.trim();
   const canSearch = !!trimmed && isActive && !!dataSource.searchDocs;
 
-  // Accumulated item count across pages for the current query, used only to
-  // cap pagination once we've observed >= total. Reset on ANY change that
-  // makes useSearchPagination clear its own response.items — i.e. when the
-  // trimmed keyword changes AND when the enabled/canSearch state flips.
-  // useSearchPagination's own effect (deps: [enabled, ...]) clears its
-  // response every time enabled changes, so a tab switch (isActive false
-  // then true again with the same keyword) leaves visible items = 0 but
-  // would otherwise leave loadedRef at its stale accumulated value; the
-  // next first-page fetch would then push loadedRef >= total and prematurely
-  // hide load-more. Keying reset on both trimmed and canSearch mirrors the
-  // hook's own reset lifecycle so the accumulator stays in sync.
-  const loadedRef = useRef(0);
-  useEffect(() => {
-    loadedRef.current = 0;
-  }, [trimmed, canSearch]);
-
   // Reuse the shared cursor-paginator by encoding the 1-based page as the
   // cursor string ("2", "3", ...). searchDocs is page-based; map both ways.
+  //
+  // The stop condition is derived purely from the CURRENT request's own page
+  // number and the server total — no cross-render mutable counter. Earlier
+  // rounds kept a `loadedRef` accumulator that was `+=`-mutated inside this
+  // callback, but that ran before useSearchPagination applied its
+  // `requestIdRef` stale-response guard, so a discarded (superseded) request
+  // could still bump the shared counter and silently truncate a later valid
+  // page. `page * PAGE_SIZE` is a pure function of this request alone: a stale
+  // response can never poison a fresh query's pagination, and the hook already
+  // accumulates visible items in `response.items` for us.
   const searchPage = useCallback(
     async (cursor?: string) => {
       const page = cursor ? Number(cursor) || 1 : 1;
@@ -96,18 +91,15 @@ const DocSearchPanel: React.FC<DocSearchPanelProps> = ({
         page,
         pageSize: PAGE_SIZE,
       });
-      loadedRef.current += res.items.length;
       // Full-page detection must use the backend's ORIGINAL page size, not
       // res.items.length: SearchService.searchDocs drops items missing a
       // usable docId, which would otherwise forge a short page and stop
       // pagination early. rawItemCount is that pre-filter count.
       const rawCount = res.rawItemCount ?? res.items.length;
-      // Stop pagination when the backend gave us a genuinely short page
-      // (real end of the corpus) OR when the accumulated count has already
-      // reached the reported total. The two clauses are independent so a
-      // stale increment on loadedRef alone can't silently truncate results:
-      // a full page from the server still forces hasMore=true.
-      const hasMore = rawCount >= PAGE_SIZE && loadedRef.current < res.total;
+      // Continue only when the server returned a full page AND the pages we've
+      // requested so far haven't yet covered the reported total. Both clauses
+      // depend solely on this request, so no stale response can corrupt them.
+      const hasMore = rawCount >= PAGE_SIZE && page * PAGE_SIZE < res.total;
       return {
         items: res.items,
         hasMore,
@@ -176,7 +168,9 @@ const DocSearchPanel: React.FC<DocSearchPanelProps> = ({
                 onClick={() => onOpenDoc?.(item)}
               >
                 <span
-                  className={`wk-doc-search__icon wk-doc-search__icon--${item.docType}`}
+                  className={`wk-doc-search__icon wk-doc-search__icon--${
+                    DOC_TYPE_BADGE[item.docType] ? item.docType : "doc"
+                  }`}
                 >
                   {DOC_TYPE_BADGE[item.docType] ?? "DOC"}
                 </span>

--- a/packages/dmworkbase/src/Components/GlobalSearch/DocSearchPanel.tsx
+++ b/packages/dmworkbase/src/Components/GlobalSearch/DocSearchPanel.tsx
@@ -9,11 +9,12 @@ import "./doc-search-panel.css";
 
 const PAGE_SIZE = 20;
 
-// Stable identity extractor for the paginator's cross-page dedup. Must be
-// module-level (not an inline arrow) so useSearchPagination's `runSearch`
-// useCallback identity stays stable across renders — an inline function would
-// change every render and re-fire the search effect.
-const docDedupeKey = (item: DocSearchItem) => item.docId;
+// Upper bound on the highlight fragment we scan/render. renderHighlight walks
+// the string with a global regex and slices around each match; an unbounded
+// fragment (a pathological OpenSearch highlight) would make that scan and the
+// resulting node array grow with the input. The backend fragment is a short
+// snippet in practice, so truncating past this bound only affects abuse cases.
+const HIGHLIGHT_MAX_LEN = 2000;
 
 interface DocSearchPanelProps {
   keyword: string;
@@ -34,7 +35,13 @@ interface DocSearchPanelProps {
 // plain React string (auto-escaped by React), and only the marked spans are
 // wrapped in <em>. This never uses dangerouslySetInnerHTML, so injected markup
 // in the fragment cannot execute.
-function renderHighlight(fragment: string): React.ReactNode {
+function renderHighlight(rawFragment: string): React.ReactNode {
+  // Bound the scan so a pathologically long fragment can't drive a large slice
+  // loop / node array (defense-in-depth; real backend fragments are short).
+  const fragment =
+    rawFragment.length > HIGHLIGHT_MAX_LEN
+      ? rawFragment.slice(0, HIGHLIGHT_MAX_LEN)
+      : rawFragment;
   const pattern = /<em>([\s\S]*?)<\/em>/gi;
   const nodes: React.ReactNode[] = [];
   let cursor = 0;
@@ -77,46 +84,28 @@ const DocSearchPanel: React.FC<DocSearchPanelProps> = ({
   const trimmed = keyword.trim();
   const canSearch = !!trimmed && isActive && !!dataSource.searchDocs;
 
-  // Reuse the shared cursor-paginator by encoding the 1-based page as the
-  // cursor string ("2", "3", ...). searchDocs is page-based; map both ways.
-  //
-  // The stop condition is derived purely from the CURRENT request's own page
-  // number and the server total — no cross-render mutable counter. Earlier
-  // rounds kept a `loadedRef` accumulator that was `+=`-mutated inside this
-  // callback, but that ran before useSearchPagination applied its
-  // `requestIdRef` stale-response guard, so a discarded (superseded) request
-  // could still bump the shared counter and silently truncate a later valid
-  // page. `page * PAGE_SIZE` is a pure function of this request alone: a stale
-  // response can never poison a fresh query's pagination, and the hook already
-  // accumulates visible items in `response.items` for us.
+  // Keyset (search_after) pagination via the shared cursor-paginator: the hook
+  // passes the previous page's `nextCursor` back as `cursor` (undefined on the
+  // first page), and we surface the backend's `nextCursor` for the next round.
+  // hasMore is simply "the backend handed us a nextCursor" — no page/total
+  // arithmetic, so index churn between pages can't skip or repeat a row.
   const searchPage = useCallback(
     async (cursor?: string) => {
-      const page = cursor ? Number(cursor) || 1 : 1;
       const res = await dataSource.searchDocs!({
         keyword: trimmed,
-        page,
+        cursor,
         pageSize: PAGE_SIZE,
       });
-      // Full-page detection must use the backend's ORIGINAL page size, not
-      // res.items.length: SearchService.searchDocs drops items missing a
-      // usable docId, which would otherwise forge a short page and stop
-      // pagination early. rawItemCount is that pre-filter count.
-      const rawCount = res.rawItemCount ?? res.items.length;
-      // Continue only when the server returned a full page AND the pages we've
-      // requested so far haven't yet covered the reported total. Both clauses
-      // depend solely on this request, so no stale response can corrupt them.
-      const hasMore = rawCount >= PAGE_SIZE && page * PAGE_SIZE < res.total;
       return {
         items: res.items,
-        hasMore,
-        nextCursor: hasMore ? String(page + 1) : undefined,
+        hasMore: !!res.nextCursor,
+        nextCursor: res.nextCursor,
       };
     },
     [dataSource, trimmed]
   );
 
   const {
-    autoPaginationPaused,
     contentRef,
     error,
     handleScroll,
@@ -130,9 +119,6 @@ const DocSearchPanel: React.FC<DocSearchPanelProps> = ({
     enabled: canSearch,
     search: searchPage,
     errorMessage: t("base.globalSearch.docs.searchFailed"),
-    // Offset paging has no stable cursor: index churn can repeat a docId across
-    // pages. Dedup by docId so a repeat can't collide React keys (contract #4).
-    dedupeKey: docDedupeKey,
   });
 
   const items = response.items;
@@ -215,28 +201,19 @@ const DocSearchPanel: React.FC<DocSearchPanelProps> = ({
             </button>
           </div>
         )}
-        {!loadingMore &&
-          !paginationError &&
-          !autoPaginationPaused &&
-          response.hasMore && (
-            <div className="wk-doc-search__loadmore">
-              <button type="button" onClick={() => loadNextPage(true)}>
-                {t("base.globalSearch.docs.loadMore")}
-              </button>
-            </div>
-          )}
-        {/* Auto-pagination paused on an empty page: force a retry so a run of
-            fully-filtered pages can't strand the user with no continuation. */}
-        {autoPaginationPaused &&
-          !paginationError &&
-          !loadingMore &&
-          response.hasMore && (
-            <div className="wk-doc-search__loadmore">
-              <button type="button" onClick={() => loadNextPage(true)}>
-                {t("base.globalSearch.docs.loadMore")}
-              </button>
-            </div>
-          )}
+        {/* Manual continuation. Shown whenever there's a next page and we're not
+            mid-load or in an error state — this single branch covers both the
+            normal case and the auto-pagination-paused case (a run of fully
+            empty pages), since loadNextPage(true) forces past the pause guard.
+            Merged from two identical buttons that only differed on the
+            autoPaginationPaused flag. */}
+        {!loadingMore && !paginationError && response.hasMore && (
+          <div className="wk-doc-search__loadmore">
+            <button type="button" onClick={() => loadNextPage(true)}>
+              {t("base.globalSearch.docs.loadMore")}
+            </button>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/packages/dmworkbase/src/Components/GlobalSearch/DocSearchPanel.tsx
+++ b/packages/dmworkbase/src/Components/GlobalSearch/DocSearchPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from "react";
+import React, { useCallback, useMemo, useRef, useEffect } from "react";
 import { useI18n } from "../../i18n";
 import type {
   DocSearchItem,
@@ -16,9 +16,10 @@ interface DocSearchPanelProps {
   // hidden panel must not run/paginate its search. Gate on isActive (same
   // reasoning as GlobalContentSearchPanel).
   isActive?: boolean;
-  // Integration point: open the clicked cloud doc, then dismiss the search
-  // modal. Wired by the host (route/endpoint TBD). No-op default keeps P0
-  // self-contained without hardcoding an unverified route.
+  // Integration point: open the clicked cloud doc. Wired by the host (Chat) to
+  // buildDocLink -> window.open in a new tab; the search modal is deliberately
+  // kept open so several results can be opened in turn. No-op default keeps this
+  // panel self-contained when the prop is unwired.
   onOpenDoc?: (item: DocSearchItem) => void;
 }
 
@@ -69,18 +70,32 @@ const DocSearchPanel: React.FC<DocSearchPanelProps> = ({
   const trimmed = keyword.trim();
   const canSearch = !!trimmed && isActive && !!dataSource.searchDocs;
 
+  // Accumulated item count across pages, used to derive hasMore (see searchPage).
+  // Reset whenever the query changes so a new search starts from zero.
+  const loadedRef = useRef(0);
+  useEffect(() => {
+    loadedRef.current = 0;
+  }, [trimmed]);
+
   // Reuse the shared cursor-paginator by encoding the 1-based page as the
   // cursor string ("2", "3", ...). searchDocs is page-based; map both ways.
   const searchPage = useCallback(
     async (cursor?: string) => {
       const page = cursor ? Number(cursor) || 1 : 1;
+      if (!cursor) loadedRef.current = 0;
       const res = await dataSource.searchDocs!({
         keyword: trimmed,
         page,
         pageSize: PAGE_SIZE,
       });
-      const loaded = page * PAGE_SIZE;
-      const hasMore = loaded < res.total;
+      loadedRef.current += res.items.length;
+      // Derive "more" from the accumulated count, not page * PAGE_SIZE: this
+      // endpoint may return a short non-final page (visibility/soft-delete
+      // filtering), and a page-number denominator would race ahead of the real
+      // item count and drop the remaining hits. A short page also means no more
+      // can follow. Mirrors the docs module's own offset paginator.
+      const hasMore =
+        res.items.length === PAGE_SIZE && loadedRef.current < res.total;
       return {
         items: res.items,
         hasMore,

--- a/packages/dmworkbase/src/Components/GlobalSearch/DocSearchPanel.tsx
+++ b/packages/dmworkbase/src/Components/GlobalSearch/DocSearchPanel.tsx
@@ -70,8 +70,14 @@ const DocSearchPanel: React.FC<DocSearchPanelProps> = ({
   const trimmed = keyword.trim();
   const canSearch = !!trimmed && isActive && !!dataSource.searchDocs;
 
-  // Accumulated item count across pages, used to derive hasMore (see searchPage).
-  // Reset whenever the query changes so a new search starts from zero.
+  // Accumulated item count across pages for the current query, used only to
+  // cap pagination once we've observed >= total. Reset on keyword change:
+  // useSearchPagination's stale-request guard (requestIdRef) only kicks in
+  // AFTER search() returns, so a stale in-flight page could otherwise leak
+  // into this counter here. Keying reset on trimmed (not on "cursor is
+  // falsy") means stale increments are wiped the moment the query changes,
+  // and hasMore does not depend on this counter alone for stop decisions
+  // (see rawItemCount check below).
   const loadedRef = useRef(0);
   useEffect(() => {
     loadedRef.current = 0;
@@ -82,20 +88,23 @@ const DocSearchPanel: React.FC<DocSearchPanelProps> = ({
   const searchPage = useCallback(
     async (cursor?: string) => {
       const page = cursor ? Number(cursor) || 1 : 1;
-      if (!cursor) loadedRef.current = 0;
       const res = await dataSource.searchDocs!({
         keyword: trimmed,
         page,
         pageSize: PAGE_SIZE,
       });
       loadedRef.current += res.items.length;
-      // Derive "more" from the accumulated count, not page * PAGE_SIZE: this
-      // endpoint may return a short non-final page (visibility/soft-delete
-      // filtering), and a page-number denominator would race ahead of the real
-      // item count and drop the remaining hits. A short page also means no more
-      // can follow. Mirrors the docs module's own offset paginator.
-      const hasMore =
-        res.items.length === PAGE_SIZE && loadedRef.current < res.total;
+      // Full-page detection must use the backend's ORIGINAL page size, not
+      // res.items.length: SearchService.searchDocs drops items missing a
+      // usable docId, which would otherwise forge a short page and stop
+      // pagination early. rawItemCount is that pre-filter count.
+      const rawCount = res.rawItemCount ?? res.items.length;
+      // Stop pagination when the backend gave us a genuinely short page
+      // (real end of the corpus) OR when the accumulated count has already
+      // reached the reported total. The two clauses are independent so a
+      // stale increment on loadedRef alone can't silently truncate results:
+      // a full page from the server still forces hasMore=true.
+      const hasMore = rawCount >= PAGE_SIZE && loadedRef.current < res.total;
       return {
         items: res.items,
         hasMore,

--- a/packages/dmworkbase/src/Components/GlobalSearch/DocSearchPanel.tsx
+++ b/packages/dmworkbase/src/Components/GlobalSearch/DocSearchPanel.tsx
@@ -71,17 +71,20 @@ const DocSearchPanel: React.FC<DocSearchPanelProps> = ({
   const canSearch = !!trimmed && isActive && !!dataSource.searchDocs;
 
   // Accumulated item count across pages for the current query, used only to
-  // cap pagination once we've observed >= total. Reset on keyword change:
-  // useSearchPagination's stale-request guard (requestIdRef) only kicks in
-  // AFTER search() returns, so a stale in-flight page could otherwise leak
-  // into this counter here. Keying reset on trimmed (not on "cursor is
-  // falsy") means stale increments are wiped the moment the query changes,
-  // and hasMore does not depend on this counter alone for stop decisions
-  // (see rawItemCount check below).
+  // cap pagination once we've observed >= total. Reset on ANY change that
+  // makes useSearchPagination clear its own response.items — i.e. when the
+  // trimmed keyword changes AND when the enabled/canSearch state flips.
+  // useSearchPagination's own effect (deps: [enabled, ...]) clears its
+  // response every time enabled changes, so a tab switch (isActive false
+  // then true again with the same keyword) leaves visible items = 0 but
+  // would otherwise leave loadedRef at its stale accumulated value; the
+  // next first-page fetch would then push loadedRef >= total and prematurely
+  // hide load-more. Keying reset on both trimmed and canSearch mirrors the
+  // hook's own reset lifecycle so the accumulator stays in sync.
   const loadedRef = useRef(0);
   useEffect(() => {
     loadedRef.current = 0;
-  }, [trimmed]);
+  }, [trimmed, canSearch]);
 
   // Reuse the shared cursor-paginator by encoding the 1-based page as the
   // cursor string ("2", "3", ...). searchDocs is page-based; map both ways.

--- a/packages/dmworkbase/src/Components/GlobalSearch/DocSearchPanel.tsx
+++ b/packages/dmworkbase/src/Components/GlobalSearch/DocSearchPanel.tsx
@@ -9,6 +9,12 @@ import "./doc-search-panel.css";
 
 const PAGE_SIZE = 20;
 
+// Stable identity extractor for the paginator's cross-page dedup. Must be
+// module-level (not an inline arrow) so useSearchPagination's `runSearch`
+// useCallback identity stays stable across renders — an inline function would
+// change every render and re-fire the search effect.
+const docDedupeKey = (item: DocSearchItem) => item.docId;
+
 interface DocSearchPanelProps {
   keyword: string;
   dataSource: GlobalSearchDataSource;
@@ -52,7 +58,7 @@ const DOC_TYPE_BADGE: Record<string, string> = {
   html: "WEB",
 };
 
-function formatUpdatedAt(ms: number, locale: string): string {
+function formatUpdatedAt(ms: number | null, locale: string): string {
   if (!ms) return "";
   try {
     return new Date(ms).toLocaleDateString(locale);
@@ -110,6 +116,7 @@ const DocSearchPanel: React.FC<DocSearchPanelProps> = ({
   );
 
   const {
+    autoPaginationPaused,
     contentRef,
     error,
     handleScroll,
@@ -123,6 +130,9 @@ const DocSearchPanel: React.FC<DocSearchPanelProps> = ({
     enabled: canSearch,
     search: searchPage,
     errorMessage: t("base.globalSearch.docs.searchFailed"),
+    // Offset paging has no stable cursor: index churn can repeat a docId across
+    // pages. Dedup by docId so a repeat can't collide React keys (contract #4).
+    dedupeKey: docDedupeKey,
   });
 
   const items = response.items;
@@ -156,11 +166,9 @@ const DocSearchPanel: React.FC<DocSearchPanelProps> = ({
         ref={contentRef}
         onScroll={handleScroll}
       >
-        {items.length === 0 ? (
-          emptyState
-        ) : (
-          <>
-            {items.map((item) => (
+        {items.length === 0
+          ? emptyState
+          : items.map((item) => (
               <button
                 type="button"
                 key={item.docId}
@@ -189,28 +197,46 @@ const DocSearchPanel: React.FC<DocSearchPanelProps> = ({
                 </span>
               </button>
             ))}
-            {loadingMore && (
-              <div className="wk-doc-search__hint" role="status">
-                {t("base.globalSearch.docs.loading")}
-              </div>
-            )}
-            {paginationError && (
-              <div className="wk-doc-search__loadmore">
-                <span>{paginationError}</span>
-                <button type="button" onClick={() => loadNextPage(true)}>
-                  {t("base.globalSearch.docs.loadMore")}
-                </button>
-              </div>
-            )}
-            {!loadingMore && !paginationError && response.hasMore && (
-              <div className="wk-doc-search__loadmore">
-                <button type="button" onClick={() => loadNextPage(true)}>
-                  {t("base.globalSearch.docs.loadMore")}
-                </button>
-              </div>
-            )}
-          </>
+        {/* Continuation controls are siblings of the results/empty branch, not
+            nested inside it — otherwise an empty accumulator (every fetched
+            page dropped by the docId filter, so items.length === 0 while the
+            server still reports hasMore) hides the only way to continue and
+            dead-ends the query. Mirrors GlobalContentSearchPanel. */}
+        {loadingMore && (
+          <div className="wk-doc-search__hint" role="status">
+            {t("base.globalSearch.docs.loading")}
+          </div>
         )}
+        {paginationError && (
+          <div className="wk-doc-search__loadmore">
+            <span>{paginationError}</span>
+            <button type="button" onClick={() => loadNextPage(true)}>
+              {t("base.globalSearch.docs.loadMore")}
+            </button>
+          </div>
+        )}
+        {!loadingMore &&
+          !paginationError &&
+          !autoPaginationPaused &&
+          response.hasMore && (
+            <div className="wk-doc-search__loadmore">
+              <button type="button" onClick={() => loadNextPage(true)}>
+                {t("base.globalSearch.docs.loadMore")}
+              </button>
+            </div>
+          )}
+        {/* Auto-pagination paused on an empty page: force a retry so a run of
+            fully-filtered pages can't strand the user with no continuation. */}
+        {autoPaginationPaused &&
+          !paginationError &&
+          !loadingMore &&
+          response.hasMore && (
+            <div className="wk-doc-search__loadmore">
+              <button type="button" onClick={() => loadNextPage(true)}>
+                {t("base.globalSearch.docs.loadMore")}
+              </button>
+            </div>
+          )}
       </div>
     </div>
   );

--- a/packages/dmworkbase/src/Components/GlobalSearch/__tests__/docSearchHighlight.test.tsx
+++ b/packages/dmworkbase/src/Components/GlobalSearch/__tests__/docSearchHighlight.test.tsx
@@ -1,0 +1,78 @@
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+// i18n: identity translator so the panel renders without a provider.
+vi.mock("../../../i18n", () => ({
+  useI18n: () => ({ t: (k: string) => k, locale: "en-US" }),
+}));
+
+import type {
+  DocSearchItem,
+  GlobalSearchDataSource,
+} from "../../../Service/SearchTypes";
+import DocSearchPanel from "../DocSearchPanel";
+
+// The backend `highlight` fragment carries <em></em> emphasis markers around
+// matched terms. renderHighlight (in DocSearchPanel) is the XSS boundary: it
+// must render ONLY <em> from an allowlist and treat everything else as plain,
+// React-escaped text — never dangerouslySetInnerHTML. These tests pin that
+// invariant so a future "simplification" toward innerHTML can't silently
+// re-open XSS.
+function makeDataSource(highlight: string): GlobalSearchDataSource {
+  const item: DocSearchItem = {
+    docId: "d1",
+    title: "Result",
+    docType: "doc",
+    updatedAt: 0,
+    highlight,
+  };
+  return {
+    searchDocs: vi.fn(async () => ({ total: 1, items: [item] })),
+  } as unknown as GlobalSearchDataSource;
+}
+
+function renderPanel(highlight: string) {
+  return render(
+    <DocSearchPanel keyword="term" dataSource={makeDataSource(highlight)} />
+  );
+}
+
+describe("DocSearchPanel renderHighlight — <em>-only XSS allowlist", () => {
+  it("wraps only the <em> span and escapes surrounding text", async () => {
+    renderPanel("before <em>hit</em> after");
+    const em = await screen.findByText("hit");
+    expect(em.tagName).toBe("EM");
+    // The surrounding text is present as plain text (React-escaped).
+    expect(await screen.findByText(/before/)).toBeInTheDocument();
+  });
+
+  it("does NOT execute injected markup — a script tag renders as inert text", async () => {
+    const { container } = renderPanel(
+      "<em>ok</em> <script>alert(1)</script> <img src=x onerror=alert(1)>"
+    );
+    await screen.findByText("ok");
+    // No live <script>/<img> element was created from the fragment.
+    expect(container.querySelector("script")).toBeNull();
+    expect(container.querySelector("img")).toBeNull();
+    // The dangerous markup survives as escaped text content.
+    expect(container.textContent).toContain("<script>alert(1)</script>");
+  });
+
+  it("treats HTML nested inside <em> as text, not elements", async () => {
+    const { container } = renderPanel("<em><b>bold</b></em>");
+    // Wait for the async search result to render before inspecting the DOM.
+    await screen.findByText("Result");
+    // The <em> is created (allowlisted) but the inner <b> is NOT an element.
+    expect(container.querySelector("em")).not.toBeNull();
+    expect(container.querySelector("b")).toBeNull();
+    expect(container.textContent).toContain("<b>bold</b>");
+  });
+
+  it("renders a plain fragment with no <em> as text without throwing", async () => {
+    const { container } = renderPanel("just plain text");
+    expect(await screen.findByText(/just plain text/)).toBeInTheDocument();
+    expect(container.querySelector("em")).toBeNull();
+  });
+});

--- a/packages/dmworkbase/src/Components/GlobalSearch/__tests__/docSearchPagination.test.tsx
+++ b/packages/dmworkbase/src/Components/GlobalSearch/__tests__/docSearchPagination.test.tsx
@@ -85,7 +85,7 @@ describe("DocSearchPanel — pagination stop conditions", () => {
     // stop condition depended on a shared mutable accumulator, the late "old"
     // resolution would still bump it and could push the "new" query's hasMore
     // false. With `page * PAGE_SIZE` derivation, the stale resolution is inert.
-    let releaseOld: (() => void) | null = null;
+    let releaseOld!: () => void;
     const oldGate = new Promise<void>((resolve) => {
       releaseOld = resolve;
     });
@@ -114,7 +114,7 @@ describe("DocSearchPanel — pagination stop conditions", () => {
     await screen.findByText("n0");
 
     // Now let the stale "old" request resolve.
-    releaseOld?.();
+    releaseOld();
     await oldGate;
     // Give React a tick to (not) apply the discarded response.
     await new Promise((r) => setTimeout(r, 50));
@@ -124,5 +124,47 @@ describe("DocSearchPanel — pagination stop conditions", () => {
     expect(document.body.querySelector(".wk-doc-search__loadmore")).toBeNull();
     expect(screen.queryByText("o0")).toBeNull();
     expect(screen.getByText("n0")).toBeInTheDocument();
+  });
+});
+
+describe("DocSearchPanel — updatedAt rendering (contract: number | null)", () => {
+  // The backend returns updatedAt as `number | null` epoch millis; SearchService
+  // coerces stray values to positive-millis-or-null. The panel's formatUpdatedAt
+  // must render "" for null (early return on falsy) and a date for valid millis,
+  // never an "Invalid Date".
+  function itemWith(updatedAt: number | null): DocSearchItem {
+    return { docId: "x1", title: "hello-doc", docType: "doc", updatedAt };
+  }
+
+  it("renders an empty sub line when updatedAt is null", async () => {
+    const dataSource = makeDataSource(async () => ({
+      total: 1,
+      items: [itemWith(null)],
+      rawItemCount: 1,
+    }));
+    const { container } = render(
+      <DocSearchPanel keyword="k" dataSource={dataSource} />
+    );
+    await screen.findByText("hello-doc");
+    const sub = container.querySelector(".wk-doc-search__sub");
+    expect(sub).not.toBeNull();
+    expect(sub?.textContent).toBe("");
+  });
+
+  it("renders a date (not Invalid Date) for valid epoch millis", async () => {
+    const millis = Date.UTC(2024, 0, 15, 12, 0, 0); // 2024-01-15
+    const dataSource = makeDataSource(async () => ({
+      total: 1,
+      items: [itemWith(millis)],
+      rawItemCount: 1,
+    }));
+    const { container } = render(
+      <DocSearchPanel keyword="k" dataSource={dataSource} />
+    );
+    await screen.findByText("hello-doc");
+    const sub = container.querySelector(".wk-doc-search__sub");
+    expect(sub?.textContent).toBe(new Date(millis).toLocaleDateString("en-US"));
+    expect(sub?.textContent).not.toContain("Invalid");
+    expect(sub?.textContent).not.toBe("");
   });
 });

--- a/packages/dmworkbase/src/Components/GlobalSearch/__tests__/docSearchPagination.test.tsx
+++ b/packages/dmworkbase/src/Components/GlobalSearch/__tests__/docSearchPagination.test.tsx
@@ -1,0 +1,123 @@
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+// i18n: identity translator so the panel renders without a provider.
+vi.mock("../../../i18n", () => ({
+  useI18n: () => ({ t: (k: string) => k, locale: "en-US" }),
+}));
+
+import type {
+  DocSearchItem,
+  DocSearchQuery,
+  DocSearchResponse,
+  GlobalSearchDataSource,
+} from "../../../Service/SearchTypes";
+import DocSearchPanel from "../DocSearchPanel";
+
+// ReviewBot round 3 P1 pair, both in DocSearchPanel's searchPage:
+//   P1-1  loadedRef self-incremented BEFORE useSearchPagination's stale
+//         guard, so a discarded response still counted toward hasMore and
+//         truncated results silently (only 80/95 visible, no hint).
+//   P1-2  A "short page => stop" rule that used items.length, but
+//         SearchService.searchDocs drops malformed rows and forges a short
+//         page — the full-page check must look at the backend's pre-filter
+//         count (rawItemCount), not the post-filter count.
+//
+// These tests pin both invariants at the panel level so a future rewrite of
+// the hasMore expression cannot silently re-open either regression.
+
+const PAGE_SIZE = 20;
+
+function makeItem(id: string): DocSearchItem {
+  return { docId: id, title: id, docType: "doc", updatedAt: 0 };
+}
+
+function makeDataSource(
+  impl: (q: DocSearchQuery) => Promise<DocSearchResponse>
+): GlobalSearchDataSource {
+  return { searchDocs: vi.fn(impl) } as unknown as GlobalSearchDataSource;
+}
+
+describe("DocSearchPanel — pagination stop conditions (ReviewBot round 3 P1)", () => {
+  it("does NOT stop when the backend returned a full page but the client filter dropped some (rawItemCount saves the day)", async () => {
+    // Backend genuinely returned PAGE_SIZE rows, but 2 of them are malformed
+    // and get filtered out by SearchService before reaching the panel.
+    // rawItemCount = PAGE_SIZE => still a full page => hasMore must stay true.
+    const dataSource = makeDataSource(async () => ({
+      total: 100,
+      items: Array.from({ length: PAGE_SIZE - 2 }, (_, i) => makeItem(`d${i}`)),
+      rawItemCount: PAGE_SIZE,
+    }));
+
+    render(<DocSearchPanel keyword="k" dataSource={dataSource} />);
+
+    // Wait for first page to render, then the "load more" button must be
+    // present (proving hasMore=true despite items.length < PAGE_SIZE).
+    await screen.findByText("d0");
+    const loadMore = await screen.findByRole("button", {
+      name: "base.globalSearch.docs.loadMore",
+    });
+    expect(loadMore).toBeInTheDocument();
+  });
+
+  it("DOES stop when the backend itself returned a short page (real end of results)", async () => {
+    // Genuine short page: rawItemCount matches items.length and is < PAGE_SIZE.
+    // The pager should treat this as the final page and NOT show load-more.
+    const dataSource = makeDataSource(async () => ({
+      total: 3,
+      items: [makeItem("a"), makeItem("b"), makeItem("c")],
+      rawItemCount: 3,
+    }));
+
+    const { container } = render(
+      <DocSearchPanel keyword="k" dataSource={dataSource} />
+    );
+
+    await screen.findByText("a");
+    // No load-more button should be rendered for a real short final page.
+    expect(container.querySelector(".wk-doc-search__loadmore")).toBeNull();
+  });
+
+  it("resets the accumulated counter on keyword change so a stale in-flight page cannot poison the next query", async () => {
+    // Simulate a stale page: for keyword "old" the backend returns a full
+    // page (rawItemCount=PAGE_SIZE, total=100), then the user changes the
+    // keyword to "new" whose corpus has only 5 items. The new query must
+    // NOT reuse the old query's loadedRef (which would already be at
+    // PAGE_SIZE and could interact with a smaller total to hide results).
+    let callArg: DocSearchQuery | null = null;
+    const dataSource = makeDataSource(async (q) => {
+      callArg = q;
+      if (q.keyword === "old") {
+        return {
+          total: 100,
+          items: Array.from({ length: PAGE_SIZE }, (_, i) => makeItem(`o${i}`)),
+          rawItemCount: PAGE_SIZE,
+        };
+      }
+      return {
+        total: 5,
+        items: Array.from({ length: 5 }, (_, i) => makeItem(`n${i}`)),
+        rawItemCount: 5,
+      };
+    });
+
+    const { rerender } = render(
+      <DocSearchPanel keyword="old" dataSource={dataSource} />
+    );
+    await screen.findByText("o0");
+    expect(callArg?.keyword).toBe("old");
+
+    rerender(<DocSearchPanel keyword="new" dataSource={dataSource} />);
+    // The new query renders its own 5 items and does NOT show load-more
+    // (correct: rawItemCount=5 < PAGE_SIZE, final page). If loadedRef had
+    // leaked across queries, this assertion would still pass — the tighter
+    // check is that the panel is not stuck showing an inflated hasMore
+    // state carried over from the previous query. See the "full page keeps
+    // hasMore true" test above for the positive case.
+    await screen.findByText("n0");
+    const { container } = { container: document.body };
+    expect(container.querySelector(".wk-doc-search__loadmore")).toBeNull();
+  });
+});

--- a/packages/dmworkbase/src/Components/GlobalSearch/__tests__/docSearchPagination.test.tsx
+++ b/packages/dmworkbase/src/Components/GlobalSearch/__tests__/docSearchPagination.test.tsx
@@ -16,17 +16,23 @@ import type {
 } from "../../../Service/SearchTypes";
 import DocSearchPanel from "../DocSearchPanel";
 
-// ReviewBot round 3 P1 pair, both in DocSearchPanel's searchPage:
-//   P1-1  loadedRef self-incremented BEFORE useSearchPagination's stale
-//         guard, so a discarded response still counted toward hasMore and
-//         truncated results silently (only 80/95 visible, no hint).
-//   P1-2  A "short page => stop" rule that used items.length, but
-//         SearchService.searchDocs drops malformed rows and forges a short
-//         page — the full-page check must look at the backend's pre-filter
-//         count (rawItemCount), not the post-filter count.
+// ReviewBot / Jerry-Xin flagged P1s that all live in DocSearchPanel's
+// searchPage stop-condition:
+//   round-3 P1-1  loadedRef self-incremented BEFORE useSearchPagination's
+//                 stale guard, so a discarded response still counted.
+//   round-3 P1-2  A "short page => stop" rule that used items.length, but
+//                 SearchService.searchDocs drops malformed rows and forges
+//                 a short page — the full-page check must look at the
+//                 backend's pre-filter count (rawItemCount).
+//   round-4 P1    loadedRef only reset on keyword change, but the hook
+//                 clears its response every time `enabled` flips. Switching
+//                 tabs (isActive false → true) with the same keyword left
+//                 loadedRef inflated, pushing hasMore false after the next
+//                 page-1 fetch. Fix: reset loadedRef on canSearch changes
+//                 too, mirroring the hook's own lifecycle.
 //
-// These tests pin both invariants at the panel level so a future rewrite of
-// the hasMore expression cannot silently re-open either regression.
+// These tests pin all three invariants so a future rewrite of hasMore
+// can't silently regress any of them.
 
 const PAGE_SIZE = 20;
 
@@ -40,7 +46,7 @@ function makeDataSource(
   return { searchDocs: vi.fn(impl) } as unknown as GlobalSearchDataSource;
 }
 
-describe("DocSearchPanel — pagination stop conditions (ReviewBot round 3 P1)", () => {
+describe("DocSearchPanel — pagination stop conditions (ReviewBot rounds 3/4 P1s)", () => {
   it("does NOT stop when the backend returned a full page but the client filter dropped some (rawItemCount saves the day)", async () => {
     // Backend genuinely returned PAGE_SIZE rows, but 2 of them are malformed
     // and get filtered out by SearchService before reaching the panel.
@@ -53,8 +59,6 @@ describe("DocSearchPanel — pagination stop conditions (ReviewBot round 3 P1)",
 
     render(<DocSearchPanel keyword="k" dataSource={dataSource} />);
 
-    // Wait for first page to render, then the "load more" button must be
-    // present (proving hasMore=true despite items.length < PAGE_SIZE).
     await screen.findByText("d0");
     const loadMore = await screen.findByRole("button", {
       name: "base.globalSearch.docs.loadMore",
@@ -64,7 +68,6 @@ describe("DocSearchPanel — pagination stop conditions (ReviewBot round 3 P1)",
 
   it("DOES stop when the backend itself returned a short page (real end of results)", async () => {
     // Genuine short page: rawItemCount matches items.length and is < PAGE_SIZE.
-    // The pager should treat this as the final page and NOT show load-more.
     const dataSource = makeDataSource(async () => ({
       total: 3,
       items: [makeItem("a"), makeItem("b"), makeItem("c")],
@@ -76,19 +79,14 @@ describe("DocSearchPanel — pagination stop conditions (ReviewBot round 3 P1)",
     );
 
     await screen.findByText("a");
-    // No load-more button should be rendered for a real short final page.
     expect(container.querySelector(".wk-doc-search__loadmore")).toBeNull();
   });
 
-  it("resets the accumulated counter on keyword change so a stale in-flight page cannot poison the next query", async () => {
-    // Simulate a stale page: for keyword "old" the backend returns a full
-    // page (rawItemCount=PAGE_SIZE, total=100), then the user changes the
-    // keyword to "new" whose corpus has only 5 items. The new query must
-    // NOT reuse the old query's loadedRef (which would already be at
-    // PAGE_SIZE and could interact with a smaller total to hide results).
-    let callArg: DocSearchQuery | null = null;
+  it("resets the accumulated counter on keyword change so a stale count cannot poison the next query", async () => {
+    // Keyword changes from "old" (full page, big total) to "new" (short page,
+    // small total). The new query must render its own items without carrying
+    // any accumulated state from the previous query.
     const dataSource = makeDataSource(async (q) => {
-      callArg = q;
       if (q.keyword === "old") {
         return {
           total: 100,
@@ -107,17 +105,38 @@ describe("DocSearchPanel — pagination stop conditions (ReviewBot round 3 P1)",
       <DocSearchPanel keyword="old" dataSource={dataSource} />
     );
     await screen.findByText("o0");
-    expect(callArg?.keyword).toBe("old");
 
     rerender(<DocSearchPanel keyword="new" dataSource={dataSource} />);
-    // The new query renders its own 5 items and does NOT show load-more
-    // (correct: rawItemCount=5 < PAGE_SIZE, final page). If loadedRef had
-    // leaked across queries, this assertion would still pass — the tighter
-    // check is that the panel is not stuck showing an inflated hasMore
-    // state carried over from the previous query. See the "full page keeps
-    // hasMore true" test above for the positive case.
     await screen.findByText("n0");
-    const { container } = { container: document.body };
-    expect(container.querySelector(".wk-doc-search__loadmore")).toBeNull();
+    // The new query is a genuine short final page, so no load-more.
+    expect(document.body.querySelector(".wk-doc-search__loadmore")).toBeNull();
+  });
+
+  it("resets the accumulated counter across tab-switch (isActive false then true) — Jerry-Xin round-4 P1 source guard", () => {
+    // Jerry-Xin round-4 P1: useSearchPagination clears its response every
+    // time `enabled` changes, but the accumulator lived in the panel and was
+    // only reset on trimmed. Switching away from the Cloud Docs tab and back
+    // with the same keyword produced: visible items = 0 but loadedRef still
+    // holding the previous accumulated value. On the next page-1 fetch,
+    // loadedRef.current += res.items.length pushed it past total and hasMore
+    // flipped false, hiding all subsequent pages. Fix: reset loadedRef on
+    // canSearch (enabled) changes too, mirroring the hook's own lifecycle.
+    //
+    // Rendering this end-to-end in jsdom is unreliable because the shared
+    // pagination hook's scroll-based auto-pagination is not gated by DOM
+    // metrics that jsdom fills in (see the older isActive.test.tsx suite for
+    // the same reason). Pin the fix at the source level instead: the effect
+    // that clears loadedRef MUST depend on canSearch, not just trimmed.
+    const fs = require("node:fs") as typeof import("node:fs");
+    const path = require("node:path") as typeof import("node:path");
+    const panelSrc = fs.readFileSync(
+      path.join(__dirname, "..", "DocSearchPanel.tsx"),
+      "utf8"
+    );
+    // Locate the loadedRef reset effect and assert its dependency array
+    // includes canSearch. This is the invariant Jerry-Xin's P1 requires.
+    expect(panelSrc).toMatch(
+      /loadedRef\.current\s*=\s*0;\s*\}\s*,\s*\[trimmed,\s*canSearch\]/
+    );
   });
 });

--- a/packages/dmworkbase/src/Components/GlobalSearch/__tests__/docSearchPagination.test.tsx
+++ b/packages/dmworkbase/src/Components/GlobalSearch/__tests__/docSearchPagination.test.tsx
@@ -16,20 +16,15 @@ import type {
 } from "../../../Service/SearchTypes";
 import DocSearchPanel from "../DocSearchPanel";
 
-// The pagination stop condition (DocSearchPanel's searchPage) went through
-// several revisions to close reachable "hasMore flips false while results
-// remain" defects:
-//   - A client-side docId filter can shrink a full page; full-page detection
-//     must use the backend's pre-filter count (rawItemCount), not
-//     items.length, or a full page reads as short and stops early.
-//   - The accumulated page count must not live in a cross-render mutable ref
-//     that a discarded (stale) response could still mutate ahead of the
-//     hook's request-id guard. It is now derived purely from the current
-//     request's own `page * PAGE_SIZE` versus the server total, so a stale
-//     response can never poison a fresh query's pagination.
-//
-// These tests pin those invariants so a future rewrite can't silently
-// regress them.
+// DocSearchPanel now paginates by keyset cursor (backend search_after): each
+// response carries an opaque `nextCursor` while a further page exists, and the
+// panel's stop condition is simply "no nextCursor" — no page/total arithmetic.
+// These tests pin that contract:
+//   - A response WITH nextCursor keeps the load-more control (more pages).
+//   - A response WITHOUT nextCursor stops pagination (final page), even when
+//     `total` is larger than the items rendered (total is display-only now).
+//   - A late (stale) response from a superseded keyword cannot corrupt the
+//     current query's pagination — the hook's requestId guard discards it.
 
 const PAGE_SIZE = 20;
 
@@ -44,31 +39,40 @@ function makeDataSource(
 }
 
 describe("DocSearchPanel — pagination stop conditions", () => {
-  it("does NOT stop when the backend returned a full page but the client filter dropped some (rawItemCount saves the day)", async () => {
-    // Backend genuinely returned PAGE_SIZE rows, but 2 of them are malformed
-    // and get filtered out by SearchService before reaching the panel.
-    // rawItemCount = PAGE_SIZE => still a full page => hasMore must stay true.
-    const dataSource = makeDataSource(async () => ({
-      total: 100,
-      items: Array.from({ length: PAGE_SIZE - 2 }, (_, i) => makeItem(`d${i}`)),
-      rawItemCount: PAGE_SIZE,
-    }));
+  it("keeps the load-more control when the backend returns a nextCursor (more pages)", async () => {
+    // jsdom reports all scroll metrics as 0, so the panel's auto-pagination
+    // effect always reads "near bottom" and keeps fetching the next page on its
+    // own. That is fine for this assertion: as long as every page keeps handing
+    // back a nextCursor, `response.hasMore` stays true and the load-more control
+    // must remain rendered. Give each page a distinct cursor + fresh rows so the
+    // crawl makes forward progress (no duplicate keys) and the button never
+    // disappears — the opposite of the terminal-page case covered below.
+    let call = 0;
+    const dataSource = makeDataSource(async () => {
+      call += 1;
+      const base = call * 100;
+      return {
+        total: 1000,
+        items: Array.from({ length: PAGE_SIZE }, (_, i) => makeItem(`d${base + i}`)),
+        nextCursor: `cursor-${call + 1}`,
+      };
+    });
 
     render(<DocSearchPanel keyword="k" dataSource={dataSource} />);
 
-    await screen.findByText("d0");
+    await screen.findByText("d100");
     const loadMore = await screen.findByRole("button", {
       name: "base.globalSearch.docs.loadMore",
     });
     expect(loadMore).toBeInTheDocument();
   });
 
-  it("DOES stop when the backend itself returned a short page (real end of results)", async () => {
-    // Genuine short page: rawItemCount matches items.length and is < PAGE_SIZE.
+  it("stops when the backend omits nextCursor, even if total exceeds the rendered items", async () => {
+    // No nextCursor => final page. total is display-only and must NOT resurrect
+    // a load-more control on its own.
     const dataSource = makeDataSource(async () => ({
-      total: 3,
+      total: 999,
       items: [makeItem("a"), makeItem("b"), makeItem("c")],
-      rawItemCount: 3,
     }));
 
     const { container } = render(
@@ -79,12 +83,40 @@ describe("DocSearchPanel — pagination stop conditions", () => {
     expect(container.querySelector(".wk-doc-search__loadmore")).toBeNull();
   });
 
+  it("sends the previous response's nextCursor back as the cursor on the next page", async () => {
+    const searchDocs = vi.fn(async (q: DocSearchQuery) => {
+      if (!q.cursor) {
+        return {
+          total: 40,
+          items: Array.from({ length: PAGE_SIZE }, (_, i) => makeItem(`p1_${i}`)),
+          nextCursor: "cursor-2",
+        };
+      }
+      return {
+        total: 40,
+        items: [makeItem("p2_0")],
+      };
+    });
+    const dataSource = { searchDocs } as unknown as GlobalSearchDataSource;
+
+    render(<DocSearchPanel keyword="k" dataSource={dataSource} />);
+    // First call: no cursor (first page).
+    await screen.findByText("p1_0");
+    expect(searchDocs.mock.calls[0]![0].cursor).toBeUndefined();
+
+    // jsdom's zeroed scroll metrics make the panel auto-fetch the next page;
+    // whether the second request comes from that or a manual click, it must
+    // echo page 1's nextCursor. Wait for it and assert the cursor round-trip.
+    await screen.findByText("p2_0");
+    expect(searchDocs.mock.calls[1]![0].cursor).toBe("cursor-2");
+  });
+
   it("keyword change: a late (stale) response from the previous query cannot corrupt the new query's pagination", async () => {
-    // Reproduce the P1 race directly. Keyword "old" resolves LATE (deferred),
-    // keyword "new" resolves immediately as a genuine short final page. If the
-    // stop condition depended on a shared mutable accumulator, the late "old"
-    // resolution would still bump it and could push the "new" query's hasMore
-    // false. With `page * PAGE_SIZE` derivation, the stale resolution is inert.
+    // Reproduce the stale-response race directly. Keyword "old" resolves LATE
+    // (deferred) as a full page WITH a nextCursor; keyword "new" resolves
+    // immediately as a genuine final page (no nextCursor). The hook's requestId
+    // guard must discard the late "old" resolution so it neither leaks its items
+    // nor re-arms the load-more control on the "new" query.
     let releaseOld!: () => void;
     const oldGate = new Promise<void>((resolve) => {
       releaseOld = resolve;
@@ -96,18 +128,25 @@ describe("DocSearchPanel — pagination stop conditions", () => {
         return {
           total: 1000,
           items: Array.from({ length: PAGE_SIZE }, (_, i) => makeItem(`o${i}`)),
-          rawItemCount: PAGE_SIZE,
+          nextCursor: "old-cursor-2",
         };
       }
       return {
         total: 4,
         items: Array.from({ length: 4 }, (_, i) => makeItem(`n${i}`)),
-        rawItemCount: 4,
       };
     });
 
     const { rerender } = render(
       <DocSearchPanel keyword="old" dataSource={dataSource} />
+    );
+    // The "old" first request must actually have fired before we supersede it —
+    // otherwise this would be a no-op shell, not a real stale-response test.
+    await vi.waitFor(() =>
+      expect(
+        (dataSource.searchDocs as unknown as ReturnType<typeof vi.fn>).mock.calls
+          .length
+      ).toBeGreaterThan(0)
     );
     // Switch to "new" while "old" is still in flight.
     rerender(<DocSearchPanel keyword="new" dataSource={dataSource} />);
@@ -129,7 +168,7 @@ describe("DocSearchPanel — pagination stop conditions", () => {
 
 describe("DocSearchPanel — updatedAt rendering (contract: number | null)", () => {
   // The backend returns updatedAt as `number | null` epoch millis; SearchService
-  // coerces stray values to positive-millis-or-null. The panel's formatUpdatedAt
+  // coerces stray values to plausible-millis-or-null. The panel's formatUpdatedAt
   // must render "" for null (early return on falsy) and a date for valid millis,
   // never an "Invalid Date".
   function itemWith(updatedAt: number | null): DocSearchItem {
@@ -140,7 +179,6 @@ describe("DocSearchPanel — updatedAt rendering (contract: number | null)", () 
     const dataSource = makeDataSource(async () => ({
       total: 1,
       items: [itemWith(null)],
-      rawItemCount: 1,
     }));
     const { container } = render(
       <DocSearchPanel keyword="k" dataSource={dataSource} />
@@ -156,7 +194,6 @@ describe("DocSearchPanel — updatedAt rendering (contract: number | null)", () 
     const dataSource = makeDataSource(async () => ({
       total: 1,
       items: [itemWith(millis)],
-      rawItemCount: 1,
     }));
     const { container } = render(
       <DocSearchPanel keyword="k" dataSource={dataSource} />

--- a/packages/dmworkbase/src/Components/GlobalSearch/__tests__/docSearchPagination.test.tsx
+++ b/packages/dmworkbase/src/Components/GlobalSearch/__tests__/docSearchPagination.test.tsx
@@ -16,23 +16,20 @@ import type {
 } from "../../../Service/SearchTypes";
 import DocSearchPanel from "../DocSearchPanel";
 
-// ReviewBot / Jerry-Xin flagged P1s that all live in DocSearchPanel's
-// searchPage stop-condition:
-//   round-3 P1-1  loadedRef self-incremented BEFORE useSearchPagination's
-//                 stale guard, so a discarded response still counted.
-//   round-3 P1-2  A "short page => stop" rule that used items.length, but
-//                 SearchService.searchDocs drops malformed rows and forges
-//                 a short page — the full-page check must look at the
-//                 backend's pre-filter count (rawItemCount).
-//   round-4 P1    loadedRef only reset on keyword change, but the hook
-//                 clears its response every time `enabled` flips. Switching
-//                 tabs (isActive false → true) with the same keyword left
-//                 loadedRef inflated, pushing hasMore false after the next
-//                 page-1 fetch. Fix: reset loadedRef on canSearch changes
-//                 too, mirroring the hook's own lifecycle.
+// The pagination stop condition (DocSearchPanel's searchPage) went through
+// several revisions to close reachable "hasMore flips false while results
+// remain" defects:
+//   - A client-side docId filter can shrink a full page; full-page detection
+//     must use the backend's pre-filter count (rawItemCount), not
+//     items.length, or a full page reads as short and stops early.
+//   - The accumulated page count must not live in a cross-render mutable ref
+//     that a discarded (stale) response could still mutate ahead of the
+//     hook's request-id guard. It is now derived purely from the current
+//     request's own `page * PAGE_SIZE` versus the server total, so a stale
+//     response can never poison a fresh query's pagination.
 //
-// These tests pin all three invariants so a future rewrite of hasMore
-// can't silently regress any of them.
+// These tests pin those invariants so a future rewrite can't silently
+// regress them.
 
 const PAGE_SIZE = 20;
 
@@ -46,7 +43,7 @@ function makeDataSource(
   return { searchDocs: vi.fn(impl) } as unknown as GlobalSearchDataSource;
 }
 
-describe("DocSearchPanel — pagination stop conditions (ReviewBot rounds 3/4 P1s)", () => {
+describe("DocSearchPanel — pagination stop conditions", () => {
   it("does NOT stop when the backend returned a full page but the client filter dropped some (rawItemCount saves the day)", async () => {
     // Backend genuinely returned PAGE_SIZE rows, but 2 of them are malformed
     // and get filtered out by SearchService before reaching the panel.
@@ -82,61 +79,50 @@ describe("DocSearchPanel — pagination stop conditions (ReviewBot rounds 3/4 P1
     expect(container.querySelector(".wk-doc-search__loadmore")).toBeNull();
   });
 
-  it("resets the accumulated counter on keyword change so a stale count cannot poison the next query", async () => {
-    // Keyword changes from "old" (full page, big total) to "new" (short page,
-    // small total). The new query must render its own items without carrying
-    // any accumulated state from the previous query.
+  it("keyword change: a late (stale) response from the previous query cannot corrupt the new query's pagination", async () => {
+    // Reproduce the P1 race directly. Keyword "old" resolves LATE (deferred),
+    // keyword "new" resolves immediately as a genuine short final page. If the
+    // stop condition depended on a shared mutable accumulator, the late "old"
+    // resolution would still bump it and could push the "new" query's hasMore
+    // false. With `page * PAGE_SIZE` derivation, the stale resolution is inert.
+    let releaseOld: (() => void) | null = null;
+    const oldGate = new Promise<void>((resolve) => {
+      releaseOld = resolve;
+    });
+
     const dataSource = makeDataSource(async (q) => {
       if (q.keyword === "old") {
+        await oldGate; // resolves only after we switch to "new"
         return {
-          total: 100,
+          total: 1000,
           items: Array.from({ length: PAGE_SIZE }, (_, i) => makeItem(`o${i}`)),
           rawItemCount: PAGE_SIZE,
         };
       }
       return {
-        total: 5,
-        items: Array.from({ length: 5 }, (_, i) => makeItem(`n${i}`)),
-        rawItemCount: 5,
+        total: 4,
+        items: Array.from({ length: 4 }, (_, i) => makeItem(`n${i}`)),
+        rawItemCount: 4,
       };
     });
 
     const { rerender } = render(
       <DocSearchPanel keyword="old" dataSource={dataSource} />
     );
-    await screen.findByText("o0");
-
+    // Switch to "new" while "old" is still in flight.
     rerender(<DocSearchPanel keyword="new" dataSource={dataSource} />);
     await screen.findByText("n0");
-    // The new query is a genuine short final page, so no load-more.
-    expect(document.body.querySelector(".wk-doc-search__loadmore")).toBeNull();
-  });
 
-  it("resets the accumulated counter across tab-switch (isActive false then true) — Jerry-Xin round-4 P1 source guard", () => {
-    // Jerry-Xin round-4 P1: useSearchPagination clears its response every
-    // time `enabled` changes, but the accumulator lived in the panel and was
-    // only reset on trimmed. Switching away from the Cloud Docs tab and back
-    // with the same keyword produced: visible items = 0 but loadedRef still
-    // holding the previous accumulated value. On the next page-1 fetch,
-    // loadedRef.current += res.items.length pushed it past total and hasMore
-    // flipped false, hiding all subsequent pages. Fix: reset loadedRef on
-    // canSearch (enabled) changes too, mirroring the hook's own lifecycle.
-    //
-    // Rendering this end-to-end in jsdom is unreliable because the shared
-    // pagination hook's scroll-based auto-pagination is not gated by DOM
-    // metrics that jsdom fills in (see the older isActive.test.tsx suite for
-    // the same reason). Pin the fix at the source level instead: the effect
-    // that clears loadedRef MUST depend on canSearch, not just trimmed.
-    const fs = require("node:fs") as typeof import("node:fs");
-    const path = require("node:path") as typeof import("node:path");
-    const panelSrc = fs.readFileSync(
-      path.join(__dirname, "..", "DocSearchPanel.tsx"),
-      "utf8"
-    );
-    // Locate the loadedRef reset effect and assert its dependency array
-    // includes canSearch. This is the invariant Jerry-Xin's P1 requires.
-    expect(panelSrc).toMatch(
-      /loadedRef\.current\s*=\s*0;\s*\}\s*,\s*\[trimmed,\s*canSearch\]/
-    );
+    // Now let the stale "old" request resolve.
+    releaseOld?.();
+    await oldGate;
+    // Give React a tick to (not) apply the discarded response.
+    await new Promise((r) => setTimeout(r, 50));
+
+    // The "new" query is a genuine 4-item final page: no load-more, and the
+    // stale "old" full page must not have leaked in.
+    expect(document.body.querySelector(".wk-doc-search__loadmore")).toBeNull();
+    expect(screen.queryByText("o0")).toBeNull();
+    expect(screen.getByText("n0")).toBeInTheDocument();
   });
 });

--- a/packages/dmworkbase/src/Components/GlobalSearch/__tests__/isActive.test.tsx
+++ b/packages/dmworkbase/src/Components/GlobalSearch/__tests__/isActive.test.tsx
@@ -72,10 +72,8 @@ describe("GlobalContentSearchPanel — isActive gate (source guard)", () => {
 
   it("§D shared pagination rejects stale work while disabled", () => {
     expect(paginationHookSrc).toMatch(/if\s*\(\s*!enabled\s*\|\|\s*\(cursor/);
-    // The load-next-page callback must depend on the stale-guard trio; an
-    // optional dedupeKey (docs search) may also be listed since the merge
-    // closure reads it. Order-tolerant so a formatter reshuffle won't break it.
-    expect(paginationHookSrc).toMatch(/\[(?:dedupeKey,\s*)?enabled,\s*errorMessage,\s*search\]/);
+    // The load-next-page callback depends on exactly the stale-guard trio.
+    expect(paginationHookSrc).toMatch(/\[enabled,\s*errorMessage,\s*search\]/);
   });
 });
 

--- a/packages/dmworkbase/src/Components/GlobalSearch/__tests__/isActive.test.tsx
+++ b/packages/dmworkbase/src/Components/GlobalSearch/__tests__/isActive.test.tsx
@@ -72,7 +72,10 @@ describe("GlobalContentSearchPanel — isActive gate (source guard)", () => {
 
   it("§D shared pagination rejects stale work while disabled", () => {
     expect(paginationHookSrc).toMatch(/if\s*\(\s*!enabled\s*\|\|\s*\(cursor/);
-    expect(paginationHookSrc).toMatch(/\[enabled,\s*errorMessage,\s*search\]/);
+    // The load-next-page callback must depend on the stale-guard trio; an
+    // optional dedupeKey (docs search) may also be listed since the merge
+    // closure reads it. Order-tolerant so a formatter reshuffle won't break it.
+    expect(paginationHookSrc).toMatch(/\[(?:dedupeKey,\s*)?enabled,\s*errorMessage,\s*search\]/);
   });
 });
 

--- a/packages/dmworkbase/src/Components/GlobalSearch/doc-search-panel.css
+++ b/packages/dmworkbase/src/Components/GlobalSearch/doc-search-panel.css
@@ -1,0 +1,119 @@
+/* Cloud-docs search tab. Mirrors the chrome of the message/file content panels
+   (see global-content-search-panel.css) using the shared theme tokens from
+   theme/semantic.css. Kept token-only (no literal fallbacks) to match the
+   existing panels and to inherit light/dark theming automatically. */
+.wk-doc-search {
+  height: 100%;
+  min-height: 0;
+}
+.wk-doc-search__list {
+  height: var(--wk-global-search-content-height, min(58vh, 640px));
+  overflow: auto;
+  padding: var(--wk-sp-1) var(--wk-sp-2);
+}
+.wk-doc-search__item {
+  display: flex;
+  gap: var(--wk-sp-3);
+  width: 100%;
+  padding: var(--wk-sp-2) var(--wk-sp-3);
+  border: 0;
+  border-radius: var(--wk-r-md);
+  background: transparent;
+  text-align: left;
+  cursor: pointer;
+  align-items: flex-start;
+}
+.wk-doc-search__item:hover {
+  background: var(--wk-bg-item-hover);
+}
+.wk-doc-search__icon {
+  flex: none;
+  width: 38px;
+  height: 38px;
+  border-radius: var(--wk-r-sm);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--wk-text-inverse);
+  background: var(--wk-text-accent);
+}
+/* doc_type accent colours. Light values follow the product palette
+   (blue/green/orange); dark variants are dimmed to match the item-file.css
+   dark-mode convention. */
+.wk-doc-search__icon--doc {
+  background: #3370ff;
+}
+.wk-doc-search__icon--sheet {
+  background: #00b42a;
+}
+.wk-doc-search__icon--board {
+  background: #f7734b;
+}
+body[theme-mode="dark"] .wk-doc-search__icon--doc {
+  background: #2b5fd9;
+}
+body[theme-mode="dark"] .wk-doc-search__icon--sheet {
+  background: #009a24;
+}
+body[theme-mode="dark"] .wk-doc-search__icon--board {
+  background: #d9603c;
+}
+.wk-doc-search__meta {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+}
+.wk-doc-search__title {
+  font-size: 14px;
+  line-height: 20px;
+  color: var(--wk-text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.wk-doc-search__snippet {
+  font-size: 12px;
+  line-height: 18px;
+  color: var(--wk-text-secondary);
+  margin-top: 2px;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+.wk-doc-search__snippet em {
+  font-style: normal;
+  color: var(--wk-text-accent);
+  font-weight: 600;
+}
+.wk-doc-search__sub {
+  font-size: 12px;
+  color: var(--wk-text-tertiary);
+  margin-top: 4px;
+}
+.wk-doc-search__hint,
+.wk-doc-search__empty {
+  padding: var(--wk-sp-6) var(--wk-sp-4);
+  text-align: center;
+  color: var(--wk-text-tertiary);
+  font-size: 13px;
+}
+.wk-doc-search__loadmore {
+  display: flex;
+  gap: var(--wk-sp-2);
+  align-items: center;
+  justify-content: center;
+  padding: var(--wk-sp-3);
+  color: var(--wk-text-tertiary);
+  font-size: 12px;
+}
+.wk-doc-search__loadmore button {
+  border: 0;
+  background: transparent;
+  color: var(--wk-text-accent);
+  cursor: pointer;
+  font-size: 12px;
+}

--- a/packages/dmworkbase/src/Components/GlobalSearch/doc-search-panel.css
+++ b/packages/dmworkbase/src/Components/GlobalSearch/doc-search-panel.css
@@ -51,6 +51,9 @@
 .wk-doc-search__icon--board {
   background: #f7734b;
 }
+.wk-doc-search__icon--html {
+  background: #7a5af5;
+}
 body[theme-mode="dark"] .wk-doc-search__icon--doc {
   background: #2b5fd9;
 }
@@ -59,6 +62,9 @@ body[theme-mode="dark"] .wk-doc-search__icon--sheet {
 }
 body[theme-mode="dark"] .wk-doc-search__icon--board {
   background: #d9603c;
+}
+body[theme-mode="dark"] .wk-doc-search__icon--html {
+  background: #5f45c9;
 }
 .wk-doc-search__meta {
   flex: 1;

--- a/packages/dmworkbase/src/Components/GlobalSearch/doc-search-panel.css
+++ b/packages/dmworkbase/src/Components/GlobalSearch/doc-search-panel.css
@@ -39,32 +39,20 @@
   color: var(--wk-text-inverse);
   background: var(--wk-text-accent);
 }
-/* doc_type accent colours. Light values follow the product palette
-   (blue/green/orange); dark variants are dimmed to match the item-file.css
-   dark-mode convention. */
+/* doc_type accent colours. Sourced from the --wk-doc-accent-* semantic tokens
+   (theme/semantic.css), which carry both the light values and the dimmed dark
+   variants, so this file stays token-only and inherits theming automatically. */
 .wk-doc-search__icon--doc {
-  background: #3370ff;
+  background: var(--wk-doc-accent-doc);
 }
 .wk-doc-search__icon--sheet {
-  background: #00b42a;
+  background: var(--wk-doc-accent-sheet);
 }
 .wk-doc-search__icon--board {
-  background: #f7734b;
+  background: var(--wk-doc-accent-board);
 }
 .wk-doc-search__icon--html {
-  background: #7a5af5;
-}
-body[theme-mode="dark"] .wk-doc-search__icon--doc {
-  background: #2b5fd9;
-}
-body[theme-mode="dark"] .wk-doc-search__icon--sheet {
-  background: #009a24;
-}
-body[theme-mode="dark"] .wk-doc-search__icon--board {
-  background: #d9603c;
-}
-body[theme-mode="dark"] .wk-doc-search__icon--html {
-  background: #5f45c9;
+  background: var(--wk-doc-accent-html);
 }
 .wk-doc-search__meta {
   flex: 1;

--- a/packages/dmworkbase/src/Pages/Chat/index.tsx
+++ b/packages/dmworkbase/src/Pages/Chat/index.tsx
@@ -1713,7 +1713,31 @@ export default class ChatPage extends Component<any, ChatPageState> {
                         docId: item.docId,
                         space: item.spaceId,
                       });
-                      window.open(url, "_blank", "noopener,noreferrer");
+                      // window.open(url, "_blank", "noopener,noreferrer")
+                      // cannot be null-checked: per MDN, passing the
+                      // `noopener` feature makes window.open return null on
+                      // SUCCESS too, so `if (!opened)` false-positives on
+                      // every successful open. Open about:blank first to get
+                      // a truthful blocked/succeeded signal, then null the
+                      // opener (equivalent noopener isolation) and navigate.
+                      // Never fall back to location.href here: the search
+                      // modal must stay open so several results can be opened
+                      // in a row (see MeInfo/vm.tsx for the same pattern).
+                      const opened = window.open("about:blank", "_blank");
+                      if (!opened) {
+                        Toast.warning(
+                          t("base.globalSearch.docs.popupBlocked")
+                        );
+                        return;
+                      }
+                      try {
+                        opened.opener = null;
+                      } catch {
+                        // A few sandboxes freeze the opener setter; continue
+                        // navigating. about:blank is same-origin so the
+                        // residual risk is already contained.
+                      }
+                      opened.location.href = url;
                     }}
                     hideModal={() => {
                       vm.showGlobalSearch = false;

--- a/packages/dmworkbase/src/Pages/Chat/index.tsx
+++ b/packages/dmworkbase/src/Pages/Chat/index.tsx
@@ -47,6 +47,7 @@ import { ChannelInfoListener } from "wukongimjssdk";
 import { ChatMenus } from "../../App";
 import ConversationContext from "../../Components/Conversation/context";
 import GlobalSearch from "../../features/globalSearch/GlobalSearchPanel";
+import { buildDocLink } from "../../Utils/docLink";
 import { ShowConversationOptions } from "../../EndpointCommon";
 import SpaceList from "../../Components/SpaceList";
 import SpaceCreate from "../../Components/SpaceCreate";
@@ -1697,6 +1698,22 @@ export default class ChatPage extends Component<any, ChatPageState> {
                       void handleGlobalSearchClick(item, type, () => {
                         vm.showGlobalSearch = false;
                       });
+                    }}
+                    onOpenDoc={(item) => {
+                      // Open the clicked cloud-doc in the standalone `/d/:docId`
+                      // page, carrying the doc's real space on `?sp=` so the
+                      // preflight addresses the right space (buildDocLink). The
+                      // `/d` namespace is intercepted by apps/web Layout OUTSIDE
+                      // the app shell and is not a RouteManager route, so it can't
+                      // be reached by an in-shell soft push — open it in a new tab
+                      // (same as DocsHome's onOpenInNewPage), which leaves this
+                      // page untouched. The search modal stays open so the user
+                      // can open more results in a row.
+                      const url = buildDocLink({
+                        docId: item.docId,
+                        space: item.spaceId,
+                      });
+                      window.open(url, "_blank", "noopener,noreferrer");
                     }}
                     hideModal={() => {
                       vm.showGlobalSearch = false;

--- a/packages/dmworkbase/src/Service/SearchService.ts
+++ b/packages/dmworkbase/src/Service/SearchService.ts
@@ -20,6 +20,8 @@ import type {
   ChannelSearchQuery,
   ChannelSearchResponse,
   ChannelSearchTab,
+  DocSearchQuery,
+  DocSearchResponse,
   GlobalContentTab,
   GlobalSearchFileTypeCategory,
   GlobalSearchFilters,
@@ -423,6 +425,27 @@ const SearchService = {
         ? mapFilesResponse(resp, query, assets)
         : mapMessagesResponse(resp, query, assets);
     return foldResponse(items, pagination);
+  },
+
+  // Cloud-docs full-text search: octo-docs-backend `POST /api/v1/docs/search`.
+  // uid/spaceId are injected by the gateway (not sent from the client). The
+  // backend already applies MySQL-realtime visibility (incl. soft-delete
+  // exclusion), so the client renders items verbatim without any filtering.
+  async searchDocs(query: DocSearchQuery): Promise<DocSearchResponse> {
+    const body: Record<string, unknown> = {
+      q: query.keyword,
+      page: query.page,
+      pageSize: query.pageSize,
+    };
+    if (query.docType !== undefined) body.docType = query.docType;
+    const resp = await APIClient.shared.post("docs/search", body, {
+      signal: query.signal,
+    });
+    const items = Array.isArray(resp?.items) ? resp.items : [];
+    return {
+      total: typeof resp?.total === "number" ? resp.total : items.length,
+      items,
+    };
   },
 
   async getGlobalFileTypes(

--- a/packages/dmworkbase/src/Service/SearchService.ts
+++ b/packages/dmworkbase/src/Service/SearchService.ts
@@ -20,6 +20,7 @@ import type {
   ChannelSearchQuery,
   ChannelSearchResponse,
   ChannelSearchTab,
+  DocSearchItem,
   DocSearchQuery,
   DocSearchResponse,
   GlobalContentTab,
@@ -438,13 +439,21 @@ const SearchService = {
       pageSize: query.pageSize,
     };
     if (query.docType !== undefined) body.docType = query.docType;
-    const resp = await APIClient.shared.post("docs/search", body, {
-      signal: query.signal,
-    });
+    const resp = await APIClient.shared.post("docs/search", body);
     const items = Array.isArray(resp?.items) ? resp.items : [];
+    // Per-item validation at the service boundary: the backend contract says
+    // docId/title are always present, but a malformed item would otherwise flow
+    // to key={docId} (React duplicate-key collisions on undefined) and
+    // buildDocLink({docId}) -> /d/undefined. Drop items missing a usable docId.
+    const validItems = items.filter(
+      (it: unknown): it is DocSearchItem =>
+        !!it &&
+        typeof (it as DocSearchItem).docId === "string" &&
+        (it as DocSearchItem).docId !== ""
+    );
     return {
-      total: typeof resp?.total === "number" ? resp.total : items.length,
-      items,
+      total: typeof resp?.total === "number" ? resp.total : validItems.length,
+      items: validItems,
     };
   },
 

--- a/packages/dmworkbase/src/Service/SearchService.ts
+++ b/packages/dmworkbase/src/Service/SearchService.ts
@@ -377,12 +377,19 @@ export interface LegacyGlobalSearchResponse {
   messages: LegacyGlobalSearchMessage[];
 }
 
-// Coerce a doc search item's updatedAt to positive epoch millis, or null.
-// Backend contract is `number | null`; anything else (missing, non-finite, or
-// <= 0) becomes null so DocSearchPanel.formatUpdatedAt early-returns "" rather
-// than rendering an Invalid Date.
+// Coerce a doc search item's updatedAt to a plausible epoch-millis value, or
+// null. Backend contract is `number | null` (doc_meta.updated_at NOW(3)).
+// A bare `> 0` check would let a stray SECONDS value (e.g. 1.7e9 ≈ 1970 in ms)
+// or an absurdly large number through and render a wrong/Invalid date, so we
+// bound to (1e11, 1e14): ~1973-03 up to ~5138, which admits every real millis
+// timestamp while rejecting seconds-scale and garbage values. Anything outside
+// (missing, non-finite, or out of range) becomes null so
+// DocSearchPanel.formatUpdatedAt early-returns "" instead of a bad date.
 function coerceUpdatedAt(value: unknown): number | null {
-  return typeof value === "number" && Number.isFinite(value) && value > 0
+  return typeof value === "number" &&
+    Number.isFinite(value) &&
+    value > 1e11 &&
+    value < 1e14
     ? value
     : null;
 }
@@ -444,41 +451,42 @@ const SearchService = {
   // exclusion), so the client renders items verbatim without any filtering.
   //
   // Contract confirmed against octo-docs-backend source (osClient.ts +
-  // api/routes/docs.ts searchDocsHandler). Response shape:
-  //   { total, items: [{ docId, title, docType, updatedAt, spaceId, highlight? }] }
-  //   1. `total` — exact POST-visibility count (OS hits.total.value with
-  //      track_total_hits:true; the visible doc_id set is computed in MySQL and
-  //      pushed down as an OS `doc_id IN` filter). So `page * PAGE_SIZE < total`
-  //      is a correct stop condition and never over-counts. The fallback below
-  //      only fires if `total` is somehow not a number; it must NOT clamp to
-  //      validItems.length (that would forge hasMore=false on a full first
-  //      page) — we defer entirely to the full-page signal by using Infinity.
-  //   2. `updatedAt` — `number | null` epoch millis (NOT ISO string; the
+  // api/routes/docs.ts searchDocsHandler). Request/response shape:
+  //   req:  { q, cursor?, pageSize }  (backend also accepts an optional
+  //         docType[] kind filter, but this UI has no doc-type facet so we
+  //         never send it — omitted => no filter on the backend.)
+  //   resp: { total, items: [{ docId, title, docType, updatedAt, spaceId, highlight? }], nextCursor? }
+  //   1. Pagination is keyset (search_after), NOT offset. We send the previous
+  //      response's `nextCursor` verbatim (omitted on the first page) and read
+  //      `nextCursor` back — an opaque base64url token wrapping the last hit's
+  //      OpenSearch sort values. It is present only while a further page exists,
+  //      so the pager stops on `!nextCursor` (never a `page * size >= total`
+  //      arithmetic that offset paging can get wrong under index churn).
+  //   2. `total` — exact post-visibility count (OS hits.total.value with
+  //      track_total_hits:true). Kept for display only; it does NOT drive the
+  //      stop condition, so a missing/garbage total can't forge hasMore.
+  //   3. `updatedAt` — `number | null` epoch millis (NOT ISO string; the
   //      `string` in packages/docs/src/pages/docsApi.ts is a different REST
   //      DocMeta endpoint, unrelated to search). Coerced below to
-  //      positive-millis-or-null so a stray seconds value or garbage can't
-  //      render as an Invalid Date.
-  //   3. `spaceId` — returned on every item; search is single-space scoped
+  //      positive-millis-in-plausible-range-or-null so a stray seconds value or
+  //      garbage can't render as an Invalid Date.
+  //   4. `spaceId` — returned on every item; search is single-space scoped
   //      (OS term space_id, injected by the gateway, never from the body). We
   //      pass it through unchanged for buildDocLink's `?sp=`.
-  //   4. No cursor — pure from/size offset paging (pageSize <= pageSizeMax).
-  //      Offset paging under index churn can repeat a docId across pages, which
-  //      would collide React keys on merge; useSearchPagination dedupes merged
-  //      items by identity as a backstop (see its `dedupeKey` option).
   async searchDocs(query: DocSearchQuery): Promise<DocSearchResponse> {
     const body: Record<string, unknown> = {
       q: query.keyword,
-      page: query.page,
       pageSize: query.pageSize,
     };
-    if (query.docType !== undefined) body.docType = query.docType;
+    // Keyset cursor: omit on the first page so the backend starts from the top.
+    if (query.cursor) body.cursor = query.cursor;
     const resp = await APIClient.shared.post("docs/search", body);
     const items = Array.isArray(resp?.items) ? resp.items : [];
     // Per-item validation at the service boundary: the backend contract says
     // docId/title are always present, but a malformed item would otherwise flow
     // to key={docId} (React duplicate-key collisions on undefined) and
     // buildDocLink({docId}) -> /d/undefined. Drop items missing a usable docId,
-    // and coerce updatedAt to positive-millis-or-null (contract fact #2).
+    // and coerce updatedAt to positive-millis-or-null (contract fact #3).
     const validItems = items
       .filter(
         (it: unknown): it is DocSearchItem =>
@@ -490,18 +498,16 @@ const SearchService = {
         ...it,
         updatedAt: coerceUpdatedAt(it.updatedAt),
       }));
+    const nextCursor =
+      typeof resp?.nextCursor === "string" && resp.nextCursor !== ""
+        ? resp.nextCursor
+        : undefined;
     return {
-      // total is contractually an exact post-visibility count. If it is ever
-      // not a number, do NOT fall back to validItems.length (that caps a full
-      // page at one page); use Infinity so the pager relies solely on the
-      // full-page signal to decide hasMore.
-      total: typeof resp?.total === "number" ? resp.total : Number.POSITIVE_INFINITY,
+      // total is display-only under keyset paging; fall back to the visible
+      // count when absent (the pager relies on nextCursor, not total).
+      total: typeof resp?.total === "number" ? resp.total : validItems.length,
       items: validItems,
-      // Preserve the backend's original page size so the pager can detect a
-      // full page independently of our client-side filtering; without this,
-      // dropping a malformed row would forge a short page and prematurely
-      // stop pagination.
-      rawItemCount: items.length,
+      nextCursor,
     };
   },
 

--- a/packages/dmworkbase/src/Service/SearchService.ts
+++ b/packages/dmworkbase/src/Service/SearchService.ts
@@ -454,6 +454,11 @@ const SearchService = {
     return {
       total: typeof resp?.total === "number" ? resp.total : validItems.length,
       items: validItems,
+      // Preserve the backend's original page size so the pager can detect a
+      // full page independently of our client-side filtering; without this,
+      // dropping a malformed row would forge a short page and prematurely
+      // stop pagination.
+      rawItemCount: items.length,
     };
   },
 

--- a/packages/dmworkbase/src/Service/SearchService.ts
+++ b/packages/dmworkbase/src/Service/SearchService.ts
@@ -377,6 +377,16 @@ export interface LegacyGlobalSearchResponse {
   messages: LegacyGlobalSearchMessage[];
 }
 
+// Coerce a doc search item's updatedAt to positive epoch millis, or null.
+// Backend contract is `number | null`; anything else (missing, non-finite, or
+// <= 0) becomes null so DocSearchPanel.formatUpdatedAt early-returns "" rather
+// than rendering an Invalid Date.
+function coerceUpdatedAt(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) && value > 0
+    ? value
+    : null;
+}
+
 const SearchService = {
   async searchChannelMessages(
     query: ChannelSearchQuery,
@@ -432,6 +442,29 @@ const SearchService = {
   // uid/spaceId are injected by the gateway (not sent from the client). The
   // backend already applies MySQL-realtime visibility (incl. soft-delete
   // exclusion), so the client renders items verbatim without any filtering.
+  //
+  // Contract confirmed against octo-docs-backend source (osClient.ts +
+  // api/routes/docs.ts searchDocsHandler). Response shape:
+  //   { total, items: [{ docId, title, docType, updatedAt, spaceId, highlight? }] }
+  //   1. `total` — exact POST-visibility count (OS hits.total.value with
+  //      track_total_hits:true; the visible doc_id set is computed in MySQL and
+  //      pushed down as an OS `doc_id IN` filter). So `page * PAGE_SIZE < total`
+  //      is a correct stop condition and never over-counts. The fallback below
+  //      only fires if `total` is somehow not a number; it must NOT clamp to
+  //      validItems.length (that would forge hasMore=false on a full first
+  //      page) — we defer entirely to the full-page signal by using Infinity.
+  //   2. `updatedAt` — `number | null` epoch millis (NOT ISO string; the
+  //      `string` in packages/docs/src/pages/docsApi.ts is a different REST
+  //      DocMeta endpoint, unrelated to search). Coerced below to
+  //      positive-millis-or-null so a stray seconds value or garbage can't
+  //      render as an Invalid Date.
+  //   3. `spaceId` — returned on every item; search is single-space scoped
+  //      (OS term space_id, injected by the gateway, never from the body). We
+  //      pass it through unchanged for buildDocLink's `?sp=`.
+  //   4. No cursor — pure from/size offset paging (pageSize <= pageSizeMax).
+  //      Offset paging under index churn can repeat a docId across pages, which
+  //      would collide React keys on merge; useSearchPagination dedupes merged
+  //      items by identity as a backstop (see its `dedupeKey` option).
   async searchDocs(query: DocSearchQuery): Promise<DocSearchResponse> {
     const body: Record<string, unknown> = {
       q: query.keyword,
@@ -444,15 +477,25 @@ const SearchService = {
     // Per-item validation at the service boundary: the backend contract says
     // docId/title are always present, but a malformed item would otherwise flow
     // to key={docId} (React duplicate-key collisions on undefined) and
-    // buildDocLink({docId}) -> /d/undefined. Drop items missing a usable docId.
-    const validItems = items.filter(
-      (it: unknown): it is DocSearchItem =>
-        !!it &&
-        typeof (it as DocSearchItem).docId === "string" &&
-        (it as DocSearchItem).docId !== ""
-    );
+    // buildDocLink({docId}) -> /d/undefined. Drop items missing a usable docId,
+    // and coerce updatedAt to positive-millis-or-null (contract fact #2).
+    const validItems = items
+      .filter(
+        (it: unknown): it is DocSearchItem =>
+          !!it &&
+          typeof (it as DocSearchItem).docId === "string" &&
+          (it as DocSearchItem).docId !== ""
+      )
+      .map((it: DocSearchItem) => ({
+        ...it,
+        updatedAt: coerceUpdatedAt(it.updatedAt),
+      }));
     return {
-      total: typeof resp?.total === "number" ? resp.total : validItems.length,
+      // total is contractually an exact post-visibility count. If it is ever
+      // not a number, do NOT fall back to validItems.length (that caps a full
+      // page at one page); use Infinity so the pager relies solely on the
+      // full-page signal to decide hasMore.
+      total: typeof resp?.total === "number" ? resp.total : Number.POSITIVE_INFINITY,
       items: validItems,
       // Preserve the backend's original page size so the pager can detect a
       // full page independently of our client-side filtering; without this,

--- a/packages/dmworkbase/src/Service/SearchService.ts
+++ b/packages/dmworkbase/src/Service/SearchService.ts
@@ -487,6 +487,10 @@ const SearchService = {
     // to key={docId} (React duplicate-key collisions on undefined) and
     // buildDocLink({docId}) -> /d/undefined. Drop items missing a usable docId,
     // and coerce updatedAt to positive-millis-or-null (contract fact #3).
+    // highlight is the one remaining OpenSearch-shaped field consumed directly
+    // (renderHighlight scans it as a string); a non-string value would throw on
+    // .length/.replace and take out the whole row. Coerce to string-or-undefined
+    // at the boundary so the panel only ever sees the contract shape.
     const validItems = items
       .filter(
         (it: unknown): it is DocSearchItem =>
@@ -497,6 +501,7 @@ const SearchService = {
       .map((it: DocSearchItem) => ({
         ...it,
         updatedAt: coerceUpdatedAt(it.updatedAt),
+        highlight: typeof it.highlight === "string" ? it.highlight : undefined,
       }));
     const nextCursor =
       typeof resp?.nextCursor === "string" && resp.nextCursor !== ""

--- a/packages/dmworkbase/src/Service/SearchTypes.ts
+++ b/packages/dmworkbase/src/Service/SearchTypes.ts
@@ -196,6 +196,43 @@ export interface GlobalSearchDataSource {
   getSelfUid: () => string;
   searchMessages: (query: GlobalSearchQuery) => Promise<GlobalSearchResponse>;
   getFileTypeCategories: () => Promise<GlobalSearchFileTypeCategory[]>;
+  // Cloud-docs full-text search (octo-docs-backend POST /api/v1/docs/search).
+  // Optional so existing DataSource fakes/tests stay valid; the docs tab is
+  // only rendered where a real API data source provides it.
+  searchDocs?: (query: DocSearchQuery) => Promise<DocSearchResponse>;
+}
+
+// --- Cloud-docs search (octo-docs-backend) -------------------------------
+// doc_type enum as returned/accepted by the backend search endpoint.
+export type DocSearchDocType = "doc" | "sheet" | "board";
+
+export interface DocSearchItem {
+  docId: string;
+  title: string;
+  docType: DocSearchDocType;
+  /** updated_at as epoch millis (backend `updatedAt`). */
+  updatedAt: number;
+  /** The doc's real space id (backend `spaceId`), passed to buildDocLink's `?sp=` so the standalone preflight addresses the doc's own space. */
+  spaceId?: string;
+  /**
+   * OpenSearch-generated highlight fragment (may contain <em></em>).
+   * MUST be rendered with an <em>-only allowlist (escape everything else)
+   * to avoid XSS — never dangerouslySetInnerHTML the raw value.
+   */
+  highlight?: string;
+}
+
+export interface DocSearchQuery {
+  keyword: string;
+  docType?: DocSearchDocType | DocSearchDocType[];
+  page: number; // 1-based
+  pageSize: number;
+  signal?: AbortSignal;
+}
+
+export interface DocSearchResponse {
+  total: number;
+  items: DocSearchItem[];
 }
 
 export interface GlobalSearchChannelOption {

--- a/packages/dmworkbase/src/Service/SearchTypes.ts
+++ b/packages/dmworkbase/src/Service/SearchTypes.ts
@@ -204,7 +204,7 @@ export interface GlobalSearchDataSource {
 
 // --- Cloud-docs search (octo-docs-backend) -------------------------------
 // doc_type enum as returned/accepted by the backend search endpoint.
-export type DocSearchDocType = "doc" | "sheet" | "board";
+export type DocSearchDocType = "doc" | "sheet" | "board" | "html";
 
 export interface DocSearchItem {
   docId: string;

--- a/packages/dmworkbase/src/Service/SearchTypes.ts
+++ b/packages/dmworkbase/src/Service/SearchTypes.ts
@@ -232,6 +232,11 @@ export interface DocSearchQuery {
 export interface DocSearchResponse {
   total: number;
   items: DocSearchItem[];
+  // Number of items the backend returned for this page BEFORE client-side
+  // sanitization (see SearchService.searchDocs docId filter). The pager uses
+  // this to detect a full page, so a client-drop of malformed rows can't be
+  // mistaken for a genuine short (final) page. Absent when equal to items.
+  rawItemCount?: number;
 }
 
 export interface GlobalSearchChannelOption {

--- a/packages/dmworkbase/src/Service/SearchTypes.ts
+++ b/packages/dmworkbase/src/Service/SearchTypes.ts
@@ -227,7 +227,6 @@ export interface DocSearchQuery {
   docType?: DocSearchDocType | DocSearchDocType[];
   page: number; // 1-based
   pageSize: number;
-  signal?: AbortSignal;
 }
 
 export interface DocSearchResponse {

--- a/packages/dmworkbase/src/Service/SearchTypes.ts
+++ b/packages/dmworkbase/src/Service/SearchTypes.ts
@@ -210,9 +210,18 @@ export interface DocSearchItem {
   docId: string;
   title: string;
   docType: DocSearchDocType;
-  /** updated_at as epoch millis (backend `updatedAt`). */
-  updatedAt: number;
-  /** The doc's real space id (backend `spaceId`), passed to buildDocLink's `?sp=` so the standalone preflight addresses the doc's own space. */
+  /**
+   * updated_at as epoch millis, or null (backend `updatedAt` is
+   * `number | null` — doc_meta.updated_at NOW(3), null when unset).
+   * SearchService coerces stray values to positive-millis-or-null.
+   */
+  updatedAt: number | null;
+  /**
+   * The doc's real space id (backend `spaceId`), passed to buildDocLink's
+   * `?sp=` so the standalone preflight addresses the doc's own space. The
+   * backend returns it on every item (search is single-space scoped, space_id
+   * injected by the gateway); optional only so DataSource fakes/tests may omit it.
+   */
   spaceId?: string;
   /**
    * OpenSearch-generated highlight fragment (may contain <em></em>).

--- a/packages/dmworkbase/src/Service/SearchTypes.ts
+++ b/packages/dmworkbase/src/Service/SearchTypes.ts
@@ -233,19 +233,19 @@ export interface DocSearchItem {
 
 export interface DocSearchQuery {
   keyword: string;
-  docType?: DocSearchDocType | DocSearchDocType[];
-  page: number; // 1-based
+  // Opaque keyset cursor (backend search_after token). Omitted on the first
+  // page; set to the previous response's nextCursor to fetch the next page.
+  cursor?: string;
   pageSize: number;
 }
 
 export interface DocSearchResponse {
   total: number;
   items: DocSearchItem[];
-  // Number of items the backend returned for this page BEFORE client-side
-  // sanitization (see SearchService.searchDocs docId filter). The pager uses
-  // this to detect a full page, so a client-drop of malformed rows can't be
-  // mistaken for a genuine short (final) page. Absent when equal to items.
-  rawItemCount?: number;
+  // Opaque keyset cursor for the NEXT page (backend `nextCursor`). Present only
+  // while a further page exists; absent => no more results, so the pager stops
+  // on `!nextCursor` rather than any offset/total arithmetic.
+  nextCursor?: string;
 }
 
 export interface GlobalSearchChannelOption {

--- a/packages/dmworkbase/src/Service/__tests__/SearchService.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/SearchService.test.ts
@@ -247,6 +247,25 @@ describe("SearchService request boundaries", () => {
     expect(bad).toEqual({ total: 0, items: [], nextCursor: undefined });
   });
 
+  it("coerces highlight to string-or-undefined (a non-string can't reach renderHighlight)", async () => {
+    postMock.mockResolvedValue({
+      total: 4,
+      items: [
+        { docId: "a", title: "A", docType: "doc", highlight: "<em>hit</em>" }, // string kept
+        { docId: "b", title: "B", docType: "doc", highlight: 123 }, // number -> undefined
+        { docId: "c", title: "C", docType: "doc", highlight: { x: 1 } }, // object -> undefined
+        { docId: "d", title: "D", docType: "doc" }, // absent -> undefined
+      ],
+    });
+    const result = await SearchService.searchDocs({ keyword: "x", pageSize: 20 });
+    expect(result.items.map((it) => it.highlight)).toEqual([
+      "<em>hit</em>",
+      undefined,
+      undefined,
+      undefined,
+    ]);
+  });
+
   it("coerces updatedAt to plausible-millis-or-null (contract: number | null)", async () => {
     postMock.mockResolvedValue({
       total: 5,

--- a/packages/dmworkbase/src/Service/__tests__/SearchService.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/SearchService.test.ts
@@ -183,83 +183,82 @@ describe("SearchService request boundaries", () => {
     });
   });
 
-  it("posts cloud-docs search with the {q,page,pageSize} body and normalizes the response", async () => {
+  it("posts cloud-docs search with the {q,pageSize} body (no cursor on the first page) and normalizes the response", async () => {
     postMock.mockResolvedValue({
       total: 2,
       items: [
         { docId: "d1", title: "A", docType: "doc", updatedAt: 1 },
         { docId: "d2", title: "B", docType: "sheet", updatedAt: 2 },
       ],
+      nextCursor: "cur-2",
     });
 
     const result = await SearchService.searchDocs({
       keyword: "spec",
-      page: 1,
       pageSize: 20,
     });
 
+    // First page: cursor omitted entirely (backend starts from the top).
     expect(postMock).toHaveBeenCalledWith("docs/search", {
       q: "spec",
-      page: 1,
       pageSize: 20,
     });
     expect(result).toEqual({
       total: 2,
       items: [
-        { docId: "d1", title: "A", docType: "doc", updatedAt: 1 },
-        { docId: "d2", title: "B", docType: "sheet", updatedAt: 2 },
+        { docId: "d1", title: "A", docType: "doc", updatedAt: null },
+        { docId: "d2", title: "B", docType: "sheet", updatedAt: null },
       ],
-      rawItemCount: 2,
+      nextCursor: "cur-2",
     });
   });
 
-  it("includes docType in the body only when provided", async () => {
+  it("sends the cursor in the body only when provided (next page)", async () => {
     postMock.mockResolvedValue({ total: 0, items: [] });
     await SearchService.searchDocs({
       keyword: "x",
-      page: 1,
       pageSize: 20,
-      docType: ["doc", "sheet"],
+      cursor: "cur-2",
     });
     expect(postMock).toHaveBeenCalledWith("docs/search", {
       q: "x",
-      page: 1,
       pageSize: 20,
-      docType: ["doc", "sheet"],
+      cursor: "cur-2",
     });
   });
 
-  it("does not clamp total to items.length when total is not a number (uses Infinity so a full page still paginates), and defaults items to []", async () => {
-    // Contract: `total` is an exact post-visibility count and is always a
-    // number in practice. If it is ever absent, we must NOT fall back to
-    // items.length (that caps a full first page at one page); we use Infinity
-    // and let the full-page signal drive hasMore. updatedAt:0 coerces to null.
-    postMock.mockResolvedValue({ items: [{ docId: "d1", title: "A", docType: "doc", updatedAt: 0 }] });
-    const withItems = await SearchService.searchDocs({ keyword: "x", page: 1, pageSize: 20 });
-    expect(withItems.total).toBe(Number.POSITIVE_INFINITY);
-    expect(withItems.items).toEqual([{ docId: "d1", title: "A", docType: "doc", updatedAt: null }]);
-
-    postMock.mockResolvedValue({ total: "nope" });
-    const noItems = await SearchService.searchDocs({ keyword: "x", page: 1, pageSize: 20 });
-    expect(noItems).toEqual({
-      total: Number.POSITIVE_INFINITY,
-      items: [],
-      rawItemCount: 0,
+  it("nextCursor: reads a non-empty string, else undefined; total falls back to the visible item count", async () => {
+    // Keyset paging: the pager stops on !nextCursor, so an absent/empty/non-string
+    // nextCursor must normalize to undefined. total is display-only; when it is
+    // missing or non-numeric we fall back to the visible item count (never
+    // Infinity — that was the offset-era hack the pager no longer needs).
+    postMock.mockResolvedValue({
+      items: [{ docId: "d1", title: "A", docType: "doc", updatedAt: 0 }],
     });
+    const noTotal = await SearchService.searchDocs({ keyword: "x", pageSize: 20 });
+    expect(noTotal.total).toBe(1);
+    expect(noTotal.nextCursor).toBeUndefined();
+    expect(noTotal.items).toEqual([
+      { docId: "d1", title: "A", docType: "doc", updatedAt: null },
+    ]);
+
+    postMock.mockResolvedValue({ total: "nope", nextCursor: "" });
+    const bad = await SearchService.searchDocs({ keyword: "x", pageSize: 20 });
+    expect(bad).toEqual({ total: 0, items: [], nextCursor: undefined });
   });
 
-  it("coerces updatedAt to positive-millis-or-null (contract: number | null)", async () => {
+  it("coerces updatedAt to plausible-millis-or-null (contract: number | null)", async () => {
     postMock.mockResolvedValue({
       total: 5,
       items: [
         { docId: "a", title: "A", docType: "doc", updatedAt: 1710000000000 }, // valid millis
         { docId: "b", title: "B", docType: "doc", updatedAt: 0 }, // falsy -> null
-        { docId: "c", title: "C", docType: "doc", updatedAt: -1 }, // <=0 -> null
+        { docId: "c", title: "C", docType: "doc", updatedAt: 1700000000 }, // seconds-scale -> null
         { docId: "d", title: "D", docType: "doc", updatedAt: "2024-01-01" }, // non-number -> null
         { docId: "e", title: "E", docType: "doc", updatedAt: null }, // null stays null
       ],
     });
-    const result = await SearchService.searchDocs({ keyword: "x", page: 1, pageSize: 20 });
+    const result = await SearchService.searchDocs({ keyword: "x", pageSize: 20 });
     expect(result.items.map((it) => it.updatedAt)).toEqual([
       1710000000000,
       null,
@@ -278,11 +277,12 @@ describe("SearchService request boundaries", () => {
         { docId: "", title: "empty id", docType: "doc", updatedAt: 0 },
       ],
     });
-    const result = await SearchService.searchDocs({ keyword: "x", page: 1, pageSize: 20 });
+    const result = await SearchService.searchDocs({ keyword: "x", pageSize: 20 });
     // updatedAt:0 is coerced to null per the number|null contract.
     expect(result.items).toEqual([{ docId: "d1", title: "A", docType: "doc", updatedAt: null }]);
-    // rawItemCount preserves the backend's pre-filter page size so the pager
-    // can tell a client-side drop apart from a genuine short final page.
-    expect(result.rawItemCount).toBe(3);
+    // total is display-only and passed through verbatim under keyset paging;
+    // there is no rawItemCount channel anymore — the pager relies on nextCursor.
+    expect(result.total).toBe(3);
+    expect(result.nextCursor).toBeUndefined();
   });
 });

--- a/packages/dmworkbase/src/Service/__tests__/SearchService.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/SearchService.test.ts
@@ -229,14 +229,44 @@ describe("SearchService request boundaries", () => {
     });
   });
 
-  it("falls back to items.length when total is not a number, and defaults items to []", async () => {
+  it("does not clamp total to items.length when total is not a number (uses Infinity so a full page still paginates), and defaults items to []", async () => {
+    // Contract: `total` is an exact post-visibility count and is always a
+    // number in practice. If it is ever absent, we must NOT fall back to
+    // items.length (that caps a full first page at one page); we use Infinity
+    // and let the full-page signal drive hasMore. updatedAt:0 coerces to null.
     postMock.mockResolvedValue({ items: [{ docId: "d1", title: "A", docType: "doc", updatedAt: 0 }] });
     const withItems = await SearchService.searchDocs({ keyword: "x", page: 1, pageSize: 20 });
-    expect(withItems.total).toBe(1);
+    expect(withItems.total).toBe(Number.POSITIVE_INFINITY);
+    expect(withItems.items).toEqual([{ docId: "d1", title: "A", docType: "doc", updatedAt: null }]);
 
     postMock.mockResolvedValue({ total: "nope" });
     const noItems = await SearchService.searchDocs({ keyword: "x", page: 1, pageSize: 20 });
-    expect(noItems).toEqual({ total: 0, items: [], rawItemCount: 0 });
+    expect(noItems).toEqual({
+      total: Number.POSITIVE_INFINITY,
+      items: [],
+      rawItemCount: 0,
+    });
+  });
+
+  it("coerces updatedAt to positive-millis-or-null (contract: number | null)", async () => {
+    postMock.mockResolvedValue({
+      total: 5,
+      items: [
+        { docId: "a", title: "A", docType: "doc", updatedAt: 1710000000000 }, // valid millis
+        { docId: "b", title: "B", docType: "doc", updatedAt: 0 }, // falsy -> null
+        { docId: "c", title: "C", docType: "doc", updatedAt: -1 }, // <=0 -> null
+        { docId: "d", title: "D", docType: "doc", updatedAt: "2024-01-01" }, // non-number -> null
+        { docId: "e", title: "E", docType: "doc", updatedAt: null }, // null stays null
+      ],
+    });
+    const result = await SearchService.searchDocs({ keyword: "x", page: 1, pageSize: 20 });
+    expect(result.items.map((it) => it.updatedAt)).toEqual([
+      1710000000000,
+      null,
+      null,
+      null,
+      null,
+    ]);
   });
 
   it("drops items missing a usable docId so /d/undefined and key collisions are impossible", async () => {
@@ -249,7 +279,8 @@ describe("SearchService request boundaries", () => {
       ],
     });
     const result = await SearchService.searchDocs({ keyword: "x", page: 1, pageSize: 20 });
-    expect(result.items).toEqual([{ docId: "d1", title: "A", docType: "doc", updatedAt: 0 }]);
+    // updatedAt:0 is coerced to null per the number|null contract.
+    expect(result.items).toEqual([{ docId: "d1", title: "A", docType: "doc", updatedAt: null }]);
     // rawItemCount preserves the backend's pre-filter page size so the pager
     // can tell a client-side drop apart from a genuine short final page.
     expect(result.rawItemCount).toBe(3);

--- a/packages/dmworkbase/src/Service/__tests__/SearchService.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/SearchService.test.ts
@@ -209,6 +209,7 @@ describe("SearchService request boundaries", () => {
         { docId: "d1", title: "A", docType: "doc", updatedAt: 1 },
         { docId: "d2", title: "B", docType: "sheet", updatedAt: 2 },
       ],
+      rawItemCount: 2,
     });
   });
 
@@ -235,7 +236,7 @@ describe("SearchService request boundaries", () => {
 
     postMock.mockResolvedValue({ total: "nope" });
     const noItems = await SearchService.searchDocs({ keyword: "x", page: 1, pageSize: 20 });
-    expect(noItems).toEqual({ total: 0, items: [] });
+    expect(noItems).toEqual({ total: 0, items: [], rawItemCount: 0 });
   });
 
   it("drops items missing a usable docId so /d/undefined and key collisions are impossible", async () => {
@@ -249,5 +250,8 @@ describe("SearchService request boundaries", () => {
     });
     const result = await SearchService.searchDocs({ keyword: "x", page: 1, pageSize: 20 });
     expect(result.items).toEqual([{ docId: "d1", title: "A", docType: "doc", updatedAt: 0 }]);
+    // rawItemCount preserves the backend's pre-filter page size so the pager
+    // can tell a client-side drop apart from a genuine short final page.
+    expect(result.rawItemCount).toBe(3);
   });
 });

--- a/packages/dmworkbase/src/Service/__tests__/SearchService.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/SearchService.test.ts
@@ -182,4 +182,72 @@ describe("SearchService request boundaries", () => {
       only_message: 1,
     });
   });
+
+  it("posts cloud-docs search with the {q,page,pageSize} body and normalizes the response", async () => {
+    postMock.mockResolvedValue({
+      total: 2,
+      items: [
+        { docId: "d1", title: "A", docType: "doc", updatedAt: 1 },
+        { docId: "d2", title: "B", docType: "sheet", updatedAt: 2 },
+      ],
+    });
+
+    const result = await SearchService.searchDocs({
+      keyword: "spec",
+      page: 1,
+      pageSize: 20,
+    });
+
+    expect(postMock).toHaveBeenCalledWith("docs/search", {
+      q: "spec",
+      page: 1,
+      pageSize: 20,
+    });
+    expect(result).toEqual({
+      total: 2,
+      items: [
+        { docId: "d1", title: "A", docType: "doc", updatedAt: 1 },
+        { docId: "d2", title: "B", docType: "sheet", updatedAt: 2 },
+      ],
+    });
+  });
+
+  it("includes docType in the body only when provided", async () => {
+    postMock.mockResolvedValue({ total: 0, items: [] });
+    await SearchService.searchDocs({
+      keyword: "x",
+      page: 1,
+      pageSize: 20,
+      docType: ["doc", "sheet"],
+    });
+    expect(postMock).toHaveBeenCalledWith("docs/search", {
+      q: "x",
+      page: 1,
+      pageSize: 20,
+      docType: ["doc", "sheet"],
+    });
+  });
+
+  it("falls back to items.length when total is not a number, and defaults items to []", async () => {
+    postMock.mockResolvedValue({ items: [{ docId: "d1", title: "A", docType: "doc", updatedAt: 0 }] });
+    const withItems = await SearchService.searchDocs({ keyword: "x", page: 1, pageSize: 20 });
+    expect(withItems.total).toBe(1);
+
+    postMock.mockResolvedValue({ total: "nope" });
+    const noItems = await SearchService.searchDocs({ keyword: "x", page: 1, pageSize: 20 });
+    expect(noItems).toEqual({ total: 0, items: [] });
+  });
+
+  it("drops items missing a usable docId so /d/undefined and key collisions are impossible", async () => {
+    postMock.mockResolvedValue({
+      total: 3,
+      items: [
+        { docId: "d1", title: "A", docType: "doc", updatedAt: 0 },
+        { title: "no id", docType: "doc", updatedAt: 0 },
+        { docId: "", title: "empty id", docType: "doc", updatedAt: 0 },
+      ],
+    });
+    const result = await SearchService.searchDocs({ keyword: "x", page: 1, pageSize: 20 });
+    expect(result.items).toEqual([{ docId: "d1", title: "A", docType: "doc", updatedAt: 0 }]);
+  });
 });

--- a/packages/dmworkbase/src/bridge/globalSearch/GlobalSearchVM.ts
+++ b/packages/dmworkbase/src/bridge/globalSearch/GlobalSearchVM.ts
@@ -45,6 +45,7 @@ export default class GlobalSearchVM extends ProviderListener {
       { tab: t("base.globalSearch.tab.groups"), itemKey: "groups" },
       { tab: t("base.globalSearch.tab.chat"), itemKey: "messages" },
       { tab: t("base.globalSearch.tab.files"), itemKey: "files" },
+      { tab: t("base.globalSearch.tab.docs"), itemKey: "docs" },
     ];
   }
 

--- a/packages/dmworkbase/src/bridge/globalSearch/GlobalSearchVM.ts
+++ b/packages/dmworkbase/src/bridge/globalSearch/GlobalSearchVM.ts
@@ -46,12 +46,15 @@ export default class GlobalSearchVM extends ProviderListener {
       { tab: t("base.globalSearch.tab.chat"), itemKey: "messages" },
       { tab: t("base.globalSearch.tab.files"), itemKey: "files" },
     ];
-    // Cloud-docs search hits /api/v1/docs/search on the independent docs-backend,
-    // so gate the tab on the same docs_on remote-config flag that hides the Docs
-    // NavRail entry (App.docsOn, default off). Without this the tab shows even
-    // when the backend isn't deployed, and any query 404s into a permanent
-    // "search failed". Mirrors the docs module's docsOn gating.
-    if (WKApp.remoteConfig.docsOn) {
+    // Cloud-docs search hits /api/v1/docs/search on the independent docs-backend.
+    // Gate on TWO flags: docsOn (the docs-backend/module is deployed at all) AND
+    // docsSearchOn (search specifically is enabled + the index is populated). The
+    // module flag alone is not enough — the search endpoint is a separate capability
+    // behind a separate switch, and lands in a separate backend PR, so a docs_on=true
+    // deployment without search would otherwise show a tab whose every query 404s
+    // into a permanent "search failed". docsSearchOn defaults false, so the tab stays
+    // hidden until ops flips docs_search_on on once search is actually ready.
+    if (WKApp.remoteConfig.docsOn && WKApp.remoteConfig.docsSearchOn) {
       tabs.push({ tab: t("base.globalSearch.tab.docs"), itemKey: "docs" });
     }
     return tabs;

--- a/packages/dmworkbase/src/bridge/globalSearch/GlobalSearchVM.ts
+++ b/packages/dmworkbase/src/bridge/globalSearch/GlobalSearchVM.ts
@@ -40,13 +40,21 @@ export default class GlobalSearchVM extends ProviderListener {
         { tab: t("base.globalSearch.tab.files"), itemKey: "files" },
       ];
     }
-    return [
+    const tabs = [
       { tab: t("base.globalSearch.tab.contacts"), itemKey: "contacts" },
       { tab: t("base.globalSearch.tab.groups"), itemKey: "groups" },
       { tab: t("base.globalSearch.tab.chat"), itemKey: "messages" },
       { tab: t("base.globalSearch.tab.files"), itemKey: "files" },
-      { tab: t("base.globalSearch.tab.docs"), itemKey: "docs" },
     ];
+    // Cloud-docs search hits /api/v1/docs/search on the independent docs-backend,
+    // so gate the tab on the same docs_on remote-config flag that hides the Docs
+    // NavRail entry (App.docsOn, default off). Without this the tab shows even
+    // when the backend isn't deployed, and any query 404s into a permanent
+    // "search failed". Mirrors the docs module's docsOn gating.
+    if (WKApp.remoteConfig.docsOn) {
+      tabs.push({ tab: t("base.globalSearch.tab.docs"), itemKey: "docs" });
+    }
+    return tabs;
   }
 
   public get selectedTabKey() {

--- a/packages/dmworkbase/src/bridge/globalSearch/createGlobalSearchDataSource.ts
+++ b/packages/dmworkbase/src/bridge/globalSearch/createGlobalSearchDataSource.ts
@@ -8,6 +8,7 @@ import SearchService from "../../Service/SearchService";
 import { createSearchAssetResolver } from "../search/createSearchAssetResolver";
 import { activeGlobalSearchFilterCount } from "./filterState";
 import type {
+  DocSearchQuery,
   GlobalSearchChannelOption,
   GlobalSearchDataSource,
   GlobalSearchFileTypeCategory,
@@ -258,6 +259,7 @@ export function createGlobalSearchApiDataSource(
       result.items.forEach((item) => rememberSender(item.sender));
       return result;
     },
+    searchDocs: (query: DocSearchQuery) => SearchService.searchDocs(query),
   };
 }
 

--- a/packages/dmworkbase/src/bridge/search/useSearchPagination.ts
+++ b/packages/dmworkbase/src/bridge/search/useSearchPagination.ts
@@ -17,11 +17,35 @@ export interface SearchPage<T> {
   hasMore: boolean;
 }
 
+// Append `next` onto `prev`, dropping any `next` item whose dedupeKey already
+// appeared (first occurrence wins). Without a dedupeKey this is a plain concat.
+function mergeDedup<T>(
+  prev: T[],
+  next: T[],
+  dedupeKey?: (item: T) => string
+): T[] {
+  if (!dedupeKey) return [...prev, ...next];
+  const seen = new Set(prev.map(dedupeKey));
+  const merged = [...prev];
+  for (const item of next) {
+    const key = dedupeKey(item);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    merged.push(item);
+  }
+  return merged;
+}
+
 export interface UseSearchPaginationOptions<T> {
   enabled: boolean;
   search: (cursor?: string) => Promise<SearchPage<T>>;
   errorMessage: string;
   debounceMs?: number;
+  // Optional identity extractor. When provided, items merged across pages are
+  // deduped by this key (first occurrence wins). Offset-based paging (e.g.
+  // docs search, which has no stable cursor) can repeat a row across pages
+  // under index churn; without this the repeat would collide React keys.
+  dedupeKey?: (item: T) => string;
 }
 
 export function useSearchPagination<T>({
@@ -29,6 +53,7 @@ export function useSearchPagination<T>({
   search,
   errorMessage,
   debounceMs = 300,
+  dedupeKey,
 }: UseSearchPaginationOptions<T>) {
   const [response, setResponse] = useState<SearchPage<T>>({
     items: [],
@@ -96,7 +121,9 @@ export function useSearchPagination<T>({
           })
         );
         setResponse((previous) => ({
-          items: cursor ? [...previous.items, ...next.items] : next.items,
+          items: cursor
+            ? mergeDedup(previous.items, next.items, dedupeKey)
+            : next.items,
           nextCursor: stopPagination ? undefined : next.nextCursor,
           hasMore: stopPagination ? false : next.hasMore,
         }));
@@ -115,7 +142,7 @@ export function useSearchPagination<T>({
         }
       }
     },
-    [enabled, errorMessage, search]
+    [dedupeKey, enabled, errorMessage, search]
   );
 
   const loadNextPage = useCallback(

--- a/packages/dmworkbase/src/bridge/search/useSearchPagination.ts
+++ b/packages/dmworkbase/src/bridge/search/useSearchPagination.ts
@@ -17,35 +17,11 @@ export interface SearchPage<T> {
   hasMore: boolean;
 }
 
-// Append `next` onto `prev`, dropping any `next` item whose dedupeKey already
-// appeared (first occurrence wins). Without a dedupeKey this is a plain concat.
-function mergeDedup<T>(
-  prev: T[],
-  next: T[],
-  dedupeKey?: (item: T) => string
-): T[] {
-  if (!dedupeKey) return [...prev, ...next];
-  const seen = new Set(prev.map(dedupeKey));
-  const merged = [...prev];
-  for (const item of next) {
-    const key = dedupeKey(item);
-    if (seen.has(key)) continue;
-    seen.add(key);
-    merged.push(item);
-  }
-  return merged;
-}
-
 export interface UseSearchPaginationOptions<T> {
   enabled: boolean;
   search: (cursor?: string) => Promise<SearchPage<T>>;
   errorMessage: string;
   debounceMs?: number;
-  // Optional identity extractor. When provided, items merged across pages are
-  // deduped by this key (first occurrence wins). Offset-based paging (e.g.
-  // docs search, which has no stable cursor) can repeat a row across pages
-  // under index churn; without this the repeat would collide React keys.
-  dedupeKey?: (item: T) => string;
 }
 
 export function useSearchPagination<T>({
@@ -53,7 +29,6 @@ export function useSearchPagination<T>({
   search,
   errorMessage,
   debounceMs = 300,
-  dedupeKey,
 }: UseSearchPaginationOptions<T>) {
   const [response, setResponse] = useState<SearchPage<T>>({
     items: [],
@@ -121,9 +96,7 @@ export function useSearchPagination<T>({
           })
         );
         setResponse((previous) => ({
-          items: cursor
-            ? mergeDedup(previous.items, next.items, dedupeKey)
-            : next.items,
+          items: cursor ? [...previous.items, ...next.items] : next.items,
           nextCursor: stopPagination ? undefined : next.nextCursor,
           hasMore: stopPagination ? false : next.hasMore,
         }));
@@ -142,7 +115,7 @@ export function useSearchPagination<T>({
         }
       }
     },
-    [dedupeKey, enabled, errorMessage, search]
+    [enabled, errorMessage, search]
   );
 
   const loadNextPage = useCallback(

--- a/packages/dmworkbase/src/features/globalSearch/GlobalSearchPanel.tsx
+++ b/packages/dmworkbase/src/features/globalSearch/GlobalSearchPanel.tsx
@@ -188,21 +188,23 @@ export default class GlobalSearch extends Component<
     this.props.hideModal?.();
   };
 
-  // Cloud-docs tab: open the clicked doc via the host `onOpenDoc` (route/endpoint
-  // is a deployment concern still being finalized); when unwired this is a no-op
-  // plus a console hint rather than a bogus navigation. The doc opens in a new
-  // browser tab, so we intentionally keep this search modal open (the current
-  // page is untouched) — letting the user click more results in a row.
+  // Cloud-docs tab: open the clicked doc via the host `onOpenDoc`, which the Chat
+  // host wires to buildDocLink -> window.open in a new browser tab. We keep this
+  // search modal open (the current page is untouched) so the user can open more
+  // results in a row. When the prop is unwired (future reuse) this is a no-op
+  // plus a dev-only console hint rather than a bogus navigation.
   handleOpenDoc = (item: DocSearchItem) => {
     if (this.props.onOpenDoc) {
       this.props.onOpenDoc(item);
       return;
     }
-    // eslint-disable-next-line no-console
-    console.warn(
-      "[GlobalSearch] onOpenDoc not wired; cannot open cloud doc",
-      item.docId
-    );
+    if (process.env.NODE_ENV !== "production") {
+      // eslint-disable-next-line no-console
+      console.warn(
+        "[GlobalSearch] onOpenDoc not wired; cannot open cloud doc",
+        item.docId
+      );
+    }
   };
 
   // 同时挂载所有 tab 组件，通过 display 切换可见性。

--- a/packages/dmworkbase/src/features/globalSearch/GlobalSearchPanel.tsx
+++ b/packages/dmworkbase/src/features/globalSearch/GlobalSearchPanel.tsx
@@ -311,14 +311,18 @@ export default class GlobalSearch extends Component<
           <DocSearchPanel
             keyword={vm.keyword}
             dataSource={this.globalDataSource}
-            // Gate the panel on docsOn as well as the selected tab: the tab
-            // LIST is gated in GlobalSearchVM, but selectedTabKey can stay
-            // "docs" if docsOn is revoked mid-session (remote-config refresh).
-            // Without this the tab button disappears while the panel keeps
-            // querying a now-disabled feature. remoteConfig is an
+            // Gate the panel on docsOn && docsSearchOn as well as the selected
+            // tab: the tab LIST is gated in GlobalSearchVM, but selectedTabKey
+            // can stay "docs" if either flag is revoked mid-session (remote-config
+            // refresh). Without this the tab button disappears while the panel
+            // keeps querying a now-disabled feature. remoteConfig is an
             // always-fresh singleton and the config listener force-updates
             // this component, so the panel deactivates on the same refresh.
-            isActive={currentKey === "docs" && WKApp.remoteConfig.docsOn}
+            isActive={
+              currentKey === "docs" &&
+              WKApp.remoteConfig.docsOn &&
+              WKApp.remoteConfig.docsSearchOn
+            }
             onOpenDoc={this.handleOpenDoc}
           />
         </div>

--- a/packages/dmworkbase/src/features/globalSearch/GlobalSearchPanel.tsx
+++ b/packages/dmworkbase/src/features/globalSearch/GlobalSearchPanel.tsx
@@ -9,6 +9,7 @@ import TabGroup from "../../Components/GlobalSearch/tab-group";
 import TabFile from "../../Components/GlobalSearch/tab-file";
 import { Channel } from "wukongimjssdk";
 import GlobalContentSearchPanel from "../../Components/GlobalSearch/GlobalContentSearchPanel";
+import DocSearchPanel from "../../Components/GlobalSearch/DocSearchPanel";
 import GlobalSearchFilterPanel, {
   type GlobalSearchFilterApplyMeta,
 } from "../../Components/GlobalSearch/GlobalSearchFilterPanel";
@@ -21,7 +22,10 @@ import {
   type GlobalSearchDataSource,
   type GlobalSearchFilters,
 } from "../../Service/SearchTypes";
-import type { ChannelSearchItem } from "../../Service/SearchTypes";
+import type {
+  ChannelSearchItem,
+  DocSearchItem,
+} from "../../Service/SearchTypes";
 import { canLocateChannelSearchItem } from "../../bridge/channelSearch/locate";
 import WKApp from "../../App";
 import { t as translate } from "../../i18n";
@@ -48,6 +52,10 @@ export interface GlobalSearchProps {
   dataSource?: GlobalSearchDataSource;
   contentSearchEnabled?: boolean;
   onLocateContentItem?: (item: ChannelSearchItem) => void;
+  // Host-provided opener for a cloud-docs search hit (docs tab). Route/endpoint
+  // is a deployment concern; when omitted the docs tab still searches but the
+  // click is a no-op (see handleOpenDoc).
+  onOpenDoc?: (item: DocSearchItem) => void;
   initialState?: Partial<GlobalSearchState>;
 }
 
@@ -180,6 +188,23 @@ export default class GlobalSearch extends Component<
     this.props.hideModal?.();
   };
 
+  // Cloud-docs tab: open the clicked doc via the host `onOpenDoc` (route/endpoint
+  // is a deployment concern still being finalized); when unwired this is a no-op
+  // plus a console hint rather than a bogus navigation. The doc opens in a new
+  // browser tab, so we intentionally keep this search modal open (the current
+  // page is untouched) — letting the user click more results in a row.
+  handleOpenDoc = (item: DocSearchItem) => {
+    if (this.props.onOpenDoc) {
+      this.props.onOpenDoc(item);
+      return;
+    }
+    // eslint-disable-next-line no-console
+    console.warn(
+      "[GlobalSearch] onOpenDoc not wired; cannot open cloud doc",
+      item.docId
+    );
+  };
+
   // 同时挂载所有 tab 组件，通过 display 切换可见性。
   // 避免切 tab 时 unmount 导致 <img>/VisibilityTrigger 全部重建，进而重新
   // 触发头像请求（浏览器 HTTP cache 不一定命中，网络面板会看到"全量重拉"）。
@@ -279,6 +304,14 @@ export default class GlobalSearch extends Component<
               onClick={onClickOf("file")}
             />
           )}
+        </div>
+        <div className="wk-search-tabs__panel" style={panelStyle("docs")}>
+          <DocSearchPanel
+            keyword={vm.keyword}
+            dataSource={this.globalDataSource}
+            isActive={currentKey === "docs"}
+            onOpenDoc={this.handleOpenDoc}
+          />
         </div>
         {showSharedFilter && (
           <aside className="wk-search-tabs__shared-filter">

--- a/packages/dmworkbase/src/features/globalSearch/GlobalSearchPanel.tsx
+++ b/packages/dmworkbase/src/features/globalSearch/GlobalSearchPanel.tsx
@@ -311,7 +311,14 @@ export default class GlobalSearch extends Component<
           <DocSearchPanel
             keyword={vm.keyword}
             dataSource={this.globalDataSource}
-            isActive={currentKey === "docs"}
+            // Gate the panel on docsOn as well as the selected tab: the tab
+            // LIST is gated in GlobalSearchVM, but selectedTabKey can stay
+            // "docs" if docsOn is revoked mid-session (remote-config refresh).
+            // Without this the tab button disappears while the panel keeps
+            // querying a now-disabled feature. remoteConfig is an
+            // always-fresh singleton and the config listener force-updates
+            // this component, so the panel deactivates on the same refresh.
+            isActive={currentKey === "docs" && WKApp.remoteConfig.docsOn}
             onOpenDoc={this.handleOpenDoc}
           />
         </div>

--- a/packages/dmworkbase/src/i18n/locales/en-US.json
+++ b/packages/dmworkbase/src/i18n/locales/en-US.json
@@ -1356,5 +1356,11 @@
   "secrets.error.deleteFailed": "Delete failed, please try again",
   "secrets.error.copyFailed": "Copy failed",
   "secrets.pasteGuard.title": "Secret paste blocked",
-  "secrets.pasteGuard.content": "We blocked pasting a possible API key into chat to keep it out of your messages. Click here to save it in Secrets instead."
+  "secrets.pasteGuard.content": "We blocked pasting a possible API key into chat to keep it out of your messages. Click here to save it in Secrets instead.",
+  "globalSearch.tab.docs": "Cloud Docs",
+  "globalSearch.docs.emptyHint": "Type a keyword to search cloud docs",
+  "globalSearch.docs.noResults": "No related cloud docs found",
+  "globalSearch.docs.loading": "Searching…",
+  "globalSearch.docs.searchFailed": "Search failed, please try again",
+  "globalSearch.docs.loadMore": "Load more"
 }

--- a/packages/dmworkbase/src/i18n/locales/en-US.json
+++ b/packages/dmworkbase/src/i18n/locales/en-US.json
@@ -1362,5 +1362,6 @@
   "globalSearch.docs.noResults": "No related cloud docs found",
   "globalSearch.docs.loading": "Searching…",
   "globalSearch.docs.searchFailed": "Search failed, please try again",
-  "globalSearch.docs.loadMore": "Load more"
+  "globalSearch.docs.loadMore": "Load more",
+  "globalSearch.docs.popupBlocked": "Your browser blocked the new tab. Allow pop-ups for this site, then click the document again."
 }

--- a/packages/dmworkbase/src/i18n/locales/zh-CN.json
+++ b/packages/dmworkbase/src/i18n/locales/zh-CN.json
@@ -1362,5 +1362,6 @@
   "globalSearch.docs.noResults": "没有找到相关云文档",
   "globalSearch.docs.loading": "搜索中…",
   "globalSearch.docs.searchFailed": "搜索失败，请稍后重试",
-  "globalSearch.docs.loadMore": "加载更多"
+  "globalSearch.docs.loadMore": "加载更多",
+  "globalSearch.docs.popupBlocked": "浏览器拦截了新标签页，请允许本站弹窗后重新点击该文档。"
 }

--- a/packages/dmworkbase/src/i18n/locales/zh-CN.json
+++ b/packages/dmworkbase/src/i18n/locales/zh-CN.json
@@ -1356,5 +1356,11 @@
   "secrets.error.deleteFailed": "删除失败，请重试",
   "secrets.error.copyFailed": "复制失败",
   "secrets.pasteGuard.title": "已拦截密钥粘贴",
-  "secrets.pasteGuard.content": "为避免密钥进入聊天，已拦截这次明文粘贴。点这里改用密钥管理保存。"
+  "secrets.pasteGuard.content": "为避免密钥进入聊天，已拦截这次明文粘贴。点这里改用密钥管理保存。",
+  "globalSearch.tab.docs": "云文档",
+  "globalSearch.docs.emptyHint": "输入关键词搜索云文档",
+  "globalSearch.docs.noResults": "没有找到相关云文档",
+  "globalSearch.docs.loading": "搜索中…",
+  "globalSearch.docs.searchFailed": "搜索失败，请稍后重试",
+  "globalSearch.docs.loadMore": "加载更多"
 }

--- a/packages/dmworkbase/src/theme/semantic.css
+++ b/packages/dmworkbase/src/theme/semantic.css
@@ -297,6 +297,13 @@
   --wk-space-color-5: #43e97b;
   --wk-space-color-6: #fa709a;
 
+  /* 云文档 doc_type 徽标底色（全局搜索云文档 tab）。这 4 组品牌色与现有
+     primitive palette 不完全一致，无法直接复用，故单列语义 token。 */
+  --wk-doc-accent-doc: #3370ff;
+  --wk-doc-accent-sheet: #00b42a;
+  --wk-doc-accent-board: #f7734b;
+  --wk-doc-accent-html: #7a5af5;
+
   /* AI 专属 */
   --wk-ai-surface: rgba(127, 59, 245, 0.03);
   --wk-ai-border: var(--wk-purple-alpha-12);
@@ -427,6 +434,12 @@ body[theme-mode="dark"] {
   /* 消息气泡双色 */
   --wk-bg-self: #1a2e2a; /* 自己的消息 — 暗色淡青 */
   --wk-bg-bubble: #1a1a2e; /* 他人 & AI 消息 — 暗色微紫 */
+
+  /* 云文档 doc_type 徽标底色（暗色，压暗以贴合 item-file 暗色约定） */
+  --wk-doc-accent-doc: #2b5fd9;
+  --wk-doc-accent-sheet: #009a24;
+  --wk-doc-accent-board: #d9603c;
+  --wk-doc-accent-html: #5f45c9;
 
   /* Shadow */
   --wk-shadow-sm: 0 1px 2px var(--wk-black-alpha-30);

--- a/packages/docs/src/octoweb/mock.ts
+++ b/packages/docs/src/octoweb/mock.ts
@@ -130,12 +130,14 @@ export class MockMenusManager {
  */
 export class MockRemoteConfig implements RemoteConfigLite {
   docsOn: boolean
+  docsSearchOn: boolean
   /** Mirrors the host contract: true once the first appconfig load has resolved. */
   requestSuccess = false
   private loadListeners: Array<() => void> = []
   private changeListeners: Array<() => void> = []
   constructor(docsOn = true) {
     this.docsOn = docsOn
+    this.docsSearchOn = docsOn
   }
   addListener(cb: () => void): () => void {
     // Mirror the host: subscribing after the first load already resolved returns a noop, so a

--- a/packages/docs/src/octoweb/types.ts
+++ b/packages/docs/src/octoweb/types.ts
@@ -109,6 +109,8 @@ export interface MenusManager {
 export interface RemoteConfigLite {
   /** Docs module display switch (backend appconfig `docs_on`); false/absent → hidden. */
   docsOn: boolean
+  /** Cloud-docs full-text search switch (backend appconfig `docs_search_on`); false/absent → hidden. Decoupled from docsOn so search can be rolled out independently of the docs module. */
+  docsSearchOn: boolean
   /**
    * True once the FIRST appconfig load has resolved. Per the host contract, a subscriber that
    * registers via `addListener` after this is already true will NOT be called (addListener


### PR DESCRIPTION
## Summary

Adds a "Cloud Docs" tab to global search. Users can run a full-text query over cloud document titles and bodies, see highlighted result snippets, and click a result to open the document's standalone page in a new tab while keeping the search modal open.

## Related Issue

Closes #1086

## Changes

- Add a "Cloud Docs" tab to the global search panel (`GlobalSearchVM`, `GlobalSearchPanel`).
- New `DocSearchPanel` component (+ styles) that lists results with title, body highlight, doc type, and last-updated time, with paginated load-more.
- `SearchService.searchDocs` calls the docs backend `POST /api/v1/docs/search`; new `DocSearchItem` / query / response types in `SearchTypes`.
- Wire the docs data source through `createGlobalSearchDataSource`.
- Host handler in `Pages/Chat` opens a clicked result via `buildDocLink({ docId, space })` in a new tab (`window.open(..., "_blank", "noopener,noreferrer")`) and keeps the modal open.
- Add en-US / zh-CN copy for the new tab and states.

## Architecture / Module Boundary

- Affected module(s): Global Search (dmworkbase).
- New or changed user-visible entry point: yes — a new "Cloud Docs" tab inside the existing global search modal (no new top-level entry point).
- Shared layer touched: Components / service / bridge (all within the global search feature).
- If shared code changed, impact scope: additive only — a new tab, a new service method, and a new optional `onOpenDoc` prop; no existing tab behavior is modified.
- Duplicate entry point checked: yes — reuses the existing global search modal and the existing `/d/<docId>` standalone doc page (same target as the Docs home "Open in new page" action); no duplicate entry point introduced.

## Testing

- [ ] Unit tests added/updated
- [x] Manually verified

Manually verified against a local deployment: the Cloud Docs tab returns results, highlight snippets render, and clicking a result opens `/d/<docId>?sp=<space>` in a new tab with the search modal staying open. Type-check passes for the changed files.

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] PR description is in English
- [ ] Added tests for my changes
- [ ] Updated documentation
- [x] Ran `pnpm i18n:check` or confirmed the change does not affect UI copy
- [x] Confirmed the change follows module ownership and does not add duplicate user-visible entry points
- [x] Described impact scope when shared components, messages, bridge, or services are changed
- [x] Followed commit message conventions (Conventional Commits)
