### PR TITLE
feat(search): support pinyin in global search

### DIFF
--- a/packages/dmworkbase/src/Components/GlobalSearch/__tests__/senderCandidates.test.ts
+++ b/packages/dmworkbase/src/Components/GlobalSearch/__tests__/senderCandidates.test.ts
@@ -274,4 +274,37 @@ describe("loadSenderCandidates (via searchSenders)", () => {
     mockState.contactsList = [];
     await expect(ds.searchSenders("jia")).resolves.toEqual([]);
   });
+
+  it("removes stale sender candidates when the contact pool shrinks in the same space", async () => {
+    mockState.commonDataSource = {
+      searchFriends: vi.fn().mockResolvedValue([]),
+    };
+    mockState.contactsList = [{ uid: "old-uid", name: "贾小明" }];
+    const ds = createGlobalSearchApiDataSource();
+    await expect(ds.searchSenders("jia")).resolves.toEqual(
+      expect.arrayContaining([expect.objectContaining({ uid: "old-uid" })])
+    );
+
+    mockState.contactsList = [];
+    await expect(ds.searchSenders("jia")).resolves.toEqual([]);
+    expect(ds.getSenders().some((sender) => sender.uid === "old-uid")).toBe(
+      false
+    );
+  });
+
+  it("removes renamed sender pinyin and excludes blacklisted contacts", async () => {
+    mockState.commonDataSource = {
+      searchFriends: vi.fn().mockResolvedValue([]),
+    };
+    mockState.contactsList = [{ uid: "user-1", name: "贾小明" }];
+    const ds = createGlobalSearchApiDataSource();
+    await expect(ds.searchSenders("jia")).resolves.toHaveLength(1);
+
+    mockState.contactsList = [{ uid: "user-1", name: "张小明" }];
+    await expect(ds.searchSenders("jia")).resolves.toEqual([]);
+    await expect(ds.searchSenders("zhang")).resolves.toHaveLength(1);
+
+    mockState.contactsList = [{ uid: "user-1", name: "张小明", status: 2 }];
+    await expect(ds.searchSenders("zhang")).resolves.toEqual([]);
+  });
 });

--- a/packages/dmworkbase/src/Components/GlobalSearch/__tests__/senderCandidates.test.ts
+++ b/packages/dmworkbase/src/Components/GlobalSearch/__tests__/senderCandidates.test.ts
@@ -21,6 +21,8 @@ import { describe, expect, it, vi, beforeEach } from "vitest";
 const mockState = vi.hoisted(() => ({
   commonDataSource: undefined as any,
   contactsList: [] as any[],
+  groups: [] as any[],
+  spaceId: "space-1",
   loginUid: "self-uid",
   loginName: "Me",
 }));
@@ -31,6 +33,9 @@ vi.mock("../../../App", () => ({
       return {
         commonDataSource: mockState.commonDataSource,
         contactsList: mockState.contactsList,
+        channelDataSource: {
+          groupSaveList: vi.fn().mockResolvedValue(mockState.groups),
+        },
       };
     },
     get loginInfo() {
@@ -41,6 +46,9 @@ vi.mock("../../../App", () => ({
       };
     },
     shared: {
+      get currentSpaceId() {
+        return mockState.spaceId;
+      },
       avatarUser: (uid: string) => `avatar://user/${uid}`,
       avatarChannel: (ch: any) =>
         `avatar://ch/${ch?.channelID ?? ""}/${ch?.channelType ?? ""}`,
@@ -52,24 +60,28 @@ vi.mock("../../../App", () => ({
   },
 }));
 
-vi.mock("wukongimjssdk", () => ({
-  Channel: class {
-    channelID: string;
-    channelType: number;
-    constructor(channelID: string, channelType: number) {
-      this.channelID = channelID;
-      this.channelType = channelType;
-    }
-  },
-  ChannelTypeGroup: 2,
-  ChannelTypePerson: 1,
-  WKSDK: {
+vi.mock("wukongimjssdk", () => {
+  const sdk = {
     shared: () => ({
       conversationManager: { conversations: [] },
       channelManager: { getChannelInfo: () => undefined },
     }),
-  },
-}));
+  };
+  return {
+    default: sdk,
+    Channel: class {
+      channelID: string;
+      channelType: number;
+      constructor(channelID: string, channelType: number) {
+        this.channelID = channelID;
+        this.channelType = channelType;
+      }
+    },
+    ChannelTypeGroup: 2,
+    ChannelTypePerson: 1,
+    WKSDK: sdk,
+  };
+});
 
 import { createGlobalSearchApiDataSource } from "../dataSource";
 
@@ -77,6 +89,8 @@ describe("loadSenderCandidates (via searchSenders)", () => {
   beforeEach(() => {
     mockState.commonDataSource = undefined;
     mockState.contactsList = [];
+    mockState.groups = [];
+    mockState.spaceId = "space-1";
   });
 
   it("§1: maps ChannelInfo[] from commonDataSource.searchFriends into ChannelSearchSender", async () => {
@@ -211,5 +225,57 @@ describe("loadSenderCandidates (via searchSenders)", () => {
 
     const ds = createGlobalSearchApiDataSource();
     await expect(ds.searchSenders("")).resolves.toBeDefined();
+  });
+
+  it("matches sender/member candidates by full pinyin without skipping remote search", async () => {
+    const searchFriends = vi.fn().mockResolvedValue([]);
+    mockState.commonDataSource = { searchFriends };
+    mockState.contactsList = [{ uid: "jia-uid", name: "贾小明" }];
+
+    const ds = createGlobalSearchApiDataSource();
+    const results = await ds.searchSenders("jia");
+
+    expect(searchFriends).toHaveBeenCalledWith("jia");
+    expect(results.map((sender) => sender.uid)).toContain("jia-uid");
+  });
+
+  it("matches group options by full pinyin", async () => {
+    mockState.groups = [
+      {
+        channel: { channelID: "group-1", channelType: 2 },
+        displayName: "全能接项目小组",
+      },
+    ];
+
+    const ds = createGlobalSearchApiDataSource();
+    const results = await ds.searchChannels("quanneng");
+
+    expect(results.map((channel) => channel.channelId)).toContain("group-1");
+  });
+
+  it("removes stale channel candidates when the readable pool changes", async () => {
+    mockState.groups = [
+      {
+        channel: { channelID: "group-1", channelType: 2 },
+        displayName: "全能接项目小组",
+      },
+    ];
+    const ds = createGlobalSearchApiDataSource();
+    await expect(ds.searchChannels("quanneng")).resolves.toHaveLength(1);
+
+    mockState.groups = [];
+    await expect(ds.searchChannels("quanneng")).resolves.toEqual([]);
+  });
+
+  it("clears cached pinyin candidates after switching spaces", async () => {
+    mockState.contactsList = [{ uid: "old-uid", name: "贾小明" }];
+    const ds = createGlobalSearchApiDataSource();
+    await expect(ds.searchSenders("jia")).resolves.toEqual(
+      expect.arrayContaining([expect.objectContaining({ uid: "old-uid" })])
+    );
+
+    mockState.spaceId = "space-2";
+    mockState.contactsList = [];
+    await expect(ds.searchSenders("jia")).resolves.toEqual([]);
   });
 });

--- a/packages/dmworkbase/src/Components/GlobalSearch/__tests__/senderCandidates.test.ts
+++ b/packages/dmworkbase/src/Components/GlobalSearch/__tests__/senderCandidates.test.ts
@@ -155,9 +155,7 @@ describe("loadSenderCandidates (via searchSenders)", () => {
 
   it("§3: surfaces contactsList when searchFriends is missing entirely", async () => {
     mockState.commonDataSource = {}; // no searchFriends method
-    mockState.contactsList = [
-      { uid: "erin-uid", name: "Erin" },
-    ];
+    mockState.contactsList = [{ uid: "erin-uid", name: "Erin" }];
 
     const ds = createGlobalSearchApiDataSource();
     const results = await ds.searchSenders("");
@@ -168,14 +166,12 @@ describe("loadSenderCandidates (via searchSenders)", () => {
   it("§4: cold panel (empty sender cache) still returns candidates from the real DS API — regression guard", async () => {
     // The exact scenario Jerry-Xin flagged: no prior search results have
     // warmed the sender cache. Before the fix, this returned only [self].
-    const searchFriends = vi
-      .fn()
-      .mockResolvedValue([
-        {
-          channel: { channelID: "frank-uid", channelType: 1 },
-          orgData: { displayName: "Frank" },
-        },
-      ]);
+    const searchFriends = vi.fn().mockResolvedValue([
+      {
+        channel: { channelID: "frank-uid", channelType: 1 },
+        orgData: { displayName: "Frank" },
+      },
+    ]);
     mockState.commonDataSource = { searchFriends };
 
     const ds = createGlobalSearchApiDataSource();

--- a/packages/dmworkbase/src/bridge/globalSearch/GlobalSearchVM.ts
+++ b/packages/dmworkbase/src/bridge/globalSearch/GlobalSearchVM.ts
@@ -13,6 +13,16 @@ import { ProviderListener } from "../../Service/Provider";
 import { debounce } from "../../Utils/rateLimit";
 import { t } from "../../i18n";
 import { addCurrentImChannelInfoListener, getCurrentImChannelInfo } from "../../im-runtime/currentChannelRuntime";
+import type { LegacyGlobalSearchResponse } from "../../Service/SearchService";
+import {
+  createEmptyGlobalSearchPinyinIndex,
+  extendGlobalSearchPinyinIndex,
+  globalSearchContactsToLegacy,
+  globalSearchGroupsToLegacy,
+  mergeGlobalSearchPinyinResults,
+  searchGlobalSearchPinyinIndex,
+  type GlobalSearchPinyinIndex,
+} from "./globalSearchPinyin";
 
 /** Legacy contacts/groups bridge retained while the aggregated tabs migrate. */
 export default class GlobalSearchVM extends ProviderListener {
@@ -31,7 +41,20 @@ export default class GlobalSearchVM extends ProviderListener {
   private unsubscribeChannelInfoListener?: () => void;
   public channel?: Channel; // 查询指定频道的消息
   private requestId = 0; // 请求计数器，用于处理竞态条件
+  private pinyinCandidateRequestId = 0;
+  private pinyinIndex: GlobalSearchPinyinIndex =
+    createEmptyGlobalSearchPinyinIndex();
+  private mounted = false;
   public searchError: string | null = null; // 搜索失败错误信息
+  private readonly contactsChangeListener = () => {
+    void this.refreshPinyinIndex();
+  };
+  private readonly spaceChangedListener = () => {
+    this.pinyinIndex = createEmptyGlobalSearchPinyinIndex();
+    this.initLoad();
+    void this.refreshPinyinIndex();
+    this.requestSearch();
+  };
   // tab数据列表
   public get tabList() {
     if (this.searchInChannel) {
@@ -96,6 +119,10 @@ export default class GlobalSearchVM extends ProviderListener {
   }
 
   didMount(): void {
+    this.mounted = true;
+    WKApp.dataSource.addContactsChangeListener(this.contactsChangeListener);
+    WKApp.mittBus.on("space-changed", this.spaceChangedListener);
+    void this.refreshPinyinIndex();
     this.requestSearch();
 
     this.channelInfoListener = (channelInfo: ChannelInfo) => {
@@ -121,6 +148,12 @@ export default class GlobalSearchVM extends ProviderListener {
   }
 
   didUnMount(): void {
+    this.mounted = false;
+    this.pinyinCandidateRequestId++;
+    this.handleInputChange.cancel();
+    this.handleComposingInputChange.cancel();
+    WKApp.dataSource.removeContactsChangeListener(this.contactsChangeListener);
+    WKApp.mittBus.off("space-changed", this.spaceChangedListener);
     this.unsubscribeChannelInfoListener?.();
     this.unsubscribeChannelInfoListener = undefined;
   }
@@ -134,12 +167,65 @@ export default class GlobalSearchVM extends ProviderListener {
     }
   }, 300);
 
+  // 中文输入法组合期间保留原有“不请求服务端”约束，但像通讯录搜索一样，
+  // 使用输入框里的原始字母即时匹配本地拼音索引。组合结束后该回调会自动
+  // 失效，最终选中的中文仍由 handleInputChange 走原服务端搜索链路。
+  public handleComposingInputChange = debounce((value: string) => {
+    if (!this.isComposing) return;
+    this.keyword = value;
+    this.initLoad();
+  }, 300);
+
   public initLoad() {
     this.page = 1;
     this.loadFinish = false;
     this.loadMoreing = false;
     this.searchResult = null;
+    this.applyPinyinMatches();
     this.notifyListener();
+  }
+
+  private async refreshPinyinIndex() {
+    if (this.searchInChannel) return;
+    const requestId = ++this.pinyinCandidateRequestId;
+    const spaceId = WKApp.shared.currentSpaceId;
+    const contacts = globalSearchContactsToLegacy(
+      WKApp.dataSource.contactsList || []
+    );
+    let groups: ChannelInfo[] = [];
+    try {
+      groups = await WKApp.dataSource.channelDataSource.groupSaveList();
+    } catch {
+      // The existing server search remains authoritative when local candidates
+      // cannot be loaded.
+    }
+    if (
+      !this.mounted ||
+      requestId !== this.pinyinCandidateRequestId ||
+      spaceId !== WKApp.shared.currentSpaceId
+    ) {
+      return;
+    }
+    this.pinyinIndex = extendGlobalSearchPinyinIndex(this.pinyinIndex, {
+      friends: contacts,
+      groups: globalSearchGroupsToLegacy(groups),
+    });
+    this.applyPinyinMatches();
+    this.notifyListener();
+  }
+
+  private applyPinyinMatches() {
+    if (this.searchInChannel || !this.keyword.trim()) return;
+    const localResult = searchGlobalSearchPinyinIndex(
+      this.keyword,
+      this.pinyinIndex
+    );
+    const current: LegacyGlobalSearchResponse = this.searchResult || {
+      friends: [],
+      groups: [],
+      messages: [],
+    };
+    this.searchResult = mergeGlobalSearchPinyinResults(current, localResult);
   }
 
   // 请求搜索
@@ -181,6 +267,14 @@ export default class GlobalSearchVM extends ProviderListener {
         } else {
           this.searchResult = res;
         }
+
+        if (!this.searchInChannel) {
+          this.pinyinIndex = extendGlobalSearchPinyinIndex(
+            this.pinyinIndex,
+            res
+          );
+        }
+        this.applyPinyinMatches();
 
         // 替换备注如果有备注的话
         this.searchResult.friends?.forEach((v: any) => {

--- a/packages/dmworkbase/src/bridge/globalSearch/GlobalSearchVM.ts
+++ b/packages/dmworkbase/src/bridge/globalSearch/GlobalSearchVM.ts
@@ -12,14 +12,21 @@ import { MessageContentTypeConst } from "../../Service/Const";
 import { ProviderListener } from "../../Service/Provider";
 import { debounce } from "../../Utils/rateLimit";
 import { t } from "../../i18n";
-import { addCurrentImChannelInfoListener, getCurrentImChannelInfo } from "../../im-runtime/currentChannelRuntime";
-import type { LegacyGlobalSearchResponse } from "../../Service/SearchService";
 import {
+  addCurrentImChannelInfoListener,
+  getCurrentImChannelInfo,
+} from "../../im-runtime/currentChannelRuntime";
+import type {
+  LegacyGlobalSearchContact,
+  LegacyGlobalSearchResponse,
+} from "../../Service/SearchService";
+import {
+  buildGlobalSearchPinyinIndex,
   createEmptyGlobalSearchPinyinIndex,
   extendGlobalSearchPinyinIndex,
   globalSearchContactsToLegacy,
-  globalSearchGroupsToLegacy,
-  mergeGlobalSearchPinyinResults,
+  refreshGlobalSearchGroupCandidates,
+  replaceGlobalSearchPinyinMatches,
   searchGlobalSearchPinyinIndex,
   type GlobalSearchPinyinIndex,
 } from "./globalSearchPinyin";
@@ -44,6 +51,11 @@ export default class GlobalSearchVM extends ProviderListener {
   private pinyinCandidateRequestId = 0;
   private pinyinIndex: GlobalSearchPinyinIndex =
     createEmptyGlobalSearchPinyinIndex();
+  private pinyinGroupCandidates: LegacyGlobalSearchContact[] = [];
+  private serverContactGroupResult: Pick<
+    LegacyGlobalSearchResponse,
+    "friends" | "groups"
+  > = { friends: [], groups: [] };
   private mounted = false;
   public searchError: string | null = null; // 搜索失败错误信息
   private readonly contactsChangeListener = () => {
@@ -51,8 +63,8 @@ export default class GlobalSearchVM extends ProviderListener {
   };
   private readonly spaceChangedListener = () => {
     this.pinyinIndex = createEmptyGlobalSearchPinyinIndex();
+    this.pinyinGroupCandidates = [];
     this.initLoad();
-    void this.refreshPinyinIndex();
     this.requestSearch();
   };
   // tab数据列表
@@ -87,9 +99,7 @@ export default class GlobalSearchVM extends ProviderListener {
   // 搜索标题
   public get searchTitle() {
     if (this.searchInChannel) {
-      const channelInfo = getCurrentImChannelInfo(
-        this.channel!
-      );
+      const channelInfo = getCurrentImChannelInfo(this.channel!);
       if (channelInfo) {
         return t("base.globalSearch.chatHistoryWith", {
           values: { name: channelInfo.title },
@@ -122,7 +132,6 @@ export default class GlobalSearchVM extends ProviderListener {
     this.mounted = true;
     WKApp.dataSource.addContactsChangeListener(this.contactsChangeListener);
     WKApp.mittBus.on("space-changed", this.spaceChangedListener);
-    void this.refreshPinyinIndex();
     this.requestSearch();
 
     this.channelInfoListener = (channelInfo: ChannelInfo) => {
@@ -181,6 +190,7 @@ export default class GlobalSearchVM extends ProviderListener {
     this.loadFinish = false;
     this.loadMoreing = false;
     this.searchResult = null;
+    this.serverContactGroupResult = { friends: [], groups: [] };
     this.applyPinyinMatches();
     this.notifyListener();
   }
@@ -192,7 +202,7 @@ export default class GlobalSearchVM extends ProviderListener {
     const contacts = globalSearchContactsToLegacy(
       WKApp.dataSource.contactsList || []
     );
-    let groups: ChannelInfo[] = [];
+    let groups: ChannelInfo[] | undefined;
     try {
       groups = await WKApp.dataSource.channelDataSource.groupSaveList();
     } catch {
@@ -206,9 +216,13 @@ export default class GlobalSearchVM extends ProviderListener {
     ) {
       return;
     }
-    this.pinyinIndex = extendGlobalSearchPinyinIndex(this.pinyinIndex, {
+    this.pinyinGroupCandidates = refreshGlobalSearchGroupCandidates(
+      this.pinyinGroupCandidates,
+      groups
+    );
+    this.pinyinIndex = buildGlobalSearchPinyinIndex({
       friends: contacts,
-      groups: globalSearchGroupsToLegacy(groups),
+      groups: this.pinyinGroupCandidates,
     });
     this.applyPinyinMatches();
     this.notifyListener();
@@ -225,11 +239,21 @@ export default class GlobalSearchVM extends ProviderListener {
       groups: [],
       messages: [],
     };
-    this.searchResult = mergeGlobalSearchPinyinResults(current, localResult);
+    this.searchResult = replaceGlobalSearchPinyinMatches(
+      current,
+      this.serverContactGroupResult,
+      localResult
+    );
   }
 
   // 请求搜索
   public requestSearch() {
+    if (!this.searchInChannel) {
+      // Refresh the authoritative readable snapshot for every new global
+      // search. Contact changes have their own listener, but readable groups
+      // can change without emitting that event.
+      void this.refreshPinyinIndex();
+    }
     // 递增请求计数器，用于识别当前请求
     this.requestId++;
     const currentRequestId = this.requestId;
@@ -265,6 +289,10 @@ export default class GlobalSearchVM extends ProviderListener {
             this.searchResult = res;
           }
         } else {
+          this.serverContactGroupResult = {
+            friends: res.friends || [],
+            groups: res.groups || [],
+          };
           this.searchResult = res;
         }
 

--- a/packages/dmworkbase/src/bridge/globalSearch/createGlobalSearchDataSource.ts
+++ b/packages/dmworkbase/src/bridge/globalSearch/createGlobalSearchDataSource.ts
@@ -13,6 +13,11 @@ import type {
   GlobalSearchFileTypeCategory,
   GlobalSearchQuery,
 } from "../../Service/SearchTypes";
+import {
+  createNamedPinyinSearchIndex,
+  extendNamedPinyinSearchIndex,
+  searchNamedPinyinIndex,
+} from "./globalSearchPinyin";
 
 const PAGE_SIZE_SENDERS = 50;
 
@@ -42,9 +47,7 @@ function selfSender(): ChannelSearchSender {
 // of the user's groups — a full group-scoped thread picker is deferred. Thread
 // hits from a picked *group* now expand to «group + all its threads» server-
 // side under the YUJ-30 unified rule (see 01-backend-search-global.md §3/§6).
-async function loadReadableChannelOptions(
-  keyword: string
-): Promise<GlobalSearchChannelOption[]> {
+async function loadReadableChannelOptions(): Promise<GlobalSearchChannelOption[]> {
   const out = new Map<string, GlobalSearchChannelOption>();
   const push = (option: GlobalSearchChannelOption) => {
     const key = `${option.channelType}:${option.channelId}`;
@@ -94,10 +97,24 @@ async function loadReadableChannelOptions(
     // Failing to load "my groups" is non-fatal — we still return recents.
   }
 
-  const kw = keyword.trim().toLowerCase();
   const options = Array.from(out.values());
-  if (!kw) return options.slice(0, 60);
-  return options.filter((o) => o.name.toLowerCase().includes(kw)).slice(0, 60);
+  return options;
+}
+
+function localContactSenders(): ChannelSearchSender[] {
+  const list: any[] = (WKApp.dataSource as any)?.contactsList ?? [];
+  return list.flatMap((contact) => {
+    const uid = contact?.uid;
+    if (!uid) return [];
+    return [
+      {
+        uid,
+        name: contact?.remark || contact?.name || uid,
+        avatarUrl: contact?.avatar || WKApp.shared.avatarUser(uid),
+        isCurrentMember: true,
+      },
+    ];
+  });
 }
 
 // RC #554 blocker (Jerry-Xin + OctoBoooot @ 2026-07-09): the previous
@@ -197,6 +214,12 @@ export function createGlobalSearchApiDataSource(
   options: CreateGlobalSearchApiDataSourceOptions = {}
 ): GlobalSearchDataSource {
   const senderCache = new Map<string, ChannelSearchSender>();
+  const senderPinyinIndex =
+    createNamedPinyinSearchIndex<ChannelSearchSender>();
+  let channelPinyinIndex =
+    createNamedPinyinSearchIndex<GlobalSearchChannelOption>();
+  let channelCandidateSignature = "";
+  let indexedSpaceId = WKApp.shared.currentSpaceId;
   const rememberSender = (sender?: ChannelSearchSender) => {
     if (!sender?.uid) return;
     senderCache.set(sender.uid, sender);
@@ -204,6 +227,18 @@ export function createGlobalSearchApiDataSource(
   // Seed with self so the "包含成员" candidate list can filter it out reliably
   // (and the "发送人" chip always resolves self's display name).
   rememberSender(selfSender());
+
+  const resetPinyinIndexesForSpace = () => {
+    const currentSpaceId = WKApp.shared.currentSpaceId;
+    if (currentSpaceId === indexedSpaceId) return;
+    indexedSpaceId = currentSpaceId;
+    senderCache.clear();
+    senderPinyinIndex.entries.clear();
+    channelPinyinIndex =
+      createNamedPinyinSearchIndex<GlobalSearchChannelOption>();
+    channelCandidateSignature = "";
+    rememberSender(selfSender());
+  };
 
   return {
     getSenders: () => Array.from(senderCache.values()),
@@ -214,17 +249,43 @@ export function createGlobalSearchApiDataSource(
       },
     getSelfUid: () => WKApp.loginInfo.uid || "",
     searchSenders: async (keyword: string) => {
+      resetPinyinIndexesForSpace();
       const remote = await loadSenderCandidates(keyword);
-      remote.forEach(rememberSender);
-      const kw = keyword.trim().toLowerCase();
+      [...localContactSenders(), ...remote].forEach(rememberSender);
       const combined = Array.from(senderCache.values());
-      if (!kw) return combined.slice(0, PAGE_SIZE_SENDERS);
-      return combined
-        .filter((s) => `${s.name}${s.uid}`.toLowerCase().includes(kw))
-        .slice(0, PAGE_SIZE_SENDERS);
+      extendNamedPinyinSearchIndex(
+        senderPinyinIndex,
+        combined,
+        (sender) => sender.uid,
+        (sender) => [sender.name, sender.uid]
+      );
+      return searchNamedPinyinIndex(keyword, senderPinyinIndex).slice(
+        0,
+        PAGE_SIZE_SENDERS
+      );
     },
     searchChannels: async (keyword: string) => {
-      return loadReadableChannelOptions(keyword);
+      resetPinyinIndexesForSpace();
+      const options = await loadReadableChannelOptions();
+      const nextSignature = options
+        .map(
+          (option) =>
+            `${option.channelType}:${option.channelId}:${option.name}`
+        )
+        .sort()
+        .join("\n");
+      if (nextSignature !== channelCandidateSignature) {
+        channelCandidateSignature = nextSignature;
+        channelPinyinIndex =
+          createNamedPinyinSearchIndex<GlobalSearchChannelOption>();
+        extendNamedPinyinSearchIndex(
+          channelPinyinIndex,
+          options,
+          (option) => `${option.channelType}:${option.channelId}`,
+          (option) => [option.name, option.channelId]
+        );
+      }
+      return searchNamedPinyinIndex(keyword, channelPinyinIndex).slice(0, 60);
     },
     getFileTypeCategories: async () => {
       const cache = options.fileTypeCategoriesCache;

--- a/packages/dmworkbase/src/bridge/globalSearch/createGlobalSearchDataSource.ts
+++ b/packages/dmworkbase/src/bridge/globalSearch/createGlobalSearchDataSource.ts
@@ -1,6 +1,7 @@
 import { Channel, ChannelTypeGroup } from "wukongimjssdk";
 import WKApp from "../../App";
 import { ChannelTypeCommunityTopic } from "../../Service/Const";
+import { ContactsStatus } from "../../Service/DataSource/DataSource";
 import { getCurrentImChannelInfo } from "../../im-runtime/currentChannelRuntime";
 import { getCurrentImConversationsDirectly } from "../../im-runtime/currentConversationRuntime";
 import type { ChannelSearchSender } from "../../Service/SearchTypes";
@@ -107,7 +108,7 @@ function localContactSenders(): ChannelSearchSender[] {
   const list: any[] = (WKApp.dataSource as any)?.contactsList ?? [];
   return list.flatMap((contact) => {
     const uid = contact?.uid;
-    if (!uid) return [];
+    if (!uid || contact?.status === ContactsStatus.Blacklist) return [];
     return [
       {
         uid,
@@ -180,7 +181,7 @@ async function loadSenderCandidates(
     const kwLower = kw.toLowerCase();
     for (const c of list) {
       const uid = c?.uid;
-      if (!uid) continue;
+      if (!uid || c?.status === ContactsStatus.Blacklist) continue;
       const name = c?.remark || c?.name || uid;
       if (kwLower && !`${name}${uid}`.toLowerCase().includes(kwLower)) {
         continue;
@@ -221,6 +222,7 @@ export function createGlobalSearchApiDataSource(
     createNamedPinyinSearchIndex<GlobalSearchChannelOption>();
   let channelCandidateSignature = "";
   let indexedSpaceId = WKApp.shared.currentSpaceId;
+  let senderCandidateSignature = "";
   const rememberSender = (sender?: ChannelSearchSender) => {
     if (!sender?.uid) return;
     senderCache.set(sender.uid, sender);
@@ -229,20 +231,33 @@ export function createGlobalSearchApiDataSource(
   // (and the "发送人" chip always resolves self's display name).
   rememberSender(selfSender());
 
-  const resetPinyinIndexesForSpace = () => {
+  const resetScopedPinyinIndexes = () => {
     const currentSpaceId = WKApp.shared.currentSpaceId;
-    if (currentSpaceId === indexedSpaceId) return;
+    const nextSenderCandidateSignature = localContactSenders()
+      .map((sender) => `${sender.uid}:${sender.name}`)
+      .sort()
+      .join("\n");
+    const spaceChanged = currentSpaceId !== indexedSpaceId;
+    const senderPoolChanged =
+      nextSenderCandidateSignature !== senderCandidateSignature;
+    if (!spaceChanged && !senderPoolChanged) return;
     indexedSpaceId = currentSpaceId;
+    senderCandidateSignature = nextSenderCandidateSignature;
     senderCache.clear();
     senderPinyinIndex.entries.clear();
-    channelPinyinIndex =
-      createNamedPinyinSearchIndex<GlobalSearchChannelOption>();
-    channelCandidateSignature = "";
+    if (spaceChanged) {
+      channelPinyinIndex =
+        createNamedPinyinSearchIndex<GlobalSearchChannelOption>();
+      channelCandidateSignature = "";
+    }
     rememberSender(selfSender());
   };
 
   return {
-    getSenders: () => Array.from(senderCache.values()),
+    getSenders: () => {
+      resetScopedPinyinIndexes();
+      return Array.from(senderCache.values());
+    },
     getSender: (uid) =>
       senderCache.get(uid) || {
         uid,
@@ -250,9 +265,20 @@ export function createGlobalSearchApiDataSource(
       },
     getSelfUid: () => WKApp.loginInfo.uid || "",
     searchSenders: async (keyword: string) => {
-      resetPinyinIndexesForSpace();
+      resetScopedPinyinIndexes();
       const remote = await loadSenderCandidates(keyword);
-      [...localContactSenders(), ...remote].forEach(rememberSender);
+      // The local snapshot is authoritative for explicit blacklist state even
+      // if a lagging server search still returns that uid.
+      const blacklistedUids = new Set(
+        (((WKApp.dataSource as any)?.contactsList ?? []) as any[])
+          .filter((contact) => contact?.status === ContactsStatus.Blacklist)
+          .map((contact) => contact?.uid)
+          .filter(Boolean)
+      );
+      resetScopedPinyinIndexes();
+      [...localContactSenders(), ...remote]
+        .filter((sender) => !blacklistedUids.has(sender.uid))
+        .forEach(rememberSender);
       const combined = Array.from(senderCache.values());
       extendNamedPinyinSearchIndex(
         senderPinyinIndex,
@@ -266,7 +292,7 @@ export function createGlobalSearchApiDataSource(
       );
     },
     searchChannels: async (keyword: string) => {
-      resetPinyinIndexesForSpace();
+      resetScopedPinyinIndexes();
       const options = await loadReadableChannelOptions();
       const nextSignature = options
         .map(

--- a/packages/dmworkbase/src/bridge/globalSearch/createGlobalSearchDataSource.ts
+++ b/packages/dmworkbase/src/bridge/globalSearch/createGlobalSearchDataSource.ts
@@ -47,7 +47,9 @@ function selfSender(): ChannelSearchSender {
 // of the user's groups — a full group-scoped thread picker is deferred. Thread
 // hits from a picked *group* now expand to «group + all its threads» server-
 // side under the YUJ-30 unified rule (see 01-backend-search-global.md §3/§6).
-async function loadReadableChannelOptions(): Promise<GlobalSearchChannelOption[]> {
+async function loadReadableChannelOptions(): Promise<
+  GlobalSearchChannelOption[]
+> {
   const out = new Map<string, GlobalSearchChannelOption>();
   const push = (option: GlobalSearchChannelOption) => {
     const key = `${option.channelType}:${option.channelId}`;
@@ -214,8 +216,7 @@ export function createGlobalSearchApiDataSource(
   options: CreateGlobalSearchApiDataSourceOptions = {}
 ): GlobalSearchDataSource {
   const senderCache = new Map<string, ChannelSearchSender>();
-  const senderPinyinIndex =
-    createNamedPinyinSearchIndex<ChannelSearchSender>();
+  const senderPinyinIndex = createNamedPinyinSearchIndex<ChannelSearchSender>();
   let channelPinyinIndex =
     createNamedPinyinSearchIndex<GlobalSearchChannelOption>();
   let channelCandidateSignature = "";
@@ -269,8 +270,7 @@ export function createGlobalSearchApiDataSource(
       const options = await loadReadableChannelOptions();
       const nextSignature = options
         .map(
-          (option) =>
-            `${option.channelType}:${option.channelId}:${option.name}`
+          (option) => `${option.channelType}:${option.channelId}:${option.name}`
         )
         .sort()
         .join("\n");

--- a/packages/dmworkbase/src/bridge/globalSearch/globalSearchPinyin.test.ts
+++ b/packages/dmworkbase/src/bridge/globalSearch/globalSearchPinyin.test.ts
@@ -5,6 +5,8 @@ import {
   extendNamedPinyinSearchIndex,
   extendGlobalSearchPinyinIndex,
   mergeGlobalSearchPinyinResults,
+  refreshGlobalSearchGroupCandidates,
+  replaceGlobalSearchPinyinMatches,
   searchNamedPinyinIndex,
   searchGlobalSearchPinyinIndex,
 } from "./globalSearchPinyin";
@@ -30,24 +32,36 @@ describe("global search pinyin index", () => {
   it("matches Chinese, full pinyin and case-insensitive pinyin", () => {
     const index = buildGlobalSearchPinyinIndex(source);
 
-    expect(searchGlobalSearchPinyinIndex("魏娇", index).friends).toHaveLength(1);
-    expect(searchGlobalSearchPinyinIndex("weijiao", index).friends).toHaveLength(1);
-    expect(searchGlobalSearchPinyinIndex("WEIJIAO", index).groups).toHaveLength(1);
+    expect(searchGlobalSearchPinyinIndex("魏娇", index).friends).toHaveLength(
+      1
+    );
+    expect(
+      searchGlobalSearchPinyinIndex("weijiao", index).friends
+    ).toHaveLength(1);
+    expect(searchGlobalSearchPinyinIndex("WEIJIAO", index).groups).toHaveLength(
+      1
+    );
   });
 
   it("uses the visible remark for matching", () => {
     const index = buildGlobalSearchPinyinIndex({
-      friends: [{
-        channel_id: "u1",
-        channel_type: 1,
-        channel_name: "原名",
-        channel_remark: "魏娇莹",
-      }],
+      friends: [
+        {
+          channel_id: "u1",
+          channel_type: 1,
+          channel_name: "原名",
+          channel_remark: "魏娇莹",
+        },
+      ],
       groups: [],
     });
 
-    expect(searchGlobalSearchPinyinIndex("weijiao", index).friends).toHaveLength(1);
-    expect(searchGlobalSearchPinyinIndex("yuanming", index).friends).toHaveLength(0);
+    expect(
+      searchGlobalSearchPinyinIndex("weijiao", index).friends
+    ).toHaveLength(1);
+    expect(
+      searchGlobalSearchPinyinIndex("yuanming", index).friends
+    ).toHaveLength(0);
   });
 
   it("keeps server order and appends only non-duplicate local matches", () => {
@@ -104,7 +118,9 @@ describe("global search pinyin index", () => {
     const index = buildGlobalSearchPinyinIndex(largeSource, toPinyin);
 
     for (let count = 0; count < 20; count += 1) {
-      expect(searchGlobalSearchPinyinIndex("weijiao", index).friends).toHaveLength(1);
+      expect(
+        searchGlobalSearchPinyinIndex("weijiao", index).friends
+      ).toHaveLength(1);
     }
 
     expect(toPinyin).toHaveBeenCalledTimes(10_000);
@@ -141,17 +157,110 @@ describe("global search pinyin index", () => {
     ).toEqual(["g2"]);
   });
 
+  it("rebuilds authoritative snapshots without removed or renamed entries", () => {
+    const initial = buildGlobalSearchPinyinIndex({
+      friends: [
+        {
+          channel_id: "u1",
+          channel_type: 1,
+          channel_name: "魏娇莹",
+        },
+      ],
+      groups: [
+        {
+          channel_id: "g1",
+          channel_type: 2,
+          channel_name: "旧项目群",
+        },
+      ],
+    });
+    expect(
+      searchGlobalSearchPinyinIndex("weijiao", initial).friends
+    ).toHaveLength(1);
+    expect(
+      searchGlobalSearchPinyinIndex("jiuxiangmu", initial).groups
+    ).toHaveLength(1);
+
+    const refreshed = buildGlobalSearchPinyinIndex({
+      friends: [
+        {
+          channel_id: "u1",
+          channel_type: 1,
+          channel_name: "张小明",
+        },
+      ],
+      groups: [],
+    });
+
+    expect(searchGlobalSearchPinyinIndex("weijiao", refreshed).friends).toEqual(
+      []
+    );
+    expect(
+      searchGlobalSearchPinyinIndex("zhangxiao", refreshed).friends
+    ).toHaveLength(1);
+    expect(
+      searchGlobalSearchPinyinIndex("jiuxiangmu", refreshed).groups
+    ).toEqual([]);
+  });
+
+  it("replaces previously merged local rows from the latest server baseline", () => {
+    const staleLocalFriend = {
+      channel_id: "removed-user",
+      channel_type: 1,
+      channel_name: "已删除联系人",
+    };
+    const staleLocalGroup = {
+      channel_id: "removed-group",
+      channel_type: 2,
+      channel_name: "已退出群聊",
+    };
+    const current = {
+      friends: [staleLocalFriend],
+      groups: [staleLocalGroup],
+      messages: [{ message_id: "message-1" }],
+    };
+
+    const replaced = replaceGlobalSearchPinyinMatches(
+      current,
+      { friends: [], groups: [] },
+      { friends: [], groups: [] }
+    );
+
+    expect(replaced.friends).toEqual([]);
+    expect(replaced.groups).toEqual([]);
+    expect(replaced.messages).toEqual(current.messages);
+  });
+
+  it("keeps the last successful group snapshot on load failure but accepts an authoritative empty snapshot", () => {
+    const current = [
+      {
+        channel_id: "g1",
+        channel_type: 2,
+        channel_name: "仍可见群聊",
+      },
+    ];
+
+    expect(refreshGlobalSearchGroupCandidates(current, undefined)).toBe(
+      current
+    );
+    expect(refreshGlobalSearchGroupCandidates(current, [])).toEqual([]);
+  });
+
   it("matches the real group name with the project's pinyin converter", () => {
     const index = buildGlobalSearchPinyinIndex({
       friends: [],
-      groups: [{
-        channel_id: "g2",
-        channel_type: 2,
-        channel_name: "全能接项目小组",
-      }],
+      groups: [
+        {
+          channel_id: "g2",
+          channel_type: 2,
+          channel_name: "全能接项目小组",
+        },
+      ],
     });
 
-    expect(searchGlobalSearchPinyinIndex("quanneng", index).groups).toHaveLength(1);
+    expect(
+      searchGlobalSearchPinyinIndex("quanneng", index).groups
+    ).toHaveLength(1);
   });
 
   it("reuses a generic named index for sender, member and channel pickers", () => {

--- a/packages/dmworkbase/src/bridge/globalSearch/globalSearchPinyin.test.ts
+++ b/packages/dmworkbase/src/bridge/globalSearch/globalSearchPinyin.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  buildGlobalSearchPinyinIndex,
+  createNamedPinyinSearchIndex,
+  extendNamedPinyinSearchIndex,
+  extendGlobalSearchPinyinIndex,
+  mergeGlobalSearchPinyinResults,
+  searchNamedPinyinIndex,
+  searchGlobalSearchPinyinIndex,
+} from "./globalSearchPinyin";
+
+describe("global search pinyin index", () => {
+  const source = {
+    friends: [
+      {
+        channel_id: "u1",
+        channel_type: 1,
+        channel_name: "魏娇莹",
+      },
+    ],
+    groups: [
+      {
+        channel_id: "g1",
+        channel_type: 2,
+        channel_name: "魏娇莹项目群",
+      },
+    ],
+  };
+
+  it("matches Chinese, full pinyin and case-insensitive pinyin", () => {
+    const index = buildGlobalSearchPinyinIndex(source);
+
+    expect(searchGlobalSearchPinyinIndex("魏娇", index).friends).toHaveLength(1);
+    expect(searchGlobalSearchPinyinIndex("weijiao", index).friends).toHaveLength(1);
+    expect(searchGlobalSearchPinyinIndex("WEIJIAO", index).groups).toHaveLength(1);
+  });
+
+  it("uses the visible remark for matching", () => {
+    const index = buildGlobalSearchPinyinIndex({
+      friends: [{
+        channel_id: "u1",
+        channel_type: 1,
+        channel_name: "原名",
+        channel_remark: "魏娇莹",
+      }],
+      groups: [],
+    });
+
+    expect(searchGlobalSearchPinyinIndex("weijiao", index).friends).toHaveLength(1);
+    expect(searchGlobalSearchPinyinIndex("yuanming", index).friends).toHaveLength(0);
+  });
+
+  it("keeps server order and appends only non-duplicate local matches", () => {
+    const serverFriend = {
+      channel_id: "server",
+      channel_type: 1,
+      channel_name: "Server",
+    };
+    const duplicateLocal = { ...serverFriend, channel_name: "Local duplicate" };
+    const localOnly = {
+      channel_id: "local",
+      channel_type: 1,
+      channel_name: "Local",
+    };
+
+    const merged = mergeGlobalSearchPinyinResults(
+      { friends: [serverFriend], groups: [], messages: [] },
+      { friends: [duplicateLocal, localOnly], groups: [] }
+    );
+
+    expect(merged.friends).toEqual([serverFriend, localOnly]);
+    expect(merged.messages).toEqual([]);
+  });
+
+  it("keeps a later server match when the local index has no match", () => {
+    const index = buildGlobalSearchPinyinIndex({ friends: [], groups: [] });
+    const localResult = searchGlobalSearchPinyinIndex("later", index);
+    const laterServerMatch = {
+      channel_id: "later-page-user",
+      channel_type: 1,
+      channel_name: "Later Server Match",
+    };
+
+    const merged = mergeGlobalSearchPinyinResults(
+      { friends: [laterServerMatch], groups: [], messages: [] },
+      localResult
+    );
+
+    expect(merged.friends).toEqual([laterServerMatch]);
+  });
+
+  it("converts 10,000 names once and reuses the index", () => {
+    const toPinyin = vi.fn((name: string) =>
+      name === "魏娇莹" ? "weijiaoying" : name
+    );
+    const largeSource = {
+      friends: Array.from({ length: 10_000 }, (_, index) => ({
+        channel_id: `u${index}`,
+        channel_type: 1,
+        channel_name: index === 9_999 ? "魏娇莹" : `User ${index}`,
+      })),
+      groups: [],
+    };
+    const index = buildGlobalSearchPinyinIndex(largeSource, toPinyin);
+
+    for (let count = 0; count < 20; count += 1) {
+      expect(searchGlobalSearchPinyinIndex("weijiao", index).friends).toHaveLength(1);
+    }
+
+    expect(toPinyin).toHaveBeenCalledTimes(10_000);
+  });
+
+  it("indexes newly allowed server results without reconverting cached names", () => {
+    const toPinyin = vi.fn((name: string) =>
+      name === "全能接项目小组" ? "quannengjiexiangmuxiaozu" : name
+    );
+    const initial = buildGlobalSearchPinyinIndex(source, toPinyin);
+    toPinyin.mockClear();
+
+    const extended = extendGlobalSearchPinyinIndex(
+      initial,
+      {
+        friends: source.friends,
+        groups: [
+          ...source.groups,
+          {
+            channel_id: "g2",
+            channel_type: 2,
+            channel_name: "全能接项目小组",
+          },
+        ],
+      },
+      toPinyin
+    );
+
+    expect(toPinyin).toHaveBeenCalledTimes(1);
+    expect(
+      searchGlobalSearchPinyinIndex("quanneng", extended).groups?.map(
+        (item) => item.channel_id
+      )
+    ).toEqual(["g2"]);
+  });
+
+  it("matches the real group name with the project's pinyin converter", () => {
+    const index = buildGlobalSearchPinyinIndex({
+      friends: [],
+      groups: [{
+        channel_id: "g2",
+        channel_type: 2,
+        channel_name: "全能接项目小组",
+      }],
+    });
+
+    expect(searchGlobalSearchPinyinIndex("quanneng", index).groups).toHaveLength(1);
+  });
+
+  it("reuses a generic named index for sender, member and channel pickers", () => {
+    const toPinyin = vi.fn((value: string) =>
+      value === "魏娇莹" ? "weijiaoying" : value
+    );
+    const index = createNamedPinyinSearchIndex<{ id: string; name: string }>();
+    const items = [{ id: "u1", name: "魏娇莹" }];
+
+    extendNamedPinyinSearchIndex(
+      index,
+      items,
+      (item) => item.id,
+      (item) => [item.name, item.id],
+      toPinyin
+    );
+    extendNamedPinyinSearchIndex(
+      index,
+      items,
+      (item) => item.id,
+      (item) => [item.name, item.id],
+      toPinyin
+    );
+
+    expect(searchNamedPinyinIndex("weijiao", index)).toEqual(items);
+    expect(toPinyin).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/dmworkbase/src/bridge/globalSearch/globalSearchPinyin.ts
+++ b/packages/dmworkbase/src/bridge/globalSearch/globalSearchPinyin.ts
@@ -1,0 +1,252 @@
+import type { ChannelInfo } from "wukongimjssdk";
+import { ChannelTypeGroup, ChannelTypePerson } from "wukongimjssdk";
+import { pinyin } from "pinyin-pro";
+import type {
+  Contacts,
+} from "../../Service/DataSource/DataSource";
+import { ContactsStatus } from "../../Service/DataSource/DataSource";
+import type {
+  LegacyGlobalSearchContact,
+  LegacyGlobalSearchResponse,
+} from "../../Service/SearchService";
+import { getPinyin } from "../../Utils/pinYin";
+import { toSimplized } from "../../Utils/t2s";
+
+export type GlobalSearchPinyinConverter = (value: string) => string;
+
+interface NamedPinyinSearchEntry<T> {
+  item: T;
+  sourceText: string;
+  searchText: string;
+}
+
+export interface NamedPinyinSearchIndex<T> {
+  entries: Map<string, NamedPinyinSearchEntry<T>>;
+}
+
+interface GlobalSearchPinyinEntry {
+  item: LegacyGlobalSearchContact;
+  searchText: string;
+}
+
+export interface GlobalSearchPinyinIndex {
+  friends: GlobalSearchPinyinEntry[];
+  groups: GlobalSearchPinyinEntry[];
+}
+
+function displayName(item: LegacyGlobalSearchContact): string {
+  return item.channel_remark || item.channel_name || item.channel_id || "";
+}
+
+function defaultPinyinConverter(value: string): string {
+  const simplified = toSimplized(value);
+  const legacyPinyin = getPinyin(simplified).toLowerCase();
+  const standardPinyin = pinyin(simplified, {
+    toneType: "none",
+    type: "array",
+  }).join("").toLowerCase();
+  return `${legacyPinyin}\n${standardPinyin}`;
+}
+
+function namedSearchText(
+  normalized: string[],
+  toPinyin: GlobalSearchPinyinConverter
+): string {
+  return [
+    normalized.join("\n"),
+    ...normalized.map((value) => toPinyin(value).toLowerCase()),
+  ].join("\n");
+}
+
+export function createNamedPinyinSearchIndex<T>(): NamedPinyinSearchIndex<T> {
+  return { entries: new Map() };
+}
+
+export function extendNamedPinyinSearchIndex<T>(
+  index: NamedPinyinSearchIndex<T>,
+  items: T[],
+  getKey: (item: T) => string,
+  getValues: (item: T) => string[],
+  toPinyin: GlobalSearchPinyinConverter = defaultPinyinConverter
+): NamedPinyinSearchIndex<T> {
+  items.forEach((item) => {
+    const key = getKey(item);
+    if (!key) return;
+    const normalized = getValues(item)
+      .map((value) => value.trim().toLowerCase())
+      .filter(Boolean);
+    const sourceText = normalized.join("\n");
+    const current = index.entries.get(key);
+    if (current?.sourceText === sourceText) {
+      current.item = item;
+      return;
+    }
+    index.entries.set(key, {
+      item,
+      sourceText,
+      searchText: namedSearchText(normalized, toPinyin),
+    });
+  });
+  return index;
+}
+
+export function searchNamedPinyinIndex<T>(
+  keyword: string,
+  index: NamedPinyinSearchIndex<T>
+): T[] {
+  const normalizedKeyword = keyword.trim().toLowerCase();
+  if (!normalizedKeyword) {
+    return Array.from(index.entries.values(), (entry) => entry.item);
+  }
+  return Array.from(index.entries.values())
+    .filter((entry) => entry.searchText.includes(normalizedKeyword))
+    .map((entry) => entry.item);
+}
+
+function searchText(
+  item: LegacyGlobalSearchContact,
+  toPinyin: GlobalSearchPinyinConverter
+): string {
+  const name = displayName(item).replace(/\*\*/g, "").toLowerCase();
+  return `${name}\n${toPinyin(name).toLowerCase()}`;
+}
+
+function uniqueByChannel(
+  items: LegacyGlobalSearchContact[]
+): LegacyGlobalSearchContact[] {
+  const seen = new Set<string>();
+  return items.filter((item) => {
+    const key = `${item.channel_type}:${item.channel_id}`;
+    if (!item.channel_id || seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+export function createEmptyGlobalSearchPinyinIndex(): GlobalSearchPinyinIndex {
+  return { friends: [], groups: [] };
+}
+
+export function buildGlobalSearchPinyinIndex(
+  source: Pick<LegacyGlobalSearchResponse, "friends" | "groups">,
+  toPinyin: GlobalSearchPinyinConverter = defaultPinyinConverter
+): GlobalSearchPinyinIndex {
+  const build = (items: LegacyGlobalSearchContact[] | undefined) =>
+    uniqueByChannel(items || []).map((item) => ({
+      item,
+      searchText: searchText(item, toPinyin),
+    }));
+
+  return {
+    friends: build(source.friends),
+    groups: build(source.groups),
+  };
+}
+
+export function extendGlobalSearchPinyinIndex(
+  index: GlobalSearchPinyinIndex,
+  source: Pick<LegacyGlobalSearchResponse, "friends" | "groups">,
+  toPinyin: GlobalSearchPinyinConverter = defaultPinyinConverter
+): GlobalSearchPinyinIndex {
+  const extend = (
+    current: GlobalSearchPinyinEntry[],
+    incoming: LegacyGlobalSearchContact[] | undefined
+  ) => {
+    const seen = new Set(
+      current.map((entry) =>
+        `${entry.item.channel_type}:${entry.item.channel_id}`
+      )
+    );
+    const additions = uniqueByChannel(incoming || [])
+      .filter((item) => {
+        const key = `${item.channel_type}:${item.channel_id}`;
+        if (seen.has(key)) return false;
+        seen.add(key);
+        return true;
+      })
+      .map((item) => ({ item, searchText: searchText(item, toPinyin) }));
+    return current.concat(additions);
+  };
+
+  return {
+    friends: extend(index.friends, source.friends),
+    groups: extend(index.groups, source.groups),
+  };
+}
+
+export function searchGlobalSearchPinyinIndex(
+  keyword: string,
+  index: GlobalSearchPinyinIndex
+): Pick<LegacyGlobalSearchResponse, "friends" | "groups"> {
+  const normalizedKeyword = keyword.trim().toLowerCase();
+  if (!normalizedKeyword) return { friends: [], groups: [] };
+
+  const search = (entries: GlobalSearchPinyinEntry[]) =>
+    entries
+      .filter((entry) => entry.searchText.includes(normalizedKeyword))
+      .map((entry) => entry.item);
+
+  return {
+    friends: search(index.friends),
+    groups: search(index.groups),
+  };
+}
+
+function mergeContacts(
+  serverItems: LegacyGlobalSearchContact[] | undefined,
+  localItems: LegacyGlobalSearchContact[] | undefined
+): LegacyGlobalSearchContact[] {
+  return uniqueByChannel([...(serverItems || []), ...(localItems || [])]);
+}
+
+export function mergeGlobalSearchPinyinResults(
+  serverResult: LegacyGlobalSearchResponse,
+  localResult: Pick<LegacyGlobalSearchResponse, "friends" | "groups">
+): LegacyGlobalSearchResponse {
+  return {
+    ...serverResult,
+    friends: mergeContacts(serverResult.friends, localResult.friends),
+    groups: mergeContacts(serverResult.groups, localResult.groups),
+  };
+}
+
+export function globalSearchContactsToLegacy(
+  contacts: Contacts[]
+): LegacyGlobalSearchContact[] {
+  return contacts
+    .filter((contact) => contact.status !== ContactsStatus.Blacklist)
+    .map((contact) => ({
+      channel_id: contact.uid,
+      channel_type: ChannelTypePerson,
+      channel_name: contact.remark || contact.name || contact.uid,
+      channel_remark: contact.remark || undefined,
+    }));
+}
+
+export function globalSearchGroupsToLegacy(
+  groups: ChannelInfo[]
+): LegacyGlobalSearchContact[] {
+  return groups.flatMap((group) => {
+    const raw = group as ChannelInfo & {
+      displayName?: string;
+      name?: string;
+      orgData?: Record<string, unknown>;
+    };
+    const channelId = raw.channel?.channelID;
+    if (!channelId) return [];
+    const org = raw.orgData || {};
+    const remark = typeof org.remark === "string" ? org.remark : "";
+    const name =
+      remark ||
+      (typeof raw.displayName === "string" ? raw.displayName : "") ||
+      (typeof org.displayName === "string" ? org.displayName : "") ||
+      (typeof raw.name === "string" ? raw.name : "") ||
+      channelId;
+    return [{
+      channel_id: channelId,
+      channel_type: raw.channel.channelType || ChannelTypeGroup,
+      channel_name: name,
+      channel_remark: remark || undefined,
+    }];
+  });
+}

--- a/packages/dmworkbase/src/bridge/globalSearch/globalSearchPinyin.ts
+++ b/packages/dmworkbase/src/bridge/globalSearch/globalSearchPinyin.ts
@@ -1,9 +1,7 @@
 import type { ChannelInfo } from "wukongimjssdk";
 import { ChannelTypeGroup, ChannelTypePerson } from "wukongimjssdk";
 import { pinyin } from "pinyin-pro";
-import type {
-  Contacts,
-} from "../../Service/DataSource/DataSource";
+import type { Contacts } from "../../Service/DataSource/DataSource";
 import { ContactsStatus } from "../../Service/DataSource/DataSource";
 import type {
   LegacyGlobalSearchContact,
@@ -44,7 +42,9 @@ function defaultPinyinConverter(value: string): string {
   const standardPinyin = pinyin(simplified, {
     toneType: "none",
     type: "array",
-  }).join("").toLowerCase();
+  })
+    .join("")
+    .toLowerCase();
   return `${legacyPinyin}\n${standardPinyin}`;
 }
 
@@ -153,8 +153,8 @@ export function extendGlobalSearchPinyinIndex(
     incoming: LegacyGlobalSearchContact[] | undefined
   ) => {
     const seen = new Set(
-      current.map((entry) =>
-        `${entry.item.channel_type}:${entry.item.channel_id}`
+      current.map(
+        (entry) => `${entry.item.channel_type}:${entry.item.channel_id}`
       )
     );
     const additions = uniqueByChannel(incoming || [])
@@ -210,6 +210,21 @@ export function mergeGlobalSearchPinyinResults(
   };
 }
 
+export function replaceGlobalSearchPinyinMatches(
+  currentResult: LegacyGlobalSearchResponse,
+  serverResult: Pick<LegacyGlobalSearchResponse, "friends" | "groups">,
+  localResult: Pick<LegacyGlobalSearchResponse, "friends" | "groups">
+): LegacyGlobalSearchResponse {
+  return mergeGlobalSearchPinyinResults(
+    {
+      ...currentResult,
+      friends: serverResult.friends,
+      groups: serverResult.groups,
+    },
+    localResult
+  );
+}
+
 export function globalSearchContactsToLegacy(
   contacts: Contacts[]
 ): LegacyGlobalSearchContact[] {
@@ -242,11 +257,20 @@ export function globalSearchGroupsToLegacy(
       (typeof org.displayName === "string" ? org.displayName : "") ||
       (typeof raw.name === "string" ? raw.name : "") ||
       channelId;
-    return [{
-      channel_id: channelId,
-      channel_type: raw.channel.channelType || ChannelTypeGroup,
-      channel_name: name,
-      channel_remark: remark || undefined,
-    }];
+    return [
+      {
+        channel_id: channelId,
+        channel_type: raw.channel.channelType || ChannelTypeGroup,
+        channel_name: name,
+        channel_remark: remark || undefined,
+      },
+    ];
   });
+}
+
+export function refreshGlobalSearchGroupCandidates(
+  current: LegacyGlobalSearchContact[],
+  groups: ChannelInfo[] | undefined
+): LegacyGlobalSearchContact[] {
+  return groups === undefined ? current : globalSearchGroupsToLegacy(groups);
 }

--- a/packages/dmworkbase/src/features/globalSearch/GlobalSearchPanel.tsx
+++ b/packages/dmworkbase/src/features/globalSearch/GlobalSearchPanel.tsx
@@ -301,7 +301,11 @@ export default class GlobalSearch extends Component<
                     },
                     onChange: (value) => {
                       this.setState({ searchValue: value });
-                      if (!vm.isComposing) vm.handleInputChange(value);
+                      if (vm.isComposing) {
+                        vm.handleComposingInputChange(value);
+                      } else {
+                        vm.handleInputChange(value);
+                      }
                     },
                     trailing: this.state.searchValue ? (
                       <button


### PR DESCRIPTION
## Summary
- add Chinese, full-pinyin, and case-insensitive matching for global contact and group search
- support pinyin matching in sender, member, and group/thread filter pickers shared by chat and file tabs
- preserve server search, pagination, result ordering, permissions, and filter request contracts
- rebuild scoped indexes when the Space or readable channel pool changes

## Validation
- `pnpm --dir packages/dmworkbase vitest run src/Components/GlobalSearch/__tests__ src/bridge/globalSearch/globalSearchPinyin.test.ts` (103 tests)
- `pnpm i18n:check`
- `pnpm --dir apps/web build`
- `git diff --check`
- manually verified `quanneng` finds 全能接项目小组 in group search and the group/thread filter
- manually verified `jia` finds Chinese names in sender and member filters, including after switching between chat and file tabs