### PR TITLE
fix(channel-setting): refresh inline save and return states

### DIFF
--- a/packages/dmworkbase/src/Components/ChannelSetting/index.css
+++ b/packages/dmworkbase/src/Components/ChannelSetting/index.css
@@ -87,6 +87,26 @@
     background: var(--wk-bg-surface);
 }
 
+/*
+ * 头像和二维码子页返回时仍保留 animationend，让 WKViewQueue 正常清理栈顶；
+ * 只取消可见位移，避免标题先切回父页、内容仍横向退场造成的闪动。
+ * 该规则不改变 RoutePage/WKViewQueue 的退栈和数据刷新逻辑。
+ */
+.wk-viewqueue-view-out:has(.wk-channelavatar),
+.wk-viewqueue-view-out:has(.wk-channelqrcode) {
+    background: var(--wk-bg-surface);
+    animation-name: wk-channelsetting-child-exit;
+    animation-duration: var(--wk-dur-fast);
+    animation-timing-function: var(--wk-ease);
+}
+
+@keyframes wk-channelsetting-child-exit {
+    from,
+    to {
+        transform: translate3d(0, 0, 0);
+    }
+}
+
 /* 仅作用于 ChannelSetting，避免影响其他 Sections/ListItem 调用方。 */
 .wk-channelsetting-content > .wk-sections {
     display: flex;

--- a/packages/dmworkbase/src/ui/ChannelSettingRows/__tests__/ChannelSettingInlineEditRow.test.tsx
+++ b/packages/dmworkbase/src/ui/ChannelSettingRows/__tests__/ChannelSettingInlineEditRow.test.tsx
@@ -88,6 +88,29 @@ describe("ChannelSettingInlineEditRow", () => {
     expect(onSave).toHaveBeenCalledWith("");
   });
 
+  it("enables saving after clearing and retyping the original nickname", () => {
+    render(
+      <ChannelSettingInlineEditRow
+        title="My nickname"
+        value="Alice"
+        allowEmpty
+        onSave={vi.fn(() => Promise.resolve())}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "My nickname" }));
+    fireEvent.mouseDown(
+      screen.getByRole("button", { name: "My nickname-base.common.clear" })
+    );
+
+    const input = screen.getByDisplayValue("");
+    fireEvent.change(input, { target: { value: "Alice" } });
+
+    expect(
+      screen.getByRole("button", { name: "base.common.save" })
+    ).toBeEnabled();
+  });
+
   it("keeps the draft open when saving fails", async () => {
     const onSave = vi.fn(() => Promise.resolve(false));
 
@@ -109,6 +132,9 @@ describe("ChannelSettingInlineEditRow", () => {
     expect(screen.getByDisplayValue("Unsaved draft")).toBe(input);
     expect(
       screen.getByRole("button", { name: "base.common.cancel" })
+    ).toBeEnabled();
+    expect(
+      screen.getByRole("button", { name: "base.common.save" })
     ).toBeEnabled();
   });
 
@@ -167,6 +193,9 @@ describe("ChannelSettingInlineEditRow", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Group name" }));
     expect(screen.getByDisplayValue("Remote name")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "base.common.save" })
+    ).toBeDisabled();
   });
 
   it("keeps a successful save visible until the external value catches up", async () => {

--- a/packages/dmworkbase/src/ui/ChannelSettingRows/index.tsx
+++ b/packages/dmworkbase/src/ui/ChannelSettingRows/index.tsx
@@ -116,6 +116,7 @@ export function ChannelSettingInlineEditRow({
   const [editing, setEditing] = useState(false);
   const [currentValue, setCurrentValue] = useState(value);
   const [draft, setDraft] = useState(value);
+  const [dirty, setDirty] = useState(false);
   const [saving, setSaving] = useState(false);
   const editingRef = useRef(false);
 
@@ -132,12 +133,12 @@ export function ChannelSettingInlineEditRow({
 
   const exceeded = maxCount !== undefined && draft.length > maxCount;
   const emptyInvalid = !allowEmpty && draft.trim().length === 0;
-  const unchanged = draft === currentValue;
-  const saveDisabled = saving || exceeded || emptyInvalid || unchanged;
+  const saveDisabled = saving || exceeded || emptyInvalid || !dirty;
 
   const startEdit = () => {
     if (onStartEdit?.() === false) return;
     setDraft(currentValue);
+    setDirty(false);
     setEditing(true);
   };
 
@@ -156,7 +157,10 @@ export function ChannelSettingInlineEditRow({
     value: draft,
     placeholder,
     disabled: saving,
-    onChange: (next: string) => setDraft(next),
+    onChange: (next: string) => {
+      setDraft(next);
+      setDirty(true);
+    },
   };
 
   return (
@@ -166,7 +170,10 @@ export function ChannelSettingInlineEditRow({
         <TextArea
           {...inputProps}
           showClear
-          onClear={() => setDraft("")}
+          onClear={() => {
+            setDraft("");
+            setDirty(true);
+          }}
           autosize={{ minRows: 2, maxRows: 6 }}
         />
       ) : (
@@ -182,6 +189,7 @@ export function ChannelSettingInlineEditRow({
                   event.preventDefault();
                   event.stopPropagation();
                   setDraft("");
+                  setDirty(true);
                 }}
               >
                 <IconClear />
@@ -205,6 +213,7 @@ export function ChannelSettingInlineEditRow({
           disabled={saving}
           onClick={() => {
             setDraft(currentValue);
+            setDirty(false);
             setEditing(false);
           }}
         >
@@ -220,6 +229,7 @@ export function ChannelSettingInlineEditRow({
               const saved = await onSave(draft);
               if (saved !== false) {
                 setCurrentValue(draft);
+                setDirty(false);
                 setEditing(false);
               }
             } catch {


### PR DESCRIPTION
## Summary

- track inline-edit intent so clearing and retyping the original group nickname enables Save immediately
- preserve existing clear, cancel, failed-save retry, external refresh, and successful-save behavior
- remove the visible exit displacement when returning from group avatar and group QR code pages while preserving WKViewQueue cleanup

## Scope

- limited to `ChannelSettingInlineEditRow`, its regression tests, and ChannelSetting-scoped transition CSS
- no changes to APIs, bridge actions, permissions, WKApp, WKSDK, datasource, Chat, Conversation, Messages, or shared route logic

## Validation

- ChannelSetting focused Vitest: 8 files, 74 tests passed
- `pnpm i18n:check`: passed
- Prettier: passed
- Stylelint: 0 errors; 6 pre-existing warnings outside the changed rules
- `git diff --check`: passed
- Web production build: passed (14,970 modules transformed)
- manual verification passed for nickname clear/retype/save and avatar/QR-code return behavior