### PR TITLE
feat(search): add scoped pinyin matching

### DIFF
--- a/packages/dmworkbase/src/Components/GlobalSearch/__tests__/senderCandidates.test.ts
+++ b/packages/dmworkbase/src/Components/GlobalSearch/__tests__/senderCandidates.test.ts
@@ -21,6 +21,9 @@ import { describe, expect, it, vi, beforeEach } from "vitest";
 const mockState = vi.hoisted(() => ({
   commonDataSource: undefined as any,
   contactsList: [] as any[],
+  groups: [] as any[],
+  groupSaveList: undefined as undefined | (() => Promise<any[]>),
+  spaceId: "space-1",
   loginUid: "self-uid",
   loginName: "Me",
 }));
@@ -31,6 +34,13 @@ vi.mock("../../../App", () => ({
       return {
         commonDataSource: mockState.commonDataSource,
         contactsList: mockState.contactsList,
+        channelDataSource: {
+          groupSaveList: vi.fn(() =>
+            mockState.groupSaveList
+              ? mockState.groupSaveList()
+              : Promise.resolve(mockState.groups)
+          ),
+        },
       };
     },
     get loginInfo() {
@@ -41,6 +51,9 @@ vi.mock("../../../App", () => ({
       };
     },
     shared: {
+      get currentSpaceId() {
+        return mockState.spaceId;
+      },
       avatarUser: (uid: string) => `avatar://user/${uid}`,
       avatarChannel: (ch: any) =>
         `avatar://ch/${ch?.channelID ?? ""}/${ch?.channelType ?? ""}`,
@@ -52,24 +65,28 @@ vi.mock("../../../App", () => ({
   },
 }));
 
-vi.mock("wukongimjssdk", () => ({
-  Channel: class {
-    channelID: string;
-    channelType: number;
-    constructor(channelID: string, channelType: number) {
-      this.channelID = channelID;
-      this.channelType = channelType;
-    }
-  },
-  ChannelTypeGroup: 2,
-  ChannelTypePerson: 1,
-  WKSDK: {
+vi.mock("wukongimjssdk", () => {
+  const sdk = {
     shared: () => ({
       conversationManager: { conversations: [] },
       channelManager: { getChannelInfo: () => undefined },
     }),
-  },
-}));
+  };
+  return {
+    default: sdk,
+    Channel: class {
+      channelID: string;
+      channelType: number;
+      constructor(channelID: string, channelType: number) {
+        this.channelID = channelID;
+        this.channelType = channelType;
+      }
+    },
+    ChannelTypeGroup: 2,
+    ChannelTypePerson: 1,
+    WKSDK: sdk,
+  };
+});
 
 import { createGlobalSearchApiDataSource } from "../dataSource";
 
@@ -77,6 +94,9 @@ describe("loadSenderCandidates (via searchSenders)", () => {
   beforeEach(() => {
     mockState.commonDataSource = undefined;
     mockState.contactsList = [];
+    mockState.groups = [];
+    mockState.groupSaveList = undefined;
+    mockState.spaceId = "space-1";
   });
 
   it("§1: maps ChannelInfo[] from commonDataSource.searchFriends into ChannelSearchSender", async () => {
@@ -141,9 +161,7 @@ describe("loadSenderCandidates (via searchSenders)", () => {
 
   it("§3: surfaces contactsList when searchFriends is missing entirely", async () => {
     mockState.commonDataSource = {}; // no searchFriends method
-    mockState.contactsList = [
-      { uid: "erin-uid", name: "Erin" },
-    ];
+    mockState.contactsList = [{ uid: "erin-uid", name: "Erin" }];
 
     const ds = createGlobalSearchApiDataSource();
     const results = await ds.searchSenders("");
@@ -154,14 +172,12 @@ describe("loadSenderCandidates (via searchSenders)", () => {
   it("§4: cold panel (empty sender cache) still returns candidates from the real DS API — regression guard", async () => {
     // The exact scenario Jerry-Xin flagged: no prior search results have
     // warmed the sender cache. Before the fix, this returned only [self].
-    const searchFriends = vi
-      .fn()
-      .mockResolvedValue([
-        {
-          channel: { channelID: "frank-uid", channelType: 1 },
-          orgData: { displayName: "Frank" },
-        },
-      ]);
+    const searchFriends = vi.fn().mockResolvedValue([
+      {
+        channel: { channelID: "frank-uid", channelType: 1 },
+        orgData: { displayName: "Frank" },
+      },
+    ]);
     mockState.commonDataSource = { searchFriends };
 
     const ds = createGlobalSearchApiDataSource();
@@ -211,5 +227,164 @@ describe("loadSenderCandidates (via searchSenders)", () => {
 
     const ds = createGlobalSearchApiDataSource();
     await expect(ds.searchSenders("")).resolves.toBeDefined();
+  });
+
+  it("matches sender/member candidates by full pinyin without skipping remote search", async () => {
+    const searchFriends = vi.fn().mockResolvedValue([]);
+    mockState.commonDataSource = { searchFriends };
+    mockState.contactsList = [{ uid: "jia-uid", name: "贾小明" }];
+
+    const ds = createGlobalSearchApiDataSource();
+    const results = await ds.searchSenders("jia");
+
+    expect(searchFriends).toHaveBeenCalledWith("jia");
+    expect(results.map((sender) => sender.uid)).toContain("jia-uid");
+  });
+
+  it("matches group options by full pinyin", async () => {
+    mockState.groups = [
+      {
+        channel: { channelID: "group-1", channelType: 2 },
+        title: "全能接项目小组",
+        orgData: { displayName: "全能接项目小组" },
+      },
+    ];
+
+    const ds = createGlobalSearchApiDataSource();
+    const results = await ds.searchChannels("quanneng");
+
+    expect(results.map((channel) => channel.channelId)).toContain("group-1");
+  });
+
+  it("removes stale channel candidates when the readable pool changes", async () => {
+    mockState.groups = [
+      {
+        channel: { channelID: "group-1", channelType: 2 },
+        displayName: "全能接项目小组",
+      },
+    ];
+    const ds = createGlobalSearchApiDataSource();
+    await expect(ds.searchChannels("quanneng")).resolves.toHaveLength(1);
+
+    mockState.groups = [];
+    await expect(ds.searchChannels("quanneng")).resolves.toEqual([]);
+  });
+
+  it("clears cached pinyin candidates after switching spaces", async () => {
+    mockState.contactsList = [{ uid: "old-uid", name: "贾小明" }];
+    const ds = createGlobalSearchApiDataSource();
+    await expect(ds.searchSenders("jia")).resolves.toEqual(
+      expect.arrayContaining([expect.objectContaining({ uid: "old-uid" })])
+    );
+
+    mockState.spaceId = "space-2";
+    mockState.contactsList = [];
+    await expect(ds.searchSenders("jia")).resolves.toEqual([]);
+  });
+
+  it("removes stale sender candidates when the contact pool shrinks in the same space", async () => {
+    mockState.commonDataSource = {
+      searchFriends: vi.fn().mockResolvedValue([]),
+    };
+    mockState.contactsList = [{ uid: "old-uid", name: "贾小明" }];
+    const ds = createGlobalSearchApiDataSource();
+    await expect(ds.searchSenders("jia")).resolves.toEqual(
+      expect.arrayContaining([expect.objectContaining({ uid: "old-uid" })])
+    );
+
+    mockState.contactsList = [];
+    await expect(ds.searchSenders("jia")).resolves.toEqual([]);
+    expect(ds.getSenders().some((sender) => sender.uid === "old-uid")).toBe(
+      false
+    );
+  });
+
+  it("removes renamed sender pinyin and excludes blacklisted contacts", async () => {
+    mockState.commonDataSource = {
+      searchFriends: vi.fn().mockResolvedValue([]),
+    };
+    mockState.contactsList = [{ uid: "user-1", name: "贾小明" }];
+    const ds = createGlobalSearchApiDataSource();
+    await expect(ds.searchSenders("jia")).resolves.toHaveLength(1);
+
+    mockState.contactsList = [{ uid: "user-1", name: "张小明" }];
+    await expect(ds.searchSenders("jia")).resolves.toEqual([]);
+    await expect(ds.searchSenders("zhang")).resolves.toHaveLength(1);
+
+    mockState.contactsList = [{ uid: "user-1", name: "张小明", status: 2 }];
+    await expect(ds.searchSenders("zhang")).resolves.toEqual([]);
+  });
+
+  it("preserves the existing server-first candidate order", async () => {
+    mockState.commonDataSource = {
+      searchFriends: vi.fn().mockResolvedValue([
+        {
+          channel: { channelID: "server-1", channelType: 1 },
+          orgData: { displayName: "服务端一" },
+        },
+        {
+          channel: { channelID: "server-2", channelType: 1 },
+          orgData: { displayName: "服务端二" },
+        },
+      ]),
+    };
+    mockState.contactsList = [{ uid: "local-1", name: "本地联系人" }];
+
+    const ds = createGlobalSearchApiDataSource();
+    const results = await ds.searchSenders("");
+
+    expect(results.map((sender) => sender.uid)).toEqual([
+      "self-uid",
+      "server-1",
+      "server-2",
+      "local-1",
+    ]);
+  });
+
+  it("does not write an in-flight sender response into a new space", async () => {
+    let resolveSearch: (value: any[]) => void = () => undefined;
+    mockState.commonDataSource = {
+      searchFriends: vi.fn().mockImplementation(
+        () =>
+          new Promise<any[]>((resolve) => {
+            resolveSearch = resolve;
+          })
+      ),
+    };
+    const ds = createGlobalSearchApiDataSource();
+    const pending = ds.searchSenders("old");
+
+    mockState.spaceId = "space-2";
+    mockState.contactsList = [];
+    resolveSearch([
+      {
+        channel: { channelID: "old-space-user", channelType: 1 },
+        orgData: { displayName: "旧空间用户" },
+      },
+    ]);
+
+    await expect(pending).resolves.toEqual([]);
+    expect(ds.getSenders().map((sender) => sender.uid)).toEqual(["self-uid"]);
+  });
+
+  it("does not write in-flight channel options into a new space", async () => {
+    let resolveGroups: (value: any[]) => void = () => undefined;
+    mockState.groupSaveList = () =>
+      new Promise<any[]>((resolve) => {
+        resolveGroups = resolve;
+      });
+    const ds = createGlobalSearchApiDataSource();
+    const pending = ds.searchChannels("quanneng");
+
+    mockState.spaceId = "space-2";
+    resolveGroups([
+      {
+        channel: { channelID: "old-space-group", channelType: 2 },
+        title: "全能接项目小组",
+        orgData: { displayName: "全能接项目小组" },
+      },
+    ]);
+
+    await expect(pending).resolves.toEqual([]);
   });
 });

--- a/packages/dmworkbase/src/Components/GlobalSearch/__tests__/senderCandidates.test.ts
+++ b/packages/dmworkbase/src/Components/GlobalSearch/__tests__/senderCandidates.test.ts
@@ -22,7 +22,6 @@ const mockState = vi.hoisted(() => ({
   commonDataSource: undefined as any,
   contactsList: [] as any[],
   groups: [] as any[],
-  groupSaveList: undefined as undefined | (() => Promise<any[]>),
   spaceId: "space-1",
   loginUid: "self-uid",
   loginName: "Me",
@@ -35,11 +34,7 @@ vi.mock("../../../App", () => ({
         commonDataSource: mockState.commonDataSource,
         contactsList: mockState.contactsList,
         channelDataSource: {
-          groupSaveList: vi.fn(() =>
-            mockState.groupSaveList
-              ? mockState.groupSaveList()
-              : Promise.resolve(mockState.groups)
-          ),
+          groupSaveList: vi.fn(() => Promise.resolve(mockState.groups)),
         },
       };
     },
@@ -95,7 +90,6 @@ describe("loadSenderCandidates (via searchSenders)", () => {
     mockState.commonDataSource = undefined;
     mockState.contactsList = [];
     mockState.groups = [];
-    mockState.groupSaveList = undefined;
     mockState.spaceId = "space-1";
   });
 
@@ -230,81 +224,144 @@ describe("loadSenderCandidates (via searchSenders)", () => {
   });
 
   it("matches sender/member candidates by full pinyin without skipping remote search", async () => {
-    const searchFriends = vi.fn().mockResolvedValue([]);
+    const searchFriends = vi.fn((keyword: string) =>
+      Promise.resolve(
+        keyword
+          ? []
+          : [
+              {
+                channel: { channelID: "user-42", channelType: 1 },
+                orgData: { displayName: "贾小明" },
+              },
+            ]
+      )
+    );
     mockState.commonDataSource = { searchFriends };
-    mockState.contactsList = [{ uid: "jia-uid", name: "贾小明" }];
+    mockState.contactsList = [{ uid: "user-42", name: "贾小明" }];
 
     const ds = createGlobalSearchApiDataSource();
+    await ds.searchSenders("");
     const results = await ds.searchSenders("jia");
 
     expect(searchFriends).toHaveBeenCalledWith("jia");
-    expect(results.map((sender) => sender.uid)).toContain("jia-uid");
+    expect(results.map((sender) => sender.uid)).toContain("user-42");
   });
 
   it("matches group options by full pinyin", async () => {
     mockState.groups = [
       {
         channel: { channelID: "group-1", channelType: 2 },
-        title: "全能接项目小组",
-        orgData: { displayName: "全能接项目小组" },
+        displayName: "魏娇莹项目群",
       },
     ];
 
     const ds = createGlobalSearchApiDataSource();
-    const results = await ds.searchChannels("quanneng");
+    const results = await ds.searchChannels("weijiao");
 
     expect(results.map((channel) => channel.channelId)).toContain("group-1");
+    expect(results[0].name).toBe("魏娇莹项目群");
+  });
+
+  it("keeps channel literal search scoped to the existing visible name", async () => {
+    mockState.groups = [
+      {
+        channel: { channelID: "opaque-weijiao-id", channelType: 2 },
+        displayName: "产品讨论群",
+        title: "魏娇莹隐藏标题",
+        orgData: { displayName: "魏娇莹隐藏名称" },
+      },
+    ];
+    const ds = createGlobalSearchApiDataSource();
+
+    await expect(ds.searchChannels("产品")).resolves.toHaveLength(1);
+    await expect(ds.searchChannels("weijiao")).resolves.toEqual([]);
+    await expect(ds.searchChannels("opaque")).resolves.toEqual([]);
   });
 
   it("removes stale channel candidates when the readable pool changes", async () => {
     mockState.groups = [
       {
         channel: { channelID: "group-1", channelType: 2 },
-        displayName: "全能接项目小组",
+        displayName: "魏娇莹项目群",
       },
     ];
     const ds = createGlobalSearchApiDataSource();
-    await expect(ds.searchChannels("quanneng")).resolves.toHaveLength(1);
+    await expect(ds.searchChannels("weijiao")).resolves.toHaveLength(1);
 
     mockState.groups = [];
-    await expect(ds.searchChannels("quanneng")).resolves.toEqual([]);
+    await expect(ds.searchChannels("weijiao")).resolves.toEqual([]);
   });
 
-  it("clears cached pinyin candidates after switching spaces", async () => {
+  it("does not reuse pinyin candidates after the contact pool changes", async () => {
+    mockState.commonDataSource = {
+      searchFriends: vi.fn((keyword: string) =>
+        Promise.resolve(
+          keyword
+            ? []
+            : [
+                {
+                  channel: { channelID: "old-uid", channelType: 1 },
+                  orgData: { displayName: "贾小明" },
+                },
+              ]
+        )
+      ),
+    };
     mockState.contactsList = [{ uid: "old-uid", name: "贾小明" }];
     const ds = createGlobalSearchApiDataSource();
+    await ds.searchSenders("");
     await expect(ds.searchSenders("jia")).resolves.toEqual(
       expect.arrayContaining([expect.objectContaining({ uid: "old-uid" })])
     );
 
-    mockState.spaceId = "space-2";
     mockState.contactsList = [];
     await expect(ds.searchSenders("jia")).resolves.toEqual([]);
   });
 
   it("removes stale sender candidates when the contact pool shrinks in the same space", async () => {
     mockState.commonDataSource = {
-      searchFriends: vi.fn().mockResolvedValue([]),
+      searchFriends: vi.fn((keyword: string) =>
+        Promise.resolve(
+          keyword
+            ? []
+            : [
+                {
+                  channel: { channelID: "old-uid", channelType: 1 },
+                  orgData: { displayName: "贾小明" },
+                },
+              ]
+        )
+      ),
     };
     mockState.contactsList = [{ uid: "old-uid", name: "贾小明" }];
     const ds = createGlobalSearchApiDataSource();
+    await ds.searchSenders("");
     await expect(ds.searchSenders("jia")).resolves.toEqual(
       expect.arrayContaining([expect.objectContaining({ uid: "old-uid" })])
     );
 
     mockState.contactsList = [];
     await expect(ds.searchSenders("jia")).resolves.toEqual([]);
-    expect(ds.getSenders().some((sender) => sender.uid === "old-uid")).toBe(
-      false
-    );
   });
 
-  it("removes renamed sender pinyin and excludes blacklisted contacts", async () => {
+  it("does not reuse renamed or blacklisted sender pinyin", async () => {
     mockState.commonDataSource = {
-      searchFriends: vi.fn().mockResolvedValue([]),
+      searchFriends: vi.fn((keyword: string) =>
+        Promise.resolve(
+          keyword
+            ? []
+            : [
+                {
+                  channel: { channelID: "user-1", channelType: 1 },
+                  orgData: { displayName: "贾小明" },
+                },
+              ]
+        )
+      ),
     };
     mockState.contactsList = [{ uid: "user-1", name: "贾小明" }];
     const ds = createGlobalSearchApiDataSource();
+    await ds.searchSenders("");
     await expect(ds.searchSenders("jia")).resolves.toHaveLength(1);
 
     mockState.contactsList = [{ uid: "user-1", name: "张小明" }];
@@ -313,6 +370,86 @@ describe("loadSenderCandidates (via searchSenders)", () => {
 
     mockState.contactsList = [{ uid: "user-1", name: "张小明", status: 2 }];
     await expect(ds.searchSenders("zhang")).resolves.toEqual([]);
+  });
+
+  it("does not add deleted or no-longer-followed contacts as pinyin matches", async () => {
+    mockState.commonDataSource = {
+      searchFriends: vi.fn((keyword: string) =>
+        Promise.resolve(
+          keyword
+            ? []
+            : [
+                {
+                  channel: { channelID: "user-1", channelType: 1 },
+                  orgData: { displayName: "贾小明" },
+                },
+              ]
+        )
+      ),
+    };
+    const ds = createGlobalSearchApiDataSource();
+
+    mockState.contactsList = [
+      { uid: "user-1", name: "贾小明", beDeleted: true },
+    ];
+    await ds.searchSenders("");
+    await expect(ds.searchSenders("jia")).resolves.toEqual([]);
+
+    mockState.contactsList = [{ uid: "user-1", name: "贾小明", follow: 0 }];
+    await expect(ds.searchSenders("jia")).resolves.toEqual([]);
+  });
+
+  it("does not expose a previous Space contact through pinyin", async () => {
+    mockState.commonDataSource = {
+      searchFriends: vi.fn((keyword: string) =>
+        Promise.resolve(
+          mockState.spaceId === "space-1" && !keyword
+            ? [
+                {
+                  channel: { channelID: "space-1-only", channelType: 1 },
+                  orgData: { displayName: "贾小明" },
+                },
+              ]
+            : []
+        )
+      ),
+    };
+    mockState.contactsList = [
+      { uid: "space-1-only", name: "贾小明", status: 1 },
+    ];
+    const ds = createGlobalSearchApiDataSource();
+
+    await ds.searchSenders("");
+    await expect(ds.searchSenders("jia")).resolves.toEqual(
+      expect.arrayContaining([expect.objectContaining({ uid: "space-1-only" })])
+    );
+
+    mockState.spaceId = "space-2";
+    // Production leaves the account-level contactsList untouched here.
+    await expect(ds.searchSenders("jia")).resolves.toEqual([]);
+  });
+
+  it("keeps server-derived sender identities across contact changes", async () => {
+    mockState.commonDataSource = {
+      searchFriends: vi.fn().mockResolvedValue([
+        {
+          channel: { channelID: "server-only", channelType: 1 },
+          orgData: {
+            displayName: "服务端用户",
+            avatar: "https://cdn/server-only.png",
+          },
+        },
+      ]),
+    };
+    const ds = createGlobalSearchApiDataSource();
+
+    await ds.searchSenders("");
+    mockState.contactsList = [{ uid: "contact-b", name: "乙" }];
+
+    expect(ds.getSender("server-only")).toMatchObject({
+      name: "服务端用户",
+      avatarUrl: "https://cdn/server-only.png",
+    });
   });
 
   it("preserves the existing server-first candidate order", async () => {
@@ -339,52 +476,5 @@ describe("loadSenderCandidates (via searchSenders)", () => {
       "server-2",
       "local-1",
     ]);
-  });
-
-  it("does not write an in-flight sender response into a new space", async () => {
-    let resolveSearch: (value: any[]) => void = () => undefined;
-    mockState.commonDataSource = {
-      searchFriends: vi.fn().mockImplementation(
-        () =>
-          new Promise<any[]>((resolve) => {
-            resolveSearch = resolve;
-          })
-      ),
-    };
-    const ds = createGlobalSearchApiDataSource();
-    const pending = ds.searchSenders("old");
-
-    mockState.spaceId = "space-2";
-    mockState.contactsList = [];
-    resolveSearch([
-      {
-        channel: { channelID: "old-space-user", channelType: 1 },
-        orgData: { displayName: "旧空间用户" },
-      },
-    ]);
-
-    await expect(pending).resolves.toEqual([]);
-    expect(ds.getSenders().map((sender) => sender.uid)).toEqual(["self-uid"]);
-  });
-
-  it("does not write in-flight channel options into a new space", async () => {
-    let resolveGroups: (value: any[]) => void = () => undefined;
-    mockState.groupSaveList = () =>
-      new Promise<any[]>((resolve) => {
-        resolveGroups = resolve;
-      });
-    const ds = createGlobalSearchApiDataSource();
-    const pending = ds.searchChannels("quanneng");
-
-    mockState.spaceId = "space-2";
-    resolveGroups([
-      {
-        channel: { channelID: "old-space-group", channelType: 2 },
-        title: "全能接项目小组",
-        orgData: { displayName: "全能接项目小组" },
-      },
-    ]);
-
-    await expect(pending).resolves.toEqual([]);
   });
 });

--- a/packages/dmworkbase/src/bridge/globalSearch/GlobalSearchVM.test.ts
+++ b/packages/dmworkbase/src/bridge/globalSearch/GlobalSearchVM.test.ts
@@ -1,0 +1,201 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  contactsList: [] as any[],
+  currentSpaceId: "space-1",
+  groupSaveList: vi.fn(),
+  searchLegacyGlobal: vi.fn(),
+}));
+
+vi.mock("../../App", () => ({
+  default: {
+    get dataSource() {
+      return {
+        contactsList: mocks.contactsList,
+        channelDataSource: { groupSaveList: mocks.groupSaveList },
+      };
+    },
+    shared: {
+      get currentSpaceId() {
+        return mocks.currentSpaceId;
+      },
+    },
+  },
+}));
+
+vi.mock("../../Service/SearchService", () => ({
+  default: { searchLegacyGlobal: mocks.searchLegacyGlobal },
+}));
+
+vi.mock("../../i18n", () => ({ t: (key: string) => key }));
+
+vi.mock("../../im-runtime/currentChannelRuntime", () => ({
+  addCurrentImChannelInfoListener: vi.fn(() => vi.fn()),
+  getCurrentImChannelInfo: vi.fn(),
+}));
+
+vi.mock("wukongimjssdk", () => ({
+  ChannelTypePerson: 1,
+  MessageContentManager: { shared: () => ({ getMessageContent: () => null }) },
+  SystemContent: class {},
+}));
+
+import GlobalSearchVM from "./GlobalSearchVM";
+
+const emptyResult = () => ({ friends: [], groups: [], messages: [] });
+
+describe("GlobalSearchVM pinyin supplement", () => {
+  beforeEach(() => {
+    mocks.contactsList = [];
+    mocks.currentSpaceId = "space-1";
+    mocks.groupSaveList.mockReset();
+    mocks.searchLegacyGlobal.mockReset().mockResolvedValue(emptyResult());
+  });
+
+  it("does not add a groupSaveList request when the global search opens", async () => {
+    const vm = new GlobalSearchVM();
+
+    vm.didMount();
+    await vi.waitFor(() => expect(mocks.searchLegacyGlobal).toHaveBeenCalled());
+
+    expect(mocks.groupSaveList).not.toHaveBeenCalled();
+    vm.didUnMount();
+  });
+
+  it("appends pinyin matches from existing scoped sources after server results", async () => {
+    mocks.searchLegacyGlobal.mockResolvedValueOnce({
+      friends: [
+        {
+          channel_id: "friend-1",
+          channel_type: 1,
+          channel_name: "魏娇莹",
+        },
+      ],
+      groups: [
+        {
+          channel_id: "group-1",
+          channel_type: 2,
+          channel_name: "魏娇莹项目群",
+        },
+      ],
+      messages: [],
+    });
+    const vm = new GlobalSearchVM();
+    vm.didMount();
+    await vi.waitFor(() => expect(vm.searchResult).toBeTruthy());
+
+    mocks.searchLegacyGlobal.mockResolvedValueOnce({
+      friends: [
+        {
+          channel_id: "server-friend",
+          channel_type: 1,
+          channel_name: "服务端联系人",
+        },
+      ],
+      groups: [
+        {
+          channel_id: "server-group",
+          channel_type: 2,
+          channel_name: "服务端群聊",
+        },
+      ],
+      messages: [],
+    });
+    vm.keyword = "weijiao";
+    vm.initLoad();
+    vm.requestSearch();
+    await vi.waitFor(() =>
+      expect(vm.searchResult?.groups?.map((item: any) => item.channel_id)).toEqual(
+        ["server-group", "group-1"]
+      )
+    );
+
+    expect(vm.searchResult.friends.map((item: any) => item.channel_id)).toEqual(
+      ["server-friend", "friend-1"]
+    );
+    expect(vm.searchResult.groups.map((item: any) => item.channel_id)).toEqual([
+      "server-group",
+      "group-1",
+    ]);
+    expect(mocks.groupSaveList).not.toHaveBeenCalled();
+
+    mocks.searchLegacyGlobal.mockResolvedValue(emptyResult());
+    vm.keyword = "";
+    vm.initLoad();
+    vm.requestSearch();
+    await vi.waitFor(() => expect(vm.searchResult?.groups).toEqual([]));
+    vm.keyword = "weijiao";
+    vm.initLoad();
+    vm.requestSearch();
+    await vi.waitFor(() => expect(vm.searchResult?.groups).toEqual([]));
+    expect(mocks.searchLegacyGlobal).toHaveBeenCalledTimes(4);
+    vm.didUnMount();
+  });
+
+  it("never indexes an account-level contact absent from the server snapshot", async () => {
+    mocks.contactsList = [{ uid: "account-only", name: "贾小明", status: 1 }];
+    const vm = new GlobalSearchVM();
+
+    vm.didMount();
+    await vi.waitFor(() => expect(vm.searchResult).toBeTruthy());
+    vm.keyword = "jia";
+    vm.initLoad();
+    vm.requestSearch();
+
+    await vi.waitFor(() =>
+      expect(mocks.searchLegacyGlobal).toHaveBeenCalledTimes(2)
+    );
+    expect(vm.searchResult.friends).toEqual([]);
+    vm.didUnMount();
+  });
+
+  it("does not supplement existing Chinese or English direct searches", async () => {
+    mocks.contactsList = [
+      { uid: "local-cn", name: "魏娇莹", status: 1 },
+      { uid: "local-en", name: "Alice", status: 1 },
+    ];
+    const vm = new GlobalSearchVM();
+
+    vm.keyword = "魏娇";
+    vm.requestSearch();
+    await vi.waitFor(() => expect(vm.searchResult).toBeTruthy());
+    expect(vm.searchResult.friends).toEqual([]);
+
+    vm.keyword = "alice";
+    vm.initLoad();
+    vm.requestSearch();
+    await vi.waitFor(() =>
+      expect(mocks.searchLegacyGlobal).toHaveBeenCalledTimes(2)
+    );
+    expect(vm.searchResult.friends).toEqual([]);
+  });
+
+  it("does not index an account-level contact after switching Spaces", async () => {
+    mocks.contactsList = [{ uid: "space-1-only", name: "贾小明", status: 1 }];
+    mocks.searchLegacyGlobal.mockResolvedValueOnce({
+      friends: [
+        {
+          channel_id: "space-1-only",
+          channel_type: 1,
+          channel_name: "贾小明",
+        },
+      ],
+      groups: [],
+      messages: [],
+    });
+    const vm = new GlobalSearchVM();
+    vm.didMount();
+    await vi.waitFor(() => expect(vm.searchResult).toBeTruthy());
+
+    mocks.currentSpaceId = "space-2";
+    // contactsList intentionally stays unchanged, matching production.
+    mocks.searchLegacyGlobal.mockResolvedValueOnce(emptyResult());
+    vm.keyword = "jia";
+    vm.initLoad();
+    vm.requestSearch();
+
+    await vi.waitFor(() => expect(vm.searchResult).toBeTruthy());
+    expect(vm.searchResult.friends).toEqual([]);
+    vm.didUnMount();
+  });
+});

--- a/packages/dmworkbase/src/bridge/globalSearch/GlobalSearchVM.ts
+++ b/packages/dmworkbase/src/bridge/globalSearch/GlobalSearchVM.ts
@@ -16,18 +16,13 @@ import {
   addCurrentImChannelInfoListener,
   getCurrentImChannelInfo,
 } from "../../im-runtime/currentChannelRuntime";
-import type {
-  LegacyGlobalSearchContact,
-  LegacyGlobalSearchResponse,
-} from "../../Service/SearchService";
+import type { LegacyGlobalSearchContact } from "../../Service/SearchService";
 import {
-  createEmptyGlobalSearchPinyinIndex,
-  globalSearchContactsToLegacy,
-  rebuildGlobalSearchPinyinIndex,
-  refreshGlobalSearchGroupCandidates,
-  replaceGlobalSearchPinyinMatches,
-  searchGlobalSearchPinyinIndex,
-  type GlobalSearchPinyinIndex,
+  appendUniqueByKey,
+  createNamedPinyinSearchIndex,
+  rebuildNamedPinyinSearchIndex,
+  searchNamedPinyinIndex,
+  type NamedPinyinSearchIndex,
 } from "./globalSearchPinyin";
 
 /** Legacy contacts/groups bridge retained while the aggregated tabs migrate. */
@@ -47,27 +42,18 @@ export default class GlobalSearchVM extends ProviderListener {
   private unsubscribeChannelInfoListener?: () => void;
   public channel?: Channel; // 查询指定频道的消息
   private requestId = 0; // 请求计数器，用于处理竞态条件
-  private pinyinCandidateRequestId = 0;
-  private pinyinIndex: GlobalSearchPinyinIndex =
-    createEmptyGlobalSearchPinyinIndex();
+  private pinyinFriendIndex: NamedPinyinSearchIndex<LegacyGlobalSearchContact> =
+    createNamedPinyinSearchIndex();
+  private pinyinGroupIndex: NamedPinyinSearchIndex<LegacyGlobalSearchContact> =
+    createNamedPinyinSearchIndex();
+  private pinyinFriendCandidates: LegacyGlobalSearchContact[] = [];
   private pinyinGroupCandidates: LegacyGlobalSearchContact[] = [];
-  private serverContactGroupResult: Pick<
-    LegacyGlobalSearchResponse,
-    "friends" | "groups"
-  > = { friends: [], groups: [] };
-  private mounted = false;
+  private pinyinSpaceId = "";
+  private serverContactGroupResult: {
+    friends: LegacyGlobalSearchContact[];
+    groups: LegacyGlobalSearchContact[];
+  } = { friends: [], groups: [] };
   public searchError: string | null = null; // 搜索失败错误信息
-  private readonly contactsChangeListener = () => {
-    this.rebuildPinyinIndexWithCurrentContacts();
-    this.applyPinyinMatches();
-    this.notifyListener();
-  };
-  private readonly spaceChangedListener = () => {
-    this.pinyinIndex = createEmptyGlobalSearchPinyinIndex();
-    this.pinyinGroupCandidates = [];
-    this.serverContactGroupResult = { friends: [], groups: [] };
-    void this.refreshPinyinIndex();
-  };
   // tab数据列表
   public get tabList() {
     if (this.searchInChannel) {
@@ -130,10 +116,6 @@ export default class GlobalSearchVM extends ProviderListener {
   }
 
   didMount(): void {
-    this.mounted = true;
-    WKApp.dataSource.addContactsChangeListener(this.contactsChangeListener);
-    WKApp.mittBus.on("space-changed", this.spaceChangedListener);
-    void this.refreshPinyinIndex();
     this.requestSearch();
 
     this.channelInfoListener = (channelInfo: ChannelInfo) => {
@@ -159,11 +141,6 @@ export default class GlobalSearchVM extends ProviderListener {
   }
 
   didUnMount(): void {
-    this.mounted = false;
-    this.pinyinCandidateRequestId++;
-    this.handleInputChange.cancel();
-    WKApp.dataSource.removeContactsChangeListener(this.contactsChangeListener);
-    WKApp.mittBus.off("space-changed", this.spaceChangedListener);
     this.unsubscribeChannelInfoListener?.();
     this.unsubscribeChannelInfoListener = undefined;
   }
@@ -186,56 +163,52 @@ export default class GlobalSearchVM extends ProviderListener {
     this.notifyListener();
   }
 
-  private async refreshPinyinIndex() {
-    if (this.searchInChannel) return;
-    const requestId = ++this.pinyinCandidateRequestId;
-    const spaceId = WKApp.shared.currentSpaceId;
-    let groups: ChannelInfo[] | undefined;
-    try {
-      groups = await WKApp.dataSource.channelDataSource.groupSaveList();
-    } catch {
-      // The existing server search remains authoritative when local candidates
-      // cannot be loaded.
-    }
-    if (
-      !this.mounted ||
-      requestId !== this.pinyinCandidateRequestId ||
-      spaceId !== WKApp.shared.currentSpaceId
-    ) {
-      return;
-    }
-    this.pinyinGroupCandidates = refreshGlobalSearchGroupCandidates(
-      this.pinyinGroupCandidates,
-      groups
+  private rebuildPinyinIndexes() {
+    const hasChineseName = (item: LegacyGlobalSearchContact) =>
+      /[\u3400-\u9fff]/.test(item.channel_remark || item.channel_name || "");
+    const key = (item: LegacyGlobalSearchContact) =>
+      `${item.channel_type}:${item.channel_id}`;
+    const values = (item: LegacyGlobalSearchContact) => [
+      item.channel_remark || item.channel_name || item.channel_id,
+    ];
+    this.pinyinFriendIndex = rebuildNamedPinyinSearchIndex(
+      this.pinyinFriendIndex,
+      this.pinyinFriendCandidates.filter(hasChineseName),
+      key,
+      values
     );
-    this.rebuildPinyinIndexWithCurrentContacts();
-    this.applyPinyinMatches();
-    this.notifyListener();
-  }
-
-  private rebuildPinyinIndexWithCurrentContacts() {
-    const contacts = globalSearchContactsToLegacy(
-      WKApp.dataSource.contactsList || []
+    this.pinyinGroupIndex = rebuildNamedPinyinSearchIndex(
+      this.pinyinGroupIndex,
+      this.pinyinGroupCandidates.filter(hasChineseName),
+      key,
+      values
     );
-    this.pinyinIndex = rebuildGlobalSearchPinyinIndex(this.pinyinIndex, {
-      friends: contacts,
-      groups: this.pinyinGroupCandidates,
-    });
   }
 
   private applyPinyinMatches() {
-    if (this.searchInChannel || !this.keyword.trim() || !this.searchResult) {
+    const keyword = this.keyword.trim();
+    if (
+      this.searchInChannel ||
+      !/^[a-z]+$/i.test(keyword) ||
+      !this.searchResult
+    ) {
       return;
     }
-    const localResult = searchGlobalSearchPinyinIndex(
-      this.keyword,
-      this.pinyinIndex
-    );
-    this.searchResult = replaceGlobalSearchPinyinMatches(
-      this.searchResult,
-      this.serverContactGroupResult,
-      localResult
-    );
+    const key = (item: LegacyGlobalSearchContact) =>
+      `${item.channel_type}:${item.channel_id}`;
+    this.searchResult = {
+      ...this.searchResult,
+      friends: appendUniqueByKey(
+        this.serverContactGroupResult.friends,
+        searchNamedPinyinIndex(keyword, this.pinyinFriendIndex),
+        key
+      ),
+      groups: appendUniqueByKey(
+        this.serverContactGroupResult.groups,
+        searchNamedPinyinIndex(keyword, this.pinyinGroupIndex),
+        key
+      ),
+    };
   }
 
   // 请求搜索
@@ -247,6 +220,14 @@ export default class GlobalSearchVM extends ProviderListener {
     this.searchError = null;
 
     const spaceId = WKApp.shared.currentSpaceId;
+    if (spaceId !== this.pinyinSpaceId) {
+      this.pinyinSpaceId = spaceId;
+      this.pinyinFriendIndex = createNamedPinyinSearchIndex();
+      this.pinyinGroupIndex = createNamedPinyinSearchIndex();
+      this.pinyinFriendCandidates = [];
+      this.pinyinGroupCandidates = [];
+      this.serverContactGroupResult = { friends: [], groups: [] };
+    }
     SearchService.searchLegacyGlobal({
       keyword: this.keyword || "",
       page: this.page,
@@ -282,7 +263,16 @@ export default class GlobalSearchVM extends ProviderListener {
           this.searchResult = res;
         }
 
-        this.applyPinyinMatches();
+        if (spaceId === WKApp.shared.currentSpaceId) {
+          // Reuse the existing empty-keyword response as the authoritative,
+          // Space-scoped candidate source without adding another API request.
+          if (!this.keyword.trim() && !this.loadMoreing) {
+            this.pinyinFriendCandidates = res.friends || [];
+            this.pinyinGroupCandidates = res.groups || [];
+          }
+          this.rebuildPinyinIndexes();
+          this.applyPinyinMatches();
+        }
 
         // 替换备注如果有备注的话
         this.searchResult.friends?.forEach((v: any) => {

--- a/packages/dmworkbase/src/bridge/globalSearch/GlobalSearchVM.ts
+++ b/packages/dmworkbase/src/bridge/globalSearch/GlobalSearchVM.ts
@@ -12,7 +12,23 @@ import { MessageContentTypeConst } from "../../Service/Const";
 import { ProviderListener } from "../../Service/Provider";
 import { debounce } from "../../Utils/rateLimit";
 import { t } from "../../i18n";
-import { addCurrentImChannelInfoListener, getCurrentImChannelInfo } from "../../im-runtime/currentChannelRuntime";
+import {
+  addCurrentImChannelInfoListener,
+  getCurrentImChannelInfo,
+} from "../../im-runtime/currentChannelRuntime";
+import type {
+  LegacyGlobalSearchContact,
+  LegacyGlobalSearchResponse,
+} from "../../Service/SearchService";
+import {
+  createEmptyGlobalSearchPinyinIndex,
+  globalSearchContactsToLegacy,
+  rebuildGlobalSearchPinyinIndex,
+  refreshGlobalSearchGroupCandidates,
+  replaceGlobalSearchPinyinMatches,
+  searchGlobalSearchPinyinIndex,
+  type GlobalSearchPinyinIndex,
+} from "./globalSearchPinyin";
 
 /** Legacy contacts/groups bridge retained while the aggregated tabs migrate. */
 export default class GlobalSearchVM extends ProviderListener {
@@ -31,7 +47,27 @@ export default class GlobalSearchVM extends ProviderListener {
   private unsubscribeChannelInfoListener?: () => void;
   public channel?: Channel; // 查询指定频道的消息
   private requestId = 0; // 请求计数器，用于处理竞态条件
+  private pinyinCandidateRequestId = 0;
+  private pinyinIndex: GlobalSearchPinyinIndex =
+    createEmptyGlobalSearchPinyinIndex();
+  private pinyinGroupCandidates: LegacyGlobalSearchContact[] = [];
+  private serverContactGroupResult: Pick<
+    LegacyGlobalSearchResponse,
+    "friends" | "groups"
+  > = { friends: [], groups: [] };
+  private mounted = false;
   public searchError: string | null = null; // 搜索失败错误信息
+  private readonly contactsChangeListener = () => {
+    this.rebuildPinyinIndexWithCurrentContacts();
+    this.applyPinyinMatches();
+    this.notifyListener();
+  };
+  private readonly spaceChangedListener = () => {
+    this.pinyinIndex = createEmptyGlobalSearchPinyinIndex();
+    this.pinyinGroupCandidates = [];
+    this.serverContactGroupResult = { friends: [], groups: [] };
+    void this.refreshPinyinIndex();
+  };
   // tab数据列表
   public get tabList() {
     if (this.searchInChannel) {
@@ -64,9 +100,7 @@ export default class GlobalSearchVM extends ProviderListener {
   // 搜索标题
   public get searchTitle() {
     if (this.searchInChannel) {
-      const channelInfo = getCurrentImChannelInfo(
-        this.channel!
-      );
+      const channelInfo = getCurrentImChannelInfo(this.channel!);
       if (channelInfo) {
         return t("base.globalSearch.chatHistoryWith", {
           values: { name: channelInfo.title },
@@ -96,6 +130,10 @@ export default class GlobalSearchVM extends ProviderListener {
   }
 
   didMount(): void {
+    this.mounted = true;
+    WKApp.dataSource.addContactsChangeListener(this.contactsChangeListener);
+    WKApp.mittBus.on("space-changed", this.spaceChangedListener);
+    void this.refreshPinyinIndex();
     this.requestSearch();
 
     this.channelInfoListener = (channelInfo: ChannelInfo) => {
@@ -121,6 +159,11 @@ export default class GlobalSearchVM extends ProviderListener {
   }
 
   didUnMount(): void {
+    this.mounted = false;
+    this.pinyinCandidateRequestId++;
+    this.handleInputChange.cancel();
+    WKApp.dataSource.removeContactsChangeListener(this.contactsChangeListener);
+    WKApp.mittBus.off("space-changed", this.spaceChangedListener);
     this.unsubscribeChannelInfoListener?.();
     this.unsubscribeChannelInfoListener = undefined;
   }
@@ -139,7 +182,60 @@ export default class GlobalSearchVM extends ProviderListener {
     this.loadFinish = false;
     this.loadMoreing = false;
     this.searchResult = null;
+    this.serverContactGroupResult = { friends: [], groups: [] };
     this.notifyListener();
+  }
+
+  private async refreshPinyinIndex() {
+    if (this.searchInChannel) return;
+    const requestId = ++this.pinyinCandidateRequestId;
+    const spaceId = WKApp.shared.currentSpaceId;
+    let groups: ChannelInfo[] | undefined;
+    try {
+      groups = await WKApp.dataSource.channelDataSource.groupSaveList();
+    } catch {
+      // The existing server search remains authoritative when local candidates
+      // cannot be loaded.
+    }
+    if (
+      !this.mounted ||
+      requestId !== this.pinyinCandidateRequestId ||
+      spaceId !== WKApp.shared.currentSpaceId
+    ) {
+      return;
+    }
+    this.pinyinGroupCandidates = refreshGlobalSearchGroupCandidates(
+      this.pinyinGroupCandidates,
+      groups
+    );
+    this.rebuildPinyinIndexWithCurrentContacts();
+    this.applyPinyinMatches();
+    this.notifyListener();
+  }
+
+  private rebuildPinyinIndexWithCurrentContacts() {
+    const contacts = globalSearchContactsToLegacy(
+      WKApp.dataSource.contactsList || []
+    );
+    this.pinyinIndex = rebuildGlobalSearchPinyinIndex(this.pinyinIndex, {
+      friends: contacts,
+      groups: this.pinyinGroupCandidates,
+    });
+  }
+
+  private applyPinyinMatches() {
+    if (this.searchInChannel || !this.keyword.trim() || !this.searchResult) {
+      return;
+    }
+    const localResult = searchGlobalSearchPinyinIndex(
+      this.keyword,
+      this.pinyinIndex
+    );
+    this.searchResult = replaceGlobalSearchPinyinMatches(
+      this.searchResult,
+      this.serverContactGroupResult,
+      localResult
+    );
   }
 
   // 请求搜索
@@ -179,8 +275,14 @@ export default class GlobalSearchVM extends ProviderListener {
             this.searchResult = res;
           }
         } else {
+          this.serverContactGroupResult = {
+            friends: res.friends || [],
+            groups: res.groups || [],
+          };
           this.searchResult = res;
         }
+
+        this.applyPinyinMatches();
 
         // 替换备注如果有备注的话
         this.searchResult.friends?.forEach((v: any) => {

--- a/packages/dmworkbase/src/bridge/globalSearch/createGlobalSearchDataSource.ts
+++ b/packages/dmworkbase/src/bridge/globalSearch/createGlobalSearchDataSource.ts
@@ -1,6 +1,7 @@
 import { Channel, ChannelTypeGroup } from "wukongimjssdk";
 import WKApp from "../../App";
 import { ChannelTypeCommunityTopic } from "../../Service/Const";
+import { ContactsStatus } from "../../Service/DataSource/DataSource";
 import { getCurrentImChannelInfo } from "../../im-runtime/currentChannelRuntime";
 import { getCurrentImConversationsDirectly } from "../../im-runtime/currentConversationRuntime";
 import type { ChannelSearchSender } from "../../Service/SearchTypes";
@@ -13,6 +14,11 @@ import type {
   GlobalSearchFileTypeCategory,
   GlobalSearchQuery,
 } from "../../Service/SearchTypes";
+import {
+  createNamedPinyinSearchIndex,
+  extendNamedPinyinSearchIndex,
+  searchNamedPinyinIndex,
+} from "./globalSearchPinyin";
 
 const PAGE_SIZE_SENDERS = 50;
 
@@ -42,9 +48,9 @@ function selfSender(): ChannelSearchSender {
 // of the user's groups — a full group-scoped thread picker is deferred. Thread
 // hits from a picked *group* now expand to «group + all its threads» server-
 // side under the YUJ-30 unified rule (see 01-backend-search-global.md §3/§6).
-async function loadReadableChannelOptions(
-  keyword: string
-): Promise<GlobalSearchChannelOption[]> {
+async function loadReadableChannelOptions(): Promise<
+  GlobalSearchChannelOption[]
+> {
   const out = new Map<string, GlobalSearchChannelOption>();
   const push = (option: GlobalSearchChannelOption) => {
     const key = `${option.channelType}:${option.channelId}`;
@@ -84,7 +90,12 @@ async function loadReadableChannelOptions(
       push({
         channelId,
         channelType,
-        name: g?.displayName || g?.name || channelId,
+        name:
+          g?.orgData?.displayName ||
+          g?.title ||
+          g?.displayName ||
+          g?.name ||
+          channelId,
         avatarUrl: WKApp.shared.avatarChannel(
           new Channel(channelId, channelType)
         ),
@@ -94,10 +105,38 @@ async function loadReadableChannelOptions(
     // Failing to load "my groups" is non-fatal — we still return recents.
   }
 
-  const kw = keyword.trim().toLowerCase();
   const options = Array.from(out.values());
-  if (!kw) return options.slice(0, 60);
-  return options.filter((o) => o.name.toLowerCase().includes(kw)).slice(0, 60);
+  return options;
+}
+
+function localContactSenders(): ChannelSearchSender[] {
+  const list: any[] = (WKApp.dataSource as any)?.contactsList ?? [];
+  return list.flatMap((contact) => {
+    const uid = contact?.uid;
+    if (!uid || contact?.status === ContactsStatus.Blacklist) return [];
+    return [
+      {
+        uid,
+        name: contact?.remark || contact?.name || uid,
+        avatarUrl: contact?.avatar || WKApp.shared.avatarUser(uid),
+        isCurrentMember: true,
+      },
+    ];
+  });
+}
+
+function localContactSignature(): string {
+  const list: any[] = (WKApp.dataSource as any)?.contactsList ?? [];
+  return list
+    .map((contact) =>
+      [
+        contact?.uid || "",
+        contact?.remark || contact?.name || "",
+        contact?.status ?? "",
+      ].join(":")
+    )
+    .sort()
+    .join("\n");
 }
 
 // RC #554 blocker (Jerry-Xin + OctoBoooot @ 2026-07-09): the previous
@@ -197,6 +236,12 @@ export function createGlobalSearchApiDataSource(
   options: CreateGlobalSearchApiDataSourceOptions = {}
 ): GlobalSearchDataSource {
   const senderCache = new Map<string, ChannelSearchSender>();
+  let senderPinyinIndex = createNamedPinyinSearchIndex<ChannelSearchSender>();
+  let channelPinyinIndex =
+    createNamedPinyinSearchIndex<GlobalSearchChannelOption>();
+  let channelCandidateSignature = "";
+  let indexedSpaceId = WKApp.shared.currentSpaceId;
+  let senderCandidateSignature = "";
   const rememberSender = (sender?: ChannelSearchSender) => {
     if (!sender?.uid) return;
     senderCache.set(sender.uid, sender);
@@ -205,26 +250,109 @@ export function createGlobalSearchApiDataSource(
   // (and the "发送人" chip always resolves self's display name).
   rememberSender(selfSender());
 
+  const resetScopedPinyinIndexes = () => {
+    const currentSpaceId = WKApp.shared.currentSpaceId;
+    const nextSenderCandidateSignature = localContactSignature();
+    const spaceChanged = currentSpaceId !== indexedSpaceId;
+    const senderPoolChanged =
+      nextSenderCandidateSignature !== senderCandidateSignature;
+    if (!spaceChanged && !senderPoolChanged) return;
+    indexedSpaceId = currentSpaceId;
+    senderCandidateSignature = nextSenderCandidateSignature;
+    senderCache.clear();
+    senderPinyinIndex = createNamedPinyinSearchIndex<ChannelSearchSender>();
+    if (spaceChanged) {
+      channelPinyinIndex =
+        createNamedPinyinSearchIndex<GlobalSearchChannelOption>();
+      channelCandidateSignature = "";
+    }
+    rememberSender(selfSender());
+  };
+
   return {
-    getSenders: () => Array.from(senderCache.values()),
-    getSender: (uid) =>
-      senderCache.get(uid) || {
-        uid,
-        name: uid,
-      },
+    getSenders: () => {
+      resetScopedPinyinIndexes();
+      return Array.from(senderCache.values());
+    },
+    getSender: (uid) => {
+      resetScopedPinyinIndexes();
+      return (
+        senderCache.get(uid) || {
+          uid,
+          name: uid,
+        }
+      );
+    },
     getSelfUid: () => WKApp.loginInfo.uid || "",
     searchSenders: async (keyword: string) => {
+      resetScopedPinyinIndexes();
+      const requestSpaceId = WKApp.shared.currentSpaceId;
       const remote = await loadSenderCandidates(keyword);
+      if (requestSpaceId !== WKApp.shared.currentSpaceId) return [];
+      // Preserve the existing remote/fallback result. The blacklist snapshot
+      // only limits the new local pinyin supplement.
+      const blacklistedUids = new Set(
+        (((WKApp.dataSource as any)?.contactsList ?? []) as any[])
+          .filter((contact) => contact?.status === ContactsStatus.Blacklist)
+          .map((contact) => contact?.uid)
+          .filter(Boolean)
+      );
       remote.forEach(rememberSender);
-      const kw = keyword.trim().toLowerCase();
       const combined = Array.from(senderCache.values());
-      if (!kw) return combined.slice(0, PAGE_SIZE_SENDERS);
-      return combined
-        .filter((s) => `${s.name}${s.uid}`.toLowerCase().includes(kw))
-        .slice(0, PAGE_SIZE_SENDERS);
+      const normalizedKeyword = keyword.trim().toLowerCase();
+      const existingResult = normalizedKeyword
+        ? combined.filter((sender) =>
+            `${sender.name}${sender.uid}`
+              .toLowerCase()
+              .includes(normalizedKeyword)
+          )
+        : combined;
+      const pinyinCandidates = new Map(
+        [...combined, ...localContactSenders()]
+          .filter((sender) => !blacklistedUids.has(sender.uid))
+          .map((sender) => [sender.uid, sender])
+      );
+      extendNamedPinyinSearchIndex(
+        senderPinyinIndex,
+        Array.from(pinyinCandidates.values()),
+        (sender) => sender.uid,
+        (sender) => [sender.name, sender.uid]
+      );
+      const pinyinResult = searchNamedPinyinIndex(keyword, senderPinyinIndex);
+      const result = Array.from(
+        new Map(
+          [...existingResult, ...pinyinResult].map((sender) => [
+            sender.uid,
+            sender,
+          ])
+        ).values()
+      ).slice(0, PAGE_SIZE_SENDERS);
+      result.forEach(rememberSender);
+      return result;
     },
     searchChannels: async (keyword: string) => {
-      return loadReadableChannelOptions(keyword);
+      resetScopedPinyinIndexes();
+      const requestSpaceId = WKApp.shared.currentSpaceId;
+      const options = await loadReadableChannelOptions();
+      if (requestSpaceId !== WKApp.shared.currentSpaceId) return [];
+      const nextSignature = options
+        .map(
+          (option) => `${option.channelType}:${option.channelId}:${option.name}`
+        )
+        .sort()
+        .join("\n");
+      if (nextSignature !== channelCandidateSignature) {
+        channelCandidateSignature = nextSignature;
+        channelPinyinIndex =
+          createNamedPinyinSearchIndex<GlobalSearchChannelOption>();
+        extendNamedPinyinSearchIndex(
+          channelPinyinIndex,
+          options,
+          (option) => `${option.channelType}:${option.channelId}`,
+          (option) => [option.name, option.channelId]
+        );
+      }
+      return searchNamedPinyinIndex(keyword, channelPinyinIndex).slice(0, 60);
     },
     getFileTypeCategories: async () => {
       const cache = options.fileTypeCategoriesCache;

--- a/packages/dmworkbase/src/bridge/globalSearch/createGlobalSearchDataSource.ts
+++ b/packages/dmworkbase/src/bridge/globalSearch/createGlobalSearchDataSource.ts
@@ -15,9 +15,11 @@ import type {
   GlobalSearchQuery,
 } from "../../Service/SearchTypes";
 import {
+  appendUniqueByKey,
   createNamedPinyinSearchIndex,
-  extendNamedPinyinSearchIndex,
+  rebuildNamedPinyinSearchIndex,
   searchNamedPinyinIndex,
+  type NamedPinyinSearchIndex,
 } from "./globalSearchPinyin";
 
 const PAGE_SIZE_SENDERS = 50;
@@ -48,9 +50,13 @@ function selfSender(): ChannelSearchSender {
 // of the user's groups — a full group-scoped thread picker is deferred. Thread
 // hits from a picked *group* now expand to «group + all its threads» server-
 // side under the YUJ-30 unified rule (see 01-backend-search-global.md §3/§6).
-async function loadReadableChannelOptions(): Promise<
-  GlobalSearchChannelOption[]
-> {
+async function loadReadableChannelOptions(
+  keyword: string,
+  currentIndex: NamedPinyinSearchIndex<GlobalSearchChannelOption>
+): Promise<{
+  index: NamedPinyinSearchIndex<GlobalSearchChannelOption>;
+  result: GlobalSearchChannelOption[];
+}> {
   const out = new Map<string, GlobalSearchChannelOption>();
   const push = (option: GlobalSearchChannelOption) => {
     const key = `${option.channelType}:${option.channelId}`;
@@ -90,12 +96,7 @@ async function loadReadableChannelOptions(): Promise<
       push({
         channelId,
         channelType,
-        name:
-          g?.orgData?.displayName ||
-          g?.title ||
-          g?.displayName ||
-          g?.name ||
-          channelId,
+        name: g?.displayName || g?.name || channelId,
         avatarUrl: WKApp.shared.avatarChannel(
           new Channel(channelId, channelType)
         ),
@@ -106,37 +107,30 @@ async function loadReadableChannelOptions(): Promise<
   }
 
   const options = Array.from(out.values());
-  return options;
-}
-
-function localContactSenders(): ChannelSearchSender[] {
-  const list: any[] = (WKApp.dataSource as any)?.contactsList ?? [];
-  return list.flatMap((contact) => {
-    const uid = contact?.uid;
-    if (!uid || contact?.status === ContactsStatus.Blacklist) return [];
-    return [
-      {
-        uid,
-        name: contact?.remark || contact?.name || uid,
-        avatarUrl: contact?.avatar || WKApp.shared.avatarUser(uid),
-        isCurrentMember: true,
-      },
-    ];
-  });
-}
-
-function localContactSignature(): string {
-  const list: any[] = (WKApp.dataSource as any)?.contactsList ?? [];
-  return list
-    .map((contact) =>
-      [
-        contact?.uid || "",
-        contact?.remark || contact?.name || "",
-        contact?.status ?? "",
-      ].join(":")
-    )
-    .sort()
-    .join("\n");
+  const pinyinCandidates = options.filter((option) =>
+    /[\u3400-\u9fff]/.test(option.name)
+  );
+  const index = rebuildNamedPinyinSearchIndex(
+    currentIndex,
+    pinyinCandidates,
+    (option) => `${option.channelType}:${option.channelId}`,
+    (option) => [option.name]
+  );
+  const kw = keyword.trim().toLowerCase();
+  const existingResult = kw
+    ? options.filter((option) => option.name.toLowerCase().includes(kw))
+    : options;
+  const pinyinResult = /^[a-z]+$/i.test(keyword.trim())
+    ? searchNamedPinyinIndex(keyword, index)
+    : [];
+  return {
+    index,
+    result: appendUniqueByKey(
+      existingResult,
+      pinyinResult,
+      (option) => `${option.channelType}:${option.channelId}`
+    ).slice(0, 60),
+  };
 }
 
 // RC #554 blocker (Jerry-Xin + OctoBoooot @ 2026-07-09): the previous
@@ -155,10 +149,18 @@ function localContactSignature(): string {
 // synced `WKApp.dataSource.contactsList` snapshot so the filter panel is
 // never empty in a normal signed-in session.
 async function loadSenderCandidates(
-  keyword: string
-): Promise<ChannelSearchSender[]> {
+  keyword: string,
+  currentIndex: NamedPinyinSearchIndex<ChannelSearchSender>,
+  currentScopedFriendUids: ReadonlySet<string>
+): Promise<{
+  index: NamedPinyinSearchIndex<ChannelSearchSender>;
+  scopedFriendUids: Set<string>;
+  senders: ChannelSearchSender[];
+}> {
   const kw = keyword.trim();
   const out: ChannelSearchSender[] = [];
+  let nextIndex = currentIndex;
+  let scopedFriendUids = new Set(currentScopedFriendUids);
   const seen = new Set<string>();
   const push = (sender: ChannelSearchSender) => {
     if (!sender.uid || seen.has(sender.uid)) return;
@@ -172,6 +174,12 @@ async function loadSenderCandidates(
     if (commonDS && typeof commonDS.searchFriends === "function") {
       const friends = (await commonDS.searchFriends(kw)) ?? [];
       if (Array.isArray(friends)) {
+        const confirmedUids = friends
+          .map((info) => info?.channel?.channelID)
+          .filter(Boolean);
+        scopedFriendUids = kw
+          ? new Set([...scopedFriendUids, ...confirmedUids])
+          : new Set(confirmedUids);
         for (const info of friends) {
           const uid = info?.channel?.channelID;
           if (!uid) continue;
@@ -182,7 +190,9 @@ async function loadSenderCandidates(
             avatarUrl: org.avatar || WKApp.shared.avatarUser(uid),
             isCurrentMember: true,
           });
-          if (out.length >= PAGE_SIZE_SENDERS) return out;
+          if (out.length >= PAGE_SIZE_SENDERS) {
+            return { index: nextIndex, scopedFriendUids, senders: out };
+          }
         }
       }
     }
@@ -193,8 +203,8 @@ async function loadSenderCandidates(
   // 2) Fallback: the already-synced local contacts list. `contactsSync`
   //    populates this on login (see DataSource.contactsSync), so a signed-in
   //    user always has *some* candidates even when the friend-search endpoint
-  //    is missing / offline. Do local case-insensitive filtering on
-  //    name/remark/uid so an empty-keyword call still returns everyone.
+  //    is missing / offline. Keep the existing literal path unchanged, then
+  //    append pinyin-only matches from the same non-blacklisted snapshot.
   try {
     const list: any[] = (WKApp.dataSource as any)?.contactsList ?? [];
     const kwLower = kw.toLowerCase();
@@ -211,13 +221,52 @@ async function loadSenderCandidates(
         avatarUrl: c?.avatar || WKApp.shared.avatarUser(uid),
         isCurrentMember: true,
       });
-      if (out.length >= PAGE_SIZE_SENDERS) return out;
+      if (out.length >= PAGE_SIZE_SENDERS) {
+        return { index: nextIndex, scopedFriendUids, senders: out };
+      }
+    }
+    const localPinyinCandidates = list.flatMap((c) => {
+      const uid = c?.uid;
+      const name = c?.remark || c?.name || uid;
+      if (
+        !uid ||
+        !scopedFriendUids.has(uid) ||
+        c?.status === ContactsStatus.Blacklist ||
+        c?.beDeleted === true ||
+        c?.follow === 0 ||
+        !/[\u3400-\u9fff]/.test(name)
+      ) {
+        return [];
+      }
+      return [
+        {
+          uid,
+          name,
+          avatarUrl: c?.avatar || WKApp.shared.avatarUser(uid),
+          isCurrentMember: true,
+        } satisfies ChannelSearchSender,
+      ];
+    });
+    nextIndex = rebuildNamedPinyinSearchIndex(
+      currentIndex,
+      localPinyinCandidates,
+      (sender) => sender.uid,
+      (sender) => [sender.name]
+    );
+    const pinyinMatches = /^[a-z]+$/i.test(kw)
+      ? searchNamedPinyinIndex(kw, nextIndex)
+      : [];
+    for (const sender of pinyinMatches) {
+      push(sender);
+      if (out.length >= PAGE_SIZE_SENDERS) {
+        return { index: nextIndex, scopedFriendUids, senders: out };
+      }
     }
   } catch (_) {
     // ignore — worst case we return whatever we already gathered
   }
 
-  return out;
+  return { index: nextIndex, scopedFriendUids, senders: out };
 }
 
 export interface CreateGlobalSearchApiDataSourceOptions {
@@ -236,12 +285,12 @@ export function createGlobalSearchApiDataSource(
   options: CreateGlobalSearchApiDataSourceOptions = {}
 ): GlobalSearchDataSource {
   const senderCache = new Map<string, ChannelSearchSender>();
-  let senderPinyinIndex = createNamedPinyinSearchIndex<ChannelSearchSender>();
+  let localSenderPinyinIndex =
+    createNamedPinyinSearchIndex<ChannelSearchSender>();
   let channelPinyinIndex =
     createNamedPinyinSearchIndex<GlobalSearchChannelOption>();
-  let channelCandidateSignature = "";
   let indexedSpaceId = WKApp.shared.currentSpaceId;
-  let senderCandidateSignature = "";
+  let scopedFriendUids = new Set<string>();
   const rememberSender = (sender?: ChannelSearchSender) => {
     if (!sender?.uid) return;
     senderCache.set(sender.uid, sender);
@@ -250,32 +299,24 @@ export function createGlobalSearchApiDataSource(
   // (and the "发送人" chip always resolves self's display name).
   rememberSender(selfSender());
 
-  const resetScopedPinyinIndexes = () => {
+  const resetSpaceScopedState = () => {
     const currentSpaceId = WKApp.shared.currentSpaceId;
-    const nextSenderCandidateSignature = localContactSignature();
-    const spaceChanged = currentSpaceId !== indexedSpaceId;
-    const senderPoolChanged =
-      nextSenderCandidateSignature !== senderCandidateSignature;
-    if (!spaceChanged && !senderPoolChanged) return;
+    if (currentSpaceId === indexedSpaceId) return;
     indexedSpaceId = currentSpaceId;
-    senderCandidateSignature = nextSenderCandidateSignature;
+    scopedFriendUids.clear();
+    localSenderPinyinIndex = createNamedPinyinSearchIndex();
+    channelPinyinIndex = createNamedPinyinSearchIndex();
     senderCache.clear();
-    senderPinyinIndex = createNamedPinyinSearchIndex<ChannelSearchSender>();
-    if (spaceChanged) {
-      channelPinyinIndex =
-        createNamedPinyinSearchIndex<GlobalSearchChannelOption>();
-      channelCandidateSignature = "";
-    }
     rememberSender(selfSender());
   };
 
   return {
     getSenders: () => {
-      resetScopedPinyinIndexes();
+      resetSpaceScopedState();
       return Array.from(senderCache.values());
     },
     getSender: (uid) => {
-      resetScopedPinyinIndexes();
+      resetSpaceScopedState();
       return (
         senderCache.get(uid) || {
           uid,
@@ -285,41 +326,38 @@ export function createGlobalSearchApiDataSource(
     },
     getSelfUid: () => WKApp.loginInfo.uid || "",
     searchSenders: async (keyword: string) => {
-      resetScopedPinyinIndexes();
+      resetSpaceScopedState();
       const requestSpaceId = WKApp.shared.currentSpaceId;
-      const remote = await loadSenderCandidates(keyword);
-      if (requestSpaceId !== WKApp.shared.currentSpaceId) return [];
-      // Preserve the existing remote/fallback result. The blacklist snapshot
-      // only limits the new local pinyin supplement.
-      const blacklistedUids = new Set(
-        (((WKApp.dataSource as any)?.contactsList ?? []) as any[])
-          .filter((contact) => contact?.status === ContactsStatus.Blacklist)
-          .map((contact) => contact?.uid)
-          .filter(Boolean)
+      const loaded = await loadSenderCandidates(
+        keyword,
+        localSenderPinyinIndex,
+        scopedFriendUids
       );
+      if (requestSpaceId !== WKApp.shared.currentSpaceId) {
+        resetSpaceScopedState();
+        return [];
+      }
+      localSenderPinyinIndex = loaded.index;
+      scopedFriendUids = loaded.scopedFriendUids;
+      const remote = loaded.senders;
       remote.forEach(rememberSender);
+      const kw = keyword.trim().toLowerCase();
       const combined = Array.from(senderCache.values());
-      const normalizedKeyword = keyword.trim().toLowerCase();
-      const existingResult = normalizedKeyword
+      const existingResult = kw
         ? combined.filter((sender) =>
-            `${sender.name}${sender.uid}`
-              .toLowerCase()
-              .includes(normalizedKeyword)
+            `${sender.name}${sender.uid}`.toLowerCase().includes(kw)
           )
         : combined;
-      const pinyinCandidates = new Map(
-        [...combined, ...localContactSenders()]
-          .filter((sender) => !blacklistedUids.has(sender.uid))
-          .map((sender) => [sender.uid, sender])
-      );
-      extendNamedPinyinSearchIndex(
-        senderPinyinIndex,
-        Array.from(pinyinCandidates.values()),
+      const remoteIndex = rebuildNamedPinyinSearchIndex(
+        createNamedPinyinSearchIndex<ChannelSearchSender>(),
+        remote,
         (sender) => sender.uid,
-        (sender) => [sender.name, sender.uid]
+        (sender) => [sender.name]
       );
-      const pinyinResult = searchNamedPinyinIndex(keyword, senderPinyinIndex);
-      const result = Array.from(
+      const pinyinResult = /^[a-z]+$/i.test(keyword.trim())
+        ? searchNamedPinyinIndex(keyword, remoteIndex)
+        : [];
+      return Array.from(
         new Map(
           [...existingResult, ...pinyinResult].map((sender) => [
             sender.uid,
@@ -327,32 +365,20 @@ export function createGlobalSearchApiDataSource(
           ])
         ).values()
       ).slice(0, PAGE_SIZE_SENDERS);
-      result.forEach(rememberSender);
-      return result;
     },
     searchChannels: async (keyword: string) => {
-      resetScopedPinyinIndexes();
+      resetSpaceScopedState();
       const requestSpaceId = WKApp.shared.currentSpaceId;
-      const options = await loadReadableChannelOptions();
-      if (requestSpaceId !== WKApp.shared.currentSpaceId) return [];
-      const nextSignature = options
-        .map(
-          (option) => `${option.channelType}:${option.channelId}:${option.name}`
-        )
-        .sort()
-        .join("\n");
-      if (nextSignature !== channelCandidateSignature) {
-        channelCandidateSignature = nextSignature;
-        channelPinyinIndex =
-          createNamedPinyinSearchIndex<GlobalSearchChannelOption>();
-        extendNamedPinyinSearchIndex(
-          channelPinyinIndex,
-          options,
-          (option) => `${option.channelType}:${option.channelId}`,
-          (option) => [option.name, option.channelId]
-        );
+      const loaded = await loadReadableChannelOptions(
+        keyword,
+        channelPinyinIndex
+      );
+      if (requestSpaceId !== WKApp.shared.currentSpaceId) {
+        resetSpaceScopedState();
+        return [];
       }
-      return searchNamedPinyinIndex(keyword, channelPinyinIndex).slice(0, 60);
+      channelPinyinIndex = loaded.index;
+      return loaded.result;
     },
     getFileTypeCategories: async () => {
       const cache = options.fileTypeCategoriesCache;
@@ -378,12 +404,16 @@ export function createGlobalSearchApiDataSource(
       return promise;
     },
     searchMessages: async (query: GlobalSearchQuery) => {
+      resetSpaceScopedState();
+      const requestSpaceId = WKApp.shared.currentSpaceId;
       const result = await SearchService.searchGlobalMessages(
         query,
         WKApp.loginInfo.uid || "",
         createSearchAssetResolver()
       );
-      result.items.forEach((item) => rememberSender(item.sender));
+      if (requestSpaceId === WKApp.shared.currentSpaceId) {
+        result.items.forEach((item) => rememberSender(item.sender));
+      }
       return result;
     },
   };

--- a/packages/dmworkbase/src/bridge/globalSearch/globalSearchPinyin.test.ts
+++ b/packages/dmworkbase/src/bridge/globalSearch/globalSearchPinyin.test.ts
@@ -1,308 +1,101 @@
 import { describe, expect, it, vi } from "vitest";
+
 import {
-  buildGlobalSearchPinyinIndex,
+  appendUniqueByKey,
   createNamedPinyinSearchIndex,
-  extendNamedPinyinSearchIndex,
-  mergeGlobalSearchPinyinResults,
-  refreshGlobalSearchGroupCandidates,
-  rebuildGlobalSearchPinyinIndex,
-  replaceGlobalSearchPinyinMatches,
+  rebuildNamedPinyinSearchIndex,
   searchNamedPinyinIndex,
-  searchGlobalSearchPinyinIndex,
 } from "./globalSearchPinyin";
 
-describe("global search pinyin index", () => {
-  const source = {
-    friends: [
-      {
-        channel_id: "u1",
-        channel_type: 1,
-        channel_name: "魏娇莹",
-      },
-    ],
-    groups: [
-      {
-        channel_id: "g1",
-        channel_type: 2,
-        channel_name: "魏娇莹项目群",
-      },
-    ],
-  };
+interface NamedItem {
+  id: string;
+  name: string;
+}
 
+const key = (item: NamedItem) => item.id;
+const values = (item: NamedItem) => [item.name, item.id];
+
+describe("global search pinyin helpers", () => {
   it("matches Chinese, full pinyin and case-insensitive pinyin", () => {
-    const index = buildGlobalSearchPinyinIndex(source);
-
-    expect(searchGlobalSearchPinyinIndex("魏娇", index).friends).toHaveLength(
-      1
-    );
-    expect(
-      searchGlobalSearchPinyinIndex("weijiao", index).friends
-    ).toHaveLength(1);
-    expect(searchGlobalSearchPinyinIndex("WEIJIAO", index).groups).toHaveLength(
-      1
-    );
-  });
-
-  it("uses the visible remark for matching", () => {
-    const index = buildGlobalSearchPinyinIndex({
-      friends: [
-        {
-          channel_id: "u1",
-          channel_type: 1,
-          channel_name: "原名",
-          channel_remark: "魏娇莹",
-        },
-      ],
-      groups: [],
-    });
-
-    expect(
-      searchGlobalSearchPinyinIndex("weijiao", index).friends
-    ).toHaveLength(1);
-    expect(
-      searchGlobalSearchPinyinIndex("yuanming", index).friends
-    ).toHaveLength(0);
-  });
-
-  it("keeps server order and appends only non-duplicate local matches", () => {
-    const serverFriend = {
-      channel_id: "server",
-      channel_type: 1,
-      channel_name: "Server",
-    };
-    const duplicateLocal = { ...serverFriend, channel_name: "Local duplicate" };
-    const localOnly = {
-      channel_id: "local",
-      channel_type: 1,
-      channel_name: "Local",
-    };
-
-    const merged = mergeGlobalSearchPinyinResults(
-      { friends: [serverFriend], groups: [], messages: [] },
-      { friends: [duplicateLocal, localOnly], groups: [] }
+    const items = [
+      { id: "u1", name: "魏娇莹" },
+      { id: "u2", name: "Alice" },
+    ];
+    const index = rebuildNamedPinyinSearchIndex(
+      createNamedPinyinSearchIndex<NamedItem>(),
+      items,
+      key,
+      values
     );
 
-    expect(merged.friends).toEqual([serverFriend, localOnly]);
-    expect(merged.messages).toEqual([]);
+    expect(searchNamedPinyinIndex("魏娇", index)).toEqual([items[0]]);
+    expect(searchNamedPinyinIndex("weijiao", index)).toEqual([items[0]]);
+    expect(searchNamedPinyinIndex("WEIJIAO", index)).toEqual([items[0]]);
+    expect(searchNamedPinyinIndex("", index)).toEqual(items);
   });
 
-  it("keeps a later server match when the local index has no match", () => {
-    const index = buildGlobalSearchPinyinIndex({ friends: [], groups: [] });
-    const localResult = searchGlobalSearchPinyinIndex("later", index);
-    const laterServerMatch = {
-      channel_id: "later-page-user",
-      channel_type: 1,
-      channel_name: "Later Server Match",
-    };
-
-    const merged = mergeGlobalSearchPinyinResults(
-      { friends: [laterServerMatch], groups: [], messages: [] },
-      localResult
-    );
-
-    expect(merged.friends).toEqual([laterServerMatch]);
-  });
-
-  it("converts 10,000 names once and reuses the index", () => {
+  it("rebuilds the authoritative pool and reuses unchanged conversions", () => {
     const toPinyin = vi.fn((name: string) =>
       name === "魏娇莹" ? "weijiaoying" : name
     );
-    const largeSource = {
-      friends: Array.from({ length: 10_000 }, (_, index) => ({
-        channel_id: `u${index}`,
-        channel_type: 1,
-        channel_name: index === 9_999 ? "魏娇莹" : `User ${index}`,
-      })),
-      groups: [],
-    };
-    const index = buildGlobalSearchPinyinIndex(largeSource, toPinyin);
+    const first = rebuildNamedPinyinSearchIndex(
+      createNamedPinyinSearchIndex<NamedItem>(),
+      [
+        { id: "u1", name: "魏娇莹" },
+        { id: "u2", name: "Alice" },
+      ],
+      key,
+      values,
+      toPinyin
+    );
+    toPinyin.mockClear();
+
+    const rebuilt = rebuildNamedPinyinSearchIndex(
+      first,
+      [
+        { id: "u1", name: "魏娇莹" },
+        { id: "u3", name: "Bob" },
+      ],
+      key,
+      values,
+      toPinyin
+    );
+
+    expect(searchNamedPinyinIndex("alice", rebuilt)).toEqual([]);
+    expect(searchNamedPinyinIndex("weijiao", rebuilt)[0].id).toBe("u1");
+    expect(toPinyin).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps existing order and appends only new keys", () => {
+    const server = [{ id: "server", name: "Server" }];
+    const result = appendUniqueByKey(
+      server,
+      [server[0], { id: "local", name: "Local" }],
+      key
+    );
+
+    expect(result.map((item) => item.id)).toEqual(["server", "local"]);
+  });
+
+  it("converts a 10,000-name pool once and reuses the index", () => {
+    const items = Array.from({ length: 10_000 }, (_, index) => ({
+      id: `u${index}`,
+      name: index === 9_999 ? "魏娇莹" : `User ${index}`,
+    }));
+    const toPinyin = vi.fn((name: string) =>
+      name === "魏娇莹" ? "weijiaoying" : name
+    );
+    const index = rebuildNamedPinyinSearchIndex(
+      createNamedPinyinSearchIndex<NamedItem>(),
+      items,
+      key,
+      (item) => [item.name],
+      toPinyin
+    );
 
     for (let count = 0; count < 20; count += 1) {
-      expect(
-        searchGlobalSearchPinyinIndex("weijiao", index).friends
-      ).toHaveLength(1);
+      expect(searchNamedPinyinIndex("weijiao", index)).toHaveLength(1);
     }
-
     expect(toPinyin).toHaveBeenCalledTimes(10_000);
-  });
-
-  it("rebuilds changed snapshots without reconverting unchanged names", () => {
-    const toPinyin = vi.fn((name: string) =>
-      name === "全能接项目小组" ? "quannengjiexiangmuxiaozu" : name
-    );
-    const initial = buildGlobalSearchPinyinIndex(source, toPinyin);
-    toPinyin.mockClear();
-
-    const rebuilt = rebuildGlobalSearchPinyinIndex(
-      initial,
-      {
-        friends: source.friends,
-        groups: [
-          ...source.groups,
-          {
-            channel_id: "g2",
-            channel_type: 2,
-            channel_name: "全能接项目小组",
-          },
-        ],
-      },
-      toPinyin
-    );
-
-    expect(toPinyin).toHaveBeenCalledTimes(1);
-    expect(
-      searchGlobalSearchPinyinIndex("quanneng", rebuilt).groups?.map(
-        (item) => item.channel_id
-      )
-    ).toEqual(["g2"]);
-
-    toPinyin.mockClear();
-    const rebuiltAgain = rebuildGlobalSearchPinyinIndex(rebuilt, {
-      friends: source.friends,
-      groups: [
-        ...source.groups,
-        {
-          channel_id: "g2",
-          channel_type: 2,
-          channel_name: "全能接项目小组",
-        },
-      ],
-    });
-    expect(toPinyin).not.toHaveBeenCalled();
-    expect(
-      searchGlobalSearchPinyinIndex("quanneng", rebuiltAgain).groups
-    ).toHaveLength(1);
-  });
-
-  it("rebuilds authoritative snapshots without removed or renamed entries", () => {
-    const initial = buildGlobalSearchPinyinIndex({
-      friends: [
-        {
-          channel_id: "u1",
-          channel_type: 1,
-          channel_name: "魏娇莹",
-        },
-      ],
-      groups: [
-        {
-          channel_id: "g1",
-          channel_type: 2,
-          channel_name: "旧项目群",
-        },
-      ],
-    });
-    expect(
-      searchGlobalSearchPinyinIndex("weijiao", initial).friends
-    ).toHaveLength(1);
-    expect(
-      searchGlobalSearchPinyinIndex("jiuxiangmu", initial).groups
-    ).toHaveLength(1);
-
-    const refreshed = buildGlobalSearchPinyinIndex({
-      friends: [
-        {
-          channel_id: "u1",
-          channel_type: 1,
-          channel_name: "张小明",
-        },
-      ],
-      groups: [],
-    });
-
-    expect(searchGlobalSearchPinyinIndex("weijiao", refreshed).friends).toEqual(
-      []
-    );
-    expect(
-      searchGlobalSearchPinyinIndex("zhangxiao", refreshed).friends
-    ).toHaveLength(1);
-    expect(
-      searchGlobalSearchPinyinIndex("jiuxiangmu", refreshed).groups
-    ).toEqual([]);
-  });
-
-  it("replaces previously merged local rows from the latest server baseline", () => {
-    const staleLocalFriend = {
-      channel_id: "removed-user",
-      channel_type: 1,
-      channel_name: "已删除联系人",
-    };
-    const staleLocalGroup = {
-      channel_id: "removed-group",
-      channel_type: 2,
-      channel_name: "已退出群聊",
-    };
-    const current = {
-      friends: [staleLocalFriend],
-      groups: [staleLocalGroup],
-      messages: [{ message_id: "message-1" }],
-    };
-
-    const replaced = replaceGlobalSearchPinyinMatches(
-      current,
-      { friends: [], groups: [] },
-      { friends: [], groups: [] }
-    );
-
-    expect(replaced.friends).toEqual([]);
-    expect(replaced.groups).toEqual([]);
-    expect(replaced.messages).toEqual(current.messages);
-  });
-
-  it("keeps the last successful group snapshot on load failure but accepts an authoritative empty snapshot", () => {
-    const current = [
-      {
-        channel_id: "g1",
-        channel_type: 2,
-        channel_name: "仍可见群聊",
-      },
-    ];
-
-    expect(refreshGlobalSearchGroupCandidates(current, undefined)).toBe(
-      current
-    );
-    expect(refreshGlobalSearchGroupCandidates(current, [])).toEqual([]);
-  });
-
-  it("matches the real group name with the project's pinyin converter", () => {
-    const index = buildGlobalSearchPinyinIndex({
-      friends: [],
-      groups: [
-        {
-          channel_id: "g2",
-          channel_type: 2,
-          channel_name: "全能接项目小组",
-        },
-      ],
-    });
-
-    expect(
-      searchGlobalSearchPinyinIndex("quanneng", index).groups
-    ).toHaveLength(1);
-  });
-
-  it("reuses a generic named index for sender, member and channel pickers", () => {
-    const toPinyin = vi.fn((value: string) =>
-      value === "魏娇莹" ? "weijiaoying" : value
-    );
-    const index = createNamedPinyinSearchIndex<{ id: string; name: string }>();
-    const items = [{ id: "u1", name: "魏娇莹" }];
-
-    extendNamedPinyinSearchIndex(
-      index,
-      items,
-      (item) => item.id,
-      (item) => [item.name, item.id],
-      toPinyin
-    );
-    extendNamedPinyinSearchIndex(
-      index,
-      items,
-      (item) => item.id,
-      (item) => [item.name, item.id],
-      toPinyin
-    );
-
-    expect(searchNamedPinyinIndex("weijiao", index)).toEqual(items);
-    expect(toPinyin).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/dmworkbase/src/bridge/globalSearch/globalSearchPinyin.test.ts
+++ b/packages/dmworkbase/src/bridge/globalSearch/globalSearchPinyin.test.ts
@@ -1,0 +1,308 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  buildGlobalSearchPinyinIndex,
+  createNamedPinyinSearchIndex,
+  extendNamedPinyinSearchIndex,
+  mergeGlobalSearchPinyinResults,
+  refreshGlobalSearchGroupCandidates,
+  rebuildGlobalSearchPinyinIndex,
+  replaceGlobalSearchPinyinMatches,
+  searchNamedPinyinIndex,
+  searchGlobalSearchPinyinIndex,
+} from "./globalSearchPinyin";
+
+describe("global search pinyin index", () => {
+  const source = {
+    friends: [
+      {
+        channel_id: "u1",
+        channel_type: 1,
+        channel_name: "魏娇莹",
+      },
+    ],
+    groups: [
+      {
+        channel_id: "g1",
+        channel_type: 2,
+        channel_name: "魏娇莹项目群",
+      },
+    ],
+  };
+
+  it("matches Chinese, full pinyin and case-insensitive pinyin", () => {
+    const index = buildGlobalSearchPinyinIndex(source);
+
+    expect(searchGlobalSearchPinyinIndex("魏娇", index).friends).toHaveLength(
+      1
+    );
+    expect(
+      searchGlobalSearchPinyinIndex("weijiao", index).friends
+    ).toHaveLength(1);
+    expect(searchGlobalSearchPinyinIndex("WEIJIAO", index).groups).toHaveLength(
+      1
+    );
+  });
+
+  it("uses the visible remark for matching", () => {
+    const index = buildGlobalSearchPinyinIndex({
+      friends: [
+        {
+          channel_id: "u1",
+          channel_type: 1,
+          channel_name: "原名",
+          channel_remark: "魏娇莹",
+        },
+      ],
+      groups: [],
+    });
+
+    expect(
+      searchGlobalSearchPinyinIndex("weijiao", index).friends
+    ).toHaveLength(1);
+    expect(
+      searchGlobalSearchPinyinIndex("yuanming", index).friends
+    ).toHaveLength(0);
+  });
+
+  it("keeps server order and appends only non-duplicate local matches", () => {
+    const serverFriend = {
+      channel_id: "server",
+      channel_type: 1,
+      channel_name: "Server",
+    };
+    const duplicateLocal = { ...serverFriend, channel_name: "Local duplicate" };
+    const localOnly = {
+      channel_id: "local",
+      channel_type: 1,
+      channel_name: "Local",
+    };
+
+    const merged = mergeGlobalSearchPinyinResults(
+      { friends: [serverFriend], groups: [], messages: [] },
+      { friends: [duplicateLocal, localOnly], groups: [] }
+    );
+
+    expect(merged.friends).toEqual([serverFriend, localOnly]);
+    expect(merged.messages).toEqual([]);
+  });
+
+  it("keeps a later server match when the local index has no match", () => {
+    const index = buildGlobalSearchPinyinIndex({ friends: [], groups: [] });
+    const localResult = searchGlobalSearchPinyinIndex("later", index);
+    const laterServerMatch = {
+      channel_id: "later-page-user",
+      channel_type: 1,
+      channel_name: "Later Server Match",
+    };
+
+    const merged = mergeGlobalSearchPinyinResults(
+      { friends: [laterServerMatch], groups: [], messages: [] },
+      localResult
+    );
+
+    expect(merged.friends).toEqual([laterServerMatch]);
+  });
+
+  it("converts 10,000 names once and reuses the index", () => {
+    const toPinyin = vi.fn((name: string) =>
+      name === "魏娇莹" ? "weijiaoying" : name
+    );
+    const largeSource = {
+      friends: Array.from({ length: 10_000 }, (_, index) => ({
+        channel_id: `u${index}`,
+        channel_type: 1,
+        channel_name: index === 9_999 ? "魏娇莹" : `User ${index}`,
+      })),
+      groups: [],
+    };
+    const index = buildGlobalSearchPinyinIndex(largeSource, toPinyin);
+
+    for (let count = 0; count < 20; count += 1) {
+      expect(
+        searchGlobalSearchPinyinIndex("weijiao", index).friends
+      ).toHaveLength(1);
+    }
+
+    expect(toPinyin).toHaveBeenCalledTimes(10_000);
+  });
+
+  it("rebuilds changed snapshots without reconverting unchanged names", () => {
+    const toPinyin = vi.fn((name: string) =>
+      name === "全能接项目小组" ? "quannengjiexiangmuxiaozu" : name
+    );
+    const initial = buildGlobalSearchPinyinIndex(source, toPinyin);
+    toPinyin.mockClear();
+
+    const rebuilt = rebuildGlobalSearchPinyinIndex(
+      initial,
+      {
+        friends: source.friends,
+        groups: [
+          ...source.groups,
+          {
+            channel_id: "g2",
+            channel_type: 2,
+            channel_name: "全能接项目小组",
+          },
+        ],
+      },
+      toPinyin
+    );
+
+    expect(toPinyin).toHaveBeenCalledTimes(1);
+    expect(
+      searchGlobalSearchPinyinIndex("quanneng", rebuilt).groups?.map(
+        (item) => item.channel_id
+      )
+    ).toEqual(["g2"]);
+
+    toPinyin.mockClear();
+    const rebuiltAgain = rebuildGlobalSearchPinyinIndex(rebuilt, {
+      friends: source.friends,
+      groups: [
+        ...source.groups,
+        {
+          channel_id: "g2",
+          channel_type: 2,
+          channel_name: "全能接项目小组",
+        },
+      ],
+    });
+    expect(toPinyin).not.toHaveBeenCalled();
+    expect(
+      searchGlobalSearchPinyinIndex("quanneng", rebuiltAgain).groups
+    ).toHaveLength(1);
+  });
+
+  it("rebuilds authoritative snapshots without removed or renamed entries", () => {
+    const initial = buildGlobalSearchPinyinIndex({
+      friends: [
+        {
+          channel_id: "u1",
+          channel_type: 1,
+          channel_name: "魏娇莹",
+        },
+      ],
+      groups: [
+        {
+          channel_id: "g1",
+          channel_type: 2,
+          channel_name: "旧项目群",
+        },
+      ],
+    });
+    expect(
+      searchGlobalSearchPinyinIndex("weijiao", initial).friends
+    ).toHaveLength(1);
+    expect(
+      searchGlobalSearchPinyinIndex("jiuxiangmu", initial).groups
+    ).toHaveLength(1);
+
+    const refreshed = buildGlobalSearchPinyinIndex({
+      friends: [
+        {
+          channel_id: "u1",
+          channel_type: 1,
+          channel_name: "张小明",
+        },
+      ],
+      groups: [],
+    });
+
+    expect(searchGlobalSearchPinyinIndex("weijiao", refreshed).friends).toEqual(
+      []
+    );
+    expect(
+      searchGlobalSearchPinyinIndex("zhangxiao", refreshed).friends
+    ).toHaveLength(1);
+    expect(
+      searchGlobalSearchPinyinIndex("jiuxiangmu", refreshed).groups
+    ).toEqual([]);
+  });
+
+  it("replaces previously merged local rows from the latest server baseline", () => {
+    const staleLocalFriend = {
+      channel_id: "removed-user",
+      channel_type: 1,
+      channel_name: "已删除联系人",
+    };
+    const staleLocalGroup = {
+      channel_id: "removed-group",
+      channel_type: 2,
+      channel_name: "已退出群聊",
+    };
+    const current = {
+      friends: [staleLocalFriend],
+      groups: [staleLocalGroup],
+      messages: [{ message_id: "message-1" }],
+    };
+
+    const replaced = replaceGlobalSearchPinyinMatches(
+      current,
+      { friends: [], groups: [] },
+      { friends: [], groups: [] }
+    );
+
+    expect(replaced.friends).toEqual([]);
+    expect(replaced.groups).toEqual([]);
+    expect(replaced.messages).toEqual(current.messages);
+  });
+
+  it("keeps the last successful group snapshot on load failure but accepts an authoritative empty snapshot", () => {
+    const current = [
+      {
+        channel_id: "g1",
+        channel_type: 2,
+        channel_name: "仍可见群聊",
+      },
+    ];
+
+    expect(refreshGlobalSearchGroupCandidates(current, undefined)).toBe(
+      current
+    );
+    expect(refreshGlobalSearchGroupCandidates(current, [])).toEqual([]);
+  });
+
+  it("matches the real group name with the project's pinyin converter", () => {
+    const index = buildGlobalSearchPinyinIndex({
+      friends: [],
+      groups: [
+        {
+          channel_id: "g2",
+          channel_type: 2,
+          channel_name: "全能接项目小组",
+        },
+      ],
+    });
+
+    expect(
+      searchGlobalSearchPinyinIndex("quanneng", index).groups
+    ).toHaveLength(1);
+  });
+
+  it("reuses a generic named index for sender, member and channel pickers", () => {
+    const toPinyin = vi.fn((value: string) =>
+      value === "魏娇莹" ? "weijiaoying" : value
+    );
+    const index = createNamedPinyinSearchIndex<{ id: string; name: string }>();
+    const items = [{ id: "u1", name: "魏娇莹" }];
+
+    extendNamedPinyinSearchIndex(
+      index,
+      items,
+      (item) => item.id,
+      (item) => [item.name, item.id],
+      toPinyin
+    );
+    extendNamedPinyinSearchIndex(
+      index,
+      items,
+      (item) => item.id,
+      (item) => [item.name, item.id],
+      toPinyin
+    );
+
+    expect(searchNamedPinyinIndex("weijiao", index)).toEqual(items);
+    expect(toPinyin).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/dmworkbase/src/bridge/globalSearch/globalSearchPinyin.ts
+++ b/packages/dmworkbase/src/bridge/globalSearch/globalSearchPinyin.ts
@@ -1,12 +1,4 @@
-import type { ChannelInfo } from "wukongimjssdk";
-import { ChannelTypeGroup, ChannelTypePerson } from "wukongimjssdk";
-import { pinyin } from "pinyin-pro";
-import type { Contacts } from "../../Service/DataSource/DataSource";
-import { ContactsStatus } from "../../Service/DataSource/DataSource";
-import type {
-  LegacyGlobalSearchContact,
-  LegacyGlobalSearchResponse,
-} from "../../Service/SearchService";
+import { getPinyin } from "../../Utils/pinYin";
 import { toSimplized } from "../../Utils/t2s";
 
 export type GlobalSearchPinyinConverter = (value: string) => string;
@@ -21,71 +13,58 @@ export interface NamedPinyinSearchIndex<T> {
   entries: Map<string, NamedPinyinSearchEntry<T>>;
 }
 
-interface GlobalSearchPinyinEntry {
-  item: LegacyGlobalSearchContact;
-  sourceText: string;
-  searchText: string;
-}
-
-export interface GlobalSearchPinyinIndex {
-  friends: GlobalSearchPinyinEntry[];
-  groups: GlobalSearchPinyinEntry[];
-}
-
-function displayName(item: LegacyGlobalSearchContact): string {
-  return item.channel_remark || item.channel_name || item.channel_id || "";
-}
-
 function defaultPinyinConverter(value: string): string {
-  const simplified = toSimplized(value);
-  return pinyin(simplified, {
-    toneType: "none",
-    type: "array",
-  })
-    .join("")
-    .toLowerCase();
+  return getPinyin(toSimplized(value)).toLowerCase();
 }
 
-function namedSearchText(
-  normalized: string[],
+function normalizedValues(values: string[]): string[] {
+  return values
+    .map((value) => value.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+function createEntry<T>(
+  item: T,
+  values: string[],
   toPinyin: GlobalSearchPinyinConverter
-): string {
-  return [
-    normalized.join("\n"),
-    ...normalized.map((value) => toPinyin(value).toLowerCase()),
-  ].join("\n");
+): NamedPinyinSearchEntry<T> {
+  const normalized = normalizedValues(values);
+  return {
+    item,
+    sourceText: normalized.join("\n"),
+    searchText: [
+      ...normalized,
+      ...normalized.map((value) => toPinyin(value).toLowerCase()),
+    ].join("\n"),
+  };
 }
 
 export function createNamedPinyinSearchIndex<T>(): NamedPinyinSearchIndex<T> {
   return { entries: new Map() };
 }
 
-export function extendNamedPinyinSearchIndex<T>(
-  index: NamedPinyinSearchIndex<T>,
+export function rebuildNamedPinyinSearchIndex<T>(
+  current: NamedPinyinSearchIndex<T>,
   items: T[],
   getKey: (item: T) => string,
   getValues: (item: T) => string[],
   toPinyin: GlobalSearchPinyinConverter = defaultPinyinConverter
 ): NamedPinyinSearchIndex<T> {
-  items.forEach((item) => {
+  const next = createNamedPinyinSearchIndex<T>();
+  for (const item of items) {
     const key = getKey(item);
-    if (!key) return;
-    const normalized = getValues(item)
-      .map((value) => value.trim().toLowerCase())
-      .filter(Boolean);
-    const sourceText = normalized.join("\n");
-    const current = index.entries.get(key);
-    if (current?.sourceText === sourceText) {
-      current.item = item;
-      return;
-    }
-    index.entries.set(key, {
-      item,
-      sourceText,
-      searchText: namedSearchText(normalized, toPinyin),
-    });
-  });
-  return index;
+    if (!key || next.entries.has(key)) continue;
+    const values = getValues(item);
+    const sourceText = normalizedValues(values).join("\n");
+    const cached = current.entries.get(key);
+    next.entries.set(
+      key,
+      cached?.sourceText === sourceText
+        ? { ...cached, item }
+        : createEntry(item, values, toPinyin)
+    );
+  }
+  return next;
 }
 
 export function searchNamedPinyinIndex<T>(
@@ -101,187 +80,18 @@ export function searchNamedPinyinIndex<T>(
     .map((entry) => entry.item);
 }
 
-function searchText(
-  name: string,
-  toPinyin: GlobalSearchPinyinConverter
-): string {
-  return `${name}\n${toPinyin(name).toLowerCase()}`;
-}
-
-function globalSearchEntry(
-  item: LegacyGlobalSearchContact,
-  toPinyin: GlobalSearchPinyinConverter
-): GlobalSearchPinyinEntry {
-  const sourceText = displayName(item).replace(/\*\*/g, "").toLowerCase();
-  return {
-    item,
-    sourceText,
-    searchText: searchText(sourceText, toPinyin),
-  };
-}
-
-function uniqueByChannel(
-  items: LegacyGlobalSearchContact[]
-): LegacyGlobalSearchContact[] {
-  const seen = new Set<string>();
-  return items.filter((item) => {
-    const key = `${item.channel_type}:${item.channel_id}`;
-    if (!item.channel_id || seen.has(key)) return false;
+export function appendUniqueByKey<T>(
+  existing: T[] | undefined,
+  additions: T[] | undefined,
+  getKey: (item: T) => string
+): T[] {
+  const result = [...(existing || [])];
+  const seen = new Set(result.map(getKey));
+  for (const item of additions || []) {
+    const key = getKey(item);
+    if (!key || seen.has(key)) continue;
     seen.add(key);
-    return true;
-  });
-}
-
-export function createEmptyGlobalSearchPinyinIndex(): GlobalSearchPinyinIndex {
-  return { friends: [], groups: [] };
-}
-
-export function buildGlobalSearchPinyinIndex(
-  source: Pick<LegacyGlobalSearchResponse, "friends" | "groups">,
-  toPinyin: GlobalSearchPinyinConverter = defaultPinyinConverter
-): GlobalSearchPinyinIndex {
-  const build = (items: LegacyGlobalSearchContact[] | undefined) =>
-    uniqueByChannel(items || []).map((item) =>
-      globalSearchEntry(item, toPinyin)
-    );
-
-  return {
-    friends: build(source.friends),
-    groups: build(source.groups),
-  };
-}
-
-export function rebuildGlobalSearchPinyinIndex(
-  index: GlobalSearchPinyinIndex,
-  source: Pick<LegacyGlobalSearchResponse, "friends" | "groups">,
-  toPinyin: GlobalSearchPinyinConverter = defaultPinyinConverter
-): GlobalSearchPinyinIndex {
-  const rebuild = (
-    current: GlobalSearchPinyinEntry[],
-    incoming: LegacyGlobalSearchContact[] | undefined
-  ) => {
-    const currentByKey = new Map(
-      current.map((entry) => [
-        `${entry.item.channel_type}:${entry.item.channel_id}`,
-        entry,
-      ])
-    );
-    return uniqueByChannel(incoming || []).map((item) => {
-      const key = `${item.channel_type}:${item.channel_id}`;
-      const sourceText = displayName(item).replace(/\*\*/g, "").toLowerCase();
-      const cached = currentByKey.get(key);
-      if (cached?.sourceText === sourceText) {
-        return { ...cached, item };
-      }
-      return globalSearchEntry(item, toPinyin);
-    });
-  };
-
-  return {
-    friends: rebuild(index.friends, source.friends),
-    groups: rebuild(index.groups, source.groups),
-  };
-}
-
-export function searchGlobalSearchPinyinIndex(
-  keyword: string,
-  index: GlobalSearchPinyinIndex
-): Pick<LegacyGlobalSearchResponse, "friends" | "groups"> {
-  const normalizedKeyword = keyword.trim().toLowerCase();
-  if (!normalizedKeyword) return { friends: [], groups: [] };
-
-  const search = (entries: GlobalSearchPinyinEntry[]) =>
-    entries
-      .filter((entry) => entry.searchText.includes(normalizedKeyword))
-      .map((entry) => entry.item);
-
-  return {
-    friends: search(index.friends),
-    groups: search(index.groups),
-  };
-}
-
-function mergeContacts(
-  serverItems: LegacyGlobalSearchContact[] | undefined,
-  localItems: LegacyGlobalSearchContact[] | undefined
-): LegacyGlobalSearchContact[] {
-  return uniqueByChannel([...(serverItems || []), ...(localItems || [])]);
-}
-
-export function mergeGlobalSearchPinyinResults(
-  serverResult: LegacyGlobalSearchResponse,
-  localResult: Pick<LegacyGlobalSearchResponse, "friends" | "groups">
-): LegacyGlobalSearchResponse {
-  return {
-    ...serverResult,
-    friends: mergeContacts(serverResult.friends, localResult.friends),
-    groups: mergeContacts(serverResult.groups, localResult.groups),
-  };
-}
-
-export function replaceGlobalSearchPinyinMatches(
-  currentResult: LegacyGlobalSearchResponse,
-  serverResult: Pick<LegacyGlobalSearchResponse, "friends" | "groups">,
-  localResult: Pick<LegacyGlobalSearchResponse, "friends" | "groups">
-): LegacyGlobalSearchResponse {
-  return mergeGlobalSearchPinyinResults(
-    {
-      ...currentResult,
-      friends: serverResult.friends,
-      groups: serverResult.groups,
-    },
-    localResult
-  );
-}
-
-export function globalSearchContactsToLegacy(
-  contacts: Contacts[]
-): LegacyGlobalSearchContact[] {
-  return contacts
-    .filter((contact) => contact.status !== ContactsStatus.Blacklist)
-    .map((contact) => ({
-      channel_id: contact.uid,
-      channel_type: ChannelTypePerson,
-      channel_name: contact.remark || contact.name || contact.uid,
-      channel_remark: contact.remark || undefined,
-    }));
-}
-
-export function globalSearchGroupsToLegacy(
-  groups: ChannelInfo[]
-): LegacyGlobalSearchContact[] {
-  return groups.flatMap((group) => {
-    const raw = group as ChannelInfo & {
-      displayName?: string;
-      name?: string;
-      title?: string;
-      orgData?: Record<string, unknown>;
-    };
-    const channelId = raw.channel?.channelID;
-    if (!channelId) return [];
-    const org = raw.orgData || {};
-    const remark = typeof org.remark === "string" ? org.remark : "";
-    const name =
-      remark ||
-      (typeof raw.displayName === "string" ? raw.displayName : "") ||
-      (typeof org.displayName === "string" ? org.displayName : "") ||
-      (typeof raw.title === "string" ? raw.title : "") ||
-      (typeof raw.name === "string" ? raw.name : "") ||
-      channelId;
-    return [
-      {
-        channel_id: channelId,
-        channel_type: raw.channel.channelType || ChannelTypeGroup,
-        channel_name: name,
-        channel_remark: remark || undefined,
-      },
-    ];
-  });
-}
-
-export function refreshGlobalSearchGroupCandidates(
-  current: LegacyGlobalSearchContact[],
-  groups: ChannelInfo[] | undefined
-): LegacyGlobalSearchContact[] {
-  return groups === undefined ? current : globalSearchGroupsToLegacy(groups);
+    result.push(item);
+  }
+  return result;
 }

--- a/packages/dmworkbase/src/bridge/globalSearch/globalSearchPinyin.ts
+++ b/packages/dmworkbase/src/bridge/globalSearch/globalSearchPinyin.ts
@@ -1,0 +1,287 @@
+import type { ChannelInfo } from "wukongimjssdk";
+import { ChannelTypeGroup, ChannelTypePerson } from "wukongimjssdk";
+import { pinyin } from "pinyin-pro";
+import type { Contacts } from "../../Service/DataSource/DataSource";
+import { ContactsStatus } from "../../Service/DataSource/DataSource";
+import type {
+  LegacyGlobalSearchContact,
+  LegacyGlobalSearchResponse,
+} from "../../Service/SearchService";
+import { toSimplized } from "../../Utils/t2s";
+
+export type GlobalSearchPinyinConverter = (value: string) => string;
+
+interface NamedPinyinSearchEntry<T> {
+  item: T;
+  sourceText: string;
+  searchText: string;
+}
+
+export interface NamedPinyinSearchIndex<T> {
+  entries: Map<string, NamedPinyinSearchEntry<T>>;
+}
+
+interface GlobalSearchPinyinEntry {
+  item: LegacyGlobalSearchContact;
+  sourceText: string;
+  searchText: string;
+}
+
+export interface GlobalSearchPinyinIndex {
+  friends: GlobalSearchPinyinEntry[];
+  groups: GlobalSearchPinyinEntry[];
+}
+
+function displayName(item: LegacyGlobalSearchContact): string {
+  return item.channel_remark || item.channel_name || item.channel_id || "";
+}
+
+function defaultPinyinConverter(value: string): string {
+  const simplified = toSimplized(value);
+  return pinyin(simplified, {
+    toneType: "none",
+    type: "array",
+  })
+    .join("")
+    .toLowerCase();
+}
+
+function namedSearchText(
+  normalized: string[],
+  toPinyin: GlobalSearchPinyinConverter
+): string {
+  return [
+    normalized.join("\n"),
+    ...normalized.map((value) => toPinyin(value).toLowerCase()),
+  ].join("\n");
+}
+
+export function createNamedPinyinSearchIndex<T>(): NamedPinyinSearchIndex<T> {
+  return { entries: new Map() };
+}
+
+export function extendNamedPinyinSearchIndex<T>(
+  index: NamedPinyinSearchIndex<T>,
+  items: T[],
+  getKey: (item: T) => string,
+  getValues: (item: T) => string[],
+  toPinyin: GlobalSearchPinyinConverter = defaultPinyinConverter
+): NamedPinyinSearchIndex<T> {
+  items.forEach((item) => {
+    const key = getKey(item);
+    if (!key) return;
+    const normalized = getValues(item)
+      .map((value) => value.trim().toLowerCase())
+      .filter(Boolean);
+    const sourceText = normalized.join("\n");
+    const current = index.entries.get(key);
+    if (current?.sourceText === sourceText) {
+      current.item = item;
+      return;
+    }
+    index.entries.set(key, {
+      item,
+      sourceText,
+      searchText: namedSearchText(normalized, toPinyin),
+    });
+  });
+  return index;
+}
+
+export function searchNamedPinyinIndex<T>(
+  keyword: string,
+  index: NamedPinyinSearchIndex<T>
+): T[] {
+  const normalizedKeyword = keyword.trim().toLowerCase();
+  if (!normalizedKeyword) {
+    return Array.from(index.entries.values(), (entry) => entry.item);
+  }
+  return Array.from(index.entries.values())
+    .filter((entry) => entry.searchText.includes(normalizedKeyword))
+    .map((entry) => entry.item);
+}
+
+function searchText(
+  name: string,
+  toPinyin: GlobalSearchPinyinConverter
+): string {
+  return `${name}\n${toPinyin(name).toLowerCase()}`;
+}
+
+function globalSearchEntry(
+  item: LegacyGlobalSearchContact,
+  toPinyin: GlobalSearchPinyinConverter
+): GlobalSearchPinyinEntry {
+  const sourceText = displayName(item).replace(/\*\*/g, "").toLowerCase();
+  return {
+    item,
+    sourceText,
+    searchText: searchText(sourceText, toPinyin),
+  };
+}
+
+function uniqueByChannel(
+  items: LegacyGlobalSearchContact[]
+): LegacyGlobalSearchContact[] {
+  const seen = new Set<string>();
+  return items.filter((item) => {
+    const key = `${item.channel_type}:${item.channel_id}`;
+    if (!item.channel_id || seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+export function createEmptyGlobalSearchPinyinIndex(): GlobalSearchPinyinIndex {
+  return { friends: [], groups: [] };
+}
+
+export function buildGlobalSearchPinyinIndex(
+  source: Pick<LegacyGlobalSearchResponse, "friends" | "groups">,
+  toPinyin: GlobalSearchPinyinConverter = defaultPinyinConverter
+): GlobalSearchPinyinIndex {
+  const build = (items: LegacyGlobalSearchContact[] | undefined) =>
+    uniqueByChannel(items || []).map((item) =>
+      globalSearchEntry(item, toPinyin)
+    );
+
+  return {
+    friends: build(source.friends),
+    groups: build(source.groups),
+  };
+}
+
+export function rebuildGlobalSearchPinyinIndex(
+  index: GlobalSearchPinyinIndex,
+  source: Pick<LegacyGlobalSearchResponse, "friends" | "groups">,
+  toPinyin: GlobalSearchPinyinConverter = defaultPinyinConverter
+): GlobalSearchPinyinIndex {
+  const rebuild = (
+    current: GlobalSearchPinyinEntry[],
+    incoming: LegacyGlobalSearchContact[] | undefined
+  ) => {
+    const currentByKey = new Map(
+      current.map((entry) => [
+        `${entry.item.channel_type}:${entry.item.channel_id}`,
+        entry,
+      ])
+    );
+    return uniqueByChannel(incoming || []).map((item) => {
+      const key = `${item.channel_type}:${item.channel_id}`;
+      const sourceText = displayName(item).replace(/\*\*/g, "").toLowerCase();
+      const cached = currentByKey.get(key);
+      if (cached?.sourceText === sourceText) {
+        return { ...cached, item };
+      }
+      return globalSearchEntry(item, toPinyin);
+    });
+  };
+
+  return {
+    friends: rebuild(index.friends, source.friends),
+    groups: rebuild(index.groups, source.groups),
+  };
+}
+
+export function searchGlobalSearchPinyinIndex(
+  keyword: string,
+  index: GlobalSearchPinyinIndex
+): Pick<LegacyGlobalSearchResponse, "friends" | "groups"> {
+  const normalizedKeyword = keyword.trim().toLowerCase();
+  if (!normalizedKeyword) return { friends: [], groups: [] };
+
+  const search = (entries: GlobalSearchPinyinEntry[]) =>
+    entries
+      .filter((entry) => entry.searchText.includes(normalizedKeyword))
+      .map((entry) => entry.item);
+
+  return {
+    friends: search(index.friends),
+    groups: search(index.groups),
+  };
+}
+
+function mergeContacts(
+  serverItems: LegacyGlobalSearchContact[] | undefined,
+  localItems: LegacyGlobalSearchContact[] | undefined
+): LegacyGlobalSearchContact[] {
+  return uniqueByChannel([...(serverItems || []), ...(localItems || [])]);
+}
+
+export function mergeGlobalSearchPinyinResults(
+  serverResult: LegacyGlobalSearchResponse,
+  localResult: Pick<LegacyGlobalSearchResponse, "friends" | "groups">
+): LegacyGlobalSearchResponse {
+  return {
+    ...serverResult,
+    friends: mergeContacts(serverResult.friends, localResult.friends),
+    groups: mergeContacts(serverResult.groups, localResult.groups),
+  };
+}
+
+export function replaceGlobalSearchPinyinMatches(
+  currentResult: LegacyGlobalSearchResponse,
+  serverResult: Pick<LegacyGlobalSearchResponse, "friends" | "groups">,
+  localResult: Pick<LegacyGlobalSearchResponse, "friends" | "groups">
+): LegacyGlobalSearchResponse {
+  return mergeGlobalSearchPinyinResults(
+    {
+      ...currentResult,
+      friends: serverResult.friends,
+      groups: serverResult.groups,
+    },
+    localResult
+  );
+}
+
+export function globalSearchContactsToLegacy(
+  contacts: Contacts[]
+): LegacyGlobalSearchContact[] {
+  return contacts
+    .filter((contact) => contact.status !== ContactsStatus.Blacklist)
+    .map((contact) => ({
+      channel_id: contact.uid,
+      channel_type: ChannelTypePerson,
+      channel_name: contact.remark || contact.name || contact.uid,
+      channel_remark: contact.remark || undefined,
+    }));
+}
+
+export function globalSearchGroupsToLegacy(
+  groups: ChannelInfo[]
+): LegacyGlobalSearchContact[] {
+  return groups.flatMap((group) => {
+    const raw = group as ChannelInfo & {
+      displayName?: string;
+      name?: string;
+      title?: string;
+      orgData?: Record<string, unknown>;
+    };
+    const channelId = raw.channel?.channelID;
+    if (!channelId) return [];
+    const org = raw.orgData || {};
+    const remark = typeof org.remark === "string" ? org.remark : "";
+    const name =
+      remark ||
+      (typeof raw.displayName === "string" ? raw.displayName : "") ||
+      (typeof org.displayName === "string" ? org.displayName : "") ||
+      (typeof raw.title === "string" ? raw.title : "") ||
+      (typeof raw.name === "string" ? raw.name : "") ||
+      channelId;
+    return [
+      {
+        channel_id: channelId,
+        channel_type: raw.channel.channelType || ChannelTypeGroup,
+        channel_name: name,
+        channel_remark: remark || undefined,
+      },
+    ];
+  });
+}
+
+export function refreshGlobalSearchGroupCandidates(
+  current: LegacyGlobalSearchContact[],
+  groups: ChannelInfo[] | undefined
+): LegacyGlobalSearchContact[] {
+  return groups === undefined ? current : globalSearchGroupsToLegacy(groups);
+}


### PR DESCRIPTION
## Summary
- add full-pinyin and case-insensitive matching to the existing global contact/group results and sender/member/channel pickers
- preserve the existing literal/server request, pagination, cache, ordering, fallback, click, and IME paths; pinyin-only matches are deduplicated and appended after existing results
- reuse the existing empty-keyword `/search/global` response as the authoritative Space-scoped contact/group source, and limit local sender pinyin candidates to UIDs confirmed by the current Space server response
- rebuild pinyin indexes from each current candidate snapshot while keeping the sender identity cache across same-Space contact changes

## Validation
- 11 focused GlobalSearch test files, 111 tests passed
- full `dmworkbase` suite: 255 files, 2225 tests passed
- `pnpm i18n:check` equivalent passed
- Web production build passed
- E2E mock bundle build passed
- `git diff --check` passed

## Regression coverage
- no extra `/group/my` request when global search opens
- previous-Space account-level contacts cannot enter the current Space pinyin supplement
- sender chips retain server-derived names and avatars after same-Space contact changes
- contact rename, pool shrink, blacklist, deletion, and no-longer-followed states
- readable channel pool shrink; channel IDs and hidden aliases do not broaden matching
- existing server-first ordering, 50-item limit, and remote sender search calls
- in-flight sender/channel results cannot populate a different Space cache
- server result ordering remains unchanged and pinyin hits only append
- 10,000-name index converts once and reuses cached pinyin