### PR TITLE
fix(market): refresh category counts with filters

### DIFF
--- a/packages/dmworkmcp/src/api/mcpService.paramsSerializer.test.ts
+++ b/packages/dmworkmcp/src/api/mcpService.paramsSerializer.test.ts
@@ -10,7 +10,7 @@ vi.mock("@octo/base", () => ({
   DEFAULT_REQUEST_TIMEOUT_MS: 20000,
 }));
 
-import { serializeMcpParams } from "./mcpService";
+import { buildMcpCategoryParams, serializeMcpParams } from "./mcpService";
 
 describe("serializeMcpParams — axios paramsSerializer wire contract", () => {
   it("emits `?a=1&a=2` for arrays (never `?a[]=1&a[]=2`)", () => {
@@ -60,5 +60,30 @@ describe("serializeMcpParams — axios paramsSerializer wire contract", () => {
 
   it("stringifies non-string primitives (limit, offset)", () => {
     expect(serializeMcpParams({ limit: 50, offset: 0 })).toBe("limit=50&offset=0");
+  });
+});
+
+describe("buildMcpCategoryParams", () => {
+  it("passes keyword and tags to category counts without the active category filter", () => {
+    const params = buildMcpCategoryParams(
+      "all",
+      {
+        tags: ["official", "v1.0,beta"],
+        createdByType: "bot",
+      },
+      "github"
+    );
+
+    expect(params).toEqual({
+      keyword: "github",
+      tag: ["official", "v1.0,beta"],
+      created_by_type: "bot",
+    });
+    expect(params).not.toHaveProperty("category");
+  });
+
+  it("adds mine mode only for the owned list", () => {
+    expect(buildMcpCategoryParams("mine", {}, "")).toEqual({ mode: "mine" });
+    expect(buildMcpCategoryParams("all", {}, "")).toEqual({});
   });
 });

--- a/packages/dmworkmcp/src/api/mcpService.ts
+++ b/packages/dmworkmcp/src/api/mcpService.ts
@@ -674,15 +674,11 @@ async function fetchMcpListPath(
   const pageSize = params.limit && params.limit > 0 ? params.limit : 20;
   query.page_size = pageSize;
   query.page = Math.floor((params.offset ?? 0) / pageSize) + 1;
-  // Category counts must honour the SAME `created_by_type` filter as the
-  // item list, otherwise the pill numbers become misleading when a source
-  // filter is active (issue #894 follow-up). `/mcps/mine` scopes to the
-  // caller via mode=mine; the source filter piggy-backs on top. Both are
-  // passed through the shared axios params serializer, so there's a single
-  // wire-shape truth for repeated-array values.
-  const categoryParams: Record<string, unknown> = {};
-  if (path === "/mcps/mine") categoryParams.mode = "mine";
-  if (params.createdByType) categoryParams.created_by_type = params.createdByType;
+  const categoryParams = buildMcpCategoryParams(
+    path === "/mcps/mine" ? "mine" : "all",
+    params,
+    keyword
+  );
   const [resp, categoryWire] = await executeMcpListRequest(() => Promise.all([
       mcpAxios.get<McpListResponseWire>(`${BASE}${path}`, { params: query }),
       mcpAxios
@@ -701,6 +697,22 @@ async function fetchMcpListPath(
     count: categoryCounts.get(key) ?? 0,
   }));
   return { items, total: resp.data.pagination.total, categories };
+}
+
+export function buildMcpCategoryParams(
+  mode: "all" | "mine",
+  params: Pick<ListMcpParams, "createdByType" | "tags">,
+  keyword = ""
+): Record<string, unknown> {
+  // Category counts must honour the same keyword/tag/provenance scope as the
+  // item list. The active category filter is intentionally excluded so category
+  // pills remain useful for switching within the current search/tag result set.
+  const categoryParams: Record<string, unknown> = {};
+  if (mode === "mine") categoryParams.mode = "mine";
+  if (keyword) categoryParams.keyword = keyword;
+  if (params.createdByType) categoryParams.created_by_type = params.createdByType;
+  if (params.tags?.length) categoryParams.tag = params.tags;
+  return categoryParams;
 }
 
 async function fetchMcpDetailReal(id: string): Promise<McpDetail> {

--- a/packages/dmworkskillmarket/src/api/skillApiMock.ts
+++ b/packages/dmworkskillmarket/src/api/skillApiMock.ts
@@ -90,15 +90,18 @@ function pageSkills(items: Skill[], query: SkillListQuery): PagedResult<Skill> {
   };
 }
 
-export function getCategories(_opts?: {
+export function getCategories(opts?: {
   signal?: AbortSignal;
+  q?: string;
+  tags?: string[];
 }): Promise<Category[]> {
+  const filtered = applySkillQuery({ q: opts?.q, tags: opts?.tags });
   const counted = CATEGORY_SEEDS.map((category) => ({
     ...category,
     skillCount:
       category.id === "all"
-        ? skills.length
-        : skills.filter((skill) => skill.categoryId === category.id).length,
+        ? filtered.length
+        : filtered.filter((skill) => skill.categoryId === category.id).length,
   }));
   return withDelay(counted);
 }

--- a/packages/dmworkskillmarket/src/api/skillApiReal.test.ts
+++ b/packages/dmworkskillmarket/src/api/skillApiReal.test.ts
@@ -103,6 +103,17 @@ describe("skillApiReal", () => {
     expect(headers).toEqual({ "Content-Type": "application/json" });
   });
 
+  it("getCategories forwards search and tag filters", async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse([]));
+
+    await getCategories({ q: "CI", tags: ["CI", "质量"] });
+
+    const url = mockFetch.mock.calls[0][0] as string;
+    expect(url).toContain("/market/api/v1/skill_categories?");
+    expect(url).toContain("q=CI");
+    expect(url).toContain("tags=CI%2C%E8%B4%A8%E9%87%8F");
+  });
+
   it("falls back to localStorage currentSpaceId when WKApp space is not hydrated", async () => {
     WKApp.shared.currentSpaceId = "";
     localStorage.setItem("currentSpaceId", "space-from-storage");

--- a/packages/dmworkskillmarket/src/api/skillApiReal.ts
+++ b/packages/dmworkskillmarket/src/api/skillApiReal.ts
@@ -316,9 +316,18 @@ export interface RequestOptions {
   signal?: AbortSignal;
 }
 
-export function getCategories(opts?: RequestOptions): Promise<Category[]> {
+export interface CategoryListOptions extends RequestOptions {
+  q?: string;
+  tags?: string[];
+}
+
+export function getCategories(opts?: CategoryListOptions): Promise<Category[]> {
+  const params = new URLSearchParams();
+  if (opts?.q) params.set("q", opts.q);
+  if (opts?.tags?.length) params.set("tags", opts.tags.join(","));
+  const qs = params.toString();
   return request<RawCategory[]>(
-    "/skill_categories",
+    `/skill_categories${qs ? `?${qs}` : ""}`,
     opts?.signal ? { signal: opts.signal } : undefined
   ).then((items) => items.map(mapCategory));
 }

--- a/packages/dmworkskillmarket/src/hooks/useSkills.ts
+++ b/packages/dmworkskillmarket/src/hooks/useSkills.ts
@@ -58,7 +58,7 @@ export function useSkills(options: UseSkillsOptions = {}): UseSkillsResult {
       try {
         const signal = controller.signal;
         const [categoryItems, page] = await Promise.all([
-          getCategories({ signal }),
+          getCategories({ q: debouncedQuery, tags: selectedTags, signal }),
           options.mine
             ? getMySkills(
                 {

--- a/packages/dmworkskillmarket/src/pages/__tests__/SkillListPage.test.tsx
+++ b/packages/dmworkskillmarket/src/pages/__tests__/SkillListPage.test.tsx
@@ -155,6 +155,7 @@ describe("SkillListPage", () => {
       await vi.runOnlyPendingTimersAsync();
     });
 
+    vi.mocked(api.getCategories).mockClear();
     vi.mocked(api.getSkills).mockClear();
     fireEvent.change(screen.getByPlaceholderText(searchPlaceholder), {
       target: { value: "ci" },
@@ -166,6 +167,13 @@ describe("SkillListPage", () => {
       await vi.runOnlyPendingTimersAsync();
     });
 
+    expect(api.getCategories).toHaveBeenCalledWith(
+      expect.objectContaining({
+        q: "ci",
+        tags: [],
+        signal: expect.any(AbortSignal),
+      })
+    );
     expect(api.getSkills).toHaveBeenCalledWith(
       {
         q: "ci",
@@ -184,6 +192,8 @@ describe("SkillListPage", () => {
 
     fireEvent.click(screen.getByRole("button", { name: tagFilterName }));
     const tagOption = await screen.findByRole("option", { name: "纪要" });
+    vi.mocked(api.getCategories).mockClear();
+    vi.mocked(api.getSkills).mockClear();
     fireEvent.click(tagOption);
 
     expect(
@@ -194,13 +204,34 @@ describe("SkillListPage", () => {
       "true"
     );
     expect(screen.getByText(selectedTagsText)).toBeInTheDocument();
+    await waitFor(() => {
+      expect(api.getCategories).toHaveBeenCalledWith(
+        expect.objectContaining({
+          q: "",
+          tags: ["纪要"],
+          signal: expect.any(AbortSignal),
+        })
+      );
+      expect(api.getSkills).toHaveBeenCalledWith(
+        expect.objectContaining({ tags: ["纪要"] }),
+        expect.objectContaining({ signal: expect.any(AbortSignal) })
+      );
+    });
 
+    vi.mocked(api.getCategories).mockClear();
     fireEvent.click(screen.getByRole("button", { name: clearFilterName }));
 
     await waitFor(() => {
       expect(screen.getByRole("option", { name: "纪要" })).toHaveAttribute(
         "aria-selected",
         "false"
+      );
+      expect(api.getCategories).toHaveBeenCalledWith(
+        expect.objectContaining({
+          q: "",
+          tags: [],
+          signal: expect.any(AbortSignal),
+        })
       );
     });
     expect(screen.getByText(noSelectedTagsText)).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- Pass active Skill search/tag filters into Skill category count requests.
- Pass active MCP keyword/tag filters into MCP category count requests, while intentionally excluding the active category filter so category pills remain switchable within the current result set.
- Add focused API/service tests for both marketplace surfaces.

## Linked Spec
- Fixes #1116
- Depends on Mininglamp-OSS/octo-marketplace#30 for backend Skill category counts.
- MCP category-count filtering is the same filtered category-count behavior on the MCP market surface.

## How verified
- `pnpm --filter @dmwork/skillmarket test -- --run packages/dmworkskillmarket/src/api/skillApiReal.test.ts packages/dmworkskillmarket/src/pages/__tests__/SkillListPage.test.tsx`
- `pnpm --filter @dmwork/mcp test -- --run packages/dmworkmcp/src/api/mcpService.paramsSerializer.test.ts`
- Browser verification against Docker marketplace backend: Skill fuzzy search `ci` and tag `CI` update category counts to the filtered result set.

## COMPREHENSION
1. **What does this change actually do** to the load-bearing path?
   Skill and MCP marketplace list views now send the same search/tag state to their category count requests that they send to item-list requests. Active category selection is not sent to the category-count endpoint, preserving cross-category switching inside the current search/tag result set.

2. **What could break** because of it (dependents + failure mode)?
   Category chips and list reload behavior depend on this path. The main risks are stale filter parameters, extra reloads, or incorrectly zeroing other category chips by passing the active category filter.

3. **How do you know it works** (specific test/repro/trace)?
   Skill page tests cover debounced search and tag selection. MCP API tests cover category-count params with repeated tags and mode handling. Manual browser verification confirmed real Docker-backed Skill category counts follow search/tag filters.
