### PR TITLE
fix: keep chat connection status interactive

### DIFF
--- a/packages/dmworkbase/src/Components/ConnectionStatus/__tests__/ConnectionStatus.test.ts
+++ b/packages/dmworkbase/src/Components/ConnectionStatus/__tests__/ConnectionStatus.test.ts
@@ -1,3 +1,4 @@
+import { renderToStaticMarkup } from "react-dom/server"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { ConnectStatus } from "wukongimjssdk"
 import ConnectionStatus from "../index"
@@ -56,8 +57,8 @@ vi.mock("../../../i18n", async () => {
 type ConnectionStatusState = ConnectionStatus["state"]
 type ConnectionStatusSetState = Parameters<ConnectionStatus["setState"]>[0]
 
-function createConnectionStatus(state?: Partial<ConnectionStatusState>) {
-    const component = new ConnectionStatus({})
+function createConnectionStatus(state?: Partial<ConnectionStatusState>, props: { compact?: boolean } = {}) {
+    const component = new ConnectionStatus(props)
     component.state = {
         status: ConnectStatus.Connected,
         latency: 88,
@@ -74,9 +75,50 @@ function createConnectionStatus(state?: Partial<ConnectionStatusState>) {
     return component
 }
 
+function renderComponent(component: ConnectionStatus) {
+    component.context = {
+        t: (key: string) => key,
+        locale: "zh-CN",
+        setLocale: vi.fn(),
+    } as any
+    return renderToStaticMarkup(component.render())
+}
+
+describe("ConnectionStatus render", () => {
+    beforeEach(() => {
+        hoisted.sdk.connectManager.connect.mockReset()
+    })
+
+    it("shows connected text when connected latency is not available yet", () => {
+        const component = createConnectionStatus({ latency: null })
+
+        const html = renderComponent(component)
+
+        expect(html).toContain("base.connectionStatus.connected")
+        expect(html).not.toContain("base.connectionStatus.disconnected")
+    })
+
+    it("keeps compact disconnected status interactive", () => {
+        const component = createConnectionStatus({
+            status: ConnectStatus.Disconnect,
+            latency: null,
+            connectedSince: null,
+        }, { compact: true })
+
+        const html = renderComponent(component)
+        component.handleClick()
+
+        expect(html).toContain("role=\"button\"")
+        expect(html).toContain("cursor:pointer")
+        expect(html).toContain("base.connectionStatus.disconnected")
+        expect(hoisted.sdk.connectManager.connect).toHaveBeenCalledTimes(1)
+    })
+})
+
 describe("ConnectionStatus measureLatency", () => {
     beforeEach(() => {
         hoisted.sdk.connectManager.status = ConnectStatus.Connected
+        hoisted.sdk.connectManager.connect.mockReset()
         hoisted.apiFetch.mockReset()
     })
 

--- a/packages/dmworkbase/src/Components/ConnectionStatus/index.tsx
+++ b/packages/dmworkbase/src/Components/ConnectionStatus/index.tsx
@@ -156,19 +156,33 @@ export default class ConnectionStatus extends Component<ConnectionStatusProps, C
 
         const inactiveBar = "var(--wk-border-default)"
 
-        const labelText = connected && latency !== null
-            ? `${latency}ms`
+        const labelText = connected
+            ? (latency !== null ? `${latency}ms` : t("base.connectionStatus.connected"))
             : connecting ? t("base.connectionStatus.connectingDots") : t("base.connectionStatus.disconnected")
+        const statusLabel = connected
+            ? t("base.connectionStatus.connected")
+            : connecting ? t("base.connectionStatus.connecting") : t("base.connectionStatus.disconnected")
+        const containerProps = {
+            onClick: this.handleClick,
+            onKeyDown: (event: React.KeyboardEvent<HTMLDivElement>) => {
+                if (!connected && (event.key === "Enter" || event.key === " ")) {
+                    event.preventDefault()
+                    this.handleClick()
+                }
+            },
+            onMouseEnter: () => this.setState({ showTooltip: true }),
+            onMouseLeave: () => this.setState({ showTooltip: false }),
+            role: connected ? undefined : "button",
+            tabIndex: connected ? undefined : 0,
+            "aria-label": statusLabel,
+            style: { cursor: connected ? "default" : "pointer" },
+        }
 
         const tooltip = showTooltip && (
             <div className="wk-conn-tooltip">
                 <div>
                     {t("base.connectionStatus.statusLabel")}
-                    {connected
-                        ? t("base.connectionStatus.connected")
-                        : connecting
-                            ? t("base.connectionStatus.connecting")
-                            : t("base.connectionStatus.disconnected")}
+                    {statusLabel}
                 </div>
                 {connected && latency !== null && <div>{t("base.connectionStatus.latencyLabel")}{latency}ms</div>}
                 {connected && connectedSince && (
@@ -197,10 +211,7 @@ export default class ConnectionStatus extends Component<ConnectionStatusProps, C
             return (
                 <div
                     className={`wk-conn-status wk-conn-status--compact${connecting ? " wk-conn-blink-wrap" : ""}`}
-                    onClick={this.handleClick}
-                    onMouseEnter={() => this.setState({ showTooltip: true })}
-                    onMouseLeave={() => this.setState({ showTooltip: false })}
-                    style={{ cursor: "default" }}
+                    {...containerProps}
                 >
                     {svgBars(12)}
                     <span style={{ fontSize: 11, color: barColor, marginLeft: 2, fontVariantNumeric: 'tabular-nums' }}>
@@ -214,10 +225,7 @@ export default class ConnectionStatus extends Component<ConnectionStatusProps, C
         return (
             <div
                 className="wk-conn-status"
-                onClick={this.handleClick}
-                onMouseEnter={() => this.setState({ showTooltip: true })}
-                onMouseLeave={() => this.setState({ showTooltip: false })}
-                style={{ cursor: connected ? "default" : "pointer" }}
+                {...containerProps}
             >
                 {svgBars(14)}
                 <span className="wk-conn-text" style={{ color: barColor }}>


### PR DESCRIPTION
## Summary
- Keep chat connection status text on the connected state when latency is temporarily unavailable
- Preserve interactive affordances for disconnected/connecting connection status, including pointer cursor and keyboard activation
- Add regression coverage for connected-without-latency rendering and compact disconnected reconnect behavior

## Test plan
- `pnpm --dir /home/mlclaw/workspaces/octo-web-fix-1121 exec vitest run packages/dmworkbase/src/Components/ConnectionStatus/__tests__/ConnectionStatus.test.ts`
- `pnpm --dir /home/mlclaw/workspaces/octo-web-fix-1121 --filter @octo/web build`
- E2E evidence run: chat header connection status disconnect → reconnect with `/health` unavailable, with screenshots/video/trace attached in the Octo Loop issue

Fixes #1121
