### PR TITLE
fix(sidebar): gate category drop highlight by drag type

### DIFF
--- a/packages/dmworkbase/src/Components/CategorySection/index.tsx
+++ b/packages/dmworkbase/src/Components/CategorySection/index.tsx
@@ -1,5 +1,6 @@
 import React from "react"
 import CategoryHeader from "../CategoryHeader"
+import { useDndContext } from "@dnd-kit/core"
 import { useSortable } from "@dnd-kit/sortable"
 import { CSS } from "@dnd-kit/utilities"
 import { useI18n } from "../../i18n"
@@ -38,6 +39,7 @@ const CategorySectionInner: React.FC<CategorySectionProps> = ({
     onRenameCancel,
 }) => {
     const { t } = useI18n()
+    const { active } = useDndContext()
     // useSortable：分组整体排序（同时作为 droppable，接受 group item 的 drop）
     const {
         attributes,
@@ -57,12 +59,13 @@ const CategorySectionInner: React.FC<CategorySectionProps> = ({
     }
 
     const isEmpty = category.isEmpty ?? (!children || (Array.isArray(children) && children.length === 0))
+    const showDropOver = isOver && active?.data.current?.type === 'category'
 
     return (
         <div
             ref={setNodeRef}
             style={style}
-            className={`wk-category-section${isOver ? ' wk-category-section--drop-over' : ''}${isDragging ? ' wk-category-section--dragging' : ''}`}
+            className={`wk-category-section${showDropOver ? ' wk-category-section--drop-over' : ''}${isDragging ? ' wk-category-section--dragging' : ''}`}
         >
             <CategoryHeader
                 name={category.name}

--- a/packages/dmworkbase/src/Components/UngroupedSection/index.tsx
+++ b/packages/dmworkbase/src/Components/UngroupedSection/index.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { useDroppable } from "@dnd-kit/core"
+import { useDndContext, useDroppable } from "@dnd-kit/core"
 import { useI18n } from "../../i18n"
 import "./index.css"
 
@@ -11,15 +11,17 @@ export interface UngroupedSectionProps {
 
 const UngroupedSectionInner: React.FC<UngroupedSectionProps> = ({ children }) => {
     const { t } = useI18n()
+    const { active } = useDndContext()
     const { setNodeRef, isOver } = useDroppable({
         id: 'drop::ungrouped',
         data: { type: 'ungrouped-drop' },
     })
+    const showDropOver = isOver && active?.data.current?.type === 'category'
 
     return (
         <div
             ref={setNodeRef}
-            className={`wk-ungrouped-section${isOver ? ' wk-ungrouped-section--drop-over' : ''}`}
+            className={`wk-ungrouped-section${showDropOver ? ' wk-ungrouped-section--drop-over' : ''}`}
         >
             <div className="wk-ungrouped-section__header">
                 <span className="wk-ungrouped-section__title">{t("base.chatSidebar.defaultCategory")}</span>


### PR DESCRIPTION
## Summary

- gate category section drop-over highlight to category drags only
- gate ungrouped section drop-over highlight to category drags only
- keep item drag drops over category headers visually neutral after #1128 made them no-op

Closes #1092

## Verification

- `pnpm --dir packages/dmworkbase test -- ConversationListGrouped`
