### PR TITLE
feat(navrail): unify bottom flyout behavior

### DIFF
--- a/packages/dmworkbase/src/Components/NavRail/NavBottom.tsx
+++ b/packages/dmworkbase/src/Components/NavRail/NavBottom.tsx
@@ -6,6 +6,7 @@ import { t } from "../../i18n";
 
 export interface NavBottomProps {
     settingSelected?: boolean;
+    settingsButtonRef?: React.RefObject<HTMLButtonElement>;
     onSettingsClick?: () => void;
     /** 外部通知有新版本，触发气泡首次弹出 */
     hasNewVersion?: boolean;
@@ -44,7 +45,7 @@ export default class NavBottom extends Component<NavBottomProps, NavBottomState>
     }
 
     render() {
-        const { onSettingsClick, hasNewVersion, onDismissNewVersion, spaces, currentSpaceId, onSpaceSelect, onJoinSpace, onCreateSpace } = this.props;
+        const { onSettingsClick, settingsButtonRef, settingSelected, hasNewVersion, onDismissNewVersion, spaces, currentSpaceId, onSpaceSelect, onJoinSpace, onCreateSpace } = this.props;
         const { bubbleVisible } = this.state;
 
         return (
@@ -57,10 +58,13 @@ export default class NavBottom extends Component<NavBottomProps, NavBottomState>
                 {/* 设置按钮 + 气泡 */}
                 <div className="wk-navrail__settings-wrap">
                     <button
+                        ref={settingsButtonRef}
                         type="button"
                         className="wk-navrail__item"
                         title={t("base.navRail.settings")}
                         aria-label={t("base.navRail.settings")}
+                        aria-haspopup="menu"
+                        aria-expanded={!!settingSelected}
                         onClick={onSettingsClick}
                     >
                         <IconSettings />

--- a/packages/dmworkbase/src/Components/NavRail/NavFlyout.tsx
+++ b/packages/dmworkbase/src/Components/NavRail/NavFlyout.tsx
@@ -1,0 +1,154 @@
+import React from "react";
+import { createPortal } from "react-dom";
+import { computePosition, flip, offset, shift } from "@floating-ui/dom";
+
+export type NavFlyoutSize = "sm" | "md" | "lg";
+
+export interface NavFlyoutProps {
+    open: boolean;
+    triggerRef: React.RefObject<HTMLElement>;
+    onOpenChange: (open: boolean) => void;
+    size?: NavFlyoutSize;
+    role?: React.AriaRole;
+    ariaLabel?: string;
+    ariaLabelledby?: string;
+    className?: string;
+    children: React.ReactNode;
+}
+
+const initialPosition: React.CSSProperties = {
+    position: "fixed",
+    left: 64,
+    bottom: 32,
+};
+
+export default function NavFlyout({
+    open,
+    triggerRef,
+    onOpenChange,
+    size = "md",
+    role,
+    ariaLabel,
+    ariaLabelledby,
+    className,
+    children,
+}: NavFlyoutProps) {
+    const flyoutRef = React.useRef<HTMLDivElement>(null);
+    const [style, setStyle] = React.useState<React.CSSProperties>(initialPosition);
+    const wasOpenRef = React.useRef(false);
+
+    React.useLayoutEffect(() => {
+        if (!open) return;
+        let cancelled = false;
+        const update = () => {
+            const trigger = triggerRef.current;
+            const flyout = flyoutRef.current;
+            if (!trigger || !flyout) return;
+            computePosition(trigger, flyout, {
+                placement: "right-end",
+                strategy: "fixed",
+                middleware: [offset(8), flip(), shift({ padding: 8 })],
+            }).then(({ x, y }) => {
+                if (!cancelled) {
+                    setStyle({ position: "fixed", left: x, top: y });
+                }
+            });
+        };
+        update();
+        window.addEventListener("resize", update);
+        window.addEventListener("scroll", update, true);
+        return () => {
+            cancelled = true;
+            window.removeEventListener("resize", update);
+            window.removeEventListener("scroll", update, true);
+        };
+    }, [open, triggerRef]);
+
+    React.useEffect(() => {
+        if (!open) return;
+        const handleKeyDown = (event: KeyboardEvent) => {
+            if (event.key === "Escape") {
+                event.stopPropagation();
+                onOpenChange(false);
+            }
+        };
+        document.addEventListener("keydown", handleKeyDown);
+        return () => document.removeEventListener("keydown", handleKeyDown);
+    }, [open, onOpenChange]);
+
+    React.useEffect(() => {
+        if (wasOpenRef.current && !open) {
+            triggerRef.current?.focus();
+        }
+        wasOpenRef.current = open;
+    }, [open, triggerRef]);
+
+    if (!open) return null;
+
+    const flyoutClassName = [
+        "wk-navrail__flyout",
+        `wk-navrail__flyout--${size}`,
+        className,
+    ]
+        .filter(Boolean)
+        .join(" ");
+
+    return createPortal(
+        <>
+            <div className="wk-navrail__flyout-mask" onClick={() => onOpenChange(false)} />
+            <div
+                ref={flyoutRef}
+                className={flyoutClassName}
+                role={role}
+                aria-label={ariaLabel}
+                aria-labelledby={ariaLabelledby}
+                style={style}
+                onClick={(event) => event.stopPropagation()}
+            >
+                {children}
+            </div>
+        </>,
+        document.body,
+    );
+}
+
+export interface NavFlyoutMenuItemProps {
+    children: React.ReactNode;
+    onSelect?: (event: React.MouseEvent<HTMLButtonElement>) => void;
+    role?: React.AriaRole;
+    ariaChecked?: boolean;
+    active?: boolean;
+    trailing?: React.ReactNode;
+    className?: string;
+}
+
+export function NavFlyoutMenuItem({
+    children,
+    onSelect,
+    role = "menuitem",
+    ariaChecked,
+    active = false,
+    trailing,
+    className,
+}: NavFlyoutMenuItemProps) {
+    const itemClassName = [
+        "wk-navrail__flyout-item",
+        active && "wk-navrail__flyout-item--active",
+        className,
+    ]
+        .filter(Boolean)
+        .join(" ");
+
+    return (
+        <button
+            type="button"
+            className={itemClassName}
+            role={role}
+            aria-checked={ariaChecked}
+            onClick={onSelect}
+        >
+            <span className="wk-navrail__flyout-item-label">{children}</span>
+            {trailing && <span className="wk-navrail__flyout-item-trailing">{trailing}</span>}
+        </button>
+    );
+}

--- a/packages/dmworkbase/src/Components/NavRail/NavLanguageSwitcher.tsx
+++ b/packages/dmworkbase/src/Components/NavRail/NavLanguageSwitcher.tsx
@@ -4,6 +4,7 @@ import WKApp from "../../App";
 import { updateUserLanguagePreference } from "../../Service/UserLanguageService";
 import { useI18n } from "../../i18n/useI18n";
 import { Locale } from "../../i18n/types";
+import NavFlyout, { NavFlyoutMenuItem } from "./NavFlyout";
 
 function getNextLocale(locale: Locale): Locale {
   return locale === "zh-CN" ? "en-US" : "zh-CN";
@@ -21,6 +22,7 @@ function summarizeLanguageSyncError(error: unknown): Record<string, unknown> | u
 
 export default function NavLanguageSwitcher() {
   const [open, setOpen] = React.useState(false);
+  const triggerRef = React.useRef<HTMLButtonElement>(null);
   const { locale, setLocale, t } = useI18n();
   const nextLocale = getNextLocale(locale);
   const titleKey = nextLocale === "en-US"
@@ -54,6 +56,7 @@ export default function NavLanguageSwitcher() {
   return (
     <div className="wk-navrail__language-wrap">
       <button
+        ref={triggerRef}
         type="button"
         className={`wk-navrail__item wk-navrail__language${open ? " wk-navrail__language--open" : ""}`}
         title={title}
@@ -65,29 +68,32 @@ export default function NavLanguageSwitcher() {
         <IconLanguage aria-hidden="true" />
       </button>
 
-      {open && (
-        <>
-          <div className="wk-navrail__language-mask" onClick={() => setOpen(false)} />
-          <div className="wk-navrail__language-menu" role="menu">
-            {locales.map((item) => {
-              const active = item.locale === locale;
-              return (
-                <button
-                  key={item.locale}
-                  type="button"
-                  className={`wk-navrail__language-menu-item${active ? " wk-navrail__language-menu-item--active" : ""}`}
-                  role="menuitemradio"
-                  aria-checked={active}
-                  onClick={() => handleSelect(item.locale)}
-                >
-                  <span className="wk-navrail__language-menu-label">{t(item.labelKey)}</span>
-                  {active && <IconTick aria-hidden="true" />}
-                </button>
-              );
-            })}
-          </div>
-        </>
-      )}
+      <NavFlyout
+        open={open}
+        triggerRef={triggerRef}
+        onOpenChange={setOpen}
+        size="sm"
+        role="menu"
+        ariaLabel={title}
+        className="wk-navrail__language-menu"
+      >
+        {locales.map((item) => {
+          const active = item.locale === locale;
+          return (
+            <NavFlyoutMenuItem
+              key={item.locale}
+              role="menuitemradio"
+              ariaChecked={active}
+              active={active}
+              trailing={active ? <IconTick aria-hidden="true" /> : undefined}
+              className="wk-navrail__language-menu-item"
+              onSelect={() => handleSelect(item.locale)}
+            >
+              {t(item.labelKey)}
+            </NavFlyoutMenuItem>
+          );
+        })}
+      </NavFlyout>
     </div>
   );
 }

--- a/packages/dmworkbase/src/Components/NavRail/NavRail.stories.tsx
+++ b/packages/dmworkbase/src/Components/NavRail/NavRail.stories.tsx
@@ -2,10 +2,10 @@ import type { Meta, StoryObj } from "@storybook/react";
 import React from "react";
 import NavRail from "./index";
 import type { NavRailProps } from "./index";
+import NavBottom from "./NavBottom";
 import NavSpaceSwitcher from "./NavSpaceSwitcher";
-import SpaceItem from "../SpaceItem";
-import ActionListItem from "../ActionListItem";
-import { IconJoinSpace } from "./icons";
+import NavSettingsPanel from "./NavSettingsPanel";
+import { Menus } from "../../Service/Menus";
 import "../../theme/index.css";
 
 const mockSpaces = [
@@ -14,17 +14,35 @@ const mockSpaces = [
     { space_id: "s3", name: "研发中心", logo: "", member_count: 20, max_users: 0 },
 ] as any[];
 
+function Icon({ label }: { label: string }) {
+    return <span aria-hidden="true" style={{ fontSize: 16 }}>{label}</span>;
+}
+
+const messagesMenu = new Menus("messages", "/chat", "会话", <Icon label="💬" />, <Icon label="💬" />);
+const contactsMenu = new Menus("contacts", "/contacts", "通讯录", <Icon label="👥" />, <Icon label="👥" />);
+
 const defaultArgs: NavRailProps = {
+    menusList: [messagesMenu, contactsMenu],
+    currentMenus: messagesMenu,
+    settingSelected: false,
+    hasNewVersion: false,
+    showNewVersion: false,
+    showAppVersion: false,
+    showAppUpdate: false,
+    appUpdateProgress: 0,
+    showAppUpdateOperation: false,
     spaces: mockSpaces,
     currentSpaceId: "s1",
-    activeItem: "messages",
-    userName: "张三",
-    unreadCount: 0,
-    onSpaceSelect: (id) => console.log("space selected:", id),
-    onItemClick: (key) => console.log("nav item clicked:", key),
-    onJoinSpace: () => console.log("join space"),
-    onSettingsClick: () => console.log("settings"),
+    onMenuClick: (menus) => console.log("nav menu clicked:", menus.id),
+    onToggleSetting: () => console.log("settings toggled"),
+    onSetShowNewVersion: (v) => console.log("show new version:", v),
+    onSetShowAppVersion: (v) => console.log("show app version:", v),
+    onInstallUpdate: () => console.log("install update"),
+    onNotifyListener: () => console.log("notify listener"),
     onAvatarClick: () => console.log("avatar"),
+    onSpaceSelect: (id) => console.log("space selected:", id),
+    onJoinSpace: () => console.log("join space"),
+    onCreateSpace: () => console.log("create space"),
 };
 
 const meta: Meta<typeof NavRail> = {
@@ -57,53 +75,88 @@ export const Default: Story = {
     args: defaultArgs,
 };
 
-export const WithBadge: Story = {
-    args: { ...defaultArgs, unreadCount: 5 },
+export const SettingsFlyoutOpen: Story = {
+    name: "设置弹层（真实组件）",
+    args: { ...defaultArgs, settingSelected: true },
 };
 
-export const WithLargeBadge: Story = {
-    args: { ...defaultArgs, unreadCount: 120 },
+function BottomLanguageOpen() {
+    const containerRef = React.useRef<HTMLDivElement>(null);
+    React.useEffect(() => {
+        const button = containerRef.current?.querySelector<HTMLButtonElement>(".wk-navrail__language");
+        button?.click();
+    }, []);
+    return (
+        <div ref={containerRef} className="wk-navrail" style={{ height: 220, justifyContent: "flex-end" }}>
+            <NavBottom
+                spaces={mockSpaces as any[]}
+                currentSpaceId="s1"
+                onSpaceSelect={(id) => console.log("space selected:", id)}
+            />
+        </div>
+    );
+}
+
+export const LanguageFlyoutOpen: StoryObj = {
+    name: "语言弹层（真实组件）",
+    render: () => <BottomLanguageOpen />,
 };
 
-export const MultipleSpaces: Story = {
-    args: { ...defaultArgs, currentSpaceId: "s2" },
+function SpaceOpen() {
+    const containerRef = React.useRef<HTMLDivElement>(null);
+    React.useEffect(() => {
+        const button = containerRef.current?.querySelector<HTMLButtonElement>(".wk-navrail__space-icon-btn");
+        button?.click();
+    }, []);
+    return (
+        <div ref={containerRef} className="wk-navrail" style={{ height: 220, justifyContent: "flex-end" }}>
+            <NavSpaceSwitcher
+                spaces={mockSpaces as any[]}
+                currentSpaceId="s1"
+                onSpaceSelect={(id) => console.log("space selected:", id)}
+                onJoinSpace={() => console.log("join space")}
+                onCreateSpace={() => console.log("create space")}
+            />
+        </div>
+    );
+}
+
+export const SpaceFlyoutOpen: StoryObj = {
+    name: "Space 弹层（真实组件）",
+    render: () => <SpaceOpen />,
 };
 
-export const NoSpaces: Story = {
-    args: { ...defaultArgs, spaces: [], currentSpaceId: undefined },
-};
-
-// ── Space 弹窗独立 Story — 静态展开状态，无需 WKApp context ──
-export const SpaceDropdownOpen = {
-    name: "Space 弹窗（展开状态）",
-    render: () => (
-        <div style={{
-            width: "100vw", height: "100vh",
-            background: "var(--wk-bg-deep, #F0F1F5)",
-            display: "flex", alignItems: "flex-end",
-            paddingBottom: 52, paddingLeft: 12,
-        }}>
-            {/* 静态展开弹窗，不依赖 WKApp，直接复现设计稿样式 */}
-            <div className="wk-navrail__dropdown" style={{ position: "static", boxSizing: "border-box" }}>
-                <div className="wk-navrail__dropdown-title">切换 Space</div>
-                <div className="wk-navrail__dropdown-spaces">
-                    {mockSpaces.map((s, i) => (
-                        <SpaceItem
-                            key={s.space_id}
-                            name={s.name}
-                            avatarSize="xs"
-                            meta={s.max_users > 0
-                                ? `${s.member_count}/${s.max_users} 人`
-                                : `${s.member_count} 人`}
-                            selected={i === 0}
-                        />
-                    ))}
-                </div>
-                <div className="wk-navrail__dropdown-divider" />
-                <div className="wk-navrail__dropdown-actions">
-                    <ActionListItem icon={<IconJoinSpace />} label="加入 Space" variant="join" compact />
+function FlyoutComparison() {
+    const settingsTriggerRef = React.useRef<HTMLButtonElement>(null);
+    return (
+        <div style={{ display: "flex", gap: 260, alignItems: "flex-end", height: "100vh", padding: "0 0 80px 24px" }}>
+            <BottomLanguageOpen />
+            <div className="wk-navrail" style={{ height: 220, justifyContent: "flex-end" }}>
+                <div className="wk-navrail__settings-wrap">
+                    <button
+                        ref={settingsTriggerRef}
+                        type="button"
+                        className="wk-navrail__item"
+                        aria-label="设置"
+                        aria-haspopup="menu"
+                        aria-expanded
+                    >
+                        <Icon label="⚙️" />
+                    </button>
                 </div>
             </div>
+            <NavSettingsPanel
+                {...defaultArgs}
+                settingSelected
+                triggerRef={settingsTriggerRef}
+                onToggleSetting={() => console.log("settings toggled")}
+            />
+            <SpaceOpen />
         </div>
-    ),
+    );
+}
+
+export const FlyoutComparisonOpen: StoryObj = {
+    name: "语言 / 设置 / Space 弹层对照",
+    render: () => <FlyoutComparison />,
 };

--- a/packages/dmworkbase/src/Components/NavRail/NavSecretsSettingsItem.tsx
+++ b/packages/dmworkbase/src/Components/NavRail/NavSecretsSettingsItem.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useCallback } from "react";
 import WKApp from "../../App";
 import SecretsSettingsPanel from "../SecretsSettings/SecretsSettingsPanel";
 import { useI18n } from "../../i18n";
+import { NavFlyoutMenuItem } from "./NavFlyout";
 
 /**
  * 设置面板里的「密钥 / Secrets」一级入口（YUJ-3539），与语音设置平级。
@@ -52,14 +53,9 @@ export default function NavSecretsSettingsItem() {
 
   return (
     <>
-      <li
-        onClick={(e) => {
-          e.stopPropagation();
-          open();
-        }}
-      >
+      <NavFlyoutMenuItem onSelect={() => open()}>
         {t("base.navRail.settingsPanel.secrets")}
-      </li>
+      </NavFlyoutMenuItem>
       {visible && (
         <SecretsSettingsPanel
           key={openSeq}

--- a/packages/dmworkbase/src/Components/NavRail/NavSettingsPanel.tsx
+++ b/packages/dmworkbase/src/Components/NavRail/NavSettingsPanel.tsx
@@ -1,6 +1,5 @@
 import WKApp from "../../App";
 import { checkVersionOnce } from "../../Utils/versionChecker";
-import classnames from "classnames";
 import React, { Component } from "react";
 import { Toast, Spin, Button, Progress } from "@douyinfe/semi-ui";
 import WKModal from "../WKModal";
@@ -9,9 +8,11 @@ import NavSecretsSettingsItem from "./NavSecretsSettingsItem";
 import ChangelogMarkdown from "./ChangelogMarkdown";
 import { i18n, t } from "../../i18n";
 import { apiFetchJson } from "../../Service/apiFetch";
+import NavFlyout, { NavFlyoutMenuItem } from "./NavFlyout";
 
 export interface NavSettingsPanelProps {
     settingSelected: boolean;
+    triggerRef: React.RefObject<HTMLElement>;
     hasNewVersion: boolean;
     showNewVersion: boolean;
     showAppVersion: boolean;
@@ -86,6 +87,7 @@ export default class NavSettingsPanel extends Component<NavSettingsPanelProps, N
     render() {
         const {
             settingSelected,
+            triggerRef,
             hasNewVersion,
             showNewVersion,
             showAppVersion,
@@ -117,17 +119,20 @@ export default class NavSettingsPanel extends Component<NavSettingsPanelProps, N
 
         return (
             <>
-                {/* 点击外部关闭 mask */}
-                {settingSelected && (
-                    <div
-                        style={{ position: "fixed", inset: 0, zIndex: 199 }}
-                        onClick={onToggleSetting}
-                    />
-                )}
-                <ul className={classnames("wk-sider-setting-list wk-navrail__settings-list", settingSelected ? "open" : undefined)}>
+                <NavFlyout
+                    open={settingSelected}
+                    triggerRef={triggerRef}
+                    onOpenChange={(next) => {
+                        if (next !== settingSelected) onToggleSetting();
+                    }}
+                    size="md"
+                    role="menu"
+                    ariaLabel={t("base.navRail.settings")}
+                    className="wk-navrail__settings-list"
+                >
                     {/* 版本更新提示（面板打开时自检，有新版本时展示） */}
                     {hasNewVersionLocal && (
-                        <li className="wk-navrail__settings-version-update" onClick={(e) => e.stopPropagation()}>
+                        <div className="wk-navrail__settings-version-update" role="none">
                             <span>{t("base.navRail.settingsPanel.versionAvailable")}</span>
                             <button
                                 className="wk-navrail__settings-version-refresh"
@@ -144,59 +149,59 @@ export default class NavSettingsPanel extends Component<NavSettingsPanelProps, N
                             >
                                 {t("base.navRail.settingsPanel.refreshNow")}
                             </button>
-                        </li>
+                        </div>
                     )}
                     {/* 暗黑模式入口已关闭 */}
                     {showAccountCenter && (
-                        <li onClick={() => {
+                        <NavFlyoutMenuItem onSelect={() => {
                             onToggleSetting();
                             window.open(accountCenterUrl, '_blank', 'noopener,noreferrer');
                         }}>
                             {t("base.navRail.settingsPanel.accountCenter")}
-                        </li>
+                        </NavFlyoutMenuItem>
                     )}
-                    <li onClick={() => {
+                    <NavFlyoutMenuItem onSelect={() => {
                         onToggleSetting();
                         this.fetchChangelog();
                         onSetShowNewVersion(true);
                     }}>
                         {t("base.navRail.settingsPanel.changelog")}
-                    </li>
+                    </NavFlyoutMenuItem>
                     {onOpenOnboarding && (
-                        <li onClick={() => {
+                        <NavFlyoutMenuItem onSelect={() => {
                             onToggleSetting();
                             onOpenOnboarding();
                         }}>
                             {t("base.navRail.settingsPanel.onboarding")}
-                        </li>
+                        </NavFlyoutMenuItem>
                     )}
                     {canManageSpace && (
-                        <li onClick={() => {
+                        <NavFlyoutMenuItem onSelect={() => {
                             onToggleSetting();
                             // /space 是独立打包的 admin SPA（同源），React Router 不识别，必须整页跳转；
                             // 真实鉴权由 admin 后端负责，此处仅用于 UI 可见性控制。
                             window.location.href = "/space";
                         }}>
                             {t("base.navRail.settingsPanel.spaceManagement")}
-                        </li>
+                        </NavFlyoutMenuItem>
                     )}
-                    <li onClick={() => {
+                    <NavFlyoutMenuItem onSelect={() => {
                         onToggleSetting();
                         WKApp.shared.notificationIsClose = !WKApp.shared.notificationIsClose;
                     }}>
                         {WKApp.shared.notificationIsClose
                             ? t("base.navRail.settingsPanel.desktopNotification.on")
                             : t("base.navRail.settingsPanel.desktopNotification.off")}
-                    </li>
+                    </NavFlyoutMenuItem>
                     <NavVoiceSettingsItem />
                     <NavSecretsSettingsItem />
-                    <li onClick={() => {
+                    <NavFlyoutMenuItem onSelect={() => {
                         onToggleSetting();
                         void WKApp.shared.logoutUserInitiated();
                     }}>
                         {t("base.navRail.settingsPanel.logout")}
-                    </li>
-                </ul>
+                    </NavFlyoutMenuItem>
+                </NavFlyout>
 
                 {/* 更新日志 Modal */}
                 <WKModal

--- a/packages/dmworkbase/src/Components/NavRail/NavSpaceSwitcher.tsx
+++ b/packages/dmworkbase/src/Components/NavRail/NavSpaceSwitcher.tsx
@@ -4,6 +4,7 @@ import SpaceItem from "../SpaceItem";
 import ActionListItem from "../ActionListItem";
 import { I18nContext } from "../../i18n";
 import WKApp from "../../App";
+import NavFlyout from "./NavFlyout";
 
 function IconBuilding() {
     return (
@@ -34,6 +35,7 @@ export default class NavSpaceSwitcher extends Component<NavSpaceSwitcherProps, N
     static contextType = I18nContext;
     declare context: React.ContextType<typeof I18nContext>;
     private unsubscribeRemoteConfig?: () => void;
+    private triggerRef = React.createRef<HTMLButtonElement>();
 
     constructor(props: NavSpaceSwitcherProps) {
         super(props);
@@ -41,22 +43,14 @@ export default class NavSpaceSwitcher extends Component<NavSpaceSwitcherProps, N
     }
 
     componentDidMount() {
-        document.addEventListener("keydown", this.handleKeyDown);
         this.unsubscribeRemoteConfig = WKApp.remoteConfig.addConfigChangeListener(() => {
             this.forceUpdate();
         });
     }
 
     componentWillUnmount() {
-        document.removeEventListener("keydown", this.handleKeyDown);
         this.unsubscribeRemoteConfig?.();
     }
-
-    private handleKeyDown = (e: KeyboardEvent) => {
-        if (e.key === "Escape" && this.state.open) {
-            this.handleClose();
-        }
-    };
 
     private handleToggle = () => {
         this.setState(prev => ({ open: !prev.open }));
@@ -76,77 +70,76 @@ export default class NavSpaceSwitcher extends Component<NavSpaceSwitcherProps, N
         return (
             <div className="wk-navrail__switcher">
                 <button
+                    ref={this.triggerRef}
                     type="button"
                     className="wk-navrail__space-icon-btn"
                     title={current?.name ?? t("base.navRail.spaceSwitcher.switch")}
                     aria-label={t("base.navRail.spaceSwitcher.switch")}
+                    aria-haspopup="dialog"
+                    aria-expanded={open}
                     onClick={this.handleToggle}
                 >
                     <IconBuilding />
                 </button>
 
-                {open && (
-                    <>
-                        {/* 点击外部关闭 */}
-                        <div
-                            className="wk-navrail__dropdown-mask"
-                            onClick={this.handleClose}
-                        />
-                        <div className="wk-navrail__dropdown" onClick={e => e.stopPropagation()}>
-                            {/* 弹窗标题 */}
-                            <div className="wk-navrail__dropdown-title">{t("base.navRail.spaceSwitcher.joinedSpaces")}</div>
-                            {/* 可滚动的 Space 列表 */}
-                            <div className="wk-navrail__dropdown-spaces">
-                                {spaces.map(space => (
-                                    <SpaceItem
-                                        key={space.space_id}
-                                        name={space.name}
-                                        logo={space.logo}
-                                        avatarSize="switcher"
-                                        meta={space.max_users > 0
-                                            ? t("base.navRail.spaceSwitcher.memberCountWithLimit", {
-                                                values: { count: space.member_count, max: space.max_users },
-                                            })
-                                            : t("base.navRail.spaceSwitcher.memberCount", {
-                                                values: { count: space.member_count },
-                                            })}
-                                        selected={space.space_id === currentSpaceId}
-                                        onClick={() => {
-                                            onSpaceSelect(space.space_id);
-                                            this.handleClose();
-                                        }}
+                <NavFlyout
+                    open={open}
+                    triggerRef={this.triggerRef}
+                    onOpenChange={(next) => this.setState({ open: next })}
+                    size="lg"
+                    role="dialog"
+                    ariaLabel={t("base.navRail.spaceSwitcher.joinedSpaces")}
+                    className="wk-navrail__dropdown"
+                >
+                    <div className="wk-navrail__dropdown-title">{t("base.navRail.spaceSwitcher.joinedSpaces")}</div>
+                    <div className="wk-navrail__dropdown-spaces">
+                        {spaces.map(space => (
+                            <SpaceItem
+                                key={space.space_id}
+                                name={space.name}
+                                logo={space.logo}
+                                avatarSize="switcher"
+                                meta={space.max_users > 0
+                                    ? t("base.navRail.spaceSwitcher.memberCountWithLimit", {
+                                        values: { count: space.member_count, max: space.max_users },
+                                    })
+                                    : t("base.navRail.spaceSwitcher.memberCount", {
+                                        values: { count: space.member_count },
+                                    })}
+                                selected={space.space_id === currentSpaceId}
+                                onClick={() => {
+                                    onSpaceSelect(space.space_id);
+                                    this.handleClose();
+                                }}
+                            />
+                        ))}
+                    </div>
+                    {(onJoinSpace || canCreateSpace) && (
+                        <>
+                            <div className="wk-navrail__dropdown-divider" />
+                            <div className="wk-navrail__dropdown-actions">
+                                {onJoinSpace && (
+                                    <ActionListItem
+                                        icon={<IconJoinSpace />}
+                                        label={t("base.navRail.spaceSwitcher.joinNewSpace")}
+                                        compact
+                                        trailing={<IconChevronRight />}
+                                        onClick={() => { this.handleClose(); onJoinSpace(); }}
                                     />
-                                ))}
+                                )}
+                                {canCreateSpace && (
+                                    <ActionListItem
+                                        icon={<IconCreateSpace />}
+                                        label={t("base.spaceList.createSpace")}
+                                        compact
+                                        trailing={<IconChevronRight />}
+                                        onClick={() => { this.handleClose(); onCreateSpace?.(); }}
+                                    />
+                                )}
                             </div>
-                            {/* 固定底部操作区 */}
-                            {(onJoinSpace || canCreateSpace) && (
-                                <>
-                                    <div className="wk-navrail__dropdown-divider" />
-                                    <div className="wk-navrail__dropdown-actions">
-                                        {onJoinSpace && (
-                                            <ActionListItem
-                                                icon={<IconJoinSpace />}
-                                                label={t("base.navRail.spaceSwitcher.joinNewSpace")}
-                                                compact
-                                                trailing={<IconChevronRight />}
-                                                onClick={() => { this.handleClose(); onJoinSpace(); }}
-                                            />
-                                        )}
-                                        {canCreateSpace && (
-                                            <ActionListItem
-                                                icon={<IconCreateSpace />}
-                                                label={t("base.spaceList.createSpace")}
-                                                compact
-                                                trailing={<IconChevronRight />}
-                                                onClick={() => { this.handleClose(); onCreateSpace?.(); }}
-                                            />
-                                        )}
-                                    </div>
-                                </>
-                            )}
-                        </div>
-                    </>
-                )}
+                        </>
+                    )}
+                </NavFlyout>
             </div>
         );
     }

--- a/packages/dmworkbase/src/Components/NavRail/NavVoiceSettingsItem.tsx
+++ b/packages/dmworkbase/src/Components/NavRail/NavVoiceSettingsItem.tsx
@@ -3,6 +3,7 @@ import { ensureVoiceFeedbackLoaded } from '../MessageInput/useSpaceFeedbackSetti
 import WKApp from '../../App';
 import VoiceSettingsPanel from './VoiceSettingsPanel';
 import { useI18n } from '../../i18n';
+import { NavFlyoutMenuItem } from './NavFlyout';
 
 export default function NavVoiceSettingsItem() {
   const [panelVisible, setPanelVisible] = useState(false);
@@ -21,12 +22,9 @@ export default function NavVoiceSettingsItem() {
 
   return (
     <>
-      <li onClick={(e) => {
-        e.stopPropagation();
-        setPanelVisible(true);
-      }}>
+      <NavFlyoutMenuItem onSelect={() => setPanelVisible(true)}>
         {t("base.navRail.settingsPanel.voiceSettings")}
-      </li>
+      </NavFlyoutMenuItem>
       {panelVisible && (
         <VoiceSettingsPanel onClose={() => setPanelVisible(false)} />
       )}

--- a/packages/dmworkbase/src/Components/NavRail/__tests__/NavFlyout.test.tsx
+++ b/packages/dmworkbase/src/Components/NavRail/__tests__/NavFlyout.test.tsx
@@ -1,0 +1,83 @@
+import React from "react";
+import ReactDOM from "react-dom";
+import { act } from "react-dom/test-utils";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import NavFlyout, { NavFlyoutMenuItem } from "../NavFlyout";
+
+let container: HTMLDivElement;
+let trigger: HTMLButtonElement;
+
+beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    trigger = document.createElement("button");
+    trigger.textContent = "trigger";
+    document.body.appendChild(trigger);
+});
+
+afterEach(() => {
+    act(() => {
+        ReactDOM.unmountComponentAtNode(container);
+    });
+    trigger.remove();
+    container.remove();
+    document.querySelectorAll(".wk-navrail__flyout, .wk-navrail__flyout-mask").forEach((node) => node.remove());
+});
+
+function renderFlyout(open: boolean, onOpenChange: (open: boolean) => void) {
+    act(() => {
+        ReactDOM.render(
+            <NavFlyout
+                open={open}
+                triggerRef={{ current: trigger }}
+                onOpenChange={onOpenChange}
+                role="menu"
+                ariaLabel="Demo menu"
+            >
+                <NavFlyoutMenuItem>Action</NavFlyoutMenuItem>
+            </NavFlyout>,
+            container,
+        );
+    });
+}
+
+describe("NavFlyout", () => {
+    it("renders through a portal with shared menu semantics", () => {
+        renderFlyout(true, () => {});
+
+        const flyout = document.body.querySelector(".wk-navrail__flyout") as HTMLElement | null;
+        expect(flyout).toBeTruthy();
+        expect(flyout?.getAttribute("role")).toBe("menu");
+        expect(flyout?.getAttribute("aria-label")).toBe("Demo menu");
+        expect(flyout?.querySelector("button")?.getAttribute("role")).toBe("menuitem");
+    });
+
+    it("closes on outside click", () => {
+        const calls: boolean[] = [];
+        renderFlyout(true, (next) => calls.push(next));
+
+        act(() => {
+            (document.body.querySelector(".wk-navrail__flyout-mask") as HTMLDivElement).click();
+        });
+
+        expect(calls).toEqual([false]);
+    });
+
+    it("closes on Escape", () => {
+        const calls: boolean[] = [];
+        renderFlyout(true, (next) => calls.push(next));
+
+        act(() => {
+            document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+        });
+
+        expect(calls).toEqual([false]);
+    });
+
+    it("restores focus to the trigger after closing", () => {
+        renderFlyout(true, () => {});
+        renderFlyout(false, () => {});
+
+        expect(document.activeElement).toBe(trigger);
+    });
+});

--- a/packages/dmworkbase/src/Components/NavRail/__tests__/NavLanguageSwitcher.test.tsx
+++ b/packages/dmworkbase/src/Components/NavRail/__tests__/NavLanguageSwitcher.test.tsx
@@ -75,7 +75,7 @@ function renderSwitcher() {
 }
 
 function clickLanguageMenuItem(label: string) {
-  const item = Array.from(container.querySelectorAll("button"))
+  const item = Array.from(document.body.querySelectorAll("button"))
     .find((button) => button.textContent?.includes(label)) as HTMLButtonElement | undefined;
   expect(item).toBeTruthy();
   act(() => {
@@ -107,6 +107,23 @@ describe("NavLanguageSwitcher", () => {
 
     expect(i18n.getLocale()).toBe("en-US");
     expect(hoisted.updateUserLanguagePreference).not.toHaveBeenCalled();
+  });
+
+  it("closes on Escape and restores focus to the trigger", () => {
+    renderSwitcher();
+    const trigger = container.querySelector(".wk-navrail__language") as HTMLButtonElement;
+
+    act(() => {
+      trigger.click();
+    });
+    expect(document.body.querySelector("[role='menu']")).toBeTruthy();
+
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    });
+
+    expect(document.body.querySelector("[role='menu']")).toBeNull();
+    expect(document.activeElement).toBe(trigger);
   });
 
   it("keeps local language when backend sync fails", async () => {

--- a/packages/dmworkbase/src/Components/NavRail/__tests__/NavSecretsSettingsItem.test.tsx
+++ b/packages/dmworkbase/src/Components/NavRail/__tests__/NavSecretsSettingsItem.test.tsx
@@ -107,10 +107,10 @@ describe('NavSecretsSettingsItem deep link', () => {
     });
     expect(container.querySelector('[data-testid="panel"]')).toBeNull();
 
-    // Re-open manually (li click) — must NOT carry the old pasted value.
+    // Re-open manually — must NOT carry the old pasted value.
     panelProps.length = 0;
     act(() => {
-      (container.querySelector('li') as HTMLLIElement).click();
+      (container.querySelector('button[role="menuitem"]') as HTMLButtonElement).click();
     });
     const last = panelProps[panelProps.length - 1];
     expect(last.prefillValue).toBeUndefined();

--- a/packages/dmworkbase/src/Components/NavRail/__tests__/NavSettingsPanelFlyout.test.tsx
+++ b/packages/dmworkbase/src/Components/NavRail/__tests__/NavSettingsPanelFlyout.test.tsx
@@ -1,0 +1,152 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import React from "react";
+import ReactDOM from "react-dom";
+import { act } from "react-dom/test-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const hoisted = vi.hoisted(() => ({
+    checkVersionOnce: vi.fn(),
+    logoutUserInitiated: vi.fn(),
+    notificationIsClose: false,
+}));
+
+vi.mock("../../../App", () => ({
+    default: {
+        loginInfo: { loginProvider: "" },
+        remoteConfig: { oidcProviders: [] },
+        apiClient: { config: { apiURL: "/" } },
+        shared: {
+            get notificationIsClose() { return hoisted.notificationIsClose; },
+            set notificationIsClose(next: boolean) { hoisted.notificationIsClose = next; },
+            logoutUserInitiated: (...args: unknown[]) => hoisted.logoutUserInitiated(...args),
+        },
+    },
+    __esModule: true,
+}));
+
+vi.mock("../../../Utils/versionChecker", () => ({
+    checkVersionOnce: (...args: unknown[]) => hoisted.checkVersionOnce(...args),
+}));
+
+vi.mock("../NavVoiceSettingsItem", () => ({
+    default: () => null,
+}));
+
+vi.mock("../NavSecretsSettingsItem", () => ({
+    default: () => null,
+}));
+
+vi.mock("@douyinfe/semi-ui", () => ({
+    Toast: { error: vi.fn() },
+    Spin: () => React.createElement("span", null, "spin"),
+    Button: ({ children, ...props }: { children: React.ReactNode }) => React.createElement("button", props, children),
+    Progress: () => React.createElement("div", null, "progress"),
+}));
+
+vi.mock("../ChangelogMarkdown", () => ({
+    default: ({ content }: { content: string }) => React.createElement("div", null, content),
+}));
+
+vi.mock("../../WKModal", () => ({
+    default: ({ children, visible }: { children: React.ReactNode; visible: boolean }) => visible ? React.createElement("div", null, children) : null,
+}));
+
+import NavSettingsPanel from "../NavSettingsPanel";
+
+let container: HTMLDivElement;
+let trigger: HTMLButtonElement;
+const baseProps = {
+    settingSelected: true,
+    hasNewVersion: false,
+    showNewVersion: false,
+    showAppVersion: false,
+    showAppUpdate: false,
+    appUpdateProgress: 0,
+    showAppUpdateOperation: false,
+    onSetShowNewVersion: vi.fn(),
+    onSetShowAppVersion: vi.fn(),
+    onInstallUpdate: vi.fn(),
+    onNotifyListener: vi.fn(),
+};
+
+beforeEach(() => {
+    hoisted.checkVersionOnce.mockReset().mockResolvedValue(null);
+    hoisted.logoutUserInitiated.mockReset().mockResolvedValue(undefined);
+    hoisted.notificationIsClose = false;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    trigger = document.createElement("button");
+    trigger.textContent = "settings";
+    document.body.appendChild(trigger);
+});
+
+afterEach(() => {
+    act(() => {
+        ReactDOM.unmountComponentAtNode(container);
+    });
+    trigger.remove();
+    container.remove();
+    document.querySelectorAll(".wk-navrail__flyout, .wk-navrail__flyout-mask").forEach((node) => node.remove());
+    vi.clearAllMocks();
+});
+
+function renderPanel(onToggleSetting = vi.fn()) {
+    act(() => {
+        ReactDOM.render(
+            <NavSettingsPanel
+                {...baseProps}
+                triggerRef={{ current: trigger }}
+                onToggleSetting={onToggleSetting}
+            />,
+            container,
+        );
+    });
+    return onToggleSetting;
+}
+
+describe("NavSettingsPanel", () => {
+    it("renders settings actions as focusable menu items", () => {
+        renderPanel();
+
+        const flyout = document.body.querySelector(".wk-navrail__settings-list") as HTMLElement | null;
+        expect(flyout?.getAttribute("role")).toBe("menu");
+        expect(flyout?.querySelectorAll("button[role='menuitem']").length).toBeGreaterThan(0);
+    });
+
+    it("closes through the shared outside-click behavior", () => {
+        const onToggleSetting = renderPanel();
+
+        act(() => {
+            (document.body.querySelector(".wk-navrail__flyout-mask") as HTMLDivElement).click();
+        });
+
+        expect(onToggleSetting).toHaveBeenCalledTimes(1);
+    });
+
+    it("closes through the shared Escape behavior", () => {
+        const onToggleSetting = renderPanel();
+
+        act(() => {
+            document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+        });
+
+        expect(onToggleSetting).toHaveBeenCalledTimes(1);
+    });
+
+    it("runs an action item and requests close", () => {
+        const onToggleSetting = renderPanel();
+        const changelogItem = Array.from(document.body.querySelectorAll("button[role='menuitem']"))
+            .find((button) => button.textContent?.includes("更新日志")) as HTMLButtonElement | undefined;
+        expect(changelogItem).toBeTruthy();
+
+        act(() => {
+            changelogItem!.click();
+        });
+
+        expect(onToggleSetting).toHaveBeenCalledTimes(1);
+        expect(baseProps.onSetShowNewVersion).toHaveBeenCalledWith(true);
+    });
+});

--- a/packages/dmworkbase/src/Components/NavRail/__tests__/NavVoiceSettingsItem.test.tsx
+++ b/packages/dmworkbase/src/Components/NavRail/__tests__/NavVoiceSettingsItem.test.tsx
@@ -48,6 +48,8 @@ afterEach(() => {
   container.remove();
 });
 
+const voiceButton = () => Array.from(container.querySelectorAll('button')).find(el => el.textContent?.includes('语音设置')) as HTMLButtonElement | undefined;
+
 describe('NavVoiceSettingsItem', () => {
   it('always renders 语音设置', async () => {
     await act(async () => {
@@ -67,8 +69,8 @@ describe('NavVoiceSettingsItem', () => {
       );
     });
     expect(container.querySelector('[data-testid="voice-settings-panel"]')).toBeNull();
-    const li = Array.from(container.querySelectorAll('li')).find(el => el.textContent?.includes('语音设置'))!;
-    act(() => { li.click(); });
+    const button = voiceButton()!;
+    act(() => { button.click(); });
     expect(container.querySelector('[data-testid="voice-settings-panel"]')).not.toBeNull();
   });
 
@@ -79,8 +81,8 @@ describe('NavVoiceSettingsItem', () => {
         container,
       );
     });
-    const li = Array.from(container.querySelectorAll('li')).find(el => el.textContent?.includes('语音设置'))!;
-    act(() => { li.click(); });
+    const button = voiceButton()!;
+    act(() => { button.click(); });
     expect(container.querySelector('[data-testid="voice-settings-panel"]')).not.toBeNull();
     const closeBtn = container.querySelector('[data-testid="voice-settings-panel"] button')!;
     act(() => { (closeBtn as HTMLElement).click(); });

--- a/packages/dmworkbase/src/Components/NavRail/index.css
+++ b/packages/dmworkbase/src/Components/NavRail/index.css
@@ -124,27 +124,79 @@
     color: var(--wk-text-tertiary);
 }
 
-/* ── Dropdown ── */
-.wk-navrail__dropdown-mask {
+/* ── Shared NavRail flyout ── */
+.wk-navrail__flyout-mask {
     position: fixed;
     inset: 0;
-    z-index: 100;
+    z-index: 190;
 }
 
-.wk-navrail__dropdown {
-    position: fixed;
-    bottom: 52px;
-    left: 12px;
+.wk-navrail__flyout {
+    background: var(--wk-bg-elevated);
+    border: 1px solid var(--wk-border-default);
+    border-radius: var(--wk-r-md, 10px);
+    box-shadow: var(--wk-shadow-lg);
+    z-index: 200;
+    overflow: hidden;
+    padding: var(--wk-sp-1, 4px) 0;
+    box-sizing: border-box;
+}
+
+.wk-navrail__flyout--sm {
+    width: 132px;
+    padding: var(--wk-sp-1, 4px);
+}
+
+.wk-navrail__flyout--md {
+    width: 224px;
+}
+
+.wk-navrail__flyout--lg {
     width: 240px;
     background: var(--wk-bg-surface);
-    border: 1px solid var(--wk-border-subtle);
+    border-color: var(--wk-border-subtle);
     border-radius: 8px;                /* Figma: cornerRadius=8 */
     box-shadow: var(--wk-shadow-dropdown);
-    z-index: 101;
-    overflow: hidden;
     display: flex;
     flex-direction: column;
-    padding: 4px 0;                    /* Figma: 上下 4px，左右 0（行内自带 padding） */
+}
+
+.wk-navrail__flyout-item {
+    width: 100%;
+    min-height: 32px;
+    padding: var(--wk-sp-2, 8px) var(--wk-sp-3, 12px);
+    border: none;
+    border-radius: var(--wk-r-sm, 6px);
+    background: transparent;
+    color: var(--wk-text-primary);
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--wk-sp-2, 8px);
+    font: var(--wk-text-sm);
+    letter-spacing: 0;
+    text-align: left;
+    transition: background var(--wk-dur-fast, 200ms);
+}
+
+.wk-navrail__flyout-item:hover,
+.wk-navrail__flyout-item:focus-visible,
+.wk-navrail__flyout-item--active {
+    background: var(--wk-bg-hover);
+    outline: none;
+}
+
+.wk-navrail__flyout-item-label {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.wk-navrail__flyout-item-trailing {
+    display: inline-flex;
+    flex-shrink: 0;
+    color: var(--wk-brand-primary);
 }
 
 .wk-navrail__dropdown-title {
@@ -348,62 +400,13 @@
     font-weight: var(--wk-font-semibold);
 }
 
-.wk-navrail__language .semi-icon {
+.wk-navrail__language-menu .semi-icon {
     display: inline-flex;
-    font-size: 20px;
-}
-
-.wk-navrail__language-mask {
-    position: fixed;
-    inset: 0;
-    z-index: 190;
-}
-
-.wk-navrail__language-menu {
-    position: absolute;
-    left: calc(100% + 8px);
-    bottom: 0;
-    width: 132px;
-    padding: var(--wk-sp-1, 4px);
-    border: 1px solid var(--wk-border-default);
-    border-radius: var(--wk-r-md, 10px);
-    background: var(--wk-bg-elevated);
-    box-shadow: var(--wk-shadow-lg);
-    z-index: 201;
-}
-
-.wk-navrail__language-menu-item {
-    width: 100%;
-    min-height: 32px;
-    padding: 0 var(--wk-sp-2, 8px);
-    border: none;
-    border-radius: var(--wk-r-sm, 6px);
-    background: transparent;
-    color: var(--wk-text-primary);
-    cursor: pointer;
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: var(--wk-sp-2, 8px);
-    font: var(--wk-text-sm);
-    letter-spacing: 0;
-}
-
-.wk-navrail__language-menu-item:hover,
-.wk-navrail__language-menu-item--active {
-    background: var(--wk-bg-hover);
-}
-
-.wk-navrail__language-menu-item .semi-icon {
-    flex-shrink: 0;
-    color: var(--wk-brand-primary);
     font-size: 14px;
 }
 
-.wk-navrail__language-menu-label {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+.wk-navrail__language-menu-item {
+    padding: 0 var(--wk-sp-2, 8px);
 }
 
 /* Figma: 选中态只有颜色变化，无背景，无指示条 */
@@ -558,13 +561,14 @@
 /* ── 设置面板内版本更新提示 ── */
 .wk-navrail__settings-version-update {
     display: flex;
+    align-items: center;
     justify-content: space-between;
+    gap: var(--wk-sp-2, 8px);
+    padding: var(--wk-sp-2, 8px) var(--wk-sp-3, 12px);
     border-bottom: 1px solid var(--wk-border-subtle);
+    color: var(--wk-text-primary);
+    font-size: var(--wk-text-size-sm, 13px);
     cursor: default;
-}
-
-.wk-navrail__settings-list li.wk-navrail__settings-version-update:hover {
-    background: transparent;
 }
 
 .wk-navrail__settings-version-refresh {
@@ -584,37 +588,13 @@
 
 /* ── Settings panel (flyout) ── */
 .wk-navrail__settings-list {
-    position: fixed;
-    left: 56px;
-    bottom: var(--wk-sp-8, 32px);
-    width: 224px;
-    background: var(--wk-bg-elevated);
-    border: 1px solid var(--wk-border-default);
-    border-radius: var(--wk-r-md, 10px);
-    box-shadow: var(--wk-shadow-lg);
-    z-index: 200;
-    padding: var(--wk-sp-1, 4px) 0;
     list-style: none;
-    display: none;
 }
 
-.wk-navrail__settings-list.open {
-    display: block;
-}
-
-.wk-navrail__settings-list li {
+.wk-navrail__settings-list .wk-navrail__flyout-item {
+    border-radius: 0;
     padding: var(--wk-sp-2, 8px) var(--wk-sp-3, 12px);
     font-size: var(--wk-text-size-sm, 13px);
-    color: var(--wk-text-primary);
-    cursor: pointer;
-    display: flex;
-    align-items: center;
-    gap: var(--wk-sp-2, 8px);
-    transition: background var(--wk-dur-fast, 200ms);
-}
-
-.wk-navrail__settings-list li:hover {
-    background: var(--wk-bg-hover);
 }
 
 /* ── User avatar ── */

--- a/packages/dmworkbase/src/Components/NavRail/index.tsx
+++ b/packages/dmworkbase/src/Components/NavRail/index.tsx
@@ -50,6 +50,8 @@ export interface NavRailVMProps {
 export interface NavRailProps extends NavRailVMProps {}
 
 export default class NavRail extends Component<NavRailProps> {
+    private settingsButtonRef = React.createRef<HTMLButtonElement>();
+
     render() {
         const {
             menusList,
@@ -119,6 +121,7 @@ export default class NavRail extends Component<NavRailProps> {
                     {/* 底部：分割线 + 设置 + Space */}
                     <NavBottom
                         settingSelected={settingSelected}
+                        settingsButtonRef={this.settingsButtonRef}
                         hasNewVersion={hasNewVersion}
                         onSettingsClick={onToggleSetting}
                         onDismissNewVersion={onDismissNewVersion}
@@ -133,6 +136,7 @@ export default class NavRail extends Component<NavRailProps> {
                 {/* 设置面板 + Modals（挂在 nav 外，避免 overflow 裁剪） */}
                 <NavSettingsPanel
                     settingSelected={settingSelected}
+                    triggerRef={this.settingsButtonRef}
                     hasNewVersion={hasNewVersion}
                     canManageSpace={canManageSpace}
                     showNewVersion={showNewVersion}


### PR DESCRIPTION
## Summary

- Add a shared `NavFlyout` primitive for the NavRail bottom flyouts, covering portal rendering, trigger anchoring, outside click, Escape close, focus restoration, shared sizing, and shell styling.
- Migrate the language, settings, and Space entries to the shared flyout while preserving their content semantics: language radio menu, settings action menu, and Space switcher/action area.
- Refresh NavRail Storybook stories to use current props and real components, including separate language/settings/Space flyout stories plus a comparison story.
- Add/update NavRail tests for shared flyout behavior and migrated menu semantics.

## Verification

- `pnpm install` — pass; lockfile unchanged.
- `pnpm --filter @octo/base test -- src/Components/NavRail` — pass: 255 test files / 2217 tests.
- `pnpm --filter @octo/base test -- src/Components/NavRail/__tests__/NavFlyout.test.tsx src/Components/NavRail/__tests__/NavLanguageSwitcher.test.tsx src/Components/NavRail/__tests__/NavSettingsPanelFlyout.test.tsx` — pass: same package-level collection, 255 test files / 2217 tests.
- `pnpm --filter @octo/web build` — pass; only existing `VITE_API_URL is not set` warning.
- `git diff --check` — pass.
- Visible check: Storybook dev server rendered `navigation-navrail--flyout-comparison-open`; Playwright confirmed 3 `.wk-navrail__flyout` instances for settings/language/Space and captured a comparison screenshot.

## Known Storybook risks

- `pnpm --filter @octo/web build-storybook` currently fails after transforming modules with `Segmentation fault (core dumped)`; the log does not point at NavRail code.
- `pnpm --filter @octo/web test:storybook` still has existing non-NavRail story failures, including `ForwardModal`, `ChannelSearch`, `React is not defined` in other stories, and Onboarding WebGL `Strands` errors. This PR keeps that risk disclosed rather than broadening scope to fix the Storybook baseline.

Closes #1115
