### PR TITLE
fix(global-search): fix filter badge count and tab reset

### DIFF
--- a/packages/dmworkbase/src/Components/GlobalSearch/GlobalSearchFilterPanel.tsx
+++ b/packages/dmworkbase/src/Components/GlobalSearch/GlobalSearchFilterPanel.tsx
@@ -22,12 +22,20 @@ import type {
 } from "../../Service/SearchTypes";
 import { cnDatePresetRange } from "../../Service/SearchService";
 
+export interface GlobalSearchFilterApplyMeta {
+  fileTypeCategoryKeys?: string[];
+}
+
 interface Props {
   tab: GlobalContentTab;
   keyword: string;
   filters: GlobalSearchFilters;
   dataSource: GlobalSearchDataSource;
-  onApply: (filters: GlobalSearchFilters) => void;
+  fileTypeCategoryKeys?: string[];
+  onApply: (
+    filters: GlobalSearchFilters,
+    meta?: GlobalSearchFilterApplyMeta
+  ) => void;
   onClose?: () => void;
   mode?: "popover" | "sidebar";
 }
@@ -105,6 +113,7 @@ const GlobalSearchFilterPanel: React.FC<Props> = ({
   keyword,
   filters,
   dataSource,
+  fileTypeCategoryKeys = [],
   onApply,
   onClose,
   mode = "popover",
@@ -131,6 +140,8 @@ const GlobalSearchFilterPanel: React.FC<Props> = ({
   const [fileCategories, setFileCategories] = useState<
     GlobalSearchFileTypeCategory[]
   >([]);
+  const [draftFileTypeCategoryKeys, setDraftFileTypeCategoryKeys] =
+    useState<string[]>(fileTypeCategoryKeys);
   const [fileSizeMinInput, setFileSizeMinInput] = useState(
     filters.fileSizeMin ? String(Math.round(filters.fileSizeMin / 1024)) : ""
   );
@@ -138,6 +149,7 @@ const GlobalSearchFilterPanel: React.FC<Props> = ({
     filters.fileSizeMax ? String(Math.round(filters.fileSizeMax / 1024)) : ""
   );
   const draftRef = useRef(filters);
+  const draftFileTypeCategoryKeysRef = useRef(fileTypeCategoryKeys);
 
   useEffect(() => {
     draftRef.current = filters;
@@ -150,13 +162,19 @@ const GlobalSearchFilterPanel: React.FC<Props> = ({
     );
   }, [filters]);
 
+  useEffect(() => {
+    draftFileTypeCategoryKeysRef.current = fileTypeCategoryKeys;
+    setDraftFileTypeCategoryKeys(fileTypeCategoryKeys);
+  }, [fileTypeCategoryKeys]);
+
   const updateDraft = (
-    updater: (current: GlobalSearchFilters) => GlobalSearchFilters
+    updater: (current: GlobalSearchFilters) => GlobalSearchFilters,
+    meta?: GlobalSearchFilterApplyMeta
   ) => {
     const next = updater(draftRef.current);
     draftRef.current = next;
     setDraft(next);
-    if (mode === "sidebar") onApply(next);
+    if (mode === "sidebar") onApply(next, meta);
   };
 
   const keywordActive = keyword.trim().length > 0;
@@ -370,15 +388,26 @@ const GlobalSearchFilterPanel: React.FC<Props> = ({
   };
 
   const toggleFileExts = (category: GlobalSearchFileTypeCategory) => {
+    const currentFileExts = new Set(draftRef.current.fileExts);
+    const allActive = category.exts.every((e) =>
+      currentFileExts.has(e.toLowerCase())
+    );
+    const currentKeys = draftFileTypeCategoryKeysRef.current;
+    const nextKeys = allActive
+      ? currentKeys.filter((key) => key !== category.key)
+      : Array.from(new Set([...currentKeys, category.key]));
+    draftFileTypeCategoryKeysRef.current = nextKeys;
+    setDraftFileTypeCategoryKeys(nextKeys);
     updateDraft((cur) => {
       const set = new Set(cur.fileExts);
-      const allActive = category.exts.every((e) => set.has(e.toLowerCase()));
       if (allActive) {
         category.exts.forEach((e) => set.delete(e.toLowerCase()));
       } else {
         category.exts.forEach((e) => set.add(e.toLowerCase()));
       }
       return { ...cur, fileExts: Array.from(set) };
+    }, {
+      fileTypeCategoryKeys: nextKeys,
     });
   };
 
@@ -447,7 +476,9 @@ const GlobalSearchFilterPanel: React.FC<Props> = ({
       sort: "time_desc" as const,
     };
     draftRef.current = next;
+    draftFileTypeCategoryKeysRef.current = [];
     setDraft(next);
+    setDraftFileTypeCategoryKeys([]);
     setFileSizeMinInput("");
     setFileSizeMaxInput("");
   };
@@ -463,7 +494,7 @@ const GlobalSearchFilterPanel: React.FC<Props> = ({
       fileSizeMax:
         Number.isFinite(maxKb) && maxKb > 0 ? maxKb * 1024 : undefined,
     };
-    onApply(next);
+    onApply(next, { fileTypeCategoryKeys: draftFileTypeCategoryKeys });
     onClose?.();
   };
 

--- a/packages/dmworkbase/src/Components/GlobalSearch/__tests__/filterState.test.ts
+++ b/packages/dmworkbase/src/Components/GlobalSearch/__tests__/filterState.test.ts
@@ -157,6 +157,37 @@ describe("selectedGlobalSearchFilterValueCount", () => {
     ).toBe(2);
   });
 
+  it("counts selected file type categories instead of expanded extensions when provided", () => {
+    expect(
+      selectedGlobalSearchFilterValueCount(
+        withOverrides({
+          fileExts: [
+            "txt",
+            "log",
+            "md",
+            "markdown",
+            "gif",
+            "mp4",
+            "mov",
+            "avi",
+          ],
+          datePreset: "last_30_days",
+        }),
+        { fileTypeCategoryCount: 4 }
+      )
+    ).toBe(5);
+  });
+
+  it("falls back to expanded file extensions when file category count is absent", () => {
+    expect(
+      selectedGlobalSearchFilterValueCount(
+        withOverrides({
+          fileExts: ["txt", "log", "md"],
+        })
+      )
+    ).toBe(3);
+  });
+
   it("counts group + thread backend values as one visible group option", () => {
     expect(
       selectedGlobalSearchFilterValueCount(

--- a/packages/dmworkbase/src/Components/GlobalSearch/__tests__/isActive.test.tsx
+++ b/packages/dmworkbase/src/Components/GlobalSearch/__tests__/isActive.test.tsx
@@ -42,6 +42,10 @@ const paginationHookPath = path.join(
 );
 const panelSrc = fs.readFileSync(panelPath, "utf8");
 const indexSrc = fs.readFileSync(indexPath, "utf8");
+const filterPanelSrc = fs.readFileSync(
+  path.join(__dirname, "..", "GlobalSearchFilterPanel.tsx"),
+  "utf8"
+);
 const paginationHookSrc = fs.readFileSync(paginationHookPath, "utf8");
 
 describe("GlobalContentSearchPanel — isActive gate (source guard)", () => {
@@ -99,6 +103,34 @@ describe("GlobalSearch index — threads isActive from tab state (§E)", () => {
   it("passes isActive={currentKey === 'files'} to the files panel", () => {
     expect(indexSrc).toMatch(
       /tab="files"[\s\S]{0,300}isActive=\{\s*currentKey\s*===\s*"files"\s*\}/
+    );
+  });
+
+  it("resets shared filters when a tab switch involves messages or files", () => {
+    expect(indexSrc).toContain("private handleTabChange");
+    expect(indexSrc).toMatch(
+      /currentKey\s*!==\s*key[\s\S]{0,240}currentKey\s*===\s*"messages"[\s\S]{0,120}currentKey\s*===\s*"files"[\s\S]{0,120}key\s*===\s*"messages"[\s\S]{0,120}key\s*===\s*"files"/
+    );
+    expect(indexSrc).toMatch(
+      /filters:\s*defaultGlobalSearchFilters\(\),[\s\S]{0,80}fileTypeCategoryKeys:\s*\[\]/
+    );
+    expect(indexSrc).toMatch(
+      /onTabChange=\{this\.handleTabChange\}/
+    );
+  });
+
+  it("counts file type badge by selected UI categories without changing fileExts", () => {
+    expect(indexSrc).toMatch(
+      /selectedGlobalSearchFilterValueCount\([\s\S]{0,180}fileTypeCategoryCount:\s*this\.state\.fileTypeCategoryKeys\.length/
+    );
+    expect(indexSrc).toMatch(
+      /<GlobalSearchFilterPanel[\s\S]{0,500}fileTypeCategoryKeys=\{this\.state\.fileTypeCategoryKeys\}/
+    );
+    expect(filterPanelSrc).toMatch(
+      /onApply:\s*\([\s\S]{0,120}meta\?:\s*GlobalSearchFilterApplyMeta/
+    );
+    expect(filterPanelSrc).toMatch(
+      /return\s*\{\s*\.\.\.cur,\s*fileExts:\s*Array\.from\(set\)\s*\}/
     );
   });
 });

--- a/packages/dmworkbase/src/bridge/globalSearch/filterState.ts
+++ b/packages/dmworkbase/src/bridge/globalSearch/filterState.ts
@@ -55,14 +55,20 @@ export function activeGlobalSearchFilterCount(filters: GlobalSearchFilters) {
 // active dimension. For example sender(1) + member(1) + chat types(2) +
 // message types(2) is displayed as 6.
 export function selectedGlobalSearchFilterValueCount(
-  filters: GlobalSearchFilters
+  filters: GlobalSearchFilters,
+  options?: { fileTypeCategoryCount?: number }
 ) {
+  const fileExtCount =
+    typeof options?.fileTypeCategoryCount === "number" &&
+    options.fileTypeCategoryCount > 0
+      ? options.fileTypeCategoryCount
+      : filters.fileExts.length;
   let count =
     filters.senderUids.length +
     filters.memberUids.length +
     filters.channels.length +
     filters.contentTypes.length +
-    filters.fileExts.length;
+    fileExtCount;
   if (filters.channelTypes.includes(1)) count += 1;
   if (filters.channelTypes.includes(2) || filters.channelTypes.includes(5)) {
     count += 1;

--- a/packages/dmworkbase/src/features/globalSearch/GlobalSearchPanel.tsx
+++ b/packages/dmworkbase/src/features/globalSearch/GlobalSearchPanel.tsx
@@ -9,7 +9,9 @@ import TabGroup from "../../Components/GlobalSearch/tab-group";
 import TabFile from "../../Components/GlobalSearch/tab-file";
 import { Channel } from "wukongimjssdk";
 import GlobalContentSearchPanel from "../../Components/GlobalSearch/GlobalContentSearchPanel";
-import GlobalSearchFilterPanel from "../../Components/GlobalSearch/GlobalSearchFilterPanel";
+import GlobalSearchFilterPanel, {
+  type GlobalSearchFilterApplyMeta,
+} from "../../Components/GlobalSearch/GlobalSearchFilterPanel";
 import GlobalChatSearchPanel from "../globalChatSearch/GlobalChatSearchPanel";
 import { createGlobalSearchApiDataSource } from "../../bridge/globalSearch/createGlobalSearchDataSource";
 import { selectedGlobalSearchFilterValueCount } from "../../bridge/globalSearch/filterState";
@@ -52,6 +54,7 @@ export interface GlobalSearchProps {
 export interface GlobalSearchState {
   filterOpen: boolean;
   filters: GlobalSearchFilters;
+  fileTypeCategoryKeys: string[];
   searchValue: string;
 }
 
@@ -73,6 +76,7 @@ export default class GlobalSearch extends Component<
     this.state = {
       filterOpen: false,
       filters: defaultGlobalSearchFilters(),
+      fileTypeCategoryKeys: [],
       searchValue: "",
       ...props.initialState,
     };
@@ -110,6 +114,39 @@ export default class GlobalSearch extends Component<
     this._removeConfigListener?.();
     this._removeConfigListener = undefined;
   }
+
+  private handleApplyFilters = (
+    filters: GlobalSearchFilters,
+    meta?: GlobalSearchFilterApplyMeta
+  ) => {
+    this.setState((prev) => ({
+      filters,
+      fileTypeCategoryKeys:
+        meta?.fileTypeCategoryKeys ??
+        (filters.fileExts.length > 0 ? prev.fileTypeCategoryKeys : []),
+    }));
+  };
+
+  private handleTabChange = (key: string) => {
+    const currentKey = this.vm.selectedTabKey;
+    const contentTabInvolved =
+      currentKey !== key &&
+      (currentKey === "messages" ||
+        currentKey === "files" ||
+        key === "messages" ||
+        key === "files");
+    if (!contentTabInvolved) {
+      this.vm.onTabClick(key);
+      return;
+    }
+    this.setState(
+      {
+        filters: defaultGlobalSearchFilters(),
+        fileTypeCategoryKeys: [],
+      },
+      () => this.vm.onTabClick(key)
+    );
+  };
 
   handleLocate = (item: ChannelSearchItem) => {
     // Guard: backend v10 always fills channel_id/channel_type on hits
@@ -251,7 +288,8 @@ export default class GlobalSearch extends Component<
               keyword={vm.keyword}
               filters={this.state.filters}
               dataSource={this.globalDataSource}
-              onApply={(filters) => this.setState({ filters })}
+              fileTypeCategoryKeys={this.state.fileTypeCategoryKeys}
+              onApply={this.handleApplyFilters}
             />
           </aside>
         )}
@@ -273,7 +311,8 @@ export default class GlobalSearch extends Component<
         }}
         render={(vm: GlobalSearchVM) => {
           const filterCount = selectedGlobalSearchFilterValueCount(
-            this.state.filters
+            this.state.filters,
+            { fileTypeCategoryCount: this.state.fileTypeCategoryKeys.length }
           );
           const isGlobalContentTab =
             vm.selectedTabKey === "messages" || vm.selectedTabKey === "files";
@@ -322,7 +361,7 @@ export default class GlobalSearch extends Component<
                     label: tab.tab,
                   }))}
                   activeTab={vm.selectedTabKey}
-                  onTabChange={(key) => vm.onTabClick(key)}
+                  onTabChange={this.handleTabChange}
                   error={vm.searchError}
                   actions={
                     this.contentSearchEnabled && isGlobalContentTab ? (
@@ -334,6 +373,7 @@ export default class GlobalSearch extends Component<
                             onClick={() =>
                               this.setState({
                                 filters: defaultGlobalSearchFilters(),
+                                fileTypeCategoryKeys: [],
                               })
                             }
                           >


### PR DESCRIPTION
## Summary
- Fixes #1129: count the file-filter badge by selected visible file-type categories while keeping the file_exts request payload unchanged.
- Fixes #1131: reset shared global-search filters whenever switching into or out of the chat/file content tabs, preventing stale file/date filters from remaining on the chat tab.

## Scope / behavior boundary
- Does not change backend search request fields: file filtering still sends the expanded suffix list through filters.file_exts.
- Does not change search result ordering, pagination, permissions, cache behavior, IME handling, or locate/click behavior.
- Contacts/groups tab switching remains unchanged except when the target/source involves chat or file content tabs, where shared filters are intentionally reset.

## Validation
- pnpm --dir packages/dmworkbase test -- src/Components/GlobalSearch/__tests__/filterState.test.ts src/Components/GlobalSearch/__tests__/isActive.test.tsx; runs dmworkbase suite: 253 files / 2212 tests passed.
- git diff --check upstream/main...HEAD.
- pnpm --dir apps/web build; passes with existing VITE_API_URL/dependency build warnings only.

## Manual verification
- On http://localhost:5175/, file tab badge now reflects selected categories plus date instead of expanded extensions.
- Switching from file tab to chat tab clears stale file/date filter state.