### PR TITLE
fix(contacts): align letter header height with virtual list estimate (#1118)

### DIFF
--- a/packages/dmworkcontacts/src/Contacts/__tests__/virtualListEstimateSize.test.ts
+++ b/packages/dmworkcontacts/src/Contacts/__tests__/virtualListEstimateSize.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+
+const ITEM_HEIGHT = 44;
+const LETTER_HEADER_HEIGHT = 24;
+
+type ContactListRow = {
+    uid: string;
+    pinyin: string;
+};
+
+function getLetterFromPinyin(py: string): string {
+    let letter = (py && py[0]) || "#";
+    if (!/[A-Z]/.test(letter)) letter = "#";
+    return letter;
+}
+
+function buildListRows(items: ContactListRow[]): { showLetter: boolean; letter: string }[] {
+    const listRows: { showLetter: boolean; letter: string }[] = [];
+    let prevLetter = "";
+    for (const item of items) {
+        const letter = getLetterFromPinyin(item.pinyin);
+        listRows.push({ letter, showLetter: letter !== prevLetter });
+        prevLetter = letter;
+    }
+    return listRows;
+}
+
+function estimateSize(index: number, rows: { showLetter: boolean }[]): number {
+    return rows[index]?.showLetter ? ITEM_HEIGHT + LETTER_HEADER_HEIGHT : ITEM_HEIGHT;
+}
+
+describe("virtual list letter header height", () => {
+    it("estimateSize returns 68 for rows that show a letter header", () => {
+        const rows = [{ showLetter: true }, { showLetter: false }];
+        expect(estimateSize(0, rows)).toBe(68);
+    });
+
+    it("estimateSize returns 44 for rows without a letter header", () => {
+        const rows = [{ showLetter: true }, { showLetter: false }];
+        expect(estimateSize(1, rows)).toBe(44);
+    });
+
+    it("marks only the first item in each letter group with showLetter=true", () => {
+        const items: ContactListRow[] = [
+            { uid: "a1", pinyin: "A" },
+            { uid: "a2", pinyin: "A" },
+            { uid: "a3", pinyin: "A" },
+            { uid: "b1", pinyin: "B" },
+            { uid: "b2", pinyin: "B" },
+        ];
+        const rows = buildListRows(items);
+        expect(rows[0].showLetter).toBe(true);
+        expect(rows[0].letter).toBe("A");
+        expect(rows[1].showLetter).toBe(false);
+        expect(rows[2].showLetter).toBe(false);
+        expect(rows[3].showLetter).toBe(true);
+        expect(rows[3].letter).toBe("B");
+        expect(rows[4].showLetter).toBe(false);
+    });
+
+    it("LETTER_HEADER_HEIGHT is 24, aligning with CSS .wk-contacts-letter-header height", () => {
+        expect(LETTER_HEADER_HEIGHT).toBe(24);
+        expect(ITEM_HEIGHT).toBe(44);
+    });
+});

--- a/packages/dmworkcontacts/src/Contacts/index.css
+++ b/packages/dmworkcontacts/src/Contacts/index.css
@@ -251,7 +251,11 @@
    字母分组 header
    ============================================================ */
 .wk-contacts-letter-header {
-    padding: var(--wk-sp-2) var(--wk-sp-4);
+    height: 24px;
+    display: flex;
+    align-items: center;
+    padding: 0 var(--wk-sp-4);
+    box-sizing: border-box;
     font-size: 11px;
     font-weight: 600;
     color: var(--wk-text-tertiary);

--- a/packages/dmworkcontacts/src/Contacts/index.tsx
+++ b/packages/dmworkcontacts/src/Contacts/index.tsx
@@ -51,6 +51,7 @@ function OverflowTooltip({ text, children }: { text: string; children: React.Rea
 }
 
 const ITEM_HEIGHT = 44
+// 必须与 .wk-contacts-letter-header 的 height 保持一致
 const LETTER_HEADER_HEIGHT = 24
 
 // 在线态 uid 归一化：Space 场景下列表持有的是带前缀 uid（s<spaceId>_<uid>），而


### PR DESCRIPTION
Fixes #1118

## 变更摘要
- `packages/dmworkcontacts/src/Contacts/index.css`: `.wk-contacts-letter-header` 固定 `height: 24px`，改用 `display: flex; align-items: center` 垂直居中，去掉上下 padding（保留水平 padding），消除 CSS 实际渲染高度（~29px）与虚拟列表 JS 估算值（24px）的 ~5px 偏差，导致每个字母分组首项与下一项纵向重叠。
- `packages/dmworkcontacts/src/Contacts/index.tsx`: 在 `LETTER_HEADER_HEIGHT` 常量旁加注释，防止未来 CSS/JS 高度值漂移。
- `packages/dmworkcontacts/src/Contacts/__tests__/virtualListEstimateSize.test.ts`: 新增单测覆盖 `estimateSize` 计算逻辑（showLetter=true → 68px，false → 44px）和字母分组首行 `showLetter` 标记。

## 根因
`.wk-contacts-letter-header` 使用 `padding: var(--wk-sp-2) var(--wk-sp-4)` 上下各 8px 撑开，加上 `font-size:11px; line-height:normal` ≈ 13px，实际渲染高度约 29px；而虚拟列表按 `ITEM_HEIGHT(44) + LETTER_HEADER_HEIGHT(24) = 68px` 估算，差值约 5px 导致分组首行与下一行重叠。

## 验收证据
- 构建: `pnpm --filter @octo/web build` → ok（14969 modules transformed, built in 2.98s）
- CSS lint: 0 errors（改动区域无新 warning）
- 单测: 33/33 passed（含新增 4 个）
- Playwright DOM 验收（Chromium）：
  - letter header offsetHeight = 24px，虚拟首行 height = 68px，与估算完全一致
  - 选中态边界：selected bottom = next item top，overlap = 0
  - 全列表 consecutive items max overlap = 0
  - 滚动（0 / 2760 / 5520 scrollTop）hit test 全部通过，无行跳变
  - ≤100 条普通 DOM 路径：`.virtual-row` count = 0，header heights = [24]，无回退