### PR TITLE
fix(global-search): address filter panel token review

### DIFF
--- a/packages/dmworkbase/src/Components/GlobalSearch/global-content-search-panel.css
+++ b/packages/dmworkbase/src/Components/GlobalSearch/global-content-search-panel.css
@@ -139,10 +139,10 @@
   height: var(--wk-sp-4);
   align-items: center;
   justify-content: center;
-  border: 1px solid var(--wk-border-default);
+  border: 1px solid var(--wk-border-strong);
   border-radius: var(--wk-r-xs);
   background: var(--wk-bg-surface);
-  color: var(--wk-text-on-brand);
+  color: var(--wk-text-inverse);
 }
 
 .wk-global-search-filter-panel

--- a/packages/dmworkbase/src/features/globalSearch/global-search-panel.css
+++ b/packages/dmworkbase/src/features/globalSearch/global-search-panel.css
@@ -121,10 +121,7 @@
   .wk-channel-search-empty,
 .wk-search-tabs__content-shell.has-filter
   .wk-global-chat-search-layout
-  .wk-channel-search-loading,
-.wk-search-tabs__content-shell.has-filter
-  .wk-global-chat-search-layout
-  .wk-channel-search-error {
+  .wk-global-chat-search-panel__state {
   gap: var(--wk-sp-4);
   padding: var(--wk-sp-4);
 }
@@ -187,7 +184,7 @@
   padding: 0 var(--wk-sp-1);
   border-radius: var(--wk-r-circle);
   background: var(--wk-text-primary);
-  color: var(--wk-text-on-brand);
+  color: var(--wk-text-inverse);
   font: var(--wk-text-caption);
 }
 


### PR DESCRIPTION
## Summary
- Fix the filter count badge and selected checkbox foreground tokens reported in the PR #1132 review.
- Use the actual rendered `.wk-global-chat-search-panel__state` selector for filtered chat loading/error states.
- Keep the checkbox border on `--wk-border-strong` to preserve unchecked checkbox visibility.

## Scope
- CSS-only follow-up for the global search filter panel.
- No changes to search logic, filter state, request parameters, count behavior, i18n, routing, or entries.
- Does not re-enable or add a dark theme switch; this only corrects existing theme token pairing.

## Validation
- `pnpm exec stylelint packages/dmworkbase/src/features/globalSearch/global-search-panel.css packages/dmworkbase/src/Components/GlobalSearch/global-content-search-panel.css --config stylelint.config.mjs --allow-empty-input`
- `pnpm lint:css` (0 errors; existing repository warnings only)
- `git diff --check`

Follow-up for PR #1132 review.