### PR TITLE
fix: enforce chat right panel mutual exclusion

### DIFF
--- a/packages/dmworkbase/src/Pages/Chat/__tests__/rightPanelState.test.ts
+++ b/packages/dmworkbase/src/Pages/Chat/__tests__/rightPanelState.test.ts
@@ -65,16 +65,19 @@ describe("Chat right panel state", () => {
       url: "https://example.test/a.pdf",
       name: "a.pdf",
     } as any;
+    const activeThread = { channel_id: "g1____t1" } as any;
 
     expect(
       openChatRightPanel("filePreview", {
         previewFile,
+        activeThread,
         activePreviewMessageId: "m1",
         previewHadThreadShell: true,
       })
     ).toEqual({
       ...closedState,
       showThreadPanel: true,
+      activeThread,
       previewFile,
       activePreviewMessageId: "m1",
       previewHadThreadShell: true,

--- a/packages/dmworkbase/src/Pages/Chat/__tests__/rightPanelState.test.ts
+++ b/packages/dmworkbase/src/Pages/Chat/__tests__/rightPanelState.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import {
+  closeChatRightPanels,
+  openChatRightPanel,
+  type ChatRightPanelStatePatch,
+} from "../rightPanelState";
+
+const closedState: ChatRightPanelStatePatch = {
+  showChannelSetting: false,
+  showThreadPanel: false,
+  activeThread: null,
+  previewFile: null,
+  activePreviewMessageId: null,
+  previewHadThreadShell: false,
+  showSummaryPanel: false,
+  showChannelSearch: false,
+  channelSearchPreviewFile: null,
+  previewReturnChannelSearch: false,
+  webhookIssuePreviewTarget: null,
+};
+
+describe("Chat right panel state", () => {
+  it("returns a fresh closed state patch", () => {
+    const first = closeChatRightPanels();
+    const second = closeChatRightPanels();
+
+    expect(first).toEqual(closedState);
+    expect(second).toEqual(closedState);
+    expect(first).not.toBe(second);
+  });
+
+  it("opens channel setting and closes the other right panels", () => {
+    expect(openChatRightPanel("channelSetting")).toEqual({
+      ...closedState,
+      showChannelSetting: true,
+    });
+  });
+
+  it("opens the thread panel and closes the other right panels", () => {
+    const activeThread = { channel_id: "g1____t1" } as any;
+
+    expect(openChatRightPanel("thread", { activeThread })).toEqual({
+      ...closedState,
+      showThreadPanel: true,
+      activeThread,
+    });
+  });
+
+  it("opens smart summary and closes the other right panels", () => {
+    expect(openChatRightPanel("summary")).toEqual({
+      ...closedState,
+      showSummaryPanel: true,
+    });
+  });
+
+  it("opens channel search and closes the other right panels", () => {
+    expect(openChatRightPanel("channelSearch")).toEqual({
+      ...closedState,
+      showChannelSearch: true,
+    });
+  });
+
+  it("opens file preview in the thread shell and closes the other right panels", () => {
+    const previewFile = {
+      url: "https://example.test/a.pdf",
+      name: "a.pdf",
+    } as any;
+
+    expect(
+      openChatRightPanel("filePreview", {
+        previewFile,
+        activePreviewMessageId: "m1",
+        previewHadThreadShell: true,
+      })
+    ).toEqual({
+      ...closedState,
+      showThreadPanel: true,
+      previewFile,
+      activePreviewMessageId: "m1",
+      previewHadThreadShell: true,
+    });
+  });
+
+  it("opens webhook preview and closes the other right panels", () => {
+    const webhookIssuePreviewTarget = { issueId: "issue-1" } as any;
+
+    expect(
+      openChatRightPanel("webhookPreview", { webhookIssuePreviewTarget })
+    ).toEqual({
+      ...closedState,
+      webhookIssuePreviewTarget,
+    });
+  });
+});

--- a/packages/dmworkbase/src/Pages/Chat/index.css
+++ b/packages/dmworkbase/src/Pages/Chat/index.css
@@ -626,8 +626,7 @@ body[theme-mode="dark"] .wk-chat-channelsetting {
    侧边面板布局（子区 + 文件预览共用）
    ============================================ */
 
-/* 只有侧边面板打开时 */
-/* 子区打开时（无论设置是否开着），消息区宽度减去子区宽度 */
+/* 子区/文件预览打开时，消息区宽度减去右侧面板宽度 */
 .wk-chat-content-right.wk-chat-threadpanel-open .wk-chat-content-chat {
   width: calc(100% - var(--wk-width-thread-panel));
 }
@@ -636,9 +635,7 @@ body[theme-mode="dark"] .wk-chat-channelsetting {
   width: calc(100% - var(--wk-width-resizable-right-panel));
 }
 
-.wk-chat-content-right.wk-chat-webhook-preview-open[
-    data-resizable-right-panel-layout="overlay"
-  ]
+.wk-chat-content-right.wk-chat-webhook-preview-open[data-resizable-right-panel-layout="overlay"]
   .wk-chat-content-chat {
   visibility: hidden;
   width: 0;

--- a/packages/dmworkbase/src/Pages/Chat/index.css
+++ b/packages/dmworkbase/src/Pages/Chat/index.css
@@ -626,14 +626,6 @@ body[theme-mode="dark"] .wk-chat-channelsetting {
    侧边面板布局（子区 + 文件预览共用）
    ============================================ */
 
-/* 子区打开时，设置面板贴在子区左侧（overlay 在消息区上，不占子区空间） */
-.wk-chat-content-right.wk-chat-threadpanel-open.wk-chat-channelsetting-open
-  .wk-chat-channelsetting {
-  right: var(--wk-width-thread-panel);
-}
-
-/* 设置面板为 overlay，子区+设置同时打开时消息区宽度只减去子区宽度 */
-
 /* 只有侧边面板打开时 */
 /* 子区打开时（无论设置是否开着），消息区宽度减去子区宽度 */
 .wk-chat-content-right.wk-chat-threadpanel-open .wk-chat-content-chat {
@@ -885,10 +877,4 @@ body[theme-mode="dark"] .wk-chat-popover {
 
 .wk-chat-content-right.wk-chat-summary-panel-open .wk-chat-content-chat {
   width: calc(100% - var(--wk-width-summary-panel));
-}
-
-/* 总结面板打开时，设置面板贴在总结面板左侧（对齐子区/事项让位行为，避免被遮挡） */
-.wk-chat-content-right.wk-chat-summary-panel-open.wk-chat-channelsetting-open
-  .wk-chat-channelsetting {
-  right: var(--wk-width-summary-panel);
 }

--- a/packages/dmworkbase/src/Pages/Chat/index.tsx
+++ b/packages/dmworkbase/src/Pages/Chat/index.tsx
@@ -78,6 +78,7 @@ import {
 } from "../../im-runtime/channelRuntime";
 import WebhookIssuePreviewPanel from "../../features/webhookMessagePreview/WebhookIssuePreviewPanel";
 import type { WebhookIssuePreviewTarget } from "../../bridge/message/webhookPreview";
+import { closeChatRightPanels, openChatRightPanel } from "./rightPanelState";
 
 // 消息 ACK 只代表发送成功；后端把归档子区恢复为活跃存在短暂异步窗口。
 // 实测立即 threadGet 可能仍返回 Archived，因此发送后用短轮询等后端状态落稳。
@@ -312,19 +313,11 @@ export class ChatContentPage extends Component<
 
   private _openWebhookPreview = (target: WebhookIssuePreviewTarget) => {
     this._clearChannelSearchState();
-    this.setState({
-      webhookIssuePreviewTarget: target,
-      showChannelSetting: false,
-      showThreadPanel: false,
-      activeThread: null,
-      previewFile: null,
-      activePreviewMessageId: null,
-      previewHadThreadShell: false,
-      showSummaryPanel: false,
-      showChannelSearch: false,
-      channelSearchPreviewFile: null,
-      previewReturnChannelSearch: false,
-    });
+    this.setState(
+      openChatRightPanel("webhookPreview", {
+        webhookIssuePreviewTarget: target,
+      })
+    );
   };
 
   private _onFilePreview = (
@@ -376,22 +369,19 @@ export class ChatContentPage extends Component<
 
     // 正常处理：打开文件预览，确保侧边面板打开（子区和文件预览共用一个壳子）。
     const fromChannelSearch = !!options?.returnToChannelSearch;
-    this.setState({
-      previewFile: file,
-      webhookIssuePreviewTarget: null,
-      showThreadPanel: true, // 确保面板打开
-      showChannelSetting: false, // 关闭设置面板，避免布局冲突
-      showChannelSearch: false,
-      showSummaryPanel: false,
-      activePreviewMessageId: file.messageId || null, // 保存激活的消息 ID
-      previewReturnChannelSearch: fromChannelSearch,
-      // 仅当预览触发前用户已经在子区面板里 (showThreadPanel 已经是 true)
-      // 才允许显示 ← 返回箭头, 让 ← 真正回到子区列表/详情。其他来源
-      // (消息附件等) 一律隐藏 ← , 避免误导用户跳到子区。
-      previewHadThreadShell: fromChannelSearch
-        ? false
-        : this.state.showThreadPanel,
-    });
+    this.setState(
+      openChatRightPanel("filePreview", {
+        previewFile: file,
+        activePreviewMessageId: file.messageId || null, // 保存激活的消息 ID
+        previewReturnChannelSearch: fromChannelSearch,
+        // 仅当预览触发前用户已经在子区面板里 (showThreadPanel 已经是 true)
+        // 才允许显示 ← 返回箭头, 让 ← 真正回到子区列表/详情。其他来源
+        // (消息附件等) 一律隐藏 ← , 避免误导用户跳到子区。
+        previewHadThreadShell: fromChannelSearch
+          ? false
+          : this.state.showThreadPanel,
+      })
+    );
   };
 
   private getChannelSearchDataSource(
@@ -484,18 +474,7 @@ export class ChatContentPage extends Component<
   private _openChannelSearchPanel = () => {
     if (!isChannelSearchEnabled(this.props.channel)) return;
     this._clearChannelSearchState();
-    this.setState({
-      showChannelSearch: true,
-      webhookIssuePreviewTarget: null,
-      channelSearchPreviewFile: null,
-      showChannelSetting: false,
-      showThreadPanel: false,
-      activeThread: null,
-      previewFile: null,
-      activePreviewMessageId: null,
-      previewReturnChannelSearch: false,
-      showSummaryPanel: false,
-    });
+    this.setState(openChatRightPanel("channelSearch"));
   };
 
   /**
@@ -569,18 +548,11 @@ export class ChatContentPage extends Component<
       thread: Thread | null;
     }) => {
       if (detail?.groupNo === this.props.channel.channelID) {
-        this.setState({
-          showThreadPanel: true,
-          activeThread: detail.thread || null,
-          showChannelSetting: false,
-          previewFile: null, // 关闭文件预览
-          activePreviewMessageId: null,
-          showSummaryPanel: false,
-          showChannelSearch: false,
-          channelSearchPreviewFile: null,
-          previewReturnChannelSearch: false,
-          webhookIssuePreviewTarget: null,
-        });
+        this.setState(
+          openChatRightPanel("thread", {
+            activeThread: detail.thread || null,
+          })
+        );
       }
     };
     WKApp.mittBus.on("wk:pending-thread", this._onPendingThread);
@@ -602,28 +574,14 @@ export class ChatContentPage extends Component<
       this.setState((prevState) => {
         // forceOpen：始终打开（用于聊天内创建总结后展示），不做 toggle 关闭
         const opening = data.forceOpen ? true : !prevState.showSummaryPanel;
+        if (!opening) {
+          return { showSummaryPanel: false };
+        }
         return {
-          showSummaryPanel: opening,
+          ...openChatRightPanel("summary"),
           summaryPanelView: opening
             ? data.summaryPanelView
             : prevState.summaryPanelView,
-          showThreadPanel: opening ? false : prevState.showThreadPanel,
-          activeThread: opening ? null : prevState.activeThread,
-          previewFile: opening ? null : prevState.previewFile,
-          previewReturnChannelSearch: opening
-            ? false
-            : prevState.previewReturnChannelSearch,
-          activePreviewMessageId: opening
-            ? null
-            : prevState.activePreviewMessageId,
-          showChannelSearch: opening ? false : prevState.showChannelSearch,
-          channelSearchPreviewFile: opening
-            ? null
-            : prevState.channelSearchPreviewFile,
-          showChannelSetting: opening ? false : prevState.showChannelSetting,
-          webhookIssuePreviewTarget: opening
-            ? null
-            : prevState.webhookIssuePreviewTarget,
         };
       });
     };
@@ -643,18 +601,7 @@ export class ChatContentPage extends Component<
 
     // 检查是否需要自动打开子区面板（查看全部子区）
     if (WKApp.shared.pendingThreadPanel === channel.channelID) {
-      this.setState({
-        showThreadPanel: true,
-        activeThread: null,
-        showChannelSetting: false,
-        previewFile: null,
-        activePreviewMessageId: null,
-        previewReturnChannelSearch: false,
-        showSummaryPanel: false,
-        showChannelSearch: false,
-        channelSearchPreviewFile: null,
-        webhookIssuePreviewTarget: null,
-      });
+      this.setState(openChatRightPanel("thread"));
       WKApp.shared.pendingThreadPanel = undefined;
     }
 
@@ -662,27 +609,23 @@ export class ChatContentPage extends Component<
     if (WKApp.shared.pendingFilePreview) {
       const pending = WKApp.shared.pendingFilePreview;
       WKApp.shared.pendingFilePreview = undefined;
-      this.setState({
-        previewFile: {
-          url: pending.url,
-          name: pending.name,
-          extension: pending.extension,
-          size: pending.size,
-          messageId: pending.messageId,
-          sourceChannelId: pending.sourceChannelId,
-          sourceChannelType: pending.sourceChannelType,
-          messageSeq: pending.messageSeq,
-          fromUID: pending.fromUID,
-          conversationDigest: pending.conversationDigest,
-        },
-        activePreviewMessageId: pending.messageId || null,
-        showChannelSetting: false,
-        showSummaryPanel: false,
-        showChannelSearch: false,
-        channelSearchPreviewFile: null,
-        previewReturnChannelSearch: false,
-        webhookIssuePreviewTarget: null,
-      });
+      this.setState(
+        openChatRightPanel("filePreview", {
+          previewFile: {
+            url: pending.url,
+            name: pending.name,
+            extension: pending.extension,
+            size: pending.size,
+            messageId: pending.messageId,
+            sourceChannelId: pending.sourceChannelId,
+            sourceChannelType: pending.sourceChannelType,
+            messageSeq: pending.messageSeq,
+            fromUID: pending.fromUID,
+            conversationDigest: pending.conversationDigest,
+          },
+          activePreviewMessageId: pending.messageId || null,
+        })
+      );
     }
 
     // 子区：预先获取父群组信息
@@ -739,18 +682,7 @@ export class ChatContentPage extends Component<
       // 打开全部子区列表
       if (WKApp.shared.pendingThreadPanel === channel.channelID) {
         WKApp.shared.pendingThreadPanel = undefined;
-        this.setState({
-          showThreadPanel: true,
-          activeThread: null,
-          showChannelSetting: false,
-          previewFile: null, // 关闭文件预览（互斥）
-          activePreviewMessageId: null,
-          previewReturnChannelSearch: false,
-          showSummaryPanel: false,
-          showChannelSearch: false,
-          channelSearchPreviewFile: null,
-          webhookIssuePreviewTarget: null,
-        });
+        this.setState(openChatRightPanel("thread"));
         return;
       }
 
@@ -758,27 +690,23 @@ export class ChatContentPage extends Component<
       if (WKApp.shared.pendingFilePreview) {
         const pending = WKApp.shared.pendingFilePreview;
         WKApp.shared.pendingFilePreview = undefined;
-        this.setState({
-          previewFile: {
-            url: pending.url,
-            name: pending.name,
-            extension: pending.extension,
-            size: pending.size,
-            messageId: pending.messageId,
-            sourceChannelId: pending.sourceChannelId,
-            sourceChannelType: pending.sourceChannelType,
-            messageSeq: pending.messageSeq,
-            fromUID: pending.fromUID,
-            conversationDigest: pending.conversationDigest,
-          },
-          activePreviewMessageId: pending.messageId || null,
-          showChannelSetting: false,
-          showSummaryPanel: false,
-          showChannelSearch: false,
-          channelSearchPreviewFile: null,
-          previewReturnChannelSearch: false,
-          webhookIssuePreviewTarget: null,
-        });
+        this.setState(
+          openChatRightPanel("filePreview", {
+            previewFile: {
+              url: pending.url,
+              name: pending.name,
+              extension: pending.extension,
+              size: pending.size,
+              messageId: pending.messageId,
+              sourceChannelId: pending.sourceChannelId,
+              sourceChannelType: pending.sourceChannelType,
+              messageSeq: pending.messageSeq,
+              fromUID: pending.fromUID,
+              conversationDigest: pending.conversationDigest,
+            },
+            activePreviewMessageId: pending.messageId || null,
+          })
+        );
         return;
       }
     }
@@ -947,9 +875,7 @@ export class ChatContentPage extends Component<
           "wk-chat-content-right",
           showChannelSetting ? "wk-chat-channelsetting-open" : "",
           showChannelSearch ? "wk-chat-channel-search-open" : "",
-          showThreadPanel || previewFile
-            ? "wk-chat-threadpanel-open"
-            : "",
+          showThreadPanel || previewFile ? "wk-chat-threadpanel-open" : "",
           showSummaryPanel ? "wk-chat-summary-panel-open" : "",
           webhookIssuePreviewTarget ? "wk-chat-webhook-preview-open" : ""
         )}
@@ -1111,17 +1037,9 @@ export class ChatContentPage extends Component<
                                 prevState.showThreadPanel &&
                                 !prevState.previewFile &&
                                 !prevState.activeThread;
-                              return {
-                                showThreadPanel: !isThreadListVisible,
-                                showChannelSetting: false,
-                                showSummaryPanel: false,
-                                showChannelSearch: false,
-                                channelSearchPreviewFile: null,
-                                activeThread: null,
-                                previewFile: null, // 关闭文件预览（互斥）
-                                activePreviewMessageId: null,
-                                webhookIssuePreviewTarget: null,
-                              };
+                              return isThreadListVisible
+                                ? closeChatRightPanels()
+                                : openChatRightPanel("thread");
                             });
                           }}
                           title={t("base.chatPage.threadPanel")}
@@ -1135,29 +1053,9 @@ export class ChatContentPage extends Component<
                         e.stopPropagation();
                         this.setState((prevState) => {
                           const opening = !prevState.showChannelSetting;
-                          return {
-                            showChannelSetting: opening,
-                            showSummaryPanel: opening
-                              ? false
-                              : prevState.showSummaryPanel,
-                            showThreadPanel: opening
-                              ? false
-                              : prevState.showThreadPanel,
-                            activeThread: opening ? null : prevState.activeThread,
-                            previewFile: opening ? null : prevState.previewFile,
-                            previewHadThreadShell: opening
-                              ? false
-                              : prevState.previewHadThreadShell,
-                            activePreviewMessageId: opening
-                              ? null
-                              : prevState.activePreviewMessageId,
-                            showChannelSearch: false,
-                            channelSearchPreviewFile: null,
-                            previewReturnChannelSearch: opening
-                              ? false
-                              : prevState.previewReturnChannelSearch,
-                            webhookIssuePreviewTarget: null,
-                          };
+                          return opening
+                            ? openChatRightPanel("channelSetting")
+                            : { showChannelSetting: false };
                         });
                       }}
                     >
@@ -1201,22 +1099,16 @@ export class ChatContentPage extends Component<
                 onOpenThreadPanel={(threadChannelId, threadName) => {
                   const threadInfo = parseThreadChannelId(threadChannelId);
                   if (threadInfo) {
-                    this.setState({
-                      showThreadPanel: true,
-                      showChannelSetting: false,
-                      showSummaryPanel: false,
-                      showChannelSearch: false,
-                      channelSearchPreviewFile: null,
-                      previewFile: null, // 关闭文件预览（互斥）
-                      activePreviewMessageId: null,
-                      webhookIssuePreviewTarget: null,
-                      activeThread: buildThreadStub(
-                        threadInfo.shortId,
-                        threadInfo.groupNo,
-                        threadChannelId,
-                        threadName
-                      ),
-                    });
+                    this.setState(
+                      openChatRightPanel("thread", {
+                        activeThread: buildThreadStub(
+                          threadInfo.shortId,
+                          threadInfo.groupNo,
+                          threadChannelId,
+                          threadName
+                        ),
+                      })
+                    );
                   }
                 }}
                 onOpenWebhookPreview={this._openWebhookPreview}
@@ -1310,10 +1202,7 @@ export class ChatContentPage extends Component<
               onClose={() => {
                 // X 关闭: 若当前是从频道内搜索打开的预览, 回到搜索面板;
                 // 否则沿用原行为, 把整个侧边壳 (子区 + 预览) 一起关掉。
-                if (
-                  previewFile &&
-                  this.state.previewReturnChannelSearch
-                ) {
+                if (previewFile && this.state.previewReturnChannelSearch) {
                   this._closePreview(true);
                   return;
                 }
@@ -1359,9 +1248,7 @@ export class ChatContentPage extends Component<
             <ThreadPanel
               onClose={() => this._closePreview(true)}
               filePreview={previewFile}
-              onFilePreviewClose={() =>
-                this._closePreview(true)
-              }
+              onFilePreviewClose={() => this._closePreview(true)}
               onReplyFile={(info) => {
                 // 触发回复功能，保持文件预览面板打开
                 this.conversationContext?.replyToFileMessage?.(info);
@@ -1378,8 +1265,9 @@ export class ChatContentPage extends Component<
 
         {showSummaryPanel && (
           <div className="wk-summary-panel">
-            {WKApp.endpoints.chatSummaryPanel(channel, () =>
-              this.setState({ showSummaryPanel: false }),
+            {WKApp.endpoints.chatSummaryPanel(
+              channel,
+              () => this.setState({ showSummaryPanel: false }),
               summaryPanelView
             )}
           </div>
@@ -1804,9 +1692,7 @@ export default class ChatPage extends Component<any, ChatPageState> {
                   vm.showGlobalSearch = false;
                 }}
               >
-                <ErrorBoundary
-                  moduleName={t("base.chatPage.searchModuleName")}
-                >
+                <ErrorBoundary moduleName={t("base.chatPage.searchModuleName")}>
                   <GlobalSearch
                     onClick={(item, type: string) => {
                       void handleGlobalSearchClick(item, type, () => {

--- a/packages/dmworkbase/src/Pages/Chat/index.tsx
+++ b/packages/dmworkbase/src/Pages/Chat/index.tsx
@@ -572,6 +572,7 @@ export class ChatContentPage extends Component<
         this.setState({
           showThreadPanel: true,
           activeThread: detail.thread || null,
+          showChannelSetting: false,
           previewFile: null, // 关闭文件预览
           activePreviewMessageId: null,
           showSummaryPanel: false,
@@ -619,6 +620,7 @@ export class ChatContentPage extends Component<
           channelSearchPreviewFile: opening
             ? null
             : prevState.channelSearchPreviewFile,
+          showChannelSetting: opening ? false : prevState.showChannelSetting,
           webhookIssuePreviewTarget: opening
             ? null
             : prevState.webhookIssuePreviewTarget,
@@ -644,6 +646,7 @@ export class ChatContentPage extends Component<
       this.setState({
         showThreadPanel: true,
         activeThread: null,
+        showChannelSetting: false,
         previewFile: null,
         activePreviewMessageId: null,
         previewReturnChannelSearch: false,
@@ -673,6 +676,7 @@ export class ChatContentPage extends Component<
           conversationDigest: pending.conversationDigest,
         },
         activePreviewMessageId: pending.messageId || null,
+        showChannelSetting: false,
         showSummaryPanel: false,
         showChannelSearch: false,
         channelSearchPreviewFile: null,
@@ -738,6 +742,7 @@ export class ChatContentPage extends Component<
         this.setState({
           showThreadPanel: true,
           activeThread: null,
+          showChannelSetting: false,
           previewFile: null, // 关闭文件预览（互斥）
           activePreviewMessageId: null,
           previewReturnChannelSearch: false,
@@ -767,6 +772,7 @@ export class ChatContentPage extends Component<
             conversationDigest: pending.conversationDigest,
           },
           activePreviewMessageId: pending.messageId || null,
+          showChannelSetting: false,
           showSummaryPanel: false,
           showChannelSearch: false,
           channelSearchPreviewFile: null,
@@ -1107,6 +1113,7 @@ export class ChatContentPage extends Component<
                                 !prevState.activeThread;
                               return {
                                 showThreadPanel: !isThreadListVisible,
+                                showChannelSetting: false,
                                 showSummaryPanel: false,
                                 showChannelSearch: false,
                                 channelSearchPreviewFile: null,
@@ -1126,12 +1133,31 @@ export class ChatContentPage extends Component<
                       className="wk-chat-conversation-header-right-item"
                       onClick={(e) => {
                         e.stopPropagation();
-                        // 点击更多按钮只切换设置面板，不影响文件预览/子区面板状态
-                        this.setState({
-                          showChannelSetting: !this.state.showChannelSetting,
-                          showChannelSearch: false,
-                          channelSearchPreviewFile: null,
-                          webhookIssuePreviewTarget: null,
+                        this.setState((prevState) => {
+                          const opening = !prevState.showChannelSetting;
+                          return {
+                            showChannelSetting: opening,
+                            showSummaryPanel: opening
+                              ? false
+                              : prevState.showSummaryPanel,
+                            showThreadPanel: opening
+                              ? false
+                              : prevState.showThreadPanel,
+                            activeThread: opening ? null : prevState.activeThread,
+                            previewFile: opening ? null : prevState.previewFile,
+                            previewHadThreadShell: opening
+                              ? false
+                              : prevState.previewHadThreadShell,
+                            activePreviewMessageId: opening
+                              ? null
+                              : prevState.activePreviewMessageId,
+                            showChannelSearch: false,
+                            channelSearchPreviewFile: null,
+                            previewReturnChannelSearch: opening
+                              ? false
+                              : prevState.previewReturnChannelSearch,
+                            webhookIssuePreviewTarget: null,
+                          };
                         });
                       }}
                     >
@@ -1177,6 +1203,7 @@ export class ChatContentPage extends Component<
                   if (threadInfo) {
                     this.setState({
                       showThreadPanel: true,
+                      showChannelSetting: false,
                       showSummaryPanel: false,
                       showChannelSearch: false,
                       channelSearchPreviewFile: null,

--- a/packages/dmworkbase/src/Pages/Chat/index.tsx
+++ b/packages/dmworkbase/src/Pages/Chat/index.tsx
@@ -372,6 +372,7 @@ export class ChatContentPage extends Component<
     this.setState(
       openChatRightPanel("filePreview", {
         previewFile: file,
+        activeThread: this.state.activeThread,
         activePreviewMessageId: file.messageId || null, // 保存激活的消息 ID
         previewReturnChannelSearch: fromChannelSearch,
         // 仅当预览触发前用户已经在子区面板里 (showThreadPanel 已经是 true)
@@ -579,9 +580,7 @@ export class ChatContentPage extends Component<
         }
         return {
           ...openChatRightPanel("summary"),
-          summaryPanelView: opening
-            ? data.summaryPanelView
-            : prevState.summaryPanelView,
+          summaryPanelView: data.summaryPanelView,
         };
       });
     };

--- a/packages/dmworkbase/src/Pages/Chat/rightPanelState.ts
+++ b/packages/dmworkbase/src/Pages/Chat/rightPanelState.ts
@@ -1,0 +1,72 @@
+import type { FilePreviewInfo } from "../../Components/FilePreviewPanel";
+import type { Thread } from "../../Service/Thread";
+import type { WebhookIssuePreviewTarget } from "../../bridge/message/webhookPreview";
+
+export type ChatRightPanelKind =
+  | "channelSetting"
+  | "thread"
+  | "summary"
+  | "channelSearch"
+  | "filePreview"
+  | "webhookPreview";
+
+export interface ChatRightPanelStatePatch {
+  showChannelSetting: boolean;
+  showThreadPanel: boolean;
+  activeThread: Thread | null;
+  previewFile: FilePreviewInfo | null;
+  activePreviewMessageId: string | null;
+  previewHadThreadShell: boolean;
+  showSummaryPanel: boolean;
+  showChannelSearch: boolean;
+  channelSearchPreviewFile: FilePreviewInfo | null;
+  previewReturnChannelSearch: boolean;
+  webhookIssuePreviewTarget: WebhookIssuePreviewTarget | null;
+}
+
+const CLOSED_RIGHT_PANEL_STATE: ChatRightPanelStatePatch = {
+  showChannelSetting: false,
+  showThreadPanel: false,
+  activeThread: null,
+  previewFile: null,
+  activePreviewMessageId: null,
+  previewHadThreadShell: false,
+  showSummaryPanel: false,
+  showChannelSearch: false,
+  channelSearchPreviewFile: null,
+  previewReturnChannelSearch: false,
+  webhookIssuePreviewTarget: null,
+};
+
+export function closeChatRightPanels(): ChatRightPanelStatePatch {
+  return { ...CLOSED_RIGHT_PANEL_STATE };
+}
+
+export function openChatRightPanel(
+  kind: ChatRightPanelKind,
+  overrides: Partial<ChatRightPanelStatePatch> = {}
+): ChatRightPanelStatePatch {
+  const patch = closeChatRightPanels();
+
+  switch (kind) {
+    case "channelSetting":
+      patch.showChannelSetting = true;
+      break;
+    case "thread":
+      patch.showThreadPanel = true;
+      break;
+    case "summary":
+      patch.showSummaryPanel = true;
+      break;
+    case "channelSearch":
+      patch.showChannelSearch = true;
+      break;
+    case "filePreview":
+      patch.showThreadPanel = true;
+      break;
+    case "webhookPreview":
+      break;
+  }
+
+  return { ...patch, ...overrides };
+}


### PR DESCRIPTION
## Summary
- make chat info, smart summary, channel search, thread panel, file preview, and webhook preview mutually exclusive in the chat right panel
- remove layout rules that allowed chat info to coexist with summary/thread panels
- close chat info when opening thread-related panels or pending previews

## Validation
- User local validation passed
- git diff --check
- pnpm exec vitest run packages/dmworkbase/src/Pages/Chat/__tests__/vm.channelListener.test.ts packages/dmworkbase/src/Pages/Chat/__tests__/vm.sortConversations.test.ts

Fixes #1134