### PR TITLE
test(dmworkbase): cover follow drag sort contract

### DIFF
--- a/packages/dmworkbase/src/Components/ConversationListGrouped/__tests__/dragSortAction.test.ts
+++ b/packages/dmworkbase/src/Components/ConversationListGrouped/__tests__/dragSortAction.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it, vi } from "vitest"
+import {
+    computeFollowDragSortItems,
+    getSortableItemId,
+    type FollowDragSortContext,
+    type SortableConversation,
+} from "../dragSortAction"
+
+const ChannelTypePerson = 1
+const ChannelTypeGroup = 2
+const ChannelTypeCommunityTopic = 5
+
+function conversation(channelType: number, channelID: string): SortableConversation {
+    return {
+        channel: { channelType, channelID },
+    }
+}
+
+function baseContext(
+    overrides: Partial<FollowDragSortContext<SortableConversation>> = {},
+): FollowDragSortContext<SortableConversation> {
+    const dmA = conversation(ChannelTypePerson, "dm-a")
+    const groupB = conversation(ChannelTypeGroup, "group-b")
+    const dmC = conversation(ChannelTypePerson, "dm-c")
+    const groupD = conversation(ChannelTypeGroup, "group-d")
+
+    return {
+        activeId: getSortableItemId(dmA),
+        overId: getSortableItemId(groupB),
+        overType: "item",
+        itemToCategory: new Map([
+            [getSortableItemId(dmA), "cat-a"],
+            [getSortableItemId(groupB), "cat-a"],
+            [getSortableItemId(dmC), "cat-a"],
+            [getSortableItemId(groupD), "cat-b"],
+        ]),
+        categoryItems: new Map([
+            ["cat-a", [dmA, groupB, dmC]],
+            ["cat-b", [groupD]],
+        ]),
+        childItemsByParent: new Map([
+            [
+                "group-b",
+                [
+                    conversation(ChannelTypeCommunityTopic, "group-b____t1"),
+                    conversation(ChannelTypeCommunityTopic, "group-b____t2"),
+                ],
+            ],
+        ]),
+        groupChannelType: ChannelTypeGroup,
+        childChannelType: ChannelTypeCommunityTopic,
+        ...overrides,
+    }
+}
+
+describe("computeFollowDragSortItems", () => {
+    it("item drop 到同 category 的另一 item 时返回排序 payload", () => {
+        const result = computeFollowDragSortItems(baseContext())
+
+        expect(result).toEqual([
+            { target_type: ChannelTypeGroup, target_id: "group-b" },
+            { target_type: ChannelTypeCommunityTopic, target_id: "group-b____t1" },
+            { target_type: ChannelTypeCommunityTopic, target_id: "group-b____t2" },
+            { target_type: ChannelTypePerson, target_id: "dm-a" },
+            { target_type: ChannelTypePerson, target_id: "dm-c" },
+        ])
+    })
+
+    it("item drop 到别 category 的 item 时保持 no-op", () => {
+        const onSortFollowItems = vi.fn()
+        const onMoveGroupToCategory = vi.fn()
+        const followDM = vi.fn()
+        const groupD = conversation(ChannelTypeGroup, "group-d")
+
+        const result = computeFollowDragSortItems(baseContext({
+            overId: getSortableItemId(groupD),
+        }))
+        if (result) onSortFollowItems(result)
+
+        expect(result).toBeNull()
+        expect(onSortFollowItems).not.toHaveBeenCalled()
+        expect(onMoveGroupToCategory).not.toHaveBeenCalled()
+        expect(followDM).not.toHaveBeenCalled()
+    })
+
+    it("item drop 到 category header / drop area 时保持 no-op", () => {
+        const onSortFollowItems = vi.fn()
+        const onMoveGroupToCategory = vi.fn()
+        const followDM = vi.fn()
+
+        const result = computeFollowDragSortItems(baseContext({
+            overId: "cat::cat-b",
+            overType: "category",
+        }))
+        if (result) onSortFollowItems(result)
+
+        expect(result).toBeNull()
+        expect(onSortFollowItems).not.toHaveBeenCalled()
+        expect(onMoveGroupToCategory).not.toHaveBeenCalled()
+        expect(followDM).not.toHaveBeenCalled()
+    })
+})

--- a/packages/dmworkbase/src/Components/ConversationListGrouped/dragSortAction.ts
+++ b/packages/dmworkbase/src/Components/ConversationListGrouped/dragSortAction.ts
@@ -1,0 +1,76 @@
+export interface SortableConversation {
+    channel: {
+        channelType: number
+        channelID: string
+    }
+}
+
+export interface FollowSortItem {
+    target_type: number
+    target_id: string
+}
+
+export interface FollowDragSortContext<T extends SortableConversation> {
+    activeId: string
+    overId: string
+    overType: unknown
+    itemToCategory: Map<string, string>
+    categoryItems: Map<string, T[]>
+    childItemsByParent: Map<string, T[]>
+    groupChannelType: number
+    childChannelType: number
+}
+
+export function getSortableItemId(item: SortableConversation): string {
+    return `item::${item.channel.channelType}::${item.channel.channelID}`
+}
+
+function arrayMoveItem<T>(items: T[], fromIndex: number, toIndex: number): T[] {
+    const next = items.slice()
+    const [item] = next.splice(fromIndex, 1)
+    next.splice(toIndex, 0, item)
+    return next
+}
+
+export function computeFollowDragSortItems<T extends SortableConversation>({
+    activeId,
+    overId,
+    overType,
+    itemToCategory,
+    categoryItems,
+    childItemsByParent,
+    groupChannelType,
+    childChannelType,
+}: FollowDragSortContext<T>): FollowSortItem[] | null {
+    if (overType !== "item") return null
+
+    const sourceCatId = itemToCategory.get(activeId)
+    const targetCatId = itemToCategory.get(overId)
+    if (!sourceCatId || !targetCatId || sourceCatId !== targetCatId) return null
+
+    const items = categoryItems.get(sourceCatId) || []
+    const oldIndex = items.findIndex(item => getSortableItemId(item) === activeId)
+    const newIndex = items.findIndex(item => getSortableItemId(item) === overId)
+    if (oldIndex === -1 || newIndex === -1 || oldIndex === newIndex) return null
+
+    const sortItems: FollowSortItem[] = []
+    const newOrder = arrayMoveItem(items, oldIndex, newIndex)
+    for (const item of newOrder) {
+        sortItems.push({
+            target_type: item.channel.channelType,
+            target_id: item.channel.channelID,
+        })
+
+        if (item.channel.channelType === groupChannelType) {
+            const childItems = childItemsByParent.get(item.channel.channelID) || []
+            for (const child of childItems) {
+                sortItems.push({
+                    target_type: childChannelType,
+                    target_id: child.channel.channelID,
+                })
+            }
+        }
+    }
+
+    return sortItems
+}

--- a/packages/dmworkbase/src/Components/ConversationListGrouped/index.tsx
+++ b/packages/dmworkbase/src/Components/ConversationListGrouped/index.tsx
@@ -32,6 +32,7 @@ import {
     type ValidCategoryItem,
 } from "./categoriesFallback"
 import { filterArchivedThreads, isArchivedThreadConversation, type ThreadSidebarStatusMap } from "./archivedThreads"
+import { computeFollowDragSortItems, getSortableItemId } from "./dragSortAction"
 import { useI18n } from "../../i18n"
 import { wkConfirm } from "../WKModal"
 import { getImChannelInfo } from "../../im-runtime/channelRuntime"
@@ -174,43 +175,20 @@ const ConversationListGrouped: React.FC<ConversationListGroupedProps> = ({
         const d = active.data.current
         if (!isDragData(d) || d.type !== 'item') return
 
-        // 分支 1：item → item，落在另一个会话上
-        if (overType === 'item') {
-            const sourceCatId = itemToCategory.get(String(active.id))
-            const targetCatId = itemToCategory.get(overId)
-            if (!sourceCatId || !targetCatId) return
-            if (sourceCatId !== targetCatId) return
-
-            // 同分组内手动排序：调 /v2/follow/sort，items 顺序由数组下标决定。
-            // 子区跟随父群在视觉上一起移动 → 提交时把每个群的已关注子区紧跟其后，
-            // 否则后端不更新子区的 follow_sort，旧值会让子区在 sidebar 里漂离父群。
-            const items = categoryItems.get(sourceCatId) || []
-            const oldIndex = items.findIndex(c => `item::${c.channel.channelType}::${c.channel.channelID}` === String(active.id))
-            const newIndex = items.findIndex(c => `item::${c.channel.channelType}::${c.channel.channelID}` === overId)
-            if (oldIndex !== -1 && newIndex !== -1 && oldIndex !== newIndex) {
-                const newOrder = arrayMove(items, oldIndex, newIndex)
-                const sortItems: { target_type: number; target_id: string }[] = []
-                for (const c of newOrder) {
-                    sortItems.push({
-                        target_type: c.channel.channelType,
-                        target_id: c.channel.channelID,
-                    })
-                    // 群下面紧跟其已关注子区。followedChildThreadsByParent 已合并
-                    // IM 缓存（按 followedKeys 过滤）+ sidebar 自带的 sidebar-only
-                    // 关注子区（通过 parent_channel_id 反挂），保证拖父群时所有
-                    // 已关注的子区都进 sort payload，不会漏掉新关注但 IM 没缓存的。
-                    if (c.channel.channelType === ChannelTypeGroup) {
-                        const childThreads = followedChildThreadsByParent.get(c.channel.channelID) || []
-                        for (const t of childThreads) {
-                            sortItems.push({
-                                target_type: ChannelTypeCommunityTopic,
-                                target_id: t.channel.channelID,
-                            })
-                        }
-                    }
-                }
-                onSortFollowItems?.(sortItems)
-            }
+        // 分支 1：item → item，落在另一个会话上。
+        // 同分组内手动排序：调 /v2/follow/sort；跨分组或 header/drop area no-op。
+        const sortItems = computeFollowDragSortItems({
+            activeId: String(active.id),
+            overId,
+            overType,
+            itemToCategory,
+            categoryItems,
+            childItemsByParent: followedChildThreadsByParent,
+            groupChannelType: ChannelTypeGroup,
+            childChannelType: ChannelTypeCommunityTopic,
+        })
+        if (sortItems) {
+            onSortFollowItems?.(sortItems)
             return
         }
 
@@ -562,7 +540,7 @@ const ConversationListGrouped: React.FC<ConversationListGroupedProps> = ({
         const sortableInCat = catConvs.filter(c => c.channel.channelType !== ChannelTypeCommunityTopic)
         categoryItems.set(cat.category_id, sortableInCat)
         for (const c of sortableInCat) {
-            itemToCategory.set(`item::${c.channel.channelType}::${c.channel.channelID}`, cat.category_id)
+            itemToCategory.set(getSortableItemId(c), cat.category_id)
         }
 
         const groupCount = catConvs.length


### PR DESCRIPTION
## Summary

Add focused regression coverage for the follow-list drag sorting contract introduced by the category-bound drag behavior.

## Related Issue

Closes #1091

## Changes

- Extracted the item drag sort decision into a pure helper for direct unit testing.
- Updated `ConversationListGrouped` to delegate item drag sorting to the helper while preserving the existing user-visible behavior.
- Added regression tests for same-category sorting, cross-category no-op drops, and category header/drop-area no-op drops.
- Covered the existing payload behavior where followed child threads stay immediately after their parent group in the sort payload.

## Architecture / Module Boundary

- Affected module(s): `packages/dmworkbase/src/Components/ConversationListGrouped`
- New or changed user-visible entry point: no
- Shared layer touched: Components
- If shared code changed, impact scope: limited to the chat sidebar grouped conversation list drag-sort helper and tests
- Duplicate entry point checked: not applicable

## Testing

- [x] Unit tests added/updated
- [ ] Manually verified

```bash
pnpm --dir packages/dmworkbase test -- ConversationListGrouped
```

Result after rebasing onto latest `upstream/main`: 256 test files passed, 2224 tests passed.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation
- [x] Ran `pnpm i18n:check` or confirmed the change does not affect UI copy
- [x] Confirmed the change follows module ownership and does not add duplicate user-visible entry points
- [x] Described impact scope when shared components, messages, bridge, or services are changed
- [x] Followed commit message conventions (Conventional Commits)
