### PR TITLE
fix(loop): sync workspace context when returning from Personal/runtime page (#631)

### DIFF
--- a/apps/web/src/__tests__/loopWorkspaceSyncOnReturn.test.ts
+++ b/apps/web/src/__tests__/loopWorkspaceSyncOnReturn.test.ts
@@ -1,0 +1,99 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * #631 回归:从 Personal/runtime 页切回 Loop 时,workspace 上下文可能被 Personal 页改写,
+ * 导致 Loop 子页面用错误的 x-workspace-slug 发请求、数据串台。
+ *
+ * 根因两处:
+ *   1. useLoopWorkspace 的 onNavMenuActivated 在重画右栏前没有重新断言 setWorkspaceContext
+ *      和 resetWorkspaceCaches,Personal 页残留的 http 层 slug 没被纠正
+ *   2. usePersonalWorkspace 的 onNavMenuActivated 没有清空 selectedWsRef,导致每次进
+ *      Personal 都用上次记住的 workspace(而非 Loop 当前选中的)覆盖 http 层 slug
+ */
+describe('LoopPage — re-assert workspace context on nav-menu-activated', () => {
+  let loopPage: string;
+
+  beforeAll(() => {
+    loopPage = fs.readFileSync(
+      path.join(__dirname, '../../../../packages/dmloop/src/bridge/useLoopWorkspace.tsx'),
+      'utf-8',
+    );
+  });
+
+  it('onNavMenuActivated re-asserts setWorkspaceContext before repainting', () => {
+    // Extract the onNavMenuActivated handler body (the one inside the wk:nav-menu-activated useEffect).
+    // Anchor on the function declaration within the effect.
+    const handlerStart = loopPage.search(/const\s+onNavMenuActivated\s*=\s*\(\{[^}]*menuId[^}]*\}\s*:\s*\{[^}]*menuId[^}]*\}\)/);
+    expect(handlerStart).toBeGreaterThanOrEqual(0);
+
+    // Bound the handler body: from the start of the function up to mittBus.on registration.
+    const afterDecl = loopPage.slice(handlerStart);
+    const handlerEnd = afterDecl.search(/mittBus\.on\(\s*["']wk:nav-menu-activated["']/);
+    const handlerBody = handlerEnd > 0 ? afterDecl.slice(0, handlerEnd) : afterDecl;
+
+    // Must call setWorkspaceContext in the normal (non-pending-re-resolve, non-empty-guide) path.
+    expect(handlerBody).toMatch(/setWorkspaceContext\(/);
+    // Must call resetWorkspaceCaches too.
+    expect(handlerBody).toMatch(/resetWorkspaceCaches\(\s*\)/);
+    // Both calls must come BEFORE replaceLoopRootPath so that when the child page mounts
+    // and fires its useEffect(reload), the http layer slug is already correct.
+    const setCtxIdx = handlerBody.search(/setWorkspaceContext\(/);
+    const resetCacheIdx = handlerBody.search(/resetWorkspaceCaches\(\s*\)/);
+    const replaceRootIdx = handlerBody.search(/replaceLoopRootPath\(\s*\)/);
+    expect(setCtxIdx).toBeGreaterThanOrEqual(0);
+    expect(resetCacheIdx).toBeGreaterThanOrEqual(0);
+    expect(replaceRootIdx).toBeGreaterThan(0);
+    expect(setCtxIdx).toBeLessThan(replaceRootIdx);
+    expect(resetCacheIdx).toBeLessThan(replaceRootIdx);
+  });
+
+  it('does NOT setWorkspaceContext in the pendingSpaceReresolve early-return path', () => {
+    // When a space change arrived while backgrounded, reResolveSpace() already handles
+    // setWorkspaceContext("", "") — the early return should not double-set.
+    const pendingIdx = loopPage.search(/pendingSpaceReresolveRef\.current\s*\)/);
+    expect(pendingIdx).toBeGreaterThanOrEqual(0);
+    // The early return block (from `if (pendingSpaceReresolveRef.current)` up to its `return;`)
+    // should not contain setWorkspaceContext (it delegates to reResolveSpace).
+    const after = loopPage.slice(pendingIdx);
+    const returnIdx = after.indexOf('return;');
+    const earlyBlock = after.slice(0, returnIdx + 7);
+    // reResolveSpace call is the only action here; no direct setWorkspaceContext.
+    expect(earlyBlock).toMatch(/reResolveSpace\(\s*\)/);
+    // Count setWorkspaceContext in this block: it should be 0 (reResolveSpace sets "" internally,
+    // but that's in a separate function, not inlined here).
+    const inlineSets = (earlyBlock.match(/setWorkspaceContext\(/g) || []).length;
+    expect(inlineSets).toBe(0);
+  });
+});
+
+describe('PersonalPage — clear selectedWsRef on nav-menu-activated to follow Loop workspace', () => {
+  let personalPage: string;
+
+  beforeAll(() => {
+    personalPage = fs.readFileSync(
+      path.join(__dirname, '../../../../packages/dmpersonal/src/bridge/usePersonalWorkspace.tsx'),
+      'utf-8',
+    );
+  });
+
+  it('onNavMenuActivated clears selectedWsRef before resolveRef', () => {
+    // Find the wk:nav-menu-activated handler in Personal (different from the one in Loop).
+    const handlerStart = personalPage.search(/const\s+onNavMenuActivated\s*=\s*\(\{[^}]*menuId[^}]*\}/);
+    expect(handlerStart).toBeGreaterThanOrEqual(0);
+
+    const afterDecl = personalPage.slice(handlerStart);
+    const handlerEnd = afterDecl.search(/mittBus\.on\(\s*["']wk:nav-menu-activated["']/);
+    const handlerBody = handlerEnd > 0 ? afterDecl.slice(0, handlerEnd) : afterDecl;
+
+    // Must clear selectedWsRef so targetId falls back to currentWorkspaceId() (= Loop's current ws).
+    expect(handlerBody).toMatch(/selectedWsRef\.current\s*=\s*null/);
+
+    // The clear must precede resolveRef.current(true) so that resolveAndPaint reads a null ref.
+    const clearIdx = handlerBody.search(/selectedWsRef\.current\s*=\s*null/);
+    const resolveIdx = handlerBody.search(/resolveRef\.current\(\s*true\s*\)/);
+    expect(clearIdx).toBeGreaterThanOrEqual(0);
+    expect(resolveIdx).toBeGreaterThan(0);
+    expect(clearIdx).toBeLessThan(resolveIdx);
+  });
+});

--- a/packages/dmloop/src/bridge/useLoopWorkspace.tsx
+++ b/packages/dmloop/src/bridge/useLoopWorkspace.tsx
@@ -334,6 +334,10 @@ export function useLoopWorkspace({
         showEmptyGuide();
         return;
       }
+      // Personal/runtime 页在自身激活期间可能改写了 http 层 workspace context;
+      // 回 Loop 时必须在重挂子页面前重新断言正确 slug,否则子页面会用 Personal 的 context 发请求(#631)。
+      setWorkspaceContext(workspace.slug, workspace.id, workspace.name);
+      resetWorkspaceCaches();
       replaceLoopRootPath();
       setTab("issue");
       WKApp.routeRight.replaceToRoot(renderTabView("issue", workspace));

--- a/packages/dmpersonal/src/bridge/usePersonalWorkspace.tsx
+++ b/packages/dmpersonal/src/bridge/usePersonalWorkspace.tsx
@@ -154,6 +154,9 @@ export function usePersonalWorkspace({
   useEffect(() => {
     const onNavMenuActivated = ({ menuId }: { menuId: string }) => {
       if (menuId !== "dmpersonal") return;
+      // Personal 没有独立的 workspace 切换器,上次记住的 selectedWsRef 可能已是 Loop 已切换掉的旧 workspace;
+      // 从导航进入时清空,让 targetId 回落到 currentWorkspaceId() 跟随 Loop 当前选中的 workspace(#631)。
+      selectedWsRef.current = null;
       // showLoading=true:框架会先 popToRoot 清空右栏,重解析是异步的,先铺加载态避免空白闪一下。
       resolveRef.current(true);
     };


### PR DESCRIPTION
Fixes Mininglamp-OSS/octo-server#631

## 变更摘要
- `packages/dmloop/src/bridge/useLoopWorkspace.tsx`: `onNavMenuActivated` 回 Loop 时，在重画页面前先调用 `setWorkspaceContext` + `resetWorkspaceCaches`，重新断言 http 层 workspace slug，防止被其他页面（Personal/Runtime）污染后不纠正
- `packages/dmpersonal/src/bridge/usePersonalWorkspace.tsx`: `onNavMenuActivated` 激活 Personal 时，先清空 `selectedWsRef.current`，使其每次跟随 Loop 当前选中的 workspace，而不是保留上一次进入 Personal 时记住的旧 workspace（该旧值会改写全局 `_workspaceSlug`，导致 Loop 回来后数据串台）
- 新增测试：`apps/web/src/__tests__/loopWorkspaceSyncOnReturn.test.ts`

## 根因
两个问题叠加：
1. `usePersonalWorkspace` 的 `selectedWsRef` 在 Personal 后台时保留旧值，下次激活优先用记住的 workspace id 而非 Loop 当前 workspace，全局改写 `_workspaceSlug`
2. `useLoopWorkspace.onNavMenuActivated` 回 Loop 时没有 re-assert workspace context，被 Personal 污染的 slug 没被纠正，子页面（IssuePage/AgentPage）挂载后用错误 slug 发请求

## 验收证据
- 相关测试（loopWorkspaceStaleWrite + personalPageSpaceChanged + loopWorkspaceSyncOnReturn）：28/28 passed
- `@octo/loop` 包测试：96/96 passed
- 构建（`pnpm build --filter @octo/loop --filter @octo/personal --filter @octo/web`）：exit 0
- lint：exit 0
- 全量 `pnpm --filter @octo/web test --run` exit 1，失败的 36 个测试均为 main 分支既存问题（Playwright e2e specs 被 Vitest 误收录、CSS 断言偏差、i18n snapshot 等），本分支无新增失败