### PR TITLE
fix: align mention AI badge

### DIFF
--- a/packages/dmworkbase/src/Components/MessageInput/MentionList.css
+++ b/packages/dmworkbase/src/Components/MessageInput/MentionList.css
@@ -29,6 +29,17 @@
   margin-right: 8px;
 }
 
+.mention-list-item-content {
+  display: inline-flex;
+  align-items: center;
+  min-width: 0;
+}
+
+.mention-list-item-ai-badge {
+  margin-left: 4px;
+  align-self: center;
+}
+
 /* @ 提醒选人弹窗「@SpaceName」后缀（企微风格），小字次要色 */
 .mention-list-item-space {
   margin-left: 6px;

--- a/packages/dmworkbase/src/Components/MessageInput/MentionList.tsx
+++ b/packages/dmworkbase/src/Components/MessageInput/MentionList.tsx
@@ -266,7 +266,7 @@ export default forwardRef((props: MentionListProps, ref) => {
                   }}
                 />
               </div>
-              <div>
+              <div className="mention-list-item-content">
                 <strong>{item.name || item.display}</strong>
                 {/* @ 提醒选人弹窗的「@SpaceName」后缀（企微风格） */}
                 {item.sourceSpaceName && (
@@ -277,7 +277,9 @@ export default forwardRef((props: MentionListProps, ref) => {
                     @{item.sourceSpaceName}
                   </span>
                 )}
-                {item.isBot && <AiBadge size="small" />}
+                {item.isBot && (
+                  <AiBadge size="small" className="mention-list-item-ai-badge" />
+                )}
               </div>
             </div>
           )

--- a/packages/dmworkbase/src/Components/MessageInput/__tests__/MentionList.test.tsx
+++ b/packages/dmworkbase/src/Components/MessageInput/__tests__/MentionList.test.tsx
@@ -94,6 +94,24 @@ describe("MentionList interaction mode", () => {
     expect(options[1].className).not.toContain("is-selected");
   });
 
+  it("renders bot badges with mention-list alignment classes", () => {
+    renderMentionList(vi.fn(), [
+      { uid: "uid-human", name: "Alice", icon: "avatar://alice" },
+      { uid: "uid-bot", name: "Bot Alpha", icon: "avatar://bot", isBot: true },
+    ]);
+
+    const [humanOption, botOption] = optionElements();
+    const content = botOption.querySelector(".mention-list-item-content");
+    const badge = botOption.querySelector(".ai-badge");
+
+    expect(content).not.toBeNull();
+    expect(content?.textContent).toContain("Bot Alpha");
+    expect(badge).not.toBeNull();
+    expect(badge?.classList.contains("ai-badge-small")).toBe(true);
+    expect(badge?.classList.contains("mention-list-item-ai-badge")).toBe(true);
+    expect(humanOption.querySelector(".ai-badge")).toBeNull();
+  });
+
   it("switches to mouse mode on pointer movement and uses click for mouse selection", () => {
     const command = vi.fn();
     renderMentionList(command);


### PR DESCRIPTION
## Summary

- Align the AI badge in the @mention suggestion list with the user name row.
- Add a local 4px gap between mention names and the AI badge without changing the shared AiBadge defaults.
- Cover bot/non-bot rendering in the MentionList component test.

Fixes #1152

## Tests

- `pnpm exec vitest run packages/dmworkbase/src/Components/MessageInput/__tests__/MentionList.test.tsx`
- `cd apps/web && pnpm exec vitest run --config vitest.config.ts src/__tests__/components/AiBadge.test.tsx`
- `pnpm exec stylelint packages/dmworkbase/src/Components/MessageInput/MentionList.css --config stylelint.config.mjs --allow-empty-input`
- `pnpm --filter @octo/web build`
- `git diff --check`

## Visual evidence

Verified with a Playwright-rendered preview that the mention row uses centered flex alignment and the AI badge has a 4px left margin.