### PR TITLE
fix: 输入框 @mention 加浅紫胶囊背景，展示层对齐设计 token (#1153)

### DIFF
--- a/packages/dmworkbase/src/Components/MessageInput/__tests__/mentionStyle.test.tsx
+++ b/packages/dmworkbase/src/Components/MessageInput/__tests__/mentionStyle.test.tsx
@@ -8,6 +8,10 @@ import StarterKit from "@tiptap/starter-kit";
 import TiptapMention from "@tiptap/extension-mention";
 import { isBroadcastSentinelUid } from "../../../Utils/mentionRender";
 
+/**
+ * 与生产代码 MessageInput/index.tsx 保持一致的 TiptapMention 配置，
+ * 防止 renderLabel / renderText / renderHTML 之间的短路行为在测试里被绕过。
+ */
 function createMentionEditor() {
   return new Editor({
     extensions: [
@@ -36,6 +40,9 @@ function createMentionEditor() {
             `@${node.attrs.label ?? node.attrs.id}`,
           ];
         },
+        renderText({ node }) {
+          return `@${node.attrs.label ?? node.attrs.id}`;
+        },
       }),
     ],
   });
@@ -56,7 +63,6 @@ describe("Mention renderHTML class distinction", () => {
     expect(html).toContain('data-label="Alice"');
     expect(html).toContain("mention-user");
     expect(html).toContain("@Alice");
-    expect(html).not.toMatch(/class="mention"\s*[^u]|<span[^>]*class="mention"[^-]/);
   });
 
   it("@所有人(-2) 广播 mention 不包含 mention-user class", () => {

--- a/packages/dmworkbase/src/Components/MessageInput/__tests__/mentionStyle.test.tsx
+++ b/packages/dmworkbase/src/Components/MessageInput/__tests__/mentionStyle.test.tsx
@@ -1,0 +1,101 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { describe, expect, it } from "vitest";
+import { Editor } from "@tiptap/core";
+import StarterKit from "@tiptap/starter-kit";
+import TiptapMention from "@tiptap/extension-mention";
+import { isBroadcastSentinelUid } from "../../../Utils/mentionRender";
+
+function createMentionEditor() {
+  return new Editor({
+    extensions: [
+      StarterKit.configure({
+        paragraph: { HTMLAttributes: {} },
+        heading: false,
+        bulletList: false,
+        orderedList: false,
+        listItem: false,
+        codeBlock: false,
+        blockquote: false,
+        horizontalRule: false,
+        code: false,
+        hardBreak: false,
+      }),
+      TiptapMention.configure({
+        HTMLAttributes: { class: "mention" },
+        suggestion: {} as any,
+        renderHTML({ options, node }) {
+          const uid = String(node.attrs.id ?? "");
+          const isBroadcast = isBroadcastSentinelUid(uid);
+          const extraClass = isBroadcast ? "" : " mention-user";
+          return [
+            "span",
+            { ...options.HTMLAttributes, class: `mention${extraClass}` },
+            `@${node.attrs.label ?? node.attrs.id}`,
+          ];
+        },
+      }),
+    ],
+  });
+}
+
+describe("Mention renderHTML class distinction", () => {
+  it("普通成员 mention 渲染包含 mention-user class 并带 data-id/data-label", () => {
+    const editor = createMentionEditor();
+    editor.commands.insertContent({
+      type: "mention",
+      attrs: { id: "user123", label: "Alice" },
+    });
+    const html = editor.getHTML();
+    editor.destroy();
+
+    expect(html).toContain('data-type="mention"');
+    expect(html).toContain('data-id="user123"');
+    expect(html).toContain('data-label="Alice"');
+    expect(html).toContain("mention-user");
+    expect(html).toContain("@Alice");
+    expect(html).not.toMatch(/class="mention"\s*[^u]|<span[^>]*class="mention"[^-]/);
+  });
+
+  it("@所有人(-2) 广播 mention 不包含 mention-user class", () => {
+    const editor = createMentionEditor();
+    editor.commands.insertContent({
+      type: "mention",
+      attrs: { id: "-2", label: "所有人" },
+    });
+    const html = editor.getHTML();
+    editor.destroy();
+
+    expect(html).toContain('class="mention"');
+    expect(html).not.toContain("mention-user");
+    expect(html).toContain("@所有人");
+  });
+
+  it("@所有AI(-3) 广播 mention 不包含 mention-user class", () => {
+    const editor = createMentionEditor();
+    editor.commands.insertContent({
+      type: "mention",
+      attrs: { id: "-3", label: "所有AI" },
+    });
+    const html = editor.getHTML();
+    editor.destroy();
+
+    expect(html).toContain('class="mention"');
+    expect(html).not.toContain("mention-user");
+  });
+
+  it("legacy @all(-1) 和 render-all 均为 broadcast，不含 mention-user", () => {
+    for (const id of ["-1", "all"]) {
+      const editor = createMentionEditor();
+      editor.commands.insertContent({
+        type: "mention",
+        attrs: { id, label: id },
+      });
+      const html = editor.getHTML();
+      editor.destroy();
+      expect(html).not.toContain("mention-user");
+    }
+  });
+});

--- a/packages/dmworkbase/src/Components/MessageInput/__tests__/mentionStyle.test.tsx
+++ b/packages/dmworkbase/src/Components/MessageInput/__tests__/mentionStyle.test.tsx
@@ -33,10 +33,11 @@ function createMentionEditor() {
         renderHTML({ options, node }) {
           const uid = String(node.attrs.id ?? "");
           const isBroadcast = isBroadcastSentinelUid(uid);
-          const extraClass = isBroadcast ? "" : " mention-user";
+          const baseClass = options.HTMLAttributes?.class ?? "mention";
+          const cls = isBroadcast ? baseClass : `${baseClass} mention-user`;
           return [
             "span",
-            { ...options.HTMLAttributes, class: `mention${extraClass}` },
+            { ...options.HTMLAttributes, class: cls },
             `@${node.attrs.label ?? node.attrs.id}`,
           ];
         },

--- a/packages/dmworkbase/src/Components/MessageInput/__tests__/mentionStyle.test.tsx
+++ b/packages/dmworkbase/src/Components/MessageInput/__tests__/mentionStyle.test.tsx
@@ -6,7 +6,12 @@ import { describe, expect, it } from "vitest";
 import { Editor } from "@tiptap/core";
 import StarterKit from "@tiptap/starter-kit";
 import TiptapMention from "@tiptap/extension-mention";
-import { mentionNodeClass, isBroadcastSentinelUid } from "../../../Utils/mentionRender";
+import { readFileSync } from "fs";
+import path from "path";
+import { isBroadcastSentinelUid } from "../../../Utils/mentionRender";
+
+const cssPath = path.resolve(__dirname, "../index.css");
+const css = readFileSync(cssPath, "utf-8");
 
 function createMentionEditor() {
   return new Editor({
@@ -26,16 +31,6 @@ function createMentionEditor() {
       TiptapMention.configure({
         HTMLAttributes: { class: "mention" },
         suggestion: {} as any,
-        renderHTML({ options, node }) {
-          const uid = String(node.attrs.id ?? "");
-          const baseClass = options.HTMLAttributes?.class ?? "mention";
-          const cls = mentionNodeClass(uid, baseClass);
-          return [
-            "span",
-            { ...options.HTMLAttributes, class: cls },
-            `@${node.attrs.label ?? node.attrs.id}`,
-          ];
-        },
         renderText({ node }) {
           return `@${node.attrs.label ?? node.attrs.id}`;
         },
@@ -44,8 +39,29 @@ function createMentionEditor() {
   });
 }
 
-describe("Mention renderHTML", () => {
-  it("普通成员 mention 渲染为 mention class 并带 data-id/data-label", () => {
+describe("Mention CSS capsule style", () => {
+  it(".wk-messageinput-editor .mention 有浅紫胶囊背景（非 transparent）", () => {
+    const match = css.match(
+      /\.wk-messageinput-editor \.mention\s*{([^}]*)}/,
+    );
+    expect(match, ".wk-messageinput-editor .mention 规则应存在").not.toBeNull();
+    const block = match![1];
+    expect(block).toMatch(/background-color\s*:\s*var\(--wk-purple-alpha-08\)/);
+    expect(block).toMatch(/color\s*:\s*var\(--wk-color-accent\)/);
+    expect(block).not.toMatch(/background-color\s*:\s*transparent/);
+  });
+
+  it(".wk-messageinput-editor .mention:hover 有加深背景", () => {
+    const match = css.match(
+      /\.wk-messageinput-editor \.mention:hover\s*{([^}]*)}/,
+    );
+    expect(match, ":hover 规则应存在").not.toBeNull();
+    expect(match![1]).toMatch(/background-color\s*:\s*var\(--wk-purple-alpha-12\)/);
+  });
+});
+
+describe("Mention DOM rendering (default renderer with renderText)", () => {
+  it("普通成员 mention 渲染出 class=mention + data-id/data-label", () => {
     const editor = createMentionEditor();
     editor.commands.insertContent({
       type: "mention",
@@ -62,7 +78,7 @@ describe("Mention renderHTML", () => {
     expect(isBroadcastSentinelUid("user123")).toBe(false);
   });
 
-  it("@所有人(-2) 广播 mention 同样渲染为 mention class（与展示层一致）", () => {
+  it("@所有人(-2) 广播 mention 同样渲染 class=mention（与展示层 .mention-entity 一致）", () => {
     const editor = createMentionEditor();
     editor.commands.insertContent({
       type: "mention",
@@ -76,38 +92,21 @@ describe("Mention renderHTML", () => {
     expect(isBroadcastSentinelUid("-2")).toBe(true);
   });
 
-  it("@所有AI(-3) 广播 mention 同样渲染为 mention class", () => {
-    const editor = createMentionEditor();
-    editor.commands.insertContent({
-      type: "mention",
-      attrs: { id: "-3", label: "所有AI" },
-    });
-    const html = editor.getHTML();
-    editor.destroy();
-
-    expect(html).toContain('class="mention"');
-    expect(isBroadcastSentinelUid("-3")).toBe(true);
-  });
-
-  it("legacy -1 和 render-all 均为 broadcast sentinel，class 为 mention", () => {
-    for (const id of ["-1", "all"]) {
+  it("@所有AI(-3)、legacy -1、all 均为 broadcast sentinel 且 class=mention", () => {
+    for (const [id, label] of [
+      ["-3", "所有AI"],
+      ["-1", "所有人"],
+      ["all", "所有人"],
+    ] as const) {
       const editor = createMentionEditor();
       editor.commands.insertContent({
         type: "mention",
-        attrs: { id, label: id },
+        attrs: { id, label },
       });
       const html = editor.getHTML();
       editor.destroy();
       expect(html).toContain('class="mention"');
       expect(isBroadcastSentinelUid(id)).toBe(true);
     }
-  });
-
-  it("mentionNodeClass 对所有 uid 统一返回 baseClass（广播/普通成员视觉一致）", () => {
-    expect(mentionNodeClass("user123", "mention")).toBe("mention");
-    expect(mentionNodeClass("-2", "mention")).toBe("mention");
-    expect(mentionNodeClass("-3", "mention")).toBe("mention");
-    expect(mentionNodeClass("-1", "mention")).toBe("mention");
-    expect(mentionNodeClass("all", "mention")).toBe("mention");
   });
 });

--- a/packages/dmworkbase/src/Components/MessageInput/__tests__/mentionStyle.test.tsx
+++ b/packages/dmworkbase/src/Components/MessageInput/__tests__/mentionStyle.test.tsx
@@ -48,15 +48,13 @@ describe("Mention CSS capsule style", () => {
     const block = match![1];
     expect(block).toMatch(/background-color\s*:\s*var\(--wk-purple-alpha-08\)/);
     expect(block).toMatch(/color\s*:\s*var\(--wk-color-accent\)/);
+    expect(block).toMatch(/padding\s*:\s*var\(--wk-sp-px\)\s+var\(--wk-sp-2\)/);
     expect(block).not.toMatch(/background-color\s*:\s*transparent/);
+    expect(block).not.toMatch(/transition/);
   });
 
-  it(".wk-messageinput-editor .mention:hover 有加深背景", () => {
-    const match = css.match(
-      /\.wk-messageinput-editor \.mention:hover\s*{([^}]*)}/,
-    );
-    expect(match, ":hover 规则应存在").not.toBeNull();
-    expect(match![1]).toMatch(/background-color\s*:\s*var\(--wk-purple-alpha-12\)/);
+  it(".wk-messageinput-editor .mention 无 :hover 态（cursor:text 不响应 hover）", () => {
+    expect(css).not.toMatch(/\.wk-messageinput-editor \.mention:hover/);
   });
 });
 

--- a/packages/dmworkbase/src/Components/MessageInput/__tests__/mentionStyle.test.tsx
+++ b/packages/dmworkbase/src/Components/MessageInput/__tests__/mentionStyle.test.tsx
@@ -6,12 +6,8 @@ import { describe, expect, it } from "vitest";
 import { Editor } from "@tiptap/core";
 import StarterKit from "@tiptap/starter-kit";
 import TiptapMention from "@tiptap/extension-mention";
-import { isBroadcastSentinelUid } from "../../../Utils/mentionRender";
+import { mentionNodeClass, isBroadcastSentinelUid } from "../../../Utils/mentionRender";
 
-/**
- * 与生产代码 MessageInput/index.tsx 保持一致的 TiptapMention 配置，
- * 防止 renderLabel / renderText / renderHTML 之间的短路行为在测试里被绕过。
- */
 function createMentionEditor() {
   return new Editor({
     extensions: [
@@ -32,9 +28,8 @@ function createMentionEditor() {
         suggestion: {} as any,
         renderHTML({ options, node }) {
           const uid = String(node.attrs.id ?? "");
-          const isBroadcast = isBroadcastSentinelUid(uid);
           const baseClass = options.HTMLAttributes?.class ?? "mention";
-          const cls = isBroadcast ? baseClass : `${baseClass} mention-user`;
+          const cls = mentionNodeClass(uid, baseClass);
           return [
             "span",
             { ...options.HTMLAttributes, class: cls },
@@ -49,8 +44,8 @@ function createMentionEditor() {
   });
 }
 
-describe("Mention renderHTML class distinction", () => {
-  it("普通成员 mention 渲染包含 mention-user class 并带 data-id/data-label", () => {
+describe("Mention renderHTML", () => {
+  it("普通成员 mention 渲染为 mention class 并带 data-id/data-label", () => {
     const editor = createMentionEditor();
     editor.commands.insertContent({
       type: "mention",
@@ -62,11 +57,12 @@ describe("Mention renderHTML class distinction", () => {
     expect(html).toContain('data-type="mention"');
     expect(html).toContain('data-id="user123"');
     expect(html).toContain('data-label="Alice"');
-    expect(html).toContain("mention-user");
+    expect(html).toContain('class="mention"');
     expect(html).toContain("@Alice");
+    expect(isBroadcastSentinelUid("user123")).toBe(false);
   });
 
-  it("@所有人(-2) 广播 mention 不包含 mention-user class", () => {
+  it("@所有人(-2) 广播 mention 同样渲染为 mention class（与展示层一致）", () => {
     const editor = createMentionEditor();
     editor.commands.insertContent({
       type: "mention",
@@ -76,11 +72,11 @@ describe("Mention renderHTML class distinction", () => {
     editor.destroy();
 
     expect(html).toContain('class="mention"');
-    expect(html).not.toContain("mention-user");
     expect(html).toContain("@所有人");
+    expect(isBroadcastSentinelUid("-2")).toBe(true);
   });
 
-  it("@所有AI(-3) 广播 mention 不包含 mention-user class", () => {
+  it("@所有AI(-3) 广播 mention 同样渲染为 mention class", () => {
     const editor = createMentionEditor();
     editor.commands.insertContent({
       type: "mention",
@@ -90,10 +86,10 @@ describe("Mention renderHTML class distinction", () => {
     editor.destroy();
 
     expect(html).toContain('class="mention"');
-    expect(html).not.toContain("mention-user");
+    expect(isBroadcastSentinelUid("-3")).toBe(true);
   });
 
-  it("legacy @all(-1) 和 render-all 均为 broadcast，不含 mention-user", () => {
+  it("legacy -1 和 render-all 均为 broadcast sentinel，class 为 mention", () => {
     for (const id of ["-1", "all"]) {
       const editor = createMentionEditor();
       editor.commands.insertContent({
@@ -102,7 +98,16 @@ describe("Mention renderHTML class distinction", () => {
       });
       const html = editor.getHTML();
       editor.destroy();
-      expect(html).not.toContain("mention-user");
+      expect(html).toContain('class="mention"');
+      expect(isBroadcastSentinelUid(id)).toBe(true);
     }
+  });
+
+  it("mentionNodeClass 对所有 uid 统一返回 baseClass（广播/普通成员视觉一致）", () => {
+    expect(mentionNodeClass("user123", "mention")).toBe("mention");
+    expect(mentionNodeClass("-2", "mention")).toBe("mention");
+    expect(mentionNodeClass("-3", "mention")).toBe("mention");
+    expect(mentionNodeClass("-1", "mention")).toBe("mention");
+    expect(mentionNodeClass("all", "mention")).toBe("mention");
   });
 });

--- a/packages/dmworkbase/src/Components/MessageInput/index.css
+++ b/packages/dmworkbase/src/Components/MessageInput/index.css
@@ -449,13 +449,27 @@
   margin: 0;
 }
 
-/* Mention 样式 */
+/* Mention 基线样式 — @所有人/@所有AI 广播态：纯紫文字，透明背景 */
 .wk-messageinput-editor .mention {
   color: var(--wk-color-theme);
   font-weight: 600;
   background-color: transparent;
   border-radius: 0.25rem;
   padding: 0 0.125rem;
+}
+
+/* 普通成员 @mention：浅紫胶囊，对齐消息展示层 .mention-entity */
+.wk-messageinput-editor .mention.mention-user {
+  background-color: rgba(107, 61, 216, 0.08);
+  border-radius: 4px;
+  padding: 2px 8px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.wk-messageinput-editor .mention.mention-user:hover {
+  background-color: rgba(107, 61, 216, 0.12);
 }
 
 /* Placeholder - Tiptap Placeholder 扩展 */

--- a/packages/dmworkbase/src/Components/MessageInput/index.css
+++ b/packages/dmworkbase/src/Components/MessageInput/index.css
@@ -449,27 +449,28 @@
   margin: 0;
 }
 
-/* Mention 基线样式 — @所有人/@所有AI 广播态：纯紫文字，透明背景 */
+/* 广播态：纯紫文字，透明背景 */
 .wk-messageinput-editor .mention {
   color: var(--wk-color-theme);
   font-weight: 600;
   background-color: transparent;
-  border-radius: 0.25rem;
-  padding: 0 0.125rem;
+  border-radius: var(--wk-r-xs);
+  padding: 0 var(--wk-sp-0-5);
 }
 
 /* 普通成员 @mention：浅紫胶囊，对齐消息展示层 .mention-entity */
 .wk-messageinput-editor .mention.mention-user {
-  background-color: rgba(107, 61, 216, 0.08);
-  border-radius: 4px;
-  padding: 2px 8px;
+  color: var(--wk-color-accent);
+  background-color: var(--wk-purple-alpha-08);
+  border-radius: var(--wk-r-xs);
+  padding: var(--wk-sp-0-5) var(--wk-sp-2);
   font-weight: 500;
   cursor: pointer;
   transition: background-color 0.2s;
 }
 
 .wk-messageinput-editor .mention.mention-user:hover {
-  background-color: rgba(107, 61, 216, 0.12);
+  background-color: var(--wk-purple-alpha-12);
 }
 
 /* Placeholder - Tiptap Placeholder 扩展 */

--- a/packages/dmworkbase/src/Components/MessageInput/index.css
+++ b/packages/dmworkbase/src/Components/MessageInput/index.css
@@ -449,27 +449,18 @@
   margin: 0;
 }
 
-/* 广播态：纯紫文字，透明背景 */
+/* @mention 胶囊：广播与普通成员视觉一致，对齐消息展示层 .mention-entity */
 .wk-messageinput-editor .mention {
-  color: var(--wk-color-theme);
-  font-weight: 600;
-  background-color: transparent;
-  border-radius: var(--wk-r-xs);
-  padding: 0 var(--wk-sp-0-5);
-}
-
-/* 普通成员 @mention：浅紫胶囊，对齐消息展示层 .mention-entity */
-.wk-messageinput-editor .mention.mention-user {
   color: var(--wk-color-accent);
   background-color: var(--wk-purple-alpha-08);
   border-radius: var(--wk-r-xs);
   padding: var(--wk-sp-0-5) var(--wk-sp-2);
   font-weight: 500;
-  cursor: pointer;
+  cursor: text;
   transition: background-color 0.2s;
 }
 
-.wk-messageinput-editor .mention.mention-user:hover {
+.wk-messageinput-editor .mention:hover {
   background-color: var(--wk-purple-alpha-12);
 }
 

--- a/packages/dmworkbase/src/Components/MessageInput/index.css
+++ b/packages/dmworkbase/src/Components/MessageInput/index.css
@@ -454,10 +454,11 @@
   color: var(--wk-color-accent);
   background-color: var(--wk-purple-alpha-08);
   border-radius: var(--wk-r-xs);
-  padding: var(--wk-sp-0-5) var(--wk-sp-2);
+  padding: 1px var(--wk-sp-2);
   font-weight: 500;
   cursor: text;
   transition: background-color 0.2s;
+  vertical-align: baseline;
 }
 
 .wk-messageinput-editor .mention:hover {

--- a/packages/dmworkbase/src/Components/MessageInput/index.css
+++ b/packages/dmworkbase/src/Components/MessageInput/index.css
@@ -454,15 +454,10 @@
   color: var(--wk-color-accent);
   background-color: var(--wk-purple-alpha-08);
   border-radius: var(--wk-r-xs);
-  padding: 1px var(--wk-sp-2);
+  padding: var(--wk-sp-px) var(--wk-sp-2);
   font-weight: 500;
   cursor: text;
-  transition: background-color 0.2s;
   vertical-align: baseline;
-}
-
-.wk-messageinput-editor .mention:hover {
-  background-color: var(--wk-purple-alpha-12);
 }
 
 /* Placeholder - Tiptap Placeholder 扩展 */

--- a/packages/dmworkbase/src/Components/MessageInput/index.tsx
+++ b/packages/dmworkbase/src/Components/MessageInput/index.tsx
@@ -582,8 +582,8 @@ const MessageInput: React.FC<MessageInputProps> = (props) => {
             `@${node.attrs.label ?? node.attrs.id}`,
           ];
         },
-        renderLabel({ options, node }) {
-          return `@${node.attrs.label}`;
+        renderText({ node }) {
+          return `@${node.attrs.label ?? node.attrs.id}`;
         },
       }),
       // 表情前缀联想：输入中文片段（如「使命」）联想出自定义表情 [使命必达]

--- a/packages/dmworkbase/src/Components/MessageInput/index.tsx
+++ b/packages/dmworkbase/src/Components/MessageInput/index.tsx
@@ -299,6 +299,7 @@ export class MentionModel {
 // them without an import cycle through this large editor module.
 import {
   buildMentionDropdownItems,
+  isBroadcastSentinelUid,
 } from "../../Utils/mentionRender";
 import {
   parseSendMentionText,
@@ -571,6 +572,16 @@ const MessageInput: React.FC<MessageInputProps> = (props) => {
             mentionActiveRef.current = active;
           }
         ),
+        renderHTML({ options, node }) {
+          const uid = String(node.attrs.id ?? "");
+          const isBroadcast = isBroadcastSentinelUid(uid);
+          const extraClass = isBroadcast ? "" : " mention-user";
+          return [
+            "span",
+            { ...options.HTMLAttributes, class: `mention${extraClass}` },
+            `@${node.attrs.label ?? node.attrs.id}`,
+          ];
+        },
         renderLabel({ options, node }) {
           return `@${node.attrs.label}`;
         },

--- a/packages/dmworkbase/src/Components/MessageInput/index.tsx
+++ b/packages/dmworkbase/src/Components/MessageInput/index.tsx
@@ -575,10 +575,11 @@ const MessageInput: React.FC<MessageInputProps> = (props) => {
         renderHTML({ options, node }) {
           const uid = String(node.attrs.id ?? "");
           const isBroadcast = isBroadcastSentinelUid(uid);
-          const extraClass = isBroadcast ? "" : " mention-user";
+          const baseClass = options.HTMLAttributes?.class ?? "mention";
+          const cls = isBroadcast ? baseClass : `${baseClass} mention-user`;
           return [
             "span",
-            { ...options.HTMLAttributes, class: `mention${extraClass}` },
+            { ...options.HTMLAttributes, class: cls },
             `@${node.attrs.label ?? node.attrs.id}`,
           ];
         },

--- a/packages/dmworkbase/src/Components/MessageInput/index.tsx
+++ b/packages/dmworkbase/src/Components/MessageInput/index.tsx
@@ -299,7 +299,7 @@ export class MentionModel {
 // them without an import cycle through this large editor module.
 import {
   buildMentionDropdownItems,
-  isBroadcastSentinelUid,
+  mentionNodeClass,
 } from "../../Utils/mentionRender";
 import {
   parseSendMentionText,
@@ -574,9 +574,8 @@ const MessageInput: React.FC<MessageInputProps> = (props) => {
         ),
         renderHTML({ options, node }) {
           const uid = String(node.attrs.id ?? "");
-          const isBroadcast = isBroadcastSentinelUid(uid);
           const baseClass = options.HTMLAttributes?.class ?? "mention";
-          const cls = isBroadcast ? baseClass : `${baseClass} mention-user`;
+          const cls = mentionNodeClass(uid, baseClass);
           return [
             "span",
             { ...options.HTMLAttributes, class: cls },

--- a/packages/dmworkbase/src/Components/MessageInput/index.tsx
+++ b/packages/dmworkbase/src/Components/MessageInput/index.tsx
@@ -299,7 +299,6 @@ export class MentionModel {
 // them without an import cycle through this large editor module.
 import {
   buildMentionDropdownItems,
-  mentionNodeClass,
 } from "../../Utils/mentionRender";
 import {
   parseSendMentionText,
@@ -572,16 +571,6 @@ const MessageInput: React.FC<MessageInputProps> = (props) => {
             mentionActiveRef.current = active;
           }
         ),
-        renderHTML({ options, node }) {
-          const uid = String(node.attrs.id ?? "");
-          const baseClass = options.HTMLAttributes?.class ?? "mention";
-          const cls = mentionNodeClass(uid, baseClass);
-          return [
-            "span",
-            { ...options.HTMLAttributes, class: cls },
-            `@${node.attrs.label ?? node.attrs.id}`,
-          ];
-        },
         renderText({ node }) {
           return `@${node.attrs.label ?? node.attrs.id}`;
         },

--- a/packages/dmworkbase/src/Utils/mentionRender.ts
+++ b/packages/dmworkbase/src/Utils/mentionRender.ts
@@ -143,6 +143,16 @@ export function isBroadcastSentinelUid(uid: string): boolean {
   );
 }
 
+/**
+ * 输入框 mention 节点在编辑器内的 DOM class：
+ * 广播 sentinel（@所有人/@所有AI/legacy）与普通成员视觉一致（胶囊背景），
+ * 统一返回 baseClass；此前版本给广播加无背景分支，但消息展示层
+ * uid==="all" 同样走 .mention-entity 胶囊，输入侧不一致会造成发送后跳变。
+ */
+export function mentionNodeClass(uid: string, baseClass: string = "mention"): string {
+  return baseClass;
+}
+
 // Internal control char that tags a broadcast-sentinel marker as originating
 // from a sanctioned editor mention node (typed-@ dropdown) rather than from
 // untrusted literal text. The send serializer prefixes a sentinel uid with this

--- a/packages/dmworkbase/src/Utils/mentionRender.ts
+++ b/packages/dmworkbase/src/Utils/mentionRender.ts
@@ -143,16 +143,6 @@ export function isBroadcastSentinelUid(uid: string): boolean {
   );
 }
 
-/**
- * 输入框 mention 节点在编辑器内的 DOM class：
- * 广播 sentinel（@所有人/@所有AI/legacy）与普通成员视觉一致（胶囊背景），
- * 统一返回 baseClass；此前版本给广播加无背景分支，但消息展示层
- * uid==="all" 同样走 .mention-entity 胶囊，输入侧不一致会造成发送后跳变。
- */
-export function mentionNodeClass(uid: string, baseClass: string = "mention"): string {
-  return baseClass;
-}
-
 // Internal control char that tags a broadcast-sentinel marker as originating
 // from a sanctioned editor mention node (typed-@ dropdown) rather than from
 // untrusted literal text. The send serializer prefixes a sentinel uid with this

--- a/packages/dmworkbase/src/theme/semantic.css
+++ b/packages/dmworkbase/src/theme/semantic.css
@@ -190,6 +190,7 @@
   --wk-text-mono-sm: 400 11px/1.4 var(--wk-font-mono);
 
   /* ── Spacing — 4px 栅格 ── */
+  --wk-sp-px: 1px;
   --wk-sp-0-5: 2px;
   --wk-sp-1: 4px;
   --wk-sp-1-5: 6px;

--- a/packages/dmworkbase/src/ui/message/TextContent/index.css
+++ b/packages/dmworkbase/src/ui/message/TextContent/index.css
@@ -32,30 +32,30 @@
  * 或者重写 @ 渲染逻辑
  */
 
-/* @所有人/@频道：Figma — 纯紫色文字，无背景，不可点击 */
+/* @频道/特殊高亮：纯紫色文字，无背景 */
 .wk-msg-text-content .mention-highlight {
-  color: rgba(127, 59, 245, 1);
+  color: var(--wk-color-accent);
   font-weight: 400;
   cursor: default;
 }
 
-/* 普通用户：紫色文字 + 浅紫背景（次优先级） */
+/* 普通用户：紫色文字 + 浅紫背景（次优先级），与输入框共用设计 token */
 .wk-msg-text-content .mention-entity {
-  color: #6B3DD8;
-  background-color: rgba(107, 61, 216, 0.08);
-  border-radius: 4px;
-  padding: 2px 8px;
+  color: var(--wk-color-accent);
+  background-color: var(--wk-purple-alpha-08);
+  border-radius: var(--wk-r-xs);
+  padding: var(--wk-sp-0-5) var(--wk-sp-2);
   font-weight: 500;
   cursor: pointer;
   transition: background-color 0.2s;
 }
 
 .wk-msg-text-content .mention-entity:hover {
-  background-color: rgba(107, 61, 216, 0.12);
+  background-color: var(--wk-purple-alpha-12);
 }
 
 /* 降级：未解析 @ — 纯紫色文字，无背景 */
 .wk-msg-text-content .mention-fallback {
-  color: #6B3DD8;
+  color: var(--wk-color-accent);
   font-weight: 400;
 }


### PR DESCRIPTION
Fixes #1153

## 背景
Web 端消息输入框内 @mention 普通成员只显示紫色文字，没有浅紫胶囊背景；发送后才出现胶囊，造成输入↔发送视觉跳变。

## 决策说明
Issue 原文要求 `@所有人`/`@所有AI` 保持纯紫文字无胶囊，但展示层 `mentionRenderState.ts:12-19` 对 `uid === "all"` 返回 `.mention-entity`（同款胶囊），GH#295 测试锁定了「广播 mention 与普通成员同款高亮（视觉一致）」。经 maintainer 确认采用统一方案：输入框与展示层一致，广播与普通成员均使用胶囊样式，消除发送跳变。

## 变更摘要（5 files, +137 -29 vs origin/main）

### 输入框（MessageInput）
- `index.css`：`.wk-messageinput-editor .mention` 统一胶囊样式，使用设计 token：`color: var(--wk-color-accent)`（#7f3bf5）、`background-color: var(--wk-purple-alpha-08)`、`border-radius: var(--wk-r-xs)`（3px）、`padding: var(--wk-sp-px) var(--wk-sp-2)`（1px 8px，垂直 1px 防止 20px 行高内溢出）、`font-weight: 500`、`cursor: text`、`vertical-align: baseline`；无 `:hover` 态（cursor:text 不响应 hover，避免虚假交互暗示）
- `index.tsx`：移除废弃 `renderLabel`（消除 deprecation warning 并修复无 label 时渲染 `@null` 的问题），改用 `renderText` 兜底（`label ?? id`）；Tiptap 默认渲染器已正确输出 `class="mention"` + `data-type`/`data-id`/`data-label`，无自定义 `renderHTML`

### 展示层（TextContent）—— 设计 token 迁移
- `ui/message/TextContent/index.css`：`.mention-entity`/`:hover`/`.mention-highlight`/`.mention-fallback` 全部从硬编码 `#6B3DD8`/`rgba(107,61,216,...)`/`4px`/`2px 8px` 迁移到设计 token，与输入框共用同一套 token 确保视觉一致
- 颜色差异：紫色从 #6B3DD8 统一为 token 标准紫 #7f3bf5（`--wk-purple-500`），圆角从 4px 统一为 3px（`--wk-r-xs`）；WCAG 对比度 5.46:1，仍高于 AA 4.5:1
- 该迁移为必须：输入框改 token 后若展示层保留旧硬编码色会导致两版紫色并存；同时遵守 DEVELOPMENT.md 禁止硬编码规则

### 设计 token
- `theme/semantic.css`：新增 `--wk-sp-px: 1px` 间距 token，供 mention 胶囊垂直 padding 使用

### 测试
- `__tests__/mentionStyle.test.tsx`：CSS 源码字符串断言 `.mention` 规则含正确 token、无 transparent、无 `:hover` 规则；最小 TiptapMention 配置验证普通成员 + 广播 sentinel（-1/-2/-3/all）均渲染 `class="mention"`

## 改动文件
- `packages/dmworkbase/src/Components/MessageInput/index.tsx`
- `packages/dmworkbase/src/Components/MessageInput/index.css`
- `packages/dmworkbase/src/Components/MessageInput/__tests__/mentionStyle.test.tsx`（新增）
- `packages/dmworkbase/src/ui/message/TextContent/index.css`
- `packages/dmworkbase/src/theme/semantic.css`

## 验证证据
```
cd /Users/guosong/Desktop/Sina/Code/octo-web/packages/dmworkbase
pnpm exec vitest run src/Components/MessageInput/__tests__/
# Test Files  7 passed (7)
#      Tests  104 passed (104)

pnpm exec vitest run src/Messages/Text/__tests__/
# Test Files  4 passed (4)
#      Tests  24 passed (24)

git diff --check origin/main...HEAD
# 无输出（无 whitespace 问题）
```

## Comprehension gate
不涉及公开 API/协议/存储格式变更，纯视觉修复。回滚方式：revert 本 PR。
