### PR TITLE
fix(conversation): clear restored draft after send

### DIFF
--- a/packages/dmworkbase/src/Components/Conversation/index.tsx
+++ b/packages/dmworkbase/src/Components/Conversation/index.tsx
@@ -1528,12 +1528,14 @@ export class Conversation
 
   async clearDraftAfterSend(
     sendDraftGeneration: number,
-    remoteDraftAtSend: string
+    remoteDraftAtSend: string,
+    draftAtSend: string
   ) {
     const remoteExtra = this.vm.currentConversation?.remoteExtra;
     if (
       !shouldClearDraftAfterSend({
         liveDraft: this.messageInputContext()?.text() || "",
+        draftAtSend,
         remoteDraft: remoteExtra?.draft || "",
         remoteDraftAtSend,
         draftSavedAfterSend: this.draftSaveGeneration !== sendDraftGeneration,
@@ -2858,6 +2860,8 @@ export class Conversation
                         const sendDraftGeneration = this.draftSaveGeneration;
                         const remoteDraftAtSend =
                           this.vm.currentConversation?.remoteExtra?.draft || "";
+                        const draftAtSend =
+                          this.messageInputContext()?.text() || "";
                         VoiceFeedback.shared()?.submitAll(text);
 
                         // ── 回复/编辑处理 ──────────────
@@ -3117,7 +3121,8 @@ export class Conversation
                           if (mixedSent) {
                             await this.clearDraftAfterSend(
                               sendDraftGeneration,
-                              remoteDraftAtSend
+                              remoteDraftAtSend,
+                              draftAtSend
                             );
                           }
                           return finishRichTextMixedSend(
@@ -3196,7 +3201,8 @@ export class Conversation
                             if (mixedSent) {
                               await this.clearDraftAfterSend(
                                 sendDraftGeneration,
-                                remoteDraftAtSend
+                                remoteDraftAtSend,
+                                draftAtSend
                               );
                             }
                             // 返回 snapshot-aware 结果 (octo-web#227 Jerry-Xin
@@ -3277,7 +3283,8 @@ export class Conversation
                         if (anyMessageSent) {
                           await this.clearDraftAfterSend(
                             sendDraftGeneration,
-                            remoteDraftAtSend
+                            remoteDraftAtSend,
+                            draftAtSend
                           );
                         }
                         if (anyMessageSent) this.props.onMessageSent?.();

--- a/packages/dmworkbase/src/Utils/__tests__/draftLifecycle.test.ts
+++ b/packages/dmworkbase/src/Utils/__tests__/draftLifecycle.test.ts
@@ -4,6 +4,7 @@ import { shouldClearDraftAfterSend } from "../draftLifecycle"
 describe("shouldClearDraftAfterSend", () => {
     it("clears the draft snapshot that belonged to the sent message", () => {
         expect(shouldClearDraftAfterSend({
+            draftAtSend: "hello",
             remoteDraft: "hello",
             remoteDraftAtSend: "hello",
             draftSavedAfterSend: false,
@@ -13,14 +14,26 @@ describe("shouldClearDraftAfterSend", () => {
     it("does not clear a live draft typed while the send is pending", () => {
         expect(shouldClearDraftAfterSend({
             liveDraft: "new draft",
+            draftAtSend: "hello",
             remoteDraft: "hello",
             remoteDraftAtSend: "hello",
             draftSavedAfterSend: false,
         })).toBe(false)
     })
 
+    it("clears a restored draft while the sent snapshot is still in the editor", () => {
+        expect(shouldClearDraftAfterSend({
+            liveDraft: "hello",
+            draftAtSend: "hello",
+            remoteDraft: "hello",
+            remoteDraftAtSend: "hello",
+            draftSavedAfterSend: false,
+        })).toBe(true)
+    })
+
     it("does not clear a newer draft saved while the send is pending", () => {
         expect(shouldClearDraftAfterSend({
+            draftAtSend: "hello",
             remoteDraft: "hello",
             remoteDraftAtSend: "hello",
             draftSavedAfterSend: true,
@@ -28,8 +41,20 @@ describe("shouldClearDraftAfterSend", () => {
         })).toBe(false)
     })
 
+    it("allows the clear when a later save still contains only the sent snapshot", () => {
+        expect(shouldClearDraftAfterSend({
+            liveDraft: "hello",
+            draftAtSend: "hello",
+            remoteDraft: "hello",
+            remoteDraftAtSend: "hello",
+            draftSavedAfterSend: true,
+            latestSavedDraft: "hello",
+        })).toBe(true)
+    })
+
     it("allows the clear when the only later save is an empty editor", () => {
         expect(shouldClearDraftAfterSend({
+            draftAtSend: "hello",
             remoteDraft: "hello",
             remoteDraftAtSend: "hello",
             draftSavedAfterSend: true,
@@ -39,15 +64,17 @@ describe("shouldClearDraftAfterSend", () => {
 
     it("clears an edited restored draft after it is sent", () => {
         expect(shouldClearDraftAfterSend({
+            draftAtSend: "hello edited",
             remoteDraft: "hello",
             remoteDraftAtSend: "hello",
-            liveDraft: "",
+            liveDraft: "hello edited",
             draftSavedAfterSend: false,
         })).toBe(true)
     })
 
     it("does not clear a remote draft updated while the send is pending", () => {
         expect(shouldClearDraftAfterSend({
+            draftAtSend: "hello",
             remoteDraft: "remote new draft",
             remoteDraftAtSend: "hello",
             liveDraft: "",

--- a/packages/dmworkbase/src/Utils/draftLifecycle.ts
+++ b/packages/dmworkbase/src/Utils/draftLifecycle.ts
@@ -1,5 +1,6 @@
 export interface ShouldClearDraftAfterSendOptions {
     liveDraft?: string
+    draftAtSend: string
     remoteDraft?: string
     remoteDraftAtSend?: string
     draftSavedAfterSend: boolean
@@ -8,13 +9,20 @@ export interface ShouldClearDraftAfterSendOptions {
 
 export function shouldClearDraftAfterSend({
     liveDraft,
+    draftAtSend,
     remoteDraft,
     remoteDraftAtSend,
     draftSavedAfterSend,
     latestSavedDraft,
 }: ShouldClearDraftAfterSendOptions): boolean {
-    if (liveDraft) return false
-    if (draftSavedAfterSend && latestSavedDraft) return false
+    // MessageInput clears the editor only after onSend resolves, so the sent
+    // snapshot can still be live here. Only a different value is a newer draft.
+    if (liveDraft && liveDraft !== draftAtSend) return false
+    if (
+        draftSavedAfterSend &&
+        latestSavedDraft &&
+        latestSavedDraft !== draftAtSend
+    ) return false
     if ((remoteDraft || "") !== (remoteDraftAtSend || "")) return false
 
     return true


### PR DESCRIPTION
## Summary

- capture the editor draft snapshot when a send starts
- clear the persisted conversation draft when the live value still matches the sent snapshot
- preserve a genuinely newer draft typed or saved while the send is pending

## Testing

- `pnpm --filter @octo/base exec vitest run src/Utils/__tests__/draftLifecycle.test.ts src/Components/MessageInput/__tests__/sendFlow.test.ts`
- `pnpm --dir apps/web build`
- `git diff --check`

Fixes #1168

Related: #1076, #1077