### PR TITLE
fix(subscribers): refresh bot avatar in expanded group info

### DIFF
--- a/apps/web/src/__tests__/components/SubscribersAvatarRefresh.test.tsx
+++ b/apps/web/src/__tests__/components/SubscribersAvatarRefresh.test.tsx
@@ -1,0 +1,117 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { Subscribers } from "../../../../../packages/dmworkbase/src/Components/Subscribers";
+
+vi.mock("wukongimjssdk", () => {
+  class Channel {
+    channelID: string;
+    channelType: number;
+
+    constructor(channelID: string, channelType: number) {
+      this.channelID = channelID;
+      this.channelType = channelType;
+    }
+  }
+
+  return {
+    Channel,
+    ChannelTypePerson: 1,
+  };
+});
+
+vi.mock("../../../../../packages/dmworkbase/src/App", () => ({
+  default: {
+    shared: {
+      baseContext: { showUserInfo: vi.fn() },
+      avatarUser: vi.fn(() => "stale-avatar.png"),
+    },
+  },
+}));
+
+vi.mock(
+  "../../../../../packages/dmworkbase/src/Components/WKAvatar",
+  () => ({
+    default: ({ channel }: any) => (
+      <img
+        data-testid="subscriber-avatar"
+        data-channel-id={channel.channelID}
+        data-channel-type={channel.channelType}
+        alt=""
+      />
+    ),
+  })
+);
+
+vi.mock("../../../../../packages/dmworkbase/src/Service/Provider", () => ({
+  default: () => null,
+}));
+vi.mock(
+  "../../../../../packages/dmworkbase/src/Components/Subscribers/vm",
+  () => ({ SubscribersVM: class {} })
+);
+vi.mock(
+  "../../../../../packages/dmworkbase/src/Components/IndexTable",
+  () => ({ default: () => null, IndexTableItem: class {} })
+);
+vi.mock("../../../../../packages/dmworkbase/src/Components/WKBase", () => ({
+  default: () => null,
+}));
+vi.mock("../../../../../packages/dmworkbase/src/Service/Context", () => ({
+  default: class {},
+}));
+vi.mock(
+  "../../../../../packages/dmworkbase/src/Components/Subscribers/list",
+  () => ({ SubscriberList: () => null })
+);
+vi.mock(
+  "../../../../../packages/dmworkbase/src/Utils/externalViewer",
+  () => ({ resolveExternalForViewer: () => ({ isExternal: false }) })
+);
+vi.mock(
+  "../../../../../packages/dmworkbase/src/Utils/displayName",
+  () => ({ isRealnameVerified: () => false })
+);
+vi.mock("../../../../../packages/dmworkbase/src/Service/Const", () => ({
+  GroupRole: { owner: 1, manager: 2 },
+}));
+vi.mock(
+  "../../../../../packages/dmworkbase/src/Components/RealnameVerifiedBadge",
+  () => ({ default: () => null })
+);
+vi.mock("../../../../../packages/dmworkbase/src/i18n", async () => {
+  const React = await import("react");
+  return {
+    I18nContext: React.createContext({ t: (key: string) => key }),
+  };
+});
+vi.mock(
+  "../../../../../packages/dmworkbase/src/features/channelSetting/channelSettingMemberSearch",
+  () => ({ createChannelSettingMemberSearch: vi.fn() })
+);
+
+describe("Subscribers member preview avatar", () => {
+  it("passes the member person channel to WKAvatar for live refresh", () => {
+    const subscribers = new Subscribers({
+      context: {} as any,
+      channel: {},
+    });
+
+    render(
+      subscribers.subscriberUI({
+        uid: "bot-1170",
+        name: "Bot",
+        role: 0,
+        orgData: {},
+      } as any)
+    );
+
+    expect(screen.getByTestId("subscriber-avatar")).toHaveAttribute(
+      "data-channel-id",
+      "bot-1170"
+    );
+    expect(screen.getByTestId("subscriber-avatar")).toHaveAttribute(
+      "data-channel-type",
+      "1"
+    );
+  });
+});

--- a/packages/dmworkbase/src/Components/Subscribers/index.tsx
+++ b/packages/dmworkbase/src/Components/Subscribers/index.tsx
@@ -1,4 +1,4 @@
-import { Channel, Subscriber } from "wukongimjssdk";
+import { Channel, ChannelTypePerson, Subscriber } from "wukongimjssdk";
 import React from "react";
 import { Component } from "react";
 import Provider from "../../Service/Provider";
@@ -15,6 +15,7 @@ import { GroupRole } from "../../Service/Const";
 import RealnameVerifiedBadge from "../RealnameVerifiedBadge";
 import { I18nContext } from "../../i18n";
 import { createChannelSettingMemberSearch } from "../../features/channelSetting/channelSettingMemberSearch";
+import WKAvatar from "../WKAvatar";
 
 export interface SubscribersProps {
   context: RouteContext<any>;
@@ -52,7 +53,9 @@ export class Subscribers extends Component<SubscribersProps> {
         }}
       >
         <div className="wk-subscribers-item-avatar-wrap">
-          <img src={WKApp.shared.avatarUser(subscriber.uid)} alt=""></img>
+          <WKAvatar
+            channel={new Channel(subscriber.uid, ChannelTypePerson)}
+          />
           {subscriber.role === GroupRole.owner && (
             <span className="wk-subscribers-item-role-badge wk-subscribers-item-role-badge-owner">
               {this.context.t("base.subscribers.role.owner")}


### PR DESCRIPTION
## Summary

- render group-info member preview avatars with `WKAvatar` bound to the member person channel
- reuse the existing `channel-avatar-changed` cache-busting flow after a bot avatar upload
- add a regression test covering the `Subscribers` integration

## Scope

- no changes to bot profile online status
- no changes to upload APIs, WKSDK, datasource, member cache, search, pagination, permissions, or entry points

## Testing

- `pnpm --dir apps/web exec vitest run src/__tests__/components/SubscribersAvatarRefresh.test.tsx src/__tests__/components/BotAvatarRefresh.test.tsx`
- `pnpm --dir packages/dmworkbase exec vitest run src/bridge/profileDetail/__tests__/BotDetailVM.test.ts src/Components/ChannelSetting/__tests__/vm.persona.test.ts`
- `pnpm --dir apps/web build`

Fixes #1170