### PR TITLE
fix(conversation): clear stale unread down-arrow state

### DIFF
--- a/packages/dmworkbase/src/Components/Conversation/__tests__/historyScroll.test.ts
+++ b/packages/dmworkbase/src/Components/Conversation/__tests__/historyScroll.test.ts
@@ -3,7 +3,9 @@ import {
     getPulldownRestoredScrollTop,
     getRestoredAnchorScrollTop,
     getScrollAnchorOffsetY,
+    shouldShowScrollToBottom,
     shouldPulldownOnWheel,
+    BOTTOM_SCROLL_TOLERANCE,
     TOP_HISTORY_TRIGGER_OFFSET,
 } from "../historyScroll"
 
@@ -63,5 +65,26 @@ describe("shouldPulldownOnWheel", () => {
 
     it("does not trigger pulldown on downward wheel movement", () => {
         expect(shouldPulldownOnWheel(12, 0, false)).toBe(false)
+    })
+})
+
+describe("shouldShowScrollToBottom", () => {
+    it("hides the button at the bottom even when the latest message has no DOM row", () => {
+        expect(shouldShowScrollToBottom(0)).toBe(false)
+        expect(shouldShowScrollToBottom(BOTTOM_SCROLL_TOLERANCE)).toBe(false)
+    })
+
+    it("shows the button away from the bottom when the latest message has no DOM row", () => {
+        expect(shouldShowScrollToBottom(BOTTOM_SCROLL_TOLERANCE + 1)).toBe(true)
+    })
+
+    it("preserves the latest-message visibility threshold when its DOM row exists", () => {
+        expect(shouldShowScrollToBottom(100, 100)).toBe(false)
+        expect(
+            shouldShowScrollToBottom(
+                100 + BOTTOM_SCROLL_TOLERANCE + 1,
+                100
+            )
+        ).toBe(true)
     })
 })

--- a/packages/dmworkbase/src/Components/Conversation/__tests__/messageOrder.test.ts
+++ b/packages/dmworkbase/src/Components/Conversation/__tests__/messageOrder.test.ts
@@ -6,6 +6,11 @@ const sdkState = vi.hoisted(() => ({
     sendingQueues: new Map<number, unknown>(),
     channelInfos: new Map<string, any>(),
     syncMessages: vi.fn(),
+    conversation: null as any,
+    notifyConversationListeners: vi.fn(),
+    scrollToBottom: vi.fn(),
+    markConversationUnread: vi.fn(() => Promise.resolve()),
+    emit: vi.fn(),
 }))
 
 vi.mock("wukongimjssdk", () => {
@@ -45,8 +50,8 @@ vi.mock("wukongimjssdk", () => {
                     notifySubscribeChangeListeners: () => {},
                 },
                 conversationManager: {
-                    findConversation: () => null,
-                    notifyConversationListeners: () => {},
+                    findConversation: () => sdkState.conversation,
+                    notifyConversationListeners: sdkState.notifyConversationListeners,
                     addConversationListener: () => {},
                     removeConversationListener: () => {},
                 },
@@ -95,9 +100,9 @@ vi.mock("../../../App", () => ({
         loginInfo: { uid: "me" },
         config: { pageSizeOfMessage: 30 },
         dataSource: { channelDataSource: { subscribers: () => Promise.resolve([]) } },
-        mittBus: { on: () => {}, off: () => {} },
+        mittBus: { on: () => {}, off: () => {}, emit: sdkState.emit },
         conversationProvider: {
-            markConversationUnread: () => Promise.resolve(),
+            markConversationUnread: sdkState.markConversationUnread,
             syncMessages: sdkState.syncMessages,
         },
         shared: { currentSpaceId: "", notifyMessageDeleteListener: () => {} },
@@ -118,7 +123,7 @@ vi.mock("../../../Service/Provider", () => ({
         didUnMount() {}
     },
 }))
-vi.mock("react-scroll", () => ({ animateScroll: { scrollToBottom: () => {} }, scroller: { scrollTo: () => {} } }))
+vi.mock("react-scroll", () => ({ animateScroll: { scrollToBottom: sdkState.scrollToBottom }, scroller: { scrollTo: () => {} } }))
 vi.mock("../../../Service/Const", () => ({
     EndpointID: {},
     MessageContentTypeConst: { time: 1001, historySplit: 1002, rtcData: 1003 },
@@ -219,6 +224,12 @@ describe("ConversationVM message ordering", () => {
         sdkState.sendingQueues.clear()
         sdkState.channelInfos.clear()
         sdkState.syncMessages.mockReset()
+        sdkState.conversation = null
+        sdkState.notifyConversationListeners.mockReset()
+        sdkState.scrollToBottom.mockReset()
+        sdkState.markConversationUnread.mockReset()
+        sdkState.markConversationUnread.mockResolvedValue(undefined)
+        sdkState.emit.mockReset()
         document.body.innerHTML = ""
     })
 
@@ -571,5 +582,67 @@ describe("ConversationVM message ordering", () => {
 
         expect(() => vm.updateReplyMessageContent({ messageID: "m1", contentEdit: "edited" } as any)).not.toThrow()
         expect(replyMsg.content.reply.content).toBe("edited")
+    })
+
+    it("clears stale unread state when the down arrow already points to the latest loaded message (#1173)", async () => {
+        const vm = new ConversationVM(channel)
+        const latest = wrap({
+            clientMsgNo: "latest",
+            messageSeq: 10,
+            timestamp: 100,
+            content: { text: "latest" },
+            fromUID: "u1",
+        })
+        sdkState.conversation = {
+            channel,
+            lastMessage: latest.message,
+            unread: 1,
+        }
+        vm.messagesOfOrigin = [latest]
+        vm.lastMessage = latest
+        vm.browseToMessageSeq = 9
+        vm.unreadCount = 1
+        vm.showScrollToBottomBtn = true
+
+        await vm.onDownArrow()
+
+        expect(sdkState.scrollToBottom).toHaveBeenCalled()
+        expect(vm.browseToMessageSeq).toBe(10)
+        expect(vm.unreadCount).toBe(0)
+        expect(vm.showScrollToBottomBtn).toBe(false)
+        expect(sdkState.markConversationUnread).toHaveBeenCalledWith(channel, 0)
+    })
+
+    it("keeps unread state when the server has a newer message that is not loaded yet (#1173)", async () => {
+        const vm = new ConversationVM(channel)
+        const loaded = wrap({
+            clientMsgNo: "loaded",
+            messageSeq: 10,
+            timestamp: 100,
+            content: { text: "loaded" },
+            fromUID: "u1",
+        })
+        sdkState.conversation = {
+            channel,
+            lastMessage: rawMessage(11),
+            unread: 1,
+        }
+        vm.messagesOfOrigin = [loaded]
+        vm.lastMessage = loaded
+        vm.browseToMessageSeq = 9
+        vm.unreadCount = 1
+        vm.showScrollToBottomBtn = true
+        const requestLatest = vi
+            .spyOn(vm, "requestMessagesOfFirstPage")
+            .mockResolvedValue(undefined as any)
+
+        await vm.onDownArrow()
+
+        expect(requestLatest).toHaveBeenCalledWith(0)
+        expect(sdkState.scrollToBottom).not.toHaveBeenCalled()
+        expect(vm.browseToMessageSeq).toBe(9)
+        expect(vm.unreadCount).toBe(1)
+        expect(vm.showScrollToBottomBtn).toBe(true)
+        expect(sdkState.markConversationUnread).not.toHaveBeenCalled()
     })
 })

--- a/packages/dmworkbase/src/Components/Conversation/historyScroll.ts
+++ b/packages/dmworkbase/src/Components/Conversation/historyScroll.ts
@@ -1,4 +1,5 @@
 export const TOP_HISTORY_TRIGGER_OFFSET = 250
+export const BOTTOM_SCROLL_TOLERANCE = 20
 
 export interface PulldownScrollRestoreInput {
     previousScrollHeight: number
@@ -39,4 +40,17 @@ export function shouldPulldownOnWheel(deltaY: number, scrollTop: number, isFullS
         return true
     }
     return scrollTop <= TOP_HISTORY_TRIGGER_OFFSET
+}
+
+export function shouldShowScrollToBottom(
+    scrollOffsetTop: number,
+    lastMessageHeight?: number
+): boolean {
+    if (scrollOffsetTop <= BOTTOM_SCROLL_TOLERANCE) {
+        return false
+    }
+    if (lastMessageHeight === undefined) {
+        return true
+    }
+    return scrollOffsetTop > lastMessageHeight + BOTTOM_SCROLL_TOLERANCE
 }

--- a/packages/dmworkbase/src/Components/Conversation/index.tsx
+++ b/packages/dmworkbase/src/Components/Conversation/index.tsx
@@ -77,6 +77,7 @@ import {
 } from "./foldSessionSummary";
 import {
   getScrollAnchorOffsetY,
+  shouldShowScrollToBottom,
   shouldPulldownOnWheel,
   TOP_HISTORY_TRIGGER_OFFSET,
 } from "./historyScroll";
@@ -2133,20 +2134,10 @@ export class Conversation
       this.vm.lastLocalMessageElement = this.getMessageElement(
         this.vm.lastMessage
       ); // 最新消息
-      if (this.vm.lastLocalMessageElement) {
-        // 如果有最新消息的dom则判断是否在可见范围内
-        if (
-          scrollOffsetTop >
-          this.vm.lastLocalMessageElement.clientHeight + 20
-        ) {
-          // 如果滚动距离超过了第一个元素则显示“滚动到底部”
-          this.vm.showScrollToBottomBtn = true;
-        } else {
-          this.vm.showScrollToBottomBtn = false;
-        }
-      } else {
-        this.vm.showScrollToBottomBtn = true;
-      }
+      this.vm.showScrollToBottomBtn = shouldShowScrollToBottom(
+        scrollOffsetTop,
+        this.vm.lastLocalMessageElement?.clientHeight
+      );
     }
 
     this.updateBrowseToMessageSeqAndReminderDoneIfNeed();

--- a/packages/dmworkbase/src/Components/Conversation/vm.ts
+++ b/packages/dmworkbase/src/Components/Conversation/vm.ts
@@ -1248,10 +1248,15 @@ export default class ConversationVM extends ProviderListener {
     async onDownArrow() {
         const conversation = WKSDK.shared().conversationManager.findConversation(this.channel)
         let onlyScroll = false
+        let latestLoadedMessage: MessageWrap | undefined
         if (conversation && conversation.lastMessage) {
             if (this.messagesOfOrigin && this.messagesOfOrigin.length > 0) {
-                const lastMessage = this.messagesOfOrigin[this.messagesOfOrigin.length - 1]
-                if (lastMessage.messageSeq >= conversation.lastMessage.messageSeq) {
+                latestLoadedMessage = this.messagesOfOrigin[this.messagesOfOrigin.length - 1]
+                const latestKnownMessageSeq = Math.max(
+                    conversation.lastMessage.messageSeq,
+                    this.lastMessage?.messageSeq || 0
+                )
+                if (latestLoadedMessage.messageSeq >= latestKnownMessageSeq) {
                     onlyScroll = true
                 }
             }
@@ -1259,6 +1264,12 @@ export default class ConversationVM extends ProviderListener {
 
         if (onlyScroll) {
             this.scrollToBottom(true)
+            this.browseToMessageSeq = Math.max(
+                this.browseToMessageSeq,
+                latestLoadedMessage?.messageSeq || 0
+            )
+            this.showScrollToBottomBtn = false
+            await this.refreshNewMsgCount()
         } else {
             return this.requestMessagesOfFirstPage(0)
         }


### PR DESCRIPTION
## Summary

- converge the unread state when the down-arrow target is already the latest locally loaded message
- hide the down-arrow whenever the message viewport is actually at the bottom, including when the latest system message has no matching DOM row
- preserve unread state and fetch the latest page when the server still has messages that are not loaded locally

## Testing

- `pnpm --filter @octo/base exec vitest run src/Components/Conversation/__tests__/historyScroll.test.ts src/Components/Conversation/__tests__/messageOrder.test.ts`
- `pnpm --dir apps/web build`
- `git diff --check`

Fixes #1173