### PR TITLE
fix(login): prevent SSO config loading flash

### DIFF
--- a/packages/dmworkbase/src/App.tsx
+++ b/packages/dmworkbase/src/App.tsx
@@ -313,27 +313,28 @@ export class WKRemoteConfig {
    */
   oidcProviders: OidcProviderConfig[] = [];
   requestSuccess: boolean = false;
+  requestFailed: boolean = false;
   private retryCount: number = 0;
   private maxRetries: number = 5; // 最大重试次数
-  // listeners 仅在 appconfig 首次成功时触发, 用来通知像登录页这种在首屏前就渲染、
-  // 而其内容(SSO 按钮文案/可见性)依赖 appconfig 字段的组件去 re-render。
+  // listeners 在 appconfig 首次完成(成功或重试耗尽失败)时触发, 用来通知像登录页这种
+  // 在首屏前就渲染、而其内容(SSO 按钮文案/可见性)依赖 appconfig 字段的组件去 re-render。
   // 不在每次失败重试上 fire, 避免重复刷新。
   private listeners: Array<() => void> = [];
   private configChangeListeners: Array<() => void> = [];
 
   /**
-   * addListener 订阅 appconfig **首次** 加载完成事件——只 fire 一次 (后续重连/手动 refetch 不再触发)。
+   * addListener 订阅 appconfig **首次** 完成事件——只 fire 一次 (后续重连/手动 refetch 不再触发)。
    * 返回 unsubscribe 函数, 调用方在卸载时务必调用。
    *
-   * 调用方契约: 订阅前应先检查 requestSuccess——已 true 时跳过订阅, 自行处理初始状态。
-   * 这里在 requestSuccess 已为 true 时返回 noop 是防御性兜底, 不构成「at-least-once 必通知」的语义。
+   * 调用方契约: 订阅前应先检查 requestSuccess / requestFailed——已完成时跳过订阅, 自行处理初始状态。
+   * 这里在已完成时返回 noop 是防御性兜底, 不构成「at-least-once 必通知」的语义。
    *
    * 为什么不在已加载时同步调一次 cb 来给「at-least-once」: cb 通常是 forceUpdate / setState,
    * 在调用方的 componentDidMount 同步栈里触发是 React 反模式; 用 microtask 又得给 cb 加
    * unmount 防护。当前唯一调用方 (Login) 已自检 requestSuccess, 不值得为此引入复杂度。
    */
   addListener(cb: () => void): () => void {
-    if (this.requestSuccess) {
+    if (this.requestSuccess || this.requestFailed) {
       return () => {
         /* noop */
       };
@@ -395,6 +396,10 @@ export class WKRemoteConfig {
       setTimeout(() => {
         this.startRequestConfig();
       }, delay);
+    } else if (!this.requestSuccess && !this.requestFailed) {
+      this.requestFailed = true;
+      console.warn("[WKRemoteConfig] requestConfig failed after max retries");
+      this.notifyListeners();
     }
   }
 
@@ -411,6 +416,7 @@ export class WKRemoteConfig {
       const previousDmpersonalOn = this.dmpersonalOn;
       const previousDriveOn = this.driveOn;
       this.requestSuccess = true;
+      this.requestFailed = false;
       this.revokeSecond = result["revoke_second"];
       this.threadOn = !!result["thread_on"];
       this.messagesSearchOn = parseRemoteBool(result["messages_search_on"]);

--- a/packages/dmworkbase/src/App.tsx
+++ b/packages/dmworkbase/src/App.tsx
@@ -203,6 +203,24 @@ export {
 } from "./Service/OidcConfig";
 export type { OidcProviderConfig } from "./Service/OidcConfig";
 
+function oidcProvidersEqual(
+  a: OidcProviderConfig[],
+  b: OidcProviderConfig[]
+): boolean {
+  if (a.length !== b.length) return false;
+  return a.every((item, index) => {
+    const other = b[index];
+    if (!other) return false;
+    return (
+      item.id === other.id &&
+      item.name === other.name &&
+      item.authorizePath === other.authorizePath &&
+      item.accountUrl === other.accountUrl &&
+      item.resetPasswordUrl === other.resetPasswordUrl
+    );
+  });
+}
+
 // StickerUploadLimits 解析同理抽到 ./Service/StickerUploadConfig：独立 leaf 文件,
 // 不拖 App.tsx 的重依赖链路, EmojiToolbar 的 vitest 可以直接测 parse 的边界情况。
 import {
@@ -415,6 +433,8 @@ export class WKRemoteConfig {
       const previousDmloopOn = this.dmloopOn;
       const previousDmpersonalOn = this.dmpersonalOn;
       const previousDriveOn = this.driveOn;
+      const previousRequestFailed = this.requestFailed;
+      const previousOidcProviders = this.oidcProviders;
       this.requestSuccess = true;
       this.requestFailed = false;
       this.revokeSecond = result["revoke_second"];
@@ -454,7 +474,9 @@ export class WKRemoteConfig {
         previousDocsOn !== this.docsOn ||
         previousDmloopOn !== this.dmloopOn ||
         previousDmpersonalOn !== this.dmpersonalOn ||
-        previousDriveOn !== this.driveOn
+        previousDriveOn !== this.driveOn ||
+        previousRequestFailed !== this.requestFailed ||
+        !oidcProvidersEqual(previousOidcProviders, this.oidcProviders)
       ) {
         this.notifyConfigChangeListeners();
       }

--- a/packages/dmworkbase/src/__tests__/remoteConfig.test.ts
+++ b/packages/dmworkbase/src/__tests__/remoteConfig.test.ts
@@ -1,0 +1,104 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const hoisted = vi.hoisted(() => {
+  const ctx = new Proxy({}, { get: () => () => {} });
+  // @ts-ignore jsdom has no canvas implementation, but lottie can be evaluated by App's import graph.
+  HTMLCanvasElement.prototype.getContext = () => ctx as any;
+  return {
+    wkConfig: { clientMsgDeviceId: "", provider: {} as any },
+  };
+});
+
+vi.mock("../EndpointCommon", () => ({
+  EndpointCommon: class {
+    addOnLogin = vi.fn();
+  },
+}));
+vi.mock("../Components/WKBase", () => ({ default: class {} }));
+vi.mock("../Service/TypingManager", () => ({
+  TypingManager: { shared: { resetAll: vi.fn() } },
+}));
+
+vi.mock("wukongimjssdk", () => {
+  class Channel {
+    channelID: string;
+    channelType: number;
+    constructor(id: string, type: number) {
+      this.channelID = id;
+      this.channelType = type;
+    }
+  }
+  return {
+    default: { Channel },
+    Channel,
+    ChannelTypePerson: 1,
+    ChannelTypeGroup: 2,
+    ChannelTypeCommunityTopic: 6,
+    Message: class {},
+    MessageContentType: { text: 1, image: 2 },
+    ConnectStatus: { Connected: 1, Disconnect: 2, ConnectKick: 3 },
+    WKSDK: {
+      shared: () => ({
+        config: hoisted.wkConfig,
+        connectManager: { addConnectStatusListener: vi.fn() },
+        channelManager: {},
+        conversationManager: {},
+      }),
+    },
+  };
+});
+
+import WKApp, { WKRemoteConfig } from "../App";
+
+describe("[api] WKRemoteConfig notifications", () => {
+  let getSpy: ReturnType<typeof vi.spyOn>;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    getSpy = vi.spyOn(WKApp.apiClient, "get");
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("notifies persistent config listeners when SSO config recovers after retry exhaustion", async () => {
+    const remoteConfig = new WKRemoteConfig();
+    (remoteConfig as unknown as { maxRetries: number }).maxRetries = 0;
+
+    const firstCompleteListener = vi.fn();
+    const configChangeListener = vi.fn();
+    remoteConfig.addListener(firstCompleteListener);
+    remoteConfig.addConfigChangeListener(configChangeListener);
+
+    getSpy.mockRejectedValueOnce(new Error("appconfig unavailable"));
+    await remoteConfig.startRequestConfig();
+
+    expect(remoteConfig.requestSuccess).toBe(false);
+    expect(remoteConfig.requestFailed).toBe(true);
+    expect(firstCompleteListener).toHaveBeenCalledTimes(1);
+    expect(configChangeListener).not.toHaveBeenCalled();
+
+    getSpy.mockResolvedValueOnce({
+      oidc_providers: [
+        {
+          id: "octo",
+          name: "Octo",
+          authorize_path: "/oidc/login",
+          account_url: "https://example.com/account",
+          reset_password_url: "https://example.com/reset",
+        },
+      ],
+    });
+    await remoteConfig.requestConfig();
+
+    expect(remoteConfig.requestSuccess).toBe(true);
+    expect(remoteConfig.requestFailed).toBe(false);
+    expect(remoteConfig.oidcProviders).toHaveLength(1);
+    expect(firstCompleteListener).toHaveBeenCalledTimes(1);
+    expect(configChangeListener).toHaveBeenCalledTimes(1);
+    expect(warnSpy).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/dmworklogin/src/__tests__/login_presentation.test.ts
+++ b/packages/dmworklogin/src/__tests__/login_presentation.test.ts
@@ -24,6 +24,25 @@ describe("login page presentation", () => {
     expect(source).toContain("addConfigChangeListener(forceUpdate)");
   });
 
+  it("holds stable space while enterprise SSO config is still loading", () => {
+    const source = readRepoFile("packages/dmworklogin/src/login.tsx");
+    const styles = readRepoFile("packages/dmworklogin/src/login.css");
+
+    expect(source).toContain(
+      "const ssoConfigPending = ENTERPRISE_SSO_ENABLED && !WKApp.remoteConfig.requestSuccess"
+    );
+    expect(source).toContain(
+      "const showLocalPasswordLogin = !ENTERPRISE_SSO_ENABLED || (!ssoConfigPending && !hasSsoProvider)"
+    );
+    expect(source).toContain("{!ssoConfigPending && (");
+    expect(source).toContain("showSsoLogin ? (");
+    expect(source).toContain("{showLocalPasswordLogin && (");
+    expect(source).toContain("wk-login-content-phonelogin--primary");
+    expect(styles).toContain(".wk-login-content-phonelogin--primary");
+    expect(styles).toContain("min-height: calc(var(--wk-sp-12) * 6);");
+    expect(styles).not.toContain("wk-login-content-config-skeleton");
+  });
+
   it("keeps registration discoverable without competing with the primary login action", () => {
     const source = readRepoFile("packages/dmworklogin/src/login.tsx");
     const styles = readRepoFile("packages/dmworklogin/src/login.css");

--- a/packages/dmworklogin/src/__tests__/login_presentation.test.ts
+++ b/packages/dmworklogin/src/__tests__/login_presentation.test.ts
@@ -37,6 +37,9 @@ describe("login page presentation", () => {
     expect(source).toContain(
       "const ssoConfigFallback = ENTERPRISE_SSO_ENABLED && WKApp.remoteConfig.requestFailed"
     );
+    expect(source).toContain(
+      "const showSsoLogin = ENTERPRISE_SSO_ENABLED && !ssoConfigPending && !ssoConfigFallback && hasSsoProvider"
+    );
     expect(source).toContain("aria-busy={ssoConfigPending}");
     expect(source).toContain('role="status"');
     expect(source).toContain("t('login.ssoConfigLoadingTitle')");
@@ -46,6 +49,12 @@ describe("login page presentation", () => {
     expect(source).toContain("wk-login-content-phonelogin--primary");
     expect(appSource).toContain("requestFailed: boolean = false;");
     expect(appSource).toContain("this.requestFailed = true;");
+    expect(appSource).toContain("const previousRequestFailed = this.requestFailed;");
+    expect(appSource).toContain("const previousOidcProviders = this.oidcProviders;");
+    expect(appSource).toContain("previousRequestFailed !== this.requestFailed");
+    expect(appSource).toContain(
+      "!oidcProvidersEqual(previousOidcProviders, this.oidcProviders)"
+    );
     expect(appSource).toContain("this.notifyListeners();");
     expect(styles).toContain(".wk-login-content-phonelogin--primary");
     expect(styles).toContain(".wk-login-content-config-status");

--- a/packages/dmworklogin/src/__tests__/login_presentation.test.ts
+++ b/packages/dmworklogin/src/__tests__/login_presentation.test.ts
@@ -21,26 +21,40 @@ describe("login page presentation", () => {
     expect(source).not.toContain("hasAcknowledgedMigrationNotice");
     expect(source).not.toContain("acknowledgeMigrationNotice");
     expect(source).not.toContain("LOGIN_MIGRATION_NOTICE_ACK_KEY");
-    expect(source).toContain("addConfigChangeListener(forceUpdate)");
+    expect(source).toContain("addConfigChangeListener(this.forceRender)");
   });
 
-  it("holds stable space while enterprise SSO config is still loading", () => {
+  it("shows recoverable states while enterprise SSO config is still loading or unavailable", () => {
     const source = readRepoFile("packages/dmworklogin/src/login.tsx");
     const styles = readRepoFile("packages/dmworklogin/src/login.css");
+    const appSource = readRepoFile("packages/dmworkbase/src/App.tsx");
+    const zhCN = readRepoFile("packages/dmworklogin/src/i18n/zh-CN.json");
+    const enUS = readRepoFile("packages/dmworklogin/src/i18n/en-US.json");
 
     expect(source).toContain(
-      "const ssoConfigPending = ENTERPRISE_SSO_ENABLED && !WKApp.remoteConfig.requestSuccess"
+      "const ssoConfigPending = ENTERPRISE_SSO_ENABLED && !WKApp.remoteConfig.requestSuccess && !WKApp.remoteConfig.requestFailed"
     );
     expect(source).toContain(
-      "const showLocalPasswordLogin = !ENTERPRISE_SSO_ENABLED || (!ssoConfigPending && !hasSsoProvider)"
+      "const ssoConfigFallback = ENTERPRISE_SSO_ENABLED && WKApp.remoteConfig.requestFailed"
     );
-    expect(source).toContain("{!ssoConfigPending && (");
+    expect(source).toContain("aria-busy={ssoConfigPending}");
+    expect(source).toContain('role="status"');
+    expect(source).toContain("t('login.ssoConfigLoadingTitle')");
+    expect(source).toContain("t('login.ssoConfigFallback')");
     expect(source).toContain("showSsoLogin ? (");
-    expect(source).toContain("{showLocalPasswordLogin && (");
+    expect(source).toContain("renderLocalPasswordLogin()");
     expect(source).toContain("wk-login-content-phonelogin--primary");
+    expect(appSource).toContain("requestFailed: boolean = false;");
+    expect(appSource).toContain("this.requestFailed = true;");
+    expect(appSource).toContain("this.notifyListeners();");
     expect(styles).toContain(".wk-login-content-phonelogin--primary");
+    expect(styles).toContain(".wk-login-content-config-status");
+    expect(styles).toContain(".wk-login-content-sso-config-fallback");
     expect(styles).toContain("min-height: calc(var(--wk-sp-12) * 6);");
-    expect(styles).not.toContain("wk-login-content-config-skeleton");
+    expect(zhCN).toContain('"ssoConfigLoadingTitle": "正在加载登录配置"');
+    expect(enUS).toContain(
+      '"ssoConfigLoadingTitle": "Loading login configuration"'
+    );
   });
 
   it("keeps registration discoverable without competing with the primary login action", () => {

--- a/packages/dmworklogin/src/i18n/en-US.json
+++ b/packages/dmworklogin/src/i18n/en-US.json
@@ -121,6 +121,9 @@
     "languageShortZh": "中文",
     "scanLogin": "QR login",
     "ssoButton": "Octo login",
+    "ssoConfigFallback": "Login configuration is temporarily unavailable. You can still use account password login.",
+    "ssoConfigLoadingSub": "Please wait. Available login methods will appear shortly.",
+    "ssoConfigLoadingTitle": "Loading login configuration",
     "ssoFlowHint": "Login and registration continue on the unified authentication page.",
     "ssoStartFailed": "Unable to start {{provider}} login",
     "welcome": "Welcome back"

--- a/packages/dmworklogin/src/i18n/zh-CN.json
+++ b/packages/dmworklogin/src/i18n/zh-CN.json
@@ -121,6 +121,9 @@
     "languageShortZh": "中文",
     "scanLogin": "扫码登录",
     "ssoButton": "Octo 登录",
+    "ssoConfigFallback": "登录配置暂时不可用，你仍可先使用账号密码登录。",
+    "ssoConfigLoadingSub": "请稍候，完成后将显示可用的登录方式",
+    "ssoConfigLoadingTitle": "正在加载登录配置",
     "ssoFlowHint": "登录和注册将在统一认证页面完成",
     "ssoStartFailed": "无法启动 {{provider}} 登录",
     "welcome": "欢迎回来"

--- a/packages/dmworklogin/src/login.css
+++ b/packages/dmworklogin/src/login.css
@@ -514,6 +514,10 @@
     width: 100%;
 }
 
+.wk-login-content-phonelogin--primary {
+    min-height: calc(var(--wk-sp-12) * 6);
+}
+
 /* ---- QR scan panel ---- */
 .wk-login-content-scanlogin {
     display: none;

--- a/packages/dmworklogin/src/login.css
+++ b/packages/dmworklogin/src/login.css
@@ -518,6 +518,39 @@
     min-height: calc(var(--wk-sp-12) * 6);
 }
 
+.wk-login-content-config-status {
+    min-height: calc(var(--wk-sp-12) * 6);
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: flex-start;
+    gap: var(--wk-sp-2);
+}
+
+.wk-login-content-config-status-title {
+    color: var(--semi-color-text-0);
+    font-size: var(--wk-text-size-lg);
+    font-weight: 600;
+    line-height: 1.35;
+}
+
+.wk-login-content-config-status-sub {
+    color: var(--semi-color-text-2);
+    font-size: var(--wk-text-size-sm);
+    line-height: 1.5;
+}
+
+.wk-login-content-sso-config-fallback {
+    margin-bottom: var(--wk-sp-4);
+    padding: var(--wk-sp-3);
+    border: 1px solid color-mix(in srgb, var(--semi-color-warning) 35%, transparent);
+    border-radius: var(--wk-r-sm);
+    background: color-mix(in srgb, var(--semi-color-warning) 10%, transparent);
+    color: var(--semi-color-text-1);
+    font-size: var(--wk-text-size-sm);
+    line-height: 1.5;
+}
+
 /* ---- QR scan panel ---- */
 .wk-login-content-scanlogin {
     display: none;

--- a/packages/dmworklogin/src/login.tsx
+++ b/packages/dmworklogin/src/login.tsx
@@ -206,7 +206,6 @@ const SsoLoginPanel: React.FC<{
     )
 }
 
-
 // 本地密码登录区域. SSO 启用时这一段默认折叠 (P0 反馈): 外部用户大多
 // 没有 Octo 本地账号, 默认显示 SSO 主按钮 + 一行"使用密码登录"链接, 比
 // 把表单常态展开干净.
@@ -438,6 +437,9 @@ class Login extends Component<any, LoginState> {
             // 按 loginInfo.loginProvider 路由各自的 reset URL, 同步检查 login.tsx:513。
             const ssoProvider = getSSOProviders()[0]
             const hasSsoProvider = !!ssoProvider
+            const ssoConfigPending = ENTERPRISE_SSO_ENABLED && !WKApp.remoteConfig.requestSuccess
+            const showSsoLogin = ENTERPRISE_SSO_ENABLED && !ssoConfigPending && hasSsoProvider
+            const showLocalPasswordLogin = !ENTERPRISE_SSO_ENABLED || (!ssoConfigPending && !hasSsoProvider)
 
             const startSsoLogin = () => {
                 if (!ssoProvider) return
@@ -527,57 +529,61 @@ class Login extends Component<any, LoginState> {
                                     : t('login.memberCount', { values: { count: vm.inviteInfo.member_count } })}</div>
                             </div>
                         )}
-                        <div className="wk-login-content-phonelogin" style={{ "display": vm.loginType === LoginType.phone ? "block" : "none" }}>
-                            <div className="wk-login-content-slogan">{t('login.welcome')}</div>
-                            {(!ENTERPRISE_SSO_ENABLED || !hasSsoProvider) && (
-                                <div className="wk-login-content-slogan-sub">{t('login.defaultSub')}</div>
-                            )}
-                            {ENTERPRISE_SSO_ENABLED && hasSsoProvider ? (
-                                // SSO 启用：统一认证作为主 CTA，注册入口和流程提示保持次级。
-                                <SsoLoginPanel
-                                    vm={vm}
-                                    ssoProvider={ssoProvider!}
-                                    startSsoLogin={startSsoLogin}
-                                    handleLogin={handleLogin}
-                                />
-                            ) : (
-                                // 未启用 SSO：保持原有布局（含本地注册入口）
-                                <div className="wk-login-content-form">
-                                    <input type="text" name="username" autoComplete="username" placeholder={t('form.email')} onChange={(v) => {
-                                        vm.username = v.target.value
-                                    }} onKeyDown={(e) => { if (e.key === 'Enter') handleLogin() }}></input>
-                                    <input type="password" name="password" autoComplete="current-password" placeholder={t('form.password')} onChange={(v) => {
-                                        vm.password = v.target.value
-                                    }} onKeyDown={(e) => { if (e.key === 'Enter') handleLogin() }}></input>
-                                    <div className="wk-login-content-form-buttons">
-                                        <Button loading={vm.loginLoading} className="wk-login-content-form-ok" type='primary' theme='solid'
-                                            onMouseDown={(e: React.MouseEvent) => { e.preventDefault() }}
-                                            onClick={handleLogin}>{t('login.button')}</Button>
-                                    </div>
-                                    <div className="wk-login-content-form-others">
-                                        <div className="wk-login-content-form-scanlogin" onClick={() => {
-                                            vm.loginType = LoginType.qrcode
-                                        }}>
-                                            {t('login.scanLogin')}
+                        <div className="wk-login-content-phonelogin wk-login-content-phonelogin--primary" style={{ "display": vm.loginType === LoginType.phone ? "block" : "none" }}>
+                            {!ssoConfigPending && (
+                                <>
+                                    <div className="wk-login-content-slogan">{t('login.welcome')}</div>
+                                    {showLocalPasswordLogin && (
+                                        <div className="wk-login-content-slogan-sub">{t('login.defaultSub')}</div>
+                                    )}
+                                    {showSsoLogin ? (
+                                        // SSO 启用：统一认证作为主 CTA，注册入口和流程提示保持次级。
+                                        <SsoLoginPanel
+                                            vm={vm}
+                                            ssoProvider={ssoProvider!}
+                                            startSsoLogin={startSsoLogin}
+                                            handleLogin={handleLogin}
+                                        />
+                                    ) : (
+                                        // 未启用 SSO：保持原有布局（含本地注册入口）
+                                        <div className="wk-login-content-form">
+                                            <input type="text" name="username" autoComplete="username" placeholder={t('form.email')} onChange={(v) => {
+                                                vm.username = v.target.value
+                                            }} onKeyDown={(e) => { if (e.key === 'Enter') handleLogin() }}></input>
+                                            <input type="password" name="password" autoComplete="current-password" placeholder={t('form.password')} onChange={(v) => {
+                                                vm.password = v.target.value
+                                            }} onKeyDown={(e) => { if (e.key === 'Enter') handleLogin() }}></input>
+                                            <div className="wk-login-content-form-buttons">
+                                                <Button loading={vm.loginLoading} className="wk-login-content-form-ok" type='primary' theme='solid'
+                                                    onMouseDown={(e: React.MouseEvent) => { e.preventDefault() }}
+                                                    onClick={handleLogin}>{t('login.button')}</Button>
+                                            </div>
+                                            <div className="wk-login-content-form-others">
+                                                <div className="wk-login-content-form-scanlogin" onClick={() => {
+                                                    vm.loginType = LoginType.qrcode
+                                                }}>
+                                                    {t('login.scanLogin')}
+                                                </div>
+                                                <div className="wk-login-content-form-switch" onClick={() => {
+                                                    vm.loginType = LoginType.register
+                                                }}>
+                                                    {t('login.noAccountRegister')}
+                                                </div>
+                                                <div className="wk-login-content-form-switch" onClick={() => {
+                                                    vm.loginType = LoginType.forgetPassword
+                                                }}>
+                                                    {t('login.forgotPassword')}
+                                                </div>
+                                            </div>
+                                            {/* 与 SSO 分支一致，保留无文案分隔线。 */}
+                                            <div className="wk-login-content-download-divider" aria-hidden="true" />
+                                            <div className="wk-login-content-download">
+                                                <AndroidDownloadButton />
+                                                <IOSDownloadButton />
+                                            </div>
                                         </div>
-                                        <div className="wk-login-content-form-switch" onClick={() => {
-                                            vm.loginType = LoginType.register
-                                        }}>
-                                            {t('login.noAccountRegister')}
-                                        </div>
-                                        <div className="wk-login-content-form-switch" onClick={() => {
-                                            vm.loginType = LoginType.forgetPassword
-                                        }}>
-                                            {t('login.forgotPassword')}
-                                        </div>
-                                    </div>
-                                    {/* 与 SSO 分支一致，保留无文案分隔线。 */}
-                                    <div className="wk-login-content-download-divider" aria-hidden="true" />
-                                    <div className="wk-login-content-download">
-                                        <AndroidDownloadButton />
-                                        <IOSDownloadButton />
-                                    </div>
-                                </div>
+                                    )}
+                                </>
                             )}
                         </div>
                         <div className="wk-login-content-phonelogin" style={{ "display": vm.loginType === LoginType.register ? "block" : "none" }}>

--- a/packages/dmworklogin/src/login.tsx
+++ b/packages/dmworklogin/src/login.tsx
@@ -442,7 +442,7 @@ class Login extends Component<any, LoginState> {
             const hasSsoProvider = !!ssoProvider
             const ssoConfigPending = ENTERPRISE_SSO_ENABLED && !WKApp.remoteConfig.requestSuccess && !WKApp.remoteConfig.requestFailed
             const ssoConfigFallback = ENTERPRISE_SSO_ENABLED && WKApp.remoteConfig.requestFailed
-            const showSsoLogin = ENTERPRISE_SSO_ENABLED && !ssoConfigPending && hasSsoProvider
+            const showSsoLogin = ENTERPRISE_SSO_ENABLED && !ssoConfigPending && !ssoConfigFallback && hasSsoProvider
             const showDefaultSloganSub = !showSsoLogin
             const renderLocalPasswordLogin = () => (
                 <div className="wk-login-content-form">

--- a/packages/dmworklogin/src/login.tsx
+++ b/packages/dmworklogin/src/login.tsx
@@ -379,16 +379,19 @@ class Login extends Component<any, LoginState> {
     private _unsubscribeRemoteConfig?: () => void
     private _unsubscribeRemoteConfigChange?: () => void
 
+    private forceRender = () => {
+        // 仓库里 React class 组件的 @types 解析有历史问题, this.forceUpdate / setState
+        // 都识别不到 (NavSettingsPanel 等处同样如此)。这里同样走 cast 跟既有写法一致。
+        ; (this as unknown as { forceUpdate(): void }).forceUpdate()
+    }
+
     componentDidMount() {
-        const forceUpdate = () => {
-            // 仓库里 React class 组件的 @types 解析有历史问题, this.forceUpdate / setState
-            // 都识别不到 (NavSettingsPanel 等处同样如此)。这里同样走 cast 跟既有写法一致。
-            ; (this as unknown as { forceUpdate(): void }).forceUpdate()
+        if (!WKApp.remoteConfig.requestSuccess && !WKApp.remoteConfig.requestFailed) {
+            this._unsubscribeRemoteConfig = WKApp.remoteConfig.addListener(this.forceRender)
+        } else {
+            this.forceRender()
         }
-        if (!WKApp.remoteConfig.requestSuccess) {
-            this._unsubscribeRemoteConfig = WKApp.remoteConfig.addListener(forceUpdate)
-        }
-        this._unsubscribeRemoteConfigChange = WKApp.remoteConfig.addConfigChangeListener(forceUpdate)
+        this._unsubscribeRemoteConfigChange = WKApp.remoteConfig.addConfigChangeListener(this.forceRender)
     }
 
     componentWillUnmount() {
@@ -437,9 +440,48 @@ class Login extends Component<any, LoginState> {
             // 按 loginInfo.loginProvider 路由各自的 reset URL, 同步检查 login.tsx:513。
             const ssoProvider = getSSOProviders()[0]
             const hasSsoProvider = !!ssoProvider
-            const ssoConfigPending = ENTERPRISE_SSO_ENABLED && !WKApp.remoteConfig.requestSuccess
+            const ssoConfigPending = ENTERPRISE_SSO_ENABLED && !WKApp.remoteConfig.requestSuccess && !WKApp.remoteConfig.requestFailed
+            const ssoConfigFallback = ENTERPRISE_SSO_ENABLED && WKApp.remoteConfig.requestFailed
             const showSsoLogin = ENTERPRISE_SSO_ENABLED && !ssoConfigPending && hasSsoProvider
-            const showLocalPasswordLogin = !ENTERPRISE_SSO_ENABLED || (!ssoConfigPending && !hasSsoProvider)
+            const showDefaultSloganSub = !showSsoLogin
+            const renderLocalPasswordLogin = () => (
+                <div className="wk-login-content-form">
+                    <input type="text" name="username" autoComplete="username" placeholder={t('form.email')} onChange={(v) => {
+                        vm.username = v.target.value
+                    }} onKeyDown={(e) => { if (e.key === 'Enter') handleLogin() }}></input>
+                    <input type="password" name="password" autoComplete="current-password" placeholder={t('form.password')} onChange={(v) => {
+                        vm.password = v.target.value
+                    }} onKeyDown={(e) => { if (e.key === 'Enter') handleLogin() }}></input>
+                    <div className="wk-login-content-form-buttons">
+                        <Button loading={vm.loginLoading} className="wk-login-content-form-ok" type='primary' theme='solid'
+                            onMouseDown={(e: React.MouseEvent) => { e.preventDefault() }}
+                            onClick={handleLogin}>{t('login.button')}</Button>
+                    </div>
+                    <div className="wk-login-content-form-others">
+                        <div className="wk-login-content-form-scanlogin" onClick={() => {
+                            vm.loginType = LoginType.qrcode
+                        }}>
+                            {t('login.scanLogin')}
+                        </div>
+                        <div className="wk-login-content-form-switch" onClick={() => {
+                            vm.loginType = LoginType.register
+                        }}>
+                            {t('login.noAccountRegister')}
+                        </div>
+                        <div className="wk-login-content-form-switch" onClick={() => {
+                            vm.loginType = LoginType.forgetPassword
+                        }}>
+                            {t('login.forgotPassword')}
+                        </div>
+                    </div>
+                    {/* 与 SSO 分支一致，保留无文案分隔线。 */}
+                    <div className="wk-login-content-download-divider" aria-hidden="true" />
+                    <div className="wk-login-content-download">
+                        <AndroidDownloadButton />
+                        <IOSDownloadButton />
+                    </div>
+                </div>
+            )
 
             const startSsoLogin = () => {
                 if (!ssoProvider) return
@@ -529,12 +571,27 @@ class Login extends Component<any, LoginState> {
                                     : t('login.memberCount', { values: { count: vm.inviteInfo.member_count } })}</div>
                             </div>
                         )}
-                        <div className="wk-login-content-phonelogin wk-login-content-phonelogin--primary" style={{ "display": vm.loginType === LoginType.phone ? "block" : "none" }}>
-                            {!ssoConfigPending && (
+                        <div
+                            className="wk-login-content-phonelogin wk-login-content-phonelogin--primary"
+                            style={{ "display": vm.loginType === LoginType.phone ? "block" : "none" }}
+                            aria-busy={ssoConfigPending}
+                        >
+                            {ssoConfigPending ? (
+                                <div className="wk-login-content-config-status" role="status" aria-live="polite">
+                                    <Spin />
+                                    <div className="wk-login-content-config-status-title">{t('login.ssoConfigLoadingTitle')}</div>
+                                    <div className="wk-login-content-config-status-sub">{t('login.ssoConfigLoadingSub')}</div>
+                                </div>
+                            ) : (
                                 <>
                                     <div className="wk-login-content-slogan">{t('login.welcome')}</div>
-                                    {showLocalPasswordLogin && (
+                                    {showDefaultSloganSub && (
                                         <div className="wk-login-content-slogan-sub">{t('login.defaultSub')}</div>
+                                    )}
+                                    {ssoConfigFallback && (
+                                        <div className="wk-login-content-sso-config-fallback" role="alert">
+                                            {t('login.ssoConfigFallback')}
+                                        </div>
                                     )}
                                     {showSsoLogin ? (
                                         // SSO 启用：统一认证作为主 CTA，注册入口和流程提示保持次级。
@@ -546,42 +603,7 @@ class Login extends Component<any, LoginState> {
                                         />
                                     ) : (
                                         // 未启用 SSO：保持原有布局（含本地注册入口）
-                                        <div className="wk-login-content-form">
-                                            <input type="text" name="username" autoComplete="username" placeholder={t('form.email')} onChange={(v) => {
-                                                vm.username = v.target.value
-                                            }} onKeyDown={(e) => { if (e.key === 'Enter') handleLogin() }}></input>
-                                            <input type="password" name="password" autoComplete="current-password" placeholder={t('form.password')} onChange={(v) => {
-                                                vm.password = v.target.value
-                                            }} onKeyDown={(e) => { if (e.key === 'Enter') handleLogin() }}></input>
-                                            <div className="wk-login-content-form-buttons">
-                                                <Button loading={vm.loginLoading} className="wk-login-content-form-ok" type='primary' theme='solid'
-                                                    onMouseDown={(e: React.MouseEvent) => { e.preventDefault() }}
-                                                    onClick={handleLogin}>{t('login.button')}</Button>
-                                            </div>
-                                            <div className="wk-login-content-form-others">
-                                                <div className="wk-login-content-form-scanlogin" onClick={() => {
-                                                    vm.loginType = LoginType.qrcode
-                                                }}>
-                                                    {t('login.scanLogin')}
-                                                </div>
-                                                <div className="wk-login-content-form-switch" onClick={() => {
-                                                    vm.loginType = LoginType.register
-                                                }}>
-                                                    {t('login.noAccountRegister')}
-                                                </div>
-                                                <div className="wk-login-content-form-switch" onClick={() => {
-                                                    vm.loginType = LoginType.forgetPassword
-                                                }}>
-                                                    {t('login.forgotPassword')}
-                                                </div>
-                                            </div>
-                                            {/* 与 SSO 分支一致，保留无文案分隔线。 */}
-                                            <div className="wk-login-content-download-divider" aria-hidden="true" />
-                                            <div className="wk-login-content-download">
-                                                <AndroidDownloadButton />
-                                                <IOSDownloadButton />
-                                            </div>
-                                        </div>
+                                        renderLocalPasswordLogin()
                                     )}
                                 </>
                             )}


### PR DESCRIPTION
## Summary
- gate the initial login content while enterprise SSO config is still loading
- keep the primary login area height stable to avoid layout jumps
- add presentation coverage for the pending SSO config state

## Tests
- git diff --check FETCH_HEAD...HEAD
- PATH=/Users/mlamp/.nvm/versions/node/v22.21.0/bin:/Users/mlamp/.yarn/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/corplink/mdm/opt/corplink-mdm/bin:/opt/homebrew/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/Users/mlamp/.codex/tmp/arg0/codex-arg0b7nIwA:/Users/mlamp/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin/override:/Users/mlamp/.yarn/bin:/opt/homebrew/sbin:/Users/mlamp/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin/fallback:/Applications/ChatGPT.app/Contents/Resources ./node_modules/.bin/vitest run packages/dmworklogin/src/__tests__/login_presentation.test.ts packages/dmworklogin/src/oidc/__tests__/providers.test.ts

Closes #1166