### PR TITLE
fix(mentions): align input and display mention states

### DIFF
--- a/packages/dmworkbase/src/Components/MessageInput/__tests__/mentionStyle.test.ts
+++ b/packages/dmworkbase/src/Components/MessageInput/__tests__/mentionStyle.test.ts
@@ -1,33 +1,134 @@
 import fs from "node:fs";
 import path from "node:path";
+import { Editor } from "@tiptap/core";
+import TiptapMention from "@tiptap/extension-mention";
+import StarterKit from "@tiptap/starter-kit";
 import { describe, expect, it } from "vitest";
+import {
+  MENTION_UID_AIS,
+  MENTION_UID_HUMANS,
+  MENTION_UID_LEGACY_ALL,
+} from "../../../Utils/mentionRender";
 
 const cssPath = path.resolve(__dirname, "../index.css");
 const css = fs.readFileSync(cssPath, "utf8");
+const cssWithoutComments = css.replace(/\/\*[\s\S]*?\*\//g, "");
+const broadcastEditorUids = [
+  MENTION_UID_LEGACY_ALL,
+  MENTION_UID_HUMANS,
+  MENTION_UID_AIS,
+];
 
 function blockFor(selector: string): string {
-  const escapedSelector = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  const match = css.match(new RegExp(`${escapedSelector}\\s*\\{([\\s\\S]*?)\\}`));
-  return match?.[1] ?? "";
+  const rulePattern = /([^{}]+)\{([^{}]*)\}/g;
+  let match: RegExpExecArray | null;
+  while ((match = rulePattern.exec(cssWithoutComments)) !== null) {
+    const selectors = match[1].split(",").map((item) => item.trim());
+    if (selectors.includes(selector)) return match[2];
+  }
+  return "";
+}
+
+function declarationsFor(selector: string): Record<string, string> {
+  return Object.fromEntries(
+    blockFor(selector)
+      .split(";")
+      .map((declaration) => declaration.trim())
+      .filter(Boolean)
+      .map((declaration) => {
+        const separatorIndex = declaration.indexOf(":");
+        return [
+          declaration.slice(0, separatorIndex).trim(),
+          declaration.slice(separatorIndex + 1).trim(),
+        ];
+      }),
+  );
+}
+
+function mentionBroadcastSelectors(): string[] {
+  const rulePattern = /([^{}]+)\{([^{}]*)\}/g;
+  const selectors: string[] = [];
+  let match: RegExpExecArray | null;
+  while ((match = rulePattern.exec(cssWithoutComments)) !== null) {
+    for (const selector of match[1].split(",").map((item) => item.trim())) {
+      if (selector.startsWith(".wk-messageinput-editor .mention[data-id=")) {
+        selectors.push(selector);
+      }
+    }
+  }
+  return selectors;
 }
 
 describe("MessageInput mention style", () => {
   it("renders ordinary member mentions as visible pills", () => {
-    const mentionBlock = blockFor(".wk-messageinput-editor .mention");
+    const declarations = declarationsFor(".wk-messageinput-editor .mention");
 
-    expect(mentionBlock).toContain("background-color: var(--wk-accent-tint-08");
-    expect(mentionBlock).toContain("border-radius: var(--wk-r-xs)");
-    expect(mentionBlock).toContain("padding: 0 var(--wk-sp-1)");
-    expect(mentionBlock).not.toContain("background-color: transparent");
+    expect(declarations.color).toBe(
+      "var(--wk-text-accent, var(--wk-color-theme))",
+    );
+    expect(declarations["background-color"]).toBe("var(--wk-bg-selected)");
+    expect(declarations["border-radius"]).toBe("var(--wk-r-xs)");
+    expect(declarations.padding).toBe("0 var(--wk-sp-1)");
   });
 
   it("keeps broadcast mention sentinels as text-only highlights", () => {
-    for (const uid of ["-1", "-2", "-3"]) {
-      expect(css).toContain(`.wk-messageinput-editor .mention[data-id="${uid}"]`);
-    }
+    expect(mentionBroadcastSelectors().sort()).toEqual(
+      broadcastEditorUids
+        .map((uid) => `.wk-messageinput-editor .mention[data-id="${uid}"]`)
+        .sort(),
+    );
 
-    const broadcastBlock = blockFor('.wk-messageinput-editor .mention[data-id="-3"]');
-    expect(broadcastBlock).toContain("background-color: transparent");
-    expect(broadcastBlock).toContain("padding: 0 var(--wk-sp-0-5)");
+    for (const uid of broadcastEditorUids) {
+      const selector = `.wk-messageinput-editor .mention[data-id="${uid}"]`;
+      const declarations = declarationsFor(selector);
+
+      expect(declarations["background-color"]).toBe("transparent");
+      expect(declarations.padding).toBe("0 var(--wk-sp-0-5)");
+    }
+  });
+
+  it("renders mention nodes with data-id for the CSS broadcast selectors", () => {
+    const editor = new Editor({
+      extensions: [
+        StarterKit.configure({
+          bold: false,
+          italic: false,
+          code: false,
+          heading: false,
+          blockquote: false,
+          horizontalRule: false,
+          codeBlock: false,
+          strike: false,
+          link: false,
+        }),
+        TiptapMention.configure({
+          HTMLAttributes: { class: "mention" },
+          renderText({ node }) {
+            return `@${node.attrs.label ?? node.attrs.id}`;
+          },
+        }),
+      ],
+      content: {
+        type: "doc",
+        content: [
+          {
+            type: "paragraph",
+            content: [
+              {
+                type: "mention",
+                attrs: { id: MENTION_UID_HUMANS, label: "所有人" },
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    const html = editor.getHTML();
+    expect(html).toContain('class="mention"');
+    expect(html).toContain('data-type="mention"');
+    expect(html).toContain(`data-id="${MENTION_UID_HUMANS}"`);
+    expect(html).toContain('data-label="所有人"');
+    editor.destroy();
   });
 });

--- a/packages/dmworkbase/src/Components/MessageInput/__tests__/mentionStyle.test.ts
+++ b/packages/dmworkbase/src/Components/MessageInput/__tests__/mentionStyle.test.ts
@@ -63,12 +63,11 @@ describe("MessageInput mention style", () => {
   it("renders ordinary member mentions as visible pills", () => {
     const declarations = declarationsFor(".wk-messageinput-editor .mention");
 
-    expect(declarations.color).toBe(
-      "var(--wk-text-accent, var(--wk-color-theme))",
-    );
-    expect(declarations["background-color"]).toBe("var(--wk-bg-selected)");
-    expect(declarations["border-radius"]).toBe("var(--wk-r-xs)");
-    expect(declarations.padding).toBe("0 var(--wk-sp-1)");
+    expect(declarations.color).toBe("var(--wk-text-mention-entity)");
+    expect(declarations["font-weight"]).toBe("500");
+    expect(declarations["background-color"]).toBe("var(--wk-accent-tint-08)");
+    expect(declarations["border-radius"]).toBe("var(--wk-r-mention-entity)");
+    expect(declarations.padding).toBe("var(--wk-sp-0-5) var(--wk-sp-2)");
   });
 
   it("keeps broadcast mention sentinels as text-only highlights", () => {
@@ -82,6 +81,10 @@ describe("MessageInput mention style", () => {
       const selector = `.wk-messageinput-editor .mention[data-id="${uid}"]`;
       const declarations = declarationsFor(selector);
 
+      expect(declarations.color).toBe(
+        "var(--wk-text-accent, var(--wk-color-theme))",
+      );
+      expect(declarations["font-weight"]).toBe("400");
       expect(declarations["background-color"]).toBe("transparent");
       expect(declarations.padding).toBe("0 var(--wk-sp-0-5)");
     }

--- a/packages/dmworkbase/src/Components/MessageInput/__tests__/mentionStyle.test.ts
+++ b/packages/dmworkbase/src/Components/MessageInput/__tests__/mentionStyle.test.ts
@@ -12,7 +12,7 @@ function blockFor(selector: string): string {
 }
 
 describe("MessageInput mention style", () => {
-  it("renders ordinary member mentions as visible pills in the editor", () => {
+  it("renders editor mentions as visible pills", () => {
     const mentionBlock = blockFor(".wk-messageinput-editor .mention");
 
     expect(mentionBlock).toContain("background-color: var(--wk-accent-tint-08");
@@ -21,13 +21,9 @@ describe("MessageInput mention style", () => {
     expect(mentionBlock).not.toContain("background-color: transparent");
   });
 
-  it("keeps broadcast mention sentinels as text-only highlights", () => {
-    expect(css).toContain('.wk-messageinput-editor .mention[data-id="-1"]');
-    expect(css).toContain('.wk-messageinput-editor .mention[data-id="-2"]');
-    expect(css).toContain('.wk-messageinput-editor .mention[data-id="-3"]');
-
-    const broadcastBlock = blockFor('.wk-messageinput-editor .mention[data-id="-3"]');
-    expect(broadcastBlock).toContain("background-color: transparent");
-    expect(broadcastBlock).toContain("padding: 0 0.125rem");
+  it("keeps broadcast mention sentinels on the same pill style", () => {
+    expect(css).not.toContain('.wk-messageinput-editor .mention[data-id="-1"]');
+    expect(css).not.toContain('.wk-messageinput-editor .mention[data-id="-2"]');
+    expect(css).not.toContain('.wk-messageinput-editor .mention[data-id="-3"]');
   });
 });

--- a/packages/dmworkbase/src/Components/MessageInput/__tests__/mentionStyle.test.ts
+++ b/packages/dmworkbase/src/Components/MessageInput/__tests__/mentionStyle.test.ts
@@ -12,7 +12,7 @@ function blockFor(selector: string): string {
 }
 
 describe("MessageInput mention style", () => {
-  it("renders editor mentions as visible pills", () => {
+  it("renders ordinary member mentions as visible pills", () => {
     const mentionBlock = blockFor(".wk-messageinput-editor .mention");
 
     expect(mentionBlock).toContain("background-color: var(--wk-accent-tint-08");
@@ -21,9 +21,13 @@ describe("MessageInput mention style", () => {
     expect(mentionBlock).not.toContain("background-color: transparent");
   });
 
-  it("keeps broadcast mention sentinels on the same pill style", () => {
-    expect(css).not.toContain('.wk-messageinput-editor .mention[data-id="-1"]');
-    expect(css).not.toContain('.wk-messageinput-editor .mention[data-id="-2"]');
-    expect(css).not.toContain('.wk-messageinput-editor .mention[data-id="-3"]');
+  it("keeps broadcast mention sentinels as text-only highlights", () => {
+    for (const uid of ["-1", "-2", "-3"]) {
+      expect(css).toContain(`.wk-messageinput-editor .mention[data-id="${uid}"]`);
+    }
+
+    const broadcastBlock = blockFor('.wk-messageinput-editor .mention[data-id="-3"]');
+    expect(broadcastBlock).toContain("background-color: transparent");
+    expect(broadcastBlock).toContain("padding: 0 var(--wk-sp-0-5)");
   });
 });

--- a/packages/dmworkbase/src/Components/MessageInput/__tests__/mentionStyle.test.ts
+++ b/packages/dmworkbase/src/Components/MessageInput/__tests__/mentionStyle.test.ts
@@ -1,0 +1,33 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const cssPath = path.resolve(__dirname, "../index.css");
+const css = fs.readFileSync(cssPath, "utf8");
+
+function blockFor(selector: string): string {
+  const escapedSelector = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = css.match(new RegExp(`${escapedSelector}\\s*\\{([\\s\\S]*?)\\}`));
+  return match?.[1] ?? "";
+}
+
+describe("MessageInput mention style", () => {
+  it("renders ordinary member mentions as visible pills in the editor", () => {
+    const mentionBlock = blockFor(".wk-messageinput-editor .mention");
+
+    expect(mentionBlock).toContain("background-color: var(--wk-accent-tint-08");
+    expect(mentionBlock).toContain("border-radius: var(--wk-r-xs)");
+    expect(mentionBlock).toContain("padding: 0 var(--wk-sp-1)");
+    expect(mentionBlock).not.toContain("background-color: transparent");
+  });
+
+  it("keeps broadcast mention sentinels as text-only highlights", () => {
+    expect(css).toContain('.wk-messageinput-editor .mention[data-id="-1"]');
+    expect(css).toContain('.wk-messageinput-editor .mention[data-id="-2"]');
+    expect(css).toContain('.wk-messageinput-editor .mention[data-id="-3"]');
+
+    const broadcastBlock = blockFor('.wk-messageinput-editor .mention[data-id="-3"]');
+    expect(broadcastBlock).toContain("background-color: transparent");
+    expect(broadcastBlock).toContain("padding: 0 0.125rem");
+  });
+});

--- a/packages/dmworkbase/src/Components/MessageInput/index.css
+++ b/packages/dmworkbase/src/Components/MessageInput/index.css
@@ -451,16 +451,18 @@
 
 /* Mention 样式 */
 .wk-messageinput-editor .mention {
-  color: var(--wk-text-accent, var(--wk-color-theme));
-  font-weight: 600;
-  background-color: var(--wk-bg-selected);
-  border-radius: var(--wk-r-xs);
-  padding: 0 var(--wk-sp-1);
+  color: var(--wk-text-mention-entity);
+  font-weight: 500;
+  background-color: var(--wk-accent-tint-08);
+  border-radius: var(--wk-r-mention-entity);
+  padding: var(--wk-sp-0-5) var(--wk-sp-2);
 }
 
 .wk-messageinput-editor .mention[data-id="-1"],
 .wk-messageinput-editor .mention[data-id="-2"],
 .wk-messageinput-editor .mention[data-id="-3"] {
+  color: var(--wk-text-accent, var(--wk-color-theme));
+  font-weight: 400;
   background-color: transparent;
   padding: 0 var(--wk-sp-0-5);
 }

--- a/packages/dmworkbase/src/Components/MessageInput/index.css
+++ b/packages/dmworkbase/src/Components/MessageInput/index.css
@@ -458,13 +458,6 @@
   padding: 0 var(--wk-sp-1);
 }
 
-.wk-messageinput-editor .mention[data-id="-1"],
-.wk-messageinput-editor .mention[data-id="-2"],
-.wk-messageinput-editor .mention[data-id="-3"] {
-  background-color: transparent;
-  padding: 0 0.125rem;
-}
-
 /* Placeholder - Tiptap Placeholder 扩展 */
 .wk-messageinput-editor .ProseMirror p.is-editor-empty:first-child::before {
   content: attr(data-placeholder);

--- a/packages/dmworkbase/src/Components/MessageInput/index.css
+++ b/packages/dmworkbase/src/Components/MessageInput/index.css
@@ -458,6 +458,13 @@
   padding: 0 var(--wk-sp-1);
 }
 
+.wk-messageinput-editor .mention[data-id="-1"],
+.wk-messageinput-editor .mention[data-id="-2"],
+.wk-messageinput-editor .mention[data-id="-3"] {
+  background-color: transparent;
+  padding: 0 var(--wk-sp-0-5);
+}
+
 /* Placeholder - Tiptap Placeholder 扩展 */
 .wk-messageinput-editor .ProseMirror p.is-editor-empty:first-child::before {
   content: attr(data-placeholder);

--- a/packages/dmworkbase/src/Components/MessageInput/index.css
+++ b/packages/dmworkbase/src/Components/MessageInput/index.css
@@ -451,10 +451,17 @@
 
 /* Mention 样式 */
 .wk-messageinput-editor .mention {
-  color: var(--wk-color-theme);
+  color: var(--wk-text-accent, var(--wk-color-theme));
   font-weight: 600;
+  background-color: var(--wk-accent-tint-08, var(--wk-bg-selected));
+  border-radius: var(--wk-r-xs);
+  padding: 0 var(--wk-sp-1);
+}
+
+.wk-messageinput-editor .mention[data-id="-1"],
+.wk-messageinput-editor .mention[data-id="-2"],
+.wk-messageinput-editor .mention[data-id="-3"] {
   background-color: transparent;
-  border-radius: 0.25rem;
   padding: 0 0.125rem;
 }
 

--- a/packages/dmworkbase/src/Components/MessageInput/index.css
+++ b/packages/dmworkbase/src/Components/MessageInput/index.css
@@ -453,7 +453,7 @@
 .wk-messageinput-editor .mention {
   color: var(--wk-text-accent, var(--wk-color-theme));
   font-weight: 600;
-  background-color: var(--wk-accent-tint-08, var(--wk-bg-selected));
+  background-color: var(--wk-bg-selected);
   border-radius: var(--wk-r-xs);
   padding: 0 var(--wk-sp-1);
 }

--- a/packages/dmworkbase/src/Messages/Text/__tests__/MarkdownContentMention.test.tsx
+++ b/packages/dmworkbase/src/Messages/Text/__tests__/MarkdownContentMention.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 //
-// Web 端广播 mention 需要保持三等级视觉里的纯紫文字高亮。
+// GH#295 regression — Web 端广播 mention 需要保持可见高亮。
+// GH#1153 明确该高亮属于三等级视觉里的纯紫文字，而不是普通成员胶囊。
 //
 // 背景：广播 mention（"@所有人"）在 buildMessageMentions 里被合成为
 // {name:"@所有人", uid:"all"}（见 Utils/mentionRender.ts），交给

--- a/packages/dmworkbase/src/Messages/Text/__tests__/MarkdownContentMention.test.tsx
+++ b/packages/dmworkbase/src/Messages/Text/__tests__/MarkdownContentMention.test.tsx
@@ -1,13 +1,11 @@
 // @vitest-environment jsdom
 //
-// GH#295 regression — Web 端「@所有人」必须像普通 @某人 一样高亮渲染。
+// Web 端广播 mention 需要保持三等级视觉里的纯紫文字高亮。
 //
 // 背景：广播 mention（"@所有人"）在 buildMessageMentions 里被合成为
 // {name:"@所有人", uid:"all"}（见 Utils/mentionRender.ts），交给
-// MarkdownContent 渲染。此前的覆盖止步于「合成返回值」层，没有 DOM 级断言，
-// 无法证明合成出来的广播 mention 真的落成了 `span.mention-entity` 高亮节点。
-// 本测试补上这一段缺口：直接 render MarkdownContent，断言广播 mention 产出
-// 与普通成员 mention 同款的 `.mention-entity` 高亮 span。
+// MarkdownContent 渲染。这里直接 render MarkdownContent，断言广播 mention 产出
+// 非交互的 `.mention-highlight`，同时普通成员 mention 仍是 `.mention-entity` 胶囊。
 
 import React from "react";
 import ReactDOM from "react-dom";
@@ -53,19 +51,19 @@ function renderContent(element: React.ReactElement) {
   return container;
 }
 
-describe("MarkdownContent — broadcast mention (@所有人) 高亮渲染 (GH#295)", () => {
-  it("把广播 mention 渲染成 span.mention-entity，文本为 @所有人", () => {
+describe("MarkdownContent — broadcast mention (@所有人) 高亮渲染", () => {
+  it("把广播 mention 渲染成 span.mention-highlight，文本为 @所有人", () => {
     const mentions: MentionInfo[] = [{ name: "@所有人", uid: "all" }];
     const root = renderContent(
       <MarkdownContent content="@所有人 测试一下" mentions={mentions} />
     );
 
-    const entity = root.querySelector("span.mention-entity");
-    expect(entity).not.toBeNull();
-    expect(entity?.textContent).toBe("@所有人");
+    const highlight = root.querySelector("span.mention-highlight");
+    expect(highlight).not.toBeNull();
+    expect(highlight?.textContent).toBe("@所有人");
   });
 
-  it("广播 mention 与普通成员 mention 同款高亮（视觉一致）", () => {
+  it("广播 mention 与普通成员 mention 保持三等级视觉区分", () => {
     const mentions: MentionInfo[] = [
       { name: "@所有人", uid: "all" },
       { name: "@张三", uid: "uid_zhang" },
@@ -74,10 +72,13 @@ describe("MarkdownContent — broadcast mention (@所有人) 高亮渲染 (GH#29
       <MarkdownContent content="@所有人 和 @张三 看一下" mentions={mentions} />
     );
 
-    const entities = Array.from(
-      root.querySelectorAll("span.mention-entity")
+    const highlights = Array.from(
+      root.querySelectorAll("span.mention-highlight")
     ).map((el) => el.textContent);
-    expect(entities).toContain("@所有人");
+    const entities = Array.from(root.querySelectorAll("span.mention-entity")).map(
+      (el) => el.textContent
+    );
+    expect(highlights).toContain("@所有人");
     expect(entities).toContain("@张三");
   });
 });

--- a/packages/dmworkbase/src/Messages/Text/__tests__/mentionRenderState.test.ts
+++ b/packages/dmworkbase/src/Messages/Text/__tests__/mentionRenderState.test.ts
@@ -2,9 +2,9 @@ import { describe, expect, it } from "vitest"
 import { getMentionRenderState } from "../mentionRenderState"
 
 describe("getMentionRenderState", () => {
-    it("renders broadcast mentions like ordinary member mentions without enabling clicks", () => {
+    it("renders broadcast mentions as non-interactive text highlights", () => {
         expect(getMentionRenderState("all")).toEqual({
-            className: "mention-entity",
+            className: "mention-highlight",
             interactive: false,
         })
     })

--- a/packages/dmworkbase/src/Messages/Text/mentionRenderState.ts
+++ b/packages/dmworkbase/src/Messages/Text/mentionRenderState.ts
@@ -10,7 +10,7 @@ export interface MentionRenderState {
 
 export function getMentionRenderState(uid?: string): MentionRenderState {
   if (uid === "all") {
-    return { className: "mention-entity", interactive: false };
+    return { className: "mention-highlight", interactive: false };
   }
   if (uid === "channel") {
     return { className: "mention-highlight", interactive: false };

--- a/packages/dmworkbase/src/Messages/Text/mentionRenderState.ts
+++ b/packages/dmworkbase/src/Messages/Text/mentionRenderState.ts
@@ -9,10 +9,7 @@ export interface MentionRenderState {
 }
 
 export function getMentionRenderState(uid?: string): MentionRenderState {
-  if (uid === "all") {
-    return { className: "mention-highlight", interactive: false };
-  }
-  if (uid === "channel") {
+  if (uid === "all" || uid === "channel") {
     return { className: "mention-highlight", interactive: false };
   }
   if (uid) {

--- a/packages/dmworkbase/src/Utils/mentionRender.ts
+++ b/packages/dmworkbase/src/Utils/mentionRender.ts
@@ -36,7 +36,12 @@ export interface MentionRenderFlags {
  * `@member` parts with synthetic `@所有人` / `@所有AI` entries derived
  * from the three-state mention flags. Synthetic entries reuse the
  * `uid: "all"` sentinel so MarkdownContent can keep them non-clickable
- * while applying the same visual style as ordinary member mentions.
+ * while applying the broadcast text-only highlight required by #1153.
+ *
+ * GH#295 originally locked broadcast mentions as visible highlights rather
+ * than inert text. #1153 keeps that visibility but clarifies the three-level
+ * visual split: ordinary members are pill entities; broadcast mentions are
+ * pure-purple, non-interactive highlights.
  *
  * Dedup is by visible name — if the conversation already contains a
  * literal `@所有人` member part (rare; admins can rename members), the
@@ -62,8 +67,8 @@ export function buildMessageMentions(
   const all = flags.all === true || flags.all === 1;
   // Plan X: when ais flag is set, all=1 is a backward-compat artifact of the
   // server rewrite (legacy @所有人 → ais=1 + preserve all=1). Do not render
-  // the @所有人 pill from all alone when ais is present — only render it from
-  // explicit humans=1.
+  // the @所有人 highlight from all alone when ais is present — only render it
+  // from explicit humans=1.
   const highlightAll = !!flags.humans || (!flags.ais && all);
   const highlightAis = !!flags.ais;
 

--- a/packages/dmworkbase/src/theme/semantic.css
+++ b/packages/dmworkbase/src/theme/semantic.css
@@ -208,6 +208,7 @@
   --wk-r-md: 8px; /* Figma: 消息气泡, 图片 */
   --wk-r-lg: 16px; /* Figma: 头像 */
   --wk-r-xl: 20px;
+  --wk-r-mention-entity: 4px; /* 已发布普通成员 mention 胶囊圆角 */
   --wk-r-full: 9999px;
   --wk-r-circle: 50%; /* circle — for avatars; distinct from --wk-r-full (9999px pill shape) */
   --wk-avatar-radius: var(--wk-r-circle);
@@ -270,6 +271,7 @@
   --wk-text-accent: var(
     --wk-purple-500
   ); /* Figma: #7F3BF5 AI链接/Thread（紫色点缀） */
+  --wk-text-mention-entity: #6B3DD8; /* 已发布普通成员 mention 胶囊文字色 */
   --wk-text-inverse: var(--wk-neutral-0);
 
   /* 边框 */
@@ -398,6 +400,7 @@ body[theme-mode="dark"] {
   --wk-text-tertiary: #7a7f96;
   --wk-text-disabled: var(--wk-neutral-500); /* 暗色禁用态文字 */
   --wk-text-accent: var(--wk-purple-400); /* 暗色下用浅紫 */
+  --wk-text-mention-entity: var(--wk-purple-400);
   --wk-text-inverse: var(--wk-neutral-900);
 
   /* 边框 */

--- a/packages/dmworkbase/src/theme/semantic.css
+++ b/packages/dmworkbase/src/theme/semantic.css
@@ -335,6 +335,11 @@
    保留以下 CSS 变量定义以备后续重启暗黑模式功能
    ============================================================ */
 body[theme-mode="dark"] {
+  --wk-accent-tint-06: rgba(127, 59, 245, 0.1);
+  --wk-accent-tint-08: rgba(127, 59, 245, 0.12);
+  --wk-accent-tint-10: rgba(127, 59, 245, 0.16);
+  --wk-accent-tint-12: rgba(127, 59, 245, 0.2);
+
   /* 背景层 */
   --wk-bg-deep: var(--wk-neutral-900);
   --wk-bg-base: var(--wk-neutral-850);

--- a/packages/dmworkbase/src/ui/message/TextContent/TextContent.stories.tsx
+++ b/packages/dmworkbase/src/ui/message/TextContent/TextContent.stories.tsx
@@ -139,7 +139,7 @@ export const MentionLevels: Story = {
       
       <div>
         <p style={{ fontSize: '12px', color: '#666', marginBottom: '8px' }}>
-          广播 mention（同普通 @ 用户视觉，不可点击）
+          广播 mention（纯紫文字，不可点击）
         </p>
         <TextContent
           content="看一下 @所有人"

--- a/packages/dmworkbase/src/ui/message/TextContent/index.css
+++ b/packages/dmworkbase/src/ui/message/TextContent/index.css
@@ -41,11 +41,11 @@
 
 /* 普通用户：紫色文字 + 浅紫背景（次优先级） */
 .wk-msg-text-content .mention-entity {
-  color: var(--wk-text-accent);
-  background-color: var(--wk-bg-selected);
-  border-radius: var(--wk-r-xs);
-  padding: 0 var(--wk-sp-1);
-  font-weight: 600;
+  color: var(--wk-text-mention-entity);
+  background-color: var(--wk-accent-tint-08);
+  border-radius: var(--wk-r-mention-entity);
+  padding: var(--wk-sp-0-5) var(--wk-sp-2);
+  font-weight: 500;
   cursor: pointer;
   transition: background-color 0.2s;
 }
@@ -56,6 +56,6 @@
 
 /* 降级：未解析 @ — 纯紫色文字，无背景 */
 .wk-msg-text-content .mention-fallback {
-  color: var(--wk-text-accent);
+  color: var(--wk-text-mention-entity);
   font-weight: 400;
 }

--- a/packages/dmworkbase/src/ui/message/TextContent/index.css
+++ b/packages/dmworkbase/src/ui/message/TextContent/index.css
@@ -34,28 +34,28 @@
 
 /* @所有人/@频道：Figma — 纯紫色文字，无背景，不可点击 */
 .wk-msg-text-content .mention-highlight {
-  color: rgba(127, 59, 245, 1);
+  color: var(--wk-text-accent);
   font-weight: 400;
   cursor: default;
 }
 
 /* 普通用户：紫色文字 + 浅紫背景（次优先级） */
 .wk-msg-text-content .mention-entity {
-  color: #6B3DD8;
-  background-color: rgba(107, 61, 216, 0.08);
-  border-radius: 4px;
-  padding: 2px 8px;
-  font-weight: 500;
+  color: var(--wk-text-accent);
+  background-color: var(--wk-bg-selected);
+  border-radius: var(--wk-r-xs);
+  padding: 0 var(--wk-sp-1);
+  font-weight: 600;
   cursor: pointer;
   transition: background-color 0.2s;
 }
 
 .wk-msg-text-content .mention-entity:hover {
-  background-color: rgba(107, 61, 216, 0.12);
+  background-color: var(--wk-accent-tint-12);
 }
 
 /* 降级：未解析 @ — 纯紫色文字，无背景 */
 .wk-msg-text-content .mention-fallback {
-  color: #6B3DD8;
+  color: var(--wk-text-accent);
   font-weight: 400;
 }


### PR DESCRIPTION
## Summary
- Give ordinary member mentions a visible pill state in the message input, matching the already-shipped sent-message pill metrics.
- Keep broadcast mentions (`@所有人`, `@所有AI`) as text-only purple highlights, following the three-level behavior requested in #1153.
- Align the input editor and display renderer so sending does not change broadcast mentions from text-only to a pill.
- Strengthen mention style coverage around broadcast sentinel IDs, Tiptap `data-id` output, and display render state.

## Product Decision
#1153 explicitly asks for ordinary member mentions to use purple text with a light-purple background, while `@所有人` / `@所有AI` may continue using the existing pure-purple text treatment so broadcast mentions remain visually distinct from ordinary members.

This PR follows that #1153 direction instead of the #1157 unified-pill direction. The repo currently records both interpretations, so maintainers should pick one approach and close or retarget the other PR before merge.

## Scope and Behavior
- Input editor: ordinary member `.mention` nodes use the pill style; broadcast sentinel IDs (`-1`, `-2`, `-3`) remain text-only.
- Message display: `uid === "all"` now maps to `mention-highlight`, matching the text-only broadcast style after send.
- Existing message history containing broadcast mentions will render as text-only purple highlights instead of ordinary-member pills.
- Existing ordinary member mentions keep the shipped display pill metrics: 8% tint background, 4px radius, `2px 8px` padding, and `500` font weight.
- Input ordinary member mentions use the same pill metrics through semantic tokens, so the fix brings the editor up to the display behavior instead of redesigning the display layer.
- Input broadcast mentions explicitly use `400` font weight to match sent-message `mention-highlight` and avoid a send-time weight jump.

## Traceability
- Keeps the GH#295 regression intent: broadcast mentions must stay visibly highlighted, not inert plain text.
- Applies #1153's clarification that this highlight is the broadcast text-only state, while ordinary members use the pill state.
- Uses semantic mention tokens for the shipped member pill color/radius so component CSS does not carry private hardcoded values.

## Verification
- `corepack pnpm --dir packages/dmworkbase exec vitest run src/Components/MessageInput/__tests__/mentionStyle.test.ts`
- `corepack pnpm --dir packages/dmworkbase exec vitest run src/Messages/Text/__tests__/mentionRenderState.test.ts src/Messages/Text/__tests__/MarkdownContentMention.test.tsx`
- `git diff --check`
- `corepack pnpm exec stylelint packages/dmworkbase/src/Components/MessageInput/index.css packages/dmworkbase/src/ui/message/TextContent/index.css packages/dmworkbase/src/theme/semantic.css --config stylelint.config.mjs --allow-empty-input` (0 errors; existing warnings remain)
- `corepack pnpm --filter @octo/base test -- --maxWorkers=4`

Fixes #1153