### PR TITLE
fix: preserve mention avatar aspect ratio

### DIFF
--- a/packages/dmworkbase/src/Components/MessageInput/MentionList.css
+++ b/packages/dmworkbase/src/Components/MessageInput/MentionList.css
@@ -27,6 +27,11 @@
 
 .mention-list-item .wk-messageinput-iconbox {
   margin-right: 8px;
+  flex-shrink: 0;
+}
+
+.mention-list-item .wk-messageinput-icon {
+  object-fit: cover;
 }
 
 .mention-list-item-content {


### PR DESCRIPTION
## Summary

- preserve non-square avatar proportions in the @mention suggestion list by cropping them with `object-fit: cover`
- prevent the avatar container from shrinking in flex rows
- keep the change scoped to the remaining affected surface; group-info member avatars already use the shared `WKAvatar` on `main`

## Testing

- `pnpm --dir packages/dmworkbase exec vitest run src/Components/MessageInput/__tests__/MentionList.test.tsx`
- `pnpm exec stylelint packages/dmworkbase/src/Components/MessageInput/MentionList.css --config stylelint.ci.config.mjs`
- `pnpm --filter @octo/web build`
- `git diff --check`

Fixes #1179