### PR TITLE
fix(channel-setting): refresh group member cache after mutations

### DIFF
--- a/packages/dmworkbase/src/bridge/channelSetting/__tests__/channelSettingActions.test.ts
+++ b/packages/dmworkbase/src/bridge/channelSetting/__tests__/channelSettingActions.test.ts
@@ -27,6 +27,7 @@ vi.mock("../../../App", () => ({
 vi.mock("../../../im-runtime/currentChannelRuntime", () => ({
   deleteCurrentImChannelInfo: vi.fn(),
   fetchCurrentImChannelInfo: vi.fn(),
+  notifyCurrentImSubscriberChangeListeners: vi.fn(),
   syncCurrentImChannelSubscribers: vi.fn(),
 }));
 
@@ -41,6 +42,10 @@ function createRuntime(
     deleteCurrentChannelInfo: vi.fn(),
     exitChannel: vi.fn(() => Promise.resolve()),
     fetchCurrentChannelInfo: vi.fn(() => Promise.resolve(undefined)),
+    fetchChannelSubscriber: vi.fn((channel, uid) =>
+      Promise.resolve({ uid, name: `member:${uid}` })
+    ),
+    getCurrentChannelSubscribers: vi.fn(() => []),
     findConversation: vi.fn(),
     getLoginUid: vi.fn(() => "self"),
     invokeClearChannelMessages: vi.fn(),
@@ -51,6 +56,8 @@ function createRuntime(
     remarkChannel: vi.fn(() => Promise.resolve()),
     saveChannel: vi.fn(() => Promise.resolve()),
     showConversation: vi.fn(),
+    notifyCurrentChannelSubscribers: vi.fn(),
+    setCurrentChannelSubscribers: vi.fn(),
     syncCurrentChannelSubscribers: vi.fn(() => Promise.resolve()),
     topChannel: vi.fn(() => Promise.resolve()),
     transferOwner: vi.fn(() => Promise.resolve()),
@@ -85,7 +92,7 @@ describe("channel setting actions", () => {
     );
   });
 
-  it("adds and removes subscribers through the runtime", async () => {
+  it("adds and removes subscribers then refreshes member and channel caches", async () => {
     const runtime = createRuntime();
     const channel = new Channel("group-1", ChannelTypeGroup);
 
@@ -102,6 +109,119 @@ describe("channel setting actions", () => {
 
     expect(runtime.addSubscribers).toHaveBeenCalledWith(channel, ["alice"]);
     expect(runtime.removeSubscribers).toHaveBeenCalledWith(channel, ["bob"]);
+    expect(runtime.syncCurrentChannelSubscribers).toHaveBeenCalledTimes(2);
+    expect(runtime.syncCurrentChannelSubscribers).toHaveBeenNthCalledWith(
+      1,
+      channel
+    );
+    expect(runtime.syncCurrentChannelSubscribers).toHaveBeenNthCalledWith(
+      2,
+      channel
+    );
+    expect(runtime.notifyCurrentChannelSubscribers).toHaveBeenCalledTimes(2);
+    expect(runtime.notifyCurrentChannelSubscribers).toHaveBeenNthCalledWith(1, channel);
+    expect(runtime.notifyCurrentChannelSubscribers).toHaveBeenNthCalledWith(2, channel);
+    expect(runtime.fetchCurrentChannelInfo).toHaveBeenCalledTimes(2);
+    expect(runtime.fetchCurrentChannelInfo).toHaveBeenNthCalledWith(1, channel);
+    expect(runtime.fetchCurrentChannelInfo).toHaveBeenNthCalledWith(2, channel);
+  });
+
+  it("removes deleted subscribers from the local cache after the server succeeds", async () => {
+    const runtime = createRuntime({
+      getCurrentChannelSubscribers: vi.fn(() => [
+        { uid: "owner" },
+        { uid: "alice" },
+        { uid: "bob" },
+      ]),
+    });
+    const channel = new Channel("group-1", ChannelTypeGroup);
+
+    await removeChannelSettingSubscribers({
+      channel,
+      uids: ["alice", "bob"],
+      runtime,
+    });
+
+    expect(runtime.setCurrentChannelSubscribers).toHaveBeenCalledWith(channel, [
+      { uid: "owner" },
+    ]);
+    expect(runtime.notifyCurrentChannelSubscribers).toHaveBeenCalledWith(
+      channel
+    );
+  });
+
+  it("fills newly added subscribers when sync leaves the local cache incomplete", async () => {
+    const runtime = createRuntime({
+      getCurrentChannelSubscribers: vi.fn(() => [{ uid: "owner" }]),
+      fetchChannelSubscriber: vi.fn((channel, uid) =>
+        Promise.resolve({ uid, name: `member:${uid}` })
+      ),
+    });
+    const channel = new Channel("group-1", ChannelTypeGroup);
+
+    await addChannelSettingSubscribers({
+      channel,
+      uids: ["alice"],
+      runtime,
+    });
+
+    expect(runtime.fetchChannelSubscriber).toHaveBeenCalledWith(
+      channel,
+      "alice"
+    );
+    expect(runtime.setCurrentChannelSubscribers).toHaveBeenCalledWith(channel, [
+      { uid: "owner" },
+      expect.objectContaining({ uid: "alice", name: "member:alice", channel }),
+    ]);
+    expect(runtime.notifyCurrentChannelSubscribers).toHaveBeenCalledWith(
+      channel
+    );
+  });
+
+  it("does not refresh members when adding subscribers fails", async () => {
+    const runtime = createRuntime({
+      addSubscribers: vi.fn(() => Promise.reject(new Error("add failed"))),
+    });
+    const channel = new Channel("group-1", ChannelTypeGroup);
+
+    await expect(
+      addChannelSettingSubscribers({
+        channel,
+        uids: ["alice"],
+        runtime,
+      })
+    ).rejects.toThrow("add failed");
+
+    expect(runtime.syncCurrentChannelSubscribers).not.toHaveBeenCalled();
+    expect(runtime.notifyCurrentChannelSubscribers).not.toHaveBeenCalled();
+    expect(runtime.fetchCurrentChannelInfo).not.toHaveBeenCalled();
+  });
+
+  it("still patches removable stale cache when member sync fails after server success", async () => {
+    const runtime = createRuntime({
+      getCurrentChannelSubscribers: vi.fn(() => [
+        { uid: "owner" },
+        { uid: "alice" },
+      ]),
+      syncCurrentChannelSubscribers: vi.fn(() =>
+        Promise.reject(new Error("sync failed"))
+      ),
+    });
+    const channel = new Channel("group-1", ChannelTypeGroup);
+
+    await removeChannelSettingSubscribers({
+      channel,
+      uids: ["alice"],
+      runtime,
+    });
+
+    expect(runtime.setCurrentChannelSubscribers).toHaveBeenCalledWith(channel, [
+      { uid: "owner" },
+    ]);
+    expect(runtime.notifyCurrentChannelSubscribers).toHaveBeenCalledWith(
+      channel
+    );
+    expect(runtime.fetchCurrentChannelInfo).toHaveBeenCalledWith(channel);
   });
 
   it("updates group fields and current user's group nickname", async () => {

--- a/packages/dmworkbase/src/bridge/channelSetting/__tests__/channelSettingActions.test.ts
+++ b/packages/dmworkbase/src/bridge/channelSetting/__tests__/channelSettingActions.test.ts
@@ -19,6 +19,7 @@ import {
   type ChannelSettingActionRuntime,
 } from "../channelSettingActions";
 import { ChannelField } from "../../../Service/DataSource/DataSource";
+import { SubscriberStatus } from "../../../Service/Const";
 
 vi.mock("../../../App", () => ({
   default: {},
@@ -27,7 +28,9 @@ vi.mock("../../../App", () => ({
 vi.mock("../../../im-runtime/currentChannelRuntime", () => ({
   deleteCurrentImChannelInfo: vi.fn(),
   fetchCurrentImChannelInfo: vi.fn(),
+  getCurrentImChannelSubscribers: vi.fn(() => []),
   notifyCurrentImSubscriberChangeListeners: vi.fn(),
+  setCurrentImChannelSubscribersCache: vi.fn(),
   syncCurrentImChannelSubscribers: vi.fn(),
 }));
 
@@ -152,7 +155,10 @@ describe("channel setting actions", () => {
 
   it("fills newly added subscribers when sync leaves the local cache incomplete", async () => {
     const runtime = createRuntime({
-      getCurrentChannelSubscribers: vi.fn(() => [{ uid: "owner" }]),
+      getCurrentChannelSubscribers: vi
+        .fn()
+        .mockReturnValueOnce([{ uid: "owner" }])
+        .mockReturnValueOnce([{ uid: "owner" }, { uid: "synced" }]),
       fetchChannelSubscriber: vi.fn((channel, uid) =>
         Promise.resolve({ uid, name: `member:${uid}` })
       ),
@@ -171,11 +177,47 @@ describe("channel setting actions", () => {
     );
     expect(runtime.setCurrentChannelSubscribers).toHaveBeenCalledWith(channel, [
       { uid: "owner" },
-      expect.objectContaining({ uid: "alice", name: "member:alice", channel }),
+      { uid: "synced" },
+      expect.objectContaining({
+        uid: "alice",
+        name: "member:alice",
+        channel,
+        status: SubscriberStatus.normal,
+      }),
     ]);
     expect(runtime.notifyCurrentChannelSubscribers).toHaveBeenCalledWith(
       channel
     );
+  });
+
+  it("refetches and normalizes a cached subscriber that is not renderable yet", async () => {
+    const runtime = createRuntime({
+      getCurrentChannelSubscribers: vi
+        .fn()
+        .mockReturnValueOnce([{ uid: "alice" }])
+        .mockReturnValueOnce([{ uid: "alice" }]),
+      fetchChannelSubscriber: vi.fn((channel, uid) =>
+        Promise.resolve({ uid, name: `member:${uid}` })
+      ),
+    });
+    const channel = new Channel("group-1", ChannelTypeGroup);
+
+    await addChannelSettingSubscribers({
+      channel,
+      uids: ["alice"],
+      runtime,
+    });
+
+    expect(runtime.fetchChannelSubscriber).toHaveBeenCalledWith(
+      channel,
+      "alice"
+    );
+    expect(runtime.setCurrentChannelSubscribers).toHaveBeenCalledWith(channel, [
+      expect.objectContaining({
+        uid: "alice",
+        status: SubscriberStatus.normal,
+      }),
+    ]);
   });
 
   it("does not refresh members when adding subscribers fails", async () => {

--- a/packages/dmworkbase/src/bridge/channelSetting/channelSettingActions.ts
+++ b/packages/dmworkbase/src/bridge/channelSetting/channelSettingActions.ts
@@ -13,7 +13,7 @@ import {
   updateChannelSubscriberAttr,
   updateThread as updateThreadApi,
 } from "../../Service/ChannelSettingService";
-import { EndpointID } from "../../Service/Const";
+import { EndpointID, SubscriberStatus } from "../../Service/Const";
 import {
   deleteCurrentImChannelInfo,
   fetchCurrentImChannelInfo,
@@ -35,8 +35,11 @@ export interface ChannelSettingActionRuntime {
   deleteCurrentChannelInfo(channel: Channel): void;
   exitChannel(channel: Channel): Promise<void>;
   fetchCurrentChannelInfo(channel: Channel): Promise<any>;
-  fetchChannelSubscriber(channel: Channel, uid: string): Promise<any | undefined>;
-  getCurrentChannelSubscribers(channel: Channel): any[];
+  fetchChannelSubscriber(
+    channel: Channel,
+    uid: string
+  ): Promise<ChannelSettingSubscriber | undefined>;
+  getCurrentChannelSubscribers(channel: Channel): ChannelSettingSubscriber[];
   findConversation(channel: Channel): any | undefined;
   getLoginUid(): string | undefined;
   invokeClearChannelMessages(channel: Channel): void;
@@ -48,7 +51,10 @@ export interface ChannelSettingActionRuntime {
   saveChannel(channel: Channel, save: boolean): Promise<void>;
   showConversation(channel: Channel): void;
   notifyCurrentChannelSubscribers(channel: Channel): void;
-  setCurrentChannelSubscribers(channel: Channel, subscribers: any[]): void;
+  setCurrentChannelSubscribers(
+    channel: Channel,
+    subscribers: ChannelSettingSubscriber[]
+  ): void;
   syncCurrentChannelSubscribers(channel: Channel): Promise<any>;
   topChannel(channel: Channel, top: boolean): Promise<void>;
   transferOwner(channel: Channel, uid: string): Promise<void>;
@@ -67,6 +73,14 @@ export interface ChannelSettingActionRuntime {
     shortId: string,
     data: Record<string, any>
   ): Promise<void>;
+}
+
+interface ChannelSettingSubscriber {
+  uid?: string;
+  status?: number;
+  isDeleted?: boolean;
+  channel?: Channel;
+  [key: string]: any;
 }
 
 function defaultRuntime(): ChannelSettingActionRuntime {
@@ -202,8 +216,25 @@ function activeSubscriber(subscriber: any) {
   return (
     subscriber &&
     !subscriber.isDeleted &&
-    (subscriber.status === undefined || subscriber.status === 1)
+    subscriber.status === SubscriberStatus.normal
   );
+}
+
+function normalizeFetchedSubscriber(
+  subscriber: ChannelSettingSubscriber | undefined,
+  channel: Channel
+) {
+  if (!subscriber || subscriber.isDeleted) {
+    return undefined;
+  }
+  if (subscriber.status === undefined) {
+    subscriber.status = SubscriberStatus.normal;
+  }
+  if (subscriber.status !== SubscriberStatus.normal) {
+    return undefined;
+  }
+  subscriber.channel = channel;
+  return subscriber;
 }
 
 async function patchSubscriberCacheAfterMemberMutation(
@@ -230,24 +261,38 @@ async function patchSubscriberCacheAfterMemberMutation(
     return false;
   }
 
-  const nextSubscribers = [...currentSubscribers];
+  const uidsToFetch = Array.from(targetUids).filter((uid) => {
+    const index = currentSubscribers.findIndex(
+      (subscriber) => subscriber?.uid === uid
+    );
+    return index < 0 || !activeSubscriber(currentSubscribers[index]);
+  });
+
+  const fetchedSubscribers = (
+    await Promise.all(
+      uidsToFetch.map((uid) =>
+        runtime.fetchChannelSubscriber(channel, uid).catch(() => undefined)
+      )
+    )
+  )
+    .map((subscriber) => normalizeFetchedSubscriber(subscriber, channel))
+    .filter(Boolean) as ChannelSettingSubscriber[];
+
+  if (fetchedSubscribers.length === 0) {
+    return false;
+  }
+
+  const latestSubscribers = runtime.getCurrentChannelSubscribers(channel) || [];
+  const nextSubscribers = [...latestSubscribers];
   let changed = false;
 
-  for (const uid of targetUids) {
+  for (const subscriber of fetchedSubscribers) {
     const index = nextSubscribers.findIndex(
-      (subscriber) => subscriber?.uid === uid
+      (item) => item?.uid === subscriber.uid
     );
     if (index >= 0 && activeSubscriber(nextSubscribers[index])) {
       continue;
     }
-
-    const subscriber = await runtime.fetchChannelSubscriber(channel, uid).catch(
-      () => undefined
-    );
-    if (!subscriber) {
-      continue;
-    }
-    subscriber.channel = channel;
     if (index >= 0) {
       nextSubscribers[index] = subscriber;
     } else {

--- a/packages/dmworkbase/src/bridge/channelSetting/channelSettingActions.ts
+++ b/packages/dmworkbase/src/bridge/channelSetting/channelSettingActions.ts
@@ -17,6 +17,9 @@ import { EndpointID } from "../../Service/Const";
 import {
   deleteCurrentImChannelInfo,
   fetchCurrentImChannelInfo,
+  getCurrentImChannelSubscribers,
+  notifyCurrentImSubscriberChangeListeners,
+  setCurrentImChannelSubscribersCache,
   syncCurrentImChannelSubscribers,
 } from "../../im-runtime/currentChannelRuntime";
 import {
@@ -32,6 +35,8 @@ export interface ChannelSettingActionRuntime {
   deleteCurrentChannelInfo(channel: Channel): void;
   exitChannel(channel: Channel): Promise<void>;
   fetchCurrentChannelInfo(channel: Channel): Promise<any>;
+  fetchChannelSubscriber(channel: Channel, uid: string): Promise<any | undefined>;
+  getCurrentChannelSubscribers(channel: Channel): any[];
   findConversation(channel: Channel): any | undefined;
   getLoginUid(): string | undefined;
   invokeClearChannelMessages(channel: Channel): void;
@@ -42,6 +47,8 @@ export interface ChannelSettingActionRuntime {
   remarkChannel(channel: Channel, remark: string): Promise<void>;
   saveChannel(channel: Channel, save: boolean): Promise<void>;
   showConversation(channel: Channel): void;
+  notifyCurrentChannelSubscribers(channel: Channel): void;
+  setCurrentChannelSubscribers(channel: Channel, subscribers: any[]): void;
   syncCurrentChannelSubscribers(channel: Channel): Promise<any>;
   topChannel(channel: Channel, top: boolean): Promise<void>;
   transferOwner(channel: Channel, uid: string): Promise<void>;
@@ -65,9 +72,7 @@ export interface ChannelSettingActionRuntime {
 function defaultRuntime(): ChannelSettingActionRuntime {
   return {
     addSubscribers(channel, uids) {
-      return addChannelSubscribersApi(channel, uids).then(() =>
-        syncChannelSubscribersAfterMemberMutation(channel, "addSubscribers")
-      );
+      return addChannelSubscribersApi(channel, uids);
     },
     clearConversationMessages(conversation) {
       return WKApp.conversationProvider.clearConversationMessages(conversation);
@@ -88,6 +93,12 @@ function defaultRuntime(): ChannelSettingActionRuntime {
     },
     fetchCurrentChannelInfo(channel) {
       return fetchCurrentImChannelInfo(channel);
+    },
+    fetchChannelSubscriber(channel, uid) {
+      return WKApp.dataSource.channelDataSource.subscriber(channel, uid);
+    },
+    getCurrentChannelSubscribers(channel) {
+      return getCurrentImChannelSubscribers(channel);
     },
     findConversation(channel) {
       return findCurrentImConversation(channel);
@@ -114,9 +125,7 @@ function defaultRuntime(): ChannelSettingActionRuntime {
       WKApp.shared.notifyListener();
     },
     removeSubscribers(channel, uids) {
-      return removeChannelSubscribersApi(channel, uids).then(() =>
-        syncChannelSubscribersAfterMemberMutation(channel, "removeSubscribers")
-      );
+      return removeChannelSubscribersApi(channel, uids);
     },
     remarkChannel(channel, remark) {
       return updateChannelSetting({ remark }, channel);
@@ -126,6 +135,12 @@ function defaultRuntime(): ChannelSettingActionRuntime {
     },
     showConversation(channel) {
       WKApp.endpoints.showConversation(channel);
+    },
+    notifyCurrentChannelSubscribers(channel) {
+      notifyCurrentImSubscriberChangeListeners(channel);
+    },
+    setCurrentChannelSubscribers(channel, subscribers) {
+      setCurrentImChannelSubscribersCache(channel, subscribers);
     },
     syncCurrentChannelSubscribers(channel) {
       return syncCurrentImChannelSubscribers(channel);
@@ -148,15 +163,103 @@ function defaultRuntime(): ChannelSettingActionRuntime {
   };
 }
 
-async function syncChannelSubscribersAfterMemberMutation(
+async function refreshChannelStateAfterMemberMutation(
+  runtime: ChannelSettingActionRuntime,
   channel: Channel,
-  action: "addSubscribers" | "removeSubscribers"
+  action: "addSubscribers" | "removeSubscribers",
+  uids: string[]
 ) {
+  let shouldNotifySubscribers = false;
+
   try {
-    await syncCurrentImChannelSubscribers(channel);
+    await runtime.syncCurrentChannelSubscribers(channel);
+    shouldNotifySubscribers = true;
   } catch (err) {
     console.warn(`[${action}] syncSubscribes failed`, err);
   }
+
+  const cachePatched = await patchSubscriberCacheAfterMemberMutation(
+    runtime,
+    channel,
+    action,
+    uids
+  );
+
+  if (cachePatched) {
+    shouldNotifySubscribers = true;
+  }
+
+  if (shouldNotifySubscribers) {
+    runtime.notifyCurrentChannelSubscribers(channel);
+  }
+
+  await runtime.fetchCurrentChannelInfo(channel).catch((err) => {
+    console.warn(`[${action}] fetchChannelInfo failed`, err);
+  });
+}
+
+function activeSubscriber(subscriber: any) {
+  return (
+    subscriber &&
+    !subscriber.isDeleted &&
+    (subscriber.status === undefined || subscriber.status === 1)
+  );
+}
+
+async function patchSubscriberCacheAfterMemberMutation(
+  runtime: ChannelSettingActionRuntime,
+  channel: Channel,
+  action: "addSubscribers" | "removeSubscribers",
+  uids: string[]
+) {
+  const targetUids = new Set(uids.filter(Boolean));
+  if (targetUids.size === 0) {
+    return false;
+  }
+
+  const currentSubscribers = runtime.getCurrentChannelSubscribers(channel) || [];
+
+  if (action === "removeSubscribers") {
+    const nextSubscribers = currentSubscribers.filter(
+      (subscriber) => !targetUids.has(subscriber?.uid)
+    );
+    if (nextSubscribers.length !== currentSubscribers.length) {
+      runtime.setCurrentChannelSubscribers(channel, nextSubscribers);
+      return true;
+    }
+    return false;
+  }
+
+  const nextSubscribers = [...currentSubscribers];
+  let changed = false;
+
+  for (const uid of targetUids) {
+    const index = nextSubscribers.findIndex(
+      (subscriber) => subscriber?.uid === uid
+    );
+    if (index >= 0 && activeSubscriber(nextSubscribers[index])) {
+      continue;
+    }
+
+    const subscriber = await runtime.fetchChannelSubscriber(channel, uid).catch(
+      () => undefined
+    );
+    if (!subscriber) {
+      continue;
+    }
+    subscriber.channel = channel;
+    if (index >= 0) {
+      nextSubscribers[index] = subscriber;
+    } else {
+      nextSubscribers.push(subscriber);
+    }
+    changed = true;
+  }
+
+  if (changed) {
+    runtime.setCurrentChannelSubscribers(channel, nextSubscribers);
+  }
+  return changed;
 }
 
 function runtimeOrDefault(runtime?: ChannelSettingActionRuntime) {
@@ -168,8 +271,12 @@ export async function addChannelSettingSubscribers(params: {
   uids: string[];
   runtime?: ChannelSettingActionRuntime;
 }) {
-  await runtimeOrDefault(params.runtime).addSubscribers(
+  const runtime = runtimeOrDefault(params.runtime);
+  await runtime.addSubscribers(params.channel, params.uids);
+  await refreshChannelStateAfterMemberMutation(
+    runtime,
     params.channel,
+    "addSubscribers",
     params.uids
   );
 }
@@ -196,8 +303,12 @@ export async function removeChannelSettingSubscribers(params: {
   uids: string[];
   runtime?: ChannelSettingActionRuntime;
 }) {
-  await runtimeOrDefault(params.runtime).removeSubscribers(
+  const runtime = runtimeOrDefault(params.runtime);
+  await runtime.removeSubscribers(params.channel, params.uids);
+  await refreshChannelStateAfterMemberMutation(
+    runtime,
     params.channel,
+    "removeSubscribers",
     params.uids
   );
 }

--- a/packages/dmworkcontacts/src/bridge/groupCreate/groupCreateRuntime.test.ts
+++ b/packages/dmworkcontacts/src/bridge/groupCreate/groupCreateRuntime.test.ts
@@ -15,6 +15,8 @@ vi.mock("@octo/base", () => ({
   getCurrentImChannelInfo: vi.fn(),
   getCurrentImChannelSubscribers: vi.fn(),
   notifyCurrentImSubscriberChangeListeners: vi.fn(),
+  setCurrentImChannelSubscribersCache: vi.fn(),
+  SubscriberStatus: { normal: 1 },
   syncCurrentImChannelSubscribers: vi.fn(),
 }));
 
@@ -209,7 +211,10 @@ describe("group create runtime bridge", () => {
 
   it("adds subscribers directly for an existing group and refreshes member state", async () => {
     const runtime = createRuntime({
-      getCurrentChannelSubscribers: vi.fn(() => [{ uid: "owner" }]),
+      getCurrentChannelSubscribers: vi
+        .fn()
+        .mockReturnValueOnce([{ uid: "owner" }])
+        .mockReturnValueOnce([{ uid: "owner" }, { uid: "synced" }]),
     });
 
     await submitGroupCreateAction({
@@ -245,9 +250,46 @@ describe("group create runtime bridge", () => {
       expect.objectContaining({ channelID: "group-1" }),
       [
         { uid: "owner" },
-        expect.objectContaining({ uid: "alice", name: "member:alice" }),
-        expect.objectContaining({ uid: "bob", name: "member:bob" }),
+        { uid: "synced" },
+        expect.objectContaining({
+          uid: "alice",
+          name: "member:alice",
+          status: 1,
+        }),
+        expect.objectContaining({
+          uid: "bob",
+          name: "member:bob",
+          status: 1,
+        }),
       ]
+    );
+  });
+
+  it("refetches and normalizes an existing-group subscriber that is not renderable yet", async () => {
+    const runtime = createRuntime({
+      getCurrentChannelSubscribers: vi
+        .fn()
+        .mockReturnValueOnce([{ uid: "alice" }])
+        .mockReturnValueOnce([{ uid: "alice" }]),
+      fetchChannelSubscriber: vi.fn((channel, uid) =>
+        Promise.resolve({ uid, name: `member:${uid}` })
+      ),
+    });
+
+    await submitGroupCreateAction({
+      action: "addMember",
+      channel: { channelID: "group-1", channelType: ChannelTypeGroup },
+      selectedUids: ["alice"],
+      runtime,
+    });
+
+    expect(runtime.fetchChannelSubscriber).toHaveBeenCalledWith(
+      expect.objectContaining({ channelID: "group-1" }),
+      "alice"
+    );
+    expect(runtime.setCurrentChannelSubscribers).toHaveBeenCalledWith(
+      expect.objectContaining({ channelID: "group-1" }),
+      [expect.objectContaining({ uid: "alice", status: 1 })]
     );
   });
 

--- a/packages/dmworkcontacts/src/bridge/groupCreate/groupCreateRuntime.test.ts
+++ b/packages/dmworkcontacts/src/bridge/groupCreate/groupCreateRuntime.test.ts
@@ -11,8 +11,10 @@ import type { GroupCreateRuntime } from "./types";
 
 vi.mock("@octo/base", () => ({
   WKApp: {},
+  fetchCurrentImChannelInfo: vi.fn(),
   getCurrentImChannelInfo: vi.fn(),
   getCurrentImChannelSubscribers: vi.fn(),
+  notifyCurrentImSubscriberChangeListeners: vi.fn(),
   syncCurrentImChannelSubscribers: vi.fn(),
 }));
 
@@ -31,10 +33,16 @@ function createRuntime(
     getCurrentChannelInfo: vi.fn(() => ({})),
     getCurrentChannelSubscribers: vi.fn(() => []),
     getCurrentSpaceId: vi.fn(() => undefined),
+    fetchCurrentChannelInfo: vi.fn(() => Promise.resolve(undefined)),
+    fetchChannelSubscriber: vi.fn((channel, uid) =>
+      Promise.resolve({ uid, name: `member:${uid}` })
+    ),
     getLoginUid: vi.fn(() => "self"),
     getSpaceMembers: vi.fn(() => Promise.resolve([])),
     getSuperGroupSubscribers: vi.fn(() => Promise.resolve([])),
     showConversation: vi.fn(),
+    notifyCurrentChannelSubscribers: vi.fn(),
+    setCurrentChannelSubscribers: vi.fn(),
     syncCurrentChannelSubscribers: vi.fn(() => Promise.resolve(undefined)),
     ...overrides,
   };
@@ -194,10 +202,15 @@ describe("group create runtime bridge", () => {
     expect(runtime.showConversation).toHaveBeenCalledWith(
       expect.objectContaining({ channelID: "group-created" })
     );
+    expect(runtime.syncCurrentChannelSubscribers).not.toHaveBeenCalled();
+    expect(runtime.notifyCurrentChannelSubscribers).not.toHaveBeenCalled();
+    expect(runtime.fetchCurrentChannelInfo).not.toHaveBeenCalled();
   });
 
-  it("adds subscribers directly for an existing group", async () => {
-    const runtime = createRuntime();
+  it("adds subscribers directly for an existing group and refreshes member state", async () => {
+    const runtime = createRuntime({
+      getCurrentChannelSubscribers: vi.fn(() => [{ uid: "owner" }]),
+    });
 
     await submitGroupCreateAction({
       action: "addMember",
@@ -211,5 +224,79 @@ describe("group create runtime bridge", () => {
       ["alice", "bob"]
     );
     expect(runtime.createChannel).not.toHaveBeenCalled();
+    expect(runtime.syncCurrentChannelSubscribers).toHaveBeenCalledWith(
+      expect.objectContaining({ channelID: "group-1" })
+    );
+    expect(runtime.notifyCurrentChannelSubscribers).toHaveBeenCalledWith(
+      expect.objectContaining({ channelID: "group-1" })
+    );
+    expect(runtime.fetchCurrentChannelInfo).toHaveBeenCalledWith(
+      expect.objectContaining({ channelID: "group-1" })
+    );
+    expect(runtime.fetchChannelSubscriber).toHaveBeenCalledWith(
+      expect.objectContaining({ channelID: "group-1" }),
+      "alice"
+    );
+    expect(runtime.fetchChannelSubscriber).toHaveBeenCalledWith(
+      expect.objectContaining({ channelID: "group-1" }),
+      "bob"
+    );
+    expect(runtime.setCurrentChannelSubscribers).toHaveBeenCalledWith(
+      expect.objectContaining({ channelID: "group-1" }),
+      [
+        { uid: "owner" },
+        expect.objectContaining({ uid: "alice", name: "member:alice" }),
+        expect.objectContaining({ uid: "bob", name: "member:bob" }),
+      ]
+    );
+  });
+
+  it("does not refresh member state when adding subscribers to an existing group fails", async () => {
+    const runtime = createRuntime({
+      addSubscribers: vi.fn(() => Promise.reject(new Error("add failed"))),
+    });
+
+    await expect(
+      submitGroupCreateAction({
+        action: "addMember",
+        channel: { channelID: "group-1", channelType: ChannelTypeGroup },
+        selectedUids: ["alice"],
+        runtime,
+      })
+    ).rejects.toThrow("add failed");
+
+    expect(runtime.syncCurrentChannelSubscribers).not.toHaveBeenCalled();
+    expect(runtime.notifyCurrentChannelSubscribers).not.toHaveBeenCalled();
+    expect(runtime.fetchCurrentChannelInfo).not.toHaveBeenCalled();
+  });
+
+  it("still fills newly added subscribers when existing group sync fails", async () => {
+    const runtime = createRuntime({
+      getCurrentChannelSubscribers: vi.fn(() => [{ uid: "owner" }]),
+      syncCurrentChannelSubscribers: vi.fn(() =>
+        Promise.reject(new Error("sync failed"))
+      ),
+    });
+
+    await submitGroupCreateAction({
+      action: "addMember",
+      channel: { channelID: "group-1", channelType: ChannelTypeGroup },
+      selectedUids: ["alice"],
+      runtime,
+    });
+
+    expect(runtime.setCurrentChannelSubscribers).toHaveBeenCalledWith(
+      expect.objectContaining({ channelID: "group-1" }),
+      [
+        { uid: "owner" },
+        expect.objectContaining({ uid: "alice", name: "member:alice" }),
+      ]
+    );
+    expect(runtime.notifyCurrentChannelSubscribers).toHaveBeenCalledWith(
+      expect.objectContaining({ channelID: "group-1" })
+    );
+    expect(runtime.fetchCurrentChannelInfo).toHaveBeenCalledWith(
+      expect.objectContaining({ channelID: "group-1" })
+    );
   });
 });

--- a/packages/dmworkcontacts/src/bridge/groupCreate/groupCreateRuntime.ts
+++ b/packages/dmworkcontacts/src/bridge/groupCreate/groupCreateRuntime.ts
@@ -6,6 +6,7 @@ import {
   getCurrentImChannelSubscribers,
   notifyCurrentImSubscriberChangeListeners,
   setCurrentImChannelSubscribersCache,
+  SubscriberStatus,
   syncCurrentImChannelSubscribers,
   WKApp,
 } from "@octo/base";
@@ -243,8 +244,25 @@ function activeSubscriber(subscriber: any) {
   return (
     subscriber &&
     !subscriber.isDeleted &&
-    (subscriber.status === undefined || subscriber.status === 1)
+    subscriber.status === SubscriberStatus.normal
   );
+}
+
+function normalizeFetchedSubscriber(
+  subscriber: any | undefined,
+  channel: Channel
+) {
+  if (!subscriber || subscriber.isDeleted) {
+    return undefined;
+  }
+  if (subscriber.status === undefined) {
+    subscriber.status = SubscriberStatus.normal;
+  }
+  if (subscriber.status !== SubscriberStatus.normal) {
+    return undefined;
+  }
+  subscriber.channel = channel;
+  return subscriber;
 }
 
 async function patchSubscriberCacheAfterAdd(
@@ -258,24 +276,38 @@ async function patchSubscriberCacheAfterAdd(
   }
 
   const currentSubscribers = runtime.getCurrentChannelSubscribers(channel) || [];
-  const nextSubscribers = [...currentSubscribers];
+  const uidsToFetch = Array.from(targetUids).filter((uid) => {
+    const index = currentSubscribers.findIndex(
+      (subscriber) => subscriber?.uid === uid
+    );
+    return index < 0 || !activeSubscriber(currentSubscribers[index]);
+  });
+
+  const fetchedSubscribers = (
+    await Promise.all(
+      uidsToFetch.map((uid) =>
+        runtime.fetchChannelSubscriber(channel, uid).catch(() => undefined)
+      )
+    )
+  )
+    .map((subscriber) => normalizeFetchedSubscriber(subscriber, channel))
+    .filter(Boolean);
+
+  if (fetchedSubscribers.length === 0) {
+    return false;
+  }
+
+  const latestSubscribers = runtime.getCurrentChannelSubscribers(channel) || [];
+  const nextSubscribers = [...latestSubscribers];
   let changed = false;
 
-  for (const uid of targetUids) {
+  for (const subscriber of fetchedSubscribers) {
     const index = nextSubscribers.findIndex(
-      (subscriber) => subscriber?.uid === uid
+      (item) => item?.uid === subscriber.uid
     );
     if (index >= 0 && activeSubscriber(nextSubscribers[index])) {
       continue;
     }
-
-    const subscriber = await runtime.fetchChannelSubscriber(channel, uid).catch(
-      () => undefined
-    );
-    if (!subscriber) {
-      continue;
-    }
-    subscriber.channel = channel;
     if (index >= 0) {
       nextSubscribers[index] = subscriber;
     } else {

--- a/packages/dmworkcontacts/src/bridge/groupCreate/groupCreateRuntime.ts
+++ b/packages/dmworkcontacts/src/bridge/groupCreate/groupCreateRuntime.ts
@@ -1,8 +1,11 @@
 import { Channel, ChannelTypeGroup, ChannelTypePerson } from "wukongimjssdk";
 
 import {
+  fetchCurrentImChannelInfo,
   getCurrentImChannelInfo,
   getCurrentImChannelSubscribers,
+  notifyCurrentImSubscriberChangeListeners,
+  setCurrentImChannelSubscribersCache,
   syncCurrentImChannelSubscribers,
   WKApp,
 } from "@octo/base";
@@ -46,6 +49,12 @@ function createDefaultGroupCreateRuntime(): GroupCreateRuntime {
     getCurrentSpaceId() {
       return WKApp.shared.currentSpaceId;
     },
+    fetchCurrentChannelInfo(channel) {
+      return fetchCurrentImChannelInfo(channel);
+    },
+    fetchChannelSubscriber(channel, uid) {
+      return WKApp.dataSource.channelDataSource.subscriber(channel, uid);
+    },
     getLoginUid() {
       return WKApp.loginInfo.uid;
     },
@@ -63,6 +72,12 @@ function createDefaultGroupCreateRuntime(): GroupCreateRuntime {
     },
     showConversation(channel, options) {
       WKApp.endpoints.showConversation(channel, options);
+    },
+    notifyCurrentChannelSubscribers(channel) {
+      notifyCurrentImSubscriberChangeListeners(channel);
+    },
+    setCurrentChannelSubscribers(channel, subscribers) {
+      setCurrentImChannelSubscribersCache(channel, subscribers);
     },
     syncCurrentChannelSubscribers(channel) {
       return syncCurrentImChannelSubscribers(channel);
@@ -191,6 +206,90 @@ export async function loadGroupCreateCandidates(params: {
   });
 }
 
+async function refreshGroupMemberStateAfterMutation(
+  runtime: GroupCreateRuntime,
+  channel: Channel,
+  addedUids: string[]
+) {
+  let shouldNotifySubscribers = false;
+
+  try {
+    await runtime.syncCurrentChannelSubscribers(channel);
+    shouldNotifySubscribers = true;
+  } catch (err) {
+    console.warn("[addMember] syncSubscribes failed", err);
+  }
+
+  const cachePatched = await patchSubscriberCacheAfterAdd(
+    runtime,
+    channel,
+    addedUids
+  );
+
+  if (cachePatched) {
+    shouldNotifySubscribers = true;
+  }
+
+  if (shouldNotifySubscribers) {
+    runtime.notifyCurrentChannelSubscribers(channel);
+  }
+
+  await runtime.fetchCurrentChannelInfo(channel).catch((err) => {
+    console.warn("[addMember] fetchChannelInfo failed", err);
+  });
+}
+
+function activeSubscriber(subscriber: any) {
+  return (
+    subscriber &&
+    !subscriber.isDeleted &&
+    (subscriber.status === undefined || subscriber.status === 1)
+  );
+}
+
+async function patchSubscriberCacheAfterAdd(
+  runtime: GroupCreateRuntime,
+  channel: Channel,
+  addedUids: string[]
+) {
+  const targetUids = new Set(addedUids.filter(Boolean));
+  if (targetUids.size === 0) {
+    return false;
+  }
+
+  const currentSubscribers = runtime.getCurrentChannelSubscribers(channel) || [];
+  const nextSubscribers = [...currentSubscribers];
+  let changed = false;
+
+  for (const uid of targetUids) {
+    const index = nextSubscribers.findIndex(
+      (subscriber) => subscriber?.uid === uid
+    );
+    if (index >= 0 && activeSubscriber(nextSubscribers[index])) {
+      continue;
+    }
+
+    const subscriber = await runtime.fetchChannelSubscriber(channel, uid).catch(
+      () => undefined
+    );
+    if (!subscriber) {
+      continue;
+    }
+    subscriber.channel = channel;
+    if (index >= 0) {
+      nextSubscribers[index] = subscriber;
+    } else {
+      nextSubscribers.push(subscriber);
+    }
+    changed = true;
+  }
+
+  if (changed) {
+    runtime.setCurrentChannelSubscribers(channel, nextSubscribers);
+  }
+  return changed;
+}
+
 export async function submitGroupCreateAction(params: {
   action: GroupCreateSubmitAction;
   channel: GroupCreateChannelInput;
@@ -233,5 +332,10 @@ export async function submitGroupCreateAction(params: {
   }
 
   await runtime.addSubscribers(channel, params.selectedUids);
+  await refreshGroupMemberStateAfterMutation(
+    runtime,
+    channel,
+    params.selectedUids
+  );
   return undefined;
 }

--- a/packages/dmworkcontacts/src/bridge/groupCreate/types.ts
+++ b/packages/dmworkcontacts/src/bridge/groupCreate/types.ts
@@ -26,6 +26,13 @@ export interface GroupCreateSpaceMember {
   robot?: boolean | number;
 }
 
+export interface GroupCreateSubscriberRecord {
+  uid?: string;
+  status?: number;
+  isDeleted?: boolean;
+  [key: string]: any;
+}
+
 export interface GroupCreateSubmitOptions {
   categoryId?: string;
   name?: string;
@@ -44,10 +51,13 @@ export interface GroupCreateRuntime {
   getAvatarUser(uid: string): string;
   getContactsList(): GroupCreateContactRecord[];
   getCurrentChannelInfo(channel: Channel): any;
-  getCurrentChannelSubscribers(channel: Channel): Array<any>;
+  getCurrentChannelSubscribers(channel: Channel): GroupCreateSubscriberRecord[];
   getCurrentSpaceId(): string | undefined;
   fetchCurrentChannelInfo(channel: Channel): Promise<any>;
-  fetchChannelSubscriber(channel: Channel, uid: string): Promise<any | undefined>;
+  fetchChannelSubscriber(
+    channel: Channel,
+    uid: string
+  ): Promise<GroupCreateSubscriberRecord | undefined>;
   getLoginUid(): string | undefined;
   getSpaceMembers(
     spaceId: string,
@@ -60,6 +70,9 @@ export interface GroupCreateRuntime {
     options?: { fromSidebarList?: boolean }
   ): void;
   notifyCurrentChannelSubscribers(channel: Channel): void;
-  setCurrentChannelSubscribers(channel: Channel, subscribers: any[]): void;
+  setCurrentChannelSubscribers(
+    channel: Channel,
+    subscribers: GroupCreateSubscriberRecord[]
+  ): void;
   syncCurrentChannelSubscribers(channel: Channel): Promise<any>;
 }

--- a/packages/dmworkcontacts/src/bridge/groupCreate/types.ts
+++ b/packages/dmworkcontacts/src/bridge/groupCreate/types.ts
@@ -44,8 +44,10 @@ export interface GroupCreateRuntime {
   getAvatarUser(uid: string): string;
   getContactsList(): GroupCreateContactRecord[];
   getCurrentChannelInfo(channel: Channel): any;
-  getCurrentChannelSubscribers(channel: Channel): Array<{ uid: string }>;
+  getCurrentChannelSubscribers(channel: Channel): Array<any>;
   getCurrentSpaceId(): string | undefined;
+  fetchCurrentChannelInfo(channel: Channel): Promise<any>;
+  fetchChannelSubscriber(channel: Channel, uid: string): Promise<any | undefined>;
   getLoginUid(): string | undefined;
   getSpaceMembers(
     spaceId: string,
@@ -57,5 +59,7 @@ export interface GroupCreateRuntime {
     channel: Channel,
     options?: { fromSidebarList?: boolean }
   ): void;
+  notifyCurrentChannelSubscribers(channel: Channel): void;
+  setCurrentChannelSubscribers(channel: Channel, subscribers: any[]): void;
   syncCurrentChannelSubscribers(channel: Channel): Promise<any>;
 }


### PR DESCRIPTION
## Summary

- Refresh the shared subscriber cache after channel-setting member add/remove succeeds.
- Reconcile stale local member cache after successful mutations so the right panel and add-member candidate filtering use the same updated state.
- Normalize backfilled subscribers to the renderable member status and merge fetched add-member records into the latest cache snapshot to avoid stale overwrites.
- Cover add/remove success, API failure, sync fallback, non-renderable cached members, and existing-group add-member paths.

## Verification

- Manually verified group member add/remove panel refresh.
- `pnpm --dir packages/dmworkbase test -- channelSettingActions.test.ts`
- `pnpm --dir packages/dmworkcontacts test -- groupCreateRuntime.test.ts useGroupCreate.test.tsx`
- `pnpm --dir apps/web build`

Fixes #1172.
Fixes #1176.