### PR TITLE
fix(drive): cache org roster and filter locally

### DIFF
--- a/packages/dmworkdrive/src/api/__tests__/driveApi.test.ts
+++ b/packages/dmworkdrive/src/api/__tests__/driveApi.test.ts
@@ -232,22 +232,13 @@ describe('share / invite / org', () => {
     expect(inst.post).toHaveBeenCalledWith('/v1/drive/invites/tok/accept', undefined);
   });
 
-  it('searchOrgUser GETs /org/search with an empty q to list team members', async () => {
+  it('listOrgMembers GETs /org/members (space scoped by the X-Space-Id header)', async () => {
     inst.get.mockResolvedValue(ok({ candidates: [{ uid: 'u1' }, { uid: 'u2' }], total: 2 }));
-    const res = await driveApi.searchOrgUser({ q: '   ' });
-    expect(inst.get).toHaveBeenCalledWith('/v1/drive/org/search', {
-      params: { q: '   ' },
+    const res = await driveApi.listOrgMembers();
+    expect(inst.get).toHaveBeenCalledWith('/v1/drive/org/members', {
+      params: {},
     });
     expect(res.total).toBe(2);
-  });
-
-  it('searchOrgUser GETs /org/search for a non-empty query', async () => {
-    inst.get.mockResolvedValue(ok({ candidates: [{ uid: 'u1' }], total: 1 }));
-    const res = await driveApi.searchOrgUser({ q: 'bob', limit: 20 });
-    expect(inst.get).toHaveBeenCalledWith('/v1/drive/org/search', {
-      params: { q: 'bob', limit: '20' },
-    });
-    expect(res.total).toBe(1);
   });
 });
 

--- a/packages/dmworkdrive/src/api/__tests__/driveApi.test.ts
+++ b/packages/dmworkdrive/src/api/__tests__/driveApi.test.ts
@@ -283,6 +283,23 @@ describe('auth-header interceptor', () => {
     expect(config.headers['Accept-Language']).toBeTruthy();
   });
 
+  it('reads the LATEST host X-Space-Id at request time, not a value captured earlier (F3)', () => {
+    // The org-members fetch is scoped only by this header, so a host space switch
+    // between two requests must be reflected — the interceptor reads
+    // WKApp.shared.currentSpaceId on each call rather than closing over it.
+    const requestUse = inst.interceptors.request.use as ReturnType<typeof vi.fn>;
+    const onRequest = requestUse.mock.calls[0][0];
+    const original = WKApp.shared.currentSpaceId;
+    try {
+      WKApp.shared.currentSpaceId = 'space-A';
+      expect(onRequest({ headers: {} }).headers['X-Space-Id']).toBe('space-A');
+      WKApp.shared.currentSpaceId = 'space-B';
+      expect(onRequest({ headers: {} }).headers['X-Space-Id']).toBe('space-B');
+    } finally {
+      WKApp.shared.currentSpaceId = original;
+    }
+  });
+
   it('logs out on a 401 from a normal drive API', async () => {
     const logout = vi.spyOn(WKApp.shared, 'logout');
     const responseUse = inst.interceptors.response.use as ReturnType<typeof vi.fn>;

--- a/packages/dmworkdrive/src/api/driveApi.ts
+++ b/packages/dmworkdrive/src/api/driveApi.ts
@@ -579,6 +579,11 @@ export async function acceptInvite(token: string): Promise<AcceptInviteResult> {
  * request interceptor injects (the octo space id, NOT the drive `space_id`);
  * drive proxies to octo-server and pages the roster exhaustively. Candidates
  * carry uid + name only — pinyin/keyword matching happens client-side.
+ *
+ * Contract: the response is a complete roster plus an authoritative `total`
+ * equal to `candidates.length`. The caller rejects any incomplete or malformed
+ * response (mismatched/missing/non-numeric total) rather than caching a partial
+ * roster — it does not client-side paginate.
  */
 export async function listOrgMembers(signal?: AbortSignal): Promise<OrgSearchResponse> {
   return get<OrgSearchResponse>('/org/members', undefined, signal);

--- a/packages/dmworkdrive/src/api/driveApi.ts
+++ b/packages/dmworkdrive/src/api/driveApi.ts
@@ -36,7 +36,6 @@ import type {
   DriveRole,
   BrowseParams,
   MountableDocsParams,
-  OrgSearchParams,
 } from '../bridge/types';
 
 /**
@@ -575,19 +574,14 @@ export async function acceptInvite(token: string): Promise<AcceptInviteResult> {
 // ─── Org picker (proxied to octo-server) ─────────────────────────────────────
 
 /**
- * Org-member picker source. A non-empty `q` keyword-searches octo-server
- * (single-user lookup); an empty `q` lists the caller's current octo space
- * members (drive branches on the X-Space-Id header the interceptor sends).
+ * List every member of the caller's current octo space, for the org picker's
+ * fetch-once-then-filter-locally flow. Scoped by the `X-Space-Id` header the
+ * request interceptor injects (the octo space id, NOT the drive `space_id`);
+ * drive proxies to octo-server and pages the roster exhaustively. Candidates
+ * carry uid + name only — pinyin/keyword matching happens client-side.
  */
-export async function searchOrgUser(
-  params: OrgSearchParams,
-  signal?: AbortSignal,
-): Promise<OrgSearchResponse> {
-  return get<OrgSearchResponse>(
-    '/org/search',
-    params as unknown as Record<string, unknown>,
-    signal,
-  );
+export async function listOrgMembers(signal?: AbortSignal): Promise<OrgSearchResponse> {
+  return get<OrgSearchResponse>('/org/members', undefined, signal);
 }
 
 export type { DriveRole };

--- a/packages/dmworkdrive/src/api/driveApi.ts
+++ b/packages/dmworkdrive/src/api/driveApi.ts
@@ -580,10 +580,11 @@ export async function acceptInvite(token: string): Promise<AcceptInviteResult> {
  * drive proxies to octo-server and pages the roster exhaustively. Candidates
  * carry uid + name only — pinyin/keyword matching happens client-side.
  *
- * Contract: the response is a complete roster plus an authoritative `total`
- * equal to `candidates.length`. The caller rejects any incomplete or malformed
- * response (mismatched/missing/non-numeric total) rather than caching a partial
- * roster — it does not client-side paginate.
+ * `total`, when present, is the authoritative roster size. The caller uses it
+ * only as a completeness hint: a missing/non-numeric total, or one that
+ * disagrees with the delivered count, surfaces a non-blocking "possibly
+ * incomplete" notice — it still caches and shows the delivered roster rather
+ * than failing closed on an unversioned field.
  */
 export async function listOrgMembers(signal?: AbortSignal): Promise<OrgSearchResponse> {
   return get<OrgSearchResponse>('/org/members', undefined, signal);

--- a/packages/dmworkdrive/src/bridge/types.ts
+++ b/packages/dmworkdrive/src/bridge/types.ts
@@ -243,10 +243,6 @@ export interface AcceptInviteResult {
 export interface OrgCandidate {
   uid: string;
   name?: string;
-  username?: string;
-  email?: string;
-  /** masked upstream: front3 + **** + last4 */
-  phone?: string;
 }
 
 // ─── Request bodies ─────────────────────────────────────────────────────────

--- a/packages/dmworkdrive/src/bridge/types.ts
+++ b/packages/dmworkdrive/src/bridge/types.ts
@@ -352,12 +352,6 @@ export interface MountableDocsParams {
   page_size?: number;
 }
 
-export interface OrgSearchParams {
-  q: string;
-  space_id?: string;
-  limit?: number;
-}
-
 // ─── List / composite responses ──────────────────────────────────────────────
 
 export interface BrowseResponse {

--- a/packages/dmworkdrive/src/hooks/__tests__/useOrgSearch.test.ts
+++ b/packages/dmworkdrive/src/hooks/__tests__/useOrgSearch.test.ts
@@ -248,4 +248,47 @@ describe('useOrgSearch', () => {
     expect(result.current.error).toBe(false);
     unmount();
   });
+
+  it('rejects a malformed/missing total as a load error (total must be a valid count)', async () => {
+    // The server contract requires an authoritative numeric total; a
+    // missing/string/NaN/negative total is a broken response, not a partial-ok.
+    const bad: Array<Record<string, unknown>> = [
+      { candidates: [cand('u1', 'Alice')] }, // total missing
+      { candidates: [cand('u1', 'Alice')], total: '1' }, // string
+      { candidates: [cand('u1', 'Alice')], total: NaN }, // NaN
+      { candidates: [cand('u1', 'Alice')], total: -1 }, // negative
+      { candidates: [cand('u1', 'Alice'), cand('u2', 'Bob')], total: 1 }, // mismatch
+    ];
+    for (const res of bad) {
+      vi.mocked(api.listOrgMembers).mockReset();
+      vi.mocked(api.listOrgMembers).mockResolvedValueOnce(res as unknown as OrgSearchResponse);
+      const { result, unmount } = renderHook(() => useOrgSearch());
+      await waitFor(() => expect(result.current.error).toBe(true));
+      expect(result.current.candidates).toEqual([]);
+      unmount();
+    }
+  });
+
+  // ── F2: account fields (username/email/phone) are locally searchable ────────
+
+  it('filters locally by username / email / phone — no extra backend call', async () => {
+    const roster: OrgCandidate[] = [
+      { uid: 'u1', name: 'Alice', username: 'alice.w', email: 'alice@corp.com', phone: '13800001111' },
+      { uid: 'u2', name: 'Bob', username: 'bob.k', email: 'bob@corp.com', phone: '13900002222' },
+    ];
+    vi.mocked(api.listOrgMembers).mockResolvedValue({ candidates: roster, total: roster.length });
+    const { result, unmount } = renderHook(() => useOrgSearch());
+    await waitFor(() => expect(result.current.candidates.length).toBe(2));
+
+    act(() => result.current.search('alice.w')); // username
+    expect(result.current.candidates).toEqual([roster[0]]);
+    act(() => result.current.search('bob@corp')); // email
+    expect(result.current.candidates).toEqual([roster[1]]);
+    act(() => result.current.search('13800001111')); // phone
+    expect(result.current.candidates).toEqual([roster[0]]);
+
+    // All local: the roster was fetched exactly once.
+    expect(api.listOrgMembers).toHaveBeenCalledTimes(1);
+    unmount();
+  });
 });

--- a/packages/dmworkdrive/src/hooks/__tests__/useOrgSearch.test.ts
+++ b/packages/dmworkdrive/src/hooks/__tests__/useOrgSearch.test.ts
@@ -2,10 +2,13 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { renderHook, waitFor, act } from '../../__tests__/harness';
 
 vi.mock('../../api/driveApi', () => ({
-  searchOrgUser: vi.fn(),
+  listOrgMembers: vi.fn(),
 }));
 
 import * as api from '../../api/driveApi';
+// Aliased to the @octo/base mock (vite.config): same mittBus singleton the hook
+// subscribes to, so emitting here drives the hook's space-changed handler.
+import { WKApp } from '@octo/base';
 import { useOrgSearch } from '../useOrgSearch';
 import type { OrgCandidate, OrgSearchResponse } from '../../bridge/types';
 
@@ -15,102 +18,165 @@ function cand(uid: string, name = uid): OrgCandidate {
 function resp(cands: OrgCandidate[]): OrgSearchResponse {
   return { candidates: cands, total: cands.length };
 }
+function deferred(): { promise: Promise<OrgSearchResponse>; resolve: (v: OrgSearchResponse) => void } {
+  let resolve!: (v: OrgSearchResponse) => void;
+  const promise = new Promise<OrgSearchResponse>((r) => { resolve = r; });
+  return { promise, resolve };
+}
 
 beforeEach(() => {
-  vi.mocked(api.searchOrgUser).mockReset();
-  vi.mocked(api.searchOrgUser).mockResolvedValue(resp([]));
+  vi.mocked(api.listOrgMembers).mockReset();
+  vi.mocked(api.listOrgMembers).mockResolvedValue(resp([]));
 });
 
 describe('useOrgSearch', () => {
-  it('debounces then searches and stores candidates', async () => {
-    vi.mocked(api.searchOrgUser).mockResolvedValue(resp([cand('u1', 'Alice'), cand('u2', 'Bob')]));
-    const { result } = renderHook(() => useOrgSearch('sp'));
-
-    act(() => result.current.search('al'));
-    expect(result.current.query).toBe('al');
+  it('fetches the full roster once on mount and caches it', async () => {
+    vi.mocked(api.listOrgMembers).mockResolvedValue(resp([cand('u1', 'Alice'), cand('u2', 'Bob')]));
+    const { result, unmount } = renderHook(() => useOrgSearch());
 
     await waitFor(() => expect(result.current.candidates.length).toBe(2));
-    expect(api.searchOrgUser).toHaveBeenCalledWith(
-      expect.objectContaining({ q: 'al', space_id: 'sp' }),
-      expect.anything(),
-    );
+    expect(api.listOrgMembers).toHaveBeenCalledTimes(1);
+    // Scoped by the X-Space-Id header (api layer), so no space arg is passed.
+    expect(api.listOrgMembers).toHaveBeenCalledWith(expect.anything());
+    unmount();
   });
 
-  it('lists team members for an empty query (default view)', async () => {
-    vi.mocked(api.searchOrgUser).mockResolvedValue(resp([cand('u1', 'Alice'), cand('u2', 'Bob')]));
-    const { result } = renderHook(() => useOrgSearch('sp'));
+  it('filters the cached roster locally by name substring — no extra backend call', async () => {
+    vi.mocked(api.listOrgMembers).mockResolvedValue(
+      resp([cand('u1', 'Alice'), cand('u2', 'Bob'), cand('u3', 'Carol')]),
+    );
+    const { result, unmount } = renderHook(() => useOrgSearch());
+    await waitFor(() => expect(result.current.candidates.length).toBe(3));
 
+    act(() => result.current.search('ali'));
+    expect(result.current.query).toBe('ali');
+    expect(result.current.candidates).toEqual([cand('u1', 'Alice')]);
+    // Local-only: the roster was fetched once, never again on keystrokes.
+    expect(api.listOrgMembers).toHaveBeenCalledTimes(1);
+    unmount();
+  });
+
+  it('filters the cached roster locally by pinyin of a CJK name', async () => {
+    vi.mocked(api.listOrgMembers).mockResolvedValue(
+      resp([cand('u1', 'Alice'), cand('u2', '张三')]),
+    );
+    const { result, unmount } = renderHook(() => useOrgSearch());
+    await waitFor(() => expect(result.current.candidates.length).toBe(2));
+
+    act(() => result.current.search('zhang'));
+    expect(result.current.candidates).toEqual([cand('u2', '张三')]);
+    expect(api.listOrgMembers).toHaveBeenCalledTimes(1);
+    unmount();
+  });
+
+  it('an empty query restores the full cached roster', async () => {
+    vi.mocked(api.listOrgMembers).mockResolvedValue(resp([cand('u1', 'Alice'), cand('u2', 'Bob')]));
+    const { result, unmount } = renderHook(() => useOrgSearch());
+    await waitFor(() => expect(result.current.candidates.length).toBe(2));
+
+    act(() => result.current.search('ali'));
+    expect(result.current.candidates.length).toBe(1);
     act(() => result.current.search('   '));
-    await waitFor(() => expect(result.current.candidates.length).toBe(2));
-    expect(api.searchOrgUser).toHaveBeenCalledWith(
-      expect.objectContaining({ q: '   ', space_id: 'sp' }),
-      expect.anything(),
-    );
+    expect(result.current.candidates.length).toBe(2);
+    unmount();
   });
 
-  it('coalesces rapid keystrokes into one trailing search', async () => {
-    vi.mocked(api.searchOrgUser).mockResolvedValue(resp([cand('u9')]));
-    const { result } = renderHook(() => useOrgSearch());
+  // ── F1: re-fetch keys on the host octo space, NOT the drive space ──────────
 
-    act(() => {
-      result.current.search('a');
-      result.current.search('ab');
-      result.current.search('abc');
-    });
+  it('does not re-fetch when the drive space changes (hook re-renders)', async () => {
+    vi.mocked(api.listOrgMembers).mockResolvedValue(resp([cand('u1', 'Alice')]));
+    // The hook takes no space arg — drive activeSpaceId lives on the consumer.
+    // A drive personal→shared switch re-renders the consumer (undefined→personal
+    // →shared); none of that may touch the backend. Only host space-changed does.
+    const { result, rerender, unmount } = renderHook(() => useOrgSearch());
     await waitFor(() => expect(result.current.candidates.length).toBe(1));
-    expect(api.searchOrgUser).toHaveBeenCalledTimes(1);
-    expect(api.searchOrgUser).toHaveBeenCalledWith(
-      expect.objectContaining({ q: 'abc' }),
-      expect.anything(),
-    );
+
+    act(() => rerender());
+    act(() => rerender());
+    expect(api.listOrgMembers).toHaveBeenCalledTimes(1);
+    unmount();
   });
 
-  it('clears candidates/query/loading synchronously on a space switch (no stale carry)', async () => {
-    vi.mocked(api.searchOrgUser).mockResolvedValue(resp([cand('a1', 'A-Alice'), cand('a2', 'A-Bob')]));
-    const { result, rerender } = renderHook((sp: string) => useOrgSearch(sp), 'space-A' as string);
-
-    act(() => result.current.search('alice'));
-    expect(result.current.query).toBe('alice');
+  it('reloads on host space-changed: clears old candidates+query synchronously and issues one new request', async () => {
+    vi.mocked(api.listOrgMembers).mockResolvedValueOnce(resp([cand('a1', 'A-Alice'), cand('a2', 'A-Bob')]));
+    const { result, unmount } = renderHook(() => useOrgSearch());
     await waitFor(() => expect(result.current.candidates.length).toBe(2));
+    act(() => result.current.search('a-alice'));
+    expect(result.current.query).toBe('a-alice');
 
-    // Switch space: state is dropped immediately, without waiting for a debounce
-    // or a new response to land.
-    act(() => rerender('space-B'));
-    expect(result.current.candidates).toEqual([]);
+    // Next load is a controllable pending promise so we can observe the sync clear.
+    const late = deferred();
+    vi.mocked(api.listOrgMembers).mockReturnValueOnce(late.promise);
+    act(() => WKApp.mittBus.emit('space-changed'));
+
+    // Synchronous: previous space's candidates + query dropped before B lands.
     expect(result.current.query).toBe('');
-    expect(result.current.loading).toBe(false);
+    expect(result.current.candidates).toEqual([]);
+    expect(api.listOrgMembers).toHaveBeenCalledTimes(2);
+
+    await act(async () => { late.resolve(resp([cand('b1', 'B-Carol')])); await Promise.resolve(); });
+    expect(result.current.candidates).toEqual([cand('b1', 'B-Carol')]);
+    unmount();
   });
 
-  it('a late Space A response cannot write back after switching to Space B; B search uses B params', async () => {
-    let resolveA!: (v: OrgSearchResponse) => void;
-    // First call (Space A) hangs until we resolve it manually; later calls (B) resolve normally.
-    vi.mocked(api.searchOrgUser).mockResolvedValue(resp([cand('b1', 'B-Carol')]));
-    vi.mocked(api.searchOrgUser).mockImplementationOnce(
-      () => new Promise<OrgSearchResponse>((res) => { resolveA = res; }),
-    );
+  it('a late previous-generation response cannot write back after space-changed', async () => {
+    // gen-1 stays pending; space-changed spawns gen-2 which resolves first.
+    const genA = deferred();
+    vi.mocked(api.listOrgMembers).mockReturnValueOnce(genA.promise);
+    const { result, unmount } = renderHook(() => useOrgSearch());
+    await waitFor(() => expect(result.current.loading).toBe(true));
 
-    const { result, rerender } = renderHook((sp: string) => useOrgSearch(sp), 'space-A' as string);
+    vi.mocked(api.listOrgMembers).mockResolvedValueOnce(resp([cand('b1', 'B-Carol')]));
+    act(() => WKApp.mittBus.emit('space-changed'));
+    expect(api.listOrgMembers).toHaveBeenCalledTimes(2);
+    await waitFor(() => expect(result.current.candidates).toEqual([cand('b1', 'B-Carol')]));
 
-    act(() => result.current.search('alice'));
-    await waitFor(() => expect(result.current.loading).toBe(true)); // A request in-flight
+    // gen-1 (aborted) responds late — the aborted-signal guard must swallow it.
+    await act(async () => { genA.resolve(resp([cand('a1', 'A-STALE')])); await Promise.resolve(); });
+    expect(result.current.candidates).toEqual([cand('b1', 'B-Carol')]);
+    unmount();
+  });
 
-    // Switch to B: A's request is aborted and state cleared.
-    act(() => rerender('space-B'));
+  it('a late roster response cannot write back after unmount', async () => {
+    const late = deferred();
+    vi.mocked(api.listOrgMembers).mockReturnValueOnce(late.promise);
+    const { result, unmount } = renderHook(() => useOrgSearch());
+    await waitFor(() => expect(result.current.loading).toBe(true));
+
+    unmount();
+    await act(async () => { late.resolve(resp([cand('u1', 'Alice')])); await Promise.resolve(); });
     expect(result.current.candidates).toEqual([]);
+  });
 
-    // A's response arrives late — must be discarded (aborted-signal guard).
+  it('on unmount removes the listener: a later space-changed does not fetch', async () => {
+    vi.mocked(api.listOrgMembers).mockResolvedValue(resp([cand('u1', 'Alice')]));
+    const { result, unmount } = renderHook(() => useOrgSearch());
+    await waitFor(() => expect(result.current.candidates.length).toBe(1));
+    expect(api.listOrgMembers).toHaveBeenCalledTimes(1);
+
+    unmount();
+    act(() => WKApp.mittBus.emit('space-changed'));
+    expect(api.listOrgMembers).toHaveBeenCalledTimes(1);
+  });
+
+  // ── F2: a query typed while loading survives the roster resolve ────────────
+
+  it('keeps a query typed during load: resolves filtered to the query, not the full roster', async () => {
+    const load = deferred();
+    vi.mocked(api.listOrgMembers).mockReturnValueOnce(load.promise);
+    const { result, unmount } = renderHook(() => useOrgSearch());
+    await waitFor(() => expect(result.current.loading).toBe(true));
+
+    act(() => result.current.search('zhang'));
+    expect(result.current.query).toBe('zhang');
+
     await act(async () => {
-      resolveA(resp([cand('a1', 'A-Alice'), cand('a2', 'A-Bob')]));
+      load.resolve(resp([cand('u1', '张三'), cand('u2', '李四')]));
       await Promise.resolve();
     });
-    expect(result.current.candidates).toEqual([]);
-
-    // A fresh search now targets Space B only.
-    act(() => result.current.search('carol'));
-    await waitFor(() => expect(result.current.candidates).toEqual([cand('b1', 'B-Carol')]));
-    expect(api.searchOrgUser).toHaveBeenLastCalledWith(
-      expect.objectContaining({ q: 'carol', space_id: 'space-B' }),
-      expect.anything(),
-    );
+    // Query preserved; roster filtered to it — the full list must not clobber.
+    expect(result.current.query).toBe('zhang');
+    expect(result.current.candidates).toEqual([cand('u1', '张三')]);
+    unmount();
   });
 });

--- a/packages/dmworkdrive/src/hooks/__tests__/useOrgSearch.test.ts
+++ b/packages/dmworkdrive/src/hooks/__tests__/useOrgSearch.test.ts
@@ -214,81 +214,83 @@ describe('useOrgSearch', () => {
     unmount();
   });
 
-  // ── F2: truncation hard check (total must equal delivered count) ────────────
+  // ── F2: partial-roster degrade (never brick the picker on a `total` mismatch) ──
 
-  it('treats a truncated roster (total > candidates.length) as a load error and caches nothing', async () => {
-    // Server-side page cap: claims 5 members but only delivered 2.
+  it('a complete roster (total === candidates.length) is not flagged incomplete', async () => {
+    vi.mocked(api.listOrgMembers).mockResolvedValue(resp([cand('u1', 'Alice'), cand('u2', 'Bob')]));
+    const { result, unmount } = renderHook(() => useOrgSearch());
+    await waitFor(() => expect(result.current.candidates.length).toBe(2));
+    expect(result.current.incomplete).toBe(false);
+    expect(result.current.error).toBe(false);
+    unmount();
+  });
+
+  it('caches a truncated roster (total > delivered) and flags it incomplete, not an error', async () => {
+    // Server-side page cap: claims 5 members but only delivered 2. The picker
+    // must stay usable with what arrived, not fail closed.
     vi.mocked(api.listOrgMembers).mockResolvedValueOnce({
       candidates: [cand('u1', 'Alice'), cand('u2', 'Bob')],
       total: 5,
     });
     const { result, unmount } = renderHook(() => useOrgSearch());
 
-    await waitFor(() => expect(result.current.error).toBe(true));
-    expect(result.current.candidates).toEqual([]);
-    // Nothing cached: a keystroke still surfaces nothing (no partial roster).
+    await waitFor(() => expect(result.current.candidates.length).toBe(2));
+    expect(result.current.incomplete).toBe(true);
+    expect(result.current.error).toBe(false);
+    // The delivered roster is cached and still locally filterable.
     act(() => result.current.search('ali'));
-    expect(result.current.candidates).toEqual([]);
+    expect(result.current.candidates).toEqual([cand('u1', 'Alice')]);
     unmount();
   });
 
-  it('recovers from a truncated response on retry when the full roster arrives', async () => {
+  it('clears the incomplete flag once a complete roster arrives on reload', async () => {
     vi.mocked(api.listOrgMembers).mockResolvedValueOnce({
       candidates: [cand('u1', 'Alice')],
       total: 3,
     });
     const { result, unmount } = renderHook(() => useOrgSearch());
-    await waitFor(() => expect(result.current.error).toBe(true));
+    await waitFor(() => expect(result.current.incomplete).toBe(true));
 
     vi.mocked(api.listOrgMembers).mockResolvedValueOnce(
       resp([cand('u1', 'Alice'), cand('u2', 'Bob'), cand('u3', 'Carol')]),
     );
     act(() => result.current.retry());
     await waitFor(() => expect(result.current.candidates.length).toBe(3));
+    expect(result.current.incomplete).toBe(false);
     expect(result.current.error).toBe(false);
     unmount();
   });
 
-  it('rejects a malformed/missing total as a load error (total must be a valid count)', async () => {
-    // The server contract requires an authoritative numeric total; a
-    // missing/string/NaN/negative total is a broken response, not a partial-ok.
-    const bad: Array<Record<string, unknown>> = [
+  it('degrades a missing/non-numeric total to incomplete but keeps the roster usable', async () => {
+    // A non-authoritative `total` (missing/string/NaN/negative) means the client
+    // cannot confirm completeness — surface a notice, but do NOT discard the
+    // delivered roster (the `total` contract is unversioned across services).
+    const nonAuthoritative: Array<Record<string, unknown>> = [
       { candidates: [cand('u1', 'Alice')] }, // total missing
       { candidates: [cand('u1', 'Alice')], total: '1' }, // string
       { candidates: [cand('u1', 'Alice')], total: NaN }, // NaN
       { candidates: [cand('u1', 'Alice')], total: -1 }, // negative
-      { candidates: [cand('u1', 'Alice'), cand('u2', 'Bob')], total: 1 }, // mismatch
     ];
-    for (const res of bad) {
+    for (const res of nonAuthoritative) {
       vi.mocked(api.listOrgMembers).mockReset();
       vi.mocked(api.listOrgMembers).mockResolvedValueOnce(res as unknown as OrgSearchResponse);
       const { result, unmount } = renderHook(() => useOrgSearch());
-      await waitFor(() => expect(result.current.error).toBe(true));
-      expect(result.current.candidates).toEqual([]);
+      await waitFor(() => expect(result.current.candidates).toEqual([cand('u1', 'Alice')]));
+      expect(result.current.incomplete).toBe(true);
+      expect(result.current.error).toBe(false);
       unmount();
     }
   });
 
-  // ── F2: account fields (username/email/phone) are locally searchable ────────
-
-  it('filters locally by username / email / phone — no extra backend call', async () => {
-    const roster: OrgCandidate[] = [
-      { uid: 'u1', name: 'Alice', username: 'alice.w', email: 'alice@corp.com', phone: '13800001111' },
-      { uid: 'u2', name: 'Bob', username: 'bob.k', email: 'bob@corp.com', phone: '13900002222' },
-    ];
-    vi.mocked(api.listOrgMembers).mockResolvedValue({ candidates: roster, total: roster.length });
+  it('an empty roster with no authoritative total is neither incomplete nor an error', async () => {
+    vi.mocked(api.listOrgMembers).mockResolvedValueOnce(
+      { candidates: [] } as unknown as OrgSearchResponse,
+    );
     const { result, unmount } = renderHook(() => useOrgSearch());
-    await waitFor(() => expect(result.current.candidates.length).toBe(2));
-
-    act(() => result.current.search('alice.w')); // username
-    expect(result.current.candidates).toEqual([roster[0]]);
-    act(() => result.current.search('bob@corp')); // email
-    expect(result.current.candidates).toEqual([roster[1]]);
-    act(() => result.current.search('13800001111')); // phone
-    expect(result.current.candidates).toEqual([roster[0]]);
-
-    // All local: the roster was fetched exactly once.
-    expect(api.listOrgMembers).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.candidates).toEqual([]);
+    expect(result.current.incomplete).toBe(false);
+    expect(result.current.error).toBe(false);
     unmount();
   });
 });

--- a/packages/dmworkdrive/src/hooks/__tests__/useOrgSearch.test.ts
+++ b/packages/dmworkdrive/src/hooks/__tests__/useOrgSearch.test.ts
@@ -179,4 +179,73 @@ describe('useOrgSearch', () => {
     expect(result.current.candidates).toEqual([cand('u1', '张三')]);
     unmount();
   });
+
+  // ── F1: load-failure state + retry ─────────────────────────────────────────
+
+  it('sets error and clears the cache when the roster load fails', async () => {
+    vi.mocked(api.listOrgMembers).mockRejectedValueOnce(new Error('network down'));
+    const { result, unmount } = renderHook(() => useOrgSearch());
+
+    await waitFor(() => expect(result.current.error).toBe(true));
+    expect(result.current.loading).toBe(false);
+    expect(result.current.candidates).toEqual([]);
+    unmount();
+  });
+
+  it('retry() reloads after a failure and recovers the roster on success', async () => {
+    vi.mocked(api.listOrgMembers).mockRejectedValueOnce(new Error('network down'));
+    const { result, unmount } = renderHook(() => useOrgSearch());
+    await waitFor(() => expect(result.current.error).toBe(true));
+
+    vi.mocked(api.listOrgMembers).mockResolvedValueOnce(resp([cand('u1', 'Alice')]));
+    act(() => result.current.retry());
+    await waitFor(() => expect(result.current.candidates).toEqual([cand('u1', 'Alice')]));
+    expect(result.current.error).toBe(false);
+    expect(api.listOrgMembers).toHaveBeenCalledTimes(2);
+    unmount();
+  });
+
+  it('an empty-but-successful roster is not an error (distinct from a failure)', async () => {
+    vi.mocked(api.listOrgMembers).mockResolvedValueOnce(resp([]));
+    const { result, unmount } = renderHook(() => useOrgSearch());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.error).toBe(false);
+    expect(result.current.candidates).toEqual([]);
+    unmount();
+  });
+
+  // ── F2: truncation hard check (total must equal delivered count) ────────────
+
+  it('treats a truncated roster (total > candidates.length) as a load error and caches nothing', async () => {
+    // Server-side page cap: claims 5 members but only delivered 2.
+    vi.mocked(api.listOrgMembers).mockResolvedValueOnce({
+      candidates: [cand('u1', 'Alice'), cand('u2', 'Bob')],
+      total: 5,
+    });
+    const { result, unmount } = renderHook(() => useOrgSearch());
+
+    await waitFor(() => expect(result.current.error).toBe(true));
+    expect(result.current.candidates).toEqual([]);
+    // Nothing cached: a keystroke still surfaces nothing (no partial roster).
+    act(() => result.current.search('ali'));
+    expect(result.current.candidates).toEqual([]);
+    unmount();
+  });
+
+  it('recovers from a truncated response on retry when the full roster arrives', async () => {
+    vi.mocked(api.listOrgMembers).mockResolvedValueOnce({
+      candidates: [cand('u1', 'Alice')],
+      total: 3,
+    });
+    const { result, unmount } = renderHook(() => useOrgSearch());
+    await waitFor(() => expect(result.current.error).toBe(true));
+
+    vi.mocked(api.listOrgMembers).mockResolvedValueOnce(
+      resp([cand('u1', 'Alice'), cand('u2', 'Bob'), cand('u3', 'Carol')]),
+    );
+    act(() => result.current.retry());
+    await waitFor(() => expect(result.current.candidates.length).toBe(3));
+    expect(result.current.error).toBe(false);
+    unmount();
+  });
 });

--- a/packages/dmworkdrive/src/hooks/useOrgSearch.ts
+++ b/packages/dmworkdrive/src/hooks/useOrgSearch.ts
@@ -1,10 +1,9 @@
 import { useState, useCallback, useEffect, useRef } from 'react';
+import { WKApp } from '@octo/base';
+import { getPinyin } from '@octo/base/src/Utils/pinYin';
+import { toSimplized } from '@octo/base/src/Utils/t2s';
 import * as api from '../api/driveApi';
 import type { OrgCandidate } from '../bridge/types';
-
-/** Debounce keystrokes before hitting the proxied octo-server user search. */
-const DEBOUNCE_MS = 250;
-const LIMIT = 20;
 
 export interface UseOrgSearchResult {
   candidates: OrgCandidate[];
@@ -13,77 +12,101 @@ export interface UseOrgSearchResult {
   search: (q: string) => void;
 }
 
+/** A candidate plus its precomputed lowercased "name\npinyin" match text. */
+interface IndexedCandidate {
+  item: OrgCandidate;
+  searchText: string;
+}
+
+/** Build the local match text: name + its (simplified) pinyin, both lowercased. */
+function buildSearchText(c: OrgCandidate): string {
+  const name = (c.name || '').toLowerCase();
+  const pinyin = getPinyin(toSimplized(name)).toLowerCase();
+  return `${name}\n${pinyin}`;
+}
+
+function filterLocal(index: IndexedCandidate[], q: string): OrgCandidate[] {
+  const kw = q.trim().toLowerCase();
+  if (!kw) return index.map((e) => e.item);
+  return index.filter((e) => e.searchText.includes(kw)).map((e) => e.item);
+}
+
 /**
- * Debounced org-member picker source, proxied through drive. A non-empty query
- * keyword-searches octo-server (/v1/user/search); an empty query lists the
- * caller's current octo space members (drive branches on the X-Space-Id header
- * the api layer sends), so the picker shows the team by default. An
- * AbortController drops out-of-order responses so the last keystroke wins.
+ * Org-member picker source using a fetch-once-then-filter-locally model
+ * (mirrors the contacts module): the full roster of the caller's current octo
+ * space is fetched once when the picker mounts (i.e. on entering the drive) and
+ * cached with a name+pinyin index. Keystrokes filter that cache locally with
+ * zero backend calls.
+ *
+ * Re-fetch is keyed on the **host octo space**, not any drive space: the fetch
+ * is scoped by the `X-Space-Id` header (= `WKApp.shared.currentSpaceId`) the api
+ * layer injects at request time, and we reload when the host fires
+ * `space-changed`. Switching between drive spaces (personal/shared) inside the
+ * same octo space does NOT re-fetch — the roster is identical. On a host switch
+ * we abort the in-flight request, synchronously drop the cache/query/candidates
+ * (so a stale roster can't linger selectable during the reload window), and
+ * start a fresh generation whose AbortController doubles as its guard, so a late
+ * previous-generation response returns early instead of writing back. Unmount
+ * removes the listener and aborts any pending request.
  */
-export function useOrgSearch(spaceId?: string): UseOrgSearchResult {
+export function useOrgSearch(): UseOrgSearchResult {
   const [candidates, setCandidates] = useState<OrgCandidate[]>([]);
   const [loading, setLoading] = useState(false);
   const [query, setQuery] = useState('');
+  const indexRef = useRef<IndexedCandidate[]>([]);
+  // Latest query, read when a fetch resolves so a keystroke made *during* the
+  // load isn't clobbered by the full roster (F2). setQuery drives render; this
+  // ref is the generation-safe copy the async continuation reads.
+  const queryRef = useRef('');
   const abortRef = useRef<AbortController | null>(null);
-  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const run = useCallback(
-    async (q: string) => {
-      abortRef.current?.abort();
-      const ctrl = new AbortController();
-      abortRef.current = ctrl;
-      setLoading(true);
+  const load = useCallback(() => {
+    // Supersede any in-flight generation, then drop the previous space's
+    // cache/query/candidates synchronously.
+    abortRef.current?.abort();
+    const ctrl = new AbortController();
+    abortRef.current = ctrl;
+    indexRef.current = [];
+    queryRef.current = '';
+    setQuery('');
+    setCandidates([]);
+    setLoading(true);
+    void (async () => {
       try {
-        const res = await api.searchOrgUser({ q, space_id: spaceId, limit: LIMIT }, ctrl.signal);
+        const res = await api.listOrgMembers(ctrl.signal);
         if (ctrl.signal.aborted) return;
-        setCandidates(res.candidates ?? []);
+        const index = (res.candidates ?? []).map((item) => ({
+          item,
+          searchText: buildSearchText(item),
+        }));
+        indexRef.current = index;
+        // Honour a query typed while the roster was loading (F2), not the full list.
+        setCandidates(filterLocal(index, queryRef.current));
       } catch (err: unknown) {
-        if ((err as Error)?.name === 'AbortError') return;
+        if ((err as Error)?.name === 'AbortError' || ctrl.signal.aborted) return;
+        indexRef.current = [];
         setCandidates([]);
       } finally {
         if (!ctrl.signal.aborted) setLoading(false);
       }
-    },
-    [spaceId],
-  );
+    })();
+  }, []);
 
-  const search = useCallback(
-    (q: string) => {
-      setQuery(q);
-      if (timerRef.current) clearTimeout(timerRef.current);
-      timerRef.current = setTimeout(() => run(q), DEBOUNCE_MS);
-    },
-    [run],
-  );
-
-  // On a space switch, synchronously drop everything scoped to the previous
-  // space: cancel the pending debounce, abort the in-flight request (each run's
-  // AbortController doubles as its generation guard, so a late Space A response
-  // returns early instead of writing back), and clear query/candidates now.
-  // Without this the picker keeps showing — and lets a user select — Space A's
-  // members during the window before Space B's debounced load resolves. The
-  // caller triggers a fresh load for the new space when the picker (re)opens.
-  // Skip the initial mount: there is no previous space to reset.
-  const mountedRef = useRef(false);
   useEffect(() => {
-    if (!mountedRef.current) {
-      mountedRef.current = true;
-      return;
-    }
-    if (timerRef.current) clearTimeout(timerRef.current);
-    abortRef.current?.abort();
-    setCandidates([]);
-    setQuery('');
-    setLoading(false);
-  }, [spaceId]);
-
-  useEffect(
-    () => () => {
-      if (timerRef.current) clearTimeout(timerRef.current);
+    load();
+    const handler = () => load();
+    WKApp.mittBus.on('space-changed', handler);
+    return () => {
+      WKApp.mittBus.off('space-changed', handler);
       abortRef.current?.abort();
-    },
-    [],
-  );
+    };
+  }, [load]);
+
+  const search = useCallback((q: string) => {
+    queryRef.current = q;
+    setQuery(q);
+    setCandidates(filterLocal(indexRef.current, q));
+  }, []);
 
   return { candidates, loading, query, search };
 }

--- a/packages/dmworkdrive/src/hooks/useOrgSearch.ts
+++ b/packages/dmworkdrive/src/hooks/useOrgSearch.ts
@@ -11,12 +11,21 @@ export interface UseOrgSearchResult {
   query: string;
   search: (q: string) => void;
   /**
-   * True when the last roster load failed (network/abort-independent error, or
-   * a truncated response — see F2). Distinct from an empty-but-successful
-   * roster (`error: false`, `candidates: []`), so the UI can show a retry
-   * affordance instead of the ordinary "no members" hint.
+   * True when the last roster load failed (network/abort-independent error).
+   * Distinct from an empty-but-successful roster (`error: false`,
+   * `candidates: []`), so the UI can show a retry affordance instead of the
+   * ordinary "no members" hint.
    */
   error: boolean;
+  /**
+   * True when the delivered roster may be partial: the server returned a
+   * non-authoritative `total` (missing/non-numeric) or one that disagrees with
+   * the delivered count (a server-side page cap). The roster is still cached and
+   * usable — this only drives a non-blocking "list may be incomplete" notice, so
+   * a capped/unversioned server response degrades gracefully instead of bricking
+   * the picker.
+   */
+  incomplete: boolean;
   /** Re-run the roster load (used by the failure-state retry affordance). */
   retry: () => void;
 }
@@ -28,19 +37,15 @@ interface IndexedCandidate {
 }
 
 /**
- * Build the local match text: name + its (simplified) pinyin, plus the account
- * fields (username/email/phone), all lowercased. Mirrors the picker's "search by
- * name / account" placeholder and the row subtitle, so a keyword matching any of
- * those hits locally.
+ * Build the local match text: name + its (simplified) pinyin, both lowercased.
+ * The `/org/members` roster carries uid + name only (see driveApi), so — like
+ * the contacts module — matching is name/pinyin only; no account fields are
+ * indexed.
  */
 function buildSearchText(c: OrgCandidate): string {
   const name = (c.name || '').toLowerCase();
   const pinyin = getPinyin(toSimplized(name)).toLowerCase();
-  const account = [c.username, c.email, c.phone]
-    .filter((v): v is string => !!v)
-    .map((v) => v.toLowerCase())
-    .join('\n');
-  return `${name}\n${pinyin}\n${account}`;
+  return `${name}\n${pinyin}`;
 }
 
 function filterLocal(index: IndexedCandidate[], q: string): OrgCandidate[] {
@@ -72,6 +77,7 @@ export function useOrgSearch(): UseOrgSearchResult {
   const [loading, setLoading] = useState(false);
   const [query, setQuery] = useState('');
   const [error, setError] = useState(false);
+  const [incomplete, setIncomplete] = useState(false);
   const indexRef = useRef<IndexedCandidate[]>([]);
   // Latest query, read when a fetch resolves so a keystroke made *during* the
   // load isn't clobbered by the full roster (F2). setQuery drives render; this
@@ -90,37 +96,31 @@ export function useOrgSearch(): UseOrgSearchResult {
     setQuery('');
     setCandidates([]);
     setError(false);
+    setIncomplete(false);
     setLoading(true);
     void (async () => {
       try {
         const res = await api.listOrgMembers(ctrl.signal);
         if (ctrl.signal.aborted) return;
         const list = res.candidates ?? [];
-        // F2: server contract — /org/members returns an exhaustive roster plus an
-        // authoritative count, so `total` must be a finite, non-negative integer
-        // that exactly equals the delivered candidate count. Anything else
-        // (missing/NaN/string/negative total, or a count mismatch from a
-        // server-side page cap) means the roster is incomplete or malformed:
-        // reject it as a load error rather than silently caching a partial list —
-        // a partial roster is exactly the "search finds nobody" symptom. This
-        // guard is a contract tripwire, not client-side paging.
-        const complete =
-          typeof res.total === 'number' &&
-          Number.isInteger(res.total) &&
-          res.total >= 0 &&
-          res.total === list.length;
-        if (!complete) {
-          indexRef.current = [];
-          setCandidates([]);
-          setError(true);
-          return;
-        }
         const index = list.map((item) => ({
           item,
           searchText: buildSearchText(item),
         }));
         indexRef.current = index;
         setError(false);
+        // `/org/members` is meant to deliver an exhaustive roster plus an
+        // authoritative `total`. If `total` is a valid count that matches the
+        // delivered list, the roster is known-complete. If it is missing /
+        // non-numeric, or disagrees with the delivered count (a server-side page
+        // cap), the roster may be partial — but we still cache and show what
+        // arrived and only flag it "possibly incomplete", rather than discarding
+        // it and bricking the picker. `total` semantics are unversioned across
+        // services, so the client must not fail closed on it.
+        const total = res.total;
+        const authoritative =
+          typeof total === 'number' && Number.isInteger(total) && total >= 0;
+        setIncomplete(authoritative ? total !== list.length : list.length > 0);
         // Honour a query typed while the roster was loading (F2), not the full list.
         setCandidates(filterLocal(index, queryRef.current));
       } catch (err: unknown) {
@@ -150,5 +150,5 @@ export function useOrgSearch(): UseOrgSearchResult {
     setCandidates(filterLocal(indexRef.current, q));
   }, []);
 
-  return { candidates, loading, query, search, error, retry: load };
+  return { candidates, loading, query, search, error, incomplete, retry: load };
 }

--- a/packages/dmworkdrive/src/hooks/useOrgSearch.ts
+++ b/packages/dmworkdrive/src/hooks/useOrgSearch.ts
@@ -10,6 +10,15 @@ export interface UseOrgSearchResult {
   loading: boolean;
   query: string;
   search: (q: string) => void;
+  /**
+   * True when the last roster load failed (network/abort-independent error, or
+   * a truncated response — see F2). Distinct from an empty-but-successful
+   * roster (`error: false`, `candidates: []`), so the UI can show a retry
+   * affordance instead of the ordinary "no members" hint.
+   */
+  error: boolean;
+  /** Re-run the roster load (used by the failure-state retry affordance). */
+  retry: () => void;
 }
 
 /** A candidate plus its precomputed lowercased "name\npinyin" match text. */
@@ -53,6 +62,7 @@ export function useOrgSearch(): UseOrgSearchResult {
   const [candidates, setCandidates] = useState<OrgCandidate[]>([]);
   const [loading, setLoading] = useState(false);
   const [query, setQuery] = useState('');
+  const [error, setError] = useState(false);
   const indexRef = useRef<IndexedCandidate[]>([]);
   // Latest query, read when a fetch resolves so a keystroke made *during* the
   // load isn't clobbered by the full roster (F2). setQuery drives render; this
@@ -62,7 +72,7 @@ export function useOrgSearch(): UseOrgSearchResult {
 
   const load = useCallback(() => {
     // Supersede any in-flight generation, then drop the previous space's
-    // cache/query/candidates synchronously.
+    // cache/query/candidates/error synchronously.
     abortRef.current?.abort();
     const ctrl = new AbortController();
     abortRef.current = ctrl;
@@ -70,22 +80,39 @@ export function useOrgSearch(): UseOrgSearchResult {
     queryRef.current = '';
     setQuery('');
     setCandidates([]);
+    setError(false);
     setLoading(true);
     void (async () => {
       try {
         const res = await api.listOrgMembers(ctrl.signal);
         if (ctrl.signal.aborted) return;
-        const index = (res.candidates ?? []).map((item) => ({
+        const list = res.candidates ?? [];
+        // F2: the backend pages the roster to exhaustion and returns the
+        // authoritative total. A numeric total that disagrees with the delivered
+        // count means the list was truncated (e.g. a server-side page cap) —
+        // refuse to cache a partial roster silently, since a partial roster is
+        // exactly the "search finds nobody" symptom this change fixes. A
+        // non-numeric total is treated as "unknown, don't assert" rather than a
+        // hard failure, so a benign response-shape drift can't wedge the picker.
+        if (typeof res.total === 'number' && res.total !== list.length) {
+          indexRef.current = [];
+          setCandidates([]);
+          setError(true);
+          return;
+        }
+        const index = list.map((item) => ({
           item,
           searchText: buildSearchText(item),
         }));
         indexRef.current = index;
+        setError(false);
         // Honour a query typed while the roster was loading (F2), not the full list.
         setCandidates(filterLocal(index, queryRef.current));
       } catch (err: unknown) {
         if ((err as Error)?.name === 'AbortError' || ctrl.signal.aborted) return;
         indexRef.current = [];
         setCandidates([]);
+        setError(true);
       } finally {
         if (!ctrl.signal.aborted) setLoading(false);
       }
@@ -108,5 +135,5 @@ export function useOrgSearch(): UseOrgSearchResult {
     setCandidates(filterLocal(indexRef.current, q));
   }, []);
 
-  return { candidates, loading, query, search };
+  return { candidates, loading, query, search, error, retry: load };
 }

--- a/packages/dmworkdrive/src/hooks/useOrgSearch.ts
+++ b/packages/dmworkdrive/src/hooks/useOrgSearch.ts
@@ -27,11 +27,20 @@ interface IndexedCandidate {
   searchText: string;
 }
 
-/** Build the local match text: name + its (simplified) pinyin, both lowercased. */
+/**
+ * Build the local match text: name + its (simplified) pinyin, plus the account
+ * fields (username/email/phone), all lowercased. Mirrors the picker's "search by
+ * name / account" placeholder and the row subtitle, so a keyword matching any of
+ * those hits locally.
+ */
 function buildSearchText(c: OrgCandidate): string {
   const name = (c.name || '').toLowerCase();
   const pinyin = getPinyin(toSimplized(name)).toLowerCase();
-  return `${name}\n${pinyin}`;
+  const account = [c.username, c.email, c.phone]
+    .filter((v): v is string => !!v)
+    .map((v) => v.toLowerCase())
+    .join('\n');
+  return `${name}\n${pinyin}\n${account}`;
 }
 
 function filterLocal(index: IndexedCandidate[], q: string): OrgCandidate[] {
@@ -87,14 +96,20 @@ export function useOrgSearch(): UseOrgSearchResult {
         const res = await api.listOrgMembers(ctrl.signal);
         if (ctrl.signal.aborted) return;
         const list = res.candidates ?? [];
-        // F2: the backend pages the roster to exhaustion and returns the
-        // authoritative total. A numeric total that disagrees with the delivered
-        // count means the list was truncated (e.g. a server-side page cap) —
-        // refuse to cache a partial roster silently, since a partial roster is
-        // exactly the "search finds nobody" symptom this change fixes. A
-        // non-numeric total is treated as "unknown, don't assert" rather than a
-        // hard failure, so a benign response-shape drift can't wedge the picker.
-        if (typeof res.total === 'number' && res.total !== list.length) {
+        // F2: server contract — /org/members returns an exhaustive roster plus an
+        // authoritative count, so `total` must be a finite, non-negative integer
+        // that exactly equals the delivered candidate count. Anything else
+        // (missing/NaN/string/negative total, or a count mismatch from a
+        // server-side page cap) means the roster is incomplete or malformed:
+        // reject it as a load error rather than silently caching a partial list —
+        // a partial roster is exactly the "search finds nobody" symptom. This
+        // guard is a contract tripwire, not client-side paging.
+        const complete =
+          typeof res.total === 'number' &&
+          Number.isInteger(res.total) &&
+          res.total >= 0 &&
+          res.total === list.length;
+        if (!complete) {
           indexRef.current = [];
           setCandidates([]);
           setError(true);

--- a/packages/dmworkdrive/src/i18n/en-US.json
+++ b/packages/dmworkdrive/src/i18n/en-US.json
@@ -118,9 +118,10 @@
   "org": {
     "title": "Pick members",
     "confirm": "Confirm",
-    "searchPlaceholder": "Search by name / account",
+    "searchPlaceholder": "Search by name",
     "noResult": "No matches",
     "hint": "Type to search organization members",
+    "incomplete": "This list may be incomplete",
     "loadFailed": "Failed to load members",
     "retry": "Retry",
     "joined": "Joined"

--- a/packages/dmworkdrive/src/i18n/en-US.json
+++ b/packages/dmworkdrive/src/i18n/en-US.json
@@ -121,6 +121,8 @@
     "searchPlaceholder": "Search by name / account",
     "noResult": "No matches",
     "hint": "Type to search organization members",
+    "loadFailed": "Failed to load members",
+    "retry": "Retry",
     "joined": "Joined"
   },
   "upload": {

--- a/packages/dmworkdrive/src/i18n/zh-CN.json
+++ b/packages/dmworkdrive/src/i18n/zh-CN.json
@@ -121,6 +121,8 @@
     "searchPlaceholder": "搜索姓名 / 账号",
     "noResult": "无匹配结果",
     "hint": "输入关键词搜索组织成员",
+    "loadFailed": "成员加载失败",
+    "retry": "重试",
     "joined": "已加入"
   },
   "upload": {

--- a/packages/dmworkdrive/src/i18n/zh-CN.json
+++ b/packages/dmworkdrive/src/i18n/zh-CN.json
@@ -118,9 +118,10 @@
   "org": {
     "title": "选择成员",
     "confirm": "确定",
-    "searchPlaceholder": "搜索姓名 / 账号",
+    "searchPlaceholder": "搜索姓名",
     "noResult": "无匹配结果",
     "hint": "输入关键词搜索组织成员",
+    "incomplete": "列表可能不完整",
     "loadFailed": "成员加载失败",
     "retry": "重试",
     "joined": "已加入"

--- a/packages/dmworkdrive/src/ui/InviteModal/__tests__/InviteModal.test.tsx
+++ b/packages/dmworkdrive/src/ui/InviteModal/__tests__/InviteModal.test.tsx
@@ -63,13 +63,12 @@ beforeEach(() => {
   addMembers.mockReset();
   vi.mocked(useOrgSearch).mockReset();
   vi.mocked(useMembers).mockReset();
-  vi.mocked(useOrgSearch).mockImplementation((spaceId?: string) => ({
-    // Space-scoped candidates: switching spaceId must swap the offered users,
-    // so Space A's picks can't even be seen (let alone selected) under Space B.
-    candidates:
-      spaceId === 'space-B'
-        ? [{ uid: 'u2', name: 'Bob' }]
-        : [{ uid: 'u1', name: 'Alice' }],
+  vi.mocked(useOrgSearch).mockImplementation(() => ({
+    // The picker roster is the caller's octo-space roster (host-scoped, fetched
+    // once via space-changed) — it does NOT vary with the drive spaceId. Cross-
+    // space safety comes from clearing selection + closing the picker on switch,
+    // not from swapping candidates, so offer a stable roster here.
+    candidates: [{ uid: 'u1', name: 'Alice' }, { uid: 'u2', name: 'Bob' }],
     loading: false,
     query: '',
     search: vi.fn(),
@@ -127,12 +126,13 @@ describe('InviteModal ↔ OrgPicker cross-space safety', () => {
     click(getByRole('button', { name: '__toB__' }));
     expect(queryByRole('button', { name: '__ok__' })).toBeNull();
 
-    // Reopen in Space B: only Space B members are offered — Alice (Space A) is
-    // no longer visible or selectable, and confirm starts disabled.
+    // Reopen after the switch: selection was cleared, so confirm starts disabled
+    // and Space A's pick (u1) is not carried over. The roster is the same octo-
+    // space roster (host-scoped), so both users stay offered — the anti-leak
+    // guarantee is the cleared selection, not a swapped candidate list.
     click(getByRole('button', { name: 'drive.invite.pickMembers' }));
-    expect(queryByRole('button', { name: 'Alice' })).toBeNull();
-    expect(queryByRole('button', { name: 'Bob' })).not.toBeNull();
     expect((getByRole('button', { name: '__ok__' }) as HTMLButtonElement).disabled).toBe(true);
+    expect(queryByRole('button', { name: 'Bob' })).not.toBeNull();
 
     // Prove no cross-space leak: pick Bob (u2) in B and confirm.
     click(getByRole('button', { name: 'Bob' }));

--- a/packages/dmworkdrive/src/ui/InviteModal/__tests__/InviteModal.test.tsx
+++ b/packages/dmworkdrive/src/ui/InviteModal/__tests__/InviteModal.test.tsx
@@ -74,6 +74,7 @@ beforeEach(() => {
     query: '',
     search: vi.fn(),
     error: false,
+    incomplete: false,
     retry: vi.fn(),
   }));
   vi.mocked(useMembers).mockReturnValue({

--- a/packages/dmworkdrive/src/ui/InviteModal/__tests__/InviteModal.test.tsx
+++ b/packages/dmworkdrive/src/ui/InviteModal/__tests__/InviteModal.test.tsx
@@ -72,6 +72,8 @@ beforeEach(() => {
     loading: false,
     query: '',
     search: vi.fn(),
+    error: false,
+    retry: vi.fn(),
   }));
   vi.mocked(useMembers).mockReturnValue({
     members: [],

--- a/packages/dmworkdrive/src/ui/InviteModal/__tests__/InviteModal.test.tsx
+++ b/packages/dmworkdrive/src/ui/InviteModal/__tests__/InviteModal.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render } from '../../../__tests__/harness';
+import { render, act } from '../../../__tests__/harness';
 
 // Semi barrel drags in jsdom-hostile deps; stub the primitives InviteModal +
 // its nested OrgPickerModal use. The mocked Modal only renders its OK button
@@ -57,6 +57,7 @@ vi.mock('../../../hooks/useMembers', () => ({ useMembers: vi.fn() }));
 
 import { useOrgSearch } from '../../../hooks/useOrgSearch';
 import { useMembers } from '../../../hooks/useMembers';
+import { WKApp } from '@octo/base';
 import InviteModal from '../index';
 
 beforeEach(() => {
@@ -145,6 +146,25 @@ describe('InviteModal ↔ OrgPicker cross-space safety', () => {
     for (const call of addMembers.mock.calls) {
       expect(call[0]).not.toContain('u1');
     }
+  });
+
+  it('clears the picker selection on a host space-changed so a stale pick is not submitted to the new tenant', () => {
+    const { getByRole, click } = render(<Harness />);
+
+    // Open the picker (drive space unchanged) and select Alice (u1).
+    click(getByRole('button', { name: 'drive.invite.pickMembers' }));
+    click(getByRole('button', { name: 'Alice' }));
+    expect((getByRole('button', { name: '__ok__' }) as HTMLButtonElement).disabled).toBe(false);
+
+    // Host octo-space switch fires while the picker is open with a live selection.
+    // The API interceptor would send the NEW host X-Space-Id at request time, so a
+    // carried-over uid would be added to the wrong tenant — selection must clear
+    // synchronously on the same event.
+    act(() => WKApp.mittBus.emit('space-changed'));
+
+    expect((getByRole('button', { name: '__ok__' }) as HTMLButtonElement).disabled).toBe(true);
+    click(getByRole('button', { name: '__ok__' }));
+    expect(addMembers).not.toHaveBeenCalled();
   });
 
   it('forces the picker shut when the parent modal hides (does not reopen on its own)', () => {

--- a/packages/dmworkdrive/src/ui/OrgPickerModal/__tests__/OrgPickerModal.test.tsx
+++ b/packages/dmworkdrive/src/ui/OrgPickerModal/__tests__/OrgPickerModal.test.tsx
@@ -47,6 +47,7 @@ function stub(candidates: OrgCandidate[], over: Partial<ReturnType<typeof useOrg
     query: '',
     search: vi.fn(),
     error: false,
+    incomplete: false,
     retry: vi.fn(),
     ...over,
   });
@@ -249,6 +250,33 @@ describe('OrgPickerModal', () => {
     click(getByRole('button', { name: '__show__' }));
     expect(retry).not.toHaveBeenCalled();
     expect(search).toHaveBeenLastCalledWith('');
+  });
+
+  it('shows a non-blocking incomplete notice but still lists candidates and allows confirm', async () => {
+    const onConfirm = vi.fn();
+    stub([{ uid: 'u1', name: 'Alice' }], { incomplete: true });
+    const { getByText, getByRole, click } = render(
+      <OrgPickerModal visible onClose={() => {}} onConfirm={onConfirm} />,
+    );
+    // Notice is shown, and the roster is still usable (not the error/empty state).
+    expect(getByText('drive.org.incomplete')).toBeInTheDocument();
+    expect(getByText('Alice')).toBeInTheDocument();
+    // Non-blocking: a selection can still be confirmed.
+    click(getByRole('button', { name: 'Alice' }));
+    click(getByRole('button', { name: '__ok__' }));
+    await waitFor(() => expect(onConfirm).toHaveBeenCalledWith(['u1']));
+  });
+
+  it('does not show the incomplete notice while loading or on a load failure', () => {
+    stub([], { incomplete: true, loading: true });
+    const loadingView = render(<OrgPickerModal visible onClose={() => {}} onConfirm={() => {}} />);
+    expect(loadingView.queryByText('drive.org.incomplete')).toBeNull();
+    loadingView.unmount();
+
+    stub([], { incomplete: true, error: true });
+    const errorView = render(<OrgPickerModal visible onClose={() => {}} onConfirm={() => {}} />);
+    expect(errorView.queryByText('drive.org.incomplete')).toBeNull();
+    expect(errorView.getByText('drive.org.loadFailed')).toBeInTheDocument();
   });
 
   it('clears the selection on a host space-changed so stale uids cannot be confirmed', () => {

--- a/packages/dmworkdrive/src/ui/OrgPickerModal/__tests__/OrgPickerModal.test.tsx
+++ b/packages/dmworkdrive/src/ui/OrgPickerModal/__tests__/OrgPickerModal.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, waitFor } from '../../../__tests__/harness';
+import { render, waitFor, act } from '../../../__tests__/harness';
 
 vi.mock('@douyinfe/semi-ui', async () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -36,6 +36,7 @@ vi.mock('../../../hooks/useMembers', () => ({ useMembers: vi.fn() }));
 
 import { useOrgSearch } from '../../../hooks/useOrgSearch';
 import { useMembers } from '../../../hooks/useMembers';
+import { WKApp } from '@octo/base';
 import OrgPickerModal from '../index';
 import type { OrgCandidate, Member } from '../../../bridge/types';
 
@@ -248,5 +249,50 @@ describe('OrgPickerModal', () => {
     click(getByRole('button', { name: '__show__' }));
     expect(retry).not.toHaveBeenCalled();
     expect(search).toHaveBeenLastCalledWith('');
+  });
+
+  it('clears the selection on a host space-changed so stale uids cannot be confirmed', () => {
+    const onConfirm = vi.fn();
+    stub([{ uid: 'u1', name: 'Alice' }, { uid: 'u2', name: 'Bob' }]);
+    const { getByRole, click } = render(
+      <OrgPickerModal visible onClose={() => {}} onConfirm={onConfirm} />,
+    );
+    // Select Alice in the current host space → confirm enabled.
+    click(getByRole('button', { name: 'Alice' }));
+    expect((getByRole('button', { name: '__ok__' }) as HTMLButtonElement).disabled).toBe(false);
+
+    // Host octo-space switch (drive spaceId unchanged): selection must clear
+    // synchronously so a pre-switch pick can't be submitted to the new tenant.
+    act(() => WKApp.mittBus.emit('space-changed'));
+
+    expect((getByRole('button', { name: '__ok__' }) as HTMLButtonElement).disabled).toBe(true);
+    click(getByRole('button', { name: '__ok__' }));
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it('disables confirm while the roster is reloading, even with a live selection', () => {
+    stub([{ uid: 'u1', name: 'Alice' }]);
+
+    function Wrapper() {
+      const [, force] = React.useState(0);
+      return (
+        <>
+          <button aria-label="__rerender__" onClick={() => force((n) => n + 1)}>
+            r
+          </button>
+          <OrgPickerModal visible onClose={() => {}} onConfirm={() => {}} />
+        </>
+      );
+    }
+
+    const { getByRole, click } = render(<Wrapper />);
+    click(getByRole('button', { name: 'Alice' }));
+    expect((getByRole('button', { name: '__ok__' }) as HTMLButtonElement).disabled).toBe(false);
+
+    // The host-switch reload flips loading true while the selection is still set;
+    // confirm must be blocked for the in-flight window.
+    stub([{ uid: 'u1', name: 'Alice' }], { loading: true });
+    click(getByRole('button', { name: '__rerender__' }));
+    expect((getByRole('button', { name: '__ok__' }) as HTMLButtonElement).disabled).toBe(true);
   });
 });

--- a/packages/dmworkdrive/src/ui/OrgPickerModal/__tests__/OrgPickerModal.test.tsx
+++ b/packages/dmworkdrive/src/ui/OrgPickerModal/__tests__/OrgPickerModal.test.tsx
@@ -45,6 +45,8 @@ function stub(candidates: OrgCandidate[], over: Partial<ReturnType<typeof useOrg
     loading: false,
     query: '',
     search: vi.fn(),
+    error: false,
+    retry: vi.fn(),
     ...over,
   });
 }
@@ -172,6 +174,79 @@ describe('OrgPickerModal', () => {
     // empty search fired for the new space rather than keeping Space A results.
     expect((getByRole('button', { name: '__ok__' }) as HTMLButtonElement).disabled).toBe(true);
     expect(search.mock.calls.length).toBeGreaterThan(searchCallsBeforeSwitch);
+    expect(search).toHaveBeenLastCalledWith('');
+  });
+
+  it('shows an explicit load-failure state with a retry action (not the empty hint)', () => {
+    stub([], { error: true });
+    const { getByText, queryByText } = render(
+      <OrgPickerModal visible onClose={() => {}} onConfirm={() => {}} />,
+    );
+    expect(getByText('drive.org.loadFailed')).toBeInTheDocument();
+    expect(getByText('drive.org.retry')).toBeInTheDocument();
+    // A failure must NOT read as an ordinary empty roster / no-match.
+    expect(queryByText('drive.org.hint')).toBeNull();
+    expect(queryByText('drive.org.noResult')).toBeNull();
+  });
+
+  it('clicking retry re-runs the roster load', () => {
+    const retry = vi.fn();
+    stub([], { error: true, retry });
+    const { getByText, click } = render(
+      <OrgPickerModal visible onClose={() => {}} onConfirm={() => {}} />,
+    );
+    // Mounting visible+error already auto-retried once; the button adds one more.
+    const before = retry.mock.calls.length;
+    click(getByText('drive.org.retry'));
+    expect(retry.mock.calls.length).toBe(before + 1);
+  });
+
+  it('auto-retries a failed roster when reopened (hidden→visible)', () => {
+    const retry = vi.fn();
+    const search = vi.fn();
+    stub([], { error: true, retry, search });
+
+    function Wrapper() {
+      const [visible, setVisible] = React.useState(false);
+      return (
+        <>
+          <button aria-label="__show__" onClick={() => setVisible(true)}>
+            show
+          </button>
+          <OrgPickerModal visible={visible} onClose={() => {}} onConfirm={() => {}} />
+        </>
+      );
+    }
+
+    const { getByRole, click } = render(<Wrapper />);
+    expect(retry).not.toHaveBeenCalled();
+    click(getByRole('button', { name: '__show__' }));
+    // Reopening a failed picker retries the fetch; it does not fall back to a
+    // local-only search('') reset.
+    expect(retry).toHaveBeenCalledTimes(1);
+    expect(search).not.toHaveBeenCalled();
+  });
+
+  it('never re-fetches a good cache on reopen — only resets the local filter', () => {
+    const retry = vi.fn();
+    const search = vi.fn();
+    stub([{ uid: 'u1', name: 'Alice' }], { error: false, retry, search });
+
+    function Wrapper() {
+      const [visible, setVisible] = React.useState(false);
+      return (
+        <>
+          <button aria-label="__show__" onClick={() => setVisible(true)}>
+            show
+          </button>
+          <OrgPickerModal visible={visible} onClose={() => {}} onConfirm={() => {}} />
+        </>
+      );
+    }
+
+    const { getByRole, click } = render(<Wrapper />);
+    click(getByRole('button', { name: '__show__' }));
+    expect(retry).not.toHaveBeenCalled();
     expect(search).toHaveBeenLastCalledWith('');
   });
 });

--- a/packages/dmworkdrive/src/ui/OrgPickerModal/index.css
+++ b/packages/dmworkdrive/src/ui/OrgPickerModal/index.css
@@ -16,6 +16,19 @@
   font-size: 13px;
 }
 
+.drive-org__error {
+  flex-direction: column;
+  gap: 10px;
+}
+
+.drive-org__retry {
+  border: none;
+  background: transparent;
+  color: var(--semi-color-primary);
+  font-size: 13px;
+  cursor: pointer;
+}
+
 .drive-org__row {
   display: flex;
   align-items: center;

--- a/packages/dmworkdrive/src/ui/OrgPickerModal/index.css
+++ b/packages/dmworkdrive/src/ui/OrgPickerModal/index.css
@@ -60,8 +60,9 @@
   font-size: 14px;
 }
 
-.drive-org__sub {
-  color: var(--semi-color-text-2);
+.drive-org__notice {
+  margin-top: 8px;
+  color: var(--semi-color-warning);
   font-size: 12px;
 }
 

--- a/packages/dmworkdrive/src/ui/OrgPickerModal/index.tsx
+++ b/packages/dmworkdrive/src/ui/OrgPickerModal/index.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback, useMemo } from 'react';
-import { useI18n } from '@octo/base';
+import { useI18n, WKApp } from '@octo/base';
 import { Modal, Input, Spin, Tag } from '@douyinfe/semi-ui';
 import { Check, Search } from 'lucide-react';
 import { useOrgSearch } from '../../hooks/useOrgSearch';
@@ -56,6 +56,20 @@ export default function OrgPickerModal({ visible, spaceId, onClose, onConfirm }:
     else search('');
   }, [visible, spaceId]); // eslint-disable-line react-hooks/exhaustive-deps
 
+  // A host octo-space switch (drive `spaceId` unchanged) reloads the roster in
+  // useOrgSearch but leaves this modal's `selected` untouched. Subscribe to the
+  // same host event and clear the selection synchronously, so a stale pick from
+  // the previous tenant can't be confirmed into the new space — the API
+  // interceptor injects the latest X-Space-Id at request time, so a stale uid
+  // would be added to the wrong space. Mounted for the modal's whole lifetime
+  // (the picker is always mounted, hidden or not); loading also gates confirm
+  // below, covering the reload in-flight window.
+  useEffect(() => {
+    const handler = () => setSelected({});
+    WKApp.mittBus.on('space-changed', handler);
+    return () => WKApp.mittBus.off('space-changed', handler);
+  }, []);
+
   const toggle = useCallback(
     (c: OrgCandidate) => {
       if (memberRoleByUid[c.uid]) return; // already a member — not selectable
@@ -72,9 +86,10 @@ export default function OrgPickerModal({ visible, spaceId, onClose, onConfirm }:
   const selectedUids = Object.keys(selected);
 
   const handleConfirm = async () => {
-    // `!visible` guards against a stale confirm firing after a space switch has
-    // hidden the picker (the parent also clears selection on spaceId change).
-    if (!visible || selectedUids.length === 0 || submitting) return;
+    // Guards against a stale confirm: `!visible` (a space switch hid the picker),
+    // and `loading` (a host space-changed is reloading the roster — block the
+    // in-flight window so a pre-switch selection can't be submitted mid-reload).
+    if (!visible || selectedUids.length === 0 || submitting || loading) return;
     setSubmitting(true);
     await onConfirm(selectedUids);
     setSubmitting(false);
@@ -96,7 +111,7 @@ export default function OrgPickerModal({ visible, spaceId, onClose, onConfirm }:
         selectedUids.length ? `${t('drive.org.confirm')} (${selectedUids.length})` : t('drive.org.confirm')
       }
       cancelText={t('drive.common.cancel')}
-      okButtonProps={{ disabled: selectedUids.length === 0 }}
+      okButtonProps={{ disabled: selectedUids.length === 0 || loading }}
       width={480}
     >
       <Input

--- a/packages/dmworkdrive/src/ui/OrgPickerModal/index.tsx
+++ b/packages/dmworkdrive/src/ui/OrgPickerModal/index.tsx
@@ -41,13 +41,14 @@ export default function OrgPickerModal({ visible, spaceId, onClose, onConfirm }:
     return map;
   }, [members]);
 
-  // Reset all space-scoped state whenever the picker opens/closes or the target
-  // space changes. Clearing `selected` on a spaceId change is the guard that
-  // stops Space A's picks from being confirmed against Space B; re-running the
-  // (empty) search when visible refreshes the candidate list + query for the new
-  // space instead of leaving Space A's stale results behind. The search is gated
-  // on `visible` so a mounted-but-hidden picker doesn't fire an org query on
-  // every space switch.
+  // Reset picker-local state whenever it opens/closes or the target drive space
+  // changes. Clearing `selected` on a spaceId change is the guard that stops
+  // Space A's picks from being confirmed against Space B. Calling search('')
+  // when visible resets the local query filter so a reopened picker starts from
+  // the full roster instead of a stale search term — this is a purely local
+  // filter reset, not a fetch: useOrgSearch loads the roster once and reloads it
+  // only on the host `space-changed` event, independent of this effect. Gating
+  // on `visible` skips the reset for a mounted-but-hidden picker.
   useEffect(() => {
     setSelected({});
     if (visible) search('');

--- a/packages/dmworkdrive/src/ui/OrgPickerModal/index.tsx
+++ b/packages/dmworkdrive/src/ui/OrgPickerModal/index.tsx
@@ -29,7 +29,7 @@ export interface OrgPickerModalProps {
  */
 export default function OrgPickerModal({ visible, spaceId, onClose, onConfirm }: OrgPickerModalProps) {
   const { t } = useI18n();
-  const { candidates, loading, query, search } = useOrgSearch(spaceId);
+  const { candidates, loading, query, search } = useOrgSearch();
   const { members } = useMembers(spaceId ?? null, visible);
   const [selected, setSelected] = useState<Record<string, OrgCandidate>>({});
   const [submitting, setSubmitting] = useState(false);

--- a/packages/dmworkdrive/src/ui/OrgPickerModal/index.tsx
+++ b/packages/dmworkdrive/src/ui/OrgPickerModal/index.tsx
@@ -29,7 +29,7 @@ export interface OrgPickerModalProps {
  */
 export default function OrgPickerModal({ visible, spaceId, onClose, onConfirm }: OrgPickerModalProps) {
   const { t } = useI18n();
-  const { candidates, loading, query, search } = useOrgSearch();
+  const { candidates, loading, query, search, error, retry } = useOrgSearch();
   const { members } = useMembers(spaceId ?? null, visible);
   const [selected, setSelected] = useState<Record<string, OrgCandidate>>({});
   const [submitting, setSubmitting] = useState(false);
@@ -43,15 +43,17 @@ export default function OrgPickerModal({ visible, spaceId, onClose, onConfirm }:
 
   // Reset picker-local state whenever it opens/closes or the target drive space
   // changes. Clearing `selected` on a spaceId change is the guard that stops
-  // Space A's picks from being confirmed against Space B. Calling search('')
-  // when visible resets the local query filter so a reopened picker starts from
-  // the full roster instead of a stale search term — this is a purely local
-  // filter reset, not a fetch: useOrgSearch loads the roster once and reloads it
-  // only on the host `space-changed` event, independent of this effect. Gating
-  // on `visible` skips the reset for a mounted-but-hidden picker.
+  // Space A's picks from being confirmed against Space B. On becoming visible we
+  // either retry a failed roster load or, for a good cache, just reset the local
+  // query filter — reopening a successfully-cached picker never re-fetches
+  // (search('') is a purely local reset; the roster is loaded once by
+  // useOrgSearch and reloaded only on the host `space-changed` event). Gating on
+  // `visible` skips this for a mounted-but-hidden picker.
   useEffect(() => {
     setSelected({});
-    if (visible) search('');
+    if (!visible) return;
+    if (error) retry();
+    else search('');
   }, [visible, spaceId]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const toggle = useCallback(
@@ -108,6 +110,13 @@ export default function OrgPickerModal({ visible, spaceId, onClose, onConfirm }:
         {loading ? (
           <div className="drive-org__center">
             <Spin />
+          </div>
+        ) : error ? (
+          <div className="drive-org__center drive-org__error">
+            <span className="drive-org__empty">{t('drive.org.loadFailed')}</span>
+            <button type="button" className="drive-org__retry" onClick={retry}>
+              {t('drive.org.retry')}
+            </button>
           </div>
         ) : candidates.length === 0 ? (
           <div className="drive-org__center drive-org__empty">

--- a/packages/dmworkdrive/src/ui/OrgPickerModal/index.tsx
+++ b/packages/dmworkdrive/src/ui/OrgPickerModal/index.tsx
@@ -29,7 +29,7 @@ export interface OrgPickerModalProps {
  */
 export default function OrgPickerModal({ visible, spaceId, onClose, onConfirm }: OrgPickerModalProps) {
   const { t } = useI18n();
-  const { candidates, loading, query, search, error, retry } = useOrgSearch();
+  const { candidates, loading, query, search, error, incomplete, retry } = useOrgSearch();
   const { members } = useMembers(spaceId ?? null, visible);
   const [selected, setSelected] = useState<Record<string, OrgCandidate>>({});
   const [submitting, setSubmitting] = useState(false);
@@ -96,8 +96,7 @@ export default function OrgPickerModal({ visible, spaceId, onClose, onConfirm }:
     onClose();
   };
 
-  const label = (c: OrgCandidate) => c.name || c.username || c.uid;
-  const sub = (c: OrgCandidate) => c.username || c.email || c.phone || '';
+  const label = (c: OrgCandidate) => c.name || c.uid;
   const roleLabel = (r: DriveRole) => t(ROLE_LABEL_KEY[r] ?? ROLE_LABEL_KEY.custom);
 
   return (
@@ -121,6 +120,9 @@ export default function OrgPickerModal({ visible, spaceId, onClose, onConfirm }:
         placeholder={t('drive.org.searchPlaceholder')}
         autoFocus
       />
+      {incomplete && !loading && !error && (
+        <div className="drive-org__notice">{t('drive.org.incomplete')}</div>
+      )}
       <div className="drive-org__list">
         {loading ? (
           <div className="drive-org__center">
@@ -155,7 +157,6 @@ export default function OrgPickerModal({ visible, spaceId, onClose, onConfirm }:
               >
                 <span className="drive-org__check">{on && <Check size={16} />}</span>
                 <span className="drive-org__name">{label(c)}</span>
-                {sub(c) && <span className="drive-org__sub">{sub(c)}</span>}
                 {joined && (
                   <span className="drive-org__joined">
                     <Tag size="small" color="grey">

--- a/packages/dmworkdrive/vite.config.ts
+++ b/packages/dmworkdrive/vite.config.ts
@@ -15,6 +15,11 @@ export default defineConfig({
   },
   resolve: {
     alias: {
+      // Real (self-contained, dependency-free) pinyin helpers the org picker
+      // uses for local search — aliased before the '@octo/base' barrel mock so
+      // the deep imports resolve to the actual util instead of the stub.
+      '@octo/base/src/Utils/pinYin': path.resolve(__dirname, '../dmworkbase/src/Utils/pinYin.ts'),
+      '@octo/base/src/Utils/t2s': path.resolve(__dirname, '../dmworkbase/src/Utils/t2s.ts'),
       '@octo/base': path.resolve(__dirname, 'src/__mocks__/dmworkBase.ts'),
       // Semi UI pulls lottie-web transitively; its canvas init throws in jsdom.
       'lottie-web': path.resolve(__dirname, 'src/__mocks__/lottieStub.ts'),


### PR DESCRIPTION
## Symptom

The drive org picker returned no results for partial name or pinyin queries and issued a backend request on every keystroke.

## Root cause

The picker used an exact-match server search for each debounced query. The roster endpoint returns `uid` and `name`, so account-field indexing was not supported by the production response shape. The initial fetch-once implementation also treated missing or mismatched `total` metadata as a hard failure, which could disable the picker even when usable roster rows were delivered.

## Fix

Replace per-keystroke server search with a fetch-once, local-filter model aligned with the contacts module:

- Load the host-space roster once through `GET /v1/drive/org/members` and build a local name + pinyin index.
- Filter locally on every keystroke without additional backend calls.
- Keep the roster contract name-only (`uid` + `name`); do not index or display username, email, or phone fields.
- Preserve queries typed while the roster is loading and apply them when the response arrives.
- On host-space changes, abort the previous fetch, clear cached candidates/query/modal selection, block confirmation during reload, and fetch using the latest space header.
- Treat missing, malformed, or mismatched `total` metadata as a non-blocking completeness signal: keep delivered rows usable and show a "list may be incomplete" notice. Actual request failures still use the error/retry state.
- Remove listeners and abort in-flight work on unmount.
- Replace `searchOrgUser` with `listOrgMembers`; remove the unused search-parameter type.

## Tests

`pnpm --filter @octo/drive test` — 23 files / 210 tests pass.

Coverage includes:

- fetch-once lifecycle and local name/pinyin filtering;
- no backend call while filtering locally;
- query preservation during initial load;
- host-space reload, stale-generation suppression, and modal-selection reset;
- confirmation disabled during roster reload;
- missing, malformed, or mismatched `total` metadata keeps delivered rows usable and marks the list incomplete;
- genuine request failures retain error/retry behavior;
- API request shape for `listOrgMembers`;
- unmount abort and listener cleanup.
