### PR TITLE
fix(contacts): clear member picker search on reopen

### DIFF
--- a/packages/dmworkcontacts/src/bridge/groupCreate/useGroupCreate.test.tsx
+++ b/packages/dmworkcontacts/src/bridge/groupCreate/useGroupCreate.test.tsx
@@ -55,17 +55,20 @@ afterEach(() => {
   container.remove();
 });
 
-function renderGroupCreateHook(options: ReturnType<typeof createOptions>) {
+function renderGroupCreateHook(initialOptions: ReturnType<typeof createOptions>) {
   let current: ReturnType<typeof useGroupCreate> | undefined;
-  function Harness() {
+  function Harness({ options }: { options: ReturnType<typeof createOptions> }) {
     current = useGroupCreate(options);
     return null;
   }
-  act(() => ReactDOM.render(<Harness />, container));
+  act(() => ReactDOM.render(<Harness options={initialOptions} />, container));
   return {
     get current() {
       if (!current) throw new Error("Hook did not render");
       return current;
+    },
+    rerender(options: ReturnType<typeof createOptions>) {
+      act(() => ReactDOM.render(<Harness options={options} />, container));
     },
   };
 }
@@ -85,6 +88,45 @@ describe("useGroupCreate", () => {
 
     expect(result.current.candidates.map((item) => item.uid)).toEqual([
       "weijiaoying",
+    ]);
+  });
+
+  it("clears add-member search state after closing and reopening", async () => {
+    const options = createOptions("addMember");
+    const result = renderGroupCreateHook(options);
+
+    await flushLoad();
+    act(() => {
+      result.current.setKeyword("weijiao");
+      result.current.toggleMember("weijiaoying");
+    });
+
+    expect(result.current.keyword).toBe("weijiao");
+    expect(result.current.candidates.map((item) => item.uid)).toEqual([
+      "weijiaoying",
+    ]);
+    expect(result.current.selected.map((item) => item.uid)).toEqual([
+      "weijiaoying",
+    ]);
+
+    result.rerender({ ...options, isOpen: false });
+
+    expect(result.current.keyword).toBe("");
+    expect(result.current.candidates.map((item) => item.uid)).toEqual([
+      "alice",
+      "weijiaoying",
+      "bot",
+    ]);
+    expect(result.current.selected).toEqual([]);
+
+    result.rerender({ ...options, isOpen: true });
+    await flushLoad();
+
+    expect(result.current.keyword).toBe("");
+    expect(result.current.candidates.map((item) => item.uid)).toEqual([
+      "alice",
+      "weijiaoying",
+      "bot",
     ]);
   });
 

--- a/packages/dmworkcontacts/src/bridge/groupCreate/useGroupCreate.ts
+++ b/packages/dmworkcontacts/src/bridge/groupCreate/useGroupCreate.ts
@@ -56,11 +56,18 @@ export function useGroupCreate(options: UseGroupCreateOptions) {
   const [isAvatarEditorOpen, setAvatarEditorOpen] = useState(false);
   const [isSubmitting, setSubmitting] = useState(false);
   const loadSequence = useRef(0);
+  const candidatesRef = useRef<GroupCreateCandidateContact[]>([]);
   const searchIndex = useRef(createEmptyGroupCreateSearchIndex());
+
+  const resetSearch = useCallback(() => {
+    setKeyword("");
+    setVisibleCandidates(candidatesRef.current);
+  }, []);
 
   useEffect(() => {
     if (!options.isOpen) {
       setSelected([]);
+      resetSearch();
       setGroupName("");
       setAvatarText("");
       setAvatarColorIndex(undefined);
@@ -69,6 +76,8 @@ export function useGroupCreate(options: UseGroupCreateOptions) {
     }
 
     const sequence = ++loadSequence.current;
+    setSelected([]);
+    resetSearch();
     setGroupName("");
     setAvatarText("");
     setAvatarColorIndex(undefined);
@@ -77,6 +86,7 @@ export function useGroupCreate(options: UseGroupCreateOptions) {
     void loadGroupCreateCandidates({ channel: options.channel }).then(
       (next) => {
         if (loadSequence.current === sequence) {
+          candidatesRef.current = next;
           searchIndex.current = buildGroupCreateSearchIndex(next);
           setCandidates(next);
           setVisibleCandidates(next);
@@ -87,7 +97,12 @@ export function useGroupCreate(options: UseGroupCreateOptions) {
     return () => {
       loadSequence.current += 1;
     };
-  }, [options.channel.channelID, options.channel.channelType, options.isOpen]);
+  }, [
+    options.channel.channelID,
+    options.channel.channelType,
+    options.isOpen,
+    resetSearch,
+  ]);
 
   const selectedUidSet = useMemo(
     () => new Set(selected.map((member) => member.uid)),


### PR DESCRIPTION
## Summary

Fix the add-member picker search state so reopening the picker starts from a clean search box and full candidate list.

## Related Issue

Fixes #1189

## Changes

- Reset the group-create member search keyword when the picker closes or opens.
- Restore the visible candidate list from the latest loaded candidate snapshot when resetting search state.
- Add a regression test that closes and reopens the picker after searching, then verifies the search state is cleared.

## Architecture / Module Boundary

- Affected module(s): `packages/dmworkcontacts/src/bridge/groupCreate`
- New or changed user-visible entry point: no; this keeps the existing add-member picker entry and only fixes its reopen state.
- Shared layer touched: bridge
- If shared code changed, impact scope: group-create / add-member picker hook state only.
- Duplicate entry point checked: yes

## Testing

- [x] Unit tests added/updated
  - `pnpm exec vitest run src/bridge/groupCreate/useGroupCreate.test.tsx` from `packages/dmworkcontacts`
- [x] Manually verified
  - User verified that the add-member search is cleared after closing and reopening the picker.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes
- [ ] Updated documentation
  - Not applicable; no docs-facing behavior or API change.
- [x] Ran `pnpm i18n:check` or confirmed the change does not affect UI copy
  - Confirmed no UI copy change.
- [x] Confirmed the change follows module ownership and does not add duplicate user-visible entry points
- [x] Described impact scope when shared components, messages, bridge, or services are changed
- [x] Followed commit message conventions (Conventional Commits)
