### PR TITLE
fix(drive): reclaim pending record when a Type-2 upload is cancelled

### DIFF
--- a/apps/web/src/__tests__/driveUploadStrictMode.test.tsx
+++ b/apps/web/src/__tests__/driveUploadStrictMode.test.tsx
@@ -1,0 +1,144 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import React, { StrictMode, useEffect } from 'react';
+import { renderHook, act, waitFor } from '@testing-library/react';
+
+/**
+ * React 18 StrictMode regression for the drive upload hook (PR #1202, I-1).
+ *
+ * The package's own useUpload.test.ts runs on the in-house react-dom@17 harness,
+ * which never double-invokes effects — so it cannot catch a `mounted` ref that
+ * is set false in cleanup but not re-armed in setup. The real app wraps its tree
+ * in <React.StrictMode> on react@18 (apps/web/src/index.tsx), where dev runs
+ * effects setup→cleanup→setup on the SAME hook instance (same refs). If the flag
+ * is not re-armed, it stays false for the whole real lifetime and silently
+ * suppresses every post-confirm refresh and stale-pending retry.
+ *
+ * This file runs in apps/web's react@18 vitest (its config aliases `react` to
+ * react@18 across the whole graph, drive source included), wraps the hook in
+ * <StrictMode>, and PROVES the double-invoke actually happens (setup counter
+ * === 2) before asserting the behaviour. A plain unmount→remount would mint a
+ * fresh ref and miss the bug; only cleanup→setup on one instance exercises it.
+ *
+ * Verified to fail against the pre-fix hook (mounted never re-armed): the
+ * refresh assertion sees 0 calls and the retry never reaches 'done'.
+ */
+
+vi.mock('@octo/drive/src/api/driveApi', () => {
+  class DriveApiError extends Error {
+    code?: string;
+    status?: number;
+    constructor(message?: string, code?: string, status?: number) {
+      super(message);
+      this.name = 'DriveApiError';
+      this.code = code;
+      this.status = status;
+    }
+  }
+  return {
+    DriveApiError,
+    prepareUpload: vi.fn(),
+    putToPresignedUrl: vi.fn(),
+    confirmUpload: vi.fn(),
+    cancelUpload: vi.fn(),
+  };
+});
+
+vi.mock('@octo/drive/src/utils/toast', () => ({
+  Toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('@octo/base', () => ({ t: (k: string) => k }));
+
+import * as api from '@octo/drive/src/api/driveApi';
+import { useUpload } from '@octo/drive/src/hooks/useUpload';
+import type { PrepareUploadResp } from '@octo/drive/src/bridge/types';
+
+function makeFile(name = 'a.pdf', body = 'hello', type = 'application/pdf'): File {
+  return new File([body], name, { type });
+}
+
+function prepResp(over: Partial<PrepareUploadResp> = {}): PrepareUploadResp {
+  return {
+    file_id: 42,
+    status: 'pending',
+    upload_url: 'https://storage.example.com/presigned-put',
+    object_path: 'sp/2026/a.pdf',
+    content_type: 'application/pdf',
+    max_file_size: 5,
+    ...over,
+  };
+}
+
+const StrictWrapper = ({ children }: { children: React.ReactNode }) => (
+  <StrictMode>{children}</StrictMode>
+);
+
+beforeEach(() => {
+  vi.mocked(api.prepareUpload).mockReset();
+  vi.mocked(api.putToPresignedUrl).mockReset();
+  vi.mocked(api.confirmUpload).mockReset();
+  vi.mocked(api.cancelUpload).mockReset();
+});
+
+describe('useUpload under React 18 StrictMode (I-1)', () => {
+  it('re-arms mounted across setup→cleanup→setup: a successful upload still refreshes', async () => {
+    vi.mocked(api.prepareUpload).mockResolvedValue(prepResp());
+    vi.mocked(api.putToPresignedUrl).mockResolvedValue(undefined);
+    vi.mocked(api.confirmUpload).mockResolvedValue({} as never);
+    const onUploaded = vi.fn();
+
+    // A sibling effect counts setups so we prove StrictMode really double-invokes
+    // in this env — otherwise the behavioural assertion below would be vacuous.
+    let setups = 0;
+    const { result } = renderHook(
+      () => {
+        useEffect(() => {
+          setups += 1;
+        }, []);
+        return useUpload(onUploaded);
+      },
+      { wrapper: StrictWrapper },
+    );
+    expect(setups).toBe(2);
+
+    await act(async () => {
+      result.current.addFiles([makeFile()], 'sp', 0);
+    });
+    await waitFor(() => expect(result.current.items[0]?.status).toBe('done'));
+
+    // With the bug (mounted stuck false after the StrictMode remount) refreshOnce
+    // suppresses this — it would be 0.
+    expect(onUploaded).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-arms mounted so a stale-pending retry re-prepares instead of bailing', async () => {
+    vi.mocked(api.prepareUpload)
+      .mockResolvedValueOnce(prepResp({ file_id: 42 }))
+      .mockResolvedValueOnce(prepResp({ file_id: 99 }));
+    vi.mocked(api.putToPresignedUrl)
+      .mockRejectedValueOnce(new Error('put boom'))
+      .mockResolvedValue(undefined);
+    vi.mocked(api.confirmUpload).mockResolvedValue({} as never);
+    vi.mocked(api.cancelUpload).mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useUpload(vi.fn()), { wrapper: StrictWrapper });
+    await act(async () => {
+      result.current.addFiles([makeFile()], 'sp', 0);
+    });
+    await waitFor(() => expect(result.current.items[0]?.status).toBe('error'));
+
+    const { id } = result.current.items[0];
+    await act(async () => {
+      result.current.retry(id);
+    });
+    await waitFor(() => expect(result.current.items[0].status).toBe('done'));
+
+    // retryRun awaits bestEffortCancel(42); its post-await guard is
+    // `!mounted.current || !jobs.has(id)`. With the bug (mounted false) it bails
+    // here and never re-prepares — prepare would stay at 1 call and status never
+    // reaches 'done'.
+    expect(api.cancelUpload).toHaveBeenCalledWith(42);
+    expect(api.prepareUpload).toHaveBeenCalledTimes(2);
+    expect(api.confirmUpload).toHaveBeenCalledWith(99, { actual_size: 5 });
+  });
+});

--- a/packages/dmworkdrive/src/api/__tests__/driveApi.test.ts
+++ b/packages/dmworkdrive/src/api/__tests__/driveApi.test.ts
@@ -190,6 +190,21 @@ describe('two-phase upload endpoints', () => {
     expect(inst.post).toHaveBeenCalledWith('/v1/drive/files/7/confirm-upload', { actual_size: 5 });
   });
 
+  it('cancelUpload POSTs /files/:id/cancel-upload with no body', async () => {
+    inst.post.mockResolvedValue(ok(undefined));
+    await driveApi.cancelUpload(7);
+    expect(inst.post).toHaveBeenCalledWith('/v1/drive/files/7/cancel-upload', undefined);
+  });
+
+  it('cancelUpload surfaces a 409 (confirm already won) as a typed DriveApiError', async () => {
+    inst.post.mockRejectedValue({ response: { status: 409, data: { error: 'conflict' } } });
+    await expect(driveApi.cancelUpload(7)).rejects.toMatchObject({
+      name: 'DriveApiError',
+      status: 409,
+      code: 'conflict',
+    });
+  });
+
   it('getDownloadUrl GETs /files/:id/download', async () => {
     inst.get.mockResolvedValue(ok({ url: 'https://s/dl', filename: 'a.txt' }));
     const res = await driveApi.getDownloadUrl(7);

--- a/packages/dmworkdrive/src/api/driveApi.ts
+++ b/packages/dmworkdrive/src/api/driveApi.ts
@@ -426,6 +426,20 @@ export async function confirmUpload(
   return post<DriveBlob>(`/files/${fileId}/confirm-upload`, req);
 }
 
+/**
+ * Cancel a still-pending upload, best-effort (spec §2 D-3).
+ *
+ * Idempotent on the backend: 204 whether the pending record still existed or
+ * was already gone / unknown id. A 409 means confirm-upload already won the
+ * race — the file is confirmed, not cancellable — so the caller surfaces the
+ * confirmed result instead of a phantom removal rather than treating it as an
+ * error. Runs on the authed `driveAxios` like the other logged-in file ops
+ * (this is a drive-member action, NOT an anonymous share endpoint).
+ */
+export async function cancelUpload(fileId: number): Promise<void> {
+  return post<void>(`/files/${fileId}/cancel-upload`);
+}
+
 export async function getDownloadUrl(fileId: number): Promise<DownloadResp> {
   return get<DownloadResp>(`/files/${fileId}/download`);
 }

--- a/packages/dmworkdrive/src/hooks/__tests__/useUpload.test.ts
+++ b/packages/dmworkdrive/src/hooks/__tests__/useUpload.test.ts
@@ -455,4 +455,175 @@ describe('useUpload', () => {
     expect(api.prepareUpload).toHaveBeenCalledTimes(2);
     expect(api.confirmUpload).toHaveBeenCalledWith(99, { actual_size: 5 });
   });
+
+  it('a PUT-failed error row retains its pending id, and dismiss reclaims it', async () => {
+    vi.mocked(api.prepareUpload).mockResolvedValue(prepResp({ file_id: 42 }));
+    vi.mocked(api.putToPresignedUrl).mockRejectedValue(new Error('put boom'));
+    vi.mocked(api.cancelUpload).mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useUpload(vi.fn()));
+    act(() => result.current.addFiles([makeFile()], 'sp', 0));
+    await waitFor(() => expect(result.current.items[0]?.status).toBe('error'));
+    // The failed run must NOT have cancelled yet — the id is held on the Job so
+    // a later dismiss/retry can still reclaim the leaked pending record.
+    expect(api.cancelUpload).not.toHaveBeenCalled();
+
+    const { id } = result.current.items[0];
+    await act(async () => {
+      result.current.dismiss(id);
+      await Promise.resolve();
+    });
+
+    expect(api.cancelUpload).toHaveBeenCalledWith(42);
+    await waitFor(() => expect(result.current.items).toHaveLength(0));
+  });
+
+  it('retry reclaims the stale pending id BEFORE re-preparing a fresh one', async () => {
+    vi.mocked(api.prepareUpload)
+      .mockResolvedValueOnce(prepResp({ file_id: 42 }))
+      .mockResolvedValueOnce(prepResp({ file_id: 99 }));
+    vi.mocked(api.putToPresignedUrl)
+      .mockRejectedValueOnce(new Error('put boom'))
+      .mockResolvedValue(undefined);
+    vi.mocked(api.confirmUpload).mockResolvedValue({} as never);
+    vi.mocked(api.cancelUpload).mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useUpload(vi.fn()));
+    act(() => result.current.addFiles([makeFile()], 'sp', 0));
+    await waitFor(() => expect(result.current.items[0]?.status).toBe('error'));
+
+    const { id } = result.current.items[0];
+    act(() => result.current.retry(id));
+    await waitFor(() => expect(result.current.items[0].status).toBe('done'));
+
+    // Stale id reclaimed, and the reclaim happened before the second prepare.
+    expect(api.cancelUpload).toHaveBeenCalledWith(42);
+    expect(api.prepareUpload).toHaveBeenCalledTimes(2);
+    const cancelOrder = vi.mocked(api.cancelUpload).mock.invocationCallOrder[0];
+    const reprepareOrder = vi.mocked(api.prepareUpload).mock.invocationCallOrder[1];
+    expect(cancelOrder).toBeLessThan(reprepareOrder);
+    // Confirm targets the FRESH id, never the reclaimed one.
+    expect(api.confirmUpload).toHaveBeenCalledWith(99, { actual_size: 5 });
+  });
+
+  it('retry cleanup 409 (old run already confirmed) aborts retry, drops the row, refreshes once', async () => {
+    vi.mocked(api.prepareUpload).mockResolvedValue(prepResp({ file_id: 42 }));
+    vi.mocked(api.putToPresignedUrl).mockRejectedValue(new Error('put boom'));
+    vi.mocked(api.cancelUpload).mockRejectedValue(new DriveApiError('conflict', 'conflict', 409));
+    const onUploaded = vi.fn();
+
+    const { result } = renderHook(() => useUpload(onUploaded));
+    act(() => result.current.addFiles([makeFile()], 'sp', 0));
+    await waitFor(() => expect(result.current.items[0]?.status).toBe('error'));
+
+    const { id } = result.current.items[0];
+    await act(async () => {
+      result.current.retry(id);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // 409 => the old run really confirmed: no second prepare (would duplicate
+    // the file), row removed, real list refreshed exactly once.
+    expect(api.prepareUpload).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(result.current.items).toHaveLength(0));
+    expect(onUploaded).toHaveBeenCalledTimes(1);
+  });
+
+  it('retry survives a non-409 cancel failure: re-prepares a fresh id, never reuses the old, no id in the warn', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      vi.mocked(api.prepareUpload)
+        .mockResolvedValueOnce(prepResp({ file_id: 42 }))
+        .mockResolvedValueOnce(prepResp({ file_id: 99 }));
+      vi.mocked(api.putToPresignedUrl)
+        .mockRejectedValueOnce(new Error('put boom'))
+        .mockResolvedValue(undefined);
+      vi.mocked(api.confirmUpload).mockResolvedValue({} as never);
+      vi.mocked(api.cancelUpload).mockRejectedValue(new Error('network down'));
+
+      const { result } = renderHook(() => useUpload(vi.fn()));
+      act(() => result.current.addFiles([makeFile()], 'sp', 0));
+      await waitFor(() => expect(result.current.items[0]?.status).toBe('error'));
+
+      const { id } = result.current.items[0];
+      act(() => result.current.retry(id));
+      await waitFor(() => expect(result.current.items[0].status).toBe('done'));
+
+      expect(api.cancelUpload).toHaveBeenCalledWith(42);
+      expect(api.prepareUpload).toHaveBeenCalledTimes(2);
+      // Fresh id used, the failed-cancel old id (42) is never reused.
+      expect(api.confirmUpload).toHaveBeenCalledWith(99, { actual_size: 5 });
+      // The breadcrumb must not leak the file id / name / url / token.
+      expect(warn).toHaveBeenCalled();
+      const line = String(warn.mock.calls[0][0]);
+      expect(line).toContain('cancel-upload failed');
+      expect(line).not.toContain('42');
+      expect(line).not.toContain('a.pdf');
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('unmount during confirming does not refresh when confirm later resolves', async () => {
+    let resolveConfirm: (b: unknown) => void = () => {};
+    vi.mocked(api.prepareUpload).mockResolvedValue(prepResp());
+    vi.mocked(api.putToPresignedUrl).mockResolvedValue(undefined);
+    vi.mocked(api.confirmUpload).mockImplementation(
+      () => new Promise((res) => { resolveConfirm = res; }) as never,
+    );
+    vi.mocked(api.cancelUpload).mockResolvedValue(undefined);
+    const onUploaded = vi.fn();
+
+    const { result, unmount } = renderHook(() => useUpload(onUploaded));
+    act(() => result.current.addFiles([makeFile()], 'sp', 0));
+    await waitFor(() => expect(result.current.items[0]?.status).toBe('confirming'));
+
+    await act(async () => {
+      unmount();
+      await Promise.resolve();
+    });
+    // Confirm resolves AFTER unmount — the cancelled + unmounted run must stay silent.
+    await act(async () => {
+      resolveConfirm({});
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(onUploaded).not.toHaveBeenCalled();
+    // Unmount still fire-and-forget reclaims the known pending id.
+    expect(api.cancelUpload).toHaveBeenCalledWith(42);
+  });
+
+  it('unmount then a cancel-409 does not refresh', async () => {
+    let rejectCancel: (e: unknown) => void = () => {};
+    vi.mocked(api.prepareUpload).mockResolvedValue(prepResp());
+    vi.mocked(api.putToPresignedUrl).mockImplementation(
+      (_url, _file, opts) =>
+        new Promise<void>((_resolve, reject) => {
+          opts.signal?.addEventListener('abort', () => reject(new Error('canceled')));
+        }),
+    );
+    vi.mocked(api.cancelUpload).mockImplementation(
+      () => new Promise((_res, rej) => { rejectCancel = rej; }),
+    );
+    const onUploaded = vi.fn();
+
+    const { result, unmount } = renderHook(() => useUpload(onUploaded));
+    act(() => result.current.addFiles([makeFile()], 'sp', 0));
+    await waitFor(() => expect(result.current.items[0]?.status).toBe('uploading'));
+
+    await act(async () => {
+      unmount();
+      await Promise.resolve();
+    });
+    // A 409 landing after unmount (confirm won) must not refresh a dead component.
+    await act(async () => {
+      rejectCancel(new DriveApiError('conflict', 'conflict', 409));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(onUploaded).not.toHaveBeenCalled();
+  });
 });

--- a/packages/dmworkdrive/src/hooks/__tests__/useUpload.test.ts
+++ b/packages/dmworkdrive/src/hooks/__tests__/useUpload.test.ts
@@ -1,15 +1,32 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { renderHook, waitFor, act } from '../../__tests__/harness';
 
-vi.mock('../../api/driveApi', () => ({
-  prepareUpload: vi.fn(),
-  putToPresignedUrl: vi.fn(),
-  confirmUpload: vi.fn(),
-}));
+vi.mock('../../api/driveApi', () => {
+  // Local DriveApiError so the hook's `instanceof` + status branching (409 →
+  // "confirm won the race") works against the mocked module.
+  class DriveApiError extends Error {
+    code?: string;
+    status?: number;
+    constructor(message: string, code?: string, status?: number) {
+      super(message);
+      this.name = 'DriveApiError';
+      this.code = code;
+      this.status = status;
+    }
+  }
+  return {
+    DriveApiError,
+    prepareUpload: vi.fn(),
+    putToPresignedUrl: vi.fn(),
+    confirmUpload: vi.fn(),
+    cancelUpload: vi.fn(),
+  };
+});
 
 vi.mock('../../utils/toast', () => ({ Toast: { success: vi.fn(), error: vi.fn() } }));
 
 import * as api from '../../api/driveApi';
+import { DriveApiError } from '../../api/driveApi';
 import { Toast } from '../../utils/toast';
 import { useUpload } from '../useUpload';
 import type { PrepareUploadResp } from '../../bridge/types';
@@ -34,6 +51,7 @@ beforeEach(() => {
   vi.mocked(api.prepareUpload).mockReset();
   vi.mocked(api.putToPresignedUrl).mockReset();
   vi.mocked(api.confirmUpload).mockReset();
+  vi.mocked(api.cancelUpload).mockReset();
   vi.mocked(Toast.error).mockReset();
 });
 
@@ -229,6 +247,7 @@ describe('useUpload', () => {
           opts.signal?.addEventListener('abort', () => reject(new Error('canceled')));
         }),
     );
+    vi.mocked(api.cancelUpload).mockResolvedValue(undefined);
     const onUploaded = vi.fn();
 
     const { result } = renderHook(() => useUpload(onUploaded));
@@ -243,10 +262,146 @@ describe('useUpload', () => {
 
     expect(capturedSignal?.aborted).toBe(true);
     // Row removed, upload never confirmed, and the cancel must NOT surface as an
-    // error toast or an onUploaded refresh.
+    // error toast or an onUploaded refresh — but it MUST best-effort reclaim the
+    // known pending file_id on the backend.
     await waitFor(() => expect(result.current.items).toHaveLength(0));
+    expect(api.cancelUpload).toHaveBeenCalledWith(42);
     expect(api.confirmUpload).not.toHaveBeenCalled();
     expect(onUploaded).not.toHaveBeenCalled();
     expect(Toast.error).not.toHaveBeenCalled();
+  });
+
+  it('cancelling while preparing best-effort cancels once file_id lands and never PUTs', async () => {
+    let resolvePrep: (r: PrepareUploadResp) => void = () => {};
+    vi.mocked(api.prepareUpload).mockImplementation(
+      () => new Promise<PrepareUploadResp>((res) => { resolvePrep = res; }),
+    );
+    vi.mocked(api.cancelUpload).mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useUpload(vi.fn()));
+    act(() => result.current.addFiles([makeFile()], 'sp', 0));
+    await waitFor(() => expect(result.current.items[0]?.status).toBe('preparing'));
+
+    const { id } = result.current.items[0];
+    // Cancel BEFORE prepare returns: no file_id yet, so the row leaves the UI
+    // immediately and cancel is deferred to when prepare resolves.
+    act(() => result.current.dismiss(id));
+    await waitFor(() => expect(result.current.items).toHaveLength(0));
+    expect(api.cancelUpload).not.toHaveBeenCalled();
+
+    await act(async () => {
+      resolvePrep(prepResp());
+      await Promise.resolve();
+    });
+
+    // The PUT must never start; the pending record is best-effort cancelled.
+    expect(api.putToPresignedUrl).not.toHaveBeenCalled();
+    await waitFor(() => expect(api.cancelUpload).toHaveBeenCalledWith(42));
+  });
+
+  it('cancelling while confirming: a 409 (confirm won) refreshes to the confirmed file', async () => {
+    let resolveConfirm: (b: unknown) => void = () => {};
+    vi.mocked(api.prepareUpload).mockResolvedValue(prepResp());
+    vi.mocked(api.putToPresignedUrl).mockResolvedValue(undefined);
+    vi.mocked(api.confirmUpload).mockImplementation(
+      () => new Promise((res) => { resolveConfirm = res; }) as never,
+    );
+    vi.mocked(api.cancelUpload).mockRejectedValue(new DriveApiError('conflict', 'conflict', 409));
+    const onUploaded = vi.fn();
+
+    const { result } = renderHook(() => useUpload(onUploaded));
+    act(() => result.current.addFiles([makeFile()], 'sp', 0));
+    await waitFor(() => expect(result.current.items[0]?.status).toBe('confirming'));
+
+    const { id } = result.current.items[0];
+    await act(async () => {
+      result.current.dismiss(id);
+      await Promise.resolve();
+    });
+
+    // Row removed immediately; cancel raced confirm on the known file_id.
+    await waitFor(() => expect(result.current.items).toHaveLength(0));
+    expect(api.cancelUpload).toHaveBeenCalledWith(42);
+
+    // Confirm then wins → the file is really confirmed; the list refreshes to
+    // reflect it (never re-adding a phantom row or claiming a cancellation).
+    await act(async () => {
+      resolveConfirm({});
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(onUploaded).toHaveBeenCalled());
+    expect(result.current.items).toHaveLength(0);
+    expect(Toast.error).not.toHaveBeenCalled();
+  });
+
+  it('a failed cancel (network/5xx) never blocks UI removal or alarms the user', async () => {
+    vi.mocked(api.prepareUpload).mockResolvedValue(prepResp());
+    vi.mocked(api.putToPresignedUrl).mockImplementation(
+      (_url, _file, opts) =>
+        new Promise<void>((_resolve, reject) => {
+          opts.signal?.addEventListener('abort', () => reject(new Error('canceled')));
+        }),
+    );
+    vi.mocked(api.cancelUpload).mockRejectedValue(new Error('network down'));
+
+    const { result } = renderHook(() => useUpload(vi.fn()));
+    act(() => result.current.addFiles([makeFile()], 'sp', 0));
+    await waitFor(() => expect(result.current.items[0]?.status).toBe('uploading'));
+
+    const { id } = result.current.items[0];
+    await act(async () => {
+      result.current.dismiss(id);
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(result.current.items).toHaveLength(0));
+    expect(api.cancelUpload).toHaveBeenCalledWith(42);
+    expect(Toast.error).not.toHaveBeenCalled();
+  });
+
+  it('unmount aborts the PUT and best-effort cancels a known pending file_id', async () => {
+    let capturedSignal: AbortSignal | undefined;
+    vi.mocked(api.prepareUpload).mockResolvedValue(prepResp());
+    vi.mocked(api.putToPresignedUrl).mockImplementation(
+      (_url, _file, opts) =>
+        new Promise<void>((_resolve, reject) => {
+          capturedSignal = opts.signal;
+          opts.signal?.addEventListener('abort', () => reject(new Error('canceled')));
+        }),
+    );
+    vi.mocked(api.cancelUpload).mockResolvedValue(undefined);
+
+    const { result, unmount } = renderHook(() => useUpload(vi.fn()));
+    act(() => result.current.addFiles([makeFile()], 'sp', 0));
+    await waitFor(() => expect(result.current.items[0]?.status).toBe('uploading'));
+
+    await act(async () => {
+      unmount();
+      await Promise.resolve();
+    });
+
+    expect(capturedSignal?.aborted).toBe(true);
+    expect(api.cancelUpload).toHaveBeenCalledWith(42);
+  });
+
+  it('retry creates a fresh prepare (new file_id), not reusing the cancelled pending', async () => {
+    vi.mocked(api.prepareUpload)
+      .mockResolvedValueOnce(prepResp({ file_id: 42 }))
+      .mockResolvedValueOnce(prepResp({ file_id: 99 }));
+    vi.mocked(api.putToPresignedUrl).mockRejectedValueOnce(new Error('put boom'));
+    vi.mocked(api.putToPresignedUrl).mockResolvedValue(undefined);
+    vi.mocked(api.confirmUpload).mockResolvedValue({} as never);
+
+    const { result } = renderHook(() => useUpload(vi.fn()));
+    act(() => result.current.addFiles([makeFile()], 'sp', 0));
+    await waitFor(() => expect(result.current.items[0]?.status).toBe('error'));
+
+    const { id } = result.current.items[0];
+    act(() => result.current.retry(id));
+    await waitFor(() => expect(result.current.items[0].status).toBe('done'));
+
+    // Second prepare produced a fresh file_id; confirm targets that new id.
+    expect(api.prepareUpload).toHaveBeenCalledTimes(2);
+    expect(api.confirmUpload).toHaveBeenCalledWith(99, { actual_size: 5 });
   });
 });

--- a/packages/dmworkdrive/src/hooks/__tests__/useUpload.test.ts
+++ b/packages/dmworkdrive/src/hooks/__tests__/useUpload.test.ts
@@ -299,14 +299,17 @@ describe('useUpload', () => {
     await waitFor(() => expect(api.cancelUpload).toHaveBeenCalledWith(42));
   });
 
-  it('cancelling while confirming: a 409 (confirm won) refreshes to the confirmed file', async () => {
+  it('confirm-wins race refreshes exactly once — confirm completes, then cancel 409', async () => {
     let resolveConfirm: (b: unknown) => void = () => {};
+    let rejectCancel: (e: unknown) => void = () => {};
     vi.mocked(api.prepareUpload).mockResolvedValue(prepResp());
     vi.mocked(api.putToPresignedUrl).mockResolvedValue(undefined);
     vi.mocked(api.confirmUpload).mockImplementation(
       () => new Promise((res) => { resolveConfirm = res; }) as never,
     );
-    vi.mocked(api.cancelUpload).mockRejectedValue(new DriveApiError('conflict', 'conflict', 409));
+    vi.mocked(api.cancelUpload).mockImplementation(
+      () => new Promise((_res, rej) => { rejectCancel = rej; }),
+    );
     const onUploaded = vi.fn();
 
     const { result } = renderHook(() => useUpload(onUploaded));
@@ -318,18 +321,66 @@ describe('useUpload', () => {
       result.current.dismiss(id);
       await Promise.resolve();
     });
-
-    // Row removed immediately; cancel raced confirm on the known file_id.
     await waitFor(() => expect(result.current.items).toHaveLength(0));
     expect(api.cancelUpload).toHaveBeenCalledWith(42);
 
-    // Confirm then wins → the file is really confirmed; the list refreshes to
-    // reflect it (never re-adding a phantom row or claiming a cancellation).
+    // Confirm resolves FIRST → runItem's cancelled branch refreshes.
     await act(async () => {
       resolveConfirm({});
       await Promise.resolve();
+      await Promise.resolve();
     });
-    await waitFor(() => expect(onUploaded).toHaveBeenCalled());
+    // Then the cancel 409 lands — its refresh must be deduped by the run.
+    await act(async () => {
+      rejectCancel(new DriveApiError('conflict', 'conflict', 409));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(onUploaded).toHaveBeenCalledTimes(1);
+    expect(result.current.items).toHaveLength(0);
+    expect(Toast.error).not.toHaveBeenCalled();
+  });
+
+  it('confirm-wins race refreshes exactly once — cancel 409 first, then confirm completes', async () => {
+    let resolveConfirm: (b: unknown) => void = () => {};
+    let rejectCancel: (e: unknown) => void = () => {};
+    vi.mocked(api.prepareUpload).mockResolvedValue(prepResp());
+    vi.mocked(api.putToPresignedUrl).mockResolvedValue(undefined);
+    vi.mocked(api.confirmUpload).mockImplementation(
+      () => new Promise((res) => { resolveConfirm = res; }) as never,
+    );
+    vi.mocked(api.cancelUpload).mockImplementation(
+      () => new Promise((_res, rej) => { rejectCancel = rej; }),
+    );
+    const onUploaded = vi.fn();
+
+    const { result } = renderHook(() => useUpload(onUploaded));
+    act(() => result.current.addFiles([makeFile()], 'sp', 0));
+    await waitFor(() => expect(result.current.items[0]?.status).toBe('confirming'));
+
+    const { id } = result.current.items[0];
+    await act(async () => {
+      result.current.dismiss(id);
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(result.current.items).toHaveLength(0));
+    expect(api.cancelUpload).toHaveBeenCalledWith(42);
+
+    // Cancel 409 lands FIRST → bestEffortCancel refreshes.
+    await act(async () => {
+      rejectCancel(new DriveApiError('conflict', 'conflict', 409));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    // Then confirm resolves — runItem's cancelled branch must not refresh again.
+    await act(async () => {
+      resolveConfirm({});
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(onUploaded).toHaveBeenCalledTimes(1);
     expect(result.current.items).toHaveLength(0);
     expect(Toast.error).not.toHaveBeenCalled();
   });

--- a/packages/dmworkdrive/src/hooks/__tests__/useUpload.test.ts
+++ b/packages/dmworkdrive/src/hooks/__tests__/useUpload.test.ts
@@ -558,8 +558,11 @@ describe('useUpload', () => {
       expect(warn).toHaveBeenCalled();
       const line = String(warn.mock.calls[0][0]);
       expect(line).toContain('cancel-upload failed');
+      expect(line).toContain('kind=');
       expect(line).not.toContain('42');
       expect(line).not.toContain('a.pdf');
+      expect(line.toLowerCase()).not.toContain('http');
+      expect(line.toLowerCase()).not.toContain('token');
     } finally {
       warn.mockRestore();
     }
@@ -618,6 +621,196 @@ describe('useUpload', () => {
       await Promise.resolve();
     });
     // A 409 landing after unmount (confirm won) must not refresh a dead component.
+    await act(async () => {
+      rejectCancel(new DriveApiError('conflict', 'conflict', 409));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(onUploaded).not.toHaveBeenCalled();
+  });
+
+  it('terminal-error row unmount reclaims the retained pending id (P1-1)', async () => {
+    vi.mocked(api.prepareUpload).mockResolvedValue(prepResp({ file_id: 42 }));
+    vi.mocked(api.putToPresignedUrl).mockRejectedValue(new Error('put boom'));
+    vi.mocked(api.cancelUpload).mockResolvedValue(undefined);
+
+    const { result, unmount } = renderHook(() => useUpload(vi.fn()));
+    act(() => result.current.addFiles([makeFile()], 'sp', 0));
+    await waitFor(() => expect(result.current.items[0]?.status).toBe('error'));
+    // Held, not cancelled yet — the id lives on the Job for a later reclaim.
+    expect(api.cancelUpload).not.toHaveBeenCalled();
+
+    await act(async () => {
+      unmount();
+      await Promise.resolve();
+    });
+
+    // Leaving the page directly must reclaim the retained pending id even though
+    // no live RunCtl exists for the error row.
+    expect(api.cancelUpload).toHaveBeenCalledWith(42);
+    expect(api.cancelUpload).toHaveBeenCalledTimes(1);
+  });
+
+  it('retry awaiting cancel then unmount: bails with no re-prepare, stale id cancelled once (P1-2/3)', async () => {
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      let resolveCancel: () => void = () => {};
+      vi.mocked(api.prepareUpload).mockResolvedValue(prepResp({ file_id: 42 }));
+      vi.mocked(api.putToPresignedUrl).mockRejectedValue(new Error('put boom'));
+      vi.mocked(api.confirmUpload).mockResolvedValue({} as never);
+      vi.mocked(api.cancelUpload).mockImplementation(
+        () => new Promise<void>((res) => { resolveCancel = res; }),
+      );
+
+      const { result, unmount } = renderHook(() => useUpload(vi.fn()));
+      act(() => result.current.addFiles([makeFile()], 'sp', 0));
+      await waitFor(() => expect(result.current.items[0]?.status).toBe('error'));
+
+      const { id } = result.current.items[0];
+      // retry reclaims stale id 42 and suspends at the cancel await.
+      act(() => result.current.retry(id));
+      await waitFor(() => expect(api.cancelUpload).toHaveBeenCalledWith(42));
+
+      // Unmount while the retry is still awaiting the cancel.
+      await act(async () => {
+        unmount();
+        await Promise.resolve();
+      });
+      // Cancel resolves AFTER unmount — retryRun must bail before re-preparing.
+      await act(async () => {
+        resolveCancel();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      // No second run, no confirm, and the stale id was cancelled exactly once
+      // (retryRun cleared it up-front so unmount cleanup didn't re-cancel it).
+      expect(api.prepareUpload).toHaveBeenCalledTimes(1);
+      expect(api.putToPresignedUrl).toHaveBeenCalledTimes(1);
+      expect(api.confirmUpload).not.toHaveBeenCalled();
+      expect(api.cancelUpload).toHaveBeenCalledTimes(1);
+      // No setState-after-unmount warning slipped through.
+      const warned = err.mock.calls.some((c) => String(c[0]).includes('unmount'));
+      expect(warned).toBe(false);
+    } finally {
+      err.mockRestore();
+    }
+  });
+
+  it('retry awaiting cancel, unmount, then cancel-409: no setItems/refresh after unmount (P1-2)', async () => {
+    let rejectCancel: (e: unknown) => void = () => {};
+    vi.mocked(api.prepareUpload).mockResolvedValue(prepResp({ file_id: 42 }));
+    vi.mocked(api.putToPresignedUrl).mockRejectedValue(new Error('put boom'));
+    vi.mocked(api.cancelUpload).mockImplementation(
+      () => new Promise((_res, rej) => { rejectCancel = rej; }),
+    );
+    const onUploaded = vi.fn();
+
+    const { result, unmount } = renderHook(() => useUpload(onUploaded));
+    act(() => result.current.addFiles([makeFile()], 'sp', 0));
+    await waitFor(() => expect(result.current.items[0]?.status).toBe('error'));
+
+    const { id } = result.current.items[0];
+    act(() => result.current.retry(id));
+    await waitFor(() => expect(api.cancelUpload).toHaveBeenCalledWith(42));
+
+    await act(async () => {
+      unmount();
+      await Promise.resolve();
+    });
+    // 409 = the old run actually confirmed. retryRun's confirmWon branch would
+    // otherwise delete the row + refresh — but after unmount the post-await
+    // guard must bail before any setItems / onUploaded on a dead component.
+    await act(async () => {
+      rejectCancel(new DriveApiError('conflict', 'conflict', 409));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(onUploaded).not.toHaveBeenCalled();
+  });
+
+  it('concurrent (double-click) retry starts only one new run (P1-4)', async () => {
+    let resolveCancel: () => void = () => {};
+    let resolveConfirm: (b: unknown) => void = () => {};
+    vi.mocked(api.prepareUpload)
+      .mockResolvedValueOnce(prepResp({ file_id: 42 }))
+      .mockResolvedValue(prepResp({ file_id: 99 }));
+    vi.mocked(api.putToPresignedUrl)
+      .mockRejectedValueOnce(new Error('put boom'))
+      .mockResolvedValue(undefined);
+    vi.mocked(api.confirmUpload).mockImplementation(
+      () => new Promise((res) => { resolveConfirm = res; }) as never,
+    );
+    // Deferred so the reclaim of the first click stays in flight while the
+    // second click's fresh run reaches confirming.
+    vi.mocked(api.cancelUpload).mockImplementation(
+      () => new Promise<void>((res) => { resolveCancel = res; }),
+    );
+
+    const { result } = renderHook(() => useUpload(vi.fn()));
+    act(() => result.current.addFiles([makeFile()], 'sp', 0));
+    await waitFor(() => expect(result.current.items[0]?.status).toBe('error'));
+
+    const { id } = result.current.items[0];
+    // Two synchronous clicks: the first reclaims id 42 (suspends at cancel),
+    // the second sees the stale id already cleared and starts the fresh run.
+    act(() => {
+      result.current.retry(id);
+      result.current.retry(id);
+    });
+    // The fresh run prepares 99 and reaches confirming (still in flight).
+    await waitFor(() => expect(result.current.items[0]?.status).toBe('confirming'));
+    expect(api.prepareUpload).toHaveBeenCalledTimes(2);
+
+    // Now the first click's cancel resolves; its runItem must hit the re-entry
+    // guard (a run is already live) and NOT start a competing third prepare.
+    await act(async () => {
+      resolveCancel();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    await act(async () => {
+      resolveConfirm({});
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(result.current.items[0].status).toBe('done'));
+
+    // Exactly one new run: prepare called twice total (42 + 99), never a third,
+    // and confirm targets only the single fresh id.
+    expect(api.prepareUpload).toHaveBeenCalledTimes(2);
+    expect(api.confirmUpload).toHaveBeenCalledTimes(1);
+    expect(api.confirmUpload).toHaveBeenCalledWith(99, { actual_size: 5 });
+  });
+
+  it('terminal-error dismiss, then unmount, then cancel-409: no refresh (mounted guard)', async () => {
+    let rejectCancel: (e: unknown) => void = () => {};
+    vi.mocked(api.prepareUpload).mockResolvedValue(prepResp({ file_id: 42 }));
+    vi.mocked(api.putToPresignedUrl).mockRejectedValue(new Error('put boom'));
+    vi.mocked(api.cancelUpload).mockImplementation(
+      () => new Promise((_res, rej) => { rejectCancel = rej; }),
+    );
+    const onUploaded = vi.fn();
+
+    const { result, unmount } = renderHook(() => useUpload(onUploaded));
+    act(() => result.current.addFiles([makeFile()], 'sp', 0));
+    await waitFor(() => expect(result.current.items[0]?.status).toBe('error'));
+
+    const { id } = result.current.items[0];
+    // Dismiss the error row: reclaims id 42 (cancel in flight), row removed.
+    await act(async () => {
+      result.current.dismiss(id);
+      await Promise.resolve();
+    });
+    expect(api.cancelUpload).toHaveBeenCalledWith(42);
+
+    await act(async () => {
+      unmount();
+      await Promise.resolve();
+    });
+    // The 409 (confirm won) lands after unmount — its refresh must be suppressed
+    // by the mounted guard rather than refreshing a dead component.
     await act(async () => {
       rejectCancel(new DriveApiError('conflict', 'conflict', 409));
       await Promise.resolve();

--- a/packages/dmworkdrive/src/hooks/useUpload.ts
+++ b/packages/dmworkdrive/src/hooks/useUpload.ts
@@ -210,33 +210,41 @@ export function useUpload(onUploaded: () => void): UseUpload {
   );
 
   useEffect(
-    () => () => {
-      mounted.current = false;
-      timers.current.forEach((tm) => clearTimeout(tm));
-      timers.current.clear();
-      runs.current.forEach((ctl) => {
-        ctl.cancelled = true;
-        ctl.controller.abort();
-        // Reclaim the pending record if we already have an id. Fire-and-forget
-        // and no onConfirmWon: the component is gone, there is nothing to
-        // refresh, and mounted is already false so any refresh would be
-        // suppressed anyway. (Only surfaces the safe non-409 warn.)
-        if (ctl.fileId !== undefined) {
-          void bestEffortCancel(ctl.fileId);
-        }
-      });
-      // Terminal-error rows have no live RunCtl (deleted in `finally`) but may
-      // still retain a pending id on the Job. Reclaim those too so leaving the
-      // page directly doesn't strand them. Skip ids already handled by a live
-      // run above — a live run's ctl.fileId equals its job.pendingFileId, and
-      // cancelling twice would fire a redundant request.
-      jobs.current.forEach((job, id) => {
-        if (!runs.current.has(id) && job.pendingFileId !== undefined) {
-          void bestEffortCancel(job.pendingFileId);
-        }
-      });
-      runs.current.clear();
-      jobs.current.clear();
+    () => {
+      // Re-arm on every effect setup. React 18 StrictMode runs effects
+      // setup→cleanup→setup in dev on the SAME hook instance (same refs); the
+      // cleanup below sets this false, so without re-arming here `mounted` would
+      // stay false for the whole real lifetime and suppress every post-confirm
+      // refresh / retry. Stable deps mean this never re-runs in production.
+      mounted.current = true;
+      return () => {
+        mounted.current = false;
+        timers.current.forEach((tm) => clearTimeout(tm));
+        timers.current.clear();
+        runs.current.forEach((ctl) => {
+          ctl.cancelled = true;
+          ctl.controller.abort();
+          // Reclaim the pending record if we already have an id. Fire-and-forget
+          // and no onConfirmWon: the component is gone, there is nothing to
+          // refresh, and mounted is already false so any refresh would be
+          // suppressed anyway. (Only surfaces the safe non-409 warn.)
+          if (ctl.fileId !== undefined) {
+            void bestEffortCancel(ctl.fileId);
+          }
+        });
+        // Terminal-error rows have no live RunCtl (deleted in `finally`) but may
+        // still retain a pending id on the Job. Reclaim those too so leaving the
+        // page directly doesn't strand them. Skip ids already handled by a live
+        // run above — a live run's ctl.fileId equals its job.pendingFileId, and
+        // cancelling twice would fire a redundant request.
+        jobs.current.forEach((job, id) => {
+          if (!runs.current.has(id) && job.pendingFileId !== undefined) {
+            void bestEffortCancel(job.pendingFileId);
+          }
+        });
+        runs.current.clear();
+        jobs.current.clear();
+      };
     },
     [bestEffortCancel],
   );

--- a/packages/dmworkdrive/src/hooks/useUpload.ts
+++ b/packages/dmworkdrive/src/hooks/useUpload.ts
@@ -146,8 +146,12 @@ export function useUpload(onUploaded: () => void): UseUpload {
         }
         const status = err instanceof DriveApiError ? err.status : undefined;
         const code = err instanceof DriveApiError ? err.code : undefined;
+        // Non-DriveApiError (network/unknown): log only the error's structural
+        // name (e.g. "TypeError"), never its message — a message could echo a
+        // URL / token / file name back into the console.
+        const kind = err instanceof Error ? err.name : 'unknown';
         console.warn(
-          `[drive] cancel-upload failed (best-effort); status=${status ?? 'n/a'} code=${code ?? 'n/a'}`,
+          `[drive] cancel-upload failed (best-effort); kind=${kind} status=${status ?? 'n/a'} code=${code ?? 'n/a'}`,
         );
       }
     },
@@ -221,7 +225,18 @@ export function useUpload(onUploaded: () => void): UseUpload {
           void bestEffortCancel(ctl.fileId);
         }
       });
+      // Terminal-error rows have no live RunCtl (deleted in `finally`) but may
+      // still retain a pending id on the Job. Reclaim those too so leaving the
+      // page directly doesn't strand them. Skip ids already handled by a live
+      // run above — a live run's ctl.fileId equals its job.pendingFileId, and
+      // cancelling twice would fire a redundant request.
+      jobs.current.forEach((job, id) => {
+        if (!runs.current.has(id) && job.pendingFileId !== undefined) {
+          void bestEffortCancel(job.pendingFileId);
+        }
+      });
       runs.current.clear();
+      jobs.current.clear();
     },
     [bestEffortCancel],
   );
@@ -230,6 +245,10 @@ export function useUpload(onUploaded: () => void): UseUpload {
     async (id: string) => {
       const job = jobs.current.get(id);
       if (!job) return;
+      // Re-entry guard: a run is already in flight for this id (e.g. a fast
+      // double-click on retry). Starting another would overwrite its RunCtl in
+      // the map and leak a duplicate upload — bail instead.
+      if (runs.current.has(id)) return;
       const { file, spaceId, parentId } = job;
       // Fresh control record per run (retry re-prepares, so it gets a new one).
       const ctl: RunCtl = { controller: new AbortController(), phase: 'preparing', cancelled: false, refreshed: false };
@@ -327,9 +346,16 @@ export function useUpload(onUploaded: () => void): UseUpload {
   // reused. runItem then re-prepares from scratch.
   const retryRun = useCallback(
     async (id: string) => {
+      // A run is already in flight for this id — don't start a competing one.
+      if (runs.current.has(id)) return;
       const job = jobs.current.get(id);
       if (!job) return;
+      // Take the stale id out and clear it BEFORE awaiting, so an interleaving
+      // unmount cleanup won't also try to cancel it. Cancel is idempotent, but
+      // one request is enough — this keeps a given stale id cancelled at most
+      // once across the retry-await + unmount paths.
       const stalePending = job.pendingFileId;
+      job.pendingFileId = undefined;
       if (stalePending !== undefined) {
         // Reflect the cleanup immediately: hide the error/retry affordance.
         patch(id, { status: 'preparing', progress: 0, error: undefined });
@@ -337,11 +363,14 @@ export function useUpload(onUploaded: () => void): UseUpload {
         await bestEffortCancel(stalePending, () => {
           confirmWon = true;
         });
-        job.pendingFileId = undefined;
+        // The await yielded: the component may have unmounted or the row may
+        // have been dismissed. Bail before any new prepare/PUT/confirm or
+        // setState so nothing runs against a dead component / removed item.
+        if (!mounted.current || !jobs.current.has(id)) return;
         if (confirmWon) {
           jobs.current.delete(id);
           setItems((list) => list.filter((it) => it.id !== id));
-          if (mounted.current) onUploadedRef.current();
+          onUploadedRef.current();
           return;
         }
       }

--- a/packages/dmworkdrive/src/hooks/useUpload.ts
+++ b/packages/dmworkdrive/src/hooks/useUpload.ts
@@ -38,6 +38,15 @@ interface Job {
   file: File;
   spaceId: string;
   parentId: number;
+  /**
+   * file_id of the current run's pending record, kept on the Job (not the
+   * RunCtl) so it OUTLIVES a terminal error: the RunCtl is deleted in `finally`,
+   * but the error row lingers in the UI and its later dismiss/retry still needs
+   * this id to reclaim the leaked pending record. Set once prepare returns;
+   * cleared on confirmed success and after a cancel is issued (204/409). No run
+   * has prepared yet while undefined.
+   */
+  pendingFileId?: number;
 }
 
 type RunPhase = 'preparing' | 'uploading' | 'confirming' | 'settled';
@@ -98,6 +107,9 @@ export function useUpload(onUploaded: () => void): UseUpload {
   const timers = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
   const onUploadedRef = useRef(onUploaded);
   onUploadedRef.current = onUploaded;
+  // Flips false on unmount so no async continuation calls the parent's
+  // onUploaded (a refresh) after the component is gone.
+  const mounted = useRef(true);
 
   const patch = useCallback((id: string, next: Partial<UploadItem>) => {
     setItems((list) => list.map((it) => (it.id === id ? { ...it, ...next } : it)));
@@ -107,32 +119,39 @@ export function useUpload(onUploaded: () => void): UseUpload {
   // cancel-409 can both signal "the file is really confirmed" for the same run,
   // in either order; without this guard they would each fire onUploaded and
   // refresh twice. Per-run (not global) so independent uploads still each
-  // refresh exactly once.
+  // refresh exactly once. Suppressed after unmount (nothing to refresh).
   const refreshOnce = useCallback((ctl: RunCtl) => {
     if (ctl.refreshed) return;
     ctl.refreshed = true;
-    onUploadedRef.current();
+    if (mounted.current) onUploadedRef.current();
   }, []);
 
-  // Best-effort cancel of a known pending file_id. Idempotent on the backend
-  // (204 even if already gone). A 409 means confirm-upload won the race, so the
-  // file is genuinely confirmed — refresh (once) to reflect it rather than
-  // leaving a phantom-removed row. Every other failure is swallowed: the
-  // backend confirmed-only filter keeps any orphan pending invisible, so we
-  // never alarm the user with a misleading "cancel failed". No-op if we don't
-  // yet have a file_id (prepare still in flight).
+  // Best-effort cancel of a pending file_id. Idempotent on the backend (204
+  // even if already gone). A 409 means confirm-upload won the race, so the file
+  // is genuinely confirmed — the caller's `onConfirmWon` reflects it (refresh /
+  // stop retry) rather than leaving a phantom-removed row. Every other failure
+  // (network / 5xx / 403) is swallowed for the user: the backend confirmed-only
+  // read filter keeps any orphan pending invisible, and we cannot safely retry
+  // cleanup here — but we log a fixed-format breadcrumb (status/code only,
+  // never file name / URL / token / id) so a front/back publish-order mismatch
+  // is still discoverable.
   const bestEffortCancel = useCallback(
-    async (ctl: RunCtl) => {
-      if (ctl.fileId === undefined) return;
+    async (fileId: number, onConfirmWon?: () => void) => {
       try {
-        await api.cancelUpload(ctl.fileId);
+        await api.cancelUpload(fileId);
       } catch (err) {
         if (err instanceof DriveApiError && err.status === 409) {
-          refreshOnce(ctl);
+          onConfirmWon?.();
+          return;
         }
+        const status = err instanceof DriveApiError ? err.status : undefined;
+        const code = err instanceof DriveApiError ? err.code : undefined;
+        console.warn(
+          `[drive] cancel-upload failed (best-effort); status=${status ?? 'n/a'} code=${code ?? 'n/a'}`,
+        );
       }
     },
-    [refreshOnce],
+    [],
   );
 
   const dismiss = useCallback(
@@ -143,6 +162,7 @@ export function useUpload(onUploaded: () => void): UseUpload {
         timers.current.delete(id);
       }
       const ctl = runs.current.get(id);
+      const job = jobs.current.get(id);
       if (ctl && ctl.phase !== 'settled') {
         // In-flight row: this is a genuine cancel, not just a panel dismiss.
         ctl.cancelled = true;
@@ -152,13 +172,21 @@ export function useUpload(onUploaded: () => void): UseUpload {
         // handled as "confirm won"). While prepare is still in flight there is
         // no id yet — the run itself cancels once prepare returns.
         if (ctl.fileId !== undefined) {
-          void bestEffortCancel(ctl);
+          void bestEffortCancel(ctl.fileId, () => refreshOnce(ctl));
         }
+      } else if (job?.pendingFileId !== undefined) {
+        // No live run (typically a terminal error row: the RunCtl was already
+        // deleted in `finally`), but a prior run left a pending record behind.
+        // Reclaim it. A 409 means that old run actually confirmed — refresh the
+        // real list to surface the file instead of dropping it silently.
+        void bestEffortCancel(job.pendingFileId, () => {
+          if (mounted.current) onUploadedRef.current();
+        });
       }
       jobs.current.delete(id);
       setItems((list) => list.filter((it) => it.id !== id));
     },
-    [bestEffortCancel],
+    [bestEffortCancel, refreshOnce],
   );
 
   // Auto-remove a successfully finished row after a short delay so the panel
@@ -179,21 +207,23 @@ export function useUpload(onUploaded: () => void): UseUpload {
 
   useEffect(
     () => () => {
+      mounted.current = false;
       timers.current.forEach((tm) => clearTimeout(tm));
       timers.current.clear();
       runs.current.forEach((ctl) => {
         ctl.cancelled = true;
         ctl.controller.abort();
         // Reclaim the pending record if we already have an id. Fire-and-forget
-        // with no 409 refresh: the component is gone, there is nothing to
-        // refresh, and we must not setState after unmount.
+        // and no onConfirmWon: the component is gone, there is nothing to
+        // refresh, and mounted is already false so any refresh would be
+        // suppressed anyway. (Only surfaces the safe non-409 warn.)
         if (ctl.fileId !== undefined) {
-          void api.cancelUpload(ctl.fileId).catch(() => {});
+          void bestEffortCancel(ctl.fileId);
         }
       });
       runs.current.clear();
     },
-    [],
+    [bestEffortCancel],
   );
 
   const runItem = useCallback(
@@ -214,10 +244,13 @@ export function useUpload(onUploaded: () => void): UseUpload {
           content_type: file.type || 'application/octet-stream',
         });
         ctl.fileId = prep.file_id;
+        // Persist on the Job too, so a later terminal error still exposes this
+        // pending id to dismiss/retry after the RunCtl is gone.
+        job.pendingFileId = prep.file_id;
         // Cancel arrived while preparing: we now have a file_id, so best-effort
         // clean up the pending record and never start the PUT.
         if (ctl.cancelled) {
-          void bestEffortCancel(ctl);
+          void bestEffortCancel(ctl.fileId, () => refreshOnce(ctl));
           return;
         }
 
@@ -232,7 +265,7 @@ export function useUpload(onUploaded: () => void): UseUpload {
         // Guards the narrow window where cancel lands just as the PUT resolves
         // (an abort mid-PUT throws instead and is handled in catch).
         if (ctl.cancelled) {
-          void bestEffortCancel(ctl);
+          void bestEffortCancel(ctl.fileId, () => refreshOnce(ctl));
           return;
         }
 
@@ -249,6 +282,8 @@ export function useUpload(onUploaded: () => void): UseUpload {
         }
 
         ctl.phase = 'settled';
+        // Confirmed: no pending record left to reclaim.
+        job.pendingFileId = undefined;
         patch(id, { status: 'done', progress: 100 });
         refreshOnce(ctl);
         scheduleAutoDismiss(id);
@@ -282,7 +317,40 @@ export function useUpload(onUploaded: () => void): UseUpload {
     [runItem],
   );
 
-  const retry = useCallback((id: string) => void runItem(id), [runItem]);
+  // Restart a failed item. Before the fresh prepare, best-effort reclaim the
+  // pending record the failed run left behind so we don't leak it. A 409 means
+  // that old run actually confirmed on the backend — starting a new upload
+  // would duplicate the file, so we stop the retry, drop the row, and refresh
+  // the real list to show the confirmed file. A non-409 cancel failure is
+  // non-fatal: we still re-prepare (the backend confirmed-only filter hides the
+  // orphan), and the fresh prepare produces a NEW id — the old one is never
+  // reused. runItem then re-prepares from scratch.
+  const retryRun = useCallback(
+    async (id: string) => {
+      const job = jobs.current.get(id);
+      if (!job) return;
+      const stalePending = job.pendingFileId;
+      if (stalePending !== undefined) {
+        // Reflect the cleanup immediately: hide the error/retry affordance.
+        patch(id, { status: 'preparing', progress: 0, error: undefined });
+        let confirmWon = false;
+        await bestEffortCancel(stalePending, () => {
+          confirmWon = true;
+        });
+        job.pendingFileId = undefined;
+        if (confirmWon) {
+          jobs.current.delete(id);
+          setItems((list) => list.filter((it) => it.id !== id));
+          if (mounted.current) onUploadedRef.current();
+          return;
+        }
+      }
+      void runItem(id);
+    },
+    [bestEffortCancel, patch, runItem],
+  );
+
+  const retry = useCallback((id: string) => void retryRun(id), [retryRun]);
 
   return { items, addFiles, retry, dismiss };
 }

--- a/packages/dmworkdrive/src/hooks/useUpload.ts
+++ b/packages/dmworkdrive/src/hooks/useUpload.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { t } from '@octo/base';
 import * as api from '../api/driveApi';
+import { DriveApiError } from '../api/driveApi';
 import { Toast } from '../utils/toast';
 
 export type UploadStatus = 'preparing' | 'uploading' | 'confirming' | 'done' | 'error';
@@ -39,8 +40,27 @@ interface Job {
   parentId: number;
 }
 
+type RunPhase = 'preparing' | 'uploading' | 'confirming' | 'settled';
+
 /**
- * Type-2 upload state machine (spec §4.2).
+ * Per-run control record kept in a ref (not React state): the cancel path reads
+ * and mutates it synchronously across the prepare→PUT→confirm await points, and
+ * it must not trigger re-renders. One live record per in-flight item id; the run
+ * deletes it in `finally`, so its presence == "a run is still in flight".
+ */
+interface RunCtl {
+  /** Aborts the in-flight PUT (the only step wired to a signal). */
+  controller: AbortController;
+  phase: RunPhase;
+  /** Set once prepareUpload returns; undefined while prepare is still in flight. */
+  fileId?: number;
+  /** User asked to cancel; the run bails at the next checkpoint. */
+  cancelled: boolean;
+}
+
+/**
+ * Type-2 upload state machine (spec §4.2) with best-effort pending cleanup on
+ * cancel (spec §2 D-3).
  *
  * Composes the three audited driveApi primitives — prepareUpload →
  * putToPresignedUrl → confirmUpload — into a per-file state machine with
@@ -49,16 +69,27 @@ interface Job {
  * URL safety check, so no session token ever crosses the storage origin. This
  * hook only orchestrates state; it never touches storage directly.
  *
+ * Cancel is race-aware. Because prepare/confirm have no abort signal, cancel is
+ * expressed as a `cancelled` flag on the run's RunCtl plus checkpoints in the
+ * flow, rather than by aborting every request:
+ *   - cancel while preparing: no file_id yet, so the flow best-effort cancels
+ *     once prepare returns and never starts the PUT;
+ *   - cancel while uploading: abort the PUT and best-effort cancel the file_id;
+ *   - cancel while confirming: best-effort cancel races confirm — a 409 means
+ *     confirm won, so we refresh to show the confirmed file instead of pretending
+ *     it was cancelled (never deleting a confirmed row).
+ * A failed cancel (network/5xx) is swallowed: the backend's confirmed-only read
+ * filter is the final safety net, so a pending record never surfaces regardless.
+ *
  * @param onUploaded Invoked after each file is confirmed, so the caller can
  *   refresh the file list.
  */
 export function useUpload(onUploaded: () => void): UseUpload {
   const [items, setItems] = useState<UploadItem[]>([]);
   const jobs = useRef<Map<string, Job>>(new Map());
-  // AbortControllers for in-flight PUTs, keyed by item id, so a manual dismiss
-  // (or unmount) actually cancels the upload instead of letting it finish
-  // behind the user's back.
-  const controllers = useRef<Map<string, AbortController>>(new Map());
+  // Live run-control records, keyed by item id (see RunCtl). Presence means a
+  // run is still in flight; a settled/errored run removes its own entry.
+  const runs = useRef<Map<string, RunCtl>>(new Map());
   // Pending auto-dismiss timers, keyed by item id, so we can cancel them on
   // manual dismiss and on unmount (avoids setState-on-unmounted + double free).
   const timers = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
@@ -69,18 +100,47 @@ export function useUpload(onUploaded: () => void): UseUpload {
     setItems((list) => list.map((it) => (it.id === id ? { ...it, ...next } : it)));
   }, []);
 
-  const dismiss = useCallback((id: string) => {
-    const timer = timers.current.get(id);
-    if (timer !== undefined) {
-      clearTimeout(timer);
-      timers.current.delete(id);
+  // Best-effort cancel of a known pending file_id. Idempotent on the backend
+  // (204 even if already gone). A 409 means confirm-upload won the race, so the
+  // file is genuinely confirmed — refresh the list to reflect it rather than
+  // leaving a phantom-removed row. Every other failure is swallowed: the
+  // backend confirmed-only filter keeps any orphan pending invisible, so we
+  // never alarm the user with a misleading "cancel failed".
+  const bestEffortCancel = useCallback(async (fileId: number) => {
+    try {
+      await api.cancelUpload(fileId);
+    } catch (err) {
+      if (err instanceof DriveApiError && err.status === 409) {
+        onUploadedRef.current();
+      }
     }
-    // Cancel an in-flight PUT so a dismissed upload doesn't complete behind us.
-    controllers.current.get(id)?.abort();
-    controllers.current.delete(id);
-    jobs.current.delete(id);
-    setItems((list) => list.filter((it) => it.id !== id));
   }, []);
+
+  const dismiss = useCallback(
+    (id: string) => {
+      const timer = timers.current.get(id);
+      if (timer !== undefined) {
+        clearTimeout(timer);
+        timers.current.delete(id);
+      }
+      const ctl = runs.current.get(id);
+      if (ctl && ctl.phase !== 'settled') {
+        // In-flight row: this is a genuine cancel, not just a panel dismiss.
+        ctl.cancelled = true;
+        ctl.controller.abort(); // stop an in-flight PUT
+        // If prepare already handed us a file_id, best-effort clean up the
+        // pending record now (in the confirm phase this races confirm; a 409 is
+        // handled as "confirm won"). While prepare is still in flight there is
+        // no id yet — the run itself cancels once prepare returns.
+        if (ctl.fileId !== undefined) {
+          void bestEffortCancel(ctl.fileId);
+        }
+      }
+      jobs.current.delete(id);
+      setItems((list) => list.filter((it) => it.id !== id));
+    },
+    [bestEffortCancel],
+  );
 
   // Auto-remove a successfully finished row after a short delay so the panel
   // doesn't accumulate stale "done" banners. Only 'done' rows schedule this;
@@ -100,10 +160,19 @@ export function useUpload(onUploaded: () => void): UseUpload {
 
   useEffect(
     () => () => {
-      timers.current.forEach((t) => clearTimeout(t));
+      timers.current.forEach((tm) => clearTimeout(tm));
       timers.current.clear();
-      controllers.current.forEach((c) => c.abort());
-      controllers.current.clear();
+      runs.current.forEach((ctl) => {
+        ctl.cancelled = true;
+        ctl.controller.abort();
+        // Reclaim the pending record if we already have an id. Fire-and-forget
+        // with no 409 refresh: the component is gone, there is nothing to
+        // refresh, and we must not setState after unmount.
+        if (ctl.fileId !== undefined) {
+          void api.cancelUpload(ctl.fileId).catch(() => {});
+        }
+      });
+      runs.current.clear();
     },
     [],
   );
@@ -113,9 +182,9 @@ export function useUpload(onUploaded: () => void): UseUpload {
       const job = jobs.current.get(id);
       if (!job) return;
       const { file, spaceId, parentId } = job;
-      // Fresh controller per run (retry re-prepares, so it gets a new one too).
-      const controller = new AbortController();
-      controllers.current.set(id, controller);
+      // Fresh control record per run (retry re-prepares, so it gets a new one).
+      const ctl: RunCtl = { controller: new AbortController(), phase: 'preparing', cancelled: false };
+      runs.current.set(id, ctl);
       try {
         patch(id, { status: 'preparing', progress: 0, error: undefined });
         const prep = await api.prepareUpload({
@@ -125,33 +194,58 @@ export function useUpload(onUploaded: () => void): UseUpload {
           size: file.size,
           content_type: file.type || 'application/octet-stream',
         });
+        ctl.fileId = prep.file_id;
+        // Cancel arrived while preparing: we now have a file_id, so best-effort
+        // clean up the pending record and never start the PUT.
+        if (ctl.cancelled) {
+          void bestEffortCancel(prep.file_id);
+          return;
+        }
 
+        ctl.phase = 'uploading';
         patch(id, { status: 'uploading', progress: 0 });
         await api.putToPresignedUrl(prep.upload_url, file, {
           contentType: prep.content_type,
           contentDisposition: prep.content_disposition,
           onProgress: (percent) => patch(id, { progress: percent }),
-          signal: controller.signal,
+          signal: ctl.controller.signal,
         });
+        // Guards the narrow window where cancel lands just as the PUT resolves
+        // (an abort mid-PUT throws instead and is handled in catch).
+        if (ctl.cancelled) {
+          void bestEffortCancel(prep.file_id);
+          return;
+        }
 
+        ctl.phase = 'confirming';
         patch(id, { status: 'confirming' });
         await api.confirmUpload(prep.file_id, { actual_size: file.size });
+        // Cancel raced confirm and confirm won: the file is really uploaded.
+        // Surface the confirmed result (the row was already removed by dismiss)
+        // instead of claiming a cancellation.
+        if (ctl.cancelled) {
+          onUploadedRef.current();
+          return;
+        }
 
+        ctl.phase = 'settled';
         patch(id, { status: 'done', progress: 100 });
         onUploadedRef.current();
         scheduleAutoDismiss(id);
       } catch (err: unknown) {
-        // A dismiss/unmount aborts the controller; the resulting cancel is
-        // expected teardown (the row is already gone) — don't flash an error.
-        if (controller.signal.aborted) return;
+        // Cancel/unmount teardown: the PUT abort (or a confirm that failed
+        // because cancel won) is expected — the row is already gone and the
+        // dismiss handler already issued the best-effort cancel, so don't flash
+        // an error.
+        if (ctl.cancelled || ctl.controller.signal.aborted) return;
         const msg = (err as Error)?.message || t('drive.upload.failed');
         patch(id, { status: 'error', error: msg });
         Toast.error(msg);
       } finally {
-        controllers.current.delete(id);
+        runs.current.delete(id);
       }
     },
-    [patch, scheduleAutoDismiss],
+    [patch, scheduleAutoDismiss, bestEffortCancel],
   );
 
   const addFiles = useCallback(

--- a/packages/dmworkdrive/src/hooks/useUpload.ts
+++ b/packages/dmworkdrive/src/hooks/useUpload.ts
@@ -56,6 +56,9 @@ interface RunCtl {
   fileId?: number;
   /** User asked to cancel; the run bails at the next checkpoint. */
   cancelled: boolean;
+  /** Guards `refreshOnce`: a single run refreshes the file list at most once,
+   *  even when confirm-success and a cancel-409 both fire for the same run. */
+  refreshed: boolean;
 }
 
 /**
@@ -100,21 +103,37 @@ export function useUpload(onUploaded: () => void): UseUpload {
     setItems((list) => list.map((it) => (it.id === id ? { ...it, ...next } : it)));
   }, []);
 
+  // Refresh the file list at most once per run. confirm-success and a
+  // cancel-409 can both signal "the file is really confirmed" for the same run,
+  // in either order; without this guard they would each fire onUploaded and
+  // refresh twice. Per-run (not global) so independent uploads still each
+  // refresh exactly once.
+  const refreshOnce = useCallback((ctl: RunCtl) => {
+    if (ctl.refreshed) return;
+    ctl.refreshed = true;
+    onUploadedRef.current();
+  }, []);
+
   // Best-effort cancel of a known pending file_id. Idempotent on the backend
   // (204 even if already gone). A 409 means confirm-upload won the race, so the
-  // file is genuinely confirmed — refresh the list to reflect it rather than
+  // file is genuinely confirmed — refresh (once) to reflect it rather than
   // leaving a phantom-removed row. Every other failure is swallowed: the
   // backend confirmed-only filter keeps any orphan pending invisible, so we
-  // never alarm the user with a misleading "cancel failed".
-  const bestEffortCancel = useCallback(async (fileId: number) => {
-    try {
-      await api.cancelUpload(fileId);
-    } catch (err) {
-      if (err instanceof DriveApiError && err.status === 409) {
-        onUploadedRef.current();
+  // never alarm the user with a misleading "cancel failed". No-op if we don't
+  // yet have a file_id (prepare still in flight).
+  const bestEffortCancel = useCallback(
+    async (ctl: RunCtl) => {
+      if (ctl.fileId === undefined) return;
+      try {
+        await api.cancelUpload(ctl.fileId);
+      } catch (err) {
+        if (err instanceof DriveApiError && err.status === 409) {
+          refreshOnce(ctl);
+        }
       }
-    }
-  }, []);
+    },
+    [refreshOnce],
+  );
 
   const dismiss = useCallback(
     (id: string) => {
@@ -133,7 +152,7 @@ export function useUpload(onUploaded: () => void): UseUpload {
         // handled as "confirm won"). While prepare is still in flight there is
         // no id yet — the run itself cancels once prepare returns.
         if (ctl.fileId !== undefined) {
-          void bestEffortCancel(ctl.fileId);
+          void bestEffortCancel(ctl);
         }
       }
       jobs.current.delete(id);
@@ -183,7 +202,7 @@ export function useUpload(onUploaded: () => void): UseUpload {
       if (!job) return;
       const { file, spaceId, parentId } = job;
       // Fresh control record per run (retry re-prepares, so it gets a new one).
-      const ctl: RunCtl = { controller: new AbortController(), phase: 'preparing', cancelled: false };
+      const ctl: RunCtl = { controller: new AbortController(), phase: 'preparing', cancelled: false, refreshed: false };
       runs.current.set(id, ctl);
       try {
         patch(id, { status: 'preparing', progress: 0, error: undefined });
@@ -198,7 +217,7 @@ export function useUpload(onUploaded: () => void): UseUpload {
         // Cancel arrived while preparing: we now have a file_id, so best-effort
         // clean up the pending record and never start the PUT.
         if (ctl.cancelled) {
-          void bestEffortCancel(prep.file_id);
+          void bestEffortCancel(ctl);
           return;
         }
 
@@ -213,7 +232,7 @@ export function useUpload(onUploaded: () => void): UseUpload {
         // Guards the narrow window where cancel lands just as the PUT resolves
         // (an abort mid-PUT throws instead and is handled in catch).
         if (ctl.cancelled) {
-          void bestEffortCancel(prep.file_id);
+          void bestEffortCancel(ctl);
           return;
         }
 
@@ -222,15 +241,16 @@ export function useUpload(onUploaded: () => void): UseUpload {
         await api.confirmUpload(prep.file_id, { actual_size: file.size });
         // Cancel raced confirm and confirm won: the file is really uploaded.
         // Surface the confirmed result (the row was already removed by dismiss)
-        // instead of claiming a cancellation.
+        // instead of claiming a cancellation. refreshOnce dedupes against the
+        // cancel-409 path, which signals the same "confirm won" outcome.
         if (ctl.cancelled) {
-          onUploadedRef.current();
+          refreshOnce(ctl);
           return;
         }
 
         ctl.phase = 'settled';
         patch(id, { status: 'done', progress: 100 });
-        onUploadedRef.current();
+        refreshOnce(ctl);
         scheduleAutoDismiss(id);
       } catch (err: unknown) {
         // Cancel/unmount teardown: the PUT abort (or a confirm that failed
@@ -245,7 +265,7 @@ export function useUpload(onUploaded: () => void): UseUpload {
         runs.current.delete(id);
       }
     },
-    [patch, scheduleAutoDismiss, bestEffortCancel],
+    [patch, scheduleAutoDismiss, bestEffortCancel, refreshOnce],
   );
 
   const addFiles = useCallback(


### PR DESCRIPTION
## Problem
Cancelling a Type-2 (object-storage) upload could leave the file stuck in a
pending state: prepare-upload had run but confirm-upload never did, and the
cancel button only aborted the in-flight PUT without notifying the backend.
The orphaned pending entry then reappeared in the file listing.

## Root cause
`useUpload` modelled cancel as a single AbortController that only covered the
PUT step. prepare-upload and confirm-upload have no abort signal, so:
- cancelling before prepare returned still let prepare create a pending
  record, and nothing ever released it;
- there was no API call to release the pending record on the backend.

## Fix
- `driveApi.cancelUpload(fileId)` -> `POST /v1/drive/files/{id}/cancel-upload`
  (authed drive call, no body). Idempotent; a 409 signals confirm already
  completed.
- `useUpload` replaces the bare AbortController with a per-run control record
  and cancels race-aware across prepare -> PUT -> confirm:
  - preparing: defer cancel until file_id lands, then best-effort cancel, never
    start the PUT;
  - uploading: abort the PUT + best-effort cancel the known file_id;
  - confirming: best-effort cancel races confirm; a 409 (confirm won) refreshes
    to show the confirmed file instead of claiming cancellation (a confirmed
    row is never deleted);
  - failed cancel (network/5xx): swallowed, no misleading toast;
  - unmount: abort the PUT + best-effort cancel a known pending file_id.
- Retry still creates a brand-new prepare/file_id.
- The object-storage PUT still goes through the interceptor-free axios instance
  + `assertSafePresignedURL`, so no session token crosses the storage origin.

## Tests (`pnpm --filter @octo/drive test`)
- useUpload: cancel-before-prepare, prepare-then-cancel-skips-PUT,
  cancel-during-PUT (aborts + cancels), cancel 409 -> refresh confirmed, failed
  cancel stays silent, unmount cleanup, retry new file_id; existing happy-path
  and credential-isolation (M-3) tests still pass.
- driveApi: cancelUpload posts the right path with no body; a 409 maps to a
  typed error carrying status 409.


## Follow-up: pending id survives a terminal error
Review found the pending `file_id` lived only on the per-run control record,
which is dropped when the run settles. After a PUT/confirm failure the error
row remained in the panel but had lost the id, so its later dismiss/retry could
no longer release the orphaned pending record.

- The pending `file_id` is now retained on the per-item job so it outlives a
  terminal error; it is cleared on confirmed success and after a cancel is
  issued.
- Dismissing an error row best-effort cancels the retained id; a 409 (confirm
  already won) refreshes the real listing instead of silently dropping the row.
- Retry best-effort cancels the stale id **before** re-preparing a fresh one; a
  409 stops the retry (the old run is confirmed — avoids a duplicate upload),
  removes the row and refreshes; a non-409 cancel failure still re-prepares with
  a brand-new id (never reusing the old one).
- Added a mounted guard: no listing refresh fires after unmount; the unmount
  cancel stays fire-and-forget.
- Non-409 cancel failures emit a fixed-format log breadcrumb (HTTP status + code
  only — never file name, URL, token or id) to surface a release-order mismatch.

New race-orchestrated tests cover each path (dismiss-reclaims-id,
retry-cancels-before-reprepare, retry-cleanup-409, retry-cleanup-network-failure,
unmount+confirm/409 no-refresh); the full suite stays green.

## Backend dependency
Relies on the drive backend serving a **confirmed-only** file listing as the
final safety net, so any orphaned pending record stays invisible regardless of
client-side cleanup. That backend change is already merged.


## Follow-up 2: P1 hardening (head `241505cf`)
Formal review raised two P1s on the pending-cleanup work above; both fixed here.

- **Unmount now reclaims terminal-error rows too.** The earlier unmount cleanup
  only walked live runs, so an error row's retained pending id was stranded when
  the user left the page directly. Unmount now also walks the jobs map and
  best-effort cancels any retained `pendingFileId` (skipping ids already handled
  by a live run, to avoid a redundant request), then clears the map.
- **retryRun is unmount/dismiss safe.** After awaiting the stale-id cancel it
  re-checks that the component is still mounted and the item still exists,
  bailing before any new prepare/PUT/confirm or `setState` — nothing runs
  against a dead component or a removed row. The stale id is taken out and
  cleared *before* the await, so an interleaving unmount cleanup cannot
  double-cancel it: a given stale id is cancelled at most once.
- **Concurrent-retry guard.** A per-item re-entry guard in `runItem` (and
  `retryRun`) means a fast double-click can no longer start a competing run that
  overwrites the live control record or duplicates the upload — exactly one new
  run starts.
- **Message-free breadcrumb.** For a non-`DriveApiError` the warn now logs only
  the structural error name (e.g. `TypeError`), never the error message, so a
  URL / token / file name cannot leak into the console; `status`/`code` remain
  the only other fields.

This supersedes the earlier "failed cancel: swallowed" phrasing: a non-409
cancel failure is still non-fatal for the user, but it is now surfaced as a
fixed-format, PII-free breadcrumb (not silently dropped), and the retained
pending id is reclaimed on **dismiss, retry, and unmount** alike.

New race-orchestrated tests (each verified mutation-sensitive): terminal-error
unmount reclaim; retry-await-unmount bail (no re-prepare, id cancelled once);
retry-await-unmount 409 (no `setItems`/refresh); double-click retry starts one
run; dismiss+unmount+409 mounted guard; warn locks out URL/token. Full suite:
**229 tests green**.


## Follow-up 3: StrictMode-safe mounted ref (head `f5825749`)
A re-review of the P1 hardening found the `mounted` ref it introduced was set
false in the effect cleanup but never re-armed in setup. The app enables
`<React.StrictMode>` app-wide (`apps/web/src/index.tsx`) on react@18, where dev
runs effects setup→cleanup→setup on the **same** hook instance — leaving
`mounted` stuck false for the whole real lifetime, silently suppressing every
post-confirm refresh and stale-pending retry. (Production is unaffected: the
double-invoke is dev-only and the effect's deps are stable.)

- Fix: re-arm `mounted.current = true` at the top of the effect setup.
- Regression test lives in **apps/web** (`driveUploadStrictMode.test.tsx`)
  because the package's react@17 harness never double-invokes effects. It wraps
  `useUpload` in `<StrictMode>`, asserts the double-invoke actually happens
  (setup counter === 2 — not a vacuous test), then proves a successful upload
  still refreshes and a stale-pending retry still re-prepares. Verified to fail
  against the pre-fix hook (refresh 0×, retry stuck at `preparing`).

Full drive suite **229 green**; new StrictMode test **2 green**; apps/web build passes.
