### PR TITLE
fix(channel-setting): smooth GROUP.md and webhook return

### DIFF
--- a/packages/dmworkbase/src/Components/ChannelSetting/index.css
+++ b/packages/dmworkbase/src/Components/ChannelSetting/index.css
@@ -90,6 +90,7 @@
 /*
  * 头像、二维码、群管理、GROUP.md、群消息推送和群管理成员选择页返回时仍保留 animationend，让 WKViewQueue 正常清理栈顶；
  * 只取消可见位移，避免标题先切回父页、内容仍横向退场造成的闪动。
+ * 通过 RoutePage 的 .wk-channelsetting 根节点限定，只作用于 ChannelSetting 内的 WKViewQueue。
  * 该规则不改变 RoutePage/WKViewQueue 的退栈和数据刷新逻辑。
  */
 .wk-channelsetting .wk-viewqueue-view-out:has(.wk-channelavatar),

--- a/packages/dmworkbase/src/Components/ChannelSetting/index.css
+++ b/packages/dmworkbase/src/Components/ChannelSetting/index.css
@@ -88,13 +88,15 @@
 }
 
 /*
- * 头像、二维码、群管理和群管理成员选择页返回时仍保留 animationend，让 WKViewQueue 正常清理栈顶；
+ * 头像、二维码、群管理、GROUP.md、群消息推送和群管理成员选择页返回时仍保留 animationend，让 WKViewQueue 正常清理栈顶；
  * 只取消可见位移，避免标题先切回父页、内容仍横向退场造成的闪动。
  * 该规则不改变 RoutePage/WKViewQueue 的退栈和数据刷新逻辑。
  */
 .wk-viewqueue-view-out:has(.wk-channelavatar),
 .wk-viewqueue-view-out:has(.wk-channelqrcode),
 .wk-viewqueue-view-out:has(.wk-group-management),
+.wk-viewqueue-view-out:has(.wk-groupmd-editor),
+.wk-viewqueue-view-out:has(.wk-webhook),
 .wk-viewqueue-view-out:has(.wk-group-member-picker) {
     background: var(--wk-bg-surface);
     animation-name: wk-channelsetting-child-exit;

--- a/packages/dmworkbase/src/Components/ChannelSetting/index.css
+++ b/packages/dmworkbase/src/Components/ChannelSetting/index.css
@@ -92,12 +92,12 @@
  * 只取消可见位移，避免标题先切回父页、内容仍横向退场造成的闪动。
  * 该规则不改变 RoutePage/WKViewQueue 的退栈和数据刷新逻辑。
  */
-.wk-viewqueue-view-out:has(.wk-channelavatar),
-.wk-viewqueue-view-out:has(.wk-channelqrcode),
-.wk-viewqueue-view-out:has(.wk-group-management),
-.wk-viewqueue-view-out:has(.wk-groupmd-editor),
-.wk-viewqueue-view-out:has(.wk-webhook),
-.wk-viewqueue-view-out:has(.wk-group-member-picker) {
+.wk-channelsetting .wk-viewqueue-view-out:has(.wk-channelavatar),
+.wk-channelsetting .wk-viewqueue-view-out:has(.wk-channelqrcode),
+.wk-channelsetting .wk-viewqueue-view-out:has(.wk-group-management),
+.wk-channelsetting .wk-viewqueue-view-out:has(.wk-groupmd-editor),
+.wk-channelsetting .wk-viewqueue-view-out:has(.wk-webhook),
+.wk-channelsetting .wk-viewqueue-view-out:has(.wk-group-member-picker) {
     background: var(--wk-bg-surface);
     animation-name: wk-channelsetting-child-exit;
     animation-duration: var(--wk-dur-fast);

--- a/packages/dmworkbase/src/Components/ChannelSetting/index.tsx
+++ b/packages/dmworkbase/src/Components/ChannelSetting/index.tsx
@@ -55,7 +55,7 @@ export default class ChannelSetting extends Component<ChannelSettingProps> {
                 memberCount = channelInfo.orgData.member_count
             }
            
-            return <RoutePage title={ vm.channel.channelType === ChannelTypeCustomerService
+            return <RoutePage className="wk-channelsetting" title={ vm.channel.channelType === ChannelTypeCustomerService
                 ? this.context.t("base.channelSetting.title")
                 : this.context.t("base.channelSetting.titleWithCount", { values: { count: memberCount } })
             } onClose={() => {


### PR DESCRIPTION
## Summary

Prevent visible flicker when returning from ChannelSetting child panels for GROUP.md and incoming webhook management, while keeping the override scoped to ChannelSetting's route stack.

## Related Issue

Fixes #1203

## Changes

- Extends the existing ChannelSetting child-exit animation override to GROUP.md.
- Extends the same no-op exit animation to incoming webhook management.
- Adds a ChannelSetting-specific RoutePage root class and scopes the selector list under it, preventing reused child components such as `ChannelWebhookPanel` from affecting unrelated WKViewQueue routes.
- Preserves WKViewQueue animationend behavior so the route stack cleanup flow remains unchanged.

## Architecture / Module Boundary

- Affected module(s): ChannelSetting
- New or changed user-visible entry point: no
- Shared layer touched: Components
- If shared code changed, impact scope: ChannelSetting passes an existing RoutePage `className` prop for local CSS scoping; the exit animation override is limited to `.wk-channelsetting` descendants. No WKViewQueue, RoutePage component implementation, data, cache, request, or permission logic changed.
- Duplicate entry point checked: not applicable

## Testing

- [ ] Unit tests added/updated — not added; scoped CSS/RoutePage class fix with no business logic changes.
- [x] Manually verified — user confirmed the issue path passes in local preview.
- [x] `git diff --check`
- [x] `pnpm exec stylelint packages/dmworkbase/src/Components/ChannelSetting/index.css --config stylelint.config.mjs --allow-empty-input` (0 errors; existing warnings remain in untouched lines)
- [x] `pnpm --dir apps/web build` (passes; existing dependency/chunk warnings only)

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [ ] Added tests for my changes
- [ ] Updated documentation
- [x] Ran `pnpm i18n:check` or confirmed the change does not affect UI copy
- [x] Confirmed the change follows module ownership and does not add duplicate user-visible entry points
- [x] Described impact scope when shared components, messages, bridge, or services are changed
- [x] Followed commit message conventions (Conventional Commits)
