### PR TITLE
fix(docs): keep board toolbar visible beside drawers

### DIFF
--- a/packages/docs/src/board/BoardContextMenu.test.tsx
+++ b/packages/docs/src/board/BoardContextMenu.test.tsx
@@ -3,13 +3,15 @@ import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { BoardContextMenu } from './BoardContextMenu.tsx'
 
+const bounds = { left: 0, top: 0, right: 600, bottom: 600 }
+
 afterEach(cleanup)
 
 describe('BoardContextMenu', () => {
   it('runs curated actions and closes', () => {
     const onSelect = vi.fn()
     const onClose = vi.fn()
-    render(<BoardContextMenu left={12} top={20} items={[{ id: 'copy', label: 'Copy', shortcut: '⌘C', onSelect }]} onClose={onClose} />)
+    render(<BoardContextMenu bounds={bounds} left={12} top={20} items={[{ id: 'copy', label: 'Copy', shortcut: '⌘C', onSelect }]} onClose={onClose} />)
     fireEvent.click(screen.getByRole('menuitem', { name: /Copy/ }))
     expect(onSelect).toHaveBeenCalledOnce()
     expect(onClose).toHaveBeenCalledOnce()
@@ -17,14 +19,14 @@ describe('BoardContextMenu', () => {
 
   it('closes on Escape and an outside pointer without swallowing non-menu events', () => {
     const onClose = vi.fn()
-    render(<><button>Outside</button><BoardContextMenu left={0} top={0} items={[]} onClose={onClose} /></>)
+    render(<><button>Outside</button><BoardContextMenu bounds={bounds} left={0} top={0} items={[]} onClose={onClose} /></>)
     fireEvent.keyDown(window, { key: 'Escape' })
     fireEvent.pointerDown(screen.getByRole('button', { name: 'Outside' }))
     expect(onClose).toHaveBeenCalledTimes(2)
   })
 
   it('marks destructive rows semantically', () => {
-    render(<BoardContextMenu left={0} top={0} items={[{ id: 'delete', label: 'Delete', destructive: true, onSelect: vi.fn() }]} onClose={vi.fn()} />)
+    render(<BoardContextMenu bounds={bounds} left={0} top={0} items={[{ id: 'delete', label: 'Delete', destructive: true, onSelect: vi.fn() }]} onClose={vi.fn()} />)
     expect(screen.getByRole('menuitem', { name: 'Delete' }).classList.contains('is-destructive')).toBe(true)
   })
 
@@ -38,9 +40,9 @@ describe('BoardContextMenu', () => {
     }))
     render(
       <BoardContextMenu
+        bounds={{ left: 20, top: 10, right: 500, bottom: 400 }}
         left={490}
         top={390}
-        bounds={{ left: 20, top: 10, right: 500, bottom: 400 }}
         items={items}
         onClose={vi.fn()}
       />,
@@ -53,16 +55,56 @@ describe('BoardContextMenu', () => {
     height.mockRestore()
   })
 
+  it('clamps a menu opened near the lower edge instead of collapsing it', () => {
+    const width = vi.spyOn(HTMLElement.prototype, 'offsetWidth', 'get').mockReturnValue(240)
+    const height = vi.spyOn(HTMLElement.prototype, 'scrollHeight', 'get').mockReturnValue(760)
+    render(
+      <BoardContextMenu
+        bounds={bounds}
+        left={20}
+        top={580}
+        items={Array.from({ length: 20 }, (_, index) => ({
+          id: `item-${index}`,
+          label: `Item ${index}`,
+          onSelect: vi.fn(),
+        }))}
+        onClose={vi.fn()}
+      />,
+    )
+
+    const menu = screen.getByRole('menu')
+    expect(menu.style.maxHeight).toBe('584px')
+    expect(Number.parseFloat(menu.style.top)).toBe(8)
+    width.mockRestore()
+    height.mockRestore()
+  })
+
+  it('keeps one action row usable during a transient zero-height measurement', () => {
+    render(
+      <BoardContextMenu
+        bounds={{ left: 0, top: 0, right: 0, bottom: 0 }}
+        left={0}
+        top={0}
+        items={[{ id: 'copy', label: 'Copy', onSelect: vi.fn() }]}
+        onClose={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByRole('menu').style.maxHeight).toBe('40px')
+    expect(screen.getByRole('menuitem', { name: 'Copy' })).toBeTruthy()
+  })
+
   it('contains pointer and wheel events so the Excalidraw canvas does not move', () => {
     const canvasPointerDown = vi.fn()
     const canvasWheel = vi.fn()
     render(
       <div onPointerDown={canvasPointerDown} onWheel={canvasWheel}>
-        <BoardContextMenu left={0} top={0} items={[{ id: 'copy', label: 'Copy', onSelect: vi.fn() }]} onClose={vi.fn()} />
+        <BoardContextMenu bounds={bounds} left={0} top={0} items={[{ id: 'copy', label: 'Copy', onSelect: vi.fn() }]} onClose={vi.fn()} />
       </div>,
     )
+    const menu = screen.getByRole('menu')
     fireEvent.pointerDown(screen.getByRole('menuitem', { name: 'Copy' }))
-    fireEvent.wheel(screen.getByRole('menu'), { deltaY: 80 })
+    fireEvent.wheel(menu, { deltaY: 80 })
     expect(canvasPointerDown).not.toHaveBeenCalled()
     expect(canvasWheel).not.toHaveBeenCalled()
   })
@@ -70,6 +112,7 @@ describe('BoardContextMenu', () => {
   it('focuses the first item and supports menu arrow, Home, and End navigation', () => {
     render(
       <BoardContextMenu
+        bounds={bounds}
         left={0}
         top={0}
         items={['One', 'Two', 'Three'].map((label) => ({ id: label, label, onSelect: vi.fn() }))}

--- a/packages/docs/src/board/BoardContextMenu.tsx
+++ b/packages/docs/src/board/BoardContextMenu.tsx
@@ -14,28 +14,28 @@ interface BoardContextMenuProps {
   left: number
   top: number
   items: BoardContextMenuItem[]
-  bounds?: BoardCommentOverlayBounds
+  bounds: BoardCommentOverlayBounds
   onClose: () => void
 }
 
 const MENU_EDGE_GAP = 8
+const MENU_MIN_USABLE_HEIGHT = 40
 
 /** Host-owned, localized replacement for Excalidraw's generic context menu. */
 export function BoardContextMenu({ left, top, items, bounds, onClose }: BoardContextMenuProps): ReactElement {
   const ref = useRef<HTMLDivElement>(null)
   const [position, setPosition] = useState({ left, top })
-  const availableHeight = bounds
-    ? Math.max(0, bounds.bottom - bounds.top - MENU_EDGE_GAP * 2)
-    : undefined
+  // Keep at least one action row reachable during transient zero-size layout measurements.
+  const availableHeight = Math.max(MENU_MIN_USABLE_HEIGHT, bounds.bottom - bounds.top - MENU_EDGE_GAP * 2)
 
   useLayoutEffect(() => {
     const menu = ref.current
-    if (!menu || !bounds) {
+    if (!menu) {
       setPosition({ left, top })
       return
     }
     const width = menu.offsetWidth
-    const height = Math.min(menu.scrollHeight, availableHeight ?? menu.scrollHeight)
+    const height = Math.min(menu.scrollHeight, availableHeight)
     const minLeft = bounds.left + MENU_EDGE_GAP
     const minTop = bounds.top + MENU_EDGE_GAP
     const maxLeft = Math.max(minLeft, bounds.right - width - MENU_EDGE_GAP)
@@ -73,6 +73,8 @@ export function BoardContextMenu({ left, top, items, bounds, onClose }: BoardCon
       role="menu"
       style={{ left: position.left, top: position.top, maxHeight: availableHeight }}
       onPointerDown={(event) => event.stopPropagation()}
+      // Let the browser perform native overflow scrolling (including deltaMode handling), while
+      // keeping the wheel event away from Excalidraw's canvas pan/zoom handler.
       onWheel={(event) => event.stopPropagation()}
       onKeyDown={(event) => {
         if (event.key !== 'ArrowDown' && event.key !== 'ArrowUp' && event.key !== 'Home' && event.key !== 'End') return

--- a/packages/docs/src/board/BoardShell.tsx
+++ b/packages/docs/src/board/BoardShell.tsx
@@ -18,6 +18,7 @@ import { BoardCommentPanel, type BoardAnchorTarget } from './BoardCommentPanel.t
 import { BoardInlineCommentComposer } from './BoardInlineCommentComposer.tsx'
 import { BoardCommentMarkers } from './BoardCommentMarkers.tsx'
 import { BoardContextMenu, type BoardContextMenuItem } from './BoardContextMenu.tsx'
+import { canReserveBoardDrawer } from './boardDrawerLayout.ts'
 import { useBoardCommentMarkers } from './useBoardCommentMarkers.ts'
 import { boardElementTypeLabelKey, decodeBoardCommentAnchor } from './boardCommentAnchor.ts'
 import {
@@ -416,12 +417,14 @@ export function BoardShell(props: BoardShellProps): ReactElement {
   const [boardContextMenu, setBoardContextMenu] = useState<{
     clientX: number
     clientY: number
+    bounds: BoardCommentOverlayBounds
     target: BoardAnchorTarget
     type: 'canvas' | 'element'
     commentOnly: boolean
   } | null>(null)
   const [boardViewRevision, setBoardViewRevision] = useState(0)
   const [commentOverlayBounds, setCommentOverlayBounds] = useState<BoardCommentOverlayBounds | null>(null)
+  const [boardCanvasSize, setBoardCanvasSize] = useState<{ width: number; height: number } | null>(null)
   const boardViewFrameRef = useRef<number | null>(null)
   const boardViewSignatureRef = useRef('')
   // Creator + creation date for the ≡ "more" menu head, fetched from the per-doc GET like EditorShell.
@@ -487,6 +490,7 @@ export function BoardShell(props: BoardShellProps): ReactElement {
   // queries/subscriptions to this element instead of a document-wide `.excalidraw` lookup, so it can
   // never latch onto a SECOND Excalidraw in the page — most importantly the read-only version-history
   // preview (BoardScenePreview), which also renders `.excalidraw` inside `.octo-board-canvas`.
+  const boardCanvasRef = useRef<HTMLDivElement>(null)
   const liveCanvasRef = useRef<HTMLDivElement>(null)
 
   // Fail-closed editability (P1-2). On the collab (permissioned) path the canvas is read-only until
@@ -1349,6 +1353,27 @@ export function BoardShell(props: BoardShellProps): ReactElement {
   const inlineCommentPoint = inlineCommentTarget ? boardCommentLocalPoint(inlineCommentTarget) : null
   const selectedCommentPoint = selectedCommentTarget ? boardCommentLocalPoint(selectedCommentTarget) : null
 
+  // The outer canvas exists even while the Excalidraw chunk or collaboration role is loading.
+  // Observe it independently so drawer reservation cannot depend on which async gate resolves first.
+  useEffect(() => {
+    const canvas = boardCanvasRef.current
+    if (!canvas) return
+    const measure = () => {
+      const { width, height } = canvas.getBoundingClientRect()
+      setBoardCanvasSize((current) => current && current.width === width && current.height === height
+        ? current
+        : { width, height })
+    }
+    measure()
+    const resizeObserver = typeof ResizeObserver === 'undefined' ? null : new ResizeObserver(measure)
+    resizeObserver?.observe(canvas)
+    window.addEventListener('resize', measure)
+    return () => {
+      resizeObserver?.disconnect()
+      window.removeEventListener('resize', measure)
+    }
+  }, [])
+
   useEffect(() => {
     const host = liveCanvasRef.current
     if (!host) return
@@ -1375,7 +1400,7 @@ export function BoardShell(props: BoardShellProps): ReactElement {
       mutationObserver.disconnect()
       window.removeEventListener('resize', measure)
     }
-  }, [Excalidraw])
+  }, [Excalidraw, accessConfirmed])
 
   const placeCommentOverlay = useCallback((
     left: number,
@@ -1398,9 +1423,12 @@ export function BoardShell(props: BoardShellProps): ReactElement {
           label: `${t('docs.board.comment.point')} · ${Math.round(payload.sceneX)}, ${Math.round(payload.sceneY)}`,
         }
     const hostRect = host.getBoundingClientRect()
+    const panelColumn = host.querySelector<HTMLElement>('.panelColumn')
+    const propertyPanel = panelColumn?.closest<HTMLElement>('.App-menu__left')
     setBoardContextMenu({
       clientX: payload.event.clientX - hostRect.left,
       clientY: payload.event.clientY - hostRect.top,
+      bounds: deriveBoardCommentOverlayBounds(hostRect, propertyPanel?.getBoundingClientRect()),
       target,
       type: payload.type,
       commentOnly: payload.event.altKey,
@@ -1907,6 +1935,10 @@ export function BoardShell(props: BoardShellProps): ReactElement {
   const creatorDisplay =
     creatorName || (ownerId ? ownerId.slice(0, 8) : t('docs.moreMenu.unknownCreator'))
 
+  const drawerOpen = (commentsOpen && role) || versionOpen
+  const reserveDrawer = !!drawerOpen && !!boardCanvasSize &&
+    canReserveBoardDrawer(boardCanvasSize.width, boardCanvasSize.height)
+
   return (
     <div className="octo-doc octo-doc--editor octo-theme octo-board">
       <header className="octo-doc-header">
@@ -2018,7 +2050,12 @@ export function BoardShell(props: BoardShellProps): ReactElement {
         </p>
       )}
 
-      <div className="octo-board-canvas">
+      <div
+        ref={boardCanvasRef}
+        className={reserveDrawer
+          ? 'octo-board-canvas octo-board-canvas--drawer-reserved'
+          : 'octo-board-canvas'}
+      >
         {failed ? (
           <div className="octo-board-state octo-error">{t('docs.state.error')}</div>
         ) : !Excalidraw || !accessConfirmed ? (
@@ -2122,7 +2159,7 @@ export function BoardShell(props: BoardShellProps): ReactElement {
             left={boardContextMenu.clientX}
             top={boardContextMenu.clientY}
             items={boardContextMenuItems}
-            bounds={commentOverlayBounds ?? undefined}
+            bounds={commentOverlayBounds ?? boardContextMenu.bounds}
             onClose={() => setBoardContextMenu(null)}
           />
         )}

--- a/packages/docs/src/board/__tests__/BoardShellAccountSwitch.test.tsx
+++ b/packages/docs/src/board/__tests__/BoardShellAccountSwitch.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { act, render, screen } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import type { ReactNode } from 'react'
 import type { WhiteboardSession } from '../collab/connect.ts'
 
@@ -107,6 +107,11 @@ describe('BoardShell — fail-closed editability across an account-switch re-pri
     boardStore.loads = []
   })
 
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
   it('mounts an imported scene only after access and forwards its first change into Yjs', async () => {
     const importedElement = { id: 'imported-1', type: 'rectangle', version: 1 }
     const importedFile = { id: 'file-1', dataURL: 'data:image/png;base64,AA==' }
@@ -209,4 +214,58 @@ describe('BoardShell — fail-closed editability across an account-switch re-pri
     expect(bindingB).not.toHaveBeenCalledWith(expect.arrayContaining([aElement]), expect.anything())
     expect(bindingA).not.toHaveBeenCalled()
   })
+
+  it('reserves drawer space when Excalidraw loads before collaboration access resolves', async () => {
+    const rect = (width: number, height: number): DOMRect => ({
+      x: 0,
+      y: 0,
+      top: 0,
+      left: 0,
+      right: width,
+      bottom: height,
+      width,
+      height,
+      toJSON: () => ({}),
+    })
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function (this: HTMLElement) {
+      return this.classList.contains('octo-board-canvas') || this.classList.contains('octo-board-live-canvas')
+        ? rect(1400, 800)
+        : rect(0, 0)
+    })
+    const observedTargets: Element[] = []
+    class ImmediateResizeObserver {
+      constructor(private readonly callback: ResizeObserverCallback) {}
+      observe(target: Element) {
+        observedTargets.push(target)
+        this.callback([{ target, contentRect: target.getBoundingClientRect() } as ResizeObserverEntry], this as unknown as ResizeObserver)
+      }
+      unobserve() {}
+      disconnect() {}
+    }
+    vi.stubGlobal('ResizeObserver', ImmediateResizeObserver)
+
+    const props = {
+      docId: 'drawer-order',
+      title: 'Shared board',
+      space: 's1',
+      collab: true,
+      user: { id: 'u_writer', name: 'Writer' },
+    }
+    const { rerender } = render(<BoardShell {...props} collabSession={undefined} />)
+
+    // The Excalidraw module is already mocked/loaded, while access is deliberately held pending.
+    await waitFor(() => expect(screen.getByText('docs.state.loading')).toBeTruthy())
+    expect(screen.queryByTestId('excalidraw-canvas')).toBeNull()
+    expect(observedTargets.some((target) => target.classList.contains('octo-board-canvas'))).toBe(true)
+    expect(observedTargets.some((target) => target.classList.contains('octo-board-live-canvas'))).toBe(false)
+
+    rerender(<BoardShell {...props} collabSession={makeSession('writer')} />)
+    await screen.findByTestId('excalidraw-canvas')
+    fireEvent.click(screen.getByRole('button', { name: 'docs.toolbar.comments' }))
+
+    await waitFor(() => {
+      expect(document.querySelector('.octo-board-canvas')?.classList.contains('octo-board-canvas--drawer-reserved')).toBe(true)
+    })
+  })
+
 })

--- a/packages/docs/src/board/board.css
+++ b/packages/docs/src/board/board.css
@@ -52,12 +52,24 @@
   display: flex;
 }
 .octo-board-live-canvas {
+  position: relative;
+  display: flex;
   flex: 1 1 auto;
   width: 100%;
   height: 100%;
   min-width: 0;
   min-height: 0;
 }
+
+/* The shared drawer is absolutely positioned, so without reserving its width Excalidraw still
+   measures the full canvas and centres the toolbar underneath the opaque drawer. BoardShell applies
+   this class only after measuring that the remaining canvas can preserve Excalidraw's desktop UI;
+   compact or short canvases keep the drawer as an overlay. */
+.octo-board-canvas--drawer-reserved .octo-board-live-canvas {
+  flex: 0 1 auto;
+  width: calc(100% - var(--octo-doc-drawer-width, 360px));
+}
+
 .octo-board-canvas .excalidraw {
   width: 100%;
   height: 100%;
@@ -427,14 +439,6 @@ body[theme-mode='dark'] .octo-board-context-menu,
   background: var(--octo-bg-1, #202124);
   box-shadow: 0 8px 28px rgb(0 0 0 / 40%);
 }
-.octo-board-live-canvas {
-  position: relative;
-  display: flex;
-  flex: 1 1 auto;
-  min-width: 0;
-  min-height: 0;
-}
-
 /* Selection comment affordance mirrors the document bubble: a compact pill near the target, while
    composing reuses the sheet comment popover dimensions and actions. */
 .octo-board-selection-comment-button {

--- a/packages/docs/src/board/boardDrawerLayout.ts
+++ b/packages/docs/src/board/boardDrawerLayout.ts
@@ -1,0 +1,13 @@
+// Keep aligned with --octo-doc-drawer-width and its board.css fallback.
+export const BOARD_DRAWER_WIDTH = 360
+const EXCALIDRAW_DESKTOP_MIN_WIDTH = 730
+const EXCALIDRAW_SHORT_DESKTOP_MIN_WIDTH = 1000
+const EXCALIDRAW_SHORT_HEIGHT = 500
+
+/** Reserve the drawer only when the remaining Excalidraw viewport stays in its desktop layout. */
+export function canReserveBoardDrawer(width: number, height: number): boolean {
+  const minimumCanvasWidth = height < EXCALIDRAW_SHORT_HEIGHT
+    ? EXCALIDRAW_SHORT_DESKTOP_MIN_WIDTH
+    : EXCALIDRAW_DESKTOP_MIN_WIDTH
+  return width - BOARD_DRAWER_WIDTH >= minimumCanvasWidth
+}

--- a/packages/docs/src/board/boardLayout.contract.test.ts
+++ b/packages/docs/src/board/boardLayout.contract.test.ts
@@ -1,18 +1,55 @@
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { describe, expect, it } from 'vitest'
+import { BOARD_DRAWER_WIDTH, canReserveBoardDrawer } from './boardDrawerLayout.ts'
 
 const css = readFileSync(resolve('src/board/board.css'), 'utf8')
+const editorCss = readFileSync(resolve('src/editor/styles.css'), 'utf8')
 
 describe('Board live canvas layout contract', () => {
   it('lets the live-canvas isolation wrapper fill the remaining board area', () => {
-    const rule = css.match(/\.octo-board-live-canvas\s*\{([^}]*)\}/)?.[1] ?? ''
+    const rules = [...css.matchAll(/^\.octo-board-live-canvas\s*\{([^}]*)\}/gm)]
+    expect(rules).toHaveLength(1)
+    const rule = rules[0]?.[1] ?? ''
 
+    expect(rule).toMatch(/position:\s*relative/)
+    expect(rule).toMatch(/display:\s*flex/)
     expect(rule).toMatch(/flex:\s*1\s+1\s+auto/)
     expect(rule).toMatch(/width:\s*100%/)
     expect(rule).toMatch(/height:\s*100%/)
     expect(rule).toMatch(/min-width:\s*0/)
     expect(rule).toMatch(/min-height:\s*0/)
+  })
+
+  it('reserves the drawer only while the remaining canvas preserves desktop breakpoints', () => {
+    expect(BOARD_DRAWER_WIDTH).toBe(360)
+    expect(canReserveBoardDrawer(1090, 600)).toBe(true)
+    expect(canReserveBoardDrawer(1089, 600)).toBe(false)
+    expect(canReserveBoardDrawer(1360, 499)).toBe(true)
+    expect(canReserveBoardDrawer(1359, 499)).toBe(false)
+  })
+
+  it('uses the shared drawer width without introducing layout containment', () => {
+    const drawerRule = css.match(
+      /\.octo-board-canvas--drawer-reserved\s+\.octo-board-live-canvas\s*\{([^}]*)\}/,
+    )?.[1] ?? ''
+
+    const configuredDrawerWidth = Number(
+      editorCss.match(/--octo-doc-drawer-width:\s*(\d+)px/)?.[1],
+    )
+    const fallbackDrawerWidth = Number(
+      drawerRule.match(/var\(--octo-doc-drawer-width,\s*(\d+)px\)/)?.[1],
+    )
+    expect(configuredDrawerWidth).toBe(BOARD_DRAWER_WIDTH)
+    expect(fallbackDrawerWidth).toBe(BOARD_DRAWER_WIDTH)
+    expect(editorCss).toMatch(/width:\s*var\(--octo-doc-drawer-width\)/)
+    const canvasRule = css.match(/\.octo-board-canvas\s*\{([^}]*)\}/)?.[1] ?? ''
+    const liveCanvasRule = css.match(/^\.octo-board-live-canvas\s*\{([^}]*)\}/m)?.[1] ?? ''
+    // Container layout containment would re-anchor Excalidraw's position:fixed tool overlays.
+    expect(canvasRule).not.toMatch(/container-type:/)
+    expect(liveCanvasRule).not.toMatch(/container-type:/)
+    expect(drawerRule).toMatch(/flex:\s*0\s+1\s+auto/)
+    expect(drawerRule).toMatch(/width:\s*calc\(100%\s*-\s*var\(--octo-doc-drawer-width,\s*360px\)\)/)
   })
 
   it('uses the Octo brand focus ring for comment marker interaction states', () => {

--- a/packages/docs/src/editor/styles.css
+++ b/packages/docs/src/editor/styles.css
@@ -1937,12 +1937,15 @@ body.octo-row-resizing {
 /* ── Right-side drawer (#4/#5): history / comments / members open here, one at a time ──
    Anchored to the right of the editor pane, above content, scrollable, with a width
    transition. The panels it hosts drop their own card chrome so they fill the drawer. */
+.octo-doc {
+  --octo-doc-drawer-width: 360px;
+}
 .octo-doc-drawer {
   position: absolute;
   top: 0;
   right: 0;
   bottom: 0;
-  width: 360px;
+  width: var(--octo-doc-drawer-width);
   max-width: 92vw;
   background: var(--octo-bg, #fff);
   border-left: 1px solid var(--octo-border, #e5e6eb);


### PR DESCRIPTION
## Summary
- reserve the shared drawer width from the live board canvas while comments or version history is open
- measure the actual board width and height so compact or short canvases keep the drawer as an overlay without introducing CSS layout containment into Excalidraw
- make long board context menus form a bounded native scroll area and stop wheel events from reaching the canvas
- centralize the shared drawer width, include a CSS fallback, and cover drawer breakpoints and context-menu scrolling with focused tests

## Linked Spec
- User-reported regressions: the right end of the board toolbar is covered when a right-side drawer opens, and long board context menus cannot reliably scroll to their final actions

## How verified
- `pnpm exec vitest run src/board/BoardContextMenu.test.tsx src/board/boardLayout.contract.test.ts src/board/excalidrawToolbarPatch.contract.test.ts` (43/43)
- `node scripts/verify-excalidraw-patch.mjs`
- real `localhost:3000` board: opened the comments drawer and confirmed the complete More tools trigger remains visible and opens its menu
- real `localhost:3000` board: opened a long element context menu and confirmed the wheel reaches the final actions without moving or zooming the canvas
- `git diff --check`
- docs typecheck has only the two pre-existing main-branch errors in `dmworkbase/src/i18n/format.ts` and `members/sort.ts`

## COMPREHENSION
### What does this change actually do?
Before, the absolute right drawer covered the canvas without changing Excalidraw's measured width, so the centred toolbar could extend underneath it. Long context menus could also lack a reliable bounded overflow area before their host bounds were measured. After, the board measures its real container and reserves the drawer only when the remaining canvas preserves Excalidraw's desktop breakpoints; compact or short boards retain overlay behavior. Context menus always receive a container-relative height bound and use native overflow scrolling while wheel events stay out of the canvas.

### What could break?
Drawer/canvas sizing and board context-menu event handling are the affected surfaces. The reservation uses Excalidraw's width/height breakpoints without CSS containment, the shared CSS variable keeps it aligned with the drawer, and context-menu scrolling remains browser-native rather than manually changing `scrollTop`.

### How do you know it works?
Focused layout, context-menu, and patched-toolbar tests pass; the vendor patch remains byte-for-byte reproducible; and both the comments-drawer toolbar and long context-menu wheel interactions were verified on the local app.
