### PR TITLE
fix(mergeforward): preserve mention styling in details

### DIFF
--- a/packages/dmworkbase/src/Components/MergeforwardMessageList/__tests__/MergeforwardMessageList.test.tsx
+++ b/packages/dmworkbase/src/Components/MergeforwardMessageList/__tests__/MergeforwardMessageList.test.tsx
@@ -1,0 +1,112 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { fireEvent, render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ChannelTypeGroup, MessageContentType } from "wukongimjssdk";
+import { I18nContext } from "../../../i18n";
+import MergeforwardMessageList from "../index";
+
+vi.mock("react-virtuoso", () => ({
+  Virtuoso: () => null,
+  TableVirtuoso: () => null,
+}));
+
+vi.mock("../../../App", () => ({
+  default: {
+    dataSource: {
+      commonDataSource: {
+        getImageURL: vi.fn(),
+        getFileURL: vi.fn(),
+      },
+    },
+    mittBus: { emit: vi.fn() },
+  },
+}));
+
+vi.mock("../../../Messages/Mergeforward", () => ({
+  default: class MockMergeforwardContent {},
+}));
+
+vi.mock("../../WKAvatar", () => ({
+  default: () => <div data-testid="avatar" />,
+  isBot: () => false,
+}));
+
+vi.mock("../../../im-runtime/channelRuntime", () => ({
+  fetchImChannelInfo: vi.fn(),
+  getImChannelInfo: () => ({ title: "Sender" }),
+}));
+
+vi.mock("yet-another-react-lightbox", () => ({
+  default: () => null,
+}));
+
+vi.mock("yet-another-react-lightbox/plugins/download", () => ({
+  default: {},
+}));
+
+const i18nValue = {
+  locale: "zh-CN",
+  t: (key: string) => key,
+};
+
+function renderList(
+  messageContent: any,
+  onMentionClick = vi.fn(),
+) {
+  const message = {
+    contentType: MessageContentType.text,
+    content: messageContent,
+    fromUID: "sender",
+    messageID: "m1",
+    timestamp: 1,
+  } as any;
+  const mergeforwardContent = {
+    channelType: ChannelTypeGroup,
+    users: [{ uid: "sender", name: "Sender" }],
+    msgs: [message],
+  };
+
+  const result = render(
+    <I18nContext.Provider value={i18nValue as any}>
+      <MergeforwardMessageList
+        mergeforwardContent={mergeforwardContent}
+        onMentionClick={onMentionClick}
+      />
+    </I18nContext.Provider>,
+  );
+
+  return { ...result, onMentionClick };
+}
+
+describe("MergeforwardMessageList mention rendering", () => {
+  it("restores member mention styling from forwarded text mention entities", () => {
+    const { container, onMentionClick } = renderList({
+      mention: { all: false },
+      contentObj: {
+        content: "请 @张三 跟进",
+        mention: {
+          entities: [{ uid: "uid_zhang", offset: 2, length: 3 }],
+        },
+      },
+    });
+
+    const entity = container.querySelector("span.mention-entity");
+    expect(entity?.textContent).toBe("@张三");
+
+    fireEvent.click(entity!);
+    expect(onMentionClick).toHaveBeenCalledWith("uid_zhang");
+  });
+
+  it("renders forwarded broadcast mentions as text-only highlights", () => {
+    const { container } = renderList({
+      text: "@所有人 请同步",
+      mention: { humans: 1 },
+    });
+
+    const highlight = container.querySelector("span.mention-highlight");
+    expect(highlight?.textContent).toBe("@所有人");
+    expect(container.querySelector("span.mention-entity")).toBeNull();
+  });
+});

--- a/packages/dmworkbase/src/Components/MergeforwardMessageList/__tests__/MergeforwardMessageList.test.tsx
+++ b/packages/dmworkbase/src/Components/MergeforwardMessageList/__tests__/MergeforwardMessageList.test.tsx
@@ -109,4 +109,30 @@ describe("MergeforwardMessageList mention rendering", () => {
     expect(highlight?.textContent).toBe("@所有人");
     expect(container.querySelector("span.mention-entity")).toBeNull();
   });
+
+  it("renders forwarded all-AI mentions as text-only highlights", () => {
+    const { container } = renderList({
+      text: "@所有AI 请总结",
+      mention: { ais: 1 },
+    });
+
+    const highlight = container.querySelector("span.mention-highlight");
+    expect(highlight?.textContent).toBe("@所有AI");
+    expect(container.querySelector("span.mention-entity")).toBeNull();
+  });
+
+  it("restores legacy member mention styling from forwarded mention uids", () => {
+    const { container, onMentionClick } = renderList({
+      contentObj: {
+        content: "@张三 请跟进",
+        mention: { uids: ["uid_zhang"] },
+      },
+    });
+
+    const entity = container.querySelector("span.mention-entity");
+    expect(entity?.textContent).toBe("@张三");
+
+    fireEvent.click(entity!);
+    expect(onMentionClick).toHaveBeenCalledWith("uid_zhang");
+  });
 });

--- a/packages/dmworkbase/src/Components/MergeforwardMessageList/index.tsx
+++ b/packages/dmworkbase/src/Components/MergeforwardMessageList/index.tsx
@@ -21,9 +21,11 @@ import WKApp from "../../App";
 import { downloadFile } from "../../Utils/download";
 import { isSafeUrl } from "../../Utils/security";
 import { getExtension } from "../FilePreviewPanel/types";
-import MarkdownContent from "../../Messages/Text/MarkdownContent";
 import { RichTextContent } from "../../Messages/RichText/RichTextContent";
 import { getRichTextBlocksUI } from "../../bridge/message/useRichTextMessageUI";
+import { buildTextMessageMentions } from "../../bridge/message/textMessageMentions";
+import { PartType } from "../../Service/Model";
+import TextContent from "../../ui/message/TextContent";
 import MixedContent from "../../ui/message/MixedContent";
 import Lightbox from "yet-another-react-lightbox";
 import Download from "yet-another-react-lightbox/plugins/download";
@@ -38,6 +40,11 @@ import "./index.css";
 /** 嵌套合并转发最大导航深度 */
 const MAX_NESTED_DEPTH = 10;
 
+function getTextMessageText(content: MessageText): string {
+  const contentObjText = (content as any).contentObj?.content;
+  return content.text ?? (typeof contentObjText === "string" ? contentObjText : "");
+}
+
 export interface MergeforwardMessageListProps {
   mergeforwardContent: MergeforwardContent;
   onClose?: () => void;
@@ -47,6 +54,8 @@ export interface MergeforwardMessageListProps {
   onNavigateChange?: (info: { title: string; canGoBack: boolean }) => void;
   /** 外部触发返回（由父组件的返回按钮调用） */
   goBackRef?: React.MutableRefObject<(() => void) | null>;
+  /** 点击普通成员 @mention 时打开资料卡；未传时详情保持只读但保留语义样式 */
+  onMentionClick?: (uid: string) => void;
 }
 
 interface MergeforwardMessageListState {
@@ -257,8 +266,19 @@ export default class MergeforwardMessageList extends Component<
 
   getMsgContent(msg: Message) {
     if (msg.contentType === MessageContentType.text) {
-      const text = (msg.content as MessageText).text ?? "";
-      return <MarkdownContent content={text} isSend={false} />;
+      const text = getTextMessageText(msg.content as MessageText);
+      const mentions = buildTextMessageMentions({
+        parts: ((msg as any).parts ?? []) as any,
+        content: msg.content,
+        partMentionType: PartType.mention as unknown as number,
+      });
+      return (
+        <TextContent
+          content={text}
+          mentions={mentions}
+          onMentionClick={this.props.onMentionClick}
+        />
+      );
     }
     if (msg.contentType === MessageContentType.image) {
       const imageContent = msg.content as ImageContent;
@@ -288,6 +308,7 @@ export default class MergeforwardMessageList extends Component<
       return (
         <MixedContent
           blocks={getRichTextBlocksUI(richTextContent.content || [])}
+          onMentionClick={this.props.onMentionClick}
           onFileDownload={(block) => {
             if (block.url) {
               downloadFile(block.url, block.name);

--- a/packages/dmworkbase/src/Messages/Mergeforward/__tests__/MergeforwardContent.test.ts
+++ b/packages/dmworkbase/src/Messages/Mergeforward/__tests__/MergeforwardContent.test.ts
@@ -526,4 +526,36 @@ describe("MergeforwardContent.encode() full payload (simulates SDK encode path)"
       all: 0,
     });
   });
+
+  it("keeps encoded text when contentObj only carries injected mention metadata", () => {
+    const innerMsg = new (hoisted.StubMessage as any)();
+    innerMsg.messageID = "m1";
+    innerMsg.fromUID = "u1";
+    innerMsg.timestamp = 100;
+    innerMsg.content = {
+      contentObj: {
+        mention: {
+          entities: [{ uid: "uid_zhang", offset: 2, length: 3 }],
+        },
+      },
+      contentType: 1,
+      mention: {
+        all: false,
+      },
+      encodeJSON: () => ({ content: "请 @张三 跟进" }),
+    };
+
+    const content = new MergeforwardContent(2, [{ uid: "u1", name: "User1" }], [innerMsg as any]);
+
+    const contentObj = content.encodeJSON();
+
+    expect(contentObj.msgs[0].payload).toMatchObject({
+      type: 1,
+      content: "请 @张三 跟进",
+      mention: {
+        entities: [{ uid: "uid_zhang", offset: 2, length: 3 }],
+        all: 0,
+      },
+    });
+  });
 });

--- a/packages/dmworkbase/src/Messages/Mergeforward/__tests__/MergeforwardContent.test.ts
+++ b/packages/dmworkbase/src/Messages/Mergeforward/__tests__/MergeforwardContent.test.ts
@@ -463,4 +463,67 @@ describe("MergeforwardContent.encode() full payload (simulates SDK encode path)"
     expect(contentObj.type).toBe(11);
     expect(contentObj.msgs[0].payload.type).toBe(1);
   });
+
+  it("preserves mention entities for locally sent text messages", () => {
+    const innerMsg = new (hoisted.StubMessage as any)();
+    innerMsg.messageID = "m1";
+    innerMsg.fromUID = "u1";
+    innerMsg.timestamp = 100;
+    innerMsg.content = {
+      contentObj: undefined,
+      contentType: 1,
+      mention: {
+        all: false,
+        uids: ["uid_zhang"],
+        entities: [{ uid: "uid_zhang", offset: 2, length: 3 }],
+      },
+      encodeJSON: () => ({ content: "请 @张三 跟进" }),
+    };
+
+    const content = new MergeforwardContent(2, [{ uid: "u1", name: "User1" }], [innerMsg as any]);
+
+    const contentObj = content.encodeJSON();
+
+    expect(contentObj.msgs[0].payload).toMatchObject({
+      type: 1,
+      content: "请 @张三 跟进",
+      mention: {
+        all: 0,
+        uids: ["uid_zhang"],
+        entities: [{ uid: "uid_zhang", offset: 2, length: 3 }],
+      },
+    });
+  });
+
+  it("keeps raw mention entities when SDK decoded mention lacks unsupported fields", () => {
+    const innerMsg = new (hoisted.StubMessage as any)();
+    innerMsg.messageID = "m1";
+    innerMsg.fromUID = "u1";
+    innerMsg.timestamp = 100;
+    innerMsg.content = {
+      contentObj: {
+        type: 1,
+        content: "请 @张三 跟进",
+        mention: {
+          entities: [{ uid: "uid_zhang", offset: 2, length: 3 }],
+          humans: 1,
+        },
+      },
+      contentType: 1,
+      mention: {
+        all: false,
+      },
+      encodeJSON: () => ({ content: "请 @张三 跟进" }),
+    };
+
+    const content = new MergeforwardContent(2, [{ uid: "u1", name: "User1" }], [innerMsg as any]);
+
+    const contentObj = content.encodeJSON();
+
+    expect(contentObj.msgs[0].payload.mention).toEqual({
+      entities: [{ uid: "uid_zhang", offset: 2, length: 3 }],
+      humans: 1,
+      all: 0,
+    });
+  });
 });

--- a/packages/dmworkbase/src/Messages/Mergeforward/index.tsx
+++ b/packages/dmworkbase/src/Messages/Mergeforward/index.tsx
@@ -249,17 +249,18 @@ export default class MergeforwardContent extends MessageContent {
   }
 
   messageToMap(message: Message): any {
-    // Use contentObj if available, otherwise fall back to encodeJSON()
-    let payload = message.content.contentObj;
-    if (!payload) {
-      payload = { ...message.content.encodeJSON(), type: message.content.contentType };
-    } else if (payload.type === undefined) {
-      // 防护性检查：确保 contentObj 包含 type 字段
-      // 正常情况下 contentObj 来自服务器 payload，应包含 type
-      // 但某些边缘情况可能导致丢失，这里兼容处理
-      payload = { ...payload, type: message.content.contentType };
-    }
-    payload = mergeMentionIntoPayload(payload, message.content);
+    // Start from encodeJSON() so locally-created messages keep their full
+    // payload even when contentObj only carries injected metadata.
+    const encodedPayload = {
+      ...message.content.encodeJSON(),
+      type: message.content.contentType,
+    };
+    const payload = mergeMentionIntoPayload(
+      isRecord(message.content.contentObj)
+        ? { ...encodedPayload, ...message.content.contentObj }
+        : encodedPayload,
+      message.content,
+    );
     return {
       message_id: message.messageID,
       from_uid: message.fromUID ?? "",

--- a/packages/dmworkbase/src/Messages/Mergeforward/index.tsx
+++ b/packages/dmworkbase/src/Messages/Mergeforward/index.tsx
@@ -26,6 +26,56 @@ import { fetchImChannelInfo, getImChannelInfo } from "../../im-runtime/channelRu
 
 import "./index.css";
 
+function isRecord(value: unknown): value is Record<string, any> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function mergeMentionIntoPayload(payload: Record<string, any>, content: MessageContent) {
+  const rawMention = isRecord(content.contentObj?.mention)
+    ? content.contentObj.mention
+    : undefined;
+  const payloadMention = isRecord(payload.mention) ? payload.mention : undefined;
+  const decodedMention = content.mention as any;
+
+  if (!rawMention && !payloadMention && !decodedMention) {
+    return payload;
+  }
+
+  const mention = {
+    ...(rawMention ?? {}),
+    ...(payloadMention ?? {}),
+  };
+
+  if (decodedMention) {
+    if (decodedMention.all === true || decodedMention.all === 1) {
+      mention.all = 1;
+    } else if (decodedMention.all === false && mention.all === undefined) {
+      mention.all = 0;
+    }
+    if (Array.isArray(decodedMention.uids)) {
+      mention.uids = decodedMention.uids;
+    }
+    if (Array.isArray(decodedMention.entities)) {
+      mention.entities = decodedMention.entities;
+    }
+    if (decodedMention.humans !== undefined) {
+      mention.humans = decodedMention.humans;
+    }
+    if (decodedMention.ais !== undefined) {
+      mention.ais = decodedMention.ais;
+    }
+  }
+
+  if (Object.keys(mention).length === 0) {
+    return payload;
+  }
+
+  return {
+    ...payload,
+    mention,
+  };
+}
+
 // users 新增外部来源字段。后端在合并转发归档时填充，前端透传即可。
 export interface MergeforwardUser {
   uid: string;
@@ -209,6 +259,7 @@ export default class MergeforwardContent extends MessageContent {
       // 但某些边缘情况可能导致丢失，这里兼容处理
       payload = { ...payload, type: message.content.contentType };
     }
+    payload = mergeMentionIntoPayload(payload, message.content);
     return {
       message_id: message.messageID,
       from_uid: message.fromUID ?? "",
@@ -375,6 +426,7 @@ export class MergeforwardCell extends MessageCell<any, MergeforwardCellState> {
               mergeforwardContent={content}
               visible={showList}
               onClose={() => this.setState({ showList: false, canGoBack: false, navTitle: "" })}
+              onMentionClick={(uid) => context.showUser(uid)}
               goBackRef={this.goBackRef}
               onNavigateChange={({ title, canGoBack }) =>
                 this.setState({ navTitle: title, canGoBack })
@@ -455,6 +507,7 @@ export class MergeforwardCell extends MessageCell<any, MergeforwardCellState> {
             mergeforwardContent={content}
             visible={showList}
             onClose={() => this.setState({ showList: false, canGoBack: false, navTitle: "" })}
+            onMentionClick={(uid) => context.showUser(uid)}
             goBackRef={this.goBackRef}
             onNavigateChange={({ title, canGoBack }) =>
               this.setState({ navTitle: title, canGoBack })

--- a/packages/dmworkbase/src/bridge/message/__tests__/textMessageMentions.test.ts
+++ b/packages/dmworkbase/src/bridge/message/__tests__/textMessageMentions.test.ts
@@ -117,4 +117,51 @@ describe("buildTextMessageMentions", () => {
             { name: "@所有人", uid: "all" },
         ])
     })
+
+    it("does not bind all-AI routing uids to raw member mention text", () => {
+        const mentions = buildTextMessageMentions({
+            parts: [],
+            content: {
+                text: "@所有AI 总结一下 @张三 的发言",
+                mention: { ais: 1, uids: ["bot_1", "bot_2"] },
+            },
+            partMentionType: PART_TYPE_MENTION,
+        })
+
+        expect(mentions).toEqual([{ name: "@所有AI", uid: "all" }])
+    })
+
+    it("skips embedded @ tokens before consuming legacy mention uids", () => {
+        const mentions = buildTextMessageMentions({
+            parts: [],
+            content: {
+                contentObj: {
+                    content: "ping eve@example.com 然后 @张三 跟进",
+                    mention: { uids: ["uid_zhang"] },
+                },
+            },
+            partMentionType: PART_TYPE_MENTION,
+        })
+
+        expect(mentions).toEqual([{ name: "@张三", uid: "uid_zhang" }])
+    })
+
+    it("does not recover member entities that overlap a broadcast sentinel entity", () => {
+        const mentions = buildTextMessageMentions({
+            parts: [],
+            content: {
+                text: "@张三 看一下",
+                mention: {
+                    entities: [
+                        { uid: "-2", offset: 0, length: 3 },
+                        { uid: "uid_zhang", offset: 0, length: 3 },
+                    ],
+                    humans: 1,
+                },
+            },
+            partMentionType: PART_TYPE_MENTION,
+        })
+
+        expect(mentions).toEqual([{ name: "@所有人", uid: "all" }])
+    })
 })

--- a/packages/dmworkbase/src/bridge/message/__tests__/textMessageMentions.test.ts
+++ b/packages/dmworkbase/src/bridge/message/__tests__/textMessageMentions.test.ts
@@ -71,4 +71,50 @@ describe("buildTextMessageMentions", () => {
 
         expect(mentions).toEqual([{ name: "@所有AI", uid: "all" }])
     })
+
+    it("restores member mentions from mention.entities when decoded parts are unavailable", () => {
+        const mentions = buildTextMessageMentions({
+            parts: [],
+            content: {
+                text: "请 @张三 和 @李四 跟进",
+                // SDK MessageText.decode() creates a Mention instance on
+                // content.mention, but unsupported entity fields remain only on
+                // contentObj.mention.
+                mention: { all: false },
+                contentObj: {
+                    mention: {
+                        entities: [
+                            { uid: "uid_zhang", offset: 2, length: 3 },
+                            { uid: "uid_li", offset: 8, length: 3 },
+                        ],
+                    },
+                },
+            },
+            partMentionType: PART_TYPE_MENTION,
+        })
+
+        expect(mentions).toEqual([
+            { name: "@张三", uid: "uid_zhang" },
+            { name: "@李四", uid: "uid_li" },
+        ])
+    })
+
+    it("restores legacy member mentions from mention.uids when entities are absent", () => {
+        const mentions = buildTextMessageMentions({
+            parts: [],
+            content: {
+                contentObj: {
+                    content: "@张三 @所有人 @李四",
+                    mention: { uids: ["uid_zhang", "uid_li"], humans: 1 },
+                },
+            },
+            partMentionType: PART_TYPE_MENTION,
+        })
+
+        expect(mentions).toEqual([
+            { name: "@张三", uid: "uid_zhang" },
+            { name: "@李四", uid: "uid_li" },
+            { name: "@所有人", uid: "all" },
+        ])
+    })
 })

--- a/packages/dmworkbase/src/bridge/message/textMessageMentions.ts
+++ b/packages/dmworkbase/src/bridge/message/textMessageMentions.ts
@@ -1,9 +1,143 @@
 import {
   buildMessageMentions,
+  isBroadcastSentinelUid,
+  MENTION_LABEL_AIS,
+  MENTION_LABEL_HUMANS,
   readMentionFlags,
   type MentionRenderInfo,
   type MentionRenderPart,
 } from "../../Utils/mentionRender";
+
+interface MentionEntity {
+  uid: string;
+  offset: number;
+  length: number;
+}
+
+interface MentionSource {
+  uids?: string[];
+  entities?: MentionEntity[];
+}
+
+function getMentionSource(content: unknown): MentionSource | undefined {
+  if (!content || typeof content !== "object") return undefined;
+  const c = content as {
+    mention?: MentionSource;
+    contentObj?: { mention?: MentionSource };
+  };
+  const mention = c.mention;
+  const contentObjMention = c.contentObj?.mention;
+  if (!mention && !contentObjMention) return undefined;
+  return {
+    uids: mention?.uids ?? contentObjMention?.uids,
+    entities: mention?.entities ?? contentObjMention?.entities,
+  };
+}
+
+function getText(content: unknown): string {
+  if (!content || typeof content !== "object") return "";
+  const c = content as { text?: unknown; contentObj?: { content?: unknown } };
+  if (typeof c.text === "string") return c.text;
+  return typeof c.contentObj?.content === "string" ? c.contentObj.content : "";
+}
+
+function isValidEntity(entity: unknown, textLength: number): entity is MentionEntity {
+  if (!entity || typeof entity !== "object" || Array.isArray(entity)) {
+    return false;
+  }
+  const e = entity as MentionEntity;
+  return (
+    typeof e.uid === "string" &&
+    typeof e.offset === "number" &&
+    typeof e.length === "number" &&
+    Number.isFinite(e.offset) &&
+    Number.isFinite(e.length) &&
+    e.offset >= 0 &&
+    e.length > 0 &&
+    e.offset + e.length <= textLength
+  );
+}
+
+function partsFromEntities(
+  text: string,
+  entities: unknown[] | undefined,
+  partMentionType: number,
+): MentionRenderPart[] {
+  const validEntities = (entities ?? [])
+    .filter((entity): entity is MentionEntity => isValidEntity(entity, text.length))
+    .sort((a, b) => a.offset - b.offset);
+
+  const result: MentionRenderPart[] = [];
+  let lastEnd = 0;
+  for (const entity of validEntities) {
+    if (entity.offset < lastEnd || isBroadcastSentinelUid(entity.uid)) {
+      continue;
+    }
+    const name = text.slice(entity.offset, entity.offset + entity.length);
+    if (!name.startsWith("@")) {
+      continue;
+    }
+    result.push({ type: partMentionType, text: name, data: { uid: entity.uid } });
+    lastEnd = entity.offset + entity.length;
+  }
+  return result;
+}
+
+function partsFromLegacyUids(
+  text: string,
+  uids: unknown[] | undefined,
+  partMentionType: number,
+): MentionRenderPart[] {
+  const uidQueue = (uids ?? []).filter((uid): uid is string => typeof uid === "string");
+  if (uidQueue.length === 0) return [];
+
+  const result: MentionRenderPart[] = [];
+  const mentionRegex = /@[\w\u4e00-\u9fa5.\-]+/gm;
+  let match: RegExpExecArray | null;
+  let index = 0;
+  while ((match = mentionRegex.exec(text)) !== null && index < uidQueue.length) {
+    const name = match[0];
+    const label = name.slice(1);
+    if (
+      label.toLowerCase() === "all" ||
+      label === MENTION_LABEL_HUMANS ||
+      label === MENTION_LABEL_AIS
+    ) {
+      continue;
+    }
+    result.push({
+      type: partMentionType,
+      text: name,
+      data: { uid: uidQueue[index] },
+    });
+    index += 1;
+  }
+  return result;
+}
+
+function getMentionParts(args: {
+  parts: MentionRenderPart[];
+  content: unknown;
+  editContent?: unknown;
+  partMentionType: number;
+}): MentionRenderPart[] {
+  const mentionParts = args.parts.filter(
+    (part) => part.type === args.partMentionType && !!part.data?.uid,
+  );
+  if (mentionParts.length > 0) return mentionParts;
+
+  const effectiveContent = args.editContent ?? args.content;
+  const text = getText(effectiveContent);
+  const mention = getMentionSource(effectiveContent);
+  const entityParts = partsFromEntities(
+    text,
+    mention?.entities,
+    args.partMentionType,
+  );
+  if (entityParts.length > 0) return entityParts;
+
+  return partsFromLegacyUids(text, mention?.uids, args.partMentionType);
+}
 
 export function buildTextMessageMentions(args: {
   parts: MentionRenderPart[];
@@ -13,6 +147,7 @@ export function buildTextMessageMentions(args: {
 }): MentionRenderInfo[] {
   const flags =
     readMentionFlags(args.editContent) ?? readMentionFlags(args.content);
+  const parts = getMentionParts(args);
 
-  return buildMessageMentions(args.parts, flags, args.partMentionType);
+  return buildMessageMentions(parts, flags, args.partMentionType);
 }

--- a/packages/dmworkbase/src/bridge/message/textMessageMentions.ts
+++ b/packages/dmworkbase/src/bridge/message/textMessageMentions.ts
@@ -4,6 +4,7 @@ import {
   MENTION_LABEL_AIS,
   MENTION_LABEL_HUMANS,
   readMentionFlags,
+  type MentionRenderFlags,
   type MentionRenderInfo,
   type MentionRenderPart,
 } from "../../Utils/mentionRender";
@@ -70,7 +71,12 @@ function partsFromEntities(
   const result: MentionRenderPart[] = [];
   let lastEnd = 0;
   for (const entity of validEntities) {
-    if (entity.offset < lastEnd || isBroadcastSentinelUid(entity.uid)) {
+    if (entity.offset < lastEnd) {
+      continue;
+    }
+    const entityEnd = entity.offset + entity.length;
+    lastEnd = entityEnd;
+    if (isBroadcastSentinelUid(entity.uid)) {
       continue;
     }
     const name = text.slice(entity.offset, entity.offset + entity.length);
@@ -78,16 +84,29 @@ function partsFromEntities(
       continue;
     }
     result.push({ type: partMentionType, text: name, data: { uid: entity.uid } });
-    lastEnd = entity.offset + entity.length;
   }
   return result;
+}
+
+function hasEmbeddedMentionPrefix(text: string, matchStart: number): boolean {
+  if (matchStart <= 0) return false;
+  const charBefore = text.charCodeAt(matchStart - 1);
+  return (
+    (charBefore >= 97 && charBefore <= 122) ||
+    (charBefore >= 65 && charBefore <= 90) ||
+    (charBefore >= 48 && charBefore <= 57) ||
+    charBefore === 95
+  );
 }
 
 function partsFromLegacyUids(
   text: string,
   uids: unknown[] | undefined,
+  flags: MentionRenderFlags | undefined,
   partMentionType: number,
 ): MentionRenderPart[] {
+  if (flags?.ais) return [];
+
   const uidQueue = (uids ?? []).filter((uid): uid is string => typeof uid === "string");
   if (uidQueue.length === 0) return [];
 
@@ -98,6 +117,9 @@ function partsFromLegacyUids(
   while ((match = mentionRegex.exec(text)) !== null && index < uidQueue.length) {
     const name = match[0];
     const label = name.slice(1);
+    if (hasEmbeddedMentionPrefix(text, match.index)) {
+      continue;
+    }
     if (
       label.toLowerCase() === "all" ||
       label === MENTION_LABEL_HUMANS ||
@@ -119,6 +141,7 @@ function getMentionParts(args: {
   parts: MentionRenderPart[];
   content: unknown;
   editContent?: unknown;
+  flags?: MentionRenderFlags;
   partMentionType: number;
 }): MentionRenderPart[] {
   const mentionParts = args.parts.filter(
@@ -136,7 +159,7 @@ function getMentionParts(args: {
   );
   if (entityParts.length > 0) return entityParts;
 
-  return partsFromLegacyUids(text, mention?.uids, args.partMentionType);
+  return partsFromLegacyUids(text, mention?.uids, args.flags, args.partMentionType);
 }
 
 export function buildTextMessageMentions(args: {
@@ -147,7 +170,7 @@ export function buildTextMessageMentions(args: {
 }): MentionRenderInfo[] {
   const flags =
     readMentionFlags(args.editContent) ?? readMentionFlags(args.content);
-  const parts = getMentionParts(args);
+  const parts = getMentionParts({ ...args, flags });
 
   return buildMessageMentions(parts, flags, args.partMentionType);
 }


### PR DESCRIPTION
## Summary

Fix merged-forward chat history details so text mentions keep the same semantic styling as normal message rendering. Ordinary member mentions now render as mention entity pills, while broadcast mentions such as `@所有人` and `@所有AI` remain text-only highlights.

## Related Issue

Fixes #1151

## Changes

- Render text messages in `MergeforwardMessageList` through the shared `TextContent` path instead of raw `MarkdownContent`.
- Restore mention metadata for merged-forward details from `parts`, `mention.entities`, `contentObj.mention.entities`, and legacy `mention.uids`.
- Preserve mention metadata when building merged-forward payloads so newly sent merged forwards do not drop `mention.entities`.
- Wire mention clicks in merged-forward detail modals to the existing user profile action.
- Add regression coverage for payload preservation, mention metadata recovery, and merged-forward detail rendering.

## Architecture / Module Boundary

- Affected module(s): dmworkbase message rendering / merge-forward message details / message bridge helpers
- New or changed user-visible entry point: no
- Shared layer touched: Components, Messages, bridge, ui message rendering path
- If shared code changed, impact scope: text mention metadata recovery now also handles decoded message shapes where `parts` are unavailable, while preserving existing broadcast mention behavior.
- Duplicate entry point checked: yes

## Testing

- [x] Unit tests added/updated
- [x] Manually verified

Commands run:

```bash
corepack pnpm --dir packages/dmworkbase exec vitest run src/Messages/Mergeforward/__tests__/MergeforwardContent.test.ts src/bridge/message/__tests__/textMessageMentions.test.ts src/Components/MergeforwardMessageList/__tests__/MergeforwardMessageList.test.tsx src/Messages/Text/__tests__/MarkdownContentMention.test.tsx
git diff --check
```

Manual verification:

- Started `apps/web` against the online API environment.
- Sent a group message with an ordinary member mention.
- Created a merged-forward message containing that message.
- Opened the merged-forward detail card and confirmed the ordinary member mention renders as a pill entity.
- Confirmed broadcast mentions remain text-only highlights.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes
- [ ] Updated documentation
- [x] Ran `pnpm i18n:check` or confirmed the change does not affect UI copy
- [x] Confirmed the change follows module ownership and does not add duplicate user-visible entry points
- [x] Described impact scope when shared components, messages, bridge, or services are changed
- [x] Followed commit message conventions (Conventional Commits)
