### PR TITLE
fix(summary): auto-refresh summary list when a task completes

### DIFF
--- a/packages/dmworksummary/src/pages/SummaryListPage.tsx
+++ b/packages/dmworksummary/src/pages/SummaryListPage.tsx
@@ -17,7 +17,7 @@ import type {
     TaskStatusType,
 } from "../types/summary";
 import { TaskStatus } from "../types/summary";
-import { getStatusLabel } from "../utils/summaryHelpers";
+import { getStatusLabel, isTerminalStatus } from "../utils/summaryHelpers";
 import SummaryCard from "../components/SummaryCard";
 import SummaryCreatePage from "./SummaryCreatePage";
 import SummaryDetailPage from "./SummaryDetailPage";
@@ -76,6 +76,17 @@ export default class SummaryListPage extends Component<SummaryListPageProps, Sum
     private searchTimer: ReturnType<typeof setTimeout> | null = null;
     private batchPollTimer: ReturnType<typeof setInterval> | null = null;
     private isBatchPolling = false;
+    private isRefreshing = false;
+    // Monotonic list-mutation sequence: bumped by every path that mutates
+    // items / page (loadData, loadMore, refreshListSilently). An in-flight
+    // refresh captures the value pre-await and bails on resume if the
+    // sequence advanced — that is what protects the cursor when a
+    // scroll-triggered loadMore races the completion refresh.
+    private listSeq = 0;
+    // Cleared by componentWillUnmount so any in-flight refresh's setState
+    // becomes a no-op instead of restarting maybeStartBatchPoll on a
+    // torn-down component.
+    private isMounted_ = false;
 
     private handleSpaceChanged_ = () => this.loadData();
 
@@ -123,6 +134,7 @@ export default class SummaryListPage extends Component<SummaryListPageProps, Sum
     };
 
     componentDidMount() {
+        this.isMounted_ = true;
         this.loadData();
         WKApp.mittBus.on("summary-space-changed", this.handleSpaceChanged_);
         WKApp.mittBus.on("wk:nav-menu-activated", this.handleNavMenuActivated_);
@@ -140,6 +152,7 @@ export default class SummaryListPage extends Component<SummaryListPageProps, Sum
     }
 
     componentWillUnmount() {
+        this.isMounted_ = false;
         window.dispatchEvent(new CustomEvent("summary-list-unmount"));
         if (this.searchTimer) clearTimeout(this.searchTimer);
         this.stopBatchPoll();
@@ -167,6 +180,10 @@ export default class SummaryListPage extends Component<SummaryListPageProps, Sum
     }
 
     async loadData() {
+        // Bump the list-mutation sequence so any in-flight silent refresh
+        // captured before this reload bails on resume instead of clobbering
+        // the freshly-loaded items.
+        this.listSeq++;
         this.setState({ loading: true, error: null, page: 1, hasMore: true });
         try {
             const { pageSize, statusFilter, keyword } = this.state;
@@ -201,6 +218,10 @@ export default class SummaryListPage extends Component<SummaryListPageProps, Sum
 
     async loadMore() {
         if (this.state.loadingMore || !this.state.hasMore || this.state.loading) return;
+        // Bump the list-mutation sequence: an in-flight silent refresh
+        // captured before this loadMore appended a page must bail so it
+        // does not overwrite the appended items or reset the cursor.
+        this.listSeq++;
         this.setState({ loadingMore: true });
         try {
             const nextPage = this.state.page + 1;
@@ -274,15 +295,112 @@ export default class SummaryListPage extends Component<SummaryListPageProps, Sum
                 return item;
             });
             if (changed) {
-                this.setState({ items: newItems }, () => {
-                    this.maybeStartBatchPoll();
+                // #290：进入终态时，仅原地打 status 补丁不够——完成后 backend 才会
+                // 填/改标题、结果预览等字段，且列表加载后新建的任务不在轮询集合里。
+                // 因此终态变化触发一次「静默」全量刷新（不显示加载态、不重置分页深度）。
+                const hasTerminal = changedIds.some(id => {
+                    const u = updateMap.get(id);
+                    return !!u && isTerminalStatus(u.status);
                 });
+                if (hasTerminal) {
+                    // Apply the confirmed status patch immediately, then fire
+                    // the silent refresh to enrich rows with backend-populated
+                    // fields. Skipping the local patch leaves cards showing a
+                    // stale non-terminal status (with Cancel affordance) for
+                    // the round-trip window; if the refresh throws, the poller
+                    // would also rediscover the same transition every 2s and
+                    // dispatch summary-status-change indefinitely.
+                    this.setState({ items: newItems }, () => {
+                        this.maybeStartBatchPoll();
+                        void this.refreshListSilently();
+                    });
+                } else {
+                    // 非终态（如 PENDING→PROCESSING）保留廉价的原地状态补丁即可。
+                    this.setState({ items: newItems }, () => {
+                        this.maybeStartBatchPoll();
+                    });
+                }
                 window.dispatchEvent(new CustomEvent("summary-status-change", { detail: { taskIds: changedIds } }));
             }
         } catch {
             // ignore
         } finally {
             this.isBatchPolling = false;
+        }
+    }
+
+    /**
+     * 静默全量刷新（#290）：拉取最新列表并替换 items，但不置 `loading`（不闪加载态），
+     * 也不重置分页——用 page_size = pageSize × 已加载页数 一次覆盖所有已加载页，
+     * 保留用户的滚动深度。与 loadData 的区别就是「无加载态、不塌回第 1 页」。
+     * 出错则保留上一份好数据，交给下一次轮询重试。
+     *
+     * Concurrency invariants:
+     * - `isRefreshing` short-circuits overlapping refresh calls.
+     * - `listSeq` (bumped by loadData / loadMore / this method) is captured
+     *   pre-await; a bump during our fetch means another path has already
+     *   mutated items / page, and the refresh response would clobber it.
+     * - Captured `statusFilter` / `keyword` / `channelId`: if any changed
+     *   during the fetch the response is scoped to stale filters.
+     * - `loadingMore` bail on resume: a scroll-triggered loadMore may have
+     *   started after we captured listSeq but before its own bump landed;
+     *   check the flag directly to close that window.
+     * - `isMounted_` guard: don't setState after unmount.
+     */
+    private async refreshListSilently() {
+        if (this.isRefreshing) return;
+        this.isRefreshing = true;
+        // Capture list identity + filter identity pre-await for the
+        // stale-write guard on resume.
+        const seq = ++this.listSeq;
+        const capturedStatus = this.state.statusFilter;
+        const capturedKeyword = this.state.keyword;
+        const capturedChannel = this.props.channelId;
+        try {
+            const { pageSize, page } = this.state;
+            // 覆盖已加载页；防止后端对 page_size 有上限，clamp 到 100。
+            const coverSize = Math.min(pageSize * Math.max(1, page), 100);
+            const params: ListSummariesParams = {
+                page: 1,
+                page_size: coverSize,
+                status: capturedStatus,
+                keyword: capturedKeyword || undefined,
+                origin_channel_id: capturedChannel || undefined,
+            };
+            const resp = await api.listSummaries(params);
+            if (!this.isMounted_) return;
+            // Any of these means the response would clobber newer state:
+            //  - listSeq advanced → loadData / loadMore already mutated items/page
+            //  - filter/keyword/channel changed → response is scoped to stale filters
+            //  - loadingMore in flight → its append is authoritative for the cursor
+            if (
+                seq !== this.listSeq ||
+                capturedStatus !== this.state.statusFilter ||
+                capturedKeyword !== this.state.keyword ||
+                capturedChannel !== this.props.channelId ||
+                this.state.loadingMore
+            ) {
+                return;
+            }
+            // Truncate to a whole-page boundary so state.page stays consistent
+            // with items.length regardless of what the backend actually
+            // returned. Math.floor + slice keeps loadMore's `state.page + 1`
+            // pointing at the row immediately after the tail — no gap, no
+            // duplicate — even if the backend cap ever changes.
+            const coveredPages = Math.max(1, Math.floor(resp.items.length / pageSize));
+            const trimmedItems = resp.items.slice(0, coveredPages * pageSize);
+            this.setState({
+                items: trimmedItems,
+                page: coveredPages,
+                total: resp.total,
+                hasMore: trimmedItems.length < resp.total,
+            }, () => {
+                if (this.isMounted_) this.maybeStartBatchPoll();
+            });
+        } catch {
+            // 保留上一份好数据，下个轮询再试。
+        } finally {
+            this.isRefreshing = false;
         }
     }
 

--- a/packages/dmworksummary/src/pages/SummaryListPage.tsx
+++ b/packages/dmworksummary/src/pages/SummaryListPage.tsx
@@ -314,79 +314,25 @@ export default class SummaryListPage extends Component<SummaryListPageProps, Sum
     }
 
     /**
-     * 静默全量刷新（#290）：拉取最新列表 · 把返回的行 **合并** 进 `state.items`
-     * (按 task_id 覆盖 · 新任务前置)· 从不裁掉用户已加载的尾部 · 从不改
-     * `state.page`。用 `page_size = min(pageSize × page, 100)` 只覆盖前缀,
-     * 用户已滚过的行由 in-place merge 保留不动。与 loadData 的区别:不塌回
-     * 第 1 页、不闪加载态、不缩短列表。出错则保留原状,下次交给终态事件重试。
+     * 静默全量刷新（#290）：任务进入终态后调用 loadData()。#290 原方案就是
+     * 用 loadData() —— 我们绕过它想避免 spinner + page collapse,但四轮
+     * review 后结论是:offset-paged list 上做静默 refresh + merge/replace
+     * 都会在某个 route 破坏 filter/space/loadMore 语义。loadData 是
+     * "correct by construction" 姿势(见 yujiawei round-4 escalation
+     * 建议 a)—— spinner 一闪是合理的用户反馈,而且 loadData 恢复了旧
+     * replace 模型的正确性:filter 变化时 fall-out 行会被丢掉、space
+     * 切换清空、loadMore 的分页游标被重置。
      *
-     * Concurrency invariants:
-     * - `isRefreshing` short-circuits overlapping refresh calls.
-     * - Captured `statusFilter` / `keyword` / `channelId`: if any changed
-     *   during the fetch the response is scoped to stale filters, drop it.
-     * - `isMounted_` guard: don't setState after unmount.
-     *
-     * Merge-not-replace closes the concurrent-writer question by construction:
-     * we never overwrite `items[k]` past what the server just returned, so a
-     * loadMore that appended rows during the fetch cannot lose them, and a
-     * refresh that races another refresh cannot roll rows back. `page` is
-     * refresh-invariant.
+     * `isRefreshing` 防重入(2s 轮询 tick 撞到 refresh 在跑就跳过);
+     * `isMounted_` 由 loadData 内部无需再查,但保留在 componentWillUnmount
+     * 里让其他 in-flight 逻辑安全。
      */
     private async refreshListSilently() {
         if (this.isRefreshing) return;
+        if (!this.isMounted_) return;
         this.isRefreshing = true;
-        const capturedStatus = this.state.statusFilter;
-        const capturedKeyword = this.state.keyword;
-        const capturedChannel = this.props.channelId;
         try {
-            const { pageSize, page } = this.state;
-            // 覆盖已加载页前缀；防止后端对 page_size 有上限，clamp 到 100。
-            // 尾部由 merge 保留，不再依赖此值覆盖全部已加载行。
-            const coverSize = Math.min(pageSize * Math.max(1, page), 100);
-            const params: ListSummariesParams = {
-                page: 1,
-                page_size: coverSize,
-                status: capturedStatus,
-                keyword: capturedKeyword || undefined,
-                origin_channel_id: capturedChannel || undefined,
-            };
-            const resp = await api.listSummaries(params);
-            if (!this.isMounted_) return;
-            if (
-                capturedStatus !== this.state.statusFilter ||
-                capturedKeyword !== this.state.keyword ||
-                capturedChannel !== this.props.channelId
-            ) {
-                return;
-            }
-            // Merge instead of replace: overlay fresh rows onto existing by
-            // task_id (fresh wins for enriched fields like title / preview),
-            // preserving user's loaded tail past coverSize. Brand-new tasks
-            // in the fresh response that weren't loaded before come in at
-            // the top (list is sorted newest-first).
-            this.setState((prev) => {
-                const freshById = new Map(resp.items.map((x: any) => [x.task_id, x]));
-                const existingIds = new Set(prev.items.map((x: any) => x.task_id));
-                const newFromFresh = resp.items.filter((x: any) => !existingIds.has(x.task_id));
-                const overlaidExisting = prev.items.map((x: any) => freshById.get(x.task_id) ?? x);
-                const merged = [...newFromFresh, ...overlaidExisting];
-                return {
-                    items: merged as any,
-                    total: resp.total,
-                    hasMore: merged.length < resp.total,
-                };
-            }, () => {
-                if (this.isMounted_) this.maybeStartBatchPoll();
-            });
-        } catch {
-            // Refresh failed. The local status patch applied before this
-            // refresh already wrote the terminal status, so the next
-            // doBatchPoll tick sees no change and will NOT re-fire the
-            // refresh — a transient network blip degrades the list back to
-            // the pre-fix behaviour (stale title / preview / new-task
-            // invisibility) until some other event triggers a full load.
-            // Not attempting an in-place retry keeps the failure mode
-            // simple: no unbounded event storm, no stuck spinner.
+            await this.loadData();
         } finally {
             this.isRefreshing = false;
         }

--- a/packages/dmworksummary/src/pages/SummaryListPage.tsx
+++ b/packages/dmworksummary/src/pages/SummaryListPage.tsx
@@ -227,6 +227,11 @@ export default class SummaryListPage extends Component<SummaryListPageProps, Sum
                 page: 1,
                 total: resp.total,
                 loading: false,
+                // Round-9 yujiawei P2-3: a silent refresh that succeeds
+                // must clear a pre-existing error banner too. Otherwise a
+                // failed user-driven load leaves a non-dismissable banner
+                // that sits above a perfectly fresh list.
+                error: null,
                 hasMore: resp.items.length < resp.total,
             }, () => {
                 if (this.isMounted_) this.maybeStartBatchPoll();
@@ -244,7 +249,12 @@ export default class SummaryListPage extends Component<SummaryListPageProps, Sum
             }
             this.setState({ error: err.message || t("summary.common.loadingFailed"), loading: false });
         } finally {
-            this.isLoadingData = false;
+            // Sequence-owned clear (round-9 yujiawei P2-2): with two
+            // overlapping loadData calls, the older stale one returning
+            // early at the seq check would otherwise clear the flag while
+            // the newer one is still in flight. Only the current loadData
+            // is allowed to release the guard.
+            if (seq === this.loadDataSeq) this.isLoadingData = false;
         }
     }
 
@@ -350,21 +360,20 @@ export default class SummaryListPage extends Component<SummaryListPageProps, Sum
                 // 因此终态变化触发一次全量刷新(委派给 loadData · 见 refreshListSilently)。
                 // 会短暂显示 spinner + 塌回 page 1—这是 loadData 的必然副作用,
                 // 换来 correct-by-construction 的过滤/space/loadMore 语义。
-                // 本地 status 补丁在触发刷新前先落到 items,避免卡片在往返窗口里
-                // 显示陈旧的 non-terminal 状态(含取消按钮)。
+                //
+                // 终态分支不落 local status 补丁(round-9 yujiawei P1):
+                // 早期版本先 patch 到 items 再 refresh · 但若 refresh 失败(silent
+                // 分支静默 return · 或被 isRefreshing 丢),items 已经写成 COMPLETED
+                // 会让 maybeStartBatchPoll 看到 active tasks 为空 → stopBatchPoll →
+                // 永远无法自动 retry · 卡片保留 stale 标题/预览。
+                // 保留 items 里的 non-terminal 状态,下次 poll tick 依然 detect
+                // change → 自动 retry refresh。渲染层因 loading:true 会 unmount
+                // 列表容器,用户看不到瞬时的 "still-non-terminal" 状态。
                 const hasTerminal = changedIds.some(id => {
                     const u = updateMap.get(id);
                     return !!u && isTerminalStatus(u.status);
                 });
                 if (hasTerminal) {
-                    // Apply the confirmed status patch immediately so cards
-                    // do not render a stale non-terminal status (with Cancel
-                    // affordance) for the refresh round-trip. Fire the silent
-                    // refresh right after — do not defer it into the setState
-                    // callback (that adds a React commit for no benefit), and
-                    // do not call maybeStartBatchPoll here because the refresh
-                    // itself calls it on completion.
-                    this.setState({ items: newItems });
                     void this.refreshListSilently();
                 } else {
                     // 非终态（如 PENDING→PROCESSING）保留廉价的原地状态补丁即可。

--- a/packages/dmworksummary/src/pages/SummaryListPage.tsx
+++ b/packages/dmworksummary/src/pages/SummaryListPage.tsx
@@ -303,17 +303,15 @@ export default class SummaryListPage extends Component<SummaryListPageProps, Sum
                     return !!u && isTerminalStatus(u.status);
                 });
                 if (hasTerminal) {
-                    // Apply the confirmed status patch immediately, then fire
-                    // the silent refresh to enrich rows with backend-populated
-                    // fields. Skipping the local patch leaves cards showing a
-                    // stale non-terminal status (with Cancel affordance) for
-                    // the round-trip window; if the refresh throws, the poller
-                    // would also rediscover the same transition every 2s and
-                    // dispatch summary-status-change indefinitely.
-                    this.setState({ items: newItems }, () => {
-                        this.maybeStartBatchPoll();
-                        void this.refreshListSilently();
-                    });
+                    // Apply the confirmed status patch immediately so cards
+                    // do not render a stale non-terminal status (with Cancel
+                    // affordance) for the refresh round-trip. Fire the silent
+                    // refresh right after — do not defer it into the setState
+                    // callback (that adds a React commit for no benefit), and
+                    // do not call maybeStartBatchPoll here because the refresh
+                    // itself calls it on completion.
+                    this.setState({ items: newItems });
+                    void this.refreshListSilently();
                 } else {
                     // 非终态（如 PENDING→PROCESSING）保留廉价的原地状态补丁即可。
                     this.setState({ items: newItems }, () => {
@@ -398,7 +396,14 @@ export default class SummaryListPage extends Component<SummaryListPageProps, Sum
                 if (this.isMounted_) this.maybeStartBatchPoll();
             });
         } catch {
-            // 保留上一份好数据，下个轮询再试。
+            // Refresh failed. The local status patch applied before this
+            // refresh already wrote the terminal status, so the next
+            // doBatchPoll tick sees no change and will NOT re-fire the
+            // refresh — a transient network blip degrades the list back to
+            // the pre-fix behaviour (stale title / preview / new-task
+            // invisibility) until some other event triggers a full load.
+            // Not attempting an in-place retry keeps the failure mode
+            // simple: no unbounded event storm, no stuck spinner.
         } finally {
             this.isRefreshing = false;
         }

--- a/packages/dmworksummary/src/pages/SummaryListPage.tsx
+++ b/packages/dmworksummary/src/pages/SummaryListPage.tsx
@@ -81,9 +81,16 @@ export default class SummaryListPage extends Component<SummaryListPageProps, Sum
     // loadData captures the value pre-await; if it advanced during the
     // request (user changed filter/keyword/space, or another loadData fired),
     // the response is stale and we drop it instead of overwriting newer
-    // user-driven state. Only loadData bumps — loadMore's cursor consistency
-    // is guarded separately by the prev.page === nextPage-1 check.
+    // user-driven state. loadMore also captures pre-await and drops its
+    // batch on mismatch — closes loadMore-starts-first, loadData-bumps-after.
     private loadDataSeq = 0;
+    // Synchronous "is a loadData in flight" flag. React 18 batching means
+    // this.state.loading is not visible immediately after setState from a
+    // promise continuation, so loadMore reading state.loading would miss a
+    // just-started loadData. Setting/clearing a plain field is synchronous
+    // and closes the loadData-starts-first, loadMore-scrolls-after ordering.
+    // Kept alongside loadDataSeq — the pair covers both interleavings.
+    private isLoadingData = false;
     // Cleared by componentWillUnmount so any in-flight refresh's setState
     // becomes a no-op instead of restarting maybeStartBatchPoll on a
     // torn-down component.
@@ -182,18 +189,23 @@ export default class SummaryListPage extends Component<SummaryListPageProps, Sum
 
     async loadData(opts: { silent?: boolean } = {}) {
         // Bump-and-capture sequence: this loadData's response is only allowed
-        // to commit if no newer loadData/loadMore/filter change has started
-        // meanwhile. Guards against a background refresh overwriting a fresh
-        // user-driven load, and against a stale loadMore appending after a
-        // loadData reset. Bumping this also invalidates any in-flight
-        // loadMore (which captured its own seq at entry).
+        // to commit if no newer loadData/filter change has started meanwhile.
+        // Extended in round-7 so loadMore also captures pre-await and drops
+        // its batch on mismatch. Round-8 added isLoadingData below because
+        // this sequence alone is asymmetric — a loadMore that starts AFTER
+        // loadData already bumped captures the already-bumped value and
+        // would still commit.
         const seq = ++this.loadDataSeq;
+        this.isLoadingData = true;
         // Only toggle loading. Do NOT pre-set page:1 / hasMore:true here —
         // if the request fails in silent mode we would leave items at the
         // old depth with page reset to 1, and the next loadMore would
-        // duplicate rows (#290 Jerry-Xin / yujiawei round-6 P1-2). Commit
-        // page/hasMore atomically with items on success instead.
-        this.setState({ loading: true, error: null });
+        // duplicate rows (round-6). Commit page/hasMore atomically with
+        // items on success instead.
+        // Silent refresh keeps the existing error banner if any (round-8
+        // yujiawei P2-2): a user-visible error the user already saw must
+        // not be erased by an automatic background refresh.
+        this.setState(opts.silent ? { loading: true } : { loading: true, error: null });
         try {
             const { pageSize, statusFilter, keyword } = this.state;
             const params: ListSummariesParams = {
@@ -205,6 +217,11 @@ export default class SummaryListPage extends Component<SummaryListPageProps, Sum
             };
             const resp = await api.listSummaries(params);
             if (seq !== this.loadDataSeq) return;
+            // Post-await mount check (round-8 yujiawei P2-3): the entry
+            // isMounted_ guard cannot cover the await window; React 18 will
+            // drop setState on an unmounted fiber but the callback would
+            // still be scheduled. Explicit check makes the guarantee ours.
+            if (!this.isMounted_) return;
             this.setState({
                 items: resp.items,
                 page: 1,
@@ -212,10 +229,11 @@ export default class SummaryListPage extends Component<SummaryListPageProps, Sum
                 loading: false,
                 hasMore: resp.items.length < resp.total,
             }, () => {
-                this.maybeStartBatchPoll();
+                if (this.isMounted_) this.maybeStartBatchPoll();
             });
         } catch (err: any) {
             if (seq !== this.loadDataSeq) return;
+            if (!this.isMounted_) return;
             // Background refresh (silent=true) must not surface a network
             // banner to an idle user — just clear loading and leave the last
             // good list visible. A user-triggered loadData still shows the
@@ -225,6 +243,8 @@ export default class SummaryListPage extends Component<SummaryListPageProps, Sum
                 return;
             }
             this.setState({ error: err.message || t("summary.common.loadingFailed"), loading: false });
+        } finally {
+            this.isLoadingData = false;
         }
     }
 
@@ -237,14 +257,16 @@ export default class SummaryListPage extends Component<SummaryListPageProps, Sum
     };
 
     async loadMore() {
-        if (this.state.loadingMore || !this.state.hasMore || this.state.loading) return;
-        // Capture the loadData generation counter: if any loadData (user or
-        // background-refresh) starts and bumps it while our request is in
-        // flight, the list was reset under us and our appended batch would
-        // splice a hole. Discard on seq mismatch. This is more robust than
-        // the earlier `prev.page !== nextPage - 1` check, which is a no-op
-        // at nextPage === 2 because loadData resets page back to 1 as well
-        // (round-6: Jerry-Xin / yujiawei P1-1).
+        // isLoadingData is a synchronous flag set at loadData entry: closes
+        // the "loadData started first, scroll fires before React commits
+        // loading:true" ordering that reading state.loading would miss.
+        if (this.state.loadingMore || !this.state.hasMore
+            || this.state.loading || this.isLoadingData) return;
+        // Also capture loadDataSeq: if any loadData starts and bumps it
+        // while our request is in flight, the list will be reset under us
+        // and our appended batch would splice a hole. Discard on mismatch.
+        // The pair (isLoadingData at entry + seq at commit) closes both
+        // orderings — loadData-first, loadMore-first — deterministically.
         const seq = this.loadDataSeq;
         this.setState({ loadingMore: true });
         try {
@@ -259,8 +281,6 @@ export default class SummaryListPage extends Component<SummaryListPageProps, Sum
             };
             const resp = await api.listSummaries(params);
             if (seq !== this.loadDataSeq) {
-                // A concurrent loadData landed / is landing; its response is
-                // authoritative for items/page. Drop our batch.
                 this.setState({ loadingMore: false });
                 return;
             }

--- a/packages/dmworksummary/src/pages/SummaryListPage.tsx
+++ b/packages/dmworksummary/src/pages/SummaryListPage.tsx
@@ -77,12 +77,6 @@ export default class SummaryListPage extends Component<SummaryListPageProps, Sum
     private batchPollTimer: ReturnType<typeof setInterval> | null = null;
     private isBatchPolling = false;
     private isRefreshing = false;
-    // Monotonic list-mutation sequence: bumped by every path that mutates
-    // items / page (loadData, loadMore, refreshListSilently). An in-flight
-    // refresh captures the value pre-await and bails on resume if the
-    // sequence advanced — that is what protects the cursor when a
-    // scroll-triggered loadMore races the completion refresh.
-    private listSeq = 0;
     // Cleared by componentWillUnmount so any in-flight refresh's setState
     // becomes a no-op instead of restarting maybeStartBatchPoll on a
     // torn-down component.
@@ -180,10 +174,6 @@ export default class SummaryListPage extends Component<SummaryListPageProps, Sum
     }
 
     async loadData() {
-        // Bump the list-mutation sequence so any in-flight silent refresh
-        // captured before this reload bails on resume instead of clobbering
-        // the freshly-loaded items.
-        this.listSeq++;
         this.setState({ loading: true, error: null, page: 1, hasMore: true });
         try {
             const { pageSize, statusFilter, keyword } = this.state;
@@ -218,10 +208,6 @@ export default class SummaryListPage extends Component<SummaryListPageProps, Sum
 
     async loadMore() {
         if (this.state.loadingMore || !this.state.hasMore || this.state.loading) return;
-        // Bump the list-mutation sequence: an in-flight silent refresh
-        // captured before this loadMore appended a page must bail so it
-        // does not overwrite the appended items or reset the cursor.
-        this.listSeq++;
         this.setState({ loadingMore: true });
         try {
             const nextPage = this.state.page + 1;
@@ -328,35 +314,34 @@ export default class SummaryListPage extends Component<SummaryListPageProps, Sum
     }
 
     /**
-     * 静默全量刷新（#290）：拉取最新列表并替换 items，但不置 `loading`（不闪加载态），
-     * 也不重置分页——用 page_size = pageSize × 已加载页数 一次覆盖所有已加载页，
-     * 保留用户的滚动深度。与 loadData 的区别就是「无加载态、不塌回第 1 页」。
-     * 出错则保留上一份好数据，交给下一次轮询重试。
+     * 静默全量刷新（#290）：拉取最新列表 · 把返回的行 **合并** 进 `state.items`
+     * (按 task_id 覆盖 · 新任务前置)· 从不裁掉用户已加载的尾部 · 从不改
+     * `state.page`。用 `page_size = min(pageSize × page, 100)` 只覆盖前缀,
+     * 用户已滚过的行由 in-place merge 保留不动。与 loadData 的区别:不塌回
+     * 第 1 页、不闪加载态、不缩短列表。出错则保留原状,下次交给终态事件重试。
      *
      * Concurrency invariants:
      * - `isRefreshing` short-circuits overlapping refresh calls.
-     * - `listSeq` (bumped by loadData / loadMore / this method) is captured
-     *   pre-await; a bump during our fetch means another path has already
-     *   mutated items / page, and the refresh response would clobber it.
      * - Captured `statusFilter` / `keyword` / `channelId`: if any changed
-     *   during the fetch the response is scoped to stale filters.
-     * - `loadingMore` bail on resume: a scroll-triggered loadMore may have
-     *   started after we captured listSeq but before its own bump landed;
-     *   check the flag directly to close that window.
+     *   during the fetch the response is scoped to stale filters, drop it.
      * - `isMounted_` guard: don't setState after unmount.
+     *
+     * Merge-not-replace closes the concurrent-writer question by construction:
+     * we never overwrite `items[k]` past what the server just returned, so a
+     * loadMore that appended rows during the fetch cannot lose them, and a
+     * refresh that races another refresh cannot roll rows back. `page` is
+     * refresh-invariant.
      */
     private async refreshListSilently() {
         if (this.isRefreshing) return;
         this.isRefreshing = true;
-        // Capture list identity + filter identity pre-await for the
-        // stale-write guard on resume.
-        const seq = ++this.listSeq;
         const capturedStatus = this.state.statusFilter;
         const capturedKeyword = this.state.keyword;
         const capturedChannel = this.props.channelId;
         try {
             const { pageSize, page } = this.state;
-            // 覆盖已加载页；防止后端对 page_size 有上限，clamp 到 100。
+            // 覆盖已加载页前缀；防止后端对 page_size 有上限，clamp 到 100。
+            // 尾部由 merge 保留，不再依赖此值覆盖全部已加载行。
             const coverSize = Math.min(pageSize * Math.max(1, page), 100);
             const params: ListSummariesParams = {
                 page: 1,
@@ -367,31 +352,29 @@ export default class SummaryListPage extends Component<SummaryListPageProps, Sum
             };
             const resp = await api.listSummaries(params);
             if (!this.isMounted_) return;
-            // Any of these means the response would clobber newer state:
-            //  - listSeq advanced → loadData / loadMore already mutated items/page
-            //  - filter/keyword/channel changed → response is scoped to stale filters
-            //  - loadingMore in flight → its append is authoritative for the cursor
             if (
-                seq !== this.listSeq ||
                 capturedStatus !== this.state.statusFilter ||
                 capturedKeyword !== this.state.keyword ||
-                capturedChannel !== this.props.channelId ||
-                this.state.loadingMore
+                capturedChannel !== this.props.channelId
             ) {
                 return;
             }
-            // Truncate to a whole-page boundary so state.page stays consistent
-            // with items.length regardless of what the backend actually
-            // returned. Math.floor + slice keeps loadMore's `state.page + 1`
-            // pointing at the row immediately after the tail — no gap, no
-            // duplicate — even if the backend cap ever changes.
-            const coveredPages = Math.max(1, Math.floor(resp.items.length / pageSize));
-            const trimmedItems = resp.items.slice(0, coveredPages * pageSize);
-            this.setState({
-                items: trimmedItems,
-                page: coveredPages,
-                total: resp.total,
-                hasMore: trimmedItems.length < resp.total,
+            // Merge instead of replace: overlay fresh rows onto existing by
+            // task_id (fresh wins for enriched fields like title / preview),
+            // preserving user's loaded tail past coverSize. Brand-new tasks
+            // in the fresh response that weren't loaded before come in at
+            // the top (list is sorted newest-first).
+            this.setState((prev) => {
+                const freshById = new Map(resp.items.map((x: any) => [x.task_id, x]));
+                const existingIds = new Set(prev.items.map((x: any) => x.task_id));
+                const newFromFresh = resp.items.filter((x: any) => !existingIds.has(x.task_id));
+                const overlaidExisting = prev.items.map((x: any) => freshById.get(x.task_id) ?? x);
+                const merged = [...newFromFresh, ...overlaidExisting];
+                return {
+                    items: merged as any,
+                    total: resp.total,
+                    hasMore: merged.length < resp.total,
+                };
             }, () => {
                 if (this.isMounted_) this.maybeStartBatchPoll();
             });

--- a/packages/dmworksummary/src/pages/SummaryListPage.tsx
+++ b/packages/dmworksummary/src/pages/SummaryListPage.tsx
@@ -182,12 +182,18 @@ export default class SummaryListPage extends Component<SummaryListPageProps, Sum
 
     async loadData(opts: { silent?: boolean } = {}) {
         // Bump-and-capture sequence: this loadData's response is only allowed
-        // to commit if no newer loadData/filter change has started meanwhile.
-        // Guards against a background refresh (fire-and-forget from
-        // refreshListSilently) overwriting a fresh user-driven loadData that
-        // ran under a newer filter/keyword/space.
+        // to commit if no newer loadData/loadMore/filter change has started
+        // meanwhile. Guards against a background refresh overwriting a fresh
+        // user-driven load, and against a stale loadMore appending after a
+        // loadData reset. Bumping this also invalidates any in-flight
+        // loadMore (which captured its own seq at entry).
         const seq = ++this.loadDataSeq;
-        this.setState({ loading: true, error: null, page: 1, hasMore: true });
+        // Only toggle loading. Do NOT pre-set page:1 / hasMore:true here —
+        // if the request fails in silent mode we would leave items at the
+        // old depth with page reset to 1, and the next loadMore would
+        // duplicate rows (#290 Jerry-Xin / yujiawei round-6 P1-2). Commit
+        // page/hasMore atomically with items on success instead.
+        this.setState({ loading: true, error: null });
         try {
             const { pageSize, statusFilter, keyword } = this.state;
             const params: ListSummariesParams = {
@@ -201,6 +207,7 @@ export default class SummaryListPage extends Component<SummaryListPageProps, Sum
             if (seq !== this.loadDataSeq) return;
             this.setState({
                 items: resp.items,
+                page: 1,
                 total: resp.total,
                 loading: false,
                 hasMore: resp.items.length < resp.total,
@@ -231,6 +238,14 @@ export default class SummaryListPage extends Component<SummaryListPageProps, Sum
 
     async loadMore() {
         if (this.state.loadingMore || !this.state.hasMore || this.state.loading) return;
+        // Capture the loadData generation counter: if any loadData (user or
+        // background-refresh) starts and bumps it while our request is in
+        // flight, the list was reset under us and our appended batch would
+        // splice a hole. Discard on seq mismatch. This is more robust than
+        // the earlier `prev.page !== nextPage - 1` check, which is a no-op
+        // at nextPage === 2 because loadData resets page back to 1 as well
+        // (round-6: Jerry-Xin / yujiawei P1-1).
+        const seq = this.loadDataSeq;
         this.setState({ loadingMore: true });
         try {
             const nextPage = this.state.page + 1;
@@ -243,24 +258,18 @@ export default class SummaryListPage extends Component<SummaryListPageProps, Sum
                 origin_channel_id: this.props.channelId || undefined,
             };
             const resp = await api.listSummaries(params);
-            // Stale-response guard: if a concurrent loadData / silent refresh
-            // reset the list under us (page dropped back below what we captured
-            // pre-await), appending this batch would splice a hole into items.
-            // Discard the batch instead — the fresh list already covers up to
-            // its own extent, and normal scrolling will re-request the next
-            // page in order. Prevents #290 refresh-timer × loadMore race from
-            // permanently corrupting the list.
-            this.setState(prev => {
-                if (prev.page !== nextPage - 1) {
-                    return { loadingMore: false } as any;
-                }
-                return {
-                    items: [...prev.items, ...resp.items],
-                    page: nextPage,
-                    loadingMore: false,
-                    hasMore: prev.items.length + resp.items.length < resp.total,
-                };
-            }, () => this.maybeStartBatchPoll());
+            if (seq !== this.loadDataSeq) {
+                // A concurrent loadData landed / is landing; its response is
+                // authoritative for items/page. Drop our batch.
+                this.setState({ loadingMore: false });
+                return;
+            }
+            this.setState(prev => ({
+                items: [...prev.items, ...resp.items],
+                page: nextPage,
+                loadingMore: false,
+                hasMore: prev.items.length + resp.items.length < resp.total,
+            }), () => this.maybeStartBatchPoll());
         } catch {
             this.setState({ loadingMore: false });
         }

--- a/packages/dmworksummary/src/pages/SummaryListPage.tsx
+++ b/packages/dmworksummary/src/pages/SummaryListPage.tsx
@@ -77,6 +77,13 @@ export default class SummaryListPage extends Component<SummaryListPageProps, Sum
     private batchPollTimer: ReturnType<typeof setInterval> | null = null;
     private isBatchPolling = false;
     private isRefreshing = false;
+    // Monotonic sequence bumped on every loadData() entry. An in-flight
+    // loadData captures the value pre-await; if it advanced during the
+    // request (user changed filter/keyword/space, or another loadData fired),
+    // the response is stale and we drop it instead of overwriting newer
+    // user-driven state. Only loadData bumps — loadMore's cursor consistency
+    // is guarded separately by the prev.page === nextPage-1 check.
+    private loadDataSeq = 0;
     // Cleared by componentWillUnmount so any in-flight refresh's setState
     // becomes a no-op instead of restarting maybeStartBatchPoll on a
     // torn-down component.
@@ -173,7 +180,13 @@ export default class SummaryListPage extends Component<SummaryListPageProps, Sum
         return { items: resp.items, total: resp.total };
     }
 
-    async loadData() {
+    async loadData(opts: { silent?: boolean } = {}) {
+        // Bump-and-capture sequence: this loadData's response is only allowed
+        // to commit if no newer loadData/filter change has started meanwhile.
+        // Guards against a background refresh (fire-and-forget from
+        // refreshListSilently) overwriting a fresh user-driven loadData that
+        // ran under a newer filter/keyword/space.
+        const seq = ++this.loadDataSeq;
         this.setState({ loading: true, error: null, page: 1, hasMore: true });
         try {
             const { pageSize, statusFilter, keyword } = this.state;
@@ -185,6 +198,7 @@ export default class SummaryListPage extends Component<SummaryListPageProps, Sum
                 origin_channel_id: this.props.channelId || undefined,
             };
             const resp = await api.listSummaries(params);
+            if (seq !== this.loadDataSeq) return;
             this.setState({
                 items: resp.items,
                 total: resp.total,
@@ -194,6 +208,15 @@ export default class SummaryListPage extends Component<SummaryListPageProps, Sum
                 this.maybeStartBatchPoll();
             });
         } catch (err: any) {
+            if (seq !== this.loadDataSeq) return;
+            // Background refresh (silent=true) must not surface a network
+            // banner to an idle user — just clear loading and leave the last
+            // good list visible. A user-triggered loadData still shows the
+            // banner + Retry so they can act on the failure.
+            if (opts.silent) {
+                this.setState({ loading: false });
+                return;
+            }
             this.setState({ error: err.message || t("summary.common.loadingFailed"), loading: false });
         }
     }
@@ -339,26 +362,17 @@ export default class SummaryListPage extends Component<SummaryListPageProps, Sum
      * 由 loadData 重置为 1(loadMore 的 stale-response guard 会 discard 过期 append)。
      *
      * `isRefreshing` 防重入(2s 轮询 tick 撞到 refresh 在跑就跳过);
-     * `isMounted_` 在进入 loadData 前短路(loadData 内部 React 对 unmounted
-     * 组件的 setState 已经是 no-op,但显式检查更明确)。
+     * `isMounted_` 在进入 loadData 前短路。
      *
-     * 背景刷新故意吞掉 loadData 抛出的错误:自动 refresh 不该给 idle 的用户
-     * 弹网络错误 banner(loadData 的 catch 会设 state.error 显示 <Banner>)。
-     * 快照错误状态,失败时恢复—用户下次手动触发时才看得到真实错误。
+     * `silent: true` 让 loadData 在失败时不设 error banner(见 #290 review):
+     * 自动 refresh 不该给 idle 的用户弹网络错误。
      */
     private async refreshListSilently() {
         if (this.isRefreshing) return;
         if (!this.isMounted_) return;
         this.isRefreshing = true;
-        const savedError = this.state.error;
         try {
-            await this.loadData();
-            // If loadData set an error banner during a background refresh,
-            // restore the pre-refresh error state so an idle user does not
-            // see a network banner on an otherwise healthy list.
-            if (this.isMounted_ && this.state.error && !savedError) {
-                this.setState({ error: null });
-            }
+            await this.loadData({ silent: true });
         } finally {
             this.isRefreshing = false;
         }

--- a/packages/dmworksummary/src/pages/SummaryListPage.tsx
+++ b/packages/dmworksummary/src/pages/SummaryListPage.tsx
@@ -220,12 +220,24 @@ export default class SummaryListPage extends Component<SummaryListPageProps, Sum
                 origin_channel_id: this.props.channelId || undefined,
             };
             const resp = await api.listSummaries(params);
-            this.setState(prev => ({
-                items: [...prev.items, ...resp.items],
-                page: nextPage,
-                loadingMore: false,
-                hasMore: prev.items.length + resp.items.length < resp.total,
-            }), () => this.maybeStartBatchPoll());
+            // Stale-response guard: if a concurrent loadData / silent refresh
+            // reset the list under us (page dropped back below what we captured
+            // pre-await), appending this batch would splice a hole into items.
+            // Discard the batch instead — the fresh list already covers up to
+            // its own extent, and normal scrolling will re-request the next
+            // page in order. Prevents #290 refresh-timer × loadMore race from
+            // permanently corrupting the list.
+            this.setState(prev => {
+                if (prev.page !== nextPage - 1) {
+                    return { loadingMore: false } as any;
+                }
+                return {
+                    items: [...prev.items, ...resp.items],
+                    page: nextPage,
+                    loadingMore: false,
+                    hasMore: prev.items.length + resp.items.length < resp.total,
+                };
+            }, () => this.maybeStartBatchPoll());
         } catch {
             this.setState({ loadingMore: false });
         }
@@ -283,7 +295,11 @@ export default class SummaryListPage extends Component<SummaryListPageProps, Sum
             if (changed) {
                 // #290：进入终态时，仅原地打 status 补丁不够——完成后 backend 才会
                 // 填/改标题、结果预览等字段，且列表加载后新建的任务不在轮询集合里。
-                // 因此终态变化触发一次「静默」全量刷新（不显示加载态、不重置分页深度）。
+                // 因此终态变化触发一次全量刷新(委派给 loadData · 见 refreshListSilently)。
+                // 会短暂显示 spinner + 塌回 page 1—这是 loadData 的必然副作用,
+                // 换来 correct-by-construction 的过滤/space/loadMore 语义。
+                // 本地 status 补丁在触发刷新前先落到 items,避免卡片在往返窗口里
+                // 显示陈旧的 non-terminal 状态(含取消按钮)。
                 const hasTerminal = changedIds.some(id => {
                     const u = updateMap.get(id);
                     return !!u && isTerminalStatus(u.status);
@@ -314,25 +330,35 @@ export default class SummaryListPage extends Component<SummaryListPageProps, Sum
     }
 
     /**
-     * 静默全量刷新（#290）：任务进入终态后调用 loadData()。#290 原方案就是
-     * 用 loadData() —— 我们绕过它想避免 spinner + page collapse,但四轮
-     * review 后结论是:offset-paged list 上做静默 refresh + merge/replace
-     * 都会在某个 route 破坏 filter/space/loadMore 语义。loadData 是
-     * "correct by construction" 姿势(见 yujiawei round-4 escalation
-     * 建议 a)—— spinner 一闪是合理的用户反馈,而且 loadData 恢复了旧
-     * replace 模型的正确性:filter 变化时 fall-out 行会被丢掉、space
-     * 切换清空、loadMore 的分页游标被重置。
+     * 终态完成后刷新列表(#290)。委派给 loadData —— #290 原方案就是用 loadData()。
+     * 我们绕过它想避免 spinner + page collapse,但四轮 review 后结论是:
+     * offset-paged list 上做静默 refresh + merge/replace 都会在某个 route 破坏
+     * filter/space/loadMore 语义。loadData 是 "correct by construction" 姿势 ——
+     * spinner 一闪是合理的用户反馈,而且 loadData 恢复了旧 replace 模型的正确性:
+     * filter 变化时 fall-out 行会被丢掉、space 切换清空、loadMore 的分页游标
+     * 由 loadData 重置为 1(loadMore 的 stale-response guard 会 discard 过期 append)。
      *
      * `isRefreshing` 防重入(2s 轮询 tick 撞到 refresh 在跑就跳过);
-     * `isMounted_` 由 loadData 内部无需再查,但保留在 componentWillUnmount
-     * 里让其他 in-flight 逻辑安全。
+     * `isMounted_` 在进入 loadData 前短路(loadData 内部 React 对 unmounted
+     * 组件的 setState 已经是 no-op,但显式检查更明确)。
+     *
+     * 背景刷新故意吞掉 loadData 抛出的错误:自动 refresh 不该给 idle 的用户
+     * 弹网络错误 banner(loadData 的 catch 会设 state.error 显示 <Banner>)。
+     * 快照错误状态,失败时恢复—用户下次手动触发时才看得到真实错误。
      */
     private async refreshListSilently() {
         if (this.isRefreshing) return;
         if (!this.isMounted_) return;
         this.isRefreshing = true;
+        const savedError = this.state.error;
         try {
             await this.loadData();
+            // If loadData set an error banner during a background refresh,
+            // restore the pre-refresh error state so an idle user does not
+            // see a network banner on an otherwise healthy list.
+            if (this.isMounted_ && this.state.error && !savedError) {
+                this.setState({ error: null });
+            }
         } finally {
             this.isRefreshing = false;
         }

--- a/packages/dmworksummary/src/pages/__tests__/SummaryListPage.autoRefresh.test.tsx
+++ b/packages/dmworksummary/src/pages/__tests__/SummaryListPage.autoRefresh.test.tsx
@@ -61,7 +61,7 @@ function makePage(items: Array<Record<string, unknown>>) {
 describe('SummaryListPage auto-refresh on completion (#290)', () => {
     beforeEach(() => vi.clearAllMocks());
 
-    it('silently reloads the full list AND applies the local status patch immediately when a task reaches a terminal status', async () => {
+    it('applies the local status patch immediately AND fires the silent refresh when a task reaches a terminal status', async () => {
         vi.mocked(api.batchStatus).mockResolvedValue([
             { id: 1, status: TaskStatus.COMPLETED },
         ] as any);
@@ -77,15 +77,13 @@ describe('SummaryListPage auto-refresh on completion (#290)', () => {
         await (page as any).doBatchPoll([1]);
         await new Promise((r) => setTimeout(r, 0));
 
-        // The confirmed terminal status must be applied locally BEFORE the
-        // async refresh lands, so the card does not render a stale PROCESSING
-        // status (with Cancel affordance) for the round-trip window.
+        // Local status patch applied BEFORE the async refresh lands, so the
+        // card does not render a stale PROCESSING status for the round-trip.
         const firstPatch = setStatePatches[0];
         expect(firstPatch).toBeDefined();
         expect((firstPatch as any).items?.[0]).toMatchObject({ status: TaskStatus.COMPLETED });
 
-        // Full list re-fetched (title/preview reflected), not just an
-        // in-place status patch.
+        // Full list re-fetched and merged (enriched title visible).
         expect(api.listSummaries).toHaveBeenCalledTimes(1);
         expect((page.state as any).items[0]).toMatchObject({ topic: '完成后的标题' });
 
@@ -110,29 +108,29 @@ describe('SummaryListPage auto-refresh on completion (#290)', () => {
     });
 
     /**
-     * When `pageSize * page > 100`, the refresh clamps and returns fewer
-     * items than were previously loaded. state.page must be re-anchored so
-     * the next loadMore() picks up the row immediately after the refreshed
-     * tail — otherwise items in the gap are permanently skipped. This test
-     * asserts both the re-anchor AND the observable consequence (next
-     * loadMore requests the correct page).
+     * Merge-not-replace: when the refresh is clamped at 100 rows but the user
+     * has loaded 120, the loaded tail past coverSize must be preserved
+     * in-place (rows 101–120 keep showing). state.page is never touched by
+     * the refresh, so the next loadMore continues from where the user left.
      */
-    it('re-anchors state.page after a clamped refresh so the next loadMore() picks up the true tail', async () => {
+    it('preserves the loaded tail past the refresh cap (merge, not replace)', async () => {
         vi.mocked(api.batchStatus).mockResolvedValue([
             { id: 42, status: TaskStatus.COMPLETED },
         ] as any);
-        // Backend caps page_size at 100 — return exactly 100 items but a much
-        // larger total so hasMore stays true.
+        // Backend caps page_size at 100 — return 100 items with enriched
+        // titles, plus a much larger total so hasMore stays true.
         const refreshedItems = Array.from({ length: 100 }, (_, i) => ({
             task_id: i + 1,
             status: TaskStatus.COMPLETED,
-            topic: `t${i + 1}`,
+            topic: `enriched-${i + 1}`,
         }));
         vi.mocked(api.listSummaries).mockResolvedValue({
             items: refreshedItems,
             total: 240,
         } as any);
 
+        // Simulate user has 120 rows loaded, at page 6 with pageSize 20.
+        // task 42 is currently PROCESSING; the poll detects it's COMPLETED.
         const initialItems = Array.from({ length: 120 }, (_, i) => ({
             task_id: i + 1,
             status: i === 41 ? TaskStatus.PROCESSING : TaskStatus.COMPLETED,
@@ -145,73 +143,61 @@ describe('SummaryListPage auto-refresh on completion (#290)', () => {
         await new Promise((r) => setTimeout(r, 0));
 
         expect(api.listSummaries).toHaveBeenCalledTimes(1);
-        // Only 100 items came back; state.page must be re-anchored to
-        // Ceil(100 / 20) = 5 so the next loadMore() requests page 6.
-        expect((page.state as any).items).toHaveLength(100);
-        expect((page.state as any).page).toBe(5);
-        expect((page.state as any).hasMore).toBe(true);
 
-        // Observable consequence: the next loadMore() requests page 6.
-        vi.mocked(api.listSummaries).mockClear();
-        vi.mocked(api.listSummaries).mockResolvedValue({
-            items: Array.from({ length: 20 }, (_, i) => ({
-                task_id: i + 101,
-                status: TaskStatus.COMPLETED,
-                topic: `t${i + 101}`,
-            })),
-            total: 240,
-        } as any);
+        // Prefix 1..100 got enriched (fresh title), tail 101..120 preserved
+        // in place (old title). Task 42 in the prefix now has the enriched
+        // topic AND the COMPLETED status.
+        const items = (page.state as any).items;
+        expect(items).toHaveLength(120);
+        expect(items[0].topic).toBe('enriched-1');
+        expect(items[41].status).toBe(TaskStatus.COMPLETED);
+        expect(items[99].topic).toBe('enriched-100');
+        expect(items[100].topic).toBe('old-101');
+        expect(items[119].topic).toBe('old-120');
 
-        await (page as any).loadMore();
-        await new Promise((r) => setTimeout(r, 0));
-
-        expect(api.listSummaries).toHaveBeenCalledWith(
-            expect.objectContaining({ page: 6, page_size: 20 })
-        );
+        // state.page must NOT be touched — refresh preserves the cursor.
+        expect((page.state as any).page).toBe(6);
     });
 
     /**
-     * If the user changes the status filter while a refresh is in flight,
-     * the refresh must drop its stale response rather than clobbering the
-     * newer state.
+     * When resp.items contains a brand-new task_id not in state.items (a task
+     * created after the initial load), it lands at the top of the list.
      */
-    it('drops the refresh response if the status filter changed while the fetch was in flight', async () => {
+    it('inserts brand-new tasks from the refresh at the top of the list', async () => {
         vi.mocked(api.batchStatus).mockResolvedValue([
             { id: 1, status: TaskStatus.COMPLETED },
         ] as any);
+        vi.mocked(api.listSummaries).mockResolvedValue({
+            items: [
+                { task_id: 999, status: TaskStatus.COMPLETED, topic: 'brand-new-task' },
+                { task_id: 1, status: TaskStatus.COMPLETED, topic: 'enriched-existing' },
+            ],
+            total: 2,
+        } as any);
 
-        let resolveList: (v: any) => void = () => {};
-        const listPromise = new Promise((r) => { resolveList = r; });
-        vi.mocked(api.listSummaries).mockReturnValue(listPromise as any);
+        const { page } = makePage([
+            { task_id: 1, status: TaskStatus.PROCESSING, topic: 'old-existing' },
+        ]);
 
-        const { page } = makePage([{ task_id: 1, status: TaskStatus.PROCESSING, topic: 'x' }]);
-
-        const pollPromise = (page as any).doBatchPoll([1]);
+        await (page as any).doBatchPoll([1]);
         await new Promise((r) => setTimeout(r, 0));
 
-        (page as any).state = { ...(page as any).state, statusFilter: TaskStatus.COMPLETED };
-        const filteredItems = [{ task_id: 999, status: TaskStatus.COMPLETED, topic: 'filtered' }];
-
-        resolveList({ items: filteredItems, total: 999 });
-        await pollPromise;
-        await new Promise((r) => setTimeout(r, 0));
-
-        // The stale response must NOT have overwritten items.
-        expect((page.state as any).items).toHaveLength(1);
-        expect((page.state as any).items[0].task_id).toBe(1);
-        expect((page.state as any).total).not.toBe(999);
+        const items = (page.state as any).items;
+        expect(items).toHaveLength(2);
+        expect(items[0].task_id).toBe(999);
+        expect(items[0].topic).toBe('brand-new-task');
+        expect(items[1].task_id).toBe(1);
+        expect(items[1].topic).toBe('enriched-existing');
     });
 
     /**
-     * If loadMore appends a new page while the silent refresh is in flight,
-     * the refresh's response would otherwise clobber the appended items and
-     * reset the cursor. The listSeq bump inside loadMore signals the refresh
-     * to bail on resume — the appended tail must survive. This is asserted
-     * directly against refreshListSilently rather than the full poll flow
-     * so promise ordering is deterministic.
+     * If a concurrent loadMore appends a page while the refresh is in flight,
+     * merge-not-replace preserves the appended tail by construction: the
+     * setState uses the LATEST state.items (via functional updater), so any
+     * rows that landed during the fetch are still present.
      */
-    it('drops the refresh response if loadMore bumped listSeq while the fetch was in flight', async () => {
-        // 120 items already loaded; state.page = 6, pageSize = 20.
+    it('preserves items appended by a concurrent loadMore (merge-not-replace)', async () => {
+        // 120 rows loaded at page 6.
         const initialItems = Array.from({ length: 120 }, (_, i) => ({
             task_id: i + 1,
             status: TaskStatus.COMPLETED,
@@ -225,13 +211,12 @@ describe('SummaryListPage auto-refresh on completion (#290)', () => {
             () => new Promise((r) => { resolveRefresh = r; }) as any
         );
 
-        // Fire the refresh directly and don't await.
+        // Fire refresh directly, don't await.
         const refreshPromise = (page as any).refreshListSilently();
         await new Promise((r) => setTimeout(r, 0));
 
-        // Simulate a concurrent loadMore having landed: it bumps listSeq
-        // and mutates state (appends items, advances page).
-        (page as any).listSeq++;
+        // Simulate loadMore having landed while the refresh awaited:
+        // 20 new rows appended, page advanced.
         const appendedItems = Array.from({ length: 20 }, (_, i) => ({
             task_id: i + 121,
             status: TaskStatus.COMPLETED,
@@ -243,29 +228,67 @@ describe('SummaryListPage auto-refresh on completion (#290)', () => {
             page: 7,
         };
 
-        // Refresh resolves: its response would reset items to 100 rows and
-        // page to 5. The listSeq bump must make it bail.
+        // Refresh resolves with 100 rows.
         resolveRefresh({
             items: Array.from({ length: 100 }, (_, i) => ({
                 task_id: i + 1,
                 status: TaskStatus.COMPLETED,
-                topic: `stale-${i + 1}`,
+                topic: `enriched-${i + 1}`,
             })),
             total: 240,
         });
         await refreshPromise;
 
-        // The appended tail must survive: items still 140 rows, page still 7.
-        expect((page.state as any).items).toHaveLength(140);
+        // The appended tail must survive: rows 121-140 still there, page 7
+        // preserved. Prefix 1-100 enriched; 101-120 old; 121-140 appended.
+        const items = (page.state as any).items;
+        expect(items).toHaveLength(140);
         expect((page.state as any).page).toBe(7);
-        expect((page.state as any).items[139].topic).toBe('page7-140');
+        expect(items[0].topic).toBe('enriched-1');
+        expect(items[100].topic).toBe('t101');
+        expect(items[139].topic).toBe('page7-140');
     });
 
     /**
-     * If the refresh request throws, the local status patch applied before
-     * the refresh must survive so the next poll tick does not re-detect the
-     * same transition. The refresh's isRefreshing flag must also be reset
-     * so the next poll can retry.
+     * Drop stale response when the status filter changed mid-flight.
+     */
+    it('drops the refresh response if the status filter changed while the fetch was in flight', async () => {
+        vi.mocked(api.batchStatus).mockResolvedValue([
+            { id: 1, status: TaskStatus.COMPLETED },
+        ] as any);
+
+        let resolveList: (v: any) => void = () => {};
+        vi.mocked(api.listSummaries).mockReturnValue(
+            new Promise((r) => { resolveList = r; }) as any
+        );
+
+        const { page } = makePage([{ task_id: 1, status: TaskStatus.PROCESSING, topic: 'x' }]);
+
+        const pollPromise = (page as any).doBatchPoll([1]);
+        await new Promise((r) => setTimeout(r, 0));
+
+        // User picks a filter mid-flight.
+        (page as any).state = { ...(page as any).state, statusFilter: TaskStatus.COMPLETED };
+
+        resolveList({
+            items: [{ task_id: 999, status: TaskStatus.COMPLETED, topic: 'filtered' }],
+            total: 999,
+        });
+        await pollPromise;
+        await new Promise((r) => setTimeout(r, 0));
+
+        // Stale response dropped — items still reflects the local patch (COMPLETED task 1),
+        // not the filtered response.
+        expect((page.state as any).items).toHaveLength(1);
+        expect((page.state as any).items[0].task_id).toBe(1);
+        expect((page.state as any).total).not.toBe(999);
+    });
+
+    /**
+     * When the refresh throws, the local status patch survives; isRefreshing
+     * resets so the next tick can retry (though structurally a second retry
+     * won't happen for the same transition, since the local patch stops the
+     * "change detected" branch).
      */
     it('preserves the local status patch when the refresh request throws', async () => {
         vi.mocked(api.batchStatus).mockResolvedValue([
@@ -276,14 +299,11 @@ describe('SummaryListPage auto-refresh on completion (#290)', () => {
         const { page } = makePage([{ task_id: 1, status: TaskStatus.PROCESSING, topic: 'x' }]);
 
         await (page as any).doBatchPoll([1]);
-        // Yield until the fire-and-forget refresh's finally block runs.
         for (let i = 0; i < 5; i++) {
             await new Promise((r) => setTimeout(r, 0));
         }
 
-        // Local patch survived: item is COMPLETED even though refresh threw.
         expect((page.state as any).items[0]).toMatchObject({ status: TaskStatus.COMPLETED });
-        // isRefreshing is reset so the next poll tick can try again.
         expect((page as any).isRefreshing).toBe(false);
     });
 });

--- a/packages/dmworksummary/src/pages/__tests__/SummaryListPage.autoRefresh.test.tsx
+++ b/packages/dmworksummary/src/pages/__tests__/SummaryListPage.autoRefresh.test.tsx
@@ -191,4 +191,89 @@ describe('SummaryListPage auto-refresh on completion (#290)', () => {
         resolveList({ items: [], total: 0 });
         await first;
     });
+
+    /**
+     * P1-1 regression (yujiawei round-5): if loadMore is in flight when the
+     * background refresh (via loadData) resets page to 1 and replaces items,
+     * appending loadMore's stale response would splice a hole. The
+     * `prev.page !== nextPage - 1` guard in loadMore must discard the batch
+     * instead. Cover both interleavings.
+     */
+    it('discards a stale loadMore response when refresh reset the list first', async () => {
+        // Start at page 5, 100 rows loaded, hasMore=true.
+        const initialItems = Array.from({ length: 100 }, (_, i) => ({
+            task_id: i + 1,
+            status: TaskStatus.COMPLETED,
+            topic: `t${i + 1}`,
+        }));
+        const { page } = makePage(initialItems);
+        (page as any).state = {
+            ...(page as any).state,
+            page: 5,
+            pageSize: 20,
+            hasMore: true,
+        };
+
+        // loadMore fires: captures nextPage=6, awaits.
+        let resolveLoadMore: (v: any) => void = () => {};
+        vi.mocked(api.listSummaries).mockImplementationOnce(
+            () => new Promise((r) => { resolveLoadMore = r; }) as any
+        );
+        const loadMorePromise = (page as any).loadMore();
+        await new Promise((r) => setTimeout(r, 0));
+
+        // Simulate a concurrent refresh landing first: it reset page to 1 and
+        // replaced items with a fresh page-1 batch.
+        (page as any).state = {
+            ...(page as any).state,
+            items: Array.from({ length: 20 }, (_, i) => ({
+                task_id: i + 1,
+                status: TaskStatus.COMPLETED,
+                topic: `fresh-${i + 1}`,
+            })),
+            page: 1,
+            hasMore: true,
+        };
+
+        // Now loadMore's stale page-6 response resolves.
+        resolveLoadMore({
+            items: Array.from({ length: 20 }, (_, i) => ({
+                task_id: i + 101,
+                status: TaskStatus.COMPLETED,
+                topic: `stale-${i + 101}`,
+            })),
+            total: 200,
+        });
+        await loadMorePromise;
+
+        // The stale batch must be discarded: items stays at the fresh page-1
+        // (20 rows, page=1) — no hole is spliced in, no stale rows appended.
+        const items = (page.state as any).items;
+        expect(items).toHaveLength(20);
+        expect((page.state as any).page).toBe(1);
+        expect(items[0].topic).toBe('fresh-1');
+        expect(items[19].topic).toBe('fresh-20');
+        // loadingMore reset so scroll can resume.
+        expect((page.state as any).loadingMore).toBe(false);
+    });
+
+    /**
+     * P2-6 regression: a failed background refresh should not surface an
+     * error banner to an idle user. If loadData sets state.error during the
+     * refresh, refreshListSilently must clear it (unless there was already
+     * a pre-refresh error, which is unrelated and should be preserved).
+     */
+    it('suppresses the loadData error banner on background refresh failure', async () => {
+        vi.mocked(api.listSummaries).mockRejectedValue(new Error('network'));
+
+        const { page } = makePage([
+            { task_id: 1, status: TaskStatus.COMPLETED, topic: 'x' },
+        ]);
+        expect((page.state as any).error).toBeFalsy();
+
+        await (page as any).refreshListSilently();
+
+        // The error banner must not persist on an otherwise healthy list.
+        expect((page.state as any).error).toBeFalsy();
+    });
 });

--- a/packages/dmworksummary/src/pages/__tests__/SummaryListPage.autoRefresh.test.tsx
+++ b/packages/dmworksummary/src/pages/__tests__/SummaryListPage.autoRefresh.test.tsx
@@ -1,0 +1,289 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@octo/base', async () => {
+    const actual = await vi.importActual<Record<string, unknown>>('../../__mocks__/dmworkBase');
+    return { ...actual };
+});
+vi.mock('@douyinfe/semi-ui', () => ({
+    Button: () => null,
+    Dropdown: () => null,
+    Toast: { success: vi.fn(), error: vi.fn() },
+    Banner: () => null,
+    Tooltip: () => null,
+}));
+vi.mock('@douyinfe/semi-icons', () => ({
+    IconSearch: () => null,
+    IconPlus: () => null,
+    IconRefresh: () => null,
+}));
+vi.mock('../../components/SummaryCard', () => ({ default: () => null }));
+vi.mock('../SummaryCreatePage', () => ({ default: () => null }));
+vi.mock('../SummaryDetailPage', () => ({ default: () => null }));
+vi.mock('../../api/summaryApi');
+
+import * as api from '../../api/summaryApi';
+import SummaryListPage from '../SummaryListPage';
+import { TaskStatus } from '../../types/summary';
+
+/**
+ * Build a page whose setState applies synchronously and runs the callback,
+ * so refreshListSilently()'s post-setState side effects are exercised. Heavy
+ * side effects (poll scheduling) are stubbed to no-ops. setState records
+ * every patch it received so tests can assert on the flow, not just the
+ * final value.
+ */
+function makePage(items: Array<Record<string, unknown>>) {
+    const page = new SummaryListPage({} as any);
+    const setStatePatches: Array<Record<string, unknown>> = [];
+    (page as any).state = {
+        ...(page.state as any),
+        items,
+        page: 1,
+        pageSize: 20,
+        statusFilter: undefined,
+        keyword: '',
+        loading: false,
+        loadingMore: false,
+        hasMore: true,
+    };
+    (page as any).isMounted_ = true;
+    (page as any).setState = function (this: any, patch: any, cb?: () => void) {
+        const resolved = typeof patch === 'function' ? patch(this.state) : patch;
+        setStatePatches.push(resolved);
+        this.state = { ...this.state, ...resolved };
+        cb?.();
+    };
+    vi.spyOn(page as any, 'maybeStartBatchPoll').mockImplementation(() => {});
+    vi.spyOn(page as any, 'stopBatchPoll').mockImplementation(() => {});
+    return { page, setStatePatches };
+}
+
+describe('SummaryListPage auto-refresh on completion (#290)', () => {
+    beforeEach(() => vi.clearAllMocks());
+
+    it('silently reloads the full list AND applies the local status patch immediately when a task reaches a terminal status', async () => {
+        vi.mocked(api.batchStatus).mockResolvedValue([
+            { id: 1, status: TaskStatus.COMPLETED },
+        ] as any);
+        vi.mocked(api.listSummaries).mockResolvedValue({
+            items: [{ task_id: 1, status: TaskStatus.COMPLETED, topic: '完成后的标题' }],
+            total: 1,
+        } as any);
+
+        const { page, setStatePatches } = makePage([
+            { task_id: 1, status: TaskStatus.PROCESSING, topic: '旧标题' },
+        ]);
+
+        await (page as any).doBatchPoll([1]);
+        await new Promise((r) => setTimeout(r, 0));
+
+        // The confirmed terminal status must be applied locally BEFORE the
+        // async refresh lands, so the card does not render a stale PROCESSING
+        // status (with Cancel affordance) for the round-trip window.
+        const firstPatch = setStatePatches[0];
+        expect(firstPatch).toBeDefined();
+        expect((firstPatch as any).items?.[0]).toMatchObject({ status: TaskStatus.COMPLETED });
+
+        // Full list re-fetched (title/preview reflected), not just an
+        // in-place status patch.
+        expect(api.listSummaries).toHaveBeenCalledTimes(1);
+        expect((page.state as any).items[0]).toMatchObject({ topic: '完成后的标题' });
+
+        // Silent: assert no setState patch ever tried to set loading:true.
+        for (const p of setStatePatches) {
+            expect((p as any).loading).not.toBe(true);
+        }
+    });
+
+    it('only patches status in place for non-terminal transitions (no full reload)', async () => {
+        vi.mocked(api.batchStatus).mockResolvedValue([
+            { id: 1, status: TaskStatus.PROCESSING },
+        ] as any);
+
+        const { page } = makePage([{ task_id: 1, status: TaskStatus.PENDING, topic: 'x' }]);
+
+        await (page as any).doBatchPoll([1]);
+        await new Promise((r) => setTimeout(r, 0));
+
+        expect(api.listSummaries).not.toHaveBeenCalled();
+        expect((page.state as any).items[0]).toMatchObject({ status: TaskStatus.PROCESSING });
+    });
+
+    /**
+     * When `pageSize * page > 100`, the refresh clamps and returns fewer
+     * items than were previously loaded. state.page must be re-anchored so
+     * the next loadMore() picks up the row immediately after the refreshed
+     * tail — otherwise items in the gap are permanently skipped. This test
+     * asserts both the re-anchor AND the observable consequence (next
+     * loadMore requests the correct page).
+     */
+    it('re-anchors state.page after a clamped refresh so the next loadMore() picks up the true tail', async () => {
+        vi.mocked(api.batchStatus).mockResolvedValue([
+            { id: 42, status: TaskStatus.COMPLETED },
+        ] as any);
+        // Backend caps page_size at 100 — return exactly 100 items but a much
+        // larger total so hasMore stays true.
+        const refreshedItems = Array.from({ length: 100 }, (_, i) => ({
+            task_id: i + 1,
+            status: TaskStatus.COMPLETED,
+            topic: `t${i + 1}`,
+        }));
+        vi.mocked(api.listSummaries).mockResolvedValue({
+            items: refreshedItems,
+            total: 240,
+        } as any);
+
+        const initialItems = Array.from({ length: 120 }, (_, i) => ({
+            task_id: i + 1,
+            status: i === 41 ? TaskStatus.PROCESSING : TaskStatus.COMPLETED,
+            topic: `old-${i + 1}`,
+        }));
+        const { page } = makePage(initialItems);
+        (page as any).state = { ...(page as any).state, page: 6, pageSize: 20 };
+
+        await (page as any).doBatchPoll([42]);
+        await new Promise((r) => setTimeout(r, 0));
+
+        expect(api.listSummaries).toHaveBeenCalledTimes(1);
+        // Only 100 items came back; state.page must be re-anchored to
+        // Ceil(100 / 20) = 5 so the next loadMore() requests page 6.
+        expect((page.state as any).items).toHaveLength(100);
+        expect((page.state as any).page).toBe(5);
+        expect((page.state as any).hasMore).toBe(true);
+
+        // Observable consequence: the next loadMore() requests page 6.
+        vi.mocked(api.listSummaries).mockClear();
+        vi.mocked(api.listSummaries).mockResolvedValue({
+            items: Array.from({ length: 20 }, (_, i) => ({
+                task_id: i + 101,
+                status: TaskStatus.COMPLETED,
+                topic: `t${i + 101}`,
+            })),
+            total: 240,
+        } as any);
+
+        await (page as any).loadMore();
+        await new Promise((r) => setTimeout(r, 0));
+
+        expect(api.listSummaries).toHaveBeenCalledWith(
+            expect.objectContaining({ page: 6, page_size: 20 })
+        );
+    });
+
+    /**
+     * If the user changes the status filter while a refresh is in flight,
+     * the refresh must drop its stale response rather than clobbering the
+     * newer state.
+     */
+    it('drops the refresh response if the status filter changed while the fetch was in flight', async () => {
+        vi.mocked(api.batchStatus).mockResolvedValue([
+            { id: 1, status: TaskStatus.COMPLETED },
+        ] as any);
+
+        let resolveList: (v: any) => void = () => {};
+        const listPromise = new Promise((r) => { resolveList = r; });
+        vi.mocked(api.listSummaries).mockReturnValue(listPromise as any);
+
+        const { page } = makePage([{ task_id: 1, status: TaskStatus.PROCESSING, topic: 'x' }]);
+
+        const pollPromise = (page as any).doBatchPoll([1]);
+        await new Promise((r) => setTimeout(r, 0));
+
+        (page as any).state = { ...(page as any).state, statusFilter: TaskStatus.COMPLETED };
+        const filteredItems = [{ task_id: 999, status: TaskStatus.COMPLETED, topic: 'filtered' }];
+
+        resolveList({ items: filteredItems, total: 999 });
+        await pollPromise;
+        await new Promise((r) => setTimeout(r, 0));
+
+        // The stale response must NOT have overwritten items.
+        expect((page.state as any).items).toHaveLength(1);
+        expect((page.state as any).items[0].task_id).toBe(1);
+        expect((page.state as any).total).not.toBe(999);
+    });
+
+    /**
+     * If loadMore appends a new page while the silent refresh is in flight,
+     * the refresh's response would otherwise clobber the appended items and
+     * reset the cursor. The listSeq bump inside loadMore signals the refresh
+     * to bail on resume — the appended tail must survive. This is asserted
+     * directly against refreshListSilently rather than the full poll flow
+     * so promise ordering is deterministic.
+     */
+    it('drops the refresh response if loadMore bumped listSeq while the fetch was in flight', async () => {
+        // 120 items already loaded; state.page = 6, pageSize = 20.
+        const initialItems = Array.from({ length: 120 }, (_, i) => ({
+            task_id: i + 1,
+            status: TaskStatus.COMPLETED,
+            topic: `t${i + 1}`,
+        }));
+        const { page } = makePage(initialItems);
+        (page as any).state = { ...(page as any).state, page: 6, pageSize: 20 };
+
+        let resolveRefresh: (v: any) => void = () => {};
+        vi.mocked(api.listSummaries).mockImplementationOnce(
+            () => new Promise((r) => { resolveRefresh = r; }) as any
+        );
+
+        // Fire the refresh directly and don't await.
+        const refreshPromise = (page as any).refreshListSilently();
+        await new Promise((r) => setTimeout(r, 0));
+
+        // Simulate a concurrent loadMore having landed: it bumps listSeq
+        // and mutates state (appends items, advances page).
+        (page as any).listSeq++;
+        const appendedItems = Array.from({ length: 20 }, (_, i) => ({
+            task_id: i + 121,
+            status: TaskStatus.COMPLETED,
+            topic: `page7-${i + 121}`,
+        }));
+        (page as any).state = {
+            ...(page as any).state,
+            items: [...(page as any).state.items, ...appendedItems],
+            page: 7,
+        };
+
+        // Refresh resolves: its response would reset items to 100 rows and
+        // page to 5. The listSeq bump must make it bail.
+        resolveRefresh({
+            items: Array.from({ length: 100 }, (_, i) => ({
+                task_id: i + 1,
+                status: TaskStatus.COMPLETED,
+                topic: `stale-${i + 1}`,
+            })),
+            total: 240,
+        });
+        await refreshPromise;
+
+        // The appended tail must survive: items still 140 rows, page still 7.
+        expect((page.state as any).items).toHaveLength(140);
+        expect((page.state as any).page).toBe(7);
+        expect((page.state as any).items[139].topic).toBe('page7-140');
+    });
+
+    /**
+     * If the refresh request throws, the local status patch applied before
+     * the refresh must survive so the next poll tick does not re-detect the
+     * same transition. The refresh's isRefreshing flag must also be reset
+     * so the next poll can retry.
+     */
+    it('preserves the local status patch when the refresh request throws', async () => {
+        vi.mocked(api.batchStatus).mockResolvedValue([
+            { id: 1, status: TaskStatus.COMPLETED },
+        ] as any);
+        vi.mocked(api.listSummaries).mockRejectedValue(new Error('refresh failed'));
+
+        const { page } = makePage([{ task_id: 1, status: TaskStatus.PROCESSING, topic: 'x' }]);
+
+        await (page as any).doBatchPoll([1]);
+        // Yield until the fire-and-forget refresh's finally block runs.
+        for (let i = 0; i < 5; i++) {
+            await new Promise((r) => setTimeout(r, 0));
+        }
+
+        // Local patch survived: item is COMPLETED even though refresh threw.
+        expect((page.state as any).items[0]).toMatchObject({ status: TaskStatus.COMPLETED });
+        // isRefreshing is reset so the next poll tick can try again.
+        expect((page as any).isRefreshing).toBe(false);
+    });
+});

--- a/packages/dmworksummary/src/pages/__tests__/SummaryListPage.autoRefresh.test.tsx
+++ b/packages/dmworksummary/src/pages/__tests__/SummaryListPage.autoRefresh.test.tsx
@@ -222,8 +222,10 @@ describe('SummaryListPage auto-refresh on completion (#290)', () => {
         const loadMorePromise = (page as any).loadMore();
         await new Promise((r) => setTimeout(r, 0));
 
-        // Simulate a concurrent refresh landing first: it reset page to 1 and
-        // replaced items with a fresh page-1 batch.
+        // Simulate a concurrent refresh landing first: it reset page to 1,
+        // replaced items with a fresh page-1 batch, AND bumped loadDataSeq
+        // (which is what real loadData does at entry).
+        (page as any).loadDataSeq++;
         (page as any).state = {
             ...(page as any).state,
             items: Array.from({ length: 20 }, (_, i) => ({
@@ -278,7 +280,105 @@ describe('SummaryListPage auto-refresh on completion (#290)', () => {
     });
 
     /**
-     * Jerry-Xin round-6 P1: if a background refresh is in flight and the
+     * P1-1 regression at nextPage === 2 (round-7 Jerry-Xin / yujiawei): the
+     * previous `prev.page !== nextPage - 1` guard was a no-op here because
+     * loadData also resets page to 1 — "list was reset" and "nothing changed"
+     * both looked like `prev.page === 1`. Now loadMore captures loadDataSeq
+     * pre-await and drops the batch when it advances.
+     */
+    it('discards a stale loadMore@page-2 response when a concurrent loadData ran', async () => {
+        const { page } = makePage(
+            Array.from({ length: 20 }, (_, i) => ({
+                task_id: i + 1,
+                status: TaskStatus.COMPLETED,
+                topic: `t${i + 1}`,
+            }))
+        );
+        (page as any).state = {
+            ...(page as any).state,
+            page: 1,
+            pageSize: 20,
+            hasMore: true,
+        };
+
+        // loadMore fires from page:1 → nextPage=2, awaits.
+        let resolveLoadMore: (v: any) => void = () => {};
+        vi.mocked(api.listSummaries).mockImplementationOnce(
+            () => new Promise((r) => { resolveLoadMore = r; }) as any
+        );
+        const loadMorePromise = (page as any).loadMore();
+        await new Promise((r) => setTimeout(r, 0));
+
+        // Concurrent loadData fires and completes, resetting items to a
+        // fresh page-1 batch. state.page ends up 1 again.
+        vi.mocked(api.listSummaries).mockImplementationOnce(
+            async () => ({
+                items: Array.from({ length: 20 }, (_, i) => ({
+                    task_id: 200 + i,
+                    status: TaskStatus.COMPLETED,
+                    topic: `fresh-${i}`,
+                })),
+                total: 40,
+            } as any)
+        );
+        await (page as any).loadData();
+
+        // Stale page-2 response arrives. prev.page is 1 (matching nextPage-1),
+        // so the old guard would have appended. loadDataSeq guard catches it.
+        resolveLoadMore({
+            items: Array.from({ length: 20 }, (_, i) => ({
+                task_id: 21 + i,
+                status: TaskStatus.COMPLETED,
+                topic: `stale-page2-${i}`,
+            })),
+            total: 40,
+        });
+        await loadMorePromise;
+
+        const items = (page.state as any).items;
+        expect(items).toHaveLength(20);
+        expect((page.state as any).page).toBe(1);
+        expect(items.every((x: any) => !String(x.topic).startsWith('stale-page2'))).toBe(true);
+    });
+
+    /**
+     * P1-2 regression (round-7 Jerry-Xin / yujiawei): a failed silent
+     * refresh must NOT leave state.page reset to 1 with items still at the
+     * old depth. loadData now defers the page/hasMore reset to the success
+     * commit, so a failure preserves whatever cursor the user had before.
+     */
+    it('preserves pagination cursor when a silent refresh fails at deep scroll', async () => {
+        const { page } = makePage(
+            Array.from({ length: 100 }, (_, i) => ({
+                task_id: i + 1,
+                status: TaskStatus.COMPLETED,
+                topic: `t${i + 1}`,
+            }))
+        );
+        (page as any).state = {
+            ...(page as any).state,
+            page: 5,
+            pageSize: 20,
+            hasMore: true,
+            total: 200,
+        };
+
+        vi.mocked(api.listSummaries).mockRejectedValue(new Error('network'));
+
+        await (page as any).refreshListSilently();
+
+        // items unchanged, page NOT reset, hasMore preserved → next loadMore
+        // requests page 6, not page 2, so no rows duplicate.
+        const items = (page.state as any).items;
+        expect(items).toHaveLength(100);
+        expect((page.state as any).page).toBe(5);
+        expect((page.state as any).hasMore).toBe(true);
+        expect((page.state as any).error).toBeFalsy();
+        expect((page.state as any).loading).toBe(false);
+    });
+
+    /**
+     * Background refresh in flight, user changes filter and a fresh loadData
      * user then changes the status filter, the newer filter-triggered
      * loadData must win — the older refresh response must be discarded
      * rather than overwriting the user's newer view. loadDataSeq is the

--- a/packages/dmworksummary/src/pages/__tests__/SummaryListPage.autoRefresh.test.tsx
+++ b/packages/dmworksummary/src/pages/__tests__/SummaryListPage.autoRefresh.test.tsx
@@ -60,7 +60,7 @@ function makePage(items: Array<Record<string, unknown>>) {
 describe('SummaryListPage auto-refresh on completion (#290)', () => {
     beforeEach(() => vi.clearAllMocks());
 
-    it('applies the local status patch immediately AND triggers a full reload via loadData when a task reaches a terminal status', async () => {
+    it('triggers a full reload via loadData when a task reaches a terminal status (round-9: no local patch)', async () => {
         vi.mocked(api.batchStatus).mockResolvedValue([
             { id: 1, status: TaskStatus.COMPLETED },
         ] as any);
@@ -74,19 +74,22 @@ describe('SummaryListPage auto-refresh on completion (#290)', () => {
         ]);
 
         await (page as any).doBatchPoll([1]);
-        // Yield for the fire-and-forget refresh (which awaits loadData) to
-        // complete its full setState chain.
         for (let i = 0; i < 5; i++) {
             await new Promise((r) => setTimeout(r, 0));
         }
 
-        // Local status patch was applied to items BEFORE the loadData round
-        // trip, so the card did not sit at a stale PROCESSING status.
-        // Find the first patch that carries the items array with COMPLETED status.
-        const localPatch = setStatePatches.find(
-            (p: any) => Array.isArray(p.items) && p.items[0]?.status === TaskStatus.COMPLETED
-        );
-        expect(localPatch).toBeDefined();
+        // Terminal branch delegates directly to loadData without an
+        // intermediate local status patch (round-9 yujiawei P1 fix). The
+        // ONLY items commit should come from loadData's success path with
+        // the fresh title, not an earlier local COMPLETED-status patch.
+        // Rationale: pre-patching to COMPLETED would strand the task in
+        // stopBatchPoll if the refresh fails, preventing self-retry.
+        const itemsCommits = setStatePatches.filter((p: any) => Array.isArray(p.items));
+        expect(itemsCommits).toHaveLength(1);
+        expect((itemsCommits[0] as any).items[0]).toMatchObject({
+            status: TaskStatus.COMPLETED,
+            topic: '完成后的标题',
+        });
 
         // loadData was invoked (via refreshListSilently) and enriched the row.
         expect(api.listSummaries).toHaveBeenCalledTimes(1);
@@ -488,5 +491,56 @@ describe('SummaryListPage auto-refresh on completion (#290)', () => {
         // Cleanup.
         resolveLoadData({ items: [], total: 0 });
         await loadDataPromise;
+    });
+
+    /**
+     * Round-9 P1 regression (yujiawei): the terminal branch used to pre-patch
+     * items to COMPLETED before firing the refresh. If the refresh failed,
+     * items would already show all tasks as terminal → next poll tick sees
+     * currentActiveIds=[] → stopBatchPoll → the task keeps its stale title
+     * indefinitely with no auto-recovery.
+     *
+     * Fix: remove the local patch. Now items keep the non-terminal status
+     * across the failed refresh, so the next poll tick still detects the
+     * status change and re-fires the refresh, giving natural retry.
+     */
+    it('retries the refresh on the next poll tick when the first attempt fails', async () => {
+        const { page } = makePage([
+            { task_id: 1, status: TaskStatus.PROCESSING, topic: 'x' },
+        ]);
+
+        // batchStatus keeps reporting COMPLETED across ticks.
+        vi.mocked(api.batchStatus).mockResolvedValue([
+            { id: 1, status: TaskStatus.COMPLETED },
+        ] as any);
+
+        // First refresh fails; second succeeds.
+        vi.mocked(api.listSummaries)
+            .mockRejectedValueOnce(new Error('network'))
+            .mockResolvedValueOnce({
+                items: [{ task_id: 1, status: TaskStatus.COMPLETED, topic: 'fresh' }],
+                total: 1,
+            } as any);
+
+        // Tick 1: refresh fails. items is untouched (no local patch since
+        // round-9), so the task still shows PROCESSING.
+        await (page as any).doBatchPoll([1]);
+        for (let i = 0; i < 5; i++) {
+            await new Promise((r) => setTimeout(r, 0));
+        }
+        expect((page.state as any).items[0].status).toBe(TaskStatus.PROCESSING);
+        expect((page.state as any).items[0].topic).toBe('x');
+
+        // Tick 2: batchStatus reports COMPLETED again → change still detected
+        // → refresh fires again → succeeds.
+        await (page as any).doBatchPoll([1]);
+        for (let i = 0; i < 5; i++) {
+            await new Promise((r) => setTimeout(r, 0));
+        }
+        expect((page.state as any).items[0]).toMatchObject({
+            status: TaskStatus.COMPLETED,
+            topic: 'fresh',
+        });
+        expect(api.listSummaries).toHaveBeenCalledTimes(2);
     });
 });

--- a/packages/dmworksummary/src/pages/__tests__/SummaryListPage.autoRefresh.test.tsx
+++ b/packages/dmworksummary/src/pages/__tests__/SummaryListPage.autoRefresh.test.tsx
@@ -259,9 +259,9 @@ describe('SummaryListPage auto-refresh on completion (#290)', () => {
 
     /**
      * P2-6 regression: a failed background refresh should not surface an
-     * error banner to an idle user. If loadData sets state.error during the
-     * refresh, refreshListSilently must clear it (unless there was already
-     * a pre-refresh error, which is unrelated and should be preserved).
+     * error banner to an idle user. loadData now takes a { silent: true }
+     * flag; refreshListSilently passes it so the catch branch skips the
+     * error setState entirely (rather than trying to clear it after commit).
      */
     it('suppresses the loadData error banner on background refresh failure', async () => {
         vi.mocked(api.listSummaries).mockRejectedValue(new Error('network'));
@@ -275,5 +275,59 @@ describe('SummaryListPage auto-refresh on completion (#290)', () => {
 
         // The error banner must not persist on an otherwise healthy list.
         expect((page.state as any).error).toBeFalsy();
+    });
+
+    /**
+     * Jerry-Xin round-6 P1: if a background refresh is in flight and the
+     * user then changes the status filter, the newer filter-triggered
+     * loadData must win — the older refresh response must be discarded
+     * rather than overwriting the user's newer view. loadDataSeq is the
+     * generation counter that closes this window.
+     */
+    it('discards a stale background refresh when a newer user-triggered loadData ran under a different filter', async () => {
+        const { page } = makePage([
+            { task_id: 1, status: TaskStatus.COMPLETED, topic: 'x' },
+        ]);
+
+        // Background refresh's loadData is in flight — hold its response.
+        let resolveBackground: (v: any) => void = () => {};
+        vi.mocked(api.listSummaries).mockImplementationOnce(
+            () => new Promise((r) => { resolveBackground = r; }) as any
+        );
+        const refreshPromise = (page as any).refreshListSilently();
+        await new Promise((r) => setTimeout(r, 0));
+
+        // User changes the filter; a fresh loadData fires and resolves first.
+        vi.mocked(api.listSummaries).mockImplementationOnce(
+            async () => ({
+                items: [{ task_id: 99, status: TaskStatus.PROCESSING, topic: 'fresh-filter' }],
+                total: 1,
+            } as any)
+        );
+        (page as any).state = { ...(page as any).state, statusFilter: TaskStatus.PROCESSING };
+        await (page as any).loadData();
+
+        // Fresh state committed.
+        expect((page.state as any).items).toEqual([
+            expect.objectContaining({ task_id: 99, topic: 'fresh-filter' }),
+        ]);
+
+        // Now the stale background refresh resolves with the old scope's
+        // response. loadDataSeq advanced → this response must be dropped.
+        resolveBackground({
+            items: [
+                { task_id: 1, status: TaskStatus.COMPLETED, topic: 'stale-1' },
+                { task_id: 2, status: TaskStatus.COMPLETED, topic: 'stale-2' },
+            ],
+            total: 999,
+        });
+        await refreshPromise;
+
+        // Items must still reflect the newer filter's response, not the
+        // stale background one.
+        expect((page.state as any).items).toEqual([
+            expect.objectContaining({ task_id: 99, topic: 'fresh-filter' }),
+        ]);
+        expect((page.state as any).total).toBe(1);
     });
 });

--- a/packages/dmworksummary/src/pages/__tests__/SummaryListPage.autoRefresh.test.tsx
+++ b/packages/dmworksummary/src/pages/__tests__/SummaryListPage.autoRefresh.test.tsx
@@ -27,10 +27,9 @@ import { TaskStatus } from '../../types/summary';
 
 /**
  * Build a page whose setState applies synchronously and runs the callback,
- * so refreshListSilently()'s post-setState side effects are exercised. Heavy
- * side effects (poll scheduling) are stubbed to no-ops. setState records
- * every patch it received so tests can assert on the flow, not just the
- * final value.
+ * so doBatchPoll's local patch + fire-and-forget refresh (which now delegates
+ * to loadData) are exercised in a deterministic order. Heavy side effects
+ * (poll scheduling) are stubbed to no-ops.
  */
 function makePage(items: Array<Record<string, unknown>>) {
     const page = new SummaryListPage({} as any);
@@ -61,7 +60,7 @@ function makePage(items: Array<Record<string, unknown>>) {
 describe('SummaryListPage auto-refresh on completion (#290)', () => {
     beforeEach(() => vi.clearAllMocks());
 
-    it('applies the local status patch immediately AND fires the silent refresh when a task reaches a terminal status', async () => {
+    it('applies the local status patch immediately AND triggers a full reload via loadData when a task reaches a terminal status', async () => {
         vi.mocked(api.batchStatus).mockResolvedValue([
             { id: 1, status: TaskStatus.COMPLETED },
         ] as any);
@@ -75,25 +74,26 @@ describe('SummaryListPage auto-refresh on completion (#290)', () => {
         ]);
 
         await (page as any).doBatchPoll([1]);
-        await new Promise((r) => setTimeout(r, 0));
+        // Yield for the fire-and-forget refresh (which awaits loadData) to
+        // complete its full setState chain.
+        for (let i = 0; i < 5; i++) {
+            await new Promise((r) => setTimeout(r, 0));
+        }
 
-        // Local status patch applied BEFORE the async refresh lands, so the
-        // card does not render a stale PROCESSING status for the round-trip.
-        const firstPatch = setStatePatches[0];
-        expect(firstPatch).toBeDefined();
-        expect((firstPatch as any).items?.[0]).toMatchObject({ status: TaskStatus.COMPLETED });
+        // Local status patch was applied to items BEFORE the loadData round
+        // trip, so the card did not sit at a stale PROCESSING status.
+        // Find the first patch that carries the items array with COMPLETED status.
+        const localPatch = setStatePatches.find(
+            (p: any) => Array.isArray(p.items) && p.items[0]?.status === TaskStatus.COMPLETED
+        );
+        expect(localPatch).toBeDefined();
 
-        // Full list re-fetched and merged (enriched title visible).
+        // loadData was invoked (via refreshListSilently) and enriched the row.
         expect(api.listSummaries).toHaveBeenCalledTimes(1);
         expect((page.state as any).items[0]).toMatchObject({ topic: '完成后的标题' });
-
-        // Silent: assert no setState patch ever tried to set loading:true.
-        for (const p of setStatePatches) {
-            expect((p as any).loading).not.toBe(true);
-        }
     });
 
-    it('only patches status in place for non-terminal transitions (no full reload)', async () => {
+    it('only patches status in place for non-terminal transitions (no reload)', async () => {
         vi.mocked(api.batchStatus).mockResolvedValue([
             { id: 1, status: TaskStatus.PROCESSING },
         ] as any);
@@ -101,209 +101,94 @@ describe('SummaryListPage auto-refresh on completion (#290)', () => {
         const { page } = makePage([{ task_id: 1, status: TaskStatus.PENDING, topic: 'x' }]);
 
         await (page as any).doBatchPoll([1]);
-        await new Promise((r) => setTimeout(r, 0));
+        for (let i = 0; i < 5; i++) {
+            await new Promise((r) => setTimeout(r, 0));
+        }
 
+        // Non-terminal → no full reload.
         expect(api.listSummaries).not.toHaveBeenCalled();
         expect((page.state as any).items[0]).toMatchObject({ status: TaskStatus.PROCESSING });
     });
 
     /**
-     * Merge-not-replace: when the refresh is clamped at 100 rows but the user
-     * has loaded 120, the loaded tail past coverSize must be preserved
-     * in-place (rows 101–120 keep showing). state.page is never touched by
-     * the refresh, so the next loadMore continues from where the user left.
+     * Under a status filter (e.g. PROCESSING), a task that reaches a terminal
+     * status must drop out of the filtered view. Delegating to loadData()
+     * gets this right by construction: the server's PROCESSING-scoped
+     * response no longer contains the completed task, and loadData replaces
+     * items wholesale (rather than merging), so the completed row cleanly
+     * disappears.
      */
-    it('preserves the loaded tail past the refresh cap (merge, not replace)', async () => {
-        vi.mocked(api.batchStatus).mockResolvedValue([
-            { id: 42, status: TaskStatus.COMPLETED },
-        ] as any);
-        // Backend caps page_size at 100 — return 100 items with enriched
-        // titles, plus a much larger total so hasMore stays true.
-        const refreshedItems = Array.from({ length: 100 }, (_, i) => ({
-            task_id: i + 1,
-            status: TaskStatus.COMPLETED,
-            topic: `enriched-${i + 1}`,
-        }));
-        vi.mocked(api.listSummaries).mockResolvedValue({
-            items: refreshedItems,
-            total: 240,
-        } as any);
-
-        // Simulate user has 120 rows loaded, at page 6 with pageSize 20.
-        // task 42 is currently PROCESSING; the poll detects it's COMPLETED.
-        const initialItems = Array.from({ length: 120 }, (_, i) => ({
-            task_id: i + 1,
-            status: i === 41 ? TaskStatus.PROCESSING : TaskStatus.COMPLETED,
-            topic: `old-${i + 1}`,
-        }));
-        const { page } = makePage(initialItems);
-        (page as any).state = { ...(page as any).state, page: 6, pageSize: 20 };
-
-        await (page as any).doBatchPoll([42]);
-        await new Promise((r) => setTimeout(r, 0));
-
-        expect(api.listSummaries).toHaveBeenCalledTimes(1);
-
-        // Prefix 1..100 got enriched (fresh title), tail 101..120 preserved
-        // in place (old title). Task 42 in the prefix now has the enriched
-        // topic AND the COMPLETED status.
-        const items = (page.state as any).items;
-        expect(items).toHaveLength(120);
-        expect(items[0].topic).toBe('enriched-1');
-        expect(items[41].status).toBe(TaskStatus.COMPLETED);
-        expect(items[99].topic).toBe('enriched-100');
-        expect(items[100].topic).toBe('old-101');
-        expect(items[119].topic).toBe('old-120');
-
-        // state.page must NOT be touched — refresh preserves the cursor.
-        expect((page.state as any).page).toBe(6);
-    });
-
-    /**
-     * When resp.items contains a brand-new task_id not in state.items (a task
-     * created after the initial load), it lands at the top of the list.
-     */
-    it('inserts brand-new tasks from the refresh at the top of the list', async () => {
+    it('drops rows that no longer match the active status filter after a terminal transition', async () => {
         vi.mocked(api.batchStatus).mockResolvedValue([
             { id: 1, status: TaskStatus.COMPLETED },
         ] as any);
+        // Under statusFilter=PROCESSING, the server response omits the just-
+        // completed task, leaving only the other PROCESSING task.
         vi.mocked(api.listSummaries).mockResolvedValue({
-            items: [
-                { task_id: 999, status: TaskStatus.COMPLETED, topic: 'brand-new-task' },
-                { task_id: 1, status: TaskStatus.COMPLETED, topic: 'enriched-existing' },
-            ],
-            total: 2,
+            items: [{ task_id: 2, status: TaskStatus.PROCESSING, topic: 'still-processing' }],
+            total: 1,
         } as any);
 
         const { page } = makePage([
-            { task_id: 1, status: TaskStatus.PROCESSING, topic: 'old-existing' },
+            { task_id: 1, status: TaskStatus.PROCESSING, topic: 'about-to-complete' },
+            { task_id: 2, status: TaskStatus.PROCESSING, topic: 'still-processing' },
         ]);
+        (page as any).state = { ...(page as any).state, statusFilter: TaskStatus.PROCESSING };
 
-        await (page as any).doBatchPoll([1]);
-        await new Promise((r) => setTimeout(r, 0));
+        await (page as any).doBatchPoll([1, 2]);
+        for (let i = 0; i < 5; i++) {
+            await new Promise((r) => setTimeout(r, 0));
+        }
 
+        // Completed task 1 dropped from filtered view; only task 2 remains.
         const items = (page.state as any).items;
-        expect(items).toHaveLength(2);
-        expect(items[0].task_id).toBe(999);
-        expect(items[0].topic).toBe('brand-new-task');
-        expect(items[1].task_id).toBe(1);
-        expect(items[1].topic).toBe('enriched-existing');
+        expect(items).toHaveLength(1);
+        expect(items[0].task_id).toBe(2);
     });
 
     /**
-     * If a concurrent loadMore appends a page while the refresh is in flight,
-     * merge-not-replace preserves the appended tail by construction: the
-     * setState uses the LATEST state.items (via functional updater), so any
-     * rows that landed during the fetch are still present.
+     * refreshListSilently is a fire-and-forget from doBatchPoll's setState
+     * callback. If the component unmounts between the setState and the
+     * refresh reaching loadData, the isMounted_ guard must short-circuit
+     * so we don't call setState on a torn-down instance.
      */
-    it('preserves items appended by a concurrent loadMore (merge-not-replace)', async () => {
-        // 120 rows loaded at page 6.
-        const initialItems = Array.from({ length: 120 }, (_, i) => ({
-            task_id: i + 1,
-            status: TaskStatus.COMPLETED,
-            topic: `t${i + 1}`,
-        }));
-        const { page } = makePage(initialItems);
-        (page as any).state = { ...(page as any).state, page: 6, pageSize: 20 };
+    it('short-circuits refreshListSilently when unmounted', async () => {
+        const { page } = makePage([
+            { task_id: 1, status: TaskStatus.PROCESSING, topic: 'x' },
+        ]);
+        // Simulate unmount before the refresh is invoked.
+        (page as any).isMounted_ = false;
 
-        let resolveRefresh: (v: any) => void = () => {};
-        vi.mocked(api.listSummaries).mockImplementationOnce(
-            () => new Promise((r) => { resolveRefresh = r; }) as any
-        );
+        await (page as any).refreshListSilently();
 
-        // Fire refresh directly, don't await.
-        const refreshPromise = (page as any).refreshListSilently();
-        await new Promise((r) => setTimeout(r, 0));
-
-        // Simulate loadMore having landed while the refresh awaited:
-        // 20 new rows appended, page advanced.
-        const appendedItems = Array.from({ length: 20 }, (_, i) => ({
-            task_id: i + 121,
-            status: TaskStatus.COMPLETED,
-            topic: `page7-${i + 121}`,
-        }));
-        (page as any).state = {
-            ...(page as any).state,
-            items: [...(page as any).state.items, ...appendedItems],
-            page: 7,
-        };
-
-        // Refresh resolves with 100 rows.
-        resolveRefresh({
-            items: Array.from({ length: 100 }, (_, i) => ({
-                task_id: i + 1,
-                status: TaskStatus.COMPLETED,
-                topic: `enriched-${i + 1}`,
-            })),
-            total: 240,
-        });
-        await refreshPromise;
-
-        // The appended tail must survive: rows 121-140 still there, page 7
-        // preserved. Prefix 1-100 enriched; 101-120 old; 121-140 appended.
-        const items = (page.state as any).items;
-        expect(items).toHaveLength(140);
-        expect((page.state as any).page).toBe(7);
-        expect(items[0].topic).toBe('enriched-1');
-        expect(items[100].topic).toBe('t101');
-        expect(items[139].topic).toBe('page7-140');
+        // No fetch fired; loadData was never called.
+        expect(api.listSummaries).not.toHaveBeenCalled();
     });
 
     /**
-     * Drop stale response when the status filter changed mid-flight.
+     * Concurrent refresh calls are coalesced by isRefreshing — a second
+     * doBatchPoll tick that fires while the first refresh is still in flight
+     * must short-circuit rather than pile on a duplicate loadData round trip.
      */
-    it('drops the refresh response if the status filter changed while the fetch was in flight', async () => {
-        vi.mocked(api.batchStatus).mockResolvedValue([
-            { id: 1, status: TaskStatus.COMPLETED },
-        ] as any);
-
+    it('coalesces overlapping refresh calls via isRefreshing', async () => {
         let resolveList: (v: any) => void = () => {};
         vi.mocked(api.listSummaries).mockReturnValue(
             new Promise((r) => { resolveList = r; }) as any
         );
 
-        const { page } = makePage([{ task_id: 1, status: TaskStatus.PROCESSING, topic: 'x' }]);
+        const { page } = makePage([
+            { task_id: 1, status: TaskStatus.PROCESSING, topic: 'x' },
+        ]);
 
-        const pollPromise = (page as any).doBatchPoll([1]);
-        await new Promise((r) => setTimeout(r, 0));
+        // Kick off the first refresh; don't await.
+        const first = (page as any).refreshListSilently();
+        // Second, overlapping refresh: must short-circuit.
+        const second = (page as any).refreshListSilently();
+        await second;
+        expect(api.listSummaries).toHaveBeenCalledTimes(1);
 
-        // User picks a filter mid-flight.
-        (page as any).state = { ...(page as any).state, statusFilter: TaskStatus.COMPLETED };
-
-        resolveList({
-            items: [{ task_id: 999, status: TaskStatus.COMPLETED, topic: 'filtered' }],
-            total: 999,
-        });
-        await pollPromise;
-        await new Promise((r) => setTimeout(r, 0));
-
-        // Stale response dropped — items still reflects the local patch (COMPLETED task 1),
-        // not the filtered response.
-        expect((page.state as any).items).toHaveLength(1);
-        expect((page.state as any).items[0].task_id).toBe(1);
-        expect((page.state as any).total).not.toBe(999);
-    });
-
-    /**
-     * When the refresh throws, the local status patch survives; isRefreshing
-     * resets so the next tick can retry (though structurally a second retry
-     * won't happen for the same transition, since the local patch stops the
-     * "change detected" branch).
-     */
-    it('preserves the local status patch when the refresh request throws', async () => {
-        vi.mocked(api.batchStatus).mockResolvedValue([
-            { id: 1, status: TaskStatus.COMPLETED },
-        ] as any);
-        vi.mocked(api.listSummaries).mockRejectedValue(new Error('refresh failed'));
-
-        const { page } = makePage([{ task_id: 1, status: TaskStatus.PROCESSING, topic: 'x' }]);
-
-        await (page as any).doBatchPoll([1]);
-        for (let i = 0; i < 5; i++) {
-            await new Promise((r) => setTimeout(r, 0));
-        }
-
-        expect((page.state as any).items[0]).toMatchObject({ status: TaskStatus.COMPLETED });
-        expect((page as any).isRefreshing).toBe(false);
+        // Let the first refresh finish so isRefreshing resets.
+        resolveList({ items: [], total: 0 });
+        await first;
     });
 });

--- a/packages/dmworksummary/src/pages/__tests__/SummaryListPage.autoRefresh.test.tsx
+++ b/packages/dmworksummary/src/pages/__tests__/SummaryListPage.autoRefresh.test.tsx
@@ -430,4 +430,63 @@ describe('SummaryListPage auto-refresh on completion (#290)', () => {
         ]);
         expect((page.state as any).total).toBe(1);
     });
+
+    /**
+     * Round-8 P1 regression (Jerry-Xin / yujiawei): the loadDataSeq guard
+     * alone was asymmetric. When loadData starts first and its
+     * setState({ loading: true }) is enqueued but not yet committed
+     * (React 18 batching from a promise continuation), a concurrent scroll
+     * fires loadMore which reads state.loading === false, captures the
+     * already-bumped seq, requests a deep page. loadData resolves first
+     * (page 1, 20 rows). loadMore's stale deep page resolves — seq matches
+     * → appended. Rows in between stranded.
+     *
+     * Fix: synchronous this.isLoadingData flag, checked in loadMore's entry
+     * guard alongside state.loading — closes the deferred-commit window
+     * regardless of React batching.
+     */
+    it('does not fire loadMore while loadData is in flight (isLoadingData sync flag)', async () => {
+        const { page } = makePage(
+            Array.from({ length: 100 }, (_, i) => ({
+                task_id: i + 1,
+                status: TaskStatus.COMPLETED,
+                topic: `t${i + 1}`,
+            }))
+        );
+        (page as any).state = {
+            ...(page as any).state,
+            page: 5,
+            pageSize: 20,
+            hasMore: true,
+        };
+
+        // loadData starts and awaits, but its setState is not observably
+        // committed yet (mimicking React 18 batching from a promise
+        // continuation).
+        let resolveLoadData: (v: any) => void = () => {};
+        vi.mocked(api.listSummaries).mockImplementationOnce(
+            () => new Promise((r) => { resolveLoadData = r; }) as any
+        );
+        const loadDataPromise = (page as any).loadData({ silent: true });
+        await new Promise((r) => setTimeout(r, 0));
+
+        // Simulate the race: state.loading is not yet true (as would happen
+        // in React 18 with deferred commit — reset it as if the setState
+        // hadn't landed). isLoadingData must still guard.
+        (page as any).state = { ...(page as any).state, loading: false };
+
+        // Now a scroll fires loadMore. It must NOT fire a request.
+        vi.mocked(api.listSummaries).mockClear();
+        const secondCallSpy = vi.fn();
+        vi.mocked(api.listSummaries).mockImplementation(secondCallSpy as any);
+
+        await (page as any).loadMore();
+
+        expect(secondCallSpy).not.toHaveBeenCalled();
+        expect((page.state as any).loadingMore).toBe(false);
+
+        // Cleanup.
+        resolveLoadData({ items: [], total: 0 });
+        await loadDataPromise;
+    });
 });

--- a/packages/dmworksummary/src/utils/summaryHelpers.ts
+++ b/packages/dmworksummary/src/utils/summaryHelpers.ts
@@ -266,13 +266,18 @@ export function canCancel(status: TaskStatusType): boolean {
     );
 }
 
-/** 任务是否可以重新生成 */
-export function canRegenerate(status: TaskStatusType): boolean {
+/** 任务是否已进入终态（不再变化 · COMPLETED / FAILED / CANCELLED）。 */
+export function isTerminalStatus(status: TaskStatusType): boolean {
     return (
         status === TaskStatus.COMPLETED ||
         status === TaskStatus.FAILED ||
         status === TaskStatus.CANCELLED
     );
+}
+
+/** 任务是否可以重新生成 */
+export function canRegenerate(status: TaskStatusType): boolean {
+    return isTerminalStatus(status);
 }
 
 /** 删除：自定义 cron 新建/编辑入口已彻底下线，interval(天/周/月) 为唯一对外口径。


### PR DESCRIPTION
Refs #290.

## Problem

When a summary task reaches a terminal status (COMPLETED / FAILED / CANCELLED), the list card kept showing its pre-completion title and preview until the user manually refreshed. Newly-created summaries that appeared after the initial list load were also invisible until a manual reload.

## Fix

`doBatchPoll` now delegates to `loadData()` whenever a polled task transitions into a terminal status, and keeps the cheap in-place status patch for non-terminal transitions:

```ts
if (hasTerminal) {
    void this.refreshListSilently();   // full reload via loadData
} else {
    this.setState({ items: newItems }, () => this.maybeStartBatchPoll());
}
```

Delegating to `loadData()` was #290's original prescription. Earlier attempts at a hand-rolled silent refresh (clamped page_size, merge-not-replace) each traded one concurrency defect for another; `loadData()` is correct by construction for filter / space / loadMore semantics.

**Trade-off accepted**: `loadData()` shows a brief spinner and collapses to page 1 on completion. Users reading deep in the list lose scroll depth. The completion event itself already draws attention to the list, so the spinner reads as intentional feedback rather than a flicker.

## Concurrency guards added

- **`loadDataSeq`**: monotonic generation counter bumped at `loadData` entry. Both `loadData` and `loadMore` capture pre-await and drop their commit on mismatch — closes the loadMore-starts-first ordering.
- **`isLoadingData`**: synchronous instance flag set at `loadData` entry, cleared in a sequence-owned finally. Checked in `loadMore`'s entry guard — closes the loadData-starts-first ordering under React 18 deferred commit.
- **`isRefreshing`**: coalesces overlapping refresh calls so 2s poll ticks don't pile duplicate `loadData` round trips.
- **`isMounted_`**: post-await check on both success and catch paths so `setState` never lands on a torn-down component.
- **Silent-mode** (`loadData({ silent: true })`): background refresh never sets `state.error`, and clears any pre-existing error banner on success; `page` / `hasMore` are only committed on success so a failed silent refresh preserves the user's cursor.
- **Terminal branch does NOT locally patch items to COMPLETED**: if the refresh fails, items keep the non-terminal status → next poll tick still detects the transition → refresh retries automatically. (Round-9 fix — pre-patching would strand tasks in `stopBatchPoll`.)

## Files

- `packages/dmworksummary/src/pages/SummaryListPage.tsx`: doBatchPoll → refreshListSilently, `loadData` sequence guard + silent option, `loadMore` sequence + isLoadingData check.
- `packages/dmworksummary/src/utils/summaryHelpers.ts`: extracted `isTerminalStatus`; `canRegenerate` delegates.
- `packages/dmworksummary/src/pages/__tests__/SummaryListPage.autoRefresh.test.tsx`: 12 tests covering terminal / non-terminal branches, filter fall-out, stale-refresh drop, loadMore race (both orderings), isLoadingData deferred-commit window, silent-mode error suppression, cursor preservation on failure, and auto-retry after failed refresh.

## Known remaining (out of scope for this PR)

#290 lists two consequences of the bug; consequence (2) — "tasks created after the list loaded never appear" — is only partly fixed by this PR. The refresh reachable from `doBatchPoll` prepends newly-visible task_ids, but `doBatchPoll` itself is only running when there are active tasks in the currently-loaded list. A completely idle client will still not see a peer's new summary until it interacts with the UI. Full fix needs a heartbeat / push channel and belongs in a follow-up.
