### PR TITLE
fix(base): hide forward action for thread-created messages

### DIFF
--- a/packages/dmworkbase/src/module.tsx
+++ b/packages/dmworkbase/src/module.tsx
@@ -1095,6 +1095,9 @@ export default class BaseModule implements IModule {
         if (WKApp.shared.notSupportForward.includes(message.contentType)) {
           return null;
         }
+        if (message.contentType === MessageContentTypeConst.threadCreated) {
+          return null;
+        }
 
         return {
           title: t("base.module.contextMenus.forward"),


### PR DESCRIPTION
## Summary

- Closes #1201.
- Skip the generic forward context-menu entry for `MessageContentTypeConst.threadCreated` cards in `packages/dmworkbase/src/module.tsx`, so the parent-group "新建了子区" notification can no longer be forwarded into another channel.
- This aligns the single-message right-click menu with the existing multi-select restriction in `messageSelection.ts`, and avoids producing the empty `🧵·0条回复` card in the target group caused by `ThreadCreatedContent` not implementing `encodeJSON()`.

## Test plan

- [ ] In a parent group, create a subthread so the "新建了子区" notification card appears.
- [ ] Right-click the notification card — confirm "转发" is no longer offered.
- [ ] Right-click a normal message in the same group — confirm "转发" still works.
- [ ] Inside the subthread, right-click a normal reply — confirm "转发" still works and forwarding into another active thread still works.