### PR TITLE
feat(docs): add html_ppt DocType entry, filter, and no-fallback routing

### DIFF
--- a/packages/docs/src/i18n/en-US.json
+++ b/packages/docs/src/i18n/en-US.json
@@ -9,11 +9,13 @@
     "newBoard": "New board",
     "newSheet": "New sheet",
     "newHtml": "New HTML",
+    "newPpt": "New slides",
     "comingSoon": "Coming soon",
     "kindDoc": "Document",
     "kindBoard": "Board",
     "kindSheet": "Spreadsheet",
     "kindHtml": "HTML",
+    "kindPpt": "Slides",
     "botBadge": "Bot",
     "back": "All documents",
     "updatedAt": "Updated",
@@ -877,6 +879,13 @@
     "nextChange": "Next",
     "oldVersion": "Old v{{v}}",
     "newVersion": "New v{{v}}"
+  },
+  "ppt": {
+    "createTitle": "New slides",
+    "createComingSoon": "Slides (Bento PPT) creation is coming soon.",
+    "createComingSoonOk": "Got it",
+    "viewTitle": "Slides",
+    "previewComingSoon": "Slides preview is coming soon."
   },
   "onboarding": {
     "helpTitle": "Agent CLI onboarding help",

--- a/packages/docs/src/i18n/zh-CN.json
+++ b/packages/docs/src/i18n/zh-CN.json
@@ -9,11 +9,13 @@
     "newBoard": "新建画板",
     "newSheet": "新建表格",
     "newHtml": "新建 HTML",
+    "newPpt": "新建幻灯片",
     "comingSoon": "即将上线",
     "kindDoc": "文档",
     "kindBoard": "画板",
     "kindSheet": "表格",
     "kindHtml": "网页",
+    "kindPpt": "幻灯片",
     "botBadge": "机器人",
     "back": "全部文档",
     "updatedAt": "更新于",
@@ -877,6 +879,13 @@
     "nextChange": "下一处",
     "oldVersion": "旧版 v{{v}}",
     "newVersion": "新版 v{{v}}"
+  },
+  "ppt": {
+    "createTitle": "新建幻灯片",
+    "createComingSoon": "幻灯片（Bento PPT）创建即将上线，敬请期待。",
+    "createComingSoonOk": "知道了",
+    "viewTitle": "幻灯片",
+    "previewComingSoon": "幻灯片预览即将上线。"
   },
   "onboarding": {
     "helpTitle": "Agent CLI 上手帮助",

--- a/packages/docs/src/pages/DocsHome.test.tsx
+++ b/packages/docs/src/pages/DocsHome.test.tsx
@@ -87,6 +87,17 @@ vi.mock('../html/HtmlDocView.tsx', () => ({
   ),
 }))
 
+// Bento slide-deck (html_ppt) read-only surface. Mocked so a routing test can assert an html_ppt
+// row/target lands here and NEVER on the Tiptap editor-shell (the no-fallback contract, XIN-1501).
+vi.mock('../ppt/PptDocView.tsx', () => ({
+  PptDocView: (props: { docId: string; slug?: string }) => (
+    <div data-testid="ppt-doc-view">
+      <span data-testid="ppt-doc">{props.docId}</span>
+      <span data-testid="ppt-slug">{props.slug ?? ''}</span>
+    </div>
+  ),
+}))
+
 // Replace the embedded bot-DM shell (pulls @octo/base Conversation + WKSDK) with a marker so the
 // new-HTML flow is testable without a live IM channel. Surfaces the bot uid, requestId and part of
 // the auto-sent task text, plus the onClose affordance (plan Task 6).
@@ -823,6 +834,33 @@ describe('DocsHome navigation (split-pane)', () => {
     expect(calls.some((c) => c.method === 'get' && c.url === '/docs/h_known')).toBe(false)
   })
 
+  it('opens a persisted html_ppt doc directly into PptDocView on refresh (NO Tiptap editor fallback, NO getDoc round-trip)', async () => {
+    // No-fallback contract (XIN-1501): a stored docType='html_ppt' must open the read-only
+    // PptDocView on first paint. It must NEVER fall through to the collab EditorShell (a Bento
+    // deck has no Yjs payload) and must not take a getDoc detour that could default it to 'doc'.
+    window.sessionStorage.setItem(
+      TARGET_KEY,
+      JSON.stringify({ space: 'sp', folder: 'fd', doc: 'p_known', docType: 'html_ppt' }),
+    )
+    const wk = createMockWKApp()
+    setWKApp(wk)
+    const calls: Array<{ method: string; url: string }> = []
+    wk.apiClient.responder = (method, url) => {
+      calls.push({ method, url })
+      if (method === 'get' && url.startsWith('/docs')) {
+        return { data: { total: 0, items: [] }, status: 200 }
+      }
+      return { data: {}, status: 200 }
+    }
+
+    render(<DocsHome />)
+    // PptDocView mounts immediately from the stored kind — never the rich-text editor.
+    expect(screen.getByTestId('ppt-doc-view')).toBeTruthy()
+    expect(screen.queryByTestId('editor-shell')).toBeNull()
+    // No per-doc getDoc round-trip (which could have defaulted an unknown kind to the editor).
+    expect(calls.some((c) => c.method === 'get' && c.url === '/docs/p_known')).toBe(false)
+  })
+
   it('opens a persisted sheet doc directly into SheetView on refresh (no getDoc round-trip)', async () => {
     // Same whitelist fix also covers sheet, which the reviewer flagged as missing alongside html.
     window.sessionStorage.setItem(
@@ -1324,6 +1362,104 @@ describe('DocsHome — sheet open path restored (XIN-520)', () => {
       docType: 'html',
       octoDocSlug: 'octo-html-report',
     })
+  })
+
+  it('opens an existing html_ppt row into the read-only PptDocView (never the editor, no per-doc lookup)', async () => {
+    const wk = createMockWKApp()
+    setWKApp(wk)
+    const calls: Array<{ method: string; url: string }> = []
+    wk.apiClient.responder = (method, url) => {
+      calls.push({ method, url })
+      if (method === 'get' && url.startsWith('/docs')) {
+        return {
+          data: {
+            total: 1,
+            items: [
+              {
+                docId: 'ppt_row',
+                title: 'Quarterly Deck',
+                ownerId: 'u_owner',
+                role: 'admin',
+                docType: 'html_ppt',
+              },
+            ],
+          },
+          status: 200,
+        }
+      }
+      return { data: {}, status: 200 }
+    }
+
+    render(<DocsHome />)
+    await waitFor(() => expect(screen.getByText('Quarterly Deck')).toBeTruthy())
+
+    fireEvent.click(screen.getByText('Quarterly Deck'))
+
+    await waitFor(() => expect(screen.getByTestId('ppt-doc-view')).toBeTruthy())
+    expect(screen.getByTestId('ppt-doc').textContent).toBe('ppt_row')
+    // Bento slide-deck: it must NOT open the rich-text editor / sheet (no-fallback contract).
+    expect(screen.queryByTestId('editor-shell')).toBeNull()
+    expect(screen.queryByTestId('sheet-view')).toBeNull()
+    // The list row already carried docType='html_ppt' — no authoritative getDoc round-trip.
+    expect(calls.some((c) => c.method === 'get' && c.url === '/docs/ppt_row')).toBe(false)
+    expect(JSON.parse(window.sessionStorage.getItem(TARGET_KEY)!)).toMatchObject({
+      doc: 'ppt_row',
+      docType: 'html_ppt',
+    })
+  })
+
+  it('resolves an unknown-kind row to PptDocView via getDoc when the backend reports html_ppt (no editor fallback)', async () => {
+    // The list API omitted docType, so the row opens with an UNKNOWN kind and defers to getDoc.
+    // A backend docType='html_ppt' must resolve to PptDocView, NOT default to the Tiptap editor.
+    const wk = createMockWKApp()
+    setWKApp(wk)
+    wk.apiClient.responder = (method, url) => {
+      if (method === 'get' && url === '/docs/ppt_shared') {
+        return { data: { docId: 'ppt_shared', title: 'Shared Deck', role: 'admin', docType: 'html_ppt' }, status: 200 }
+      }
+      if (method === 'get' && url.startsWith('/docs')) {
+        return {
+          data: { total: 1, items: [{ docId: 'ppt_shared', title: 'Shared Deck', ownerId: 'u_owner', role: 'admin' }] },
+          status: 200,
+        }
+      }
+      return { data: {}, status: 200 }
+    }
+
+    render(<DocsHome />)
+    await waitFor(() => expect(screen.getByText('Shared Deck')).toBeTruthy())
+
+    fireEvent.click(screen.getByText('Shared Deck'))
+
+    // getDoc resolved html_ppt → the read-only PPT surface, never the rich-text editor.
+    await waitFor(() => expect(screen.getByTestId('ppt-doc-view')).toBeTruthy())
+    expect(screen.queryByTestId('editor-shell')).toBeNull()
+  })
+
+  it('shows the "new slides" caret-menu entry that opens the R1 coming-soon notice without creating a doc', async () => {
+    const wk = createMockWKApp()
+    setWKApp(wk)
+    const calls: Array<{ method: string; url: string }> = []
+    wk.apiClient.responder = (method, url) => {
+      calls.push({ method, url })
+      if (method === 'get' && url.startsWith('/docs')) {
+        return { data: { total: 0, items: [] }, status: 200 }
+      }
+      return { data: {}, status: 200 }
+    }
+
+    render(<DocsHome />)
+
+    // Open the split "New" dropdown and choose "New slides".
+    fireEvent.click(screen.getByLabelText('docs.list.newMenu'))
+    fireEvent.click(screen.getByText('docs.list.newPpt'))
+
+    // R1: a "coming soon" notice appears — no doc is created and no editor/PPT surface opens.
+    await waitFor(() => expect(screen.getByText('docs.ppt.createComingSoon')).toBeTruthy())
+    expect(screen.queryByTestId('editor-shell')).toBeNull()
+    expect(screen.queryByTestId('ppt-doc-view')).toBeNull()
+    // The entry must NOT call createDoc (a Bento deck is never minted through the rich-doc path).
+    expect(calls.some((c) => c.method === 'post' && c.url === '/docs')).toBe(false)
   })
 
   it('re-pushes an open html doc WITH its slug when the docs nav menu is re-activated', async () => {
@@ -1889,6 +2025,7 @@ describe('DocsHome — type distinction + filter (XIN-1188)', () => {
     { docId: 'd_sheet', title: 'A Sheet', ownerId: 'u_o', role: 'admin', docType: 'sheet', viewedAt: '2026-07-15T05:00:00.000Z' },
     { docId: 'd_board', title: 'A Board', ownerId: 'u_o', role: 'admin', docType: 'board', viewedAt: '2026-07-15T04:00:00.000Z' },
     { docId: 'd_html', title: 'A Web Page', ownerId: 'u_o', role: 'admin', docType: 'html', octoDocSlug: 'sp/fd/html-slug', viewedAt: '2026-07-15T03:00:00.000Z' },
+    { docId: 'd_ppt', title: 'A Slide Deck', ownerId: 'u_o', role: 'admin', docType: 'html_ppt', viewedAt: '2026-07-15T02:30:00.000Z' },
   ]
 
   function mountList() {
@@ -1925,6 +2062,13 @@ describe('DocsHome — type distinction + filter (XIN-1188)', () => {
     await waitFor(() => expect(screen.getByText('A Web Page')).toBeTruthy())
     // The html row carries its own aria-label/title on the row icon (HtmlRowIcon).
     expect(screen.getByLabelText('docs.list.kindHtml')).toBeTruthy()
+  })
+
+  it('renders the html_ppt row with its own kindPpt icon (distinct from doc/sheet/board/html)', async () => {
+    mountList()
+    await waitFor(() => expect(screen.getByText('A Slide Deck')).toBeTruthy())
+    // The slide-deck row carries its own aria-label/title on the row icon (PptRowIcon).
+    expect(screen.getByLabelText('docs.list.kindPpt')).toBeTruthy()
   })
 
   it('shows the type filter on both tabs and drives a multi-select OR request', async () => {

--- a/packages/docs/src/pages/DocsHome.tsx
+++ b/packages/docs/src/pages/DocsHome.tsx
@@ -6,6 +6,8 @@ import { SheetView } from '../sheet/SheetView.tsx'
 import { parseXlsxToMatrix, pendingSheetImports } from '../sheet/xlsxImport.ts'
 import { BoardSession } from '../board/BoardSession.tsx'
 import { HtmlDocView } from '../html/HtmlDocView.tsx'
+import { PptDocView } from '../ppt/PptDocView.tsx'
+import { ConfirmModal } from '../editor/ConfirmModal.tsx'
 import { CreateHtmlModal } from '../html-create/CreateHtmlModal.tsx'
 import { DocsBotConversation } from '../html-create/DocsBotConversation.tsx'
 import { docsApiBaseUrl, type HtmlCreationDraft } from '../html-create/createHtmlTask.ts'
@@ -363,6 +365,21 @@ function HtmlRowIcon(): React.ReactElement {
   )
 }
 
+/**
+ * PPT (slide-deck) row glyph — a framed 16:9 slide with a play/present triangle, drawn in the same
+ * stroked style (no fill blocks) as the doc/board/sheet/html glyphs so an `html_ppt` row reads as a
+ * peer of the other four kinds rather than borrowing the plain-doc icon.
+ */
+function PptRowIcon(): React.ReactElement {
+  return (
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+      <rect x="2" y="3" width="12" height="8" rx="1" stroke="currentColor" strokeWidth="1" fill="none" />
+      <path d="M6.5 5.75 10 7.5 6.5 9.25V5.75Z" stroke="currentColor" strokeWidth="1" fill="none" strokeLinejoin="round" />
+      <path d="M6 13.5h4" stroke="currentColor" strokeWidth="1" strokeLinecap="round" />
+    </svg>
+  )
+}
+
 function WordImportIcon(): React.ReactElement {
   return (
     <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
@@ -494,6 +511,7 @@ function DocsList({
   selectedDocId,
   onSelect,
   onCreateHtml,
+  onCreatePpt,
   reloadToken,
   botUids,
 }: {
@@ -505,6 +523,12 @@ function DocsList({
   onSelect: (docId: string, docType?: string, octoDocSlug?: string, title?: string) => void
   /** Open the "new HTML (embedded bot DM)" flow (plan Task 6). Menu-only; never calls createDoc. */
   onCreateHtml: () => void
+  /**
+   * Open the "new slides (html_ppt)" flow. R1 (XIN-1501) is entry-only: this opens a "coming soon"
+   * notice — live create + template picker land in R2 with `POST /api/v1/ppt/docs`. Menu-only;
+   * never calls createDoc (a Bento deck is not a rich-text doc).
+   */
+  onCreatePpt: () => void
   reloadToken?: number
   /** uids of every bot in the space; a row whose ownerId is here shows a bot badge. */
   botUids: Set<string>
@@ -728,26 +752,30 @@ function DocsList({
     // so a known spreadsheet row opens straight into SheetView. When the list API omitted docType
     // AND we have no local board record — a NON-creator viewing a shared board — pass `undefined`
     // so openDoc resolves the authoritative kind via getDoc (the M2 routing bug).
-    const knownKind: 'board' | 'doc' | 'sheet' | 'html' | undefined = board
+    const knownKind: 'board' | 'doc' | 'sheet' | 'html' | 'html_ppt' | undefined = board
       ? 'board'
       : d.docType === 'sheet'
         ? 'sheet'
         : d.docType === 'html'
           ? 'html'
-          : d.docType === 'doc'
-            ? 'doc'
-            : undefined
+          : d.docType === 'html_ppt'
+            ? 'html_ppt'
+            : d.docType === 'doc'
+              ? 'doc'
+              : undefined
     // Row-icon kind (visual only, always concrete): a known board, then an explicit sheet, else a
     // plain doc — the three-way distinction so a spreadsheet never renders as a document icon
     // (XIN-1188). Independent of `knownKind` above, which stays `undefined` for an unresolved
     // shared row so openDoc can still resolve the authoritative shell via getDoc.
-    const iconKind: 'board' | 'sheet' | 'html' | 'doc' = board
+    const iconKind: 'board' | 'sheet' | 'html' | 'html_ppt' | 'doc' = board
       ? 'board'
       : d.docType === 'sheet'
         ? 'sheet'
         : d.docType === 'html'
           ? 'html'
-          : 'doc'
+          : d.docType === 'html_ppt'
+            ? 'html_ppt'
+            : 'doc'
     const kindLabel =
       iconKind === 'board'
         ? t('docs.list.kindBoard')
@@ -755,7 +783,9 @@ function DocsList({
           ? t('docs.list.kindSheet')
           : iconKind === 'html'
             ? t('docs.list.kindHtml')
-            : t('docs.list.kindDoc')
+            : iconKind === 'html_ppt'
+              ? t('docs.list.kindPpt')
+              : t('docs.list.kindDoc')
     // Recent rows put the creator on its OWN line, then a SINGLE merged time line reporting only
     // the LATEST event (XIN-1236 merged design). Mine rows keep the plain "updated" sub-line
     // (frontend-design §2.1 / §5.1).
@@ -809,6 +839,8 @@ function DocsList({
               <SheetRowIcon />
             ) : iconKind === 'html' ? (
               <HtmlRowIcon />
+            ) : iconKind === 'html_ppt' ? (
+              <PptRowIcon />
             ) : (
               <DocRowIcon />
             )}
@@ -1021,6 +1053,21 @@ function DocsList({
             >
               <span className="octo-docs-new-menu-icon" aria-hidden="true"><HtmlRowIcon /></span>
               {t('docs.list.newHtml')}
+            </button>
+            {/* New slides (html_ppt). R1 (XIN-1501) is entry + routing shell only: this opens a
+                "coming soon" notice rather than creating a deck. Live create + the 4-template picker
+                (POST /api/v1/ppt/docs) land in R2 — like the HTML entry, it NEVER calls createDoc. */}
+            <button
+              type="button"
+              className="octo-docs-new-menu-item"
+              disabled={creating}
+              onClick={() => {
+                setNewMenuAt(null)
+                onCreatePpt()
+              }}
+            >
+              <span className="octo-docs-new-menu-icon" aria-hidden="true"><PptRowIcon /></span>
+              {t('docs.list.newPpt')}
             </button>
             {/* Import entries merged into the "New" dropdown (was a standalone "Import" button).
                 Flag ON; formal owner sign-off still PENDING, gated by needs-human-review (was hidden
@@ -1311,16 +1358,18 @@ export function DocsHome() {
   // persisted/deep-link target that already carries one of them opens straight into the right
   // shell on first paint — no getDoc detour, and (for html) no risk of falling back to the
   // rich-text editor. Only a docId with an UNKNOWN kind still defers to getDoc on mount.
-  const initialKnownKind: 'board' | 'doc' | 'sheet' | 'html' | undefined =
+  const initialKnownKind: 'board' | 'doc' | 'sheet' | 'html' | 'html_ppt' | undefined =
     initialTarget.current?.docType === 'board'
       ? 'board'
       : initialTarget.current?.docType === 'sheet'
         ? 'sheet'
         : initialTarget.current?.docType === 'html'
           ? 'html'
-          : initialTarget.current?.docType === 'doc'
-            ? 'doc'
-            : undefined
+          : initialTarget.current?.docType === 'html_ppt'
+            ? 'html_ppt'
+            : initialTarget.current?.docType === 'doc'
+              ? 'doc'
+              : undefined
   const [selectedDocId, setSelectedDocId] = useState<string | null>(
     () => (initialKnownKind ? (initialTarget.current?.docId ?? null) : null),
   )
@@ -1423,6 +1472,10 @@ export function DocsHome() {
   // closes the other). A ref mirrors the draft so the NavRail re-entry handler can re-mount the
   // SAME chat (same requestId) without a stale closure and without re-sending (§5 risk 1).
   const [htmlModalOpen, setHtmlModalOpen] = useState(false)
+  // R1 (XIN-1501) "new slides" entry: the caret-menu item is wired but live create + the template
+  // picker land in R2 (POST /api/v1/ppt/docs). Until then the entry opens this "coming soon" notice
+  // — it NEVER creates a doc, so a Bento deck is never mis-minted as a rich-text placeholder.
+  const [pptComingSoonOpen, setPptComingSoonOpen] = useState(false)
   const [htmlChatDraft, setHtmlChatDraft] = useState<HtmlCreationDraft | null>(null)
   const htmlChatDraftRef = useRef<HtmlCreationDraft | null>(null)
   useEffect(() => {
@@ -1729,8 +1782,10 @@ export function DocsHome() {
 
   // Choose the right-pane renderer by doc type: a spreadsheet ('sheet') mounts the collaborative
   // Univer SheetView; a whiteboard ('board') mounts the Excalidraw shell; an agent-authored
-  // read-only HTML doc ('html') mounts the view-only HtmlDocView; everything else (incl.
-  // unknown/absent kind) uses the Tiptap EditorShell — the safe default for legacy docs.
+  // read-only HTML doc ('html') mounts the view-only HtmlDocView; a Bento slide-deck ('html_ppt')
+  // mounts the read-only PptDocView — an EXPLICIT peer branch so PPT NEVER falls through to the
+  // Tiptap EditorShell / Hocuspocus collab-token path (no-fallback contract, XIN-1501). Everything
+  // else (incl. unknown/absent kind) uses the Tiptap EditorShell — the safe default for legacy docs.
   const buildRightPane = useCallback(
     (
       docId: string,
@@ -1741,6 +1796,11 @@ export function DocsHome() {
       // Read-only HTML: NO editor/collab wiring — a human may only view it (comments arrive in 2b).
       if (docType === 'html') {
         return <HtmlDocView key={docId} docId={docId} slug={octoDocSlug} space={space} onDeleted={onDocDeleted} />
+      }
+      // Bento slide-deck: read-only PPT surface (R1 placeholder). NO editor/collab wiring and NO
+      // Hocuspocus token — the live editor/preview/present surfaces land in R2+.
+      if (docType === 'html_ppt') {
+        return <PptDocView key={docId} docId={docId} slug={octoDocSlug} space={space} />
       }
       if (docType === 'sheet') {
         return (
@@ -1770,7 +1830,7 @@ export function DocsHome() {
   // (durable sessionStorage + shareable `?doc=` URL), and push the matching shell into the host's
   // right pane. Split out from openDoc so the kind can be resolved asynchronously first.
   const commitOpen = useCallback(
-    (docId: string, docType: 'board' | 'doc' | 'sheet' | 'html', octoDocSlug?: string, title?: string) => {
+    (docId: string, docType: 'board' | 'doc' | 'sheet' | 'html' | 'html_ppt', octoDocSlug?: string, title?: string) => {
       // Opening a doc closes any active html chat (mutually exclusive right-pane modes, §8). Clear
       // the draft + its refresh timers here; the doc shell is pushed below, so no empty-state flash.
       if (htmlChatDraftRef.current) {
@@ -1827,9 +1887,16 @@ export function DocsHome() {
       latestOpenRef.current = docId
       // Known kind — the creator's own board (API `docType` or the local registry, both surfaced
       // by isBoardDoc at the call site), an explicit `'doc'`, a `'sheet'` (created / imported /
-      // known list row), or an agent-authored read-only `'html'` doc: open the right shell
-      // immediately without a round-trip.
-      if (docType === 'board' || docType === 'doc' || docType === 'sheet' || docType === 'html') {
+      // known list row), an agent-authored read-only `'html'` doc, or a Bento `'html_ppt'`
+      // slide-deck: open the right shell immediately without a round-trip. `html_ppt` is listed
+      // explicitly so it reaches the read-only PptDocView and never the rich-text editor.
+      if (
+        docType === 'board' ||
+        docType === 'doc' ||
+        docType === 'sheet' ||
+        docType === 'html' ||
+        docType === 'html_ppt'
+      ) {
         commitOpen(docId, docType, octoDocSlug, title)
         return
       }
@@ -1852,8 +1919,8 @@ export function DocsHome() {
         .then((meta) => {
           if (superseded()) return // superseded by a newer open or a Space switch
           // Preserve the resolved kind verbatim: a real 'sheet' must reach SheetView, a 'board'
-          // the whiteboard shell, an 'html' the read-only view; everything else falls back to the
-          // rich-text editor.
+          // the whiteboard shell, an 'html' the read-only view, an 'html_ppt' the read-only PPT
+          // surface (never the rich-text editor); everything else falls back to the rich-text editor.
           commitOpen(
             docId,
             meta?.docType === 'board'
@@ -1862,7 +1929,9 @@ export function DocsHome() {
                 ? 'sheet'
                 : meta?.docType === 'html'
                   ? 'html'
-                  : 'doc',
+                  : meta?.docType === 'html_ppt'
+                    ? 'html_ppt'
+                    : 'doc',
             meta?.octoDocSlug,
             meta?.title,
           )
@@ -2019,6 +2088,7 @@ export function DocsHome() {
           selectedDocId={selectedDocId}
           onSelect={openDoc}
           onCreateHtml={() => setHtmlModalOpen(true)}
+          onCreatePpt={() => setPptComingSoonOpen(true)}
           reloadToken={listReloadToken}
           botUids={botUids}
         />
@@ -2028,6 +2098,15 @@ export function DocsHome() {
           publishBaseUrl={docsApiBaseUrl(typeof window !== 'undefined' ? window.location.origin : '')}
           onClose={() => setHtmlModalOpen(false)}
           onSubmit={onSubmitHtml}
+        />
+        <ConfirmModal
+          open={pptComingSoonOpen}
+          title={t('docs.ppt.createTitle')}
+          message={t('docs.ppt.createComingSoon')}
+          confirmLabel={t('docs.ppt.createComingSoonOk')}
+          cancelLabel={t('docs.ppt.createComingSoonOk')}
+          onConfirm={() => setPptComingSoonOpen(false)}
+          onCancel={() => setPptComingSoonOpen(false)}
         />
       </div>
     )
@@ -2043,6 +2122,7 @@ export function DocsHome() {
           selectedDocId={selectedDocId}
           onSelect={openDoc}
           onCreateHtml={() => setHtmlModalOpen(true)}
+          onCreatePpt={() => setPptComingSoonOpen(true)}
           reloadToken={listReloadToken}
           botUids={botUids}
         />
@@ -2064,6 +2144,15 @@ export function DocsHome() {
         publishBaseUrl={docsApiBaseUrl(typeof window !== 'undefined' ? window.location.origin : '')}
         onClose={() => setHtmlModalOpen(false)}
         onSubmit={onSubmitHtml}
+      />
+      <ConfirmModal
+        open={pptComingSoonOpen}
+        title={t('docs.ppt.createTitle')}
+        message={t('docs.ppt.createComingSoon')}
+        confirmLabel={t('docs.ppt.createComingSoonOk')}
+        cancelLabel={t('docs.ppt.createComingSoonOk')}
+        onConfirm={() => setPptComingSoonOpen(false)}
+        onCancel={() => setPptComingSoonOpen(false)}
       />
     </div>
   )

--- a/packages/docs/src/pages/StandaloneDocPage.tsx
+++ b/packages/docs/src/pages/StandaloneDocPage.tsx
@@ -5,6 +5,7 @@ import { EditorShell } from '../editor/EditorShell.tsx'
 import { SheetView } from '../sheet/SheetView.tsx'
 import { BoardSession } from '../board/BoardSession.tsx'
 import { HtmlDocView } from '../html/HtmlDocView.tsx'
+import { PptDocView } from '../ppt/PptDocView.tsx'
 import { DocTerminal, type TerminalKind } from '../editor/DocTerminal.tsx'
 import { RequestAccessButton } from '../access-request/RequestAccessButton.tsx'
 import { LinkIcon, type DocMoreMenuItem } from '../editor/DocMoreMenu.tsx'
@@ -625,6 +626,24 @@ export function StandaloneDocPage({
           slug={meta.octoDocSlug}
           space={addressing.space}
           creatorNicknameOnly
+        />
+      </div>
+    )
+  }
+  // Bento slide-deck ('html_ppt'): render the read-only PptDocView (R1 placeholder), mirroring
+  // DocsHome.buildRightPane. This is an EXPLICIT peer branch so a shared /d/<docId> PPT link does
+  // NOT fall through to the collab EditorShell below — a Bento deck has no Yjs data and would 404
+  // there, and the standalone editor would otherwise try to open a Hocuspocus room for it. The
+  // preflight reader gate already ran and recordDocView logged the view, same as every other kind.
+  if (meta.docType === 'html_ppt') {
+    return (
+      <div className="octo-doc-standalone">
+        <PptDocView
+          key={editorDocId}
+          docId={editorDocId}
+          slug={meta.octoDocSlug}
+          space={addressing.space}
+          title={meta.title}
         />
       </div>
     )

--- a/packages/docs/src/pages/TypeFilter.tsx
+++ b/packages/docs/src/pages/TypeFilter.tsx
@@ -5,7 +5,7 @@ import { DOC_TYPES, type DocType } from './docsApi.ts'
 
 /**
  * i18n label key per document kind. The candidates are the fixed {@link DOC_TYPES} enum
- * (doc/sheet/board/html), so — unlike the creator facet — there is NO server `type-facet` endpoint: the
+ * (doc/sheet/board/html/html_ppt), so — unlike the creator facet — there is NO server `type-facet` endpoint: the
  * dropdown writes the candidate set directly and reuses the same labels the list-row icon uses
  * (docs.list.kind*), keeping the filter and the rows consistent (XIN-1188).
  */
@@ -14,6 +14,7 @@ const TYPE_LABEL_KEY: Record<DocType, string> = {
   sheet: 'docs.list.kindSheet',
   board: 'docs.list.kindBoard',
   html: 'docs.list.kindHtml',
+  html_ppt: 'docs.list.kindPpt',
 }
 
 /** Shared kind label so the dropdown and the chips label a type identically. */

--- a/packages/docs/src/pages/docsApi.ts
+++ b/packages/docs/src/pages/docsApi.ts
@@ -14,8 +14,18 @@ import type { Role } from '../auth/roles.ts'
  * the type filter narrows the recent/mine feeds on them (`?type=doc&type=sheet`). Never mock a value
  * that the backend does not persist — a drifting enum is exactly the assumed-wire trap FEAT-B avoids.
  */
-export const DOC_TYPES = ['doc', 'sheet', 'board', 'html'] as const
+export const DOC_TYPES = ['doc', 'sheet', 'board', 'html', 'html_ppt'] as const
 export type DocType = (typeof DOC_TYPES)[number]
+
+/**
+ * The Bento-backed slide-deck kind (`html_ppt`) — a first-class B-owned document type, NOT a
+ * C-hosted HTML doc and NOT a Yjs/ProseMirror rich doc. Its collab/version/source paths live under
+ * `/api/v1/ppt/**` and it is an EXPLICIT sibling of `html` at every routing site (never a
+ * fall-through to the Tiptap editor or the Hocuspocus collab-token path). Named constant kept in
+ * lockstep with the backend wire value (octo-docs-backend `HTML_PPT_DOC_TYPE`) so no guard
+ * re-hardcodes the string.
+ */
+export const HTML_PPT_DOC_TYPE = 'html_ppt'
 
 export interface DocListItem {
   docId: string

--- a/packages/docs/src/ppt/PptDocView.css
+++ b/packages/docs/src/ppt/PptDocView.css
@@ -6,34 +6,36 @@
   justify-content: center;
   width: 100%;
   height: 100%;
-  min-height: 240px;
+  /* No single spacing token reaches this height (scale tops out at --wk-sp-12 = 48px),
+     so compose the empty-state minimum from the largest existing token rather than a raw px. */
+  min-height: calc(var(--wk-sp-12) * 5);
 }
 
 .octo-ppt-view-state {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 8px;
+  gap: var(--wk-sp-2);
   text-align: center;
-  padding: 32px;
+  padding: var(--wk-sp-8);
 }
 
 .octo-ppt-view-kind {
-  font-size: 13px;
-  font-weight: 600;
+  font-size: var(--wk-text-size-base);
+  font-weight: var(--wk-font-semibold);
   letter-spacing: 0.02em;
   opacity: 0.6;
   margin: 0;
 }
 
 .octo-ppt-view-title {
-  font-size: 18px;
-  font-weight: 600;
+  font-size: var(--wk-text-size-2xl);
+  font-weight: var(--wk-font-semibold);
   margin: 0;
 }
 
 .octo-ppt-view-hint {
-  font-size: 14px;
+  font-size: var(--wk-text-size-md);
   opacity: 0.7;
   margin: 0;
 }

--- a/packages/docs/src/ppt/PptDocView.css
+++ b/packages/docs/src/ppt/PptDocView.css
@@ -1,0 +1,39 @@
+/* R1 placeholder styling for the html_ppt read-only surface. Centered empty-state card mirroring
+   the docs list empty-state treatment; no bespoke colors so it inherits the docs theme. */
+.octo-ppt-view {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  min-height: 240px;
+}
+
+.octo-ppt-view-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  text-align: center;
+  padding: 32px;
+}
+
+.octo-ppt-view-kind {
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  opacity: 0.6;
+  margin: 0;
+}
+
+.octo-ppt-view-title {
+  font-size: 18px;
+  font-weight: 600;
+  margin: 0;
+}
+
+.octo-ppt-view-hint {
+  font-size: 14px;
+  opacity: 0.7;
+  margin: 0;
+}

--- a/packages/docs/src/ppt/PptDocView.tsx
+++ b/packages/docs/src/ppt/PptDocView.tsx
@@ -1,0 +1,44 @@
+// Read-only placeholder view for a `docType==='html_ppt'` (Bento slide-deck) document.
+//
+// R1 SCOPE (XIN-1501): this is the routing shell only. `html_ppt` is a first-class, B-owned
+// document type whose editor/preview/present surfaces and `/api/v1/ppt/**` source endpoints land
+// in later rings (R2+). Until those endpoints are deployed this component renders a static,
+// self-contained "coming soon" placeholder.
+//
+// WHY A DEDICATED COMPONENT (no-fallback contract): an `html_ppt` row must NEVER fall through to
+// the Tiptap `EditorShell` — a Bento deck has no Yjs/ProseMirror payload and no Hocuspocus collab
+// room, so the rich-text editor would report "not found" and, worse, could mint a Hocuspocus token
+// against a PPT documentName (which the backend rejects with 422, see octo-docs-backend #152). This
+// component is the explicit peer branch that keeps PPT off both the editor and the collab-token
+// path. It fetches nothing and opens no socket.
+
+import { t } from '../octoweb/index.ts'
+import './PptDocView.css'
+
+export interface PptDocViewProps {
+  /** Doc id of the slide deck (used only for the stable React key at the call site today). */
+  docId: string
+  /** Owning space — carried for parity with HtmlDocView / SheetView and future source scoping. */
+  space?: string
+  /** octo-doc slug when it differs from docId; unused in the R1 placeholder. */
+  slug?: string
+  /** Deck title, when the caller resolved one. */
+  title?: string
+}
+
+/**
+ * R1 read-only placeholder. Intentionally free of any editing chrome, collab wiring, or network
+ * calls — it exists so the docs list / deep-link / right-pane routing has a concrete PPT surface to
+ * land on instead of silently defaulting to the rich-text editor.
+ */
+export function PptDocView({ title }: PptDocViewProps): React.ReactElement {
+  return (
+    <div className="octo-doc octo-ppt-view octo-theme" role="region" aria-label={t('docs.ppt.viewTitle')}>
+      <div className="octo-ppt-view-state">
+        <p className="octo-ppt-view-kind">{t('docs.ppt.viewTitle')}</p>
+        {title && title.trim() && <p className="octo-ppt-view-title">{title.trim()}</p>}
+        <p className="octo-ppt-view-hint">{t('docs.ppt.previewComingSoon')}</p>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

Wires the Bento slide-deck kind (`html_ppt`) into the docs frontend as a first-class fifth `DocType`, in lockstep with the backend contract spine (octo-docs-backend #152: `DOC_TYPES = ['doc','sheet','board','html','html_ppt']`, `HTML_PPT_DOC_TYPE = 'html_ppt'`). The wire value `html_ppt` was verified against the merged backend source, not assumed.

This is **R1: DocType entry + filters + no-fallback routing only**. There is no live PPT create yet — the editor/preview/present surfaces and `/api/v1/ppt/**` source endpoints land in later rings. The "new slides" menu entry is present but stubbed (opens a "coming soon" notice; never calls `createDoc`).

## Changes

- **DocType wire** (`docsApi.ts`): add `'html_ppt'` to `DOC_TYPES` and a `HTML_PPT_DOC_TYPE` constant.
- **Compile-time guard** (`TypeFilter.tsx`): add `html_ppt: 'docs.list.kindPpt'` to the exhaustive `Record<DocType, string>`. The new enum value fails to compile until the label is added; the filter chip is derived from `DOC_TYPES`, so it appears with no further change.
- **Row icon + kind label** (`DocsHome.tsx`): new `PptRowIcon` and explicit `html_ppt` arms in the `knownKind` / `iconKind` / `kindLabel` ladders and the row-icon switch.
- **Create entry** (`DocsHome.tsx`): a "新建幻灯片 / New slides" item after "New HTML" in the split-button caret menu. R1 stub — it opens a "coming soon" notice and never mints a doc (live create + the 4-template picker come in R2 with `POST /api/v1/ppt/docs`).
- **No-fallback routing**: `html_ppt` is an explicit peer branch that renders a read-only `PptDocView` placeholder and **never** falls through to the Tiptap `EditorShell` or a Hocuspocus collab token. Added in `buildRightPane`, the `openDoc` known-kind fast path, the `getDoc` resolve, `initialKnownKind`, and `StandaloneDocPage.tsx` (`/d/:docId` deep-links).
- **i18n** (`zh-CN` + `en-US`): `list.newPpt`, `list.kindPpt`, and a `ppt.*` group for the placeholder view + create notice. Key parity across locales is preserved.

## How the two guarantees are proven

- **Exhaustive-TypeFilter compile guard**: `TYPE_LABEL_KEY` is `Record<DocType, string>`. Adding `html_ppt` to the enum makes `tsc` error there until the label is added — verified by a clean `pnpm typecheck` after adding the key.
- **No-fallback routing**: new tests assert that a persisted `html_ppt` target, a clicked `html_ppt` list row, and an unknown-kind row that `getDoc` resolves to `html_ppt` all mount `PptDocView` and that `editor-shell` is **never** present; and that the create entry shows the notice without issuing `POST /docs`.

## Test / typecheck run

- `pnpm typecheck` (`tsc --noEmit`): **green** for all changed code. The only remaining error is a pre-existing baseline issue in `dmworkbase/src/i18n/format.ts:38` (`fractionalSecondDigits`), present unchanged on `main` `9c25b101` and unrelated to this PR.
- `pnpm test` (docs, vitest): **2391 passed** (+5 new `html_ppt` tests). The single failing file, `src/editor/Toolbar.test.tsx`, is a pre-existing full-suite flake (a tiptap "editor view not available" thrown from an async `requestAnimationFrame` in an unrelated editor test) — it fails identically on `main` `9c25b101` (baseline: 1 failed / 2386 passed) and passes in isolation on both baseline and this branch. This PR touches no editor code.
- Directly affected suites in isolation: `i18n.test.ts` + `DocsHome.test.tsx` → **100 passed**.

Note: the dev-only `build:standalone` harness fails on both baseline and this branch due to missing exports in its `dev/octoBase.dev.ts` stub (`AiBadge`, `Conversation`, `Channel`, …, all pre-existing imports); it is not a real build gate. `tsc --noEmit` is the authoritative compile check.

## Out of scope (later rings)

Live PPT create + template picker (R2), the bento editor route + transport (R4), publish/version/comment surfaces (R5). The `MemberPanel` commenter role stays the existing global 4-role select (no PPT-local role filtering).
