### PR TITLE
feat(docs): run HTML scripts in isolated sandbox

### DIFF
--- a/packages/docs/src/html/HtmlDiffModal.test.tsx
+++ b/packages/docs/src/html/HtmlDiffModal.test.tsx
@@ -181,6 +181,16 @@ describe('HtmlDiffModal', () => {
     expect(screen.getByTestId('html-diff-old')).toBeTruthy()
     expect(screen.getByTestId('html-diff-new')).toBeTruthy()
     expect(screen.getByText('1/1')).toBeTruthy()
+    // The diff panes use readonly-dom isolation: EXACT allow-same-origin (never allow-scripts),
+    // no bridge injected, and no <script> in the built srcdoc — the parent reads the DOM directly.
+    const frames = document.querySelectorAll('iframe.octo-diff-frame')
+    expect(frames.length).toBe(2)
+    frames.forEach((f) => {
+      expect(f.getAttribute('sandbox')).toBe('allow-same-origin')
+      const srcdoc = f.getAttribute('srcdoc') ?? ''
+      expect(srcdoc).not.toContain('octodoc-bridge')
+      expect(srcdoc).not.toMatch(/<script/i)
+    })
   })
 
   it('switches page layout and closes on Esc/backdrop', async () => {

--- a/packages/docs/src/html/HtmlDiffModal.tsx
+++ b/packages/docs/src/html/HtmlDiffModal.tsx
@@ -446,6 +446,9 @@ export function HtmlDiffModal({ slug, from, to, title, onClose }: HtmlDiffModalP
                     version={from}
                     title={`${title} · v${from}`}
                     className="octo-html-doc-frame octo-diff-frame"
+                    // Static diff view: read the (script-free) DOM directly to highlight changes and
+                    // mirror scroll. No scripts run, so same-origin DOM access stays safe.
+                    isolation="readonly-dom"
                     onFrameLoad={onFrameLoad('old')}
                   />
                 </div>
@@ -458,6 +461,7 @@ export function HtmlDiffModal({ slug, from, to, title, onClose }: HtmlDiffModalP
                     version={to}
                     title={`${title} · v${to}`}
                     className="octo-html-doc-frame octo-diff-frame"
+                    isolation="readonly-dom"
                     onFrameLoad={onFrameLoad('new')}
                   />
                 </div>

--- a/packages/docs/src/html/HtmlDocCommentPanel.test.tsx
+++ b/packages/docs/src/html/HtmlDocCommentPanel.test.tsx
@@ -264,6 +264,87 @@ describe('HtmlDocCommentPanel — list + compose (octo-doc data layer)', () => {
     expect(onClearPendingAnchor).toHaveBeenCalledTimes(1)
   })
 
+  it('reports composer engagement on focus/blur and while a non-empty draft is held', async () => {
+    const onComposerEngagedChange = vi.fn()
+    stubFetch(() => jsonResponse({ data: [] }))
+    render(
+      <HtmlDocCommentPanel
+        docId="d1"
+        space="sp"
+        slug="s"
+        listVersion="v1"
+        mayComment
+        onComposerEngagedChange={onComposerEngagedChange}
+      />,
+    )
+    const input = await screen.findByPlaceholderText('docs.comment.placeholder')
+
+    // Initial: not engaged.
+    expect(onComposerEngagedChange).toHaveBeenLastCalledWith(false)
+
+    // Focus → engaged.
+    fireEvent.focus(input)
+    await waitFor(() => expect(onComposerEngagedChange).toHaveBeenLastCalledWith(true))
+
+    // Blur with empty draft → disengaged.
+    fireEvent.blur(input)
+    await waitFor(() => expect(onComposerEngagedChange).toHaveBeenLastCalledWith(false))
+
+    // A non-empty draft keeps it engaged even after blur.
+    fireEvent.focus(input)
+    fireEvent.change(input, { target: { value: 'note' } })
+    fireEvent.blur(input)
+    await waitFor(() => expect(onComposerEngagedChange).toHaveBeenLastCalledWith(true))
+
+    // Clearing the draft disengages again.
+    fireEvent.change(input, { target: { value: '' } })
+    await waitFor(() => expect(onComposerEngagedChange).toHaveBeenLastCalledWith(false))
+  })
+
+  it('reports engaged=false on unmount so a stale engaged=true never outlives the panel', async () => {
+    const onComposerEngagedChange = vi.fn()
+    stubFetch(() => jsonResponse({ data: [] }))
+    const { unmount } = render(
+      <HtmlDocCommentPanel
+        docId="d1"
+        space="sp"
+        slug="s"
+        listVersion="v1"
+        mayComment
+        onComposerEngagedChange={onComposerEngagedChange}
+      />,
+    )
+    const input = await screen.findByPlaceholderText('docs.comment.placeholder')
+    fireEvent.focus(input)
+    fireEvent.change(input, { target: { value: 'note' } })
+    await waitFor(() => expect(onComposerEngagedChange).toHaveBeenLastCalledWith(true))
+
+    unmount()
+    // The effect cleanup fires a final false.
+    expect(onComposerEngagedChange).toHaveBeenLastCalledWith(false)
+  })
+
+  it('reports engaged=false to a replaced callback (callback identity change resets the prior parent)', async () => {
+    const first = vi.fn()
+    const second = vi.fn()
+    stubFetch(() => jsonResponse({ data: [] }))
+    const { rerender } = render(
+      <HtmlDocCommentPanel docId="d1" space="sp" slug="s" listVersion="v1" mayComment onComposerEngagedChange={first} />,
+    )
+    const input = await screen.findByPlaceholderText('docs.comment.placeholder')
+    fireEvent.focus(input)
+    fireEvent.change(input, { target: { value: 'note' } })
+    await waitFor(() => expect(first).toHaveBeenLastCalledWith(true))
+
+    // Swapping the callback re-runs the effect: the OLD callback gets a cleanup false, the new one
+    // is re-notified with the current engagement.
+    rerender(
+      <HtmlDocCommentPanel docId="d1" space="sp" slug="s" listVersion="v1" mayComment onComposerEngagedChange={second} />,
+    )
+    expect(first).toHaveBeenLastCalledWith(false)
+    await waitFor(() => expect(second).toHaveBeenLastCalledWith(true))
+  })
+
   it('shows doc-level target state when there is no pending anchor', async () => {
     stubFetch(() => jsonResponse({ data: [] }))
     render(<HtmlDocCommentPanel docId="d1" space="sp" slug="s" listVersion="v1" mayComment />)

--- a/packages/docs/src/html/HtmlDocCommentPanel.tsx
+++ b/packages/docs/src/html/HtmlDocCommentPanel.tsx
@@ -51,6 +51,13 @@ export interface HtmlDocCommentPanelProps {
   onVisibleAnchors?: (aids: string[]) => void
   /** Explicit activation: scroll the thread's element anchor into view + highlight it in the frame. */
   onActivateAnchor?: (anchor: Anchor | null | undefined) => void
+  /**
+   * Reports whether the root-comment composer is "engaged" (focused OR holds a non-empty draft).
+   * The parent freezes the pending selection anchor while engaged so a hostile document cannot swap
+   * the reviewed target out from under the human right before they submit (anchor-race). Explicit
+   * clear / a fresh selection made before engaging are unaffected.
+   */
+  onComposerEngagedChange?: (engaged: boolean) => void
 }
 
 /** Short human label for how a comment is anchored (element aid / selected text / doc-level). */
@@ -128,6 +135,7 @@ export function HtmlDocCommentPanel({
   onActivateAnchor,
   onClearPendingAnchor,
   onPosted,
+  onComposerEngagedChange,
 }: HtmlDocCommentPanelProps) {
   const [threads, setThreads] = useState<OctoDocCommentThread[]>([])
   const [draft, setDraft] = useState('')
@@ -137,7 +145,19 @@ export function HtmlDocCommentPanel({
   const [replyingToId, setReplyingToId] = useState<string | null>(null)
   const [replyDraft, setReplyDraft] = useState('')
   const [replyBusy, setReplyBusy] = useState(false)
+  // Whether the root composer currently has focus. Combined with a non-empty draft this makes the
+  // composer "engaged", which the parent uses to freeze the pending anchor against a doc-driven swap.
+  const [composerFocused, setComposerFocused] = useState(false)
   const reloadSeq = useRef(0)
+
+  // Report composer engagement (focus OR non-empty draft) so the parent can freeze the reviewed
+  // anchor. Cleanup reports false on unmount / callback change so the parent never holds a stale
+  // engaged=true after this panel goes away.
+  const composerEngaged = composerFocused || draft.trim() !== ''
+  useEffect(() => {
+    onComposerEngagedChange?.(composerEngaged)
+    return () => onComposerEngagedChange?.(false)
+  }, [composerEngaged, onComposerEngagedChange])
 
   const reload = useCallback(async () => {
     const seq = ++reloadSeq.current
@@ -382,6 +402,8 @@ export function HtmlDocCommentPanel({
             className="octo-comment-input"
             value={draft}
             placeholder={t('docs.comment.placeholder')}
+            onFocus={() => setComposerFocused(true)}
+            onBlur={() => setComposerFocused(false)}
             onChange={(e) => setDraft(e.target.value)}
           />
           <button type="button" className="octo-doc-primary-btn" disabled={busy || draft.trim() === ''} onClick={submit}>

--- a/packages/docs/src/html/HtmlDocCommentPanel.tsx
+++ b/packages/docs/src/html/HtmlDocCommentPanel.tsx
@@ -47,6 +47,10 @@ export interface HtmlDocCommentPanelProps {
   onPosted?: () => void
   /** Resolves the full anchored source text from the iframe document when available. */
   resolveAnchorText?: (anchor: Anchor | null | undefined) => string | null
+  /** Post-commit report of the element aids this panel renders, so the parent can resolve them. */
+  onVisibleAnchors?: (aids: string[]) => void
+  /** Explicit activation: scroll the thread's element anchor into view + highlight it in the frame. */
+  onActivateAnchor?: (anchor: Anchor | null | undefined) => void
 }
 
 /** Short human label for how a comment is anchored (element aid / selected text / doc-level). */
@@ -120,6 +124,8 @@ export function HtmlDocCommentPanel({
   mutationVersion,
   pendingAnchor,
   resolveAnchorText,
+  onVisibleAnchors,
+  onActivateAnchor,
   onClearPendingAnchor,
   onPosted,
 }: HtmlDocCommentPanelProps) {
@@ -150,6 +156,18 @@ export function HtmlDocCommentPanel({
     void reload()
     return () => { reloadSeq.current += 1 }
   }, [reload])
+
+  // Post-commit: report the element aids currently rendered so the parent can resolve their text
+  // over the bridge. Derived from committed thread data, so the parent never schedules work during
+  // render. Recomputed only when threads change.
+  useEffect(() => {
+    if (!onVisibleAnchors) return
+    const aids: string[] = []
+    for (const th of threads) {
+      if (th.anchor?.kind === 'element' && !aids.includes(th.anchor.aid)) aids.push(th.anchor.aid)
+    }
+    onVisibleAnchors(aids)
+  }, [threads, onVisibleAnchors])
 
   // A concrete positive integer version is required for every mutation (PR #1096 contract:
   // list may use `latest`, mutations must target a concrete version). Shared by root + reply.
@@ -245,17 +263,44 @@ export function HtmlDocCommentPanel({
           const canResolveAnchor = thread.anchor?.kind === 'element' || thread.anchor?.kind === 'text'
           const quoteText = (canResolveAnchor ? resolveAnchorText?.(thread.anchor) : null) ?? fallbackAnchorText(thread.anchor)
           const label = anchorLabel(thread.anchor)
+          // Only element anchors carry a locatable aid, so only they are click-to-scroll.
+          const canActivate = thread.anchor?.kind === 'element' && !!onActivateAnchor
+          const activate = canActivate ? () => onActivateAnchor?.(thread.anchor) : undefined
 
           return (
             <li key={thread.id} className="octo-html-doc-comment" data-testid="html-doc-comment">
               {quoteText ? (
-                <blockquote className="octo-html-doc-comment-quote" data-testid="comment-quote" title={quoteText}>
-                  {quoteText}
-                </blockquote>
+                canActivate ? (
+                  <button
+                    type="button"
+                    className="octo-html-doc-comment-quote octo-html-doc-comment-quote--activatable"
+                    data-testid="comment-quote"
+                    title={t('docs.comment.scrollToAnchor')}
+                    onClick={activate}
+                  >
+                    {quoteText}
+                  </button>
+                ) : (
+                  <blockquote className="octo-html-doc-comment-quote" data-testid="comment-quote" title={quoteText}>
+                    {quoteText}
+                  </blockquote>
+                )
               ) : thread.anchor ? (
-                <div className="octo-html-doc-comment-anchor" title={label}>
-                  {label}
-                </div>
+                canActivate ? (
+                  <button
+                    type="button"
+                    className="octo-html-doc-comment-anchor octo-html-doc-comment-anchor--activatable"
+                    data-testid="comment-anchor"
+                    title={t('docs.comment.scrollToAnchor')}
+                    onClick={activate}
+                  >
+                    {label}
+                  </button>
+                ) : (
+                  <div className="octo-html-doc-comment-anchor" title={label}>
+                    {label}
+                  </div>
+                )
               ) : null}
               <CommentMeta author={thread.author} createdAt={thread.created_at} />
               <p className="octo-html-doc-comment-text">{thread.text}</p>

--- a/packages/docs/src/html/HtmlDocView.css
+++ b/packages/docs/src/html/HtmlDocView.css
@@ -115,6 +115,26 @@
   margin: 4px 0;
   font-size: 13px;
 }
+/* Activatable anchor/quote: a click scrolls + highlights the anchor in the frame. Reset button
+   chrome so it reads as the quote/anchor it replaces; only add an affordance cursor. */
+.octo-html-doc-comment-quote--activatable,
+.octo-html-doc-comment-anchor--activatable {
+  display: block;
+  width: 100%;
+  text-align: left;
+  border: none;
+  font: inherit;
+  cursor: pointer;
+}
+.octo-html-doc-comment-anchor--activatable {
+  background: none;
+  padding: 0;
+  color: var(--octo-doc-accent, var(--semi-color-primary, currentColor));
+}
+.octo-html-doc-comment-quote--activatable:hover,
+.octo-html-doc-comment-anchor--activatable:hover {
+  text-decoration: underline;
+}
 /* Author + time meta line under each comment / reply. */
 .octo-html-doc-comment-meta {
   display: flex;

--- a/packages/docs/src/html/HtmlDocView.test.tsx
+++ b/packages/docs/src/html/HtmlDocView.test.tsx
@@ -588,6 +588,158 @@ describe('HtmlDocView — read-only rendering', () => {
     expect(screen.getByTestId('pending-anchor').textContent).not.toContain('#a2')
   })
 
+  it('freezes the pending anchor once the composer is engaged (focus): a hostile doc cannot swap it', async () => {
+    const wk = createMockWKApp({ uid: 'u_viewer', token: 't' })
+    wk.apiClient.responder = (method, url) =>
+      method === 'get' && url === '/docs/d1'
+        ? { data: { docId: 'd1', ownerId: 'u_owner', role: 'commenter' }, status: 200 }
+        : { data: {}, status: 200 }
+    setWKApp(wk)
+    stubFetch((url) =>
+      url.includes('/comments')
+        ? jsonResponse({ data: [] })
+        : htmlResponse('<p data-odoc-aid="good">reviewed target</p><p data-odoc-aid="evil">swapped target</p>'),
+    )
+    const { container } = render(<HtmlDocView docId="d1" space="sp" />)
+    const frame = await waitForFrame(container)
+    fireEvent.load(frame)
+
+    // Human selects the target they intend to comment on.
+    bridgeSelection(frame, { kind: 'element', aid: 'good', selector: '[data-odoc-aid="good"]', label: 'p' })
+    await waitFor(() => expect(screen.getByTestId('pending-anchor').textContent).toContain('#good'))
+
+    // Human engages the composer (focus). From here the anchor is FROZEN.
+    fireEvent.focus(screen.getByPlaceholderText('docs.comment.placeholder'))
+    // Hostile document fires a selection message trying to swap the reviewed target.
+    bridgeSelection(frame, { kind: 'element', aid: 'evil', selector: '[data-odoc-aid="evil"]', label: 'p' })
+
+    // Give the coalesce timer room to flush; the swap must be ignored (still #good, never #evil).
+    await new Promise((r) => setTimeout(r, 100))
+    expect(screen.getByTestId('pending-anchor').textContent).toContain('#good')
+    expect(screen.getByTestId('pending-anchor').textContent).not.toContain('#evil')
+  })
+
+  it('freezes the pending anchor while a non-empty draft is held (even without focus)', async () => {
+    const wk = createMockWKApp({ uid: 'u_viewer', token: 't' })
+    wk.apiClient.responder = (method, url) =>
+      method === 'get' && url === '/docs/d1'
+        ? { data: { docId: 'd1', ownerId: 'u_owner', role: 'commenter' }, status: 200 }
+        : { data: {}, status: 200 }
+    setWKApp(wk)
+    stubFetch((url) =>
+      url.includes('/comments')
+        ? jsonResponse({ data: [] })
+        : htmlResponse('<p data-odoc-aid="good">reviewed</p><p data-odoc-aid="evil">swap</p>'),
+    )
+    const { container } = render(<HtmlDocView docId="d1" space="sp" />)
+    const frame = await waitForFrame(container)
+    fireEvent.load(frame)
+
+    bridgeSelection(frame, { kind: 'element', aid: 'good', selector: '[data-odoc-aid="good"]', label: 'p' })
+    await waitFor(() => expect(screen.getByTestId('pending-anchor').textContent).toContain('#good'))
+
+    const input = screen.getByPlaceholderText('docs.comment.placeholder')
+    fireEvent.focus(input)
+    fireEvent.change(input, { target: { value: 'my review note' } })
+    fireEvent.blur(input) // blur, but the non-empty draft keeps the composer engaged
+
+    bridgeSelection(frame, { kind: 'element', aid: 'evil', selector: '[data-odoc-aid="evil"]', label: 'p' })
+    await new Promise((r) => setTimeout(r, 100))
+    expect(screen.getByTestId('pending-anchor').textContent).toContain('#good')
+    expect(screen.getByTestId('pending-anchor').textContent).not.toContain('#evil')
+  })
+
+  it('accepts a fresh selection again after the human explicitly clears (disengaging the composer)', async () => {
+    const wk = createMockWKApp({ uid: 'u_viewer', token: 't' })
+    wk.apiClient.responder = (method, url) =>
+      method === 'get' && url === '/docs/d1'
+        ? { data: { docId: 'd1', ownerId: 'u_owner', role: 'commenter' }, status: 200 }
+        : { data: {}, status: 200 }
+    setWKApp(wk)
+    stubFetch((url) =>
+      url.includes('/comments')
+        ? jsonResponse({ data: [] })
+        : htmlResponse('<p data-odoc-aid="good">a</p><p data-odoc-aid="next">b</p>'),
+    )
+    const { container } = render(<HtmlDocView docId="d1" space="sp" />)
+    const frame = await waitForFrame(container)
+    fireEvent.load(frame)
+
+    bridgeSelection(frame, { kind: 'element', aid: 'good', selector: '[data-odoc-aid="good"]', label: 'p' })
+    await waitFor(() => expect(screen.getByTestId('pending-anchor').textContent).toContain('#good'))
+
+    // Engage (focus, no draft), then explicitly clear: an empty draft + blur means the composer is
+    // no longer engaged, so a new legitimate selection is honored again.
+    fireEvent.focus(screen.getByPlaceholderText('docs.comment.placeholder'))
+    fireEvent.click(screen.getByText('docs.comment.clearAnchor'))
+    fireEvent.blur(screen.getByPlaceholderText('docs.comment.placeholder'))
+
+    bridgeSelection(frame, { kind: 'element', aid: 'next', selector: '[data-odoc-aid="next"]', label: 'p' })
+    await waitFor(() => expect(screen.getByTestId('pending-anchor').textContent).toContain('#next'))
+  })
+
+  it('coalesces a burst of selection messages into a single adopted anchor (the latest wins)', async () => {
+    const wk = createMockWKApp({ uid: 'u_viewer', token: 't' })
+    wk.apiClient.responder = (method, url) =>
+      method === 'get' && url === '/docs/d1'
+        ? { data: { docId: 'd1', ownerId: 'u_owner', role: 'commenter' }, status: 200 }
+        : { data: {}, status: 200 }
+    setWKApp(wk)
+    stubFetch((url) =>
+      url.includes('/comments')
+        ? jsonResponse({ data: [] })
+        : htmlResponse('<p data-odoc-aid="a1">1</p><p data-odoc-aid="a2">2</p><p data-odoc-aid="a3">3</p>'),
+    )
+    const { container } = render(<HtmlDocView docId="d1" space="sp" />)
+    const frame = await waitForFrame(container)
+    fireEvent.load(frame)
+    await waitFor(() => expect(screen.getByPlaceholderText('docs.comment.placeholder')).toBeTruthy())
+
+    // Fire three selection messages synchronously (a drag-select burst) inside one coalesce window.
+    bridgeSelection(frame, { kind: 'element', aid: 'a1', selector: '[data-odoc-aid="a1"]', label: 'p' })
+    bridgeSelection(frame, { kind: 'element', aid: 'a2', selector: '[data-odoc-aid="a2"]', label: 'p' })
+    bridgeSelection(frame, { kind: 'element', aid: 'a3', selector: '[data-odoc-aid="a3"]', label: 'p' })
+
+    // Only the LAST anchor is adopted after the single trailing flush.
+    await waitFor(() => expect(screen.getByTestId('pending-anchor').textContent).toContain('#a3'))
+    expect(screen.getByTestId('pending-anchor').textContent).not.toContain('#a1')
+    expect(screen.getByTestId('pending-anchor').textContent).not.toContain('#a2')
+  })
+
+  it('safely resolves element anchors whose aid is an Object.prototype key name (Map cache, no proto hit)', async () => {
+    const wk = createMockWKApp({ uid: 'u_viewer', token: 't' })
+    wk.apiClient.responder = (method, url) =>
+      method === 'get' && url === '/docs/d1'
+        ? { data: { docId: 'd1', ownerId: 'u_owner', role: 'commenter' }, status: 200 }
+        : { data: {}, status: 200 }
+    setWKApp(wk)
+    // All three prototype-poisoning names plus Object.prototype member names must round-trip: the
+    // Map cache uses own-key semantics, so none is a prototype-chain hit and each resolves/renders.
+    const aids = ['__proto__', 'constructor', 'prototype', 'toString', 'valueOf', 'hasOwnProperty']
+    stubFetch((url) => {
+      if (url.includes('/comments')) {
+        return jsonResponse({
+          data: aids.map((aid, i) => ({
+            id: `c${i}`,
+            text: `note ${aid}`,
+            anchor: { kind: 'element', aid, selector: `[data-odoc-aid="${aid}"]`, label: 'p' },
+            replies: [],
+          })),
+        })
+      }
+      return htmlResponse(aids.map((aid) => `<p data-odoc-aid="${aid}">text-${aid}</p>`).join(''))
+    })
+    const { container } = render(<HtmlDocView docId="d1" space="sp" />)
+    const frame = await waitForFrame(container)
+    autoAnswerAnchorText(frame, Object.fromEntries(aids.map((aid) => [aid, `text-${aid}`])))
+    fireEvent.load(frame)
+
+    // Every thread renders (no crash) and each resolves its own distinct quote from the Map cache.
+    await waitFor(() => expect(screen.getAllByTestId('comment-quote')).toHaveLength(aids.length))
+    const quotes = screen.getAllByTestId('comment-quote').map((n) => n.textContent)
+    for (const aid of aids) expect(quotes).toContain(`text-${aid}`)
+  })
+
   it('ignores bridge messages whose source is not the iframe (forged origin / other window)', async () => {
     const wk = createMockWKApp({ uid: 'u_viewer', token: 't' })
     wk.apiClient.responder = (method, url) =>
@@ -990,21 +1142,77 @@ describe('sanitizeDocHtml', () => {
   })
 })
 
-describe('injectBaseHref', () => {
-  it('inserts <base> at the START of an existing <head> with a trailing-slash href', () => {
+describe('injectBaseHref (parser-aware)', () => {
+  it('inserts <base> as the FIRST child of an existing <head> with a trailing-slash href', () => {
     const out = injectBaseHref('<html><head><title>t</title></head><body>x</body></html>', 'https://od.test')
-    expect(out).toContain('<head><base href="https://od.test/">')
+    expect(out).toContain('<base href="https://od.test/">')
     // Only one base, and it precedes the original head content.
+    expect(out.split('<base').length - 1).toBe(1)
     expect(out.indexOf('<base')).toBeLessThan(out.indexOf('<title>'))
   })
 
-  it('preserves an already-trailing slash and prepends <base> when there is no <head>', () => {
+  it('preserves an already-trailing slash and synthesizes a <head> when the doc has only a body', () => {
     const out = injectBaseHref('<p>no head</p>', 'https://od.test/')
-    expect(out).toBe('<base href="https://od.test/"><p>no head</p>')
+    expect(out).toContain('<base href="https://od.test/">')
+    // DOMParser normalizes the fragment: base lands in the synthesized <head>, before <body>.
+    expect(out.indexOf('<base')).toBeLessThan(out.indexOf('<body'))
+    expect(out).toContain('<p>no head</p>')
   })
 
   it('is a no-op when baseUrl is empty', () => {
     expect(injectBaseHref('<p>x</p>', '')).toBe('<p>x</p>')
+  })
+
+  it('does NOT mis-target a FAKE <head> inside an HTML comment (only the real head gets <base>)', () => {
+    const out = injectBaseHref(
+      '<html><head><title>t</title></head><body><!-- <head>fake</head> --></body></html>',
+      'https://od.test',
+    )
+    expect(out.split('<base').length - 1).toBe(1)
+    expect(out.indexOf('<base')).toBeLessThan(out.indexOf('<title>'))
+  })
+
+  it('does NOT mis-target a fake <head> living in an attribute value', () => {
+    const out = injectBaseHref(
+      '<html><head></head><body><div data-x="<head>">z</div></body></html>',
+      'https://od.test',
+    )
+    expect(out.split('<base').length - 1).toBe(1)
+    // The <base> sits in the real head, not inside the div attribute.
+    expect(out.indexOf('<base')).toBeLessThan(out.indexOf('<body'))
+  })
+
+  it('does NOT mis-target a fake <head> inside <script>/<style> raw-text', () => {
+    const script = injectBaseHref(
+      '<html><head><script>var s="<head>";<\/script></head><body>y</body></html>',
+      'https://od.test',
+    )
+    expect(script.split('<base').length - 1).toBe(1)
+    const style = injectBaseHref(
+      '<html><head><style>/* <head> */</style></head><body>y</body></html>',
+      'https://od.test',
+    )
+    expect(style.split('<base').length - 1).toBe(1)
+  })
+
+  it('does NOT treat a <head> inside a <template> as the document head', () => {
+    const out = injectBaseHref(
+      '<html><head><title>t</title></head><body><template><head>nope</head></template></body></html>',
+      'https://od.test',
+    )
+    expect(out.split('<base').length - 1).toBe(1)
+    expect(out.indexOf('<base')).toBeLessThan(out.indexOf('<title>'))
+  })
+
+  it('fails closed without DOMParser (SSR): returns the HTML unchanged, never regex-injects', () => {
+    const raw = '<html><head><title>t</title></head><body>x</body></html>'
+    const saved = globalThis.DOMParser
+    delete (globalThis as { DOMParser?: unknown }).DOMParser
+    try {
+      expect(injectBaseHref(raw, 'https://od.test')).toBe(raw)
+    } finally {
+      ;(globalThis as { DOMParser?: unknown }).DOMParser = saved
+    }
   })
 })
 
@@ -1666,5 +1874,201 @@ describe('HtmlDocView — Members panel gate (author OR admin)', () => {
     await waitForFrame(container)
     expect(screen.queryByTitle('docs.toolbar.members')).toBeNull()
     expect(container.querySelector('.octo-modal-overlay')).toBeNull()
+  })
+})
+
+describe('HtmlDocView — coalesced selection bound to bridge generation (fake timers)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  function commenter() {
+    const wk = createMockWKApp({ uid: 'u_viewer', token: 't' })
+    wk.apiClient.responder = (method, url) =>
+      method === 'get' && url === '/docs/d1'
+        ? { data: { docId: 'd1', ownerId: 'u_owner', role: 'commenter' }, status: 200 }
+        : { data: {}, status: 200 }
+    setWKApp(wk)
+  }
+
+  async function mountReadyFrame(html: string) {
+    stubFetch((url) => (url.includes('/comments') ? jsonResponse({ data: [] }) : htmlResponse(html)))
+    const { container, rerender } = render(<HtmlDocView docId="d1" space="sp" />)
+    // Drive the async fetch + role resolution to completion under fake timers.
+    await vi.waitFor(() => {
+      const f = container.querySelector('iframe.octo-html-doc-frame') as HTMLIFrameElement | null
+      expect(f).toBeTruthy()
+      return f as HTMLIFrameElement
+    })
+    const frame = container.querySelector('iframe.octo-html-doc-frame') as HTMLIFrameElement
+    fireEvent.load(frame)
+    await vi.waitFor(() => expect(screen.getByPlaceholderText('docs.comment.placeholder')).toBeTruthy())
+    return { container, rerender, frame }
+  }
+
+  it('drops an old-generation queued selection after the frame reloads before the flush', async () => {
+    commenter()
+    const { container, frame } = await mountReadyFrame('<p data-odoc-aid="a1">one</p>')
+
+    // Queue a selection under generation A but do NOT let the 60ms flush fire yet.
+    bridgeSelection(frame, { kind: 'element', aid: 'a1', selector: '[data-odoc-aid="a1"]', label: 'p' })
+    // Frame reloads (a new generation) before the coalesce timer elapses.
+    fireEvent.load(frame)
+    // Advance past the coalesce window: the gen-A anchor is stale and must be dropped.
+    await vi.advanceTimersByTimeAsync(120)
+    expect(screen.getByTestId('pending-anchor').textContent).not.toContain('#a1')
+    expect(screen.getByTestId('pending-anchor').textContent).toContain('docs.comment.targetDoc')
+
+    // A fresh selection under the current generation still flushes normally.
+    bridgeSelection(frame, { kind: 'element', aid: 'a1', selector: '[data-odoc-aid="a1"]', label: 'p' })
+    await vi.advanceTimersByTimeAsync(120)
+    expect(screen.getByTestId('pending-anchor').textContent).toContain('#a1')
+    expect(container.querySelector('iframe.octo-html-doc-frame')).toBe(frame)
+  })
+
+  it('drops a queued selection when code mode is entered before the flush', async () => {
+    commenter()
+    const { frame } = await mountReadyFrame('<p data-odoc-aid="a1">one</p>')
+    bridgeSelection(frame, { kind: 'element', aid: 'a1', selector: '[data-odoc-aid="a1"]', label: 'p' })
+    // Switch to code mode within the coalesce window (mayCommentRef → false).
+    fireEvent.click(screen.getByRole('tab', { name: 'docs.mode.code' }))
+    await vi.advanceTimersByTimeAsync(120)
+    // Code mode has no pending-anchor UI; switching back must not show the dropped anchor.
+    fireEvent.click(screen.getByRole('tab', { name: 'docs.mode.page' }))
+    await vi.waitFor(() => expect(screen.queryByTestId('pending-anchor')).toBeTruthy())
+    expect(screen.getByTestId('pending-anchor').textContent).not.toContain('#a1')
+  })
+
+  it('drops a queued selection when commenting permission is removed before the flush', async () => {
+    let role: 'commenter' | 'reader' = 'commenter'
+    const wk = createMockWKApp({ uid: 'u_viewer', token: 't' })
+    wk.apiClient.responder = (method, url) =>
+      method === 'get' && url === '/docs/d1'
+        ? { data: { docId: 'd1', ownerId: 'u_owner', role }, status: 200 }
+        : { data: {}, status: 200 }
+    setWKApp(wk)
+    stubFetch((url) => (url.includes('/comments') ? jsonResponse({ data: [] }) : htmlResponse('<p data-odoc-aid="a1">one</p>')))
+    const { container, rerender } = render(<HtmlDocView docId="d1" space="sp1" />)
+    await vi.waitFor(() => expect(container.querySelector('iframe.octo-html-doc-frame')).toBeTruthy())
+    const frame = container.querySelector('iframe.octo-html-doc-frame') as HTMLIFrameElement
+    fireEvent.load(frame)
+    await vi.waitFor(() => expect(screen.getByPlaceholderText('docs.comment.placeholder')).toBeTruthy())
+
+    // Queue a selection under commenter, then demote to reader within the coalesce window. The
+    // commenting-off effect cancels the queued flush, so the demoted human never gets the anchor.
+    bridgeSelection(frame, { kind: 'element', aid: 'a1', selector: '[data-odoc-aid="a1"]', label: 'p' })
+    role = 'reader'
+    rerender(<HtmlDocView docId="d1" space="sp2" />)
+    await vi.waitFor(() => expect(screen.queryByPlaceholderText('docs.comment.placeholder')).toBeNull())
+    await vi.advanceTimersByTimeAsync(120)
+    // Reader has no pending-anchor UI; the queued anchor was dropped, not committed.
+    expect(screen.queryByTestId('pending-anchor')).toBeNull()
+  })
+
+  it('honors a queued selection that arrives before the composer engages, and freezes one that engages during the delay', async () => {
+    commenter()
+    const { frame } = await mountReadyFrame('<p data-odoc-aid="good">good</p><p data-odoc-aid="evil">evil</p>')
+
+    // First selection queued, composer NOT engaged: it flushes and is adopted.
+    bridgeSelection(frame, { kind: 'element', aid: 'good', selector: '[data-odoc-aid="good"]', label: 'p' })
+    await vi.advanceTimersByTimeAsync(120)
+    expect(screen.getByTestId('pending-anchor').textContent).toContain('#good')
+
+    // Queue a swap, then engage the composer during the coalesce delay: the flush must re-check
+    // engagement and drop the swap (still #good, never #evil).
+    bridgeSelection(frame, { kind: 'element', aid: 'evil', selector: '[data-odoc-aid="evil"]', label: 'p' })
+    fireEvent.focus(screen.getByPlaceholderText('docs.comment.placeholder'))
+    await vi.advanceTimersByTimeAsync(120)
+    expect(screen.getByTestId('pending-anchor').textContent).toContain('#good')
+    expect(screen.getByTestId('pending-anchor').textContent).not.toContain('#evil')
+  })
+})
+
+describe('HtmlDocView — composer engagement reset across transitions', () => {
+  function commenter() {
+    const wk = createMockWKApp({ uid: 'u_viewer', token: 't' })
+    wk.apiClient.responder = (method, url) =>
+      method === 'get' && url === '/docs/d1'
+        ? { data: { docId: 'd1', ownerId: 'u_owner', role: 'commenter' }, status: 200 }
+        : { data: {}, status: 200 }
+    setWKApp(wk)
+  }
+
+  it('accepts a fresh selection after the comment panel is closed and reopened (engagement reset)', async () => {
+    commenter()
+    stubFetch((url) => (url.includes('/comments') ? jsonResponse({ data: [] }) : htmlResponse('<p data-odoc-aid="a1">one</p><p data-odoc-aid="a2">two</p>')))
+    const { container } = render(<HtmlDocView docId="d1" space="sp" />)
+    const frame = await waitForFrame(container)
+    fireEvent.load(frame)
+    await waitFor(() => expect(screen.getByPlaceholderText('docs.comment.placeholder')).toBeTruthy())
+
+    // Engage the composer (focus + draft), then close the panel: the panel's cleanup reports
+    // engaged=false so the parent's freeze is released.
+    const input = screen.getByPlaceholderText('docs.comment.placeholder')
+    fireEvent.focus(input)
+    fireEvent.change(input, { target: { value: 'draft' } })
+    fireEvent.click(screen.getByTitle('docs.toolbar.comments')) // close panel (unmount)
+    await waitFor(() => expect(screen.queryByTestId('html-doc-comment-panel')).toBeNull())
+
+    // Reopen the panel; a fresh selection is honored (not frozen by a stale engaged=true).
+    fireEvent.click(screen.getByTitle('docs.toolbar.comments'))
+    await waitFor(() => expect(screen.getByPlaceholderText('docs.comment.placeholder')).toBeTruthy())
+    bridgeSelection(frame, { kind: 'element', aid: 'a2', selector: '[data-odoc-aid="a2"]', label: 'p' })
+    await waitFor(() => expect(screen.getByTestId('pending-anchor').textContent).toContain('#a2'))
+  })
+
+  it('accepts a fresh selection after a code→page mode round-trip while a draft was held', async () => {
+    commenter()
+    stubFetch((url) => (url.includes('/comments') ? jsonResponse({ data: [] }) : htmlResponse('<p data-odoc-aid="a1">one</p><p data-odoc-aid="a2">two</p>')))
+    const { container } = render(<HtmlDocView docId="d1" space="sp" />)
+    const frame = await waitForFrame(container)
+    fireEvent.load(frame)
+    await waitFor(() => expect(screen.getByPlaceholderText('docs.comment.placeholder')).toBeTruthy())
+
+    const input = screen.getByPlaceholderText('docs.comment.placeholder')
+    fireEvent.focus(input)
+    fireEvent.change(input, { target: { value: 'draft' } })
+    // Code mode drops the composer + resets engagement; page mode reloads the frame.
+    fireEvent.click(screen.getByRole('tab', { name: 'docs.mode.code' }))
+    fireEvent.click(screen.getByRole('tab', { name: 'docs.mode.page' }))
+    const nextFrame = await waitForFrame(container)
+    fireEvent.load(nextFrame)
+    await waitFor(() => expect(screen.getByPlaceholderText('docs.comment.placeholder')).toBeTruthy())
+    bridgeSelection(nextFrame, { kind: 'element', aid: 'a2', selector: '[data-odoc-aid="a2"]', label: 'p' })
+    await waitFor(() => expect(screen.getByTestId('pending-anchor').textContent).toContain('#a2'))
+  })
+
+  it('accepts a fresh selection after a permission demotion→re-promotion (engagement reset)', async () => {
+    let role: 'commenter' | 'reader' = 'commenter'
+    const wk = createMockWKApp({ uid: 'u_viewer', token: 't' })
+    wk.apiClient.responder = (method, url) =>
+      method === 'get' && url === '/docs/d1'
+        ? { data: { docId: 'd1', ownerId: 'u_owner', role }, status: 200 }
+        : { data: {}, status: 200 }
+    setWKApp(wk)
+    stubFetch((url) => (url.includes('/comments') ? jsonResponse({ data: [] }) : htmlResponse('<p data-odoc-aid="a1">one</p><p data-odoc-aid="a2">two</p>')))
+    const { container, rerender } = render(<HtmlDocView docId="d1" space="sp1" />)
+    const frame = await waitForFrame(container)
+    fireEvent.load(frame)
+    await waitFor(() => expect(screen.getByPlaceholderText('docs.comment.placeholder')).toBeTruthy())
+
+    // Engage, then demote to reader: commenting-off resets engagement + clears the anchor.
+    const input = screen.getByPlaceholderText('docs.comment.placeholder')
+    fireEvent.focus(input)
+    fireEvent.change(input, { target: { value: 'draft' } })
+    role = 'reader'
+    rerender(<HtmlDocView docId="d1" space="sp2" />)
+    await waitFor(() => expect(screen.queryByPlaceholderText('docs.comment.placeholder')).toBeNull())
+
+    // Re-promote to commenter (same frame); a fresh selection is honored again.
+    role = 'commenter'
+    rerender(<HtmlDocView docId="d1" space="sp3" />)
+    await waitFor(() => expect(screen.getByPlaceholderText('docs.comment.placeholder')).toBeTruthy())
+    expect(container.querySelector('iframe.octo-html-doc-frame')).toBe(frame)
+    bridgeSelection(frame, { kind: 'element', aid: 'a2', selector: '[data-odoc-aid="a2"]', label: 'p' })
+    await waitFor(() => expect(screen.getByTestId('pending-anchor').textContent).toContain('#a2'))
   })
 })

--- a/packages/docs/src/html/HtmlDocView.test.tsx
+++ b/packages/docs/src/html/HtmlDocView.test.tsx
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { StrictMode } from 'react'
 import { render, screen, waitFor, cleanup, fireEvent } from '@testing-library/react'
 import {
   HtmlDocView,
@@ -38,22 +39,53 @@ function jsonResponse(body: unknown, ok = true, status = 200): Response {
   } as unknown as Response
 }
 
-function selectNodeTextInDocument(doc: Document, node: Node) {
-  const range = doc.createRange()
-  range.selectNodeContents(node)
-  const sel = doc.getSelection?.() ?? doc.defaultView?.getSelection()
-  sel?.removeAllRanges()
-  sel?.addRange(range)
-  doc.dispatchEvent(new Event('selectionchange'))
+// The iframe now runs with sandbox="allow-scripts" (NO allow-same-origin), so the parent can no
+// longer read contentDocument or attach a selectionchange listener to it. Selection/anchor data
+// crosses the boundary over the postMessage bridge (htmlDocBridge). These helpers simulate the
+// in-frame bridge script by posting bridge-shaped messages with source === the frame's
+// contentWindow (the exact identity check HtmlDocView enforces).
+import { BRIDGE_CHANNEL, type BridgeAnchor } from './htmlDocBridge.ts'
+
+// The parent gates bridge traffic on a per-render token embedded in the srcDoc bridge script
+// (TOKEN = "..."). Tests read it back out so simulated frame messages echo the current generation.
+function frameToken(iframe: HTMLIFrameElement): string {
+  const src = iframe.getAttribute('srcdoc') ?? ''
+  const m = /TOKEN = "([^"]*)"/.exec(src)
+  return m ? m[1] : ''
 }
 
-function writeIframeBody(iframe: HTMLIFrameElement, body: string): Document {
-  const doc = iframe.contentDocument as Document
-  doc.open()
-  doc.write(`<!doctype html><html><body>${body}</body></html>`)
-  doc.close()
-  fireEvent.load(iframe)
-  return doc
+function postBridge(iframe: HTMLIFrameElement, data: Record<string, unknown>) {
+  // jsdom won't let us set MessageEvent.source to an arbitrary Window, so define it directly to
+  // match the frame's contentWindow — the value HtmlDocView compares event.source against.
+  const token = 'token' in data ? data.token : frameToken(iframe)
+  const ev = new MessageEvent('message', { data: { channel: BRIDGE_CHANNEL, token, ...data } })
+  Object.defineProperty(ev, 'source', { value: iframe.contentWindow, configurable: true })
+  window.dispatchEvent(ev)
+}
+
+/** Simulate the in-frame bridge reporting a selection anchor (or null to clear). */
+function bridgeSelection(iframe: HTMLIFrameElement, anchor: BridgeAnchor | null) {
+  postBridge(iframe, { type: 'selection', anchor })
+}
+
+/**
+ * Stand in for the in-frame bridge answering element-text lookups. Intercepts the parent's
+ * postMessage request to the frame, reads its nonce, and posts back the matching anchor-text
+ * reply (source === contentWindow, echoing the request token). Returns a restore fn.
+ */
+function autoAnswerAnchorText(iframe: HTMLIFrameElement, textByAid: Record<string, string | null>) {
+  const win = iframe.contentWindow as Window
+  const orig = win.postMessage.bind(win)
+  win.postMessage = ((msg: unknown) => {
+    const m = msg as { channel?: string; type?: string; nonce?: string; aid?: string; token?: string }
+    if (m && m.channel === BRIDGE_CHANNEL && m.type === 'resolve-anchor-text' && m.nonce && m.aid) {
+      const text = m.aid in textByAid ? textByAid[m.aid] : null
+      postBridge(iframe, { type: 'anchor-text', token: m.token, nonce: m.nonce, text })
+    }
+  }) as typeof win.postMessage
+  return () => {
+    win.postMessage = orig
+  }
 }
 
 async function waitForFrame(container: HTMLElement): Promise<HTMLIFrameElement> {
@@ -226,6 +258,23 @@ describe('resolveHtmlDocAnchorText', () => {
       )
     ).toBeNull()
   })
+
+  it('safely resolves a hostile data-odoc-aid (selector metacharacters) without throwing', () => {
+    // The aid carries a quote+bracket that would break a naive attribute selector; escaping must
+    // neutralize it. The matching element resolves; a non-matching hostile aid returns null.
+    const hostile = '"] , script'
+    const doc = new DOMParser().parseFromString(
+      `<p data-odoc-aid='${hostile}'>hostile text</p>`,
+      'text/html'
+    )
+    expect(() =>
+      resolveHtmlDocAnchorText({ kind: 'element', aid: hostile, selector: 'x', label: 'p' }, doc)
+    ).not.toThrow()
+    expect(resolveHtmlDocAnchorText({ kind: 'element', aid: hostile, selector: 'x', label: 'p' }, doc)).toBe('hostile text')
+    expect(
+      resolveHtmlDocAnchorText({ kind: 'element', aid: '"] , [x], nope', selector: 'x', label: 'p' }, doc)
+    ).toBeNull()
+  })
 })
 
 describe('HtmlDocView — read-only rendering', () => {
@@ -239,8 +288,9 @@ describe('HtmlDocView — read-only rendering', () => {
     const { container } = render(<HtmlDocView docId="d_html_1" space="sp" />)
 
     const frame = await waitForFrame(container)
-    expect(frame.getAttribute('sandbox')).toBe('allow-same-origin')
-    expect(frame.getAttribute('sandbox')).not.toContain('allow-scripts')
+    // allow-scripts WITHOUT allow-same-origin: doc JS runs but is walled off from the parent.
+    expect(frame.getAttribute('sandbox')).toBe('allow-scripts')
+    expect(frame.getAttribute('sandbox')).not.toContain('allow-same-origin')
     expect(frame.getAttribute('srcdoc')).toContain('Agent Report')
     expect(frame.getAttribute('srcdoc')).toContain('style="color:red"')
     expect(container.querySelector('.octo-html-doc-content')).toBeNull()
@@ -303,7 +353,7 @@ describe('HtmlDocView — read-only rendering', () => {
     expect(container.querySelector('[role="toolbar"]')).toBeNull()
   })
 
-  it('keeps raw HTML in srcdoc while sandbox blocks scripts from running', async () => {
+  it('keeps raw HTML in srcdoc and runs it only under the allow-scripts (no same-origin) sandbox', async () => {
     stubFetch((url) => {
       if (url.includes('/comments')) return jsonResponse({ data: [] })
       return htmlResponse('<p>safe body</p><script>window.__pwned = 1</script>')
@@ -311,8 +361,9 @@ describe('HtmlDocView — read-only rendering', () => {
     const { container } = render(<HtmlDocView docId="d1" space="sp" />)
     const frame = await waitForFrame(container)
     expect(frame.getAttribute('srcdoc')).toContain('<script>window.__pwned = 1</script>')
-    expect(frame.getAttribute('sandbox')).toBe('allow-same-origin')
-    expect(frame.getAttribute('sandbox')).not.toContain('allow-scripts')
+    // Scripts run, but only inside an opaque origin walled off from the parent.
+    expect(frame.getAttribute('sandbox')).toBe('allow-scripts')
+    expect(frame.getAttribute('sandbox')).not.toContain('allow-same-origin')
   })
 
   it('neutralizes interactive payload markup inside srcdoc instead of inlining it into the host DOM', async () => {
@@ -409,7 +460,11 @@ describe('HtmlDocView — read-only rendering', () => {
     const { container } = render(<HtmlDocView docId="d1" space="sp" />)
     const frame = await waitForFrame(container)
 
-    writeIframeBody(frame, '<p data-odoc-aid="a4">quoted paragraph from iframe</p>')
+    // The parent can't read the cross-origin frame; it asks the bridge for the element's text.
+    // Install the auto-answering bridge stub BEFORE the frame loads so the very first resolve
+    // request (fired when the comment panel first renders the element anchor) is answered.
+    autoAnswerAnchorText(frame, { a4: 'quoted paragraph from iframe' })
+    fireEvent.load(frame)
 
     await waitFor(() => expect(screen.getByTestId('comment-quote').textContent).toBe('quoted paragraph from iframe'))
   })
@@ -428,16 +483,15 @@ describe('HtmlDocView — read-only rendering', () => {
     })
     const { container } = render(<HtmlDocView docId="d1" space="sp" />)
     const frame = await waitForFrame(container)
-    const frameDoc = writeIframeBody(frame, '<p data-odoc-aid="a1">selected words</p>')
-    const anchored = frameDoc.querySelector('p') as HTMLElement
+    fireEvent.load(frame)
 
-    selectNodeTextInDocument(frameDoc, anchored.firstChild ?? anchored)
+    bridgeSelection(frame, { kind: 'element', aid: 'a1', selector: '[data-odoc-aid="a1"]', label: 'p' })
     await waitFor(() => expect(screen.getByTestId('pending-anchor').textContent).toContain('#a1'))
 
     const input = screen.getByPlaceholderText('docs.comment.placeholder')
     fireEvent.focus(input)
-    frameDoc.getSelection()?.removeAllRanges()
-    frameDoc.dispatchEvent(new Event('selectionchange'))
+    // Collapsing the selection makes the bridge report null; the locked anchor must survive it.
+    bridgeSelection(frame, null)
 
     expect(screen.getByTestId('pending-anchor').textContent).toContain('#a1')
   })
@@ -453,19 +507,22 @@ describe('HtmlDocView — read-only rendering', () => {
 
     const { container } = render(<HtmlDocView docId="d1" space="sp" />)
     const frame = await waitForFrame(container)
-    const frameDoc = writeIframeBody(frame, '<p data-odoc-aid="late">late role</p>')
+    fireEvent.load(frame)
+    const lateAnchor: BridgeAnchor = { kind: 'element', aid: 'late', selector: '[data-odoc-aid="late"]', label: 'p' }
 
-    selectNodeTextInDocument(frameDoc, frameDoc.querySelector('p')!.firstChild!)
+    // Before role resolves, mayComment is false so the bridge selection is ignored.
+    bridgeSelection(frame, lateAnchor)
     expect(screen.queryByTestId('pending-anchor')).toBeNull()
 
     resolveDoc({ data: { docId: 'd1', ownerId: 'u_owner', role: 'commenter' }, status: 200 })
     await waitFor(() => expect(screen.getByPlaceholderText('docs.comment.placeholder')).toBeTruthy())
-    selectNodeTextInDocument(frameDoc, frameDoc.querySelector('p')!.firstChild!)
+    // Same frame, no reload; the live permission now lets the next selection through.
+    bridgeSelection(frame, lateAnchor)
     await waitFor(() => expect(screen.getByTestId('pending-anchor').textContent).toContain('#late'))
     expect(container.querySelector('iframe.octo-html-doc-frame')).toBe(frame)
   })
 
-  it('reconciles one selection listener across permission and mode transitions', async () => {
+  it('gates one bridge selection channel across permission and mode transitions', async () => {
     let currentRole: 'commenter' | 'reader' = 'commenter'
     const wk = createMockWKApp({ uid: 'u_viewer', token: 't' })
     wk.apiClient.responder = (method, url) =>
@@ -477,32 +534,33 @@ describe('HtmlDocView — read-only rendering', () => {
 
     const { container, rerender } = render(<HtmlDocView docId="d1" space="sp1" />)
     const frame = await waitForFrame(container)
-    const frameDoc = writeIframeBody(frame, '<p data-odoc-aid="a1">one</p><p data-odoc-aid="a2">two</p>')
+    fireEvent.load(frame)
     await waitFor(() => expect(screen.getByPlaceholderText('docs.comment.placeholder')).toBeTruthy())
-    const addSpy = vi.spyOn(frameDoc, 'addEventListener')
-    const removeSpy = vi.spyOn(frameDoc, 'removeEventListener')
+    const a1: BridgeAnchor = { kind: 'element', aid: 'a1', selector: '[data-odoc-aid="a1"]', label: 'p' }
+    const a2: BridgeAnchor = { kind: 'element', aid: 'a2', selector: '[data-odoc-aid="a2"]', label: 'p' }
 
+    // Demote to reader: the same window listener stays, but its mayComment gate now drops selections.
     currentRole = 'reader'
     rerender(<HtmlDocView docId="d1" space="sp2" />)
     await waitFor(() => expect(screen.queryByPlaceholderText('docs.comment.placeholder')).toBeNull())
-    expect(removeSpy.mock.calls.filter(([type]) => type === 'selectionchange')).toHaveLength(1)
-    selectNodeTextInDocument(frameDoc, frameDoc.querySelector('[data-odoc-aid="a1"]')!.firstChild!)
+    bridgeSelection(frame, a1)
     expect(screen.queryByTestId('pending-anchor')).toBeNull()
 
+    // Re-promote to commenter without reloading the iframe; the live gate lets selections through.
     currentRole = 'commenter'
     rerender(<HtmlDocView docId="d1" space="sp3" />)
     await waitFor(() => expect(screen.getByPlaceholderText('docs.comment.placeholder')).toBeTruthy())
     expect(container.querySelector('iframe.octo-html-doc-frame')).toBe(frame)
-    expect(addSpy.mock.calls.filter(([type]) => type === 'selectionchange')).toHaveLength(1)
-    selectNodeTextInDocument(frameDoc, frameDoc.querySelector('[data-odoc-aid="a2"]')!.firstChild!)
+    bridgeSelection(frame, a2)
     await waitFor(() => expect(screen.getByTestId('pending-anchor').textContent).toContain('#a2'))
 
+    // Code mode drops the anchor; back to page reloads the frame and selection resumes.
     fireEvent.click(screen.getByRole('tab', { name: 'docs.mode.code' }))
     expect(screen.queryByTestId('pending-anchor')).toBeNull()
     fireEvent.click(screen.getByRole('tab', { name: 'docs.mode.page' }))
     const nextFrame = await waitForFrame(container)
-    const nextDoc = writeIframeBody(nextFrame, '<p data-odoc-aid="a3">three</p>')
-    selectNodeTextInDocument(nextDoc, nextDoc.querySelector('p')!.firstChild!)
+    fireEvent.load(nextFrame)
+    bridgeSelection(nextFrame, { kind: 'element', aid: 'a3', selector: '[data-odoc-aid="a3"]', label: 'p' })
     await waitFor(() => expect(screen.getByTestId('pending-anchor').textContent).toContain('#a3'))
   })
 
@@ -519,16 +577,47 @@ describe('HtmlDocView — read-only rendering', () => {
     })
     const { container } = render(<HtmlDocView docId="d1" space="sp" />)
     const frame = await waitForFrame(container)
-    const frameDoc = writeIframeBody(frame, '<p data-odoc-aid="a2">clearable words</p>')
-    const anchored = frameDoc.querySelector('p') as HTMLElement
+    fireEvent.load(frame)
 
-    selectNodeTextInDocument(frameDoc, anchored.firstChild ?? anchored)
+    bridgeSelection(frame, { kind: 'element', aid: 'a2', selector: '[data-odoc-aid="a2"]', label: 'p' })
     await waitFor(() => expect(screen.getByTestId('pending-anchor').textContent).toContain('#a2'))
 
     fireEvent.click(screen.getByText('docs.comment.clearAnchor'))
 
     expect(screen.getByTestId('pending-anchor').textContent).toContain('docs.comment.targetDoc')
     expect(screen.getByTestId('pending-anchor').textContent).not.toContain('#a2')
+  })
+
+  it('ignores bridge messages whose source is not the iframe (forged origin / other window)', async () => {
+    const wk = createMockWKApp({ uid: 'u_viewer', token: 't' })
+    wk.apiClient.responder = (method, url) =>
+      method === 'get' && url === '/docs/d1'
+        ? { data: { docId: 'd1', ownerId: 'u_owner', role: 'commenter' }, status: 200 }
+        : { data: {}, status: 200 }
+    setWKApp(wk)
+    stubFetch((url) => {
+      if (url.includes('/comments')) return jsonResponse({ data: [] })
+      return htmlResponse('<p data-odoc-aid="a9">words</p>')
+    })
+    const { container } = render(<HtmlDocView docId="d1" space="sp" />)
+    const frame = await waitForFrame(container)
+    fireEvent.load(frame)
+    await waitFor(() => expect(screen.getByPlaceholderText('docs.comment.placeholder')).toBeTruthy())
+
+    // A perfectly-shaped selection message but from a source that is NOT the frame's contentWindow
+    // (e.g. window itself, an extension, or another frame) must be dropped by the identity check.
+    const forged = new MessageEvent('message', {
+      data: { channel: BRIDGE_CHANNEL, type: 'selection', anchor: { kind: 'element', aid: 'a9', selector: '[data-odoc-aid="a9"]', label: 'p' } },
+    })
+    Object.defineProperty(forged, 'source', { value: window, configurable: true })
+    window.dispatchEvent(forged)
+
+    // The forged message was dropped: the composer target stays doc-level (no #a9 adopted).
+    expect(screen.getByTestId('pending-anchor').textContent).not.toContain('#a9')
+
+    // The same message from the real frame IS honored, proving the gate is source identity, not shape.
+    bridgeSelection(frame, { kind: 'element', aid: 'a9', selector: '[data-odoc-aid="a9"]', label: 'p' })
+    await waitFor(() => expect(screen.getByTestId('pending-anchor').textContent).toContain('#a9'))
   })
 
   it('uses the rendered numeric version when posting from the latest route with an element anchor', async () => {
@@ -547,16 +636,15 @@ describe('HtmlDocView — read-only rendering', () => {
     })
     const { container } = render(<HtmlDocView docId="d1" space="sp" slug="slug-1" />)
     const frame = await waitForFrame(container)
-    const frameDoc = writeIframeBody(frame, '<p data-odoc-aid="a3">post anchored words</p>')
-    const anchored = frameDoc.querySelector('p') as HTMLElement
+    fireEvent.load(frame)
 
-    selectNodeTextInDocument(frameDoc, anchored.firstChild ?? anchored)
+    bridgeSelection(frame, { kind: 'element', aid: 'a3', selector: '[data-odoc-aid="a3"]', label: 'p' })
     await waitFor(() => expect(screen.getByTestId('pending-anchor').textContent).toContain('#a3'))
 
     const input = screen.getByPlaceholderText('docs.comment.placeholder')
     fireEvent.focus(input)
-    frameDoc.getSelection()?.removeAllRanges()
-    frameDoc.dispatchEvent(new Event('selectionchange'))
+    // Collapse is reported as a null selection; the locked anchor must persist through posting.
+    bridgeSelection(frame, null)
     fireEvent.change(input, { target: { value: 'anchored note' } })
     fireEvent.click(screen.getByText('docs.comment.send'))
 
@@ -576,6 +664,269 @@ describe('HtmlDocView — read-only rendering', () => {
     ).toBe(true)
     expect(body.version).toBe(4)
     expect(body.anchor).toMatchObject({ kind: 'element', aid: 'a3' })
+  })
+
+  // --- issue #27 iteration-2 reviewer findings: deterministic bridge behaviour ---
+
+  it('resolves an element-anchor quote via the post-commit bridge queue (render stays pure)', async () => {
+    // resolveAnchorText must not postMessage during render; the request is flushed after commit.
+    // We assert the request is only observed AFTER render settles, and the reply fills the quote.
+    const wk = createMockWKApp({ uid: 'u_viewer', token: 't' })
+    wk.apiClient.responder = (method, url) =>
+      method === 'get' && url === '/docs/d1'
+        ? { data: { docId: 'd1', ownerId: 'u_owner', role: 'commenter' }, status: 200 }
+        : { data: {}, status: 200 }
+    setWKApp(wk)
+    stubFetch((url) => {
+      if (url.includes('/comments')) {
+        return jsonResponse({
+          data: [
+            {
+              id: 'c1', text: 'note', author: { uid: 'u_owner' }, created_at: 1,
+              anchor: { kind: 'element', aid: 'aq', selector: '[data-odoc-aid="aq"]', label: 'p' },
+              replies: [],
+            },
+          ],
+        })
+      }
+      return htmlResponse('<p data-odoc-aid="aq">resolved quote text</p>')
+    })
+    const { container } = render(<HtmlDocView docId="d1" space="sp" />)
+    const frame = await waitForFrame(container)
+    let sawRequest = false
+    const win = frame.contentWindow as Window
+    const orig = win.postMessage.bind(win)
+    win.postMessage = ((msg: unknown) => {
+      const m = msg as { channel?: string; type?: string; nonce?: string; token?: string }
+      if (m?.channel === BRIDGE_CHANNEL && m.type === 'resolve-anchor-text') {
+        sawRequest = true
+        // Answer as the frame would, echoing the token.
+        postBridge(frame, { type: 'anchor-text', token: m.token, nonce: m.nonce, text: 'resolved quote text' })
+      }
+    }) as typeof win.postMessage
+    fireEvent.load(frame)
+    await waitFor(() => expect(screen.getByTestId('comment-quote').textContent).toBe('resolved quote text'))
+    expect(sawRequest).toBe(true)
+    win.postMessage = orig
+  })
+
+  it('resolves anchor text under StrictMode with no render-phase update warning (render stays pure)', async () => {
+    // Regression for finding #1: resolveAnchorText must be a pure cache read — no ref writes and no
+    // queueMicrotask/setState during render. Under StrictMode (double-invoked render) any such
+    // side effect surfaces as a React "Cannot update a component while rendering" console.error.
+    // We capture console.error and assert the anchor path emits none while the quote still resolves.
+    const errors: string[] = []
+    const errSpy = vi.spyOn(console, 'error').mockImplementation((...args: unknown[]) => {
+      errors.push(args.map(String).join(' '))
+    })
+    const wk = createMockWKApp({ uid: 'u_viewer', token: 't' })
+    wk.apiClient.responder = (method, url) =>
+      method === 'get' && url === '/docs/d1'
+        ? { data: { docId: 'd1', ownerId: 'u_owner', role: 'commenter' }, status: 200 }
+        : { data: {}, status: 200 }
+    setWKApp(wk)
+    stubFetch((url) => {
+      if (url.includes('/comments')) {
+        return jsonResponse({
+          data: [
+            {
+              id: 'c1', text: 'note', author: { uid: 'u_owner' }, created_at: 1,
+              anchor: { kind: 'element', aid: 'asm', selector: '[data-odoc-aid="asm"]', label: 'p' },
+              replies: [],
+            },
+          ],
+        })
+      }
+      return htmlResponse('<p data-odoc-aid="asm">strict quote</p>')
+    })
+    const { container } = render(
+      <StrictMode>
+        <HtmlDocView docId="d1" space="sp" />
+      </StrictMode>,
+    )
+    const frame = await waitForFrame(container)
+    autoAnswerAnchorText(frame, { asm: 'strict quote' })
+    fireEvent.load(frame)
+    await waitFor(() => expect(screen.getByTestId('comment-quote').textContent).toBe('strict quote'))
+    // No render-phase state-update warning attributable to anchor resolution.
+    const bad = errors.filter(
+      (e) => /Cannot update a component .* while rendering/i.test(e) || /Warning: Cannot update/i.test(e),
+    )
+    expect(bad).toEqual([])
+    errSpy.mockRestore()
+  })
+
+  it('rejects a stale/replayed anchor-text reply (unknown nonce) and a wrong-token reply', async () => {
+    const wk = createMockWKApp({ uid: 'u_viewer', token: 't' })
+    wk.apiClient.responder = (method, url) =>
+      method === 'get' && url === '/docs/d1'
+        ? { data: { docId: 'd1', ownerId: 'u_owner', role: 'commenter' }, status: 200 }
+        : { data: {}, status: 200 }
+    setWKApp(wk)
+    stubFetch((url) => {
+      if (url.includes('/comments')) {
+        return jsonResponse({
+          data: [
+            {
+              id: 'c1', text: 'note', author: { uid: 'u_owner' }, created_at: 1,
+              anchor: { kind: 'element', aid: 'as', selector: '[data-odoc-aid="as"]', label: 'p' },
+              replies: [],
+            },
+          ],
+        })
+      }
+      return htmlResponse('<p data-odoc-aid="as">real text</p>')
+    })
+    const { container } = render(<HtmlDocView docId="d1" space="sp" />)
+    const frame = await waitForFrame(container)
+    fireEvent.load(frame)
+    // A forged reply with a nonce we never issued must be ignored (no injected quote).
+    postBridge(frame, { type: 'anchor-text', nonce: 'never-issued', text: 'FORGED' })
+    // A reply with a wrong token is also ignored.
+    postBridge(frame, { type: 'anchor-text', token: 'wrong-token', nonce: 'never-issued', text: 'FORGED2' })
+    // Give effects a tick; the quote must NOT be the forged text.
+    await waitFor(() => expect(screen.getByTestId('html-doc-comment')).toBeTruthy())
+    expect(screen.queryByText('FORGED')).toBeNull()
+    expect(screen.queryByText('FORGED2')).toBeNull()
+  })
+
+  it('rejects a replayed gen-A token+nonce against gen B (two real srcDoc generations)', async () => {
+    // Build TWO actual generations with distinct tokens: gen A at v1, gen B at v2 (each a fresh
+    // fetch → fresh srcDoc → fresh newBridgeToken). Issue a resolve nonce in gen A, switch to gen B,
+    // then replay gen A's (token, nonce) from the SAME contentWindow — it must be rejected (stale
+    // token). A gen-A nonce replayed under gen B's token is also rejected (unissued nonce).
+    const wk = createMockWKApp({ uid: 'u_viewer', token: 't' })
+    wk.apiClient.responder = (method, url) =>
+      method === 'get' && url === '/docs/d1'
+        ? { data: { docId: 'd1', ownerId: 'u_owner', role: 'commenter' }, status: 200 }
+        : { data: {}, status: 200 }
+    setWKApp(wk)
+    stubFetch((url) => {
+      if (url.includes('/comments')) {
+        return jsonResponse({
+          data: [
+            {
+              id: 'c1', text: 'note', author: { uid: 'u_owner' }, created_at: 1,
+              anchor: { kind: 'element', aid: 'ar', selector: '[data-odoc-aid="ar"]', label: 'p' },
+              replies: [],
+            },
+          ],
+        })
+      }
+      return htmlResponse('<p data-odoc-aid="ar">gen text</p>')
+    })
+
+    // Capture the (token, nonce) of every resolve request the parent issues, per generation.
+    const issued: Array<{ token?: string; nonce?: string }> = []
+    function tapFrame(f: HTMLIFrameElement) {
+      const win = f.contentWindow as Window
+      const orig = win.postMessage.bind(win)
+      win.postMessage = ((msg: unknown) => {
+        const m = msg as { channel?: string; type?: string; token?: string; nonce?: string }
+        if (m?.channel === BRIDGE_CHANNEL && m.type === 'resolve-anchor-text') {
+          issued.push({ token: m.token, nonce: m.nonce })
+        }
+      }) as typeof win.postMessage
+      return orig
+    }
+
+    // --- Generation A (v1) ---
+    const { container, rerender } = render(<HtmlDocView docId="d1" space="sp" version="1" />)
+    const frameA = await waitForFrame(container)
+    const tokenA = frameToken(frameA)
+    tapFrame(frameA)
+    fireEvent.load(frameA)
+    // The post-commit resolve effect issues a request for the visible element anchor under gen A.
+    await waitFor(() => expect(issued.some((r) => r.token === tokenA && r.nonce)).toBe(true))
+    const nonceA = issued.find((r) => r.token === tokenA)?.nonce as string
+
+    // --- Generation B (v2): a fresh fetch rebuilds srcDoc with a NEW token ---
+    rerender(<HtmlDocView docId="d1" space="sp" version="2" />)
+    const frameB = await waitFor(() => {
+      const f = container.querySelector('iframe.octo-html-doc-frame') as HTMLIFrameElement
+      const tk = frameToken(f)
+      if (!tk || tk === tokenA) throw new Error('gen B token not ready')
+      return f
+    })
+    const tokenB = frameToken(frameB)
+    expect(tokenB).not.toBe(tokenA)
+    tapFrame(frameB)
+    fireEvent.load(frameB)
+
+    // Replay gen A's token+nonce from the current frame: dropped by the stale-token gate.
+    postBridge(frameB, { type: 'anchor-text', token: tokenA, nonce: nonceA, text: 'REPLAY_A' })
+    // Gen A's nonce under gen B's (current) token: dropped by the unissued-nonce gate.
+    postBridge(frameB, { type: 'anchor-text', token: tokenB, nonce: nonceA, text: 'REPLAY_A_B' })
+    await waitFor(() => expect(screen.getByTestId('html-doc-comment')).toBeTruthy())
+    expect(screen.queryByText('REPLAY_A')).toBeNull()
+    expect(screen.queryByText('REPLAY_A_B')).toBeNull()
+
+    // A legitimate gen-B reply (current token + a gen-B-issued nonce) IS accepted.
+    await waitFor(() => expect(issued.some((r) => r.token === tokenB && r.nonce)).toBe(true))
+    const nonceB = issued.find((r) => r.token === tokenB)?.nonce as string
+    postBridge(frameB, { type: 'anchor-text', token: tokenB, nonce: nonceB, text: 'gen text' })
+    await waitFor(() => expect(screen.getByTestId('comment-quote').textContent).toBe('gen text'))
+  })
+
+  it('safely handles a hostile data-odoc-aid selection anchor (no selector break-out)', async () => {
+    const wk = createMockWKApp({ uid: 'u_viewer', token: 't' })
+    wk.apiClient.responder = (method, url) =>
+      method === 'get' && url === '/docs/d1'
+        ? { data: { docId: 'd1', ownerId: 'u_owner', role: 'commenter' }, status: 200 }
+        : { data: {}, status: 200 }
+    setWKApp(wk)
+    stubFetch((url) => (url.includes('/comments') ? jsonResponse({ data: [] }) : htmlResponse('<p>x</p>')))
+    const { container } = render(<HtmlDocView docId="d1" space="sp" />)
+    const frame = await waitForFrame(container)
+    fireEvent.load(frame)
+    // A selection anchor whose aid carries selector metacharacters is accepted as a bounded string
+    // (worst case: a bogus comment target). It must NOT throw and must surface as the target.
+    const hostile = '"] , [data-x="'
+    bridgeSelection(frame, { kind: 'element', aid: hostile, selector: `[data-odoc-aid="${hostile}"]`, label: 'p' })
+    await waitFor(() => expect(screen.getByTestId('pending-anchor').textContent).toContain(`#${hostile}`))
+  })
+
+  it('activates a thread anchor: clicking the quote posts a scroll-to-anchor to the frame', async () => {
+    const wk = createMockWKApp({ uid: 'u_viewer', token: 't' })
+    wk.apiClient.responder = (method, url) =>
+      method === 'get' && url === '/docs/d1'
+        ? { data: { docId: 'd1', ownerId: 'u_owner', role: 'commenter' }, status: 200 }
+        : { data: {}, status: 200 }
+    setWKApp(wk)
+    stubFetch((url) => {
+      if (url.includes('/comments')) {
+        return jsonResponse({
+          data: [
+            {
+              id: 'c1', text: 'note', author: { uid: 'u_owner' }, created_at: 1,
+              anchor: { kind: 'element', aid: 'ah', selector: '[data-odoc-aid="ah"]', label: 'p' },
+              replies: [],
+            },
+          ],
+        })
+      }
+      return htmlResponse('<p data-odoc-aid="ah">scroll target</p>')
+    })
+    const { container } = render(<HtmlDocView docId="d1" space="sp" />)
+    const frame = await waitForFrame(container)
+    const sent: Array<{ type?: string; aid?: string; token?: string }> = []
+    const win = frame.contentWindow as Window
+    const orig = win.postMessage.bind(win)
+    win.postMessage = ((msg: unknown) => {
+      const m = msg as { channel?: string; type?: string; aid?: string; token?: string; nonce?: string }
+      if (m?.channel === BRIDGE_CHANNEL) {
+        sent.push({ type: m.type, aid: m.aid, token: m.token })
+        if (m.type === 'resolve-anchor-text') postBridge(frame, { type: 'anchor-text', token: m.token, nonce: m.nonce, text: 'scroll target' })
+      }
+    }) as typeof win.postMessage
+    fireEvent.load(frame)
+    const quote = await screen.findByTestId('comment-quote')
+    fireEvent.click(quote)
+    await waitFor(() => expect(sent.some((m) => m.type === 'scroll-to-anchor' && m.aid === 'ah')).toBe(true))
+    // The scroll request carries the current render token.
+    const scroll = sent.find((m) => m.type === 'scroll-to-anchor')
+    expect(scroll?.token).toBe(frameToken(frame))
+    win.postMessage = orig
   })
 })
 

--- a/packages/docs/src/html/HtmlDocView.tsx
+++ b/packages/docs/src/html/HtmlDocView.tsx
@@ -1,19 +1,18 @@
 // Read-only viewer for a `docType==='html'` document (env ring 2a).
 //
-// Contract:
-//   - READ-ONLY: the HTML is agent-authored; a human may only read it (comments + "让 AI
-//     处理" arrive in ring 2b). This component renders NO editing chrome and loads the
-//     payload in a sandboxed iframe without script permission.
-//   - IFRAME: the published HTML is fetched as-is and rendered by the browser so agent CSS
-//     (<style>, inline style, external stylesheet links) stays intact.
-//   - SEPARATE BACKEND: octo-doc is a distinct deployment from the same-origin Yjs
-//     `/api/v1` docs backend, so we use a plain fetch (with credentials) against
-//     resolveOctoDocBase() rather than the octoweb apiClient.
+// Contract: agent-authored HTML the human may only read (no editing chrome). The payload runs in a
+// sandboxed iframe that may execute the doc's OWN JavaScript (issue #27) but is walled off from the
+// parent. octo-doc is a separate backend, so the frame fetches via plain credentialed fetch, not
+// the octoweb apiClient.
 //
-// SECURITY: the published HTML is NOT sanitized end-to-end by the backend (ring 1 only
-// validates aid-replace fragments, not the whole Publish payload), so it may contain
-// <script>, on* handlers, javascript: URLs, or interactive/editable controls. The render
-// path isolates it with iframe sandbox="allow-same-origin" and never grants allow-scripts.
+// SECURITY (issue #27): the Publish payload is NOT sanitized end-to-end, so it may carry <script>,
+// on* handlers, javascript: URLs, or controls. The frame uses sandbox="allow-scripts" WITHOUT
+// allow-same-origin (combining them defeats the sandbox — NEVER do it): doc JS runs in an opaque
+// origin and cannot reach the parent DOM/credentials/origin; forms/popups/downloads/top-nav stay
+// denied. This does NOT stop outbound network from doc JS — egress is an accepted capability for
+// agent HTML (see htmlDocBridge threat-boundary note). Selection/anchor data crosses the
+// constrained postMessage bridge (htmlDocBridge): the parent gates on event.source === the frame's
+// contentWindow + a bounded schema and accepts only non-privileged UI facts.
 
 import { useCallback, useEffect, useRef, useState } from 'react'
 import DOMPurify from 'dompurify'
@@ -37,8 +36,9 @@ import { isHtmlSourceDiffEnabled } from './htmlSourceDiffFeature.ts'
 import { ConfirmModal } from '../editor/ConfirmModal.tsx'
 import { useDocDelete } from '../editor/useDocDelete.ts'
 import { DocMoreMenu, OpenNewPageIcon, LinkIcon, DeleteIcon, type DocMoreMenuItem } from '../editor/DocMoreMenu.tsx'
-import { buildAnchorFromSelection, truncateAnchorText } from './htmlDocAnchor.ts'
+import { truncateAnchorText } from './htmlDocAnchor.ts'
 import type { Anchor } from './htmlDocComments.ts'
+import { BRIDGE_CHANNEL, isValidAid, parseBridgeInbound } from './htmlDocBridge.ts'
 import {
   absolutizeDocAssetUrls,
   buildOctoDocUrl,
@@ -55,26 +55,18 @@ export {
 } from './htmlDocFrameHelpers.ts'
 import './HtmlDocView.css'
 
-// Interactive/editable elements the read-only view must never render, even if DOMPurify's
-// default (script/handler) baseline would otherwise let their markup through. This enforces
-// the product's "human reads, never edits" hard constraint.
+// Interactive/editable elements the read-only view must never render (enforces "human reads,
+// never edits"), even though DOMPurify's default baseline would let their markup through.
 const FORBID_TAGS = ['input', 'button', 'textarea', 'select', 'option', 'form', 'label', 'fieldset']
-// contenteditable would make plain elements editable; autofocus/onfocus are event-ish
-// affordances. (Generic on* handlers + javascript: URLs are already removed by DOMPurify's
-// default profile; contenteditable must be forbidden explicitly.)
-// style is forbidden: DOMPurify keeps inline style verbatim without deep-cleaning CSS values,
-// leaving a CSS injection surface (url(javascript:…)/expression()/url(//evil?leak) exfil/UI
-// overlay). Presentational styling belongs to octo-doc's published-page class/external CSS.
+// contenteditable makes plain elements editable; autofocus/onfocus are event-ish affordances.
+// style is forbidden because DOMPurify keeps inline CSS verbatim (url(javascript:)/expression()/
+// exfil url() surface it does not deep-clean). Presentational styling belongs to published CSS.
 const FORBID_ATTR = ['contenteditable', 'autofocus', 'onfocus', 'style']
 
 /**
- * Legacy sanitizer retained for callers that still need a stripped inline fragment.
- *
- * Relies on DOMPurify's default safe baseline (drops <script>, on* handlers and
- * javascript:/data: script URLs) and additionally strips interactive/editable elements and
- * the contenteditable attribute so the rendered doc is strictly presentational. Ordinary
- * display markup is preserved by the default allow-list; inline style is forbidden (see
- * FORBID_ATTR) to close the CSS-value injection surface DOMPurify does not deep-clean.
+ * Legacy sanitizer for callers that still need a stripped inline fragment. DOMPurify default
+ * baseline (drops script tags, on* handlers, javascript: URLs) plus FORBID_TAGS/FORBID_ATTR
+ * (interactive tags, contenteditable, inline style) yields strictly presentational output.
  */
 export function sanitizeDocHtml(raw: string): string {
   return DOMPurify.sanitize(raw, {
@@ -83,8 +75,12 @@ export function sanitizeDocHtml(raw: string): string {
   })
 }
 
-function cssAttrValue(value: string): string {
-  return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
+// Escape a (bounded) aid interpolated into an attribute selector. Prefer platform CSS.escape;
+// else escape every non-word char so a hostile aid can't break out of the selector.
+function escapeAidForSelector(value: string): string {
+  const cssApi = (globalThis as { CSS?: { escape?: (s: string) => string } }).CSS
+  if (cssApi?.escape) return cssApi.escape(value)
+  return value.replace(/[^\w-]/g, (c) => `\\${c}`)
 }
 
 export function resolveHtmlDocAnchorText(
@@ -96,7 +92,7 @@ export function resolveHtmlDocAnchorText(
   if (anchor.kind !== 'element') return null
   if (!doc) return null
   try {
-    const el = doc.querySelector(`[data-odoc-aid="${cssAttrValue(anchor.aid)}"]`)
+    const el = doc.querySelector(`[data-odoc-aid="${escapeAidForSelector(anchor.aid)}"]`)
     const text = el?.textContent?.trim()
     return text ? truncateAnchorText(text) : null
   } catch {
@@ -137,16 +133,11 @@ type LoadState =
       isAuthor: boolean
     }
 
-// Minimal metadata the render page injects as window.__ODOC__ (see doc-side render).
-// ⚠️ identity here is the CURRENT VIEWER's session identity (identityFromSession), NOT the
-// doc creator. __ODOC__ (core.OverlayConfig) does NOT carry creator_uid — so never derive
-// authorship by comparing viewer uid against identity.login (that is always the viewer =
-// always true). Authorship comes from window.__ODOC_CAP__.isAuthor (see parseOdocCap).
-//
-// creator_uid / creator_name / created_at fields are DEPRECATED — the header now reads
-// ownerId/createdAt from docs-backend getDoc (single source of truth, same as EditorShell).
-// Interface entries retained only so a payload that still carries them parses cleanly; DO NOT
-// reintroduce readers of these fields — future backends may drop them without notice.
+// Minimal metadata the render page injects as window.__ODOC__. ⚠️ identity is the CURRENT VIEWER,
+// NOT the doc creator, and __ODOC__ carries no creator_uid — so never derive authorship from it
+// (that always makes the viewer the "author"). Authorship comes from __ODOC_CAP__.isAuthor.
+// creator_uid/creator_name/created_at are DEPRECATED — header now reads ownerId/createdAt from
+// docs-backend getDoc. Kept only so legacy payloads parse; do NOT reintroduce readers.
 interface OctoDocMeta {
   slug?: string
   title?: string
@@ -172,11 +163,9 @@ function parseOdocMeta(html: string): OctoDocMeta | null {
   }
 }
 
-// Authorship is decided by the backend (resolveCap: viewer Login == doc CreatorUID → CapAuthor)
-// and inlined as window.__ODOC_CAP__ = {isAuthor: true}. ⚠️ That marker is a JS object literal
-// (unquoted key), NOT valid JSON — JSON.parse would throw and make EVERY viewer non-author
-// (incl. the real author). Read the boolean directly. This is the only trustworthy author signal
-// on the client (__ODOC__ carries no creator_uid). Missing marker → not author (fail closed).
+// Authorship is backend-decided (resolveCap) and inlined as window.__ODOC_CAP__ = {isAuthor: true}.
+// ⚠️ That marker is a JS object literal (unquoted key), NOT JSON — parse the boolean directly;
+// JSON.parse would throw and make every viewer non-author. Missing marker → not author (fail closed).
 function parseOdocCap(html: string): boolean {
   const m = html.match(/__ODOC_CAP__\s*=\s*\{[^}]*\bisAuthor\b\s*:\s*(true|false)/)
   return m?.[1] === 'true'
@@ -203,9 +192,21 @@ export function HtmlDocView({
   // content. Overlay state only — the content itself is never mutated / made editable.
   const [pendingAnchor, setPendingAnchor] = useState<Anchor | null>(null)
   const frameRef = useRef<HTMLIFrameElement | null>(null)
-  const selectionDocRef = useRef<Document | null>(null)
   const mayCommentRef = useRef(false)
   const [frameReadyTick, setFrameReadyTick] = useState(0)
+  // Element-anchor display text resolved over the bridge (aid → text). The parent cannot read the
+  // cross-origin iframe DOM, so it asks the frame and caches the reply here. resolveAnchorText is a
+  // pure cache read; the comment panel reports which element aids are visible (post-commit) and a
+  // parent effect sends one bridge request per not-yet-requested aid.
+  const [anchorTextCache, setAnchorTextCache] = useState<Record<string, string | null>>({})
+  const requestedAidsRef = useRef<Set<string>>(new Set())
+  const pendingResolveRef = useRef<Map<string, string>>(new Map())
+  // Element aids the comment panel currently renders (reported post-commit); drives the resolve
+  // effect below. State (not a ref) so a new set re-runs the effect.
+  const [visibleAnchorAids, setVisibleAnchorAids] = useState<string[]>([])
+  // Current render generation's bridge token (from HtmlPreviewFrame). Requests carry it and replies
+  // must echo it; a token mismatch drops stale / cross-document / replayed traffic.
+  const bridgeTokenRef = useRef<string | null>(null)
   // Header UI state.
   const [membersOpen, setMembersOpen] = useState(false)
   // 历史版本 panel (≡ → 历史版本) + two-version diff modal state.
@@ -301,22 +302,16 @@ export function HtmlDocView({
   // Creator display: resolved name → short uid → placeholder. Never blank, never crashes.
   const headerCreator = creatorName || (ownerId ? ownerId.slice(0, 8) : '—')
   const creatorAvatarUrl = avatarUrlForUid(ownerId)
-  // Two independent gates, kept separate on purpose (合并 = UI 骗人):
-  //   - canManageBackend: docs-backend admin, drives Share/Invite/Requests inside the panel.
-  //     role=null (still resolving) collapses to false — the panel renders a loading placeholder
-  //     for those slots rather than a half-baked admin UI.
-  //   - canOpenPanel: entry-visibility union — either authority is enough to see the button and
-  //     open the modal. When role is still resolving, canOpenPanel short-circuits on isAuthor so
-  //     a non-author viewer never gets a flashed entry that later disappears.
-  // The panel itself derives canManageAuthorGrants from isAuthor alone; we intentionally stop
-  // forwarding the legacy `canManage` prop so a merged authority can never leak the author-only
-  // slots (Add member / Current Members) or trigger the author-only listGrants 403.
-  // The header ≡ Delete affordance is gated on isAuthor for the same reason — symmetric with the
-  // grants-side hiding, so a docs-backend admin who is not the author never sees a guaranteed-403
-  // affordance whose backend is octo-doc /v1/docs/{slug} (author-only).
+  // Two independent gates, kept separate on purpose:
+  //   - canManageBackend: docs-backend admin (Share/Invite/Requests). role=null → false (loading).
+  //   - canOpenPanel: entry-visibility union (author OR admin); short-circuits on isAuthor while
+  //     role resolves so a non-author viewer never gets a flashed entry.
+  // The panel derives author-only grants from isAuthor alone; we stop forwarding legacy `canManage`
+  // so a merged authority can never leak author-only slots or trigger the author-only listGrants
+  // 403. Delete is likewise isAuthor-gated (its backend is author-only octo-doc /v1/docs/{slug}).
   const creatorUid = ownerId
-  // Centralised capability derivation from the backend-resolved role (fail closed while null).
-  // These are the single seam every write affordance gates on — never viewer-uid vs __ODOC__.
+  // Capability derivation from the backend-resolved role (fail closed while null). Single seam
+  // every write affordance gates on — never viewer-uid vs __ODOC__.
   const mayComment = resolvedRole != null && resolvedRole !== 'reader'
   mayCommentRef.current = mayComment && mode === 'page'
   const mayEdit = resolvedRole != null && canEdit(resolvedRole)
@@ -435,86 +430,111 @@ export function HtmlDocView({
     [selectModeTab],
   )
 
-  const onFrameSelectionChange = useCallback(() => {
-    // Only a commenter+ may lift a selection anchor; a reader's selection is never actionable.
-    if (!mayCommentRef.current) return
-    const doc = frameRef.current?.contentDocument
-    const body = doc?.body
-    const sel = doc?.getSelection?.() ?? doc?.defaultView?.getSelection?.() ?? null
-    if (!sel || sel.rangeCount === 0 || sel.isCollapsed || !body) return
-    if (!body.contains(sel.getRangeAt(0).commonAncestorContainer)) return
-    const anchor = buildAnchorFromSelection(sel)
-    if (anchor) setPendingAnchor(anchor)
+  // Reset per-generation bridge state on each frame load: the new token gates all subsequent
+  // traffic (prior-document requests/replies drop on mismatch) and the resolved-text cache is
+  // invalidated since aids may now map to different content.
+  const handleFrameLoad = useCallback((_doc: Document | null, frame: HTMLIFrameElement, token: string | null) => {
+    frameRef.current = frame
+    bridgeTokenRef.current = token
+    requestedAidsRef.current = new Set()
+    pendingResolveRef.current = new Map()
+    setAnchorTextCache({})
+    setFrameReadyTick((v) => v + 1)
   }, [])
 
-  const cleanupFrameSelectionWatcher = useCallback(() => {
-    selectionDocRef.current?.removeEventListener('selectionchange', onFrameSelectionChange)
-    selectionDocRef.current = null
-  }, [onFrameSelectionChange])
-
-  const syncFrameSelectionWatcher = useCallback(() => {
-    cleanupFrameSelectionWatcher()
-    if (!mayCommentRef.current) return
-    const doc = frameRef.current?.contentDocument
-    if (!doc) return
-    try {
-      doc.addEventListener('selectionchange', onFrameSelectionChange)
-      selectionDocRef.current = doc
-    } catch (err) {
-      console.warn('[HtmlDocView] unable to initialize iframe document hooks', err)
-    }
-  }, [cleanupFrameSelectionWatcher, onFrameSelectionChange])
-
-  const handleFrameLoad = useCallback(
-    (doc: Document | null, frame: HTMLIFrameElement) => {
-      frameRef.current = frame
-      setFrameReadyTick((v) => v + 1)
-      cleanupFrameSelectionWatcher()
-      try {
-        if (!doc) throw new Error('missing iframe document')
-        if (mayCommentRef.current) {
-          doc.addEventListener('selectionchange', onFrameSelectionChange)
-          selectionDocRef.current = doc
-        }
-      } catch (err) {
-        console.warn('[HtmlDocView] unable to initialize iframe document hooks', err)
+  // Single window-level bridge listener. The iframe is cross-origin (no allow-same-origin) so the
+  // parent gates on event.source === contentWindow + current token + a bounded schema before
+  // trusting anything. Only non-privileged UI facts are accepted (a selection anchor the human
+  // still submits; text we explicitly requested).
+  useEffect(() => {
+    const onMessage = (ev: MessageEvent) => {
+      const frame = frameRef.current
+      // srcDoc frames have an opaque origin, so identity is the exact contentWindow, not origin.
+      if (!frame || ev.source !== frame.contentWindow) return
+      const msg = parseBridgeInbound(ev.data)
+      if (!msg) return
+      // Correlate to the CURRENT generation; a stale/forged token is discarded.
+      if (!bridgeTokenRef.current || msg.token !== bridgeTokenRef.current) return
+      if (msg.type === 'selection') {
+        if (!mayCommentRef.current) return
+        // Adopt only a fresh non-null anchor; a null (collapse) report is ignored so a locked
+        // anchor survives the selection collapsing when the human moves to the composer.
+        if (msg.anchor) setPendingAnchor(msg.anchor)
+      } else if (msg.type === 'anchor-text') {
+        // Accept only replies to a nonce WE issued this generation (reject stale/replayed nonces).
+        const aid = pendingResolveRef.current.get(msg.nonce)
+        if (!aid) return
+        pendingResolveRef.current.delete(msg.nonce)
+        setAnchorTextCache((prev) => ({ ...prev, [aid]: msg.text }))
       }
-    },
-    [cleanupFrameSelectionWatcher, onFrameSelectionChange],
-  )
+    }
+    window.addEventListener('message', onMessage)
+    return () => window.removeEventListener('message', onMessage)
+  }, [])
 
+  // RENDER-PURE cache read: no ref writes, no scheduling. Cache misses are filled by the resolve
+  // effect, which is driven by the aids the comment panel reports post-commit (onVisibleAnchors).
   const resolveAnchorText = useCallback(
     (anchor: Anchor | null | undefined): string | null => {
-      try {
-        return resolveHtmlDocAnchorText(anchor, frameRef.current?.contentDocument)
-      } catch {
-        return null
-      }
+      if (!anchor) return null
+      if (anchor.kind === 'text') return truncateAnchorText(anchor.text)
+      if (anchor.kind !== 'element') return null
+      const aid = anchor.aid
+      if (!isValidAid(aid)) return null
+      return aid in anchorTextCache ? anchorTextCache[aid] : null
     },
-    [frameReadyTick],
+    [anchorTextCache],
   )
 
-  useEffect(() => {
-    if (state.status !== 'ready') {
-      cleanupFrameSelectionWatcher()
-    }
-  }, [cleanupFrameSelectionWatcher, state.status])
+  // The comment panel reports the element aids it renders in a post-commit effect; adopt them here
+  // (identity-stable when unchanged so the resolve effect below doesn't churn).
+  const handleVisibleAnchorAids = useCallback((aids: string[]) => {
+    setVisibleAnchorAids((prev) =>
+      prev.length === aids.length && prev.every((a, i) => a === aids[i]) ? prev : aids,
+    )
+  }, [])
 
-  // Keep the watcher reconciled with runtime permission/mode changes. This handles both removal
-  // and re-attachment without requiring another iframe load, while the sync's remove-first rule
-  // guarantees at most one listener on the current document.
+  // Post-commit resolve: send one bridge request per reported aid not yet requested/cached. Runs
+  // AFTER render off reported aids, so nothing schedules during render. Each request carries the
+  // current token + a unique nonce; the listener accepts only a matching-token, issued-nonce reply.
   useEffect(() => {
-    if (!mayComment || mode === 'code') {
-      setPendingAnchor(null)
+    const win = frameRef.current?.contentWindow
+    const token = bridgeTokenRef.current
+    if (!win || !token) return
+    for (const aid of visibleAnchorAids) {
+      if (!isValidAid(aid) || requestedAidsRef.current.has(aid) || aid in anchorTextCache) continue
+      requestedAidsRef.current.add(aid)
+      const nonce = `${Date.now()}-${Math.random().toString(36).slice(2)}`
+      pendingResolveRef.current.set(nonce, aid)
+      try {
+        win.postMessage({ channel: BRIDGE_CHANNEL, type: 'resolve-anchor-text', token, nonce, aid }, '*')
+      } catch {
+        // Frame gone: leave uncached so a later render retries.
+        requestedAidsRef.current.delete(aid)
+        pendingResolveRef.current.delete(nonce)
+      }
     }
-    syncFrameSelectionWatcher()
-  }, [mayComment, mode, syncFrameSelectionWatcher])
+  }, [visibleAnchorAids, frameReadyTick, anchorTextCache])
 
-  useEffect(() => {
-    return () => {
-      cleanupFrameSelectionWatcher()
+  // Explicit activation: clicking a comment thread scrolls its element anchor into view and briefly
+  // highlights it in the frame (non-destructive). Only element anchors carry a locatable aid; the
+  // aid is validated/bounded before it crosses the bridge.
+  const activateAnchor = useCallback((anchor: Anchor | null | undefined) => {
+    if (!anchor || anchor.kind !== 'element' || !isValidAid(anchor.aid)) return
+    const win = frameRef.current?.contentWindow
+    const token = bridgeTokenRef.current
+    if (!win || !token) return
+    try {
+      win.postMessage({ channel: BRIDGE_CHANNEL, type: 'scroll-to-anchor', token, aid: anchor.aid }, '*')
+    } catch {
+      /* frame gone; nothing to scroll */
     }
-  }, [cleanupFrameSelectionWatcher])
+  }, [])
+
+  // A permission/mode change that turns commenting off must drop any pending selection anchor.
+  useEffect(() => {
+    if (!mayComment || mode === 'code') setPendingAnchor(null)
+  }, [mayComment, mode])
 
   return (
     <div className="octo-doc octo-doc--editor octo-theme octo-html-doc" data-testid="html-doc-view">
@@ -765,6 +785,8 @@ export function HtmlDocView({
               mutationVersion={meta?.version}
               pendingAnchor={pendingAnchor}
               resolveAnchorText={resolveAnchorText}
+              onVisibleAnchors={handleVisibleAnchorAids}
+              onActivateAnchor={activateAnchor}
               onClearPendingAnchor={() => setPendingAnchor(null)}
               onPosted={() => setPendingAnchor(null)}
             />

--- a/packages/docs/src/html/HtmlDocView.tsx
+++ b/packages/docs/src/html/HtmlDocView.tsx
@@ -6,13 +6,11 @@
 // the octoweb apiClient.
 //
 // SECURITY (issue #27): the Publish payload is NOT sanitized end-to-end, so it may carry <script>,
-// on* handlers, javascript: URLs, or controls. The frame uses sandbox="allow-scripts" WITHOUT
-// allow-same-origin (combining them defeats the sandbox — NEVER do it): doc JS runs in an opaque
-// origin and cannot reach the parent DOM/credentials/origin; forms/popups/downloads/top-nav stay
-// denied. This does NOT stop outbound network from doc JS — egress is an accepted capability for
-// agent HTML (see htmlDocBridge threat-boundary note). Selection/anchor data crosses the
-// constrained postMessage bridge (htmlDocBridge): the parent gates on event.source === the frame's
-// contentWindow + a bounded schema and accepts only non-privileged UI facts.
+// on* handlers, javascript: URLs, or controls. sandbox="allow-scripts" WITHOUT allow-same-origin
+// (combining them defeats the sandbox): doc JS runs in an opaque origin that cannot read the parent
+// DOM/storage/origin; forms/popups/downloads/top-nav stay denied. Outbound network from doc JS is
+// NOT blocked (accepted egress capability). Selection/anchor data crosses the constrained
+// postMessage bridge (htmlDocBridge), gated on event.source === the frame's contentWindow.
 
 import { useCallback, useEffect, useRef, useState } from 'react'
 import DOMPurify from 'dompurify'
@@ -193,12 +191,13 @@ export function HtmlDocView({
   const [pendingAnchor, setPendingAnchor] = useState<Anchor | null>(null)
   const frameRef = useRef<HTMLIFrameElement | null>(null)
   const mayCommentRef = useRef(false)
+  // True while the comment composer is engaged (focus or non-empty draft); inbound `selection`
+  // messages are frozen so a hostile doc cannot swap the reviewed anchor just before submit.
+  const composerEngagedRef = useRef(false)
   const [frameReadyTick, setFrameReadyTick] = useState(0)
-  // Element-anchor display text resolved over the bridge (aid → text). The parent cannot read the
-  // cross-origin iframe DOM, so it asks the frame and caches the reply here. resolveAnchorText is a
-  // pure cache read; the comment panel reports which element aids are visible (post-commit) and a
-  // parent effect sends one bridge request per not-yet-requested aid.
-  const [anchorTextCache, setAnchorTextCache] = useState<Record<string, string | null>>({})
+  // aid → resolved text over the bridge. A Map (own-key semantics) so a `__proto__`/`constructor`
+  // aid is an own key, never a prototype-chain hit. resolveAnchorText is a pure cache read.
+  const [anchorTextCache, setAnchorTextCache] = useState<Map<string, string | null>>(() => new Map())
   const requestedAidsRef = useRef<Set<string>>(new Set())
   const pendingResolveRef = useRef<Map<string, string>>(new Map())
   // Element aids the comment panel currently renders (reported post-commit); drives the resolve
@@ -207,6 +206,9 @@ export function HtmlDocView({
   // Current render generation's bridge token (from HtmlPreviewFrame). Requests carry it and replies
   // must echo it; a token mismatch drops stale / cross-document / replayed traffic.
   const bridgeTokenRef = useRef<string | null>(null)
+  // Monotonic frame generation; a coalesced selection captures it and drops on flush if the frame
+  // reloaded meanwhile (stale-generation guard alongside the token check).
+  const bridgeGenRef = useRef(0)
   // Header UI state.
   const [membersOpen, setMembersOpen] = useState(false)
   // 历史版本 panel (≡ → 历史版本) + two-version diff modal state.
@@ -362,6 +364,11 @@ export function HtmlDocView({
     setState({ status: 'loading' })
     setPendingAnchor(null)
     setFrameReadyTick(0)
+    // Drop any queued selection + composer engagement from the outgoing doc/version.
+    if (selectionFlushRef.current != null) clearTimeout(selectionFlushRef.current)
+    selectionFlushRef.current = null
+    pendingSelectionRef.current = null
+    composerEngagedRef.current = false
   }, [effectiveSlug, viewVersion])
 
   const handlePreviewState = useCallback((s: PreviewLoadState) => {
@@ -430,23 +437,54 @@ export function HtmlDocView({
     [selectModeTab],
   )
 
-  // Reset per-generation bridge state on each frame load: the new token gates all subsequent
-  // traffic (prior-document requests/replies drop on mismatch) and the resolved-text cache is
-  // invalidated since aids may now map to different content.
-  const handleFrameLoad = useCallback((_doc: Document | null, frame: HTMLIFrameElement, token: string | null) => {
-    frameRef.current = frame
-    bridgeTokenRef.current = token
-    requestedAidsRef.current = new Set()
-    pendingResolveRef.current = new Map()
-    setAnchorTextCache({})
-    setFrameReadyTick((v) => v + 1)
+  // Coalesce accepted `selection` messages: a drag-select (or hostile loop) can fire dozens/sec.
+  // Stash the latest anchor + the generation it was captured under, flush once on a trailing timer.
+  const SELECTION_COALESCE_MS = 60
+  const pendingSelectionRef = useRef<{ anchor: Anchor; gen: number } | null>(null)
+  const selectionFlushRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  // Cancel any queued selection flush and drop the stashed anchor (frame reload / commenting off).
+  const cancelPendingSelection = useCallback(() => {
+    if (selectionFlushRef.current != null) {
+      clearTimeout(selectionFlushRef.current)
+      selectionFlushRef.current = null
+    }
+    pendingSelectionRef.current = null
   }, [])
+
+  // Reset per-generation bridge state on each frame load: bump the generation, cancel any queued
+  // selection from the prior frame, adopt the new token (it gates all later traffic), and clear the
+  // resolved-text cache (aids may now map to different content).
+  const handleFrameLoad = useCallback(
+    (_doc: Document | null, frame: HTMLIFrameElement, token: string | null) => {
+      frameRef.current = frame
+      bridgeTokenRef.current = token
+      bridgeGenRef.current += 1
+      cancelPendingSelection()
+      composerEngagedRef.current = false
+      requestedAidsRef.current = new Set()
+      pendingResolveRef.current = new Map()
+      setAnchorTextCache(new Map())
+      setFrameReadyTick((v) => v + 1)
+    },
+    [cancelPendingSelection],
+  )
 
   // Single window-level bridge listener. The iframe is cross-origin (no allow-same-origin) so the
   // parent gates on event.source === contentWindow + current token + a bounded schema before
   // trusting anything. Only non-privileged UI facts are accepted (a selection anchor the human
   // still submits; text we explicitly requested).
   useEffect(() => {
+    const flushSelection = () => {
+      selectionFlushRef.current = null
+      const queued = pendingSelectionRef.current
+      pendingSelectionRef.current = null
+      // Re-check every gate at flush time: the frame may have reloaded (stale generation/token),
+      // commenting may have turned off (mayCommentRef folds in mode), or the composer may have
+      // engaged during the coalesce window.
+      if (!queued || queued.gen !== bridgeGenRef.current) return
+      if (!bridgeTokenRef.current || !mayCommentRef.current || composerEngagedRef.current) return
+      setPendingAnchor(queued.anchor)
+    }
     const onMessage = (ev: MessageEvent) => {
       const frame = frameRef.current
       // srcDoc frames have an opaque origin, so identity is the exact contentWindow, not origin.
@@ -457,20 +495,28 @@ export function HtmlDocView({
       if (!bridgeTokenRef.current || msg.token !== bridgeTokenRef.current) return
       if (msg.type === 'selection') {
         if (!mayCommentRef.current) return
-        // Adopt only a fresh non-null anchor; a null (collapse) report is ignored so a locked
-        // anchor survives the selection collapsing when the human moves to the composer.
-        if (msg.anchor) setPendingAnchor(msg.anchor)
+        // Ignore a null (collapse) report and freeze while the composer is engaged so a hostile doc
+        // cannot swap the reviewed target before submit.
+        if (!msg.anchor || composerEngagedRef.current) return
+        // Coalesce: keep the latest anchor + its generation, flush once on a trailing timer.
+        pendingSelectionRef.current = { anchor: msg.anchor, gen: bridgeGenRef.current }
+        if (selectionFlushRef.current == null) {
+          selectionFlushRef.current = setTimeout(flushSelection, SELECTION_COALESCE_MS)
+        }
       } else if (msg.type === 'anchor-text') {
         // Accept only replies to a nonce WE issued this generation (reject stale/replayed nonces).
         const aid = pendingResolveRef.current.get(msg.nonce)
         if (!aid) return
         pendingResolveRef.current.delete(msg.nonce)
-        setAnchorTextCache((prev) => ({ ...prev, [aid]: msg.text }))
+        setAnchorTextCache((prev) => new Map(prev).set(aid, msg.text))
       }
     }
     window.addEventListener('message', onMessage)
-    return () => window.removeEventListener('message', onMessage)
-  }, [])
+    return () => {
+      window.removeEventListener('message', onMessage)
+      cancelPendingSelection()
+    }
+  }, [cancelPendingSelection])
 
   // RENDER-PURE cache read: no ref writes, no scheduling. Cache misses are filled by the resolve
   // effect, which is driven by the aids the comment panel reports post-commit (onVisibleAnchors).
@@ -481,7 +527,9 @@ export function HtmlDocView({
       if (anchor.kind !== 'element') return null
       const aid = anchor.aid
       if (!isValidAid(aid)) return null
-      return aid in anchorTextCache ? anchorTextCache[aid] : null
+      // Explicit typeof string|null guard: Map.get returns undefined for a miss; normalize to null.
+      const cached = anchorTextCache.get(aid)
+      return typeof cached === 'string' ? cached : null
     },
     [anchorTextCache],
   )
@@ -502,7 +550,7 @@ export function HtmlDocView({
     const token = bridgeTokenRef.current
     if (!win || !token) return
     for (const aid of visibleAnchorAids) {
-      if (!isValidAid(aid) || requestedAidsRef.current.has(aid) || aid in anchorTextCache) continue
+      if (!isValidAid(aid) || requestedAidsRef.current.has(aid) || anchorTextCache.has(aid)) continue
       requestedAidsRef.current.add(aid)
       const nonce = `${Date.now()}-${Math.random().toString(36).slice(2)}`
       pendingResolveRef.current.set(nonce, aid)
@@ -531,10 +579,19 @@ export function HtmlDocView({
     }
   }, [])
 
-  // A permission/mode change that turns commenting off must drop any pending selection anchor.
+  const handleComposerEngagedChange = useCallback((engaged: boolean) => {
+    composerEngagedRef.current = engaged
+  }, [])
+
+  // Commenting off (permission loss / code mode) cancels any queued selection and resets composer
+  // engagement before dropping the committed anchor, so a mid-coalesce flush can't re-arm it.
   useEffect(() => {
-    if (!mayComment || mode === 'code') setPendingAnchor(null)
-  }, [mayComment, mode])
+    if (!mayComment || mode === 'code') {
+      cancelPendingSelection()
+      composerEngagedRef.current = false
+      setPendingAnchor(null)
+    }
+  }, [mayComment, mode, cancelPendingSelection])
 
   return (
     <div className="octo-doc octo-doc--editor octo-theme octo-html-doc" data-testid="html-doc-view">
@@ -789,6 +846,7 @@ export function HtmlDocView({
               onActivateAnchor={activateAnchor}
               onClearPendingAnchor={() => setPendingAnchor(null)}
               onPosted={() => setPendingAnchor(null)}
+              onComposerEngagedChange={handleComposerEngagedChange}
             />
           )}
         </div>

--- a/packages/docs/src/html/HtmlPreviewFrame.test.tsx
+++ b/packages/docs/src/html/HtmlPreviewFrame.test.tsx
@@ -1,0 +1,148 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, waitFor, cleanup } from '@testing-library/react'
+import { HtmlPreviewFrame } from './HtmlPreviewFrame.tsx'
+import { injectBaseHref, resolveAbsoluteOctoDocBase } from './htmlDocFrameHelpers.ts'
+import { setWKApp } from '../octoweb/index.ts'
+import { createMockWKApp } from '../octoweb/mock.ts'
+
+// HtmlPreviewFrame fetches published octo-doc HTML from a SEPARATE backend, so we stub global
+// fetch (not the octoweb apiClient) — mirroring the component's raw-fetch design.
+function stubFetch(body: string, ok = true, status = 200) {
+  const spy = vi.fn(() =>
+    Promise.resolve({ ok, status, text: async () => body } as unknown as Response)
+  ) as unknown as typeof fetch
+  vi.stubGlobal('fetch', spy)
+  return spy
+}
+
+async function waitForFrame(container: HTMLElement): Promise<HTMLIFrameElement> {
+  return waitFor(() => {
+    const f = container.querySelector('iframe') as HTMLIFrameElement | null
+    if (!f) throw new Error('no iframe yet')
+    return f
+  })
+}
+
+beforeEach(() => setWKApp(createMockWKApp({ uid: 'u', token: 't' })))
+afterEach(() => {
+  vi.unstubAllGlobals()
+  cleanup()
+})
+
+describe('HtmlPreviewFrame — sandbox isolation (issue #27)', () => {
+  it('scripts mode: EXACT sandbox="allow-scripts", never allow-same-origin', async () => {
+    stubFetch('<html><head></head><body><p>x</p></body></html>')
+    const { container } = render(<HtmlPreviewFrame slug="s" version="latest" title="t" isolation="scripts" />)
+    const frame = await waitForFrame(container)
+    // Exact token set — the dangerous allow-same-origin pairing (and forms/popups/downloads/top-nav)
+    // must be absent.
+    expect(frame.getAttribute('sandbox')).toBe('allow-scripts')
+  })
+
+  it('sets referrerPolicy="no-referrer" so the page URL never leaks as a Referer (both modes)', async () => {
+    // The sandbox does NOT stop outbound network from doc JS (accepted capability), so we cap the
+    // one leak channel we own: never send our URL as a Referer on doc-initiated requests.
+    stubFetch('<html><head></head><body><p>x</p></body></html>')
+    const scripts = render(<HtmlPreviewFrame slug="s" version="latest" title="t" isolation="scripts" />)
+    const sf = await waitForFrame(scripts.container)
+    expect(sf.getAttribute('referrerpolicy')).toBe('no-referrer')
+    scripts.unmount()
+    stubFetch('<html><head></head><body><p>x</p></body></html>')
+    const ro = render(<HtmlPreviewFrame slug="s" version="1" title="t" isolation="readonly-dom" />)
+    const rf = await waitForFrame(ro.container)
+    expect(rf.getAttribute('referrerpolicy')).toBe('no-referrer')
+  })
+
+  it('readonly-dom mode: EXACT sandbox="allow-same-origin", never allow-scripts', async () => {
+    stubFetch('<html><head></head><body><p>x</p></body></html>')
+    const { container } = render(<HtmlPreviewFrame slug="s" version="1" title="t" isolation="readonly-dom" />)
+    const frame = await waitForFrame(container)
+    expect(frame.getAttribute('sandbox')).toBe('allow-same-origin')
+  })
+
+  it('scripts mode injects the bridge into srcdoc; readonly-dom does NOT (and carries no scripts)', async () => {
+    stubFetch('<html><head><style>.a{color:red}</style></head><body><p>hi</p></body></html>')
+    const scripts = render(<HtmlPreviewFrame slug="s" version="latest" title="t" isolation="scripts" />)
+    const sf = await waitForFrame(scripts.container)
+    const scriptsDoc = sf.getAttribute('srcdoc') ?? ''
+    expect(scriptsDoc).toContain('octodoc-bridge')
+    // Author CSS is preserved verbatim.
+    expect(scriptsDoc).toContain('.a{color:red}')
+    scripts.unmount()
+
+    stubFetch('<html><head><style>.a{color:red}</style></head><body><p>hi</p></body></html>')
+    const ro = render(<HtmlPreviewFrame slug="s" version="1" title="t" isolation="readonly-dom" />)
+    const rf = await waitForFrame(ro.container)
+    const roDoc = rf.getAttribute('srcdoc') ?? ''
+    // No bridge, and (readonly-dom) no <script> at all — the parent reads the DOM directly instead.
+    expect(roDoc).not.toContain('octodoc-bridge')
+    expect(roDoc).not.toMatch(/<script/i)
+    // Author CSS still preserved.
+    expect(roDoc).toContain('.a{color:red}')
+  })
+
+  it('scripts mode: the bridge precedes an author <meta CSP> in the built srcdoc (CSP ordering)', async () => {
+    stubFetch(
+      '<html><head><meta http-equiv="Content-Security-Policy" content="script-src \'none\'"></head><body></body></html>'
+    )
+    const { container } = render(<HtmlPreviewFrame slug="s" version="latest" title="t" isolation="scripts" />)
+    const frame = await waitForFrame(container)
+    const doc = frame.getAttribute('srcdoc') ?? ''
+    expect(doc.indexOf('octodoc-bridge')).toBeGreaterThan(-1)
+    expect(doc.indexOf('octodoc-bridge')).toBeLessThan(doc.indexOf('Content-Security-Policy'))
+    // Author CSP is preserved for the rest of the document.
+    expect(doc).toContain("script-src 'none'")
+  })
+
+  it('bridge unavailable (no DOMParser): srcdoc is the unbridged normalized HTML and onFrameLoad token is null', async () => {
+    // injectBridgeScript AND absolutizeDocAssetUrls both fail closed to identity without DOMParser
+    // (SSR); only injectBaseHref (regex) still runs. The frame must then mint NO token, embed NO
+    // bridge, and hand onFrameLoad a null token — tokenRef stays in lockstep with the real srcDoc.
+    const raw = '<html><head><style>.a{color:red}</style></head><body><p>hi</p></body></html>'
+    // Capture the expected normalized srcDoc under the same (DOMParser-absent) conditions.
+    const savedDOMParser = globalThis.DOMParser
+    // @ts-expect-error deleting a global for the fail-closed path
+    delete (globalThis as { DOMParser?: unknown }).DOMParser
+    try {
+      expect(typeof DOMParser).toBe('undefined')
+      const expected = injectBaseHref(raw, resolveAbsoluteOctoDocBase())
+      stubFetch(raw)
+      const onFrameLoad = vi.fn()
+      const { container } = render(
+        <HtmlPreviewFrame slug="s" version="latest" title="t" isolation="scripts" onFrameLoad={onFrameLoad} />,
+      )
+      const frame = await waitForFrame(container)
+      const srcdoc = frame.getAttribute('srcdoc') ?? ''
+      // Byte-equivalent to the unbridged normalized HTML — no bridge, no token literal.
+      expect(srcdoc).toBe(expected)
+      expect(srcdoc).not.toContain('octodoc-bridge')
+      expect(srcdoc).not.toMatch(/TOKEN = "/)
+      // onLoad hands back a null token (bridge disabled), and doc is null in scripts mode.
+      await waitFor(() => expect(onFrameLoad).toHaveBeenCalled())
+      const [doc, , token] = onFrameLoad.mock.calls[0]
+      expect(token).toBeNull()
+      expect(doc).toBeNull()
+    } finally {
+      // Restore reliably so later tests keep a working DOMParser.
+      ;(globalThis as { DOMParser?: unknown }).DOMParser = savedDOMParser
+    }
+    expect(typeof DOMParser).toBe('function')
+  })
+
+  it('embeds a fresh bridge token per load; two loads get different tokens', async () => {
+    stubFetch('<html><head></head><body></body></html>')
+    const first = render(<HtmlPreviewFrame slug="s" version="latest" title="t" isolation="scripts" />)
+    const f1 = await waitForFrame(first.container)
+    const t1 = /TOKEN = "([^"]*)"/.exec(f1.getAttribute('srcdoc') ?? '')?.[1]
+    first.unmount()
+
+    stubFetch('<html><head></head><body></body></html>')
+    const second = render(<HtmlPreviewFrame slug="s" version="latest" title="t" isolation="scripts" />)
+    const f2 = await waitForFrame(second.container)
+    const t2 = /TOKEN = "([^"]*)"/.exec(f2.getAttribute('srcdoc') ?? '')?.[1]
+
+    expect(t1).toBeTruthy()
+    expect(t2).toBeTruthy()
+    expect(t1).not.toBe(t2)
+  })
+})

--- a/packages/docs/src/html/HtmlPreviewFrame.test.tsx
+++ b/packages/docs/src/html/HtmlPreviewFrame.test.tsx
@@ -95,13 +95,12 @@ describe('HtmlPreviewFrame — sandbox isolation (issue #27)', () => {
   })
 
   it('bridge unavailable (no DOMParser): srcdoc is the unbridged normalized HTML and onFrameLoad token is null', async () => {
-    // injectBridgeScript AND absolutizeDocAssetUrls both fail closed to identity without DOMParser
-    // (SSR); only injectBaseHref (regex) still runs. The frame must then mint NO token, embed NO
+    // injectBridgeScript, absolutizeDocAssetUrls AND injectBaseHref all fail closed to identity
+    // without DOMParser (SSR). The frame must then mint NO token, embed NO
     // bridge, and hand onFrameLoad a null token — tokenRef stays in lockstep with the real srcDoc.
     const raw = '<html><head><style>.a{color:red}</style></head><body><p>hi</p></body></html>'
     // Capture the expected normalized srcDoc under the same (DOMParser-absent) conditions.
     const savedDOMParser = globalThis.DOMParser
-    // @ts-expect-error deleting a global for the fail-closed path
     delete (globalThis as { DOMParser?: unknown }).DOMParser
     try {
       expect(typeof DOMParser).toBe('undefined')

--- a/packages/docs/src/html/HtmlPreviewFrame.tsx
+++ b/packages/docs/src/html/HtmlPreviewFrame.tsx
@@ -1,8 +1,8 @@
 // Shared sandboxed preview. Scripts run in an isolated (allow-scripts, NO allow-same-origin)
 // sandbox; the parent talks to the frame only through the constrained postMessage bridge
-// (htmlDocBridge). The sandbox blocks parent DOM/origin/credential access but NOT outbound network
-// from doc JS — network egress is an accepted capability for agent-authored HTML. Editable controls
-// are still neutralized in the markup; referrerPolicy="no-referrer" strips the Referer leak channel.
+// (htmlDocBridge). The sandbox blocks parent DOM/storage/origin access but NOT outbound network
+// from doc JS (an accepted egress capability). Editable controls are still neutralized in the
+// markup; referrerPolicy="no-referrer" strips the Referer leak channel.
 
 import { useEffect, useRef, useState } from 'react'
 import {
@@ -161,14 +161,10 @@ export function HtmlPreviewFrame({
       ref={iframeRef}
       className={className ?? 'octo-html-doc-frame'}
       // Two mutually-exclusive, both-safe sandboxes. NEVER combine allow-scripts with
-      // allow-same-origin (that pairing fully defeats the sandbox). No allow-forms/allow-popups/
-      // allow-top-navigation/allow-downloads in either mode.
-      //   scripts:      doc JS runs in an opaque origin, walled off from the PARENT (issue #27).
-      //   readonly-dom: no scripts execute, so same-origin DOM reads by the parent are safe.
-      // THREAT BOUNDARY: the sandbox stops parent DOM/origin/credential access, NOT arbitrary
-      // OUTBOUND network from doc JS (fetch/img/beacon to author-chosen hosts still work — network
-      // egress is an accepted capability for agent-authored HTML, see htmlDocBridge). referrerPolicy
-      // caps one leak channel by never sending our URL as a Referer on those requests.
+      // allow-same-origin. scripts: doc JS runs in an opaque origin, walled off from the PARENT
+      // DOM/storage/origin (issue #27). readonly-dom: no scripts, so parent DOM reads are safe.
+      // Outbound network from doc JS is NOT blocked (accepted egress); referrerPolicy caps the
+      // Referer leak channel.
       sandbox={scriptsMode ? 'allow-scripts' : 'allow-same-origin'}
       referrerPolicy="no-referrer"
       title={title}

--- a/packages/docs/src/html/HtmlPreviewFrame.tsx
+++ b/packages/docs/src/html/HtmlPreviewFrame.tsx
@@ -1,4 +1,8 @@
-// Shared sandboxed preview. Scripts stay disabled and editable controls are neutralized.
+// Shared sandboxed preview. Scripts run in an isolated (allow-scripts, NO allow-same-origin)
+// sandbox; the parent talks to the frame only through the constrained postMessage bridge
+// (htmlDocBridge). The sandbox blocks parent DOM/origin/credential access but NOT outbound network
+// from doc JS — network egress is an accepted capability for agent-authored HTML. Editable controls
+// are still neutralized in the markup; referrerPolicy="no-referrer" strips the Referer leak channel.
 
 import { useEffect, useRef, useState } from 'react'
 import {
@@ -8,6 +12,7 @@ import {
   resolveAbsoluteOctoDocBase,
   resolveOctoDocBase,
 } from './htmlDocFrameHelpers.ts'
+import { bridgeAvailable, injectBridgeScript, newBridgeToken } from './htmlDocBridge.ts'
 import { getWKApp, t } from '../octoweb/index.ts'
 
 export type PreviewLoadState =
@@ -21,8 +26,24 @@ export interface HtmlPreviewFrameProps {
   version: string
   title: string
   className?: string
-  /** Fired once the iframe document has loaded; hands back the live contentDocument (or null). */
-  onFrameLoad?: (doc: Document | null, frame: HTMLIFrameElement) => void
+  /**
+   * Isolation mode for the untrusted agent HTML. Two mutually-exclusive, both-safe modes — the
+   * dangerous allow-scripts + allow-same-origin combination is NEVER offered:
+   *   - 'scripts' (DEFAULT, issue #27): sandbox="allow-scripts", NO allow-same-origin. Doc JS runs
+   *     in an opaque origin walled off from the parent; the postMessage bridge is injected and
+   *     selection/anchor data crosses the boundary over it. contentDocument is unreadable (null).
+   *   - 'readonly-dom': sandbox="allow-same-origin", NO allow-scripts. Scripts never execute, so
+   *     the parent may safely read contentDocument directly (used by the static page-diff view,
+   *     which mirrors scroll and highlights changes across two panes). No bridge is injected.
+   */
+  isolation?: 'scripts' | 'readonly-dom'
+  /**
+   * Fired once the iframe has loaded; hands back the frame. NOTE: in the default 'scripts' mode
+   * the contentDocument is a cross-origin, opaque document the parent CANNOT read — selection/
+   * anchor data crosses the boundary over the postMessage bridge instead, and `doc` is null. In
+   * 'readonly-dom' mode `doc` is the live (script-free) contentDocument.
+   */
+  onFrameLoad?: (doc: Document | null, frame: HTMLIFrameElement, token: string | null) => void
   /** Fired on every state transition so a parent can read the raw source / react to error. */
   onStateChange?: (state: PreviewLoadState) => void
   /** Test/imperative hook: receive the iframe ref once mounted. */
@@ -41,6 +62,7 @@ export function HtmlPreviewFrame({
   version,
   title,
   className,
+  isolation = 'scripts',
   onFrameLoad,
   onStateChange,
   frameRef,
@@ -48,6 +70,10 @@ export function HtmlPreviewFrame({
   const [state, setState] = useState<PreviewLoadState>({ status: 'loading' })
   const iframeRef = useRef<HTMLIFrameElement>(null)
   const seq = useRef(0)
+  // Per-render bridge token embedded in this srcDoc build; handed to the parent on load so it can
+  // reject replies from a stale generation. Not a secret (hostile doc JS reads it), just a
+  // correlation id — accepted facts stay non-privileged.
+  const tokenRef = useRef<string | null>(null)
 
   useEffect(() => {
     const mySeq = ++seq.current
@@ -71,15 +97,21 @@ export function HtmlPreviewFrame({
         }
         const raw = await res.text()
         if (mySeq !== seq.current) return
-        const next: PreviewLoadState = raw.trim()
-          ? {
-              status: 'ready',
-              // Absolutize known asset attrs, then inject <base> as the catch-all (CSS url()/root
-              // resources) — identical to the original HtmlDocView pipeline.
-              html: injectBaseHref(absolutizeDocAssetUrls(raw, url), resolveAbsoluteOctoDocBase()),
-              raw,
-            }
-          : { status: 'empty' }
+        // Absolutize asset attrs + inject <base> (CSS url()/root resource catch-all). In 'scripts'
+        // isolation append the postMessage bridge; 'readonly-dom' runs no scripts, so it's omitted.
+        const prepared = injectBaseHref(absolutizeDocAssetUrls(raw, url), resolveAbsoluteOctoDocBase())
+        let html = prepared
+        // Only mint/store a token when the bridge can ACTUALLY be injected. injectBridgeScript fails
+        // closed (returns HTML unchanged, no bridge) when DOMParser is unavailable (SSR), so gate on
+        // bridgeAvailable() to keep tokenRef in lockstep with what's really in the srcDoc.
+        if (raw.trim() && isolation === 'scripts' && bridgeAvailable()) {
+          const token = newBridgeToken()
+          tokenRef.current = token
+          html = injectBridgeScript(prepared, token)
+        } else {
+          tokenRef.current = null
+        }
+        const next: PreviewLoadState = raw.trim() ? { status: 'ready', html, raw } : { status: 'empty' }
         setState(next)
         onStateChange?.(next)
       })
@@ -95,9 +127,10 @@ export function HtmlPreviewFrame({
         onStateChange?.(next)
       })
     return () => controller.abort()
-    // onStateChange intentionally excluded — parents pass inline callbacks; refetch keys on slug/version.
+    // onStateChange intentionally excluded — parents pass inline callbacks; refetch keys on
+    // slug/version/isolation (isolation flips bridge injection, so a change must rebuild srcDoc).
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [slug, version])
+  }, [slug, version, isolation])
 
   useEffect(() => {
     frameRef?.(iframeRef.current)
@@ -122,15 +155,34 @@ export function HtmlPreviewFrame({
   if (state.status === 'empty') {
     return <div className="octo-html-doc-state">{t('docs.state.empty')}</div>
   }
+  const scriptsMode = isolation === 'scripts'
   return (
     <iframe
       ref={iframeRef}
       className={className ?? 'octo-html-doc-frame'}
-      // allow-same-origin lets comments read selections; scripts stay disabled.
-      sandbox="allow-same-origin"
+      // Two mutually-exclusive, both-safe sandboxes. NEVER combine allow-scripts with
+      // allow-same-origin (that pairing fully defeats the sandbox). No allow-forms/allow-popups/
+      // allow-top-navigation/allow-downloads in either mode.
+      //   scripts:      doc JS runs in an opaque origin, walled off from the PARENT (issue #27).
+      //   readonly-dom: no scripts execute, so same-origin DOM reads by the parent are safe.
+      // THREAT BOUNDARY: the sandbox stops parent DOM/origin/credential access, NOT arbitrary
+      // OUTBOUND network from doc JS (fetch/img/beacon to author-chosen hosts still work — network
+      // egress is an accepted capability for agent-authored HTML, see htmlDocBridge). referrerPolicy
+      // caps one leak channel by never sending our URL as a Referer on those requests.
+      sandbox={scriptsMode ? 'allow-scripts' : 'allow-same-origin'}
+      referrerPolicy="no-referrer"
       title={title}
       srcDoc={state.html}
-      onLoad={() => onFrameLoad?.(iframeRef.current?.contentDocument ?? null, iframeRef.current as HTMLIFrameElement)}
+      // In 'scripts' mode contentDocument is cross-origin (opaque) and unreadable — hand back null
+      // and let the postMessage bridge carry selection/anchor data. In 'readonly-dom' mode the
+      // (script-free) document is safe to read, so pass it through.
+      onLoad={() =>
+        onFrameLoad?.(
+          scriptsMode ? null : iframeRef.current?.contentDocument ?? null,
+          iframeRef.current as HTMLIFrameElement,
+          scriptsMode ? tokenRef.current : null,
+        )
+      }
     />
   )
 }

--- a/packages/docs/src/html/htmlDocAnchor.test.ts
+++ b/packages/docs/src/html/htmlDocAnchor.test.ts
@@ -47,6 +47,24 @@ describe('buildAnchorFromSelection', () => {
     expect(anchor).toMatchObject({ kind: 'element', aid: 'sec1', label: 'section' })
   })
 
+  it('CSS.escapes a hostile aid so the selector cannot break out', () => {
+    // A hostile aid with a quote/bracket must produce a valid, escaped attribute selector that
+    // still matches ONLY the intended element (querySelector must not throw and must resolve it).
+    const hostile = '"] , script'
+    const el = document.createElement('p')
+    el.setAttribute('data-odoc-aid', hostile)
+    el.textContent = 'x'
+    document.body.appendChild(el)
+    const anchor = buildAnchorFromSelection(selectContents(el.firstChild as Node))
+    expect(anchor?.kind).toBe('element')
+    if (anchor?.kind === 'element') {
+      expect(anchor.aid).toBe(hostile)
+      // The escaped selector round-trips: it matches exactly the hostile element and nothing throws.
+      expect(() => document.querySelector(anchor.selector)).not.toThrow()
+      expect(document.querySelector(anchor.selector)).toBe(el)
+    }
+  })
+
   it('builds a TEXT anchor with the selected text when no aid is present', () => {
     document.body.innerHTML = '<div><p>just plain text here</p></div>'
     const p = document.querySelector('p') as HTMLElement

--- a/packages/docs/src/html/htmlDocAnchor.ts
+++ b/packages/docs/src/html/htmlDocAnchor.ts
@@ -7,6 +7,17 @@ import type { Anchor } from './htmlDocComments.ts'
 import type { OctoDocComment } from './htmlDocComments.ts'
 import { t } from '../octoweb/index.ts'
 
+/**
+ * Robust CSS escaping for a hostile aid interpolated into an attribute selector: prefer the
+ * platform CSS.escape, else escape every non-word char so quotes/brackets/backslashes cannot
+ * break out of the selector.
+ */
+function escapeAidForSelector(value: string): string {
+  const cssApi = (globalThis as { CSS?: { escape?: (s: string) => string } }).CSS
+  if (cssApi?.escape) return cssApi.escape(value)
+  return value.replace(/[^\w-]/g, (c) => `\\${c}`)
+}
+
 /** How much surrounding text to snapshot for a text anchor (drift re-location aid). */
 const CONTEXT_CHARS = 40
 
@@ -62,7 +73,7 @@ export function buildAnchorFromSelection(sel: Selection | null): Anchor | null {
     return {
       kind: 'element',
       aid,
-      selector: `[data-odoc-aid="${aid}"]`,
+      selector: `[data-odoc-aid="${escapeAidForSelector(aid)}"]`,
       label: aidEl.tagName.toLowerCase(),
     }
   }

--- a/packages/docs/src/html/htmlDocAnchor.ts
+++ b/packages/docs/src/html/htmlDocAnchor.ts
@@ -59,6 +59,12 @@ function closestAidElement(node: Node | null): Element | null {
  *   3. null — nothing meaningfully selected (collapsed / whitespace-only).
  *
  * Pure: reads the Selection/Range but mutates nothing (never makes the doc editable).
+ *
+ * NOTE (kept intentionally, not dead): production selection capture now happens INSIDE the sandboxed
+ * iframe via the bridge script's `anchorFromSelection` (buildBridgeScriptBody) — the parent can't read
+ * the cross-origin doc's Selection. This TS function is the side-effect-free REFERENCE the bridge JS
+ * mirrors 1:1 (element-aid preference, text + bounded context, collapse/whitespace → null); its unit
+ * tests pin that contract so the two implementations cannot silently drift.
  */
 export function buildAnchorFromSelection(sel: Selection | null): Anchor | null {
   if (!sel || sel.rangeCount === 0 || sel.isCollapsed) return null

--- a/packages/docs/src/html/htmlDocBridge.test.ts
+++ b/packages/docs/src/html/htmlDocBridge.test.ts
@@ -91,6 +91,14 @@ describe('isValidAid — bounded aid guard', () => {
     // selector (see buildBridgeScript / resolveHtmlDocAnchorText), which the frame does.
     expect(isValidAid('"] , script')).toBe(true)
   })
+
+  it('accepts Object.prototype key names as aids (Map own-key semantics make them safe)', () => {
+    // aids double as parent Map cache keys; a Map never walks the prototype chain, so these names
+    // are safe own keys. Rejecting them would wrongly drop legitimate ids that happen to collide.
+    for (const aid of ['__proto__', 'constructor', 'prototype', 'toString', 'valueOf', 'hasOwnProperty']) {
+      expect(isValidAid(aid)).toBe(true)
+    }
+  })
 })
 
 describe('parseBridgeAnchor', () => {
@@ -109,6 +117,16 @@ describe('parseBridgeAnchor', () => {
   it('rejects an element anchor with a control-char / oversized aid', () => {
     expect(parseBridgeAnchor({ kind: 'element', aid: 'a\u0000', selector: 's' })).toBeNull()
     expect(parseBridgeAnchor({ kind: 'element', aid: 'x'.repeat(300), selector: 's' })).toBeNull()
+  })
+
+  it('accepts an element anchor whose aid is an Object.prototype key name (Map-safe)', () => {
+    for (const aid of ['__proto__', 'constructor', 'prototype', 'toString', 'valueOf', 'hasOwnProperty']) {
+      expect(parseBridgeAnchor({ kind: 'element', aid, selector: 's' })).toEqual({
+        kind: 'element',
+        aid,
+        selector: 's',
+      })
+    }
   })
 })
 

--- a/packages/docs/src/html/htmlDocBridge.test.ts
+++ b/packages/docs/src/html/htmlDocBridge.test.ts
@@ -1,0 +1,307 @@
+import { describe, it, expect } from 'vitest'
+import {
+  BRIDGE_CHANNEL,
+  parseBridgeInbound,
+  parseBridgeAnchor,
+  injectBridgeScript,
+  bridgeAvailable,
+  buildBridgeScript,
+  buildBridgeScriptBody,
+  isValidAid,
+  newBridgeToken,
+} from './htmlDocBridge.ts'
+
+const TOK = 'tok-1'
+
+// The doc script is UNTRUSTED and can forge any message shape. parseBridgeInbound is the parent's
+// schema gate (after the event.source identity + token checks); it must accept only the bounded
+// selection/anchor-text UI facts and reject everything else.
+describe('parseBridgeInbound — untrusted message validation', () => {
+  it('accepts a well-formed element selection', () => {
+    const out = parseBridgeInbound({
+      channel: BRIDGE_CHANNEL,
+      type: 'selection',
+      token: TOK,
+      anchor: { kind: 'element', aid: 'a1', selector: '[data-odoc-aid="a1"]', label: 'p' },
+    })
+    expect(out).toMatchObject({ type: 'selection', token: TOK, anchor: { kind: 'element', aid: 'a1' } })
+  })
+
+  it('accepts a well-formed text selection and a null (clear) selection', () => {
+    expect(parseBridgeInbound({ channel: BRIDGE_CHANNEL, type: 'selection', token: TOK, anchor: { kind: 'text', text: 'hi' } }))
+      .toMatchObject({ type: 'selection', anchor: { kind: 'text', text: 'hi' } })
+    expect(parseBridgeInbound({ channel: BRIDGE_CHANNEL, type: 'selection', token: TOK, anchor: null }))
+      .toEqual({ channel: BRIDGE_CHANNEL, type: 'selection', token: TOK, anchor: null })
+  })
+
+  it('accepts a bounded anchor-text reply', () => {
+    expect(parseBridgeInbound({ channel: BRIDGE_CHANNEL, type: 'anchor-text', token: TOK, nonce: 'n1', text: 'quote' }))
+      .toEqual({ channel: BRIDGE_CHANNEL, type: 'anchor-text', token: TOK, nonce: 'n1', text: 'quote' })
+    expect(parseBridgeInbound({ channel: BRIDGE_CHANNEL, type: 'anchor-text', token: TOK, nonce: 'n1', text: null }))
+      .toEqual({ channel: BRIDGE_CHANNEL, type: 'anchor-text', token: TOK, nonce: 'n1', text: null })
+  })
+
+  it('rejects wrong/absent channel and absent/oversized token', () => {
+    expect(parseBridgeInbound({ channel: 'evil', type: 'selection', token: TOK, anchor: null })).toBeNull()
+    expect(parseBridgeInbound({ type: 'selection', token: TOK, anchor: null })).toBeNull()
+    // token is mandatory on the wire (the caller then equality-checks it against the render gen).
+    expect(parseBridgeInbound({ channel: BRIDGE_CHANNEL, type: 'selection', anchor: null })).toBeNull()
+    expect(parseBridgeInbound({ channel: BRIDGE_CHANNEL, type: 'selection', token: 'x'.repeat(5000), anchor: null })).toBeNull()
+  })
+
+  it('rejects unknown / privileged message types (no generic RPC)', () => {
+    expect(parseBridgeInbound({ channel: BRIDGE_CHANNEL, type: 'fetch', token: TOK, url: 'https://evil' })).toBeNull()
+    expect(parseBridgeInbound({ channel: BRIDGE_CHANNEL, type: 'navigate', token: TOK, to: '/' })).toBeNull()
+    expect(parseBridgeInbound({ channel: BRIDGE_CHANNEL, type: 'eval', token: TOK, code: '1' })).toBeNull()
+    expect(parseBridgeInbound({ channel: BRIDGE_CHANNEL, token: TOK })).toBeNull()
+  })
+
+  it('rejects malformed / non-object / oversized payloads', () => {
+    expect(parseBridgeInbound(null)).toBeNull()
+    expect(parseBridgeInbound('string')).toBeNull()
+    expect(parseBridgeInbound(42)).toBeNull()
+    const big = 'x'.repeat(5000)
+    expect(parseBridgeInbound({ channel: BRIDGE_CHANNEL, type: 'anchor-text', token: TOK, nonce: big, text: 'ok' })).toBeNull()
+    expect(parseBridgeInbound({ channel: BRIDGE_CHANNEL, type: 'anchor-text', token: TOK, nonce: 'n', text: big })).toBeNull()
+    expect(
+      parseBridgeInbound({ channel: BRIDGE_CHANNEL, type: 'selection', token: TOK, anchor: { kind: 'text', text: big } })
+    ).toBeNull()
+  })
+
+  it('rejects a selection whose anchor is structurally invalid', () => {
+    expect(parseBridgeInbound({ channel: BRIDGE_CHANNEL, type: 'selection', token: TOK, anchor: { kind: 'element' } })).toBeNull()
+    expect(parseBridgeInbound({ channel: BRIDGE_CHANNEL, type: 'selection', token: TOK, anchor: { kind: 'text', text: '   ' } })).toBeNull()
+    expect(parseBridgeInbound({ channel: BRIDGE_CHANNEL, type: 'selection', token: TOK, anchor: { kind: 'lost' } })).toBeNull()
+  })
+})
+
+describe('isValidAid — bounded aid guard', () => {
+  it('accepts a plausible aid and rejects empty/oversized/control-char values', () => {
+    expect(isValidAid('a1')).toBe(true)
+    expect(isValidAid('el-42_x')).toBe(true)
+    expect(isValidAid('')).toBe(false)
+    expect(isValidAid('x'.repeat(257))).toBe(false)
+    expect(isValidAid('a\u0000b')).toBe(false)
+    expect(isValidAid('a\nb')).toBe(false)
+    expect(isValidAid(123 as unknown)).toBe(false)
+  })
+
+  it('a hostile aid with selector metacharacters is still bounded (escaping happens at the selector)', () => {
+    // A short hostile value is a valid string here; it must be CSS.escape-d before use in a
+    // selector (see buildBridgeScript / resolveHtmlDocAnchorText), which the frame does.
+    expect(isValidAid('"] , script')).toBe(true)
+  })
+})
+
+describe('parseBridgeAnchor', () => {
+  it('drops unexpected fields, keeping only the bounded wire shape', () => {
+    const out = parseBridgeAnchor({
+      kind: 'element',
+      aid: 'a1',
+      selector: 's',
+      label: 'p',
+      onclick: 'alert(1)',
+      __proto__polluter: true,
+    })
+    expect(out).toEqual({ kind: 'element', aid: 'a1', selector: 's', label: 'p' })
+  })
+
+  it('rejects an element anchor with a control-char / oversized aid', () => {
+    expect(parseBridgeAnchor({ kind: 'element', aid: 'a\u0000', selector: 's' })).toBeNull()
+    expect(parseBridgeAnchor({ kind: 'element', aid: 'x'.repeat(300), selector: 's' })).toBeNull()
+  })
+})
+
+describe('newBridgeToken', () => {
+  it('produces distinct non-empty tokens', () => {
+    const a = newBridgeToken()
+    const b = newBridgeToken()
+    expect(a).toBeTruthy()
+    expect(a).not.toBe(b)
+  })
+})
+
+// Parser-aware injection (issue #27 reviewer finding). Built on DOMParser so fake <head> strings in
+// raw-text/comment/template content are never matched, malformed/fragment markup normalizes, the
+// bridge lands as the first real <head> child (before author meta CSP / author scripts), the
+// doctype and body survive, and the serialized bridge stays inert-then-executable safely.
+describe('injectBridgeScript — parser-aware CSP ordering & malformed HTML', () => {
+  it('injects the bridge as the first head content, BEFORE an author meta CSP', () => {
+    const html =
+      '<html><head><meta http-equiv="Content-Security-Policy" content="script-src \'none\'"><title>t</title></head><body><p>x</p></body></html>'
+    const out = injectBridgeScript(html, TOK)
+    const bridgeAt = out.indexOf('octodoc-bridge')
+    const cspAt = out.indexOf('Content-Security-Policy')
+    expect(bridgeAt).toBeGreaterThan(-1)
+    expect(bridgeAt).toBeLessThan(cspAt)
+    expect(out).toContain("script-src 'none'")
+    // Body content is preserved.
+    expect(out).toContain('<p>x</p>')
+  })
+
+  it('embeds the per-render token and keeps the bridge before the author CSP', () => {
+    const out = injectBridgeScript('<head><meta http-equiv="Content-Security-Policy" content="default-src \'self\'"></head><body></body>', TOK)
+    expect(out).toContain(`TOKEN = "${TOK}"`)
+    expect(out).toContain("default-src 'self'")
+    expect(out.indexOf('octodoc-bridge')).toBeLessThan(out.indexOf('Content-Security-Policy'))
+  })
+
+  it('is the FIRST head child, before an author script already in <head> (author JS still present)', () => {
+    const html = '<html><head><script>window.__author=1<\/script></head><body></body></html>'
+    const out = injectBridgeScript(html, TOK)
+    // Bridge precedes the author script.
+    expect(out.indexOf('octodoc-bridge')).toBeLessThan(out.indexOf('window.__author=1'))
+    // Author script is preserved (executes when srcDoc re-parses).
+    expect(out).toContain('window.__author=1')
+  })
+
+  it('synthesizes a <head> when the document has only a body (bridge precedes body CSP)', () => {
+    const out = injectBridgeScript('<html><body><meta http-equiv="Content-Security-Policy" content="x"><p>x</p></body></html>', TOK)
+    expect(out).toContain('<head>')
+    expect(out.indexOf('octodoc-bridge')).toBeLessThan(out.indexOf('Content-Security-Policy'))
+    expect(out).toContain('<p>x</p>')
+  })
+
+  it('normalizes a bare fragment into a document with the bridge in <head> and the fragment in <body>', () => {
+    // DOMParser puts a fragment in <body> and synthesizes <head>; the bridge lands in that head.
+    const out = injectBridgeScript('<p>bare fragment</p>', TOK)
+    expect(out).toContain('octodoc-bridge')
+    expect(out).toContain('<p>bare fragment</p>')
+    // Bridge (in head) precedes the fragment (in body).
+    expect(out.indexOf('octodoc-bridge')).toBeLessThan(out.indexOf('bare fragment'))
+  })
+
+  it('does NOT treat a fake <head> in TEXT / an HTML comment as a real tag', () => {
+    // A visible "<head>" string and a commented-out <head> must not be matched as the head anchor.
+    const html =
+      '<head><title>&lt;head&gt; shown as text</title></head><body><!-- <head>fake</head> --><p>&lt;/head&gt; text</p></body>'
+    const out = injectBridgeScript(html, TOK)
+    // Exactly one real bridge injection, before the real <title>.
+    expect(out.split('octodoc-bridge').length - 1).toBe(1)
+    expect(out.indexOf('octodoc-bridge')).toBeLessThan(out.indexOf('<title>'))
+    expect(out).toContain('shown as text')
+  })
+
+  it('does NOT treat a <head> inside a <template> as the document head', () => {
+    // <template> content is inert/parsed as a separate fragment; the real head is the anchor.
+    const html = '<head><meta charset="utf-8"></head><body><template><head>nope</head></template><p>x</p></body>'
+    const out = injectBridgeScript(html, TOK)
+    expect(out.split('octodoc-bridge').length - 1).toBe(1)
+    // Bridge precedes the real <meta charset>, i.e. it went into the document head, not the template.
+    expect(out.indexOf('octodoc-bridge')).toBeLessThan(out.indexOf('<meta charset'))
+    expect(out).toContain('<template>')
+  })
+
+  it('does NOT treat a fake </head> inside a <script>/<style> raw-text element as a tag', () => {
+    const html =
+      '<head><style>/* </head> */ .a{color:red}</style><script>var s="</head>";<\/script></head><body><p>x</p></body>'
+    const out = injectBridgeScript(html, TOK)
+    expect(out.split('octodoc-bridge').length - 1).toBe(1)
+    // The bridge is first — before the author style/script that contain the fake </head> text.
+    expect(out.indexOf('octodoc-bridge')).toBeLessThan(out.indexOf('color:red'))
+    // Author raw-text content is preserved verbatim.
+    expect(out).toContain('.a{color:red}')
+  })
+
+  it('tolerates malformed markup (unclosed tags) and still injects one bridge', () => {
+    const out = injectBridgeScript('<html><head><meta charset="utf-8"><body><p>oops no head close', TOK)
+    expect(out.split('octodoc-bridge').length - 1).toBe(1)
+    expect(out).toContain('<p>oops no head close</p>')
+    expect(out.indexOf('octodoc-bridge')).toBeLessThan(out.indexOf('<meta charset'))
+  })
+
+  it('preserves a leading doctype', () => {
+    const out = injectBridgeScript('<!doctype html><html><head><title>t</title></head><body><p>x</p></body></html>', TOK)
+    expect(out.toLowerCase().startsWith('<!doctype html>')).toBe(true)
+    expect(out.indexOf('octodoc-bridge')).toBeLessThan(out.indexOf('<title>'))
+  })
+
+  it('tolerates a <head> with attributes', () => {
+    const out = injectBridgeScript('<head data-x="1"><meta charset="utf-8"></head><body></body>', TOK)
+    expect(out.indexOf('octodoc-bridge')).toBeLessThan(out.indexOf('<meta charset'))
+    expect(out).toContain('data-x="1"')
+  })
+
+  it('serializes the bridge script inert-safe: no literal </script> in the body, present after re-parse', () => {
+    // A literal </script> in the bridge body would prematurely close it when srcDoc re-parses. The
+    // body must contain none, yet the serialized document must carry a real closing </script>.
+    expect(buildBridgeScriptBody(TOK)).not.toMatch(/<\/script/i)
+    const out = injectBridgeScript('<head></head><body><p>x</p></body>', TOK)
+    expect(out).toMatch(/<script>[\s\S]*octodoc-bridge[\s\S]*<\/script>/i)
+  })
+})
+
+describe('injectBridgeScript — fail-closed SSR fallback (no DOMParser)', () => {
+  it('returns the HTML unchanged and does NOT regex-guess a fake <head> in comment/CSP content', () => {
+    const realDOMParser = globalThis.DOMParser
+    // Simulate a non-DOM (SSR) environment.
+    ;(globalThis as { DOMParser?: unknown }).DOMParser = undefined
+    try {
+      expect(bridgeAvailable()).toBe(false)
+      // Fake <head> hidden inside a comment + a restrictive author CSP. A regex fallback could match
+      // the fake tag and land the bridge AFTER the CSP (unsafe) or double-inject; fail-closed must not.
+      const html =
+        '<!-- <head>fake</head> -->' +
+        '<head><meta http-equiv="Content-Security-Policy" content="script-src \'none\'"><title>t</title></head>' +
+        '<body><p>x</p></body>'
+      const out = injectBridgeScript(html, TOK)
+      // Unchanged: no bridge injected, so no unsafe/mis-ordered script and nothing before the CSP.
+      expect(out).toBe(html)
+      expect(out).not.toContain('octodoc-bridge')
+      expect(out).not.toContain(TOK)
+    } finally {
+      ;(globalThis as { DOMParser?: unknown }).DOMParser = realDOMParser
+    }
+    // Normal DOMParser path is restored and unchanged.
+    expect(bridgeAvailable()).toBe(true)
+    const ok = injectBridgeScript('<head><title>t</title></head><body></body>', TOK)
+    expect(ok).toContain('octodoc-bridge')
+  })
+
+  it('bridgeAvailable() reflects DOMParser presence', () => {
+    expect(bridgeAvailable()).toBe(true)
+  })
+})
+
+describe('highlight — no injected CSS, no !important, no hardcoded color (UI-SPEC)', () => {
+  it('injects no <style> and the serialized document carries no !important / arbitrary hex color', () => {
+    const out = injectBridgeScript('<head></head><body><p>x</p></body>', TOK)
+    // The temporary highlight is a Web Animations pulse, so no product stylesheet is injected.
+    expect(out).not.toContain('octodoc-anchor-hl')
+    expect(out).not.toContain('!important')
+    // No hardcoded arbitrary highlight color leaked into the doc.
+    expect(out.toLowerCase()).not.toContain('#f5a623')
+    expect(out.toLowerCase()).not.toContain('rgba(245,166,35')
+  })
+
+  it('bridge body highlights via el.animate + currentColor (no hardcoded color, no !important)', () => {
+    const body = buildBridgeScriptBody(TOK)
+    expect(body).toContain('el.animate')
+    expect(body).toContain('currentColor')
+    expect(body).not.toContain('!important')
+    // No injected highlight stylesheet / class-toggle scheme.
+    expect(body).not.toContain('octodoc-anchor-hl')
+    // No arbitrary hardcoded color literal.
+    expect(body).not.toMatch(/#[0-9a-f]{3,8}\b/i)
+  })
+})
+
+describe('buildBridgeScript — self-contained, non-privileged relay', () => {
+  it('only talks to parent, never grants a generic RPC, and CSS.escapes aids', () => {
+    const s = buildBridgeScript(TOK)
+    expect(s).toContain('parent.postMessage')
+    expect(s).not.toMatch(/\bfetch\(/)
+    expect(s).not.toMatch(/XMLHttpRequest/)
+    // Gates inbound on parent identity AND the render token.
+    expect(s).toContain('ev.source !== parent')
+    expect(s).toContain('d.token!==TOKEN')
+    // Only the two UI-fact verbs — no eval/navigation/privileged actions.
+    expect(s).toContain('resolve-anchor-text')
+    expect(s).toContain('scroll-to-anchor')
+    expect(s).not.toMatch(/\beval\(/)
+    // Hostile aids are escaped before entering any selector.
+    expect(s).toContain('CSS.escape')
+    // Every reply carries the token so a stale generation is discarded by the parent.
+    expect(s).toContain('msg.token = TOKEN')
+  })
+})

--- a/packages/docs/src/html/htmlDocBridge.ts
+++ b/packages/docs/src/html/htmlDocBridge.ts
@@ -4,9 +4,10 @@
 //   Agent-authored HTML is NOT sanitized end-to-end, so it may run arbitrary <script>. The frame
 //   uses sandbox="allow-scripts" WITHOUT allow-same-origin (the two together defeat the sandbox and
 //   must NEVER be combined). With allow-scripts alone the doc runs in an opaque origin: it cannot
-//   touch the parent DOM/credentials/origin, submit forms, open popups, download, or navigate the
-//   top frame, and the parent cannot read the cross-origin contentDocument — selection/anchor data
-//   crosses this narrow postMessage bridge instead.
+//   read the parent DOM/storage/origin, submit forms, open popups, download, or navigate the top
+//   frame, and the parent cannot read the cross-origin contentDocument — selection/anchor data
+//   crosses this narrow postMessage bridge instead. Outbound requests/subresources still work;
+//   cookie attachment on them depends on request + cookie policy (not blocked by the opaque origin).
 //
 //   THREAT BOUNDARY: the sandbox does NOT stop OUTBOUND network from doc JS (fetch/XHR/img/beacon
 //   to author-chosen hosts). Network egress is an ACCEPTED capability for agent-authored HTML — do
@@ -83,11 +84,8 @@ function isBoundedString(v: unknown): v is string {
   return typeof v === 'string' && v.length <= MAX_STR
 }
 
-/**
- * Bound + validate an aid before it is interpolated into any selector. Hostile aids can contain
- * quotes/brackets/backslashes; we cap length and reject control chars so a malformed value can
- * never smuggle selector syntax past CSS.escape on either side of the bridge.
- */
+// Bound + validate an aid before it enters a selector or the parent's Map cache. Map own-key
+// semantics make `__proto__`/`constructor`/`prototype` safe keys, so they are allowed through.
 export function isValidAid(v: unknown): v is string {
   return typeof v === 'string' && v.length > 0 && v.length <= 256 && !/[\u0000-\u001f]/.test(v)
 }

--- a/packages/docs/src/html/htmlDocBridge.ts
+++ b/packages/docs/src/html/htmlDocBridge.ts
@@ -1,0 +1,277 @@
+// postMessage bridge between the sandboxed HTML-doc iframe and the parent viewer (issue #27).
+//
+// SECURITY MODEL (critical — read before editing):
+//   Agent-authored HTML is NOT sanitized end-to-end, so it may run arbitrary <script>. The frame
+//   uses sandbox="allow-scripts" WITHOUT allow-same-origin (the two together defeat the sandbox and
+//   must NEVER be combined). With allow-scripts alone the doc runs in an opaque origin: it cannot
+//   touch the parent DOM/credentials/origin, submit forms, open popups, download, or navigate the
+//   top frame, and the parent cannot read the cross-origin contentDocument — selection/anchor data
+//   crosses this narrow postMessage bridge instead.
+//
+//   THREAT BOUNDARY: the sandbox does NOT stop OUTBOUND network from doc JS (fetch/XHR/img/beacon
+//   to author-chosen hosts). Network egress is an ACCEPTED capability for agent-authored HTML — do
+//   NOT claim "no exfiltration." The iframe sets referrerPolicy="no-referrer" so our page URL never
+//   leaks as a Referer, but content the doc already holds can still be sent out.
+//
+//   The doc script is UNTRUSTED and can forge any same-document message. The parent accepts ONLY
+//   non-privileged UI FACTS (a selection-anchor descriptor, an anchor's display text) whose
+//   worst-case forgery is a bogus comment target the human still reviews and submits. There is NO
+//   privileged RPC. Every inbound message is gated by event.source === the iframe's contentWindow
+//   AND a bounded schema check.
+//
+//   A per-render TOKEN is embedded in each srcDoc build and echoed on frame→parent replies. It is
+//   NOT a secret (hostile doc JS can read it) and grants NO authority; it only isolates stale /
+//   cross-generation traffic. Facts stay non-privileged — the token is a correlation id, not auth.
+
+export const BRIDGE_CHANNEL = 'octodoc-bridge'
+
+/** Frame→parent: selection changed. anchor=null clears a prior report. */
+export interface BridgeSelectionMessage {
+  channel: typeof BRIDGE_CHANNEL
+  type: 'selection'
+  token: string
+  anchor: BridgeAnchor | null
+}
+
+/** Parent→frame: resolve an element anchor's display text. nonce correlates the reply. */
+export interface BridgeResolveRequest {
+  channel: typeof BRIDGE_CHANNEL
+  type: 'resolve-anchor-text'
+  token: string
+  nonce: string
+  aid: string
+}
+
+/** Frame→parent: resolved element text for a prior request. */
+export interface BridgeResolveResponse {
+  channel: typeof BRIDGE_CHANNEL
+  type: 'anchor-text'
+  token: string
+  nonce: string
+  text: string | null
+}
+
+/** Parent→frame: scroll an anchored element into view and briefly highlight it. */
+export interface BridgeScrollRequest {
+  channel: typeof BRIDGE_CHANNEL
+  type: 'scroll-to-anchor'
+  token: string
+  aid: string
+}
+
+export type BridgeInbound = BridgeSelectionMessage | BridgeResolveResponse
+
+// WIRE contract the parent validates. Structurally the text/element halves of the htmlDocComments
+// Anchor union, redeclared here so the parent never trusts the frame to send a full Anchor.
+export interface BridgeTextAnchor {
+  kind: 'text'
+  text: string
+  context_before?: string
+  context_after?: string
+}
+export interface BridgeElementAnchor {
+  kind: 'element'
+  aid: string
+  selector: string
+  label?: string
+}
+export type BridgeAnchor = BridgeTextAnchor | BridgeElementAnchor
+
+const MAX_STR = 4096
+
+function isBoundedString(v: unknown): v is string {
+  return typeof v === 'string' && v.length <= MAX_STR
+}
+
+/**
+ * Bound + validate an aid before it is interpolated into any selector. Hostile aids can contain
+ * quotes/brackets/backslashes; we cap length and reject control chars so a malformed value can
+ * never smuggle selector syntax past CSS.escape on either side of the bridge.
+ */
+export function isValidAid(v: unknown): v is string {
+  return typeof v === 'string' && v.length > 0 && v.length <= 256 && !/[\u0000-\u001f]/.test(v)
+}
+
+/**
+ * Parent's schema gate (run AFTER event.source === iframe.contentWindow). Enforces bounded
+ * types so a forged frame payload can't smuggle an unexpected field or oversized string into
+ * comment/selection state. Callers must additionally check `token` against the current render.
+ */
+export function parseBridgeInbound(data: unknown): BridgeInbound | null {
+  if (!data || typeof data !== 'object') return null
+  const m = data as Record<string, unknown>
+  if (m.channel !== BRIDGE_CHANNEL) return null
+  if (!isBoundedString(m.token)) return null
+
+  if (m.type === 'selection') {
+    if (m.anchor === null) return { channel: BRIDGE_CHANNEL, type: 'selection', token: m.token, anchor: null }
+    const anchor = parseBridgeAnchor(m.anchor)
+    return anchor ? { channel: BRIDGE_CHANNEL, type: 'selection', token: m.token, anchor } : null
+  }
+  if (m.type === 'anchor-text') {
+    if (!isBoundedString(m.nonce)) return null
+    if (!(m.text === null || isBoundedString(m.text))) return null
+    return { channel: BRIDGE_CHANNEL, type: 'anchor-text', token: m.token, nonce: m.nonce, text: m.text as string | null }
+  }
+  return null
+}
+
+/** Validate an untrusted anchor descriptor into the bounded text/element wire shape. */
+export function parseBridgeAnchor(value: unknown): BridgeAnchor | null {
+  if (!value || typeof value !== 'object') return null
+  const a = value as Record<string, unknown>
+  if (a.kind === 'text') {
+    if (!isBoundedString(a.text) || !a.text.trim()) return null
+    const out: BridgeTextAnchor = { kind: 'text', text: a.text }
+    if (isBoundedString(a.context_before)) out.context_before = a.context_before
+    if (isBoundedString(a.context_after)) out.context_after = a.context_after
+    return out
+  }
+  if (a.kind === 'element') {
+    if (!isValidAid(a.aid)) return null
+    if (!isBoundedString(a.selector)) return null
+    const out: BridgeElementAnchor = { kind: 'element', aid: a.aid, selector: a.selector }
+    if (isBoundedString(a.label)) out.label = a.label
+    return out
+  }
+  return null
+}
+
+/** Fresh per-render correlation token. Not a secret; isolates stale/cross-generation replies. */
+export function newBridgeToken(): string {
+  const rnd = typeof crypto !== 'undefined' && crypto.getRandomValues
+    ? crypto.getRandomValues(new Uint32Array(2)).join('-')
+    : Math.random().toString(36).slice(2)
+  return `${Date.now().toString(36)}-${rnd}`
+}
+
+/**
+ * Body of the bridge script (no wrapping <script> tags). Relays UI facts to the parent only:
+ * selections, element-text lookups, scroll+highlight. No network/parent access (opaque origin);
+ * targetOrigin '*' (only non-secret facts posted). The embedded token is echoed/required so stale
+ * generations drop; CSS.escape guards the bounded aid. Free of a literal `</script>` so it stays
+ * inert-then-executable when DOMParser serializes it into srcDoc.
+ */
+export function buildBridgeScriptBody(token: string): string {
+  const tokenLiteral = JSON.stringify(token)
+  return `(function(){
+  var CH = ${JSON.stringify(BRIDGE_CHANNEL)}, TOKEN = ${tokenLiteral};
+  var CONTEXT = 40, LIMIT = 120, hlAnim = null;
+  function esc(s){ try{ return CSS.escape(s); }catch(e){ return String(s).replace(/[^a-zA-Z0-9_-]/g, '\\\\$&'); } }
+  function trunc(s){ var a=Array.from(s); return a.length<=LIMIT ? s : a.slice(0,LIMIT).join('')+'\\u2026'; }
+  function post(msg){ msg.channel = CH; msg.token = TOKEN; try{ parent.postMessage(msg, '*'); }catch(e){} }
+  function findByAid(aid){
+    if(typeof aid!=='string' || !aid || aid.length>256) return null;
+    try{ return document.querySelector('[data-odoc-aid="'+esc(aid)+'"]'); }catch(e){ return null; }
+  }
+  function closestAid(node){
+    var el = node && node.nodeType===1 ? node : (node && node.parentElement);
+    while(el){ if(el.hasAttribute && el.hasAttribute('data-odoc-aid')) return el; el=el.parentElement; }
+    return null;
+  }
+  function around(range, side){
+    var c = side==='before' ? range.startContainer : range.endContainer;
+    var full = c.textContent || '';
+    if(side==='before'){ var e=range.startOffset; return full.slice(Math.max(0,e-CONTEXT), e).trim(); }
+    var st=range.endOffset; return full.slice(st, st+CONTEXT).trim();
+  }
+  function anchorFromSelection(sel){
+    if(!sel || sel.rangeCount===0 || sel.isCollapsed) return null;
+    var text = sel.toString(); if(!text.trim()) return null;
+    var range = sel.getRangeAt(0);
+    var aidEl = closestAid(range.commonAncestorContainer);
+    if(aidEl){ var aid=aidEl.getAttribute('data-odoc-aid'); return {kind:'element', aid:aid, selector:'[data-odoc-aid="'+esc(aid)+'"]', label:aidEl.tagName.toLowerCase()}; }
+    var a={kind:'text', text:text}; var b=around(range,'before'), af=around(range,'after');
+    if(b) a.context_before=b; if(af) a.context_after=af; return a;
+  }
+  // Non-destructive highlight: a Web Animations pulse that auto-restores. No injected CSS, no
+  // forced-priority declarations, no hardcoded color — outline uses the doc's own currentColor.
+  // Falls back to a scroll-only pulse when el.animate is unavailable, so styles are never mutated.
+  function highlight(el){
+    try{
+      if(!el || typeof el.animate!=='function') return;
+      if(hlAnim){ try{ hlAnim.cancel(); }catch(e){} }
+      hlAnim = el.animate(
+        [ {outline:'2px solid currentColor', outlineOffset:'2px'},
+          {outline:'2px solid currentColor', outlineOffset:'2px', offset:0.85},
+          {outline:'2px solid transparent', outlineOffset:'2px'} ],
+        {duration:1600, easing:'ease-out'}
+      );
+    }catch(e){}
+  }
+  document.addEventListener('selectionchange', function(){
+    var sel = document.getSelection ? document.getSelection() : null;
+    var body = document.body;
+    if(!sel || sel.rangeCount===0 || sel.isCollapsed || !body || !body.contains(sel.getRangeAt(0).commonAncestorContainer)){
+      post({type:'selection', anchor:null}); return;
+    }
+    post({type:'selection', anchor: anchorFromSelection(sel)});
+  });
+  window.addEventListener('message', function(ev){
+    if(ev.source !== parent) return;
+    var d = ev.data; if(!d || d.channel!==CH || d.token!==TOKEN) return;
+    if(d.type==='resolve-anchor-text' && typeof d.nonce==='string'){
+      var el=findByAid(d.aid);
+      var txt = el && el.textContent ? el.textContent.trim() : '';
+      post({type:'anchor-text', nonce:d.nonce, text: txt ? trunc(txt) : null});
+    } else if(d.type==='scroll-to-anchor'){
+      var t=findByAid(d.aid);
+      if(t){ if(t.scrollIntoView) t.scrollIntoView({block:'center'}); highlight(t); }
+    }
+  });
+})();`
+}
+
+/** Bridge as a full <script> string (raw-HTML fallback path). buildBridgeScriptBody has no
+ *  literal `</script>`, so wrapping is safe. */
+export function buildBridgeScript(token: string): string {
+  return `<script>${buildBridgeScriptBody(token)}<\/script>`
+}
+
+// Serialize a parsed document back to a string, preserving the doctype when present (mirrors
+// absolutizeDocAssetUrls so the two DOMParser passes round-trip identically).
+function serializeDoc(doc: Document): string {
+  const doctype = doc.doctype ? `<!doctype ${doc.doctype.name}>` : ''
+  return `${doctype}${doc.documentElement.outerHTML}`
+}
+
+// Fail-closed fallback for environments without DOMParser (SSR). We do NOT regex-guess where the
+// <head> is: a raw-string match can be fooled by a fake <head> inside a comment/script/style/
+// template, mis-placing (or double-injecting) the bridge and, worse, landing it AFTER an author
+// <meta CSP>. Rather than risk unsafe/mis-ordered injection we disable the bridge and return the
+// HTML unchanged. Browsers (the production + test render path) always have DOMParser, so this only
+// affects non-DOM SSR, where the interactive bridge is not used anyway.
+export function injectBridgeRaw(html: string, _token: string): string {
+  return html
+}
+
+/**
+ * Insert the product bridge (<script> only — the highlight is a Web Animations pulse, no injected
+ * CSS) as the FIRST real <head> child, BEFORE any author <meta CSP> and author scripts (a CSP
+ * governs only resources declared after it, so a first-child inline script survives an author
+ * `script-src 'none'`). Parser-aware by construction: DOMParser never treats a fake `<head>` inside
+ * raw-text/comment/template content as a tag, and normalizes malformed/fragment markup. The bridge
+ * script's body carries no literal `</script>`, so it stays intact (and becomes executable in
+ * srcDoc — intended) after serialize.
+ * SSR (no DOMParser) fails closed: injectBridgeRaw returns the HTML unchanged (bridge disabled).
+ * Use bridgeAvailable() to check whether injection is active in the current environment.
+ */
+export function bridgeAvailable(): boolean {
+  return typeof DOMParser !== 'undefined'
+}
+
+export function injectBridgeScript(html: string, token: string): string {
+  if (typeof DOMParser === 'undefined') return injectBridgeRaw(html, token)
+  const doc = new DOMParser().parseFromString(html, 'text/html')
+  const head = doc.head
+  if (!head) return injectBridgeRaw(html, token)
+
+  const script = doc.createElement('script')
+  // textContent (not innerHTML) so the JS is not HTML-parsed; serialization emits real tags. The
+  // body has no literal `</script>`, so no premature close on re-parse in srcDoc.
+  script.textContent = buildBridgeScriptBody(token)
+
+  // Prepend so the bridge precedes author <meta CSP> / author scripts already in <head>.
+  head.insertBefore(script, head.firstChild)
+  return serializeDoc(doc)
+}

--- a/packages/docs/src/html/htmlDocFrameHelpers.ts
+++ b/packages/docs/src/html/htmlDocFrameHelpers.ts
@@ -51,6 +51,8 @@ function absolutizeAssetAttr(el: Element, attr: 'src' | 'href', docUrl: string, 
   if (resolved) el.setAttribute(attr, resolved)
 }
 
+// Cosmetic-only in 'scripts' isolation (doc JS can re-enable these post-load); the real read-only
+// guarantee is the sandbox's opaque origin, not this.
 function neutralizeEditableControls(doc: Document) {
   doc.querySelectorAll('[contenteditable]').forEach((el) => el.setAttribute('contenteditable', 'false'))
   doc.querySelectorAll('input, textarea, select, button').forEach((el) => el.setAttribute('disabled', ''))
@@ -69,12 +71,20 @@ export function absolutizeDocAssetUrls(html: string, docUrl = resolveAbsoluteOct
   return `${doctype}${doc.documentElement.outerHTML}`
 }
 
+// Prepend `<base href>` as the real <head>'s first child so relative/root-relative doc URLs resolve
+// against octo-doc. Parser-aware (DOMParser) so a fake <head> in text/comment/raw-text/template is
+// never matched; SSR (no DOMParser) fails closed and returns the HTML unchanged. Mirrors
+// injectBridgeScript.
 export function injectBaseHref(html: string, baseUrl: string): string {
   if (!baseUrl) return html
+  if (typeof DOMParser === 'undefined') return html
   const href = baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`
-  const baseTag = `<base href="${href.replace(/"/g, '&quot;')}">`
-  const headOpen = /<head[^>]*>/i.exec(html)
-  if (!headOpen) return `${baseTag}${html}`
-  const at = headOpen.index + headOpen[0].length
-  return `${html.slice(0, at)}${baseTag}${html.slice(at)}`
+  const doc = new DOMParser().parseFromString(html, 'text/html')
+  const head = doc.head
+  if (!head) return html
+  const base = doc.createElement('base')
+  base.setAttribute('href', href)
+  head.insertBefore(base, head.firstChild)
+  const doctype = doc.doctype ? `<!doctype ${doc.doctype.name}>` : ''
+  return `${doctype}${doc.documentElement.outerHTML}`
 }

--- a/packages/docs/src/i18n/en-US.json
+++ b/packages/docs/src/i18n/en-US.json
@@ -541,6 +541,7 @@
     "targetDoc": "Document-level comment",
     "targetAnchor": "Comment will be anchored to",
     "clearAnchor": "Clear target",
+    "scrollToAnchor": "Jump to anchor",
     "placeholder": "Write a comment…",
     "send": "Send",
     "readOnlyHint": "You have read-only access — commenting is disabled.",

--- a/packages/docs/src/i18n/zh-CN.json
+++ b/packages/docs/src/i18n/zh-CN.json
@@ -541,6 +541,7 @@
     "targetDoc": "文档级评论",
     "targetAnchor": "将评论定位到",
     "clearAnchor": "取消定位",
+    "scrollToAnchor": "跳转到锚点位置",
     "placeholder": "写下评论…",
     "send": "发送",
     "readOnlyHint": "你只有只读权限，无法评论。",


### PR DESCRIPTION
## Summary

- run HTML document JavaScript inside an opaque-origin `sandbox="allow-scripts"` iframe without `allow-same-origin`
- preserve comments, selections, anchor quote resolution, scrolling, and highlighting through a constrained postMessage bridge
- keep page-diff previews script-free with a separate `readonly-dom` isolation mode
- preserve inline/external CSS and document assets; use `referrerPolicy="no-referrer"`

## Security model

- never combines `allow-scripts` with `allow-same-origin`
- grants no forms, popups, downloads, or top-level navigation
- validates frame identity, message schema/size, document-generation token, and request nonce
- bridge exposes only non-privileged selection/anchor UI facts; it has no generic host RPC
- author HTML may still use outbound network resources by design; it cannot access host DOM, origin, cookies, or storage

## Validation

- `cd packages/docs && npx vitest run src/html` — 273 passed
- `node scripts/i18n-scan.mjs check` — passed
- `git diff --check` — passed
- code-loops final reviewer — APPROVE

## Deployment prerequisites / required environment variables

None. This change adds no environment variables, feature flags, backend migrations, or server deployment requirements.

## Notes

- No `octo-docs-html` server change is required: the Web client fetches published HTML as text and renders it through `srcDoc`, so server response CSP does not govern the iframe document.
- Full standalone docs build remains blocked by pre-existing `@octo/base` development-stub missing exports, unrelated to this diff.

Closes Mininglamp-OSS/octo-docs-html#27
