### PR TITLE
style(drive): align Drive visuals with Docs

### DIFF
--- a/packages/dmworkdrive/src/__visual__/DriveChrome.stories.tsx
+++ b/packages/dmworkdrive/src/__visual__/DriveChrome.stories.tsx
@@ -1,0 +1,162 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { Button } from '@douyinfe/semi-ui';
+import { FolderPlus, FilePlus2, UserPlus, Users } from 'lucide-react';
+import Breadcrumb from '../ui/Breadcrumb';
+import SpaceSidebar from '../ui/SpaceSidebar';
+import FileList from '../ui/FileList';
+import UploadButton from '../ui/UploadButton';
+import type { DriveEntry, Space } from '../bridge/types';
+import '../pages/DrivePage.css';
+
+/**
+ * Whole-page Drive chrome — space rail, breadcrumb, toolbar and file list in one
+ * frame.
+ *
+ * The per-component stories cover each part in isolation, but two of the visual
+ * states this module owns only exist across parts: the brand keyboard focus ring
+ * (rows, rail items, breadcrumb links and the header actions all share one
+ * treatment) and the dark-mode CTA. The toolbar in particular has no story of its
+ * own, because in the app it lives inside DriveContent behind a VM and live API
+ * hooks.
+ *
+ * The header below therefore mirrors `DriveContent`'s action row rather than
+ * rendering DriveContent itself: same wrapper classes, same real `UploadButton`,
+ * same `drive-btn` Semi buttons. Keep it in sync if that markup changes.
+ *
+ * Focus states need real keyboard input — `:focus-visible` keys off the browser's
+ * keyboard modality, which synthetic events don't set — so press Tab to walk the
+ * ring rather than expecting a play function to stage it.
+ */
+
+function space(id: string, name: string, type: Space['type']): Space {
+  return {
+    id,
+    type,
+    name,
+    super_admin_uid: 'u1',
+    created_at: '2026-07-01T00:00:00.000Z',
+    updated_at: '2026-07-01T00:00:00.000Z',
+  };
+}
+
+function entry(over: Partial<DriveEntry> & Pick<DriveEntry, 'id' | 'name' | 'type'>): DriveEntry {
+  return {
+    space_id: 's1',
+    parent_id: 0,
+    is_folder: over.type === 'folder',
+    size: 0,
+    source: 'user-upload',
+    owner_uid: 'u1',
+    created_at: '2026-07-20T09:00:00.000Z',
+    updated_at: '2026-07-22T14:30:00.000Z',
+    ...over,
+  };
+}
+
+const personalSpace = space('p1', '个人空间', 'personal');
+const sharedSpaces = [space('s1', '产品设计', 'shared'), space('s2', '市场活动', 'shared')];
+
+const entries: DriveEntry[] = [
+  entry({ id: 1, name: 'Design assets', type: 'folder' }),
+  entry({ id: 2, name: 'Product spec', type: 'doc', source: 'user-mount', ref_id: 'doc-abc' }),
+  entry({ id: 3, name: 'quarterly-report.pdf', type: 'blob', size: 2_483_910, content_type: 'application/pdf' }),
+  entry({ id: 4, name: 'logo.png', type: 'blob', size: 91_233, content_type: 'image/png' }),
+];
+
+const path = [
+  { id: 0, name: '我的空间' },
+  { id: 10, name: 'Design assets' },
+];
+
+const noop = () => {};
+
+function DriveChrome() {
+  return (
+    <div className="drive-page">
+      <div className="drive-sidebar-pane" style={{ width: 240, flex: '0 0 240px' }}>
+        <SpaceSidebar
+          personalSpace={personalSpace}
+          sharedSpaces={sharedSpaces}
+          activeSpaceId="s1"
+          loading={false}
+          onSelect={noop}
+          onCreateShared={noop}
+        />
+      </div>
+
+      <main className="drive-main">
+        <div className="drive-main__header">
+          <Breadcrumb path={path} onNavigate={noop} />
+          <div className="drive-main__actions">
+            <UploadButton onFiles={noop} />
+            <Button className="drive-btn" icon={<FolderPlus size={16} />} onClick={noop}>
+              新建文件夹
+            </Button>
+            <Button className="drive-btn" icon={<FilePlus2 size={16} />} onClick={noop}>
+              挂载文档
+            </Button>
+            <Button className="drive-btn" icon={<UserPlus size={16} />} onClick={noop}>
+              邀请
+            </Button>
+            <Button className="drive-btn" icon={<Users size={16} />} onClick={noop}>
+              成员
+            </Button>
+          </div>
+        </div>
+
+        <div className="drive-main__body">
+          <FileList
+            entries={entries}
+            loading={false}
+            onOpenFolder={noop}
+            onOpenDoc={noop}
+            onRename={noop}
+            onMove={noop}
+            onCopy={noop}
+            onDelete={noop}
+            onShare={noop}
+            onDownload={noop}
+            canDownload
+            canEdit
+            canShare
+          />
+        </div>
+      </main>
+    </div>
+  );
+}
+
+const meta: Meta<typeof DriveChrome> = {
+  title: 'Drive/Chrome',
+  component: DriveChrome,
+  parameters: { layout: 'fullscreen' },
+  decorators: [
+    (Story) => (
+      <div style={{ height: 520, display: 'flex' }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof DriveChrome>;
+
+/**
+ * Keyboard focus fixture. Tab from the top: rail items, then the breadcrumb
+ * ancestor link, then the five header actions, then each file row's name and its
+ * action buttons. Every stop should draw the same 2px `--wk-text-accent` ring;
+ * file rows additionally take docs' selected tint and a 600 title. Clicking with
+ * the mouse must leave no ring behind.
+ */
+export const Focused: Story = {};
+
+/**
+ * Dark mode. Checks the documented CTA deviation (the upload pill switches to
+ * the inverse pairing so it stays visible against `--wk-bg-base`) and that the
+ * focus ring stays legible on the dark page.
+ */
+export const Dark: Story = {
+  globals: { theme: 'dark' },
+};

--- a/packages/dmworkdrive/src/pages/DriveContent.tsx
+++ b/packages/dmworkdrive/src/pages/DriveContent.tsx
@@ -152,6 +152,7 @@ export default function DriveContent({ vm }: { vm: DriveVM }) {
           )}
           {canEdit && (
             <Button
+              className="drive-btn"
               icon={<FolderPlus size={16} />}
               disabled={!hasSpace}
               onClick={() => setFolderModalOpen(true)}
@@ -163,6 +164,7 @@ export default function DriveContent({ vm }: { vm: DriveVM }) {
               unmount/remove is editor+ and lives in the file row menu. */}
           {canUpload && (
             <Button
+              className="drive-btn"
               icon={<FilePlus2 size={16} />}
               disabled={!hasSpace}
               onClick={() => setMountModalOpen(true)}
@@ -172,6 +174,7 @@ export default function DriveContent({ vm }: { vm: DriveVM }) {
           )}
           {canManage && (
             <Button
+              className="drive-btn"
               icon={<UserPlus size={16} />}
               onClick={() => setInviteModalOpen(true)}
             >
@@ -180,6 +183,7 @@ export default function DriveContent({ vm }: { vm: DriveVM }) {
           )}
           {canManage && (
             <Button
+              className="drive-btn"
               icon={<Users size={16} />}
               onClick={() => setMemberModalOpen(true)}
             >

--- a/packages/dmworkdrive/src/pages/DrivePage.css
+++ b/packages/dmworkdrive/src/pages/DrivePage.css
@@ -107,6 +107,23 @@
   cursor: default;
 }
 
+/* Dark-mode CTA contrast — a deliberate, documented deviation from docs.
+   `--wk-brand-primary` is not redefined for dark, so it stays #1c1c23 while
+   `--wk-bg-base` becomes `--wk-neutral-850` (also #1c1c23): docs' brand pill and
+   ours both dissolve into the page. Dark therefore uses the inverse pairing
+   (light surface + inverse text), which is the only existing token combination
+   that keeps both the button and its label readable. Light mode is untouched and
+   stays value-identical to docs. */
+body[theme-mode='dark'] .drive-main__actions .drive-btn--primary.semi-button {
+  background: var(--wk-text-primary, #e4e6ed);
+  color: var(--wk-text-inverse, #111318);
+}
+
+body[theme-mode='dark'] .drive-main__actions .drive-btn--primary.semi-button:not(:disabled):hover {
+  background: var(--wk-color-white, #fff);
+  color: var(--wk-text-inverse, #111318);
+}
+
 .drive-main__body {
   flex: 1;
   min-height: 0;

--- a/packages/dmworkdrive/src/pages/DrivePage.css
+++ b/packages/dmworkdrive/src/pages/DrivePage.css
@@ -61,10 +61,13 @@
 /* Toolbar buttons: docs' pill primary / outlined secondary specs mapped onto the
    Semi buttons Drive already renders, so behaviour (disabled, focus ring, icon
    slot) is untouched and only the skin changes. Secondary mirrors docs'
-   `filter-btn`; primary mirrors docs' `list-new` pill. */
+   `filter-btn`; primary mirrors docs' `list-new` pill.
+   Both specs share docs' 32px control height: docs never puts its content-height
+   `filter-btn` next to its 32px pill, but Drive does, so the height has to be
+   stated here rather than left to each button's content. */
 .drive-main__actions .drive-btn.semi-button {
   height: auto;
-  min-height: 0;
+  min-height: 32px;
   padding: 5px 10px;
   border: 1px solid var(--wk-border-default, rgba(0, 0, 0, 0.08));
   border-radius: var(--wk-r-sm, 6px);
@@ -105,6 +108,18 @@
 .drive-main__actions .drive-btn.semi-button:disabled {
   opacity: 0.6;
   cursor: default;
+}
+
+/* Keyboard focus for the header actions, same brand ring the rows, rail and
+   breadcrumb use. `@octo/base` deliberately kills Semi's own ring app-wide
+   (`WKBase/index.css`: `.semi-button.semi-button-primary:focus-visible` et al →
+   `outline: none`, specificity 0,3,0), so without this rule these buttons — the
+   upload CTA included — have no focus indicator at all. Three classes plus the
+   pseudo-class puts us at 0,4,0, which outranks that global rule regardless of
+   stylesheet order. `--wk-text-accent` is theme-aware, so dark follows. */
+.drive-main__actions .drive-btn.semi-button:focus-visible {
+  outline: 2px solid var(--wk-text-accent, #7f3bf5);
+  outline-offset: 1px;
 }
 
 /* Dark-mode CTA contrast — a deliberate, documented deviation from docs.

--- a/packages/dmworkdrive/src/pages/DrivePage.css
+++ b/packages/dmworkdrive/src/pages/DrivePage.css
@@ -1,15 +1,25 @@
+/* Drive chrome, visually aligned with octo-doc.
+   Drive keeps its own information architecture (space rail, breadcrumb, folder
+   hierarchy); only the visual layer follows docs. Colours come from the SAME
+   host `--wk-*` semantic tokens docs resolves to (docs aliases them as
+   `--octo-*` on `.octo-theme`), so both modules track light/dark together.
+   Hex fallbacks equal the light-mode token values so a Storybook harness
+   without the theme entry still renders. */
+
 .drive-page {
   display: flex;
   height: 100%;
   width: 100%;
-  background: var(--semi-color-bg-0, #fff);
-  color: var(--semi-color-text-0, #1d2129);
+  background: var(--wk-bg-base, #f5f6f7);
+  color: var(--wk-text-primary, #1f2329);
+  font-family: var(--wk-font-sans);
 }
 
 /* Left pane wrapper (WKLayout.contentLeft): fills the host's fixed-width rail. */
 .drive-sidebar-pane {
   height: 100%;
   width: 100%;
+  font-family: var(--wk-font-sans);
 }
 
 .drive-main {
@@ -19,28 +29,88 @@
   min-width: 0;
   display: flex;
   flex-direction: column;
-  background: var(--semi-color-bg-0, #fff);
-  color: var(--semi-color-text-0, #1d2129);
+  box-sizing: border-box;
+  /* Docs' resident list pads its whole container by 12px and lets rows carry
+     their own inset; mirror that instead of the old per-region 20px gutters. */
+  padding: 12px;
+  background: var(--wk-bg-base, #f5f6f7);
+  color: var(--wk-text-primary, #1f2329);
+  font-family: var(--wk-font-sans);
 }
 
+/* Mirrors docs' list header: hairline rule under the title row, 8px breathing
+   space before the list body. Wraps because Drive can show up to five actions. */
 .drive-main__header {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 12px;
-  padding: 16px 20px;
-  border-bottom: 1px solid var(--semi-color-border, #e5e6eb);
+  flex-wrap: wrap;
+  padding: 4px 4px 12px;
+  border-bottom: 1px solid var(--wk-border-subtle, rgba(0, 0, 0, 0.05));
+  margin-bottom: 8px;
 }
 
 .drive-main__actions {
-  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  flex: 0 0 auto;
+}
+
+/* Toolbar buttons: docs' pill primary / outlined secondary specs mapped onto the
+   Semi buttons Drive already renders, so behaviour (disabled, focus ring, icon
+   slot) is untouched and only the skin changes. Secondary mirrors docs'
+   `filter-btn`; primary mirrors docs' `list-new` pill. */
+.drive-main__actions .drive-btn.semi-button {
+  height: auto;
+  min-height: 0;
+  padding: 5px 10px;
+  border: 1px solid var(--wk-border-default, rgba(0, 0, 0, 0.08));
+  border-radius: var(--wk-r-sm, 6px);
+  background: var(--wk-bg-surface, #fff);
+  color: var(--wk-text-primary, #1f2329);
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 1.3;
+}
+
+.drive-main__actions .drive-btn.semi-button .semi-button-content {
+  font-size: 13px;
+  line-height: 1.3;
+}
+
+.drive-main__actions .drive-btn.semi-button:not(:disabled):hover {
+  background: var(--wk-bg-hover, #dfe0e2);
+  border-color: var(--wk-border-strong, rgba(0, 0, 0, 0.14));
+  color: var(--wk-text-primary, #1f2329);
+}
+
+.drive-main__actions .drive-btn--primary.semi-button {
+  min-height: 32px;
+  padding: 4px 14px;
+  border-color: transparent;
+  border-radius: var(--wk-r-full, 9999px);
+  background: var(--wk-brand-primary, #1c1c23);
+  color: var(--wk-text-inverse, #fff);
+  box-shadow: var(--wk-shadow-sm, 0 1px 2px rgba(0, 0, 0, 0.06));
+}
+
+.drive-main__actions .drive-btn--primary.semi-button:not(:disabled):hover {
+  border-color: transparent;
+  background: var(--wk-brand-primary-hover, #2a2a33);
+  color: var(--wk-text-inverse, #fff);
+}
+
+.drive-main__actions .drive-btn.semi-button:disabled {
+  opacity: 0.6;
+  cursor: default;
 }
 
 .drive-main__body {
   flex: 1;
   min-height: 0;
   overflow-y: auto;
-  padding: 8px 20px 20px;
 }
 
 .drive-main__center {
@@ -50,9 +120,12 @@
   min-height: 240px;
 }
 
+/* Same treatment as docs' infinite-scroll footer line. */
 .drive-main__truncated {
-  margin: 8px 16px 0;
+  margin: 0;
+  padding: 12px 10px;
   font-size: 12px;
-  color: var(--semi-color-text-2);
+  line-height: 1.3;
+  color: var(--wk-text-tertiary, #6b7075);
   text-align: center;
 }

--- a/packages/dmworkdrive/src/ui/Breadcrumb/index.css
+++ b/packages/dmworkdrive/src/ui/Breadcrumb/index.css
@@ -1,42 +1,51 @@
+/* Folder trail in the header slot. The current folder reads as the page title
+   (docs' list-title scale); ancestors sit one step down in size and tone. */
+
 .drive-breadcrumb {
   display: flex;
   align-items: center;
   flex-wrap: wrap;
   gap: 2px;
-  font-size: 14px;
+  min-width: 0;
   min-height: 28px;
+  font-family: var(--wk-font-sans);
 }
 
 .drive-breadcrumb__sep {
-  color: var(--semi-color-text-2, #c9cdd4);
   flex-shrink: 0;
+  color: var(--wk-text-tertiary, #6b7075);
 }
 
 .drive-breadcrumb__link {
-  border: none;
-  background: transparent;
-  padding: 2px 6px;
-  border-radius: 4px;
-  color: var(--semi-color-text-1, #4e5969);
-  font-size: 14px;
-  cursor: pointer;
   max-width: 200px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  border: none;
+  background: transparent;
+  padding: 2px 6px;
+  border-radius: var(--wk-r-xs, 4px);
+  color: var(--wk-text-secondary, #555b61);
+  font-family: inherit;
+  font-size: 14px;
+  line-height: 1.3;
+  cursor: pointer;
+  transition: background 0.12s ease, color 0.12s ease;
 }
 
 .drive-breadcrumb__link:hover {
-  background: var(--semi-color-fill-0, #f2f3f5);
-  color: var(--wk-brand-primary, #7c5cfc);
+  background: var(--wk-bg-hover, #dfe0e2);
+  color: var(--wk-text-primary, #1f2329);
 }
 
 .drive-breadcrumb__current {
-  padding: 2px 6px;
-  color: var(--semi-color-text-0, #1d2129);
-  font-weight: 500;
   max-width: 240px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  padding: 2px 6px;
+  color: var(--wk-text-primary, #1f2329);
+  font-size: 15px;
+  font-weight: 600;
+  line-height: 1.3;
 }

--- a/packages/dmworkdrive/src/ui/Breadcrumb/index.css
+++ b/packages/dmworkdrive/src/ui/Breadcrumb/index.css
@@ -38,6 +38,11 @@
   color: var(--wk-text-primary, #1f2329);
 }
 
+.drive-breadcrumb__link:focus-visible {
+  outline: 2px solid var(--wk-text-accent, #7f3bf5);
+  outline-offset: 1px;
+}
+
 .drive-breadcrumb__current {
   max-width: 240px;
   overflow: hidden;

--- a/packages/dmworkdrive/src/ui/FileList/FileList.stories.tsx
+++ b/packages/dmworkdrive/src/ui/FileList/FileList.stories.tsx
@@ -23,6 +23,11 @@ const meta: Meta<typeof FileList> = {
     onDelete: () => {},
     onShare: () => {},
     onDownload: () => {},
+    // Full-capability role. Without these the ops column renders nothing, so the
+    // hover reveal and the focus ring on the row actions are unreachable.
+    canDownload: true,
+    canEdit: true,
+    canShare: true,
   },
 };
 

--- a/packages/dmworkdrive/src/ui/FileList/index.css
+++ b/packages/dmworkdrive/src/ui/FileList/index.css
@@ -130,22 +130,28 @@
 }
 
 /* Hidden until the row is hovered or holds focus (docs' row-menu behaviour),
-   and kept visible while its dropdown is open. */
+   and kept visible while its dropdown is open. Every reveal selector repeats
+   `:not(--head)` so it outranks the hide rule above on specificity rather than
+   on source order — and so the `aria-expanded` case, which would otherwise sit
+   a step below it, actually wins while a menu is open. */
 .drive-file-row:not(.drive-file-row--head) .drive-file__ops .semi-button {
   opacity: 0;
   color: var(--wk-text-tertiary, #6b7075);
   transition: opacity 0.12s ease, background 0.12s ease;
 }
 
-.drive-file-row:hover .drive-file__ops .semi-button,
-.drive-file-row:focus-within .drive-file__ops .semi-button,
-.drive-file__ops .semi-button[aria-expanded='true'] {
+.drive-file-row:not(.drive-file-row--head):hover .drive-file__ops .semi-button,
+.drive-file-row:not(.drive-file-row--head):focus-within .drive-file__ops .semi-button,
+.drive-file-row:not(.drive-file-row--head) .drive-file__ops .semi-button[aria-expanded='true'] {
   opacity: 1;
 }
 
 /* A blob row has no focusable name, so its action buttons are the focused
-   component; give them the same brand ring on their own boundary. */
-.drive-file__ops .semi-button:focus-visible {
+   component; give them the same brand ring on their own boundary. Scoped
+   through `.drive-file-row` to clear both Semi's own `:focus-visible` outline
+   and `@octo/base`'s app-wide `outline: none` (both 0,3,0) on specificity
+   instead of stylesheet order. */
+.drive-file-row .drive-file__ops .semi-button:focus-visible {
   outline: 2px solid var(--wk-text-accent, #7f3bf5);
   outline-offset: 1px;
 }

--- a/packages/dmworkdrive/src/ui/FileList/index.css
+++ b/packages/dmworkdrive/src/ui/FileList/index.css
@@ -41,13 +41,28 @@
 }
 
 /* Drive rows are navigational rather than selectable, so the active treatment
-   binds to keyboard focus — same tokens docs uses for its selected row. */
-.drive-file-row:not(.drive-file-row--head):focus-within {
+   binds to KEYBOARD focus: docs' selected tint plus a brand focus ring drawn
+   around the whole row, which is the interactive bound the row represents.
+   `:has(…:focus-visible)` is what keeps a mouse click from leaving a ring
+   behind, and the ring uses `--wk-text-accent` because docs'
+   `--wk-brand-primary-ring` is not redefined for dark (it stays #1c1c23 on a
+   #1c1c23 page). `outline-offset: -2px` draws inside the row so the scroll
+   container cannot clip it. */
+.drive-file-row:not(.drive-file-row--head):has(.drive-file__name-link:focus-visible) {
   background: var(--wk-bg-selected, rgba(127, 59, 245, 0.06));
+  outline: 2px solid var(--wk-text-accent, #7f3bf5);
+  outline-offset: -2px;
 }
 
-.drive-file-row:not(.drive-file-row--head):focus-within .drive-file__name-link {
+.drive-file-row:not(.drive-file-row--head):has(.drive-file__name-link:focus-visible)
+  .drive-file__name-link {
   font-weight: 600;
+}
+
+/* The row owns the focus treatment, so the name button drops the UA ring. */
+.drive-file__name-link:focus,
+.drive-file__name-link:focus-visible {
+  outline: none;
 }
 
 /* Column labels: docs has no table head, so this stays a quiet caption row —
@@ -126,4 +141,11 @@
 .drive-file-row:focus-within .drive-file__ops .semi-button,
 .drive-file__ops .semi-button[aria-expanded='true'] {
   opacity: 1;
+}
+
+/* A blob row has no focusable name, so its action buttons are the focused
+   component; give them the same brand ring on their own boundary. */
+.drive-file__ops .semi-button:focus-visible {
+  outline: 2px solid var(--wk-text-accent, #7f3bf5);
+  outline-offset: 1px;
 }

--- a/packages/dmworkdrive/src/ui/FileList/index.css
+++ b/packages/dmworkdrive/src/ui/FileList/index.css
@@ -1,3 +1,8 @@
+/* File rows follow docs' row-list language: borderless rounded rows with a
+   hover tint instead of a ruled table, a 14px title over 12px muted meta, and
+   row actions that only appear on hover. Drive keeps its own columns (size /
+   updated time) and its folder/doc/blob glyphs. */
+
 .drive-file-list {
   display: flex;
   flex-direction: column;
@@ -11,82 +16,114 @@
 }
 
 .drive-file-list__empty {
-  color: var(--semi-color-text-2, #86909c);
+  padding: 32px 12px;
+  text-align: center;
   font-size: 14px;
+  line-height: 1.3;
+  color: var(--wk-text-secondary, #555b61);
 }
 
 .drive-file-row {
   display: grid;
   grid-template-columns: 1fr 120px 180px 48px;
   align-items: center;
-  gap: 12px;
-  padding: 10px 12px;
-  border-bottom: 1px solid var(--semi-color-border, #f2f3f5);
+  gap: 10px;
+  padding: 8px 10px;
+  border-radius: var(--wk-r-sm, 6px);
   font-size: 14px;
+  line-height: 1.3;
+  color: var(--wk-text-primary, #1f2329);
+  transition: background 0.12s ease;
 }
 
 .drive-file-row:not(.drive-file-row--head):hover {
-  background: var(--semi-color-fill-0, #f7f8fa);
+  background: var(--wk-bg-hover, #dfe0e2);
 }
 
-.drive-file-row--head {
-  font-size: 12px;
+/* Drive rows are navigational rather than selectable, so the active treatment
+   binds to keyboard focus — same tokens docs uses for its selected row. */
+.drive-file-row:not(.drive-file-row--head):focus-within {
+  background: var(--wk-bg-selected, rgba(127, 59, 245, 0.06));
+}
+
+.drive-file-row:not(.drive-file-row--head):focus-within .drive-file__name-link {
   font-weight: 600;
-  color: var(--semi-color-text-2, #86909c);
-  text-transform: uppercase;
-  letter-spacing: 0.02em;
+}
+
+/* Column labels: docs has no table head, so this stays a quiet caption row —
+   the one hairline in the list, matching the rule under docs' list header. */
+.drive-file-row--head {
+  padding: 4px 10px;
+  margin-bottom: 4px;
+  border-bottom: 1px solid var(--wk-border-subtle, rgba(0, 0, 0, 0.05));
+  border-radius: 0;
+  font-size: 12px;
+  font-weight: 400;
+  color: var(--wk-text-tertiary, #6b7075);
 }
 
 .drive-file__name {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 10px;
   min-width: 0;
 }
 
+/* One muted tone for every kind, as in docs; the glyph carries the type. */
 .drive-file__icon {
-  flex-shrink: 0;
-}
-
-.drive-file__icon--folder {
-  color: var(--wk-brand-primary, #7c5cfc);
-}
-
-.drive-file__icon--doc {
-  color: #2f7de1;
-}
-
-.drive-file__icon--blob {
-  color: #86909c;
+  flex: 0 0 auto;
+  color: var(--wk-text-tertiary, #6b7075);
 }
 
 .drive-file__name-link,
 .drive-file__name-text {
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  font-size: 14px;
+  line-height: 1.3;
+  color: var(--wk-text-primary, #1f2329);
 }
 
+/* No underline or colour shift on hover: the row tint is the affordance, which
+   is how a docs row reads. */
 .drive-file__name-link {
   border: none;
   background: transparent;
   padding: 0;
-  color: var(--semi-color-text-0, #1d2129);
-  font-size: 14px;
+  text-align: left;
+  font-family: inherit;
   cursor: pointer;
-}
-
-.drive-file__name-link:hover {
-  color: var(--wk-brand-primary, #7c5cfc);
-  text-decoration: underline;
 }
 
 .drive-file__size,
 .drive-file__time {
-  color: var(--semi-color-text-1, #4e5969);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 12px;
+  line-height: 1.3;
+  color: var(--wk-text-tertiary, #6b7075);
 }
 
 .drive-file__ops {
   display: flex;
+  align-items: center;
   justify-content: flex-end;
+  gap: 2px;
+}
+
+/* Hidden until the row is hovered or holds focus (docs' row-menu behaviour),
+   and kept visible while its dropdown is open. */
+.drive-file-row:not(.drive-file-row--head) .drive-file__ops .semi-button {
+  opacity: 0;
+  color: var(--wk-text-tertiary, #6b7075);
+  transition: opacity 0.12s ease, background 0.12s ease;
+}
+
+.drive-file-row:hover .drive-file__ops .semi-button,
+.drive-file-row:focus-within .drive-file__ops .semi-button,
+.drive-file__ops .semi-button[aria-expanded='true'] {
+  opacity: 1;
 }

--- a/packages/dmworkdrive/src/ui/FileList/index.tsx
+++ b/packages/dmworkdrive/src/ui/FileList/index.tsx
@@ -28,10 +28,11 @@ export interface FileListProps {
   canShare: boolean;
 }
 
+/** Per-kind glyph at docs' 16px row-icon size; colour is uniform (see index.css). */
 function EntryIcon({ entry }: { entry: DriveEntry }) {
-  if (entry.type === 'folder') return <Folder size={18} className="drive-file__icon drive-file__icon--folder" />;
-  if (entry.type === 'doc') return <FileText size={18} className="drive-file__icon drive-file__icon--doc" />;
-  return <File size={18} className="drive-file__icon drive-file__icon--blob" />;
+  if (entry.type === 'folder') return <Folder size={16} className="drive-file__icon" />;
+  if (entry.type === 'doc') return <FileText size={16} className="drive-file__icon" />;
+  return <File size={16} className="drive-file__icon" />;
 }
 
 /** Mixed listing of folders, Type-1 docs and Type-2 blobs for one folder. */
@@ -61,7 +62,7 @@ export default function FileList({
   }
 
   if (entries.length === 0) {
-    return <div className="drive-file-list__center drive-file-list__empty">{t('drive.file.empty')}</div>;
+    return <div className="drive-file-list__empty">{t('drive.file.empty')}</div>;
   }
 
   return (

--- a/packages/dmworkdrive/src/ui/SpaceSidebar/index.css
+++ b/packages/dmworkdrive/src/ui/SpaceSidebar/index.css
@@ -1,12 +1,18 @@
+/* Space rail, aligned with docs' row list: same row geometry, muted section
+   caption, and the shared selected-row treatment (no module-local accent).
+   Background is left to the host rail so the pane keeps the app's chrome. */
+
 .drive-sidebar {
   width: 100%;
   height: 100%;
   flex-shrink: 0;
   display: flex;
   flex-direction: column;
-  gap: 20px;
-  padding: 16px 12px;
+  gap: 16px;
+  padding: 12px;
+  box-sizing: border-box;
   overflow-y: auto;
+  font-family: var(--wk-font-sans);
 }
 
 .drive-sidebar__group {
@@ -19,54 +25,63 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 0 8px 4px;
+  padding: 0 10px 4px;
   font-size: 12px;
-  font-weight: 600;
-  color: var(--semi-color-text-2, #86909c);
-  text-transform: uppercase;
-  letter-spacing: 0.02em;
+  line-height: 1.3;
+  font-weight: 500;
+  color: var(--wk-text-tertiary, #6b7075);
 }
 
 .drive-space-item {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 10px;
   width: 100%;
   padding: 8px 10px;
   border: none;
-  border-radius: 6px;
+  border-radius: var(--wk-r-sm, 6px);
   background: transparent;
-  color: var(--semi-color-text-0, #1d2129);
+  color: var(--wk-text-primary, #1f2329);
+  font-family: inherit;
   font-size: 14px;
+  line-height: 1.3;
   cursor: pointer;
   text-align: left;
+  transition: background 0.12s ease;
 }
 
 .drive-space-item:hover {
-  background: var(--semi-color-fill-0, #f2f3f5);
+  background: var(--wk-bg-hover, #dfe0e2);
 }
 
 .drive-space-item--active {
-  background: var(--semi-color-primary-light-default, #eae7ff);
-  color: var(--wk-brand-primary, #7c5cfc);
-  font-weight: 500;
+  background: var(--wk-bg-selected, rgba(127, 59, 245, 0.06));
+  color: var(--wk-text-primary, #1f2329);
+  font-weight: 600;
 }
 
 .drive-space-item__icon {
   display: inline-flex;
-  flex-shrink: 0;
+  flex: 0 0 auto;
+  color: var(--wk-text-tertiary, #6b7075);
+}
+
+.drive-space-item--active .drive-space-item__icon {
+  color: var(--wk-text-primary, #1f2329);
 }
 
 .drive-space-item__name {
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
 .drive-sidebar__empty {
-  padding: 4px 10px;
+  padding: 8px 10px;
   font-size: 12px;
-  color: var(--semi-color-text-2, #86909c);
+  line-height: 1.3;
+  color: var(--wk-text-tertiary, #6b7075);
 }
 
 .drive-sidebar__loading {

--- a/packages/dmworkdrive/src/ui/SpaceSidebar/index.css
+++ b/packages/dmworkdrive/src/ui/SpaceSidebar/index.css
@@ -54,6 +54,13 @@
   background: var(--wk-bg-hover, #dfe0e2);
 }
 
+/* Same brand focus ring as the file rows; drawn inside the row so the scrolling
+   rail cannot clip it. Keyboard-only, so a click leaves no ring behind. */
+.drive-space-item:focus-visible {
+  outline: 2px solid var(--wk-text-accent, #7f3bf5);
+  outline-offset: -2px;
+}
+
 .drive-space-item--active {
   background: var(--wk-bg-selected, rgba(127, 59, 245, 0.06));
   color: var(--wk-text-primary, #1f2329);

--- a/packages/dmworkdrive/src/ui/SpaceSidebar/index.css
+++ b/packages/dmworkdrive/src/ui/SpaceSidebar/index.css
@@ -32,6 +32,14 @@
   color: var(--wk-text-tertiary, #6b7075);
 }
 
+/* The create-shared "+" is the one Semi button in this rail, so it needs the same
+   brand ring the space rows get — `@octo/base` drops Semi's own ring app-wide.
+   Scoped through `.drive-sidebar` to win on specificity, not on load order. */
+.drive-sidebar .drive-sidebar__label .semi-button:focus-visible {
+  outline: 2px solid var(--wk-text-accent, #7f3bf5);
+  outline-offset: 1px;
+}
+
 .drive-space-item {
   display: flex;
   align-items: center;

--- a/packages/dmworkdrive/src/ui/UploadButton/index.tsx
+++ b/packages/dmworkdrive/src/ui/UploadButton/index.tsx
@@ -23,6 +23,7 @@ export default function UploadButton({ disabled, onFiles }: UploadButtonProps) {
   return (
     <>
       <Button
+        className="drive-btn drive-btn--primary"
         icon={<Upload size={16} />}
         disabled={disabled}
         onClick={() => inputRef.current?.click()}

--- a/packages/dmworkdrive/src/ui/UploadProgress/index.css
+++ b/packages/dmworkdrive/src/ui/UploadProgress/index.css
@@ -1,10 +1,11 @@
+/* Upload panel sits between the header and the list. Rows in this module render
+   directly on the page surface (as docs' list rows do), so the panel itself adds
+   no chrome — each item card carries the surface. */
 .drive-upload-panel {
   display: flex;
   flex-direction: column;
   gap: 6px;
-  padding: 8px 12px;
-  border-bottom: 1px solid var(--semi-color-border, #e5e6eb);
-  background: var(--semi-color-fill-0, #f7f8fa);
+  margin-bottom: 8px;
 }
 
 .drive-upload-item {
@@ -12,9 +13,9 @@
   flex-direction: column;
   gap: 4px;
   padding: 6px 8px;
-  border-radius: 6px;
-  background: var(--semi-color-bg-0, #fff);
-  border: 1px solid var(--semi-color-border, #e5e6eb);
+  border-radius: var(--wk-r-sm, 6px);
+  background: var(--wk-bg-surface, #fff);
+  border: 1px solid var(--wk-border-default, rgba(0, 0, 0, 0.08));
 }
 
 .drive-upload-item__main {
@@ -31,7 +32,8 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   font-size: 13px;
-  color: var(--semi-color-text-0, #1c1f23);
+  line-height: 1.3;
+  color: var(--wk-text-primary, #1f2329);
 }
 
 .drive-upload-item__meta {
@@ -40,23 +42,24 @@
   gap: 4px;
   flex-shrink: 0;
   font-size: 12px;
-  color: var(--semi-color-text-2, #86909c);
+  line-height: 1.3;
+  color: var(--wk-text-tertiary, #6b7075);
 }
 
 .drive-upload-item__size {
-  color: var(--semi-color-text-2, #86909c);
+  color: var(--wk-text-tertiary, #6b7075);
 }
 
 .drive-upload-item__ok {
-  color: var(--semi-color-success, #00b42a);
+  color: var(--wk-color-success, #41cd59);
 }
 
 .drive-upload-item__err {
-  color: var(--semi-color-danger, #f53f3f);
+  color: var(--wk-color-error, #f54a45);
 }
 
 .drive-upload-item[data-status='error'] .drive-upload-item__meta {
-  color: var(--semi-color-danger, #f53f3f);
+  color: var(--wk-color-error, #f54a45);
 }
 
 .drive-upload-item__ops {


### PR DESCRIPTION
## Summary

- align the Drive page chrome, space rail, breadcrumb, file rows, empty state, and upload progress styling with the Docs visual language while preserving Drive's existing information architecture
- use shared theme-aware design tokens for light styling and future dark-theme support, including accessible keyboard focus indicators and consistent toolbar sizing
- add Storybook fixtures for Drive chrome and file-list action states

## Test plan

- `pnpm --filter @octo/drive test` (229 tests)
