### PR TITLE
fix(base): 修复 token 过期后登录页反复跳转/401 刷屏的死循环

### DIFF
--- a/apps/web/src/features/documentTitle/octoDocumentTitle.ts
+++ b/apps/web/src/features/documentTitle/octoDocumentTitle.ts
@@ -153,6 +153,9 @@ export function createOctoDocumentTitleController(): DocumentTitleController {
     subscribeAuthChanges,
     subscribeLocaleChanges: (listener) => i18n.subscribe(() => listener()),
     restoreUnreadState: async () => {
+      // 未登录（含 token 过期已被清）时不要发 conversation/sync —— 否则必然 401，
+      // 徒增无效请求并可能叠加到登出跳转的噪音里。登录态由 title 渲染的 getIsLoggedIn 兜底。
+      if (!WKApp.loginInfo.isLogined()) return;
       const pathname = window.location.pathname;
       const menuId = resolveTitleMenuId(pathname, WKApp.currentMenuId);
       // ChatPage owns the normal conversation hydration. Other full-page modules

--- a/packages/dmworkbase/src/App.tsx
+++ b/packages/dmworkbase/src/App.tsx
@@ -847,6 +847,11 @@ export default class WKApp extends ProviderListener {
   deviceModel: string = ""; // 设备型号
   private remoteConfigForegroundRefreshStarted: boolean = false;
   private lastRemoteConfigForegroundRefreshAt: number = 0;
+  // 幂等登出闸门：token 过期后往往有多个并发请求同时 401，各自触发一次
+  // logoutCallback → logout()。若不加护栏，window.location.replace("/login")
+  // 会被连发多次，且导航是异步的、飞行中的请求继续 reject 继续 logout，
+  // 造成"登录页反复跳转 / 控制台疯狂刷 401"的死循环。首次进入即置位，后续重入直接返回。
+  private _loggingOut: boolean = false;
 
   set notificationIsClose(v: boolean) {
     this._notificationIsClose = v;
@@ -1080,6 +1085,10 @@ export default class WKApp extends ProviderListener {
 
   // 登出
   logout() {
+    // 幂等守卫：并发 401 会重复调用本方法，只允许第一次真正执行清理与跳转，
+    // 后续重入直接返回，避免 window.location.replace 被连发导致的反复跳转/刷屏。
+    if (this._loggingOut) return;
+    this._loggingOut = true;
     this.clearLocalLoginState();
     window.location.replace("/login");
   }


### PR DESCRIPTION
## Background

After the token expires, the page keeps redirecting to `/login` and floods the console with 401s, never settling on the login page. The logs show `POST /api/v1/conversation/sync 401` + `同步最近会话失败` (failed to sync recent conversations) + `已转到 .../login` (navigated to .../login) repeating at high frequency.

## Root cause

When the `APIClient` response interceptor detects an auth-expired 401, it calls `logoutCallback` → `WKApp.logout()` → `window.location.replace("/login")`.

On token expiry, several startup requests (conversation/sync, etc.) fire almost simultaneously and each independently 401s, so `logout()` is invoked N times. Because:

1. `logout()` has no idempotency guard, so it runs repeatedly;
2. `window.location.replace` is asynchronous — the current JS keeps running before navigation completes, and in-flight requests continue to reject and re-trigger logout.

As a result `location.replace("/login")` is fired multiple times, producing the "repeated redirect + console flooding" loop.

## Changes

- `WKApp.logout()`: add an idempotent gate `_loggingOut` so only the first call actually clears state and redirects; concurrent re-entries return early.
- `octoDocumentTitle.restoreUnreadState`: skip `conversation/sync` when not logged in (including when the expired token has already been cleared), avoiding the pointless startup 401 at the source.

## Verification

- `DocumentTitleController.test.ts` — 8/8 pass
- `App.startMain.test.ts` — 3/3 pass
- Focused change, +12 lines only; introduces no new type errors (the full `tsc` errors are pre-existing missing declarations for react/storybook/semi and are unrelated to this change).
