### PR TITLE
feat(messages): add copy button for markdown code blocks (EVE-3, #864)

### DIFF
--- a/packages/dmworkbase/src/Messages/Text/MarkdownContent.tsx
+++ b/packages/dmworkbase/src/Messages/Text/MarkdownContent.tsx
@@ -6,7 +6,7 @@ import remarkMath from "remark-math";
 import rehypeHighlight from "rehype-highlight";
 import rehypeKatex from "rehype-katex";
 import rehypeSanitize, { defaultSchema } from "rehype-sanitize";
-import { Toast } from "@douyinfe/semi-ui";
+import Toast from "@douyinfe/semi-ui/lib/es/toast";
 import { Copy } from "lucide-react";
 import Lightbox from "yet-another-react-lightbox";
 import Download from "yet-another-react-lightbox/plugins/download";
@@ -321,7 +321,8 @@ function reactNodeText(children: React.ReactNode): string {
 const MarkdownCodeBlock: React.FC<{
   children: React.ReactNode;
   preProps: any;
-}> = ({ children, preProps }) => {
+  isStreaming?: boolean;
+}> = ({ children, preProps, isStreaming = false }) => {
   const [copying, setCopying] = useState(false);
 
   const handleCopy = async (event: React.MouseEvent<HTMLButtonElement>) => {
@@ -331,7 +332,9 @@ const MarkdownCodeBlock: React.FC<{
 
     setCopying(true);
     try {
-      const ok = await copyToClipboard(reactNodeText(children));
+      const ok = await copyToClipboard(
+        reactNodeText(children).replace(/\n$/, "")
+      );
       if (ok) {
         Toast.success(t("base.message.markdown.copyCodeSuccess"));
       } else {
@@ -348,16 +351,18 @@ const MarkdownCodeBlock: React.FC<{
 
   return (
     <div className="wk-markdown-pre-wrapper">
-      <button
-        type="button"
-        className="wk-markdown-code-copy"
-        aria-label={copyLabel}
-        title={copyLabel}
-        disabled={copying}
-        onClick={handleCopy}
-      >
-        <Copy size={14} strokeWidth={2} aria-hidden="true" />
-      </button>
+      {!isStreaming && (
+        <button
+          type="button"
+          className="wk-markdown-code-copy"
+          aria-label={copyLabel}
+          title={copyLabel}
+          disabled={copying}
+          onClick={handleCopy}
+        >
+          <Copy size={14} strokeWidth={2} aria-hidden="true" />
+        </button>
+      )}
       <pre {...preProps}>{children}</pre>
     </div>
   );
@@ -392,6 +397,15 @@ const baseComponents: any = {
     <MarkdownCodeBlock preProps={props}>{children}</MarkdownCodeBlock>
   ),
   img: ({ src, alt }: any) => <MarkdownImage src={src} alt={alt} />,
+};
+
+const streamingBaseComponents: any = {
+  ...baseComponents,
+  pre: ({ children, ...props }: any) => (
+    <MarkdownCodeBlock preProps={props} isStreaming>
+      {children}
+    </MarkdownCodeBlock>
+  ),
 };
 
 /**
@@ -623,7 +637,10 @@ const MarkdownContent: React.FC<MarkdownContentProps> = ({
     stableMentions.current.length > 0 || stableEmojis.current.length > 0;
 
   const components = useMemo(() => {
-    if (!hasTokens) return baseComponents;
+    const activeBaseComponents = isStreaming
+      ? streamingBaseComponents
+      : baseComponents;
+    if (!hasTokens) return activeBaseComponents;
     const process = (children: React.ReactNode) =>
       processTextChildren(
         children,
@@ -637,7 +654,7 @@ const MarkdownContent: React.FC<MarkdownContentProps> = ({
       ({ node, children, ordered, checked, index, siblingCount, ...props }: any) =>
         React.createElement(Tag, props, process(children));
     return {
-      ...baseComponents,
+      ...activeBaseComponents,
       p: wrap("p"),
       td: wrap("td"),
       th: wrap("th"),
@@ -655,6 +672,7 @@ const MarkdownContent: React.FC<MarkdownContentProps> = ({
     stableEmojis.current,
     stableOnMentionClick,
     isSend,
+    isStreaming,
   ]);
 
   // 根据是否启用数学公式 / markdown 选择插件

--- a/packages/dmworkbase/src/Messages/Text/MarkdownContent.tsx
+++ b/packages/dmworkbase/src/Messages/Text/MarkdownContent.tsx
@@ -6,6 +6,8 @@ import remarkMath from "remark-math";
 import rehypeHighlight from "rehype-highlight";
 import rehypeKatex from "rehype-katex";
 import rehypeSanitize, { defaultSchema } from "rehype-sanitize";
+import { Toast } from "@douyinfe/semi-ui";
+import { Copy } from "lucide-react";
 import Lightbox from "yet-another-react-lightbox";
 import Download from "yet-another-react-lightbox/plugins/download";
 import "yet-another-react-lightbox/styles.css";
@@ -16,6 +18,7 @@ import WKApp from "../../App";
 import { isSafeUrl } from "../../Utils/security";
 import { linkifySafeUrls } from "../../Utils/linkify";
 import { downloadFile } from "../../Utils/download";
+import { copyToClipboard } from "../../Utils/clipboard";
 import { t } from "../../i18n";
 import { getMentionRenderState } from "./mentionRenderState";
 import {
@@ -303,6 +306,63 @@ function segmentText(
   return segments;
 }
 
+function reactNodeText(children: React.ReactNode): string {
+  if (children == null || typeof children === "boolean") return "";
+  if (typeof children === "string" || typeof children === "number") {
+    return String(children);
+  }
+  if (Array.isArray(children)) return children.map(reactNodeText).join("");
+  if (React.isValidElement(children)) {
+    return reactNodeText((children.props as any)?.children);
+  }
+  return "";
+}
+
+const MarkdownCodeBlock: React.FC<{
+  children: React.ReactNode;
+  preProps: any;
+}> = ({ children, preProps }) => {
+  const [copying, setCopying] = useState(false);
+
+  const handleCopy = async (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+    if (copying) return;
+
+    setCopying(true);
+    try {
+      const ok = await copyToClipboard(reactNodeText(children));
+      if (ok) {
+        Toast.success(t("base.message.markdown.copyCodeSuccess"));
+      } else {
+        Toast.warning(t("base.module.contextMenus.copyFailed"));
+      }
+    } catch {
+      Toast.warning(t("base.module.contextMenus.copyFailed"));
+    } finally {
+      setCopying(false);
+    }
+  };
+
+  const copyLabel = t("base.message.markdown.copyCode");
+
+  return (
+    <div className="wk-markdown-pre-wrapper">
+      <button
+        type="button"
+        className="wk-markdown-code-copy"
+        aria-label={copyLabel}
+        title={copyLabel}
+        disabled={copying}
+        onClick={handleCopy}
+      >
+        <Copy size={14} strokeWidth={2} aria-hidden="true" />
+      </button>
+      <pre {...preProps}>{children}</pre>
+    </div>
+  );
+};
+
 const baseComponents: any = {
   a: ({ href, children, ...props }: any) => {
     // AC-13b (feature #511): middle-ellipsize the DISPLAY text only when it is itself a long bare
@@ -329,9 +389,7 @@ const baseComponents: any = {
   },
   p: ({ node: _node, children, ...props }: any) => renderParagraph(children, props),
   pre: ({ children, ...props }: any) => (
-    <div className="wk-markdown-pre-wrapper">
-      <pre {...props}>{children}</pre>
-    </div>
+    <MarkdownCodeBlock preProps={props}>{children}</MarkdownCodeBlock>
   ),
   img: ({ src, alt }: any) => <MarkdownImage src={src} alt={alt} />,
 };

--- a/packages/dmworkbase/src/Messages/Text/__tests__/MarkdownContentCodeCopy.test.tsx
+++ b/packages/dmworkbase/src/Messages/Text/__tests__/MarkdownContentCodeCopy.test.tsx
@@ -28,8 +28,8 @@ vi.mock("../../../Utils/clipboard", () => ({
   copyToClipboard: copyToClipboardMock,
 }));
 
-vi.mock("@douyinfe/semi-ui", () => ({
-  Toast: {
+vi.mock("@douyinfe/semi-ui/lib/es/toast", () => ({
+  default: {
     success: toastSuccessMock,
     warning: toastWarningMock,
   },
@@ -40,6 +40,7 @@ vi.mock("lucide-react", () => ({
 }));
 
 import MarkdownContent from "../MarkdownContent";
+import type { ComponentProps } from "react";
 
 let container: HTMLDivElement | null = null;
 
@@ -54,11 +55,17 @@ afterEach(() => {
   toastWarningMock.mockReset();
 });
 
-function renderContent(content: string) {
+function renderContent(
+  content: string,
+  props: Partial<ComponentProps<typeof MarkdownContent>> = {}
+) {
   container = document.createElement("div");
   document.body.appendChild(container);
   act(() => {
-    ReactDOM.render(<MarkdownContent content={content} />, container);
+    ReactDOM.render(
+      <MarkdownContent content={content} {...props} />,
+      container
+    );
   });
   return container;
 }
@@ -70,7 +77,7 @@ async function clickCopy(button: Element) {
 }
 
 describe("MarkdownContent — code block copy", () => {
-  it("renders a copy button for a fenced code block and preserves whitespace", async () => {
+  it("renders a copy button for a fenced code block and preserves source whitespace", async () => {
     copyToClipboardMock.mockResolvedValue(true);
     const root = renderContent(
       "```ts\nconst value = 1;\n  console.log(value);\n```"
@@ -84,7 +91,7 @@ describe("MarkdownContent — code block copy", () => {
     await clickCopy(button!);
 
     expect(copyToClipboardMock).toHaveBeenCalledWith(
-      "const value = 1;\n  console.log(value);\n"
+      "const value = 1;\n  console.log(value);"
     );
     expect(toastSuccessMock).toHaveBeenCalledWith(
       "base.message.markdown.copyCodeSuccess"
@@ -103,12 +110,35 @@ describe("MarkdownContent — code block copy", () => {
     await clickCopy(buttons[0]);
 
     expect(copyToClipboardMock).toHaveBeenCalledTimes(1);
-    expect(copyToClipboardMock).toHaveBeenCalledWith("first();\n");
+    expect(copyToClipboardMock).toHaveBeenCalledWith("first();");
+  });
+
+  it("keeps intentional blank lines but trims ReactMarkdown's synthetic trailing newline", async () => {
+    copyToClipboardMock.mockResolvedValue(true);
+    const root = renderContent("```\nline 1\n\nline 3\n```");
+    const button = root.querySelector(
+      "button[aria-label='base.message.markdown.copyCode']"
+    );
+
+    await clickCopy(button!);
+
+    expect(copyToClipboardMock).toHaveBeenCalledWith("line 1\n\nline 3");
   });
 
   it("does not render a block copy button for inline code", () => {
     const root = renderContent("Use `inlineCode()` here.");
 
+    expect(
+      root.querySelector("button[aria-label='base.message.markdown.copyCode']")
+    ).toBeNull();
+  });
+
+  it("does not render a copy button for streaming partial fenced code", () => {
+    const root = renderContent("```ts\nconst partial = ", {
+      isStreaming: true,
+    });
+
+    expect(root.querySelector("pre")).not.toBeNull();
     expect(
       root.querySelector("button[aria-label='base.message.markdown.copyCode']")
     ).toBeNull();

--- a/packages/dmworkbase/src/Messages/Text/__tests__/MarkdownContentCodeCopy.test.tsx
+++ b/packages/dmworkbase/src/Messages/Text/__tests__/MarkdownContentCodeCopy.test.tsx
@@ -1,0 +1,130 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import ReactDOM from "react-dom";
+import { act } from "react-dom/test-utils";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { copyToClipboardMock, toastSuccessMock, toastWarningMock } = vi.hoisted(
+  () => ({
+    copyToClipboardMock: vi.fn(),
+    toastSuccessMock: vi.fn(),
+    toastWarningMock: vi.fn(),
+  })
+);
+
+vi.mock("../../../App", () => ({
+  default: {
+    dataSource: { commonDataSource: { getImageURL: (src: string) => src } },
+  },
+}));
+
+vi.mock("../../../i18n", () => ({
+  t: (key: string) => key,
+  useI18n: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("../../../Utils/clipboard", () => ({
+  copyToClipboard: copyToClipboardMock,
+}));
+
+vi.mock("@douyinfe/semi-ui", () => ({
+  Toast: {
+    success: toastSuccessMock,
+    warning: toastWarningMock,
+  },
+}));
+
+vi.mock("lucide-react", () => ({
+  Copy: (props: any) => React.createElement("span", props),
+}));
+
+import MarkdownContent from "../MarkdownContent";
+
+let container: HTMLDivElement | null = null;
+
+afterEach(() => {
+  if (container) {
+    ReactDOM.unmountComponentAtNode(container);
+    container.remove();
+    container = null;
+  }
+  copyToClipboardMock.mockReset();
+  toastSuccessMock.mockReset();
+  toastWarningMock.mockReset();
+});
+
+function renderContent(content: string) {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  act(() => {
+    ReactDOM.render(<MarkdownContent content={content} />, container);
+  });
+  return container;
+}
+
+async function clickCopy(button: Element) {
+  await act(async () => {
+    button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  });
+}
+
+describe("MarkdownContent — code block copy", () => {
+  it("renders a copy button for a fenced code block and preserves whitespace", async () => {
+    copyToClipboardMock.mockResolvedValue(true);
+    const root = renderContent(
+      "```ts\nconst value = 1;\n  console.log(value);\n```"
+    );
+
+    const button = root.querySelector(
+      "button[aria-label='base.message.markdown.copyCode']"
+    );
+    expect(button).not.toBeNull();
+
+    await clickCopy(button!);
+
+    expect(copyToClipboardMock).toHaveBeenCalledWith(
+      "const value = 1;\n  console.log(value);\n"
+    );
+    expect(toastSuccessMock).toHaveBeenCalledWith(
+      "base.message.markdown.copyCodeSuccess"
+    );
+  });
+
+  it("copies only the clicked code block when a message contains multiple blocks", async () => {
+    copyToClipboardMock.mockResolvedValue(true);
+    const root = renderContent("```js\nfirst();\n```\n\n```js\nsecond();\n```");
+
+    const buttons = root.querySelectorAll(
+      "button[aria-label='base.message.markdown.copyCode']"
+    );
+    expect(buttons).toHaveLength(2);
+
+    await clickCopy(buttons[0]);
+
+    expect(copyToClipboardMock).toHaveBeenCalledTimes(1);
+    expect(copyToClipboardMock).toHaveBeenCalledWith("first();\n");
+  });
+
+  it("does not render a block copy button for inline code", () => {
+    const root = renderContent("Use `inlineCode()` here.");
+
+    expect(
+      root.querySelector("button[aria-label='base.message.markdown.copyCode']")
+    ).toBeNull();
+  });
+
+  it("shows the existing copy failure warning when clipboard copy fails", async () => {
+    copyToClipboardMock.mockResolvedValue(false);
+    const root = renderContent("```\ncopy me\n```");
+    const button = root.querySelector(
+      "button[aria-label='base.message.markdown.copyCode']"
+    );
+
+    await clickCopy(button!);
+
+    expect(toastWarningMock).toHaveBeenCalledWith(
+      "base.module.contextMenus.copyFailed"
+    );
+  });
+});

--- a/packages/dmworkbase/src/Messages/Text/markdown.css
+++ b/packages/dmworkbase/src/Messages/Text/markdown.css
@@ -112,12 +112,56 @@
 
 .wk-markdown pre {
   margin: 0;
-  padding: var(--wk-sp-3) var(--wk-sp-4);
+  padding: var(--wk-sp-3) calc(var(--wk-sp-4) + 36px) var(--wk-sp-3)
+    var(--wk-sp-4);
   overflow-x: auto;
   font-size: 0.875em;
   font-family: "JetBrains Mono", "Fira Code", "Cascadia Code", monospace;
   line-height: 1.5;
   /* highlight.js 的 github-dark 主题提供背景色 */
+}
+
+.wk-markdown-code-copy {
+  position: absolute;
+  top: var(--wk-sp-2);
+  right: var(--wk-sp-2);
+  z-index: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: 1px solid var(--wk-border-subtle);
+  border-radius: var(--wk-r-sm);
+  color: var(--semi-color-text-2);
+  background: var(--semi-color-bg-2);
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity var(--wk-dur-fast) var(--wk-ease),
+    color var(--wk-dur-fast) var(--wk-ease),
+    background var(--wk-dur-fast) var(--wk-ease);
+}
+
+.wk-markdown-pre-wrapper:hover .wk-markdown-code-copy,
+.wk-markdown-code-copy:focus-visible {
+  opacity: 1;
+}
+
+.wk-markdown-code-copy:hover:not(:disabled),
+.wk-markdown-code-copy:focus-visible {
+  color: var(--semi-color-text-0);
+  background: var(--semi-color-fill-0);
+}
+
+.wk-markdown-code-copy:focus-visible {
+  outline: 2px solid var(--wk-border-glow);
+  outline-offset: 2px;
+}
+
+.wk-markdown-code-copy:disabled {
+  cursor: default;
+  opacity: 0.6;
 }
 
 .wk-markdown pre code {

--- a/packages/dmworkbase/src/i18n/locales/en-US.json
+++ b/packages/dmworkbase/src/i18n/locales/en-US.json
@@ -1030,6 +1030,8 @@
   "message.interactiveCard.inputTooLarge": "Submission is too large",
   "message.interactiveCard.copySuccess": "Copied",
   "message.interactiveCard.copyFailed": "Copy failed",
+  "message.markdown.copyCode": "Copy code",
+  "message.markdown.copyCodeSuccess": "Code copied",
   "message.imagePreview.rotate": "Rotate",
   "message.interactiveCard.copyTable": "Copy",
   "message.interactiveCard.denyDialog.title": "Deny document access request",

--- a/packages/dmworkbase/src/i18n/locales/zh-CN.json
+++ b/packages/dmworkbase/src/i18n/locales/zh-CN.json
@@ -1030,6 +1030,8 @@
   "message.interactiveCard.inputTooLarge": "提交内容过大",
   "message.interactiveCard.copySuccess": "已复制",
   "message.interactiveCard.copyFailed": "复制失败",
+  "message.markdown.copyCode": "复制代码",
+  "message.markdown.copyCodeSuccess": "已复制代码",
   "message.imagePreview.rotate": "旋转",
   "message.interactiveCard.copyTable": "复制",
   "message.interactiveCard.denyDialog.title": "拒绝文档访问申请",


### PR DESCRIPTION
## Summary

- Add a copy button to block-level markdown code blocks in message rendering.
- Preserve highlighted code text, including line breaks and indentation, when copying.
- Add copy success/failure messages and focused component coverage.

## Verification

- `./node_modules/.bin/vitest run packages/dmworkbase/src/Messages/Text/__tests__/MarkdownContentCodeCopy.test.tsx`
- `./node_modules/.bin/stylelint '**/*.css' --config stylelint.config.mjs --allow-empty-input`
- `node scripts/check-wkmodal-semi-overrides.mjs`
- `git diff --check`

Related to EVE-3.
Fixes #864.
