### PR TITLE
test(e2e): extend summary coverage

### DIFF
--- a/apps/web/e2e-kit/case-specs/summary/create/S5-summary-create-basic.md
+++ b/apps/web/e2e-kit/case-specs/summary/create/S5-summary-create-basic.md
@@ -1,0 +1,63 @@
+# S5 Summary Create Basic
+
+## Metadata
+
+- Case 类型: feature flow
+- 目标模式: real-page seed
+- 登录状态: authed fixture
+- 优先级: P1
+- Tags: `@S5 @p1 @summary @create @summary-create`
+
+## 目标
+
+验证用户能从「智能总结」创建页选择一个群聊、输入总结主题并提交，提交成功后看到「总结任务已创建」toast 并进入新总结详情页。这条 case 守护 Summary 创建主流程，不验证请求 body。
+
+## 前置条件
+
+- fixture: `fixtures-authed`，本地 mock 模式已预置登录态、Space 和中文 locale。
+- Per-case MSW handler: `s5-summary-create-basic.ts`
+  - `GET */summary/api/v1/summaries` — 初始返回空列表，让用户从空态进入创建页。
+  - `GET */summary/api/v1/summary-templates` — 返回空模板列表和 `custom_template_limit`，供创建页 mount。
+  - `GET */summary/api/v1/summary-chat-candidates` — 返回一个群聊候选 `S5 项目群`。
+  - `POST */summary/api/v1/summaries` — 返回 `{task_id:9501}`。
+  - `GET */summary/api/v1/summaries/9501` — 返回新建总结详情 `S5 项目复盘总结`。
+  - `POST */summary/api/v1/summaries/9501/read`、`GET */summary/api/v1/summaries/9501/versions` — 详情页后续请求兜底。
+- 不需要 mock-im-runtime seed；本 case 只验证 Summary real-page HTTP create flow。
+
+## 用户操作步骤
+
+1. 从默认 app shell 点击主导航「智能总结」。
+2. 在空态点击「创建第一份总结」进入创建页。
+3. 点击「选择聊天」，切到「全部群聊」，选择 `S5 项目群` 并确认。
+4. 在主题输入框输入 `S5 项目复盘总结`。
+5. 点击「开始总结」。
+
+## 预期结果
+
+- 创建页显示「邀请同事一起总结信息」。
+- 选择聊天后，创建页显示已选群聊 `S5 项目群`。
+- 提交后出现 toast「总结任务已创建」。
+- 页面进入新总结详情，显示标题「S5 项目复盘总结」。
+- 详情页显示摘要「S5 创建流程已完成」。
+
+## 反例
+
+- 进入创建页但未选择聊天、未输入主题时，「开始总结」按钮应不可用。
+- 提交成功后不应显示「创建失败」或「加载失败」。
+
+## 视觉基准
+
+不建 pixel baseline；用实际文案和角色/文本 locator 断言创建主流程。
+
+## 摸清依据
+
+- `packages/dmworksummary/src/pages/SummaryListPage.tsx:414`: `handleCreate` 将 `SummaryCreatePage` 推入右侧路由。
+- `packages/dmworksummary/src/pages/SummaryCreatePage.tsx:574`: `handleSubmit` 组装 `CreateSummaryParams` 并调用 `api.createSummary`。
+- `packages/dmworksummary/src/pages/SummaryCreatePage.tsx:643`: 创建成功 toast 使用 `summary.create.success`。
+- `packages/dmworksummary/src/pages/SummaryCreatePage.tsx:654`: 非 embedded 创建成功后进入 `SummaryDetailPage`。
+- `packages/dmworksummary/src/api/summaryApi.ts:290`: `createSummary()` 请求 `POST /summary/api/v1/summaries`。
+- `packages/dmworksummary/src/api/summaryApi.ts:956`: `getChatCandidates()` 请求 `/summary-chat-candidates`。
+- `packages/dmworksummary/src/types/summary.ts:285`: `CreateSummaryParams` 字段 shape。
+- `packages/dmworksummary/src/types/summary.ts:591`: `ChatCandidate` 字段 shape。
+- `packages/dmworksummary/src/i18n/zh-CN.json:170`: 创建页标题「邀请同事一起总结信息」。
+- `packages/dmworksummary/src/i18n/zh-CN.json:178`: 创建成功 toast「总结任务已创建」。

--- a/apps/web/e2e-kit/case-specs/summary/create/S8-summary-create-participants.md
+++ b/apps/web/e2e-kit/case-specs/summary/create/S8-summary-create-participants.md
@@ -1,0 +1,64 @@
+# S8 Summary Create Participants
+
+## Metadata
+
+- Case 类型: feature flow
+- 目标模式: real-page seed
+- 登录状态: authed fixture, mock IM runtime
+- 优先级: P1
+- Tags: `@S8 @p1 @summary @create @summary-create @member-select`
+
+## 目标
+
+验证用户创建 Summary 时能先选择聊天，再从该聊天的成员列表中选择参与者，提交后进入多人协作总结详情。这条 case 守护创建页「选择参与者」入口与 IM subscribers 接缝。
+
+## 前置条件
+
+- fixture: `fixtures-authed`，本地 mock 模式已预置登录态、Space 和中文 locale。
+- mock-im-runtime seed:
+  - group: `s8-project-group` / `S8 项目群`
+  - users: `e2e-user-1`、`s8-member-a`、`s8-member-b`
+  - subscribers: `S8 Alice`、`S8 Bob` 挂到 `s8-project-group`
+- Per-case MSW handler: `s8-summary-create-participants.ts`
+  - `GET */summary/api/v1/summaries` — 初始空列表。
+  - `GET */summary/api/v1/summary-templates` — 创建页模板预加载兜底。
+  - `GET */summary/api/v1/summary-chat-candidates` — 返回群聊候选 `S8 项目群`。
+  - `POST */summary/api/v1/summaries` — 返回 `{task_id:9801}`。
+  - `GET */summary/api/v1/summaries/9801` — 返回包含参与者 `S8 Alice` 的详情。
+  - `POST */summary/api/v1/summaries/9801/read`、`GET */summary/api/v1/summaries/9801/versions` — 详情页后续请求兜底。
+
+## 用户操作步骤
+
+1. 从默认 app shell 点击主导航「智能总结」。
+2. 在空态点击「创建第一份总结」进入创建页。
+3. 点击「选择聊天」，切到「全部群聊」，选择 `S8 项目群` 并确认。
+4. 点击「选择参与者」，选择 `S8 Alice` 并确认。
+5. 输入主题 `S8 多人协作总结`。
+6. 点击「开始总结」。
+
+## 预期结果
+
+- 创建页显示已选聊天 `S8 项目群`。
+- 成员选择弹窗显示 `S8 Alice`。
+- 确认后创建页显示已选参与者 `S8 Alice`。
+- 提交后出现 toast「总结任务已创建」。
+- 详情页显示标题「S8 多人协作总结」和摘要「S8 多人协作创建完成」。
+
+## 反例
+
+- 未选择聊天、未输入主题时「开始总结」按钮不可用。
+- 提交成功后不应显示「创建失败」或「加载失败」。
+
+## 视觉基准
+
+不建 pixel baseline；用实际文案和角色/文本 locator 断言成员选择与创建结果。
+
+## 摸清依据
+
+- `packages/dmworksummary/src/pages/SummaryCreatePage.tsx:763`: `handleOpenMemberSelector` 有已选聊天时传入 `Channel`。
+- `packages/dmworksummary/src/components/ChatSelectorModal.tsx:111`: members 模式有 channel 时通过 IM SDK `syncSubscribes` 加载群成员。
+- `packages/dmworksummary/src/components/ChatSelectorModal.tsx:581`: 右侧已选数量使用 `selectedCount` 文案。
+- `packages/dmworksummary/src/pages/SummaryCreatePage.tsx:1390`: 成员选择确认后映射为 `{user_id,name}`。
+- `packages/dmworksummary/src/pages/SummaryCreatePage.tsx:604`: 提交时把 `selectedMembers` 转成 `participants`。
+- `packages/dmworksummary/src/api/summaryApi.ts:290`: `createSummary()` 请求 `POST /summary/api/v1/summaries`。
+- `apps/web/e2e-kit/_kit/mock-im-runtime/seed-types.ts:55`: `MockSubscriberSeed` 定义群成员 seed shape。

--- a/apps/web/e2e-kit/case-specs/summary/detail/S6-summary-detail-failed.md
+++ b/apps/web/e2e-kit/case-specs/summary/detail/S6-summary-detail-failed.md
@@ -1,0 +1,55 @@
+# S6 Summary Detail Failed
+
+## Metadata
+
+- Case 类型: feature flow
+- 目标模式: real-page seed
+- 登录状态: authed fixture
+- 优先级: P1
+- Tags: `@S6 @p1 @summary @detail @summary-detail`
+
+## 目标
+
+验证用户从 Summary 列表打开一条失败总结时，详情页展示失败态和后端错误原因，不展示已完成总结正文。这条 case 守护失败结果的可见反馈分支。
+
+## 前置条件
+
+- fixture: `fixtures-authed`，本地 mock 模式已预置登录态、Space 和中文 locale。
+- Per-case MSW handler: `s6-summary-detail-failed.ts`
+  - `GET */summary/api/v1/summaries` — 返回一条状态为 `FAILED(4)` 的总结 `S6 失败总结`。
+  - `GET */summary/api/v1/summaries/9601` — 返回 `{code,message,data: SummaryDetail}`，其中 `status=4` 且 `error_message` 为 `S6 模拟生成失败：模型服务暂不可用`。
+  - `GET */summary/api/v1/summary-templates` — 创建页预加载模板兜底，避免漏 mock。
+- 不需要 mock-im-runtime seed。
+
+## 用户操作步骤
+
+1. 从默认 app shell 点击主导航「智能总结」。
+2. 在列表页点击「S6 失败总结」。
+3. 在详情页查看失败态。
+
+## 预期结果
+
+- 列表页显示「S6 失败总结」，并显示状态「失败」。
+- 点击卡片后，详情页显示标题「S6 失败总结」。
+- 详情页显示「总结生成失败」。
+- 详情页显示错误原因「S6 模拟生成失败：模型服务暂不可用」。
+
+## 反例
+
+- 失败详情页不应显示已完成总结正文标题「📝 总结内容」。
+- 失败详情页不应显示「AI 摘要」或任何 mock 的完成内容。
+
+## 视觉基准
+
+不建 pixel baseline；用实际文案断言失败态结构。
+
+## 摸清依据
+
+- `packages/dmworksummary/src/types/summary.ts:8`: `TaskStatus.FAILED` 为 `4`。
+- `packages/dmworksummary/src/pages/SummaryListPage.tsx:346`: 点击列表卡片进入 `SummaryDetailPage`。
+- `packages/dmworksummary/src/pages/SummaryDetailPage.tsx:607`: 详情页调用 `getSummaryDetail()`。
+- `packages/dmworksummary/src/pages/SummaryDetailPage.tsx:2423`: `renderFailed()` 渲染失败态。
+- `packages/dmworksummary/src/pages/SummaryDetailPage.tsx:2452`: 失败态标题来自 `summary.detail.failedTitle`。
+- `packages/dmworksummary/src/i18n/zh-CN.json`: `summary.detail.failedTitle` 实际文案为「总结生成失败」。
+- `packages/dmworksummary/src/api/summaryApi.ts:526`: 列表接口 `listSummaries()` 请求 `/summaries`。
+- `packages/dmworksummary/src/api/summaryApi.ts:533`: 详情接口 `getSummaryDetail()` 请求 `/summaries/:taskId`。

--- a/apps/web/e2e-kit/case-specs/summary/schedule/S7-summary-schedule-list.md
+++ b/apps/web/e2e-kit/case-specs/summary/schedule/S7-summary-schedule-list.md
@@ -1,0 +1,58 @@
+# S7 Summary Detail Schedule Summary
+
+## Metadata
+
+- Case 类型: feature flow
+- 目标模式: real-page seed
+- 登录状态: authed fixture
+- 优先级: P1
+- Tags: `@S7 @p1 @summary @schedule @summary-detail @summary-schedule`
+
+## 目标
+
+验证用户从 Summary 列表打开一条带定时配置的已完成总结时，详情页标题下方能展示当前定时更新信息。这条 case 守护详情页 schedule_id → getSchedule → renderScheduleSummary 的真实链路。
+
+## 前置条件
+
+- fixture: `fixtures-authed`，本地 mock 模式已预置登录态、Space 和中文 locale。
+- Per-case MSW handler: `s7-summary-schedule-list.ts`
+  - `GET */summary/api/v1/summaries` — 返回一条已完成总结 `S7 定时项目总结`，带 `schedule_id=9701`。
+  - `GET */summary/api/v1/summaries/9701` — 返回对应详情，`permissions.can_view_schedule=true`。
+  - `GET */summary/api/v1/summary-schedules/9701` — 返回每周一 09:30 执行的 active 定时配置。
+  - `POST */summary/api/v1/summaries/9701/read` 与 `GET */summary/api/v1/summaries/9701/versions` — 详情页后续请求兜底。
+  - `GET */summary/api/v1/summary-templates` — 创建页预加载模板兜底。
+- 不需要 mock-im-runtime seed。
+
+## 用户操作步骤
+
+1. 从默认 app shell 点击主导航「智能总结」。
+2. 在列表页点击「S7 定时项目总结」。
+3. 在详情页查看标题下方的定时说明。
+
+## 预期结果
+
+- 列表页显示「S7 定时项目总结」。
+- 详情页显示标题「S7 定时项目总结」。
+- 标题下方显示「定时：」。
+- 定时说明包含「每周」、「周一」和「09:30」。
+- 定时说明包含「下次」。
+
+## 反例
+
+- 详情页不应显示「定时已关闭」。
+- 详情页不应显示「加载失败」或「网络连接异常，请检查网络后重试」。
+
+## 视觉基准
+
+不建 pixel baseline；用实际文案断言定时信息展示。
+
+## 摸清依据
+
+- `packages/dmworksummary/src/module.tsx:149`: `/summary/schedules` 路由存在，但本 case 使用真实列表 → 详情入口。
+- `packages/dmworksummary/src/pages/SummaryDetailPage.tsx:607`: 详情页调用 `getSummaryDetail()`。
+- `packages/dmworksummary/src/pages/SummaryDetailPage.tsx:640`: 详情带 `schedule_id` 时调用 `loadSchedule()`。
+- `packages/dmworksummary/src/pages/SummaryDetailPage.tsx:693`: `loadSchedule()` 调用 `api.getSchedule()`。
+- `packages/dmworksummary/src/pages/SummaryDetailPage.tsx:3830`: `renderScheduleSummary()` 渲染详情页定时说明。
+- `packages/dmworksummary/src/utils/summaryHelpers.ts:561`: `formatScheduleSummary()` 组装「定时：」说明。
+- `packages/dmworksummary/src/api/summaryApi.ts:922`: `getSchedule()` 请求 `/summary-schedules/:id`。
+- `packages/dmworksummary/src/i18n/zh-CN.json`: `summary.detail.schedulePrefix` 实际文案「定时：」。

--- a/apps/web/e2e-kit/msw-handlers/s5-summary-create-basic.ts
+++ b/apps/web/e2e-kit/msw-handlers/s5-summary-create-basic.ts
@@ -1,0 +1,122 @@
+/* eslint-disable no-undef -- e2e code runs in Node */
+/* eslint-disable @typescript-eslint/no-explicit-any -- msw resolver types */
+import type { Page } from "@playwright/test";
+
+/** S5: Summary 选择聊天 + 输入主题 + 创建成功. */
+export async function registerS5SummaryCreateBasic(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    type MSW = {
+      worker: { use: (...h: unknown[]) => void };
+      http: {
+        get: (path: string, resolver: (info: any) => unknown) => unknown;
+        post: (path: string, resolver: (info: any) => unknown) => unknown;
+      };
+      HttpResponse: { json: (body: unknown, init?: unknown) => unknown };
+    };
+    const msw = (window as unknown as { __msw?: MSW }).__msw;
+    if (!msw) throw new Error("[S5] MSW worker 未就绪 (等 __MSW_READY__).");
+    const { worker, http, HttpResponse } = msw;
+    const env = (data: unknown) => HttpResponse.json({ code: 0, message: "ok", data });
+    const taskId = 9501;
+    const now = "2026-08-05T08:30:00Z";
+    const source = { source_type: 1, source_id: "s5-project-group", source_name: "S5 项目群" };
+    const detail = {
+      task_id: taskId,
+      task_no: "S5-TASK-9501",
+      title: "S5 项目复盘总结",
+      topic: "S5 项目复盘总结",
+      summary_mode: 1,
+      status: 3,
+      trigger_type: 1,
+      schedule_id: null,
+      creator_id: "e2e-user-1",
+      time_range_start: "2026-08-04T00:00:00Z",
+      time_range_end: "2026-08-05T00:00:00Z",
+      sources: [source],
+      participants: [{ user_id: "e2e-user-1", user_name: "E2E Tester", status: 1, confirmed_at: now }],
+      total_msg_count: 16,
+      creator_name: "E2E Tester",
+      origin_channel_id: "s5-project-group",
+      origin_channel_type: 2,
+      created_at: now,
+      updated_at: "2026-08-05T08:35:30Z",
+      completed_at: "2026-08-05T08:35:00Z",
+      is_unread: true,
+      has_pending_invitation: false,
+      has_pending_submission: false,
+      needs_attention: false,
+      current_result_id: 8501,
+      current_personal_version_id: null,
+      activity_at: "2026-08-05T08:35:00Z",
+      result_id: 8501,
+      result_edited_at: null,
+      result_is_edited: false,
+      error_message: null,
+      permissions: {
+        can_edit: true,
+        can_schedule: true,
+        can_edit_team: true,
+        can_edit_personal: false,
+        can_view_schedule: true,
+        can_add_member: true,
+        can_remove_member: true,
+      },
+      result: {
+        content: "## S5 创建结果\n\n- 已选择 S5 项目群\n- 已生成复盘总结\n",
+        abstract: "S5 创建流程已完成，已进入新总结详情。",
+        total_msg_count: 16,
+        total_token_used: 1024,
+        model_version: "e2e-summary-model",
+        version: 1,
+        operation_type: "generate",
+        operation_note: "",
+        parent_result_id: null,
+        generated_at: "2026-08-05T08:35:00Z",
+        citations: [],
+        team_citations: [],
+      },
+    };
+
+    (window as unknown as { __s5State__: { listCalls: number; createCalls: number } }).__s5State__ = {
+      listCalls: 0,
+      createCalls: 0,
+    };
+
+    worker.use(
+      http.get("*/summary/api/v1/summaries", () => {
+        const state = (window as unknown as { __s5State__: { listCalls: number } }).__s5State__;
+        state.listCalls += 1;
+        return env({ items: [], total: 0, attention_count: 0, unread_count: 0, pending_invitation_count: 0 });
+      }),
+      http.get("*/summary/api/v1/summary-templates", () =>
+        env({ templates: [], custom_template_limit: 30 })
+      ),
+      http.get("*/summary/api/v1/summary-chat-candidates", () =>
+        env([
+          {
+            chat_id: "s5-project-group",
+            chat_type: "group",
+            name: "S5 项目群",
+            member_count: 5,
+            is_archived: false,
+          },
+        ])
+      ),
+      http.post("*/sidebar/sync", () =>
+        HttpResponse.json({ items: [], version: 0, follow_version: 0 })
+      ),
+      http.post("*/summary/api/v1/summaries", () => {
+        const state = (window as unknown as { __s5State__: { createCalls: number } }).__s5State__;
+        state.createCalls += 1;
+        return env({ task_id: taskId });
+      }),
+      http.get("*/summary/api/v1/summaries/9501", () => env(detail)),
+      http.post("*/summary/api/v1/summaries/9501/read", () =>
+        env({ is_unread: false, has_pending_invitation: false, needs_attention: false })
+      ),
+      http.get("*/summary/api/v1/summaries/9501/versions", () =>
+        env({ versions: [], keep_limit: 3 })
+      )
+    );
+  });
+}

--- a/apps/web/e2e-kit/msw-handlers/s6-summary-detail-failed.ts
+++ b/apps/web/e2e-kit/msw-handlers/s6-summary-detail-failed.ts
@@ -1,0 +1,92 @@
+/* eslint-disable no-undef -- e2e code runs in Node */
+/* eslint-disable @typescript-eslint/no-explicit-any -- msw resolver types */
+import type { Page } from "@playwright/test";
+
+/** S6: Summary 失败详情态. */
+export async function registerS6SummaryDetailFailed(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    type MSW = {
+      worker: { use: (...h: unknown[]) => void };
+      http: { get: (path: string, resolver: (info: any) => unknown) => unknown };
+      HttpResponse: { json: (body: unknown, init?: unknown) => unknown };
+    };
+    const msw = (window as unknown as { __msw?: MSW }).__msw;
+    if (!msw) throw new Error("[S6] MSW worker 未就绪 (等 __MSW_READY__).");
+    const { worker, http, HttpResponse } = msw;
+    const env = (data: unknown) => HttpResponse.json({ code: 0, message: "ok", data });
+    const now = "2026-08-05T09:30:00Z";
+    const item = {
+      task_id: 9601,
+      task_no: "S6-TASK-9601",
+      title: "S6 失败总结",
+      topic: "S6 失败总结",
+      summary_mode: 1,
+      status: 4,
+      trigger_type: 1,
+      schedule_id: null,
+      creator_id: "e2e-user-1",
+      time_range_start: "2026-08-04T00:00:00Z",
+      time_range_end: "2026-08-05T00:00:00Z",
+      sources: [{ source_type: 1, source_id: "s6-failed-group", source_name: "S6 异常群" }],
+      participants: [{ user_id: "e2e-user-1", user_name: "E2E Tester", status: 1, confirmed_at: now }],
+      total_msg_count: 8,
+      creator_name: "E2E Tester",
+      origin_channel_id: "s6-failed-group",
+      origin_channel_type: 2,
+      created_at: now,
+      updated_at: "2026-08-05T09:31:00Z",
+      completed_at: null,
+      is_unread: false,
+      has_pending_invitation: false,
+      has_pending_submission: false,
+      needs_attention: true,
+      current_result_id: null,
+      current_personal_version_id: null,
+      activity_at: "2026-08-05T09:31:00Z",
+    };
+    const detail = {
+      ...item,
+      result_id: null,
+      error_message: "S6 模拟生成失败：模型服务暂不可用",
+      result_edited_at: null,
+      result_is_edited: false,
+      permissions: {
+        can_edit: false,
+        can_schedule: false,
+        can_edit_team: false,
+        can_edit_personal: false,
+        can_view_schedule: true,
+        can_add_member: false,
+        can_remove_member: false,
+      },
+      result: null,
+    };
+
+    (window as unknown as { __s6State__: { listCalls: number; detailCalls: number } }).__s6State__ = {
+      listCalls: 0,
+      detailCalls: 0,
+    };
+
+    worker.use(
+      http.get("*/summary/api/v1/summaries", () => {
+        const state = (window as unknown as { __s6State__: { listCalls: number } }).__s6State__;
+        state.listCalls += 1;
+        return env({
+          items: [item],
+          total: 1,
+          attention_count: 1,
+          unread_count: 0,
+          pending_invitation_count: 0,
+        });
+      }),
+      http.get("*/summary/api/v1/summaries/9601", () => {
+        const state = (window as unknown as { __s6State__: { detailCalls: number } }).__s6State__;
+        state.detailCalls += 1;
+        return env(detail);
+      }),
+      http.get("*/summary/api/v1/summary-templates", () =>
+        env({ templates: [], custom_template_limit: 30 })
+      )
+    );
+  });
+}

--- a/apps/web/e2e-kit/msw-handlers/s7-summary-schedule-list.ts
+++ b/apps/web/e2e-kit/msw-handlers/s7-summary-schedule-list.ts
@@ -1,0 +1,138 @@
+/* eslint-disable no-undef -- e2e code runs in Node */
+/* eslint-disable @typescript-eslint/no-explicit-any -- msw resolver types */
+import type { Page } from "@playwright/test";
+
+/** S7: Summary 详情页定时信息展示. */
+export async function registerS7SummaryScheduleList(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    type MSW = {
+      worker: { use: (...h: unknown[]) => void };
+      http: {
+        get: (path: string, resolver: (info: any) => unknown) => unknown;
+        post: (path: string, resolver: (info: any) => unknown) => unknown;
+      };
+      HttpResponse: { json: (body: unknown, init?: unknown) => unknown };
+    };
+    const msw = (window as unknown as { __msw?: MSW }).__msw;
+    if (!msw) throw new Error("[S7] MSW worker 未就绪 (等 __MSW_READY__).");
+    const { worker, http, HttpResponse } = msw;
+    const env = (data: unknown) => HttpResponse.json({ code: 0, message: "ok", data });
+    const taskId = 9701;
+    const scheduleId = 9701;
+    const now = "2026-08-05T09:30:00Z";
+    const source = { source_type: 1, source_id: "s7-project-group", source_name: "S7 项目群" };
+    const item = {
+      task_id: taskId,
+      task_no: "S7-TASK-9701",
+      title: "S7 定时项目总结",
+      topic: "S7 定时项目总结",
+      summary_mode: 1,
+      status: 3,
+      trigger_type: 1,
+      schedule_id: scheduleId,
+      creator_id: "e2e-user-1",
+      time_range_start: "2026-08-04T00:00:00Z",
+      time_range_end: "2026-08-05T00:00:00Z",
+      sources: [source],
+      participants: [{ user_id: "e2e-user-1", user_name: "E2E Tester", status: 1, confirmed_at: now }],
+      total_msg_count: 20,
+      creator_name: "E2E Tester",
+      origin_channel_id: "s7-project-group",
+      origin_channel_type: 2,
+      created_at: now,
+      updated_at: "2026-08-05T09:35:00Z",
+      completed_at: "2026-08-05T09:35:00Z",
+      is_unread: false,
+      has_pending_invitation: false,
+      has_pending_submission: false,
+      needs_attention: false,
+      current_result_id: 8701,
+      current_personal_version_id: null,
+      activity_at: "2026-08-05T09:35:00Z",
+    };
+    const detail = {
+      ...item,
+      result_id: 8701,
+      error_message: null,
+      result_edited_at: null,
+      result_is_edited: false,
+      permissions: {
+        can_edit: true,
+        can_schedule: true,
+        can_edit_team: true,
+        can_edit_personal: false,
+        can_view_schedule: true,
+        can_add_member: true,
+        can_remove_member: true,
+      },
+      result: {
+        content: "## S7 定时总结\n\n- 定时配置正常展示\n",
+        abstract: "S7 定时信息已展示。",
+        total_msg_count: 20,
+        total_token_used: 1024,
+        model_version: "e2e-summary-model",
+        version: 1,
+        operation_type: "generate",
+        operation_note: "",
+        parent_result_id: null,
+        generated_at: "2026-08-05T09:35:00Z",
+        citations: [],
+        team_citations: [],
+      },
+    };
+    const schedule = {
+      schedule_id: scheduleId,
+      title: "S7 每周项目总结",
+      generation_instruction: "每周整理项目进展",
+      summary_mode: 1,
+      cron_expr: "",
+      interval_days: 7,
+      interval_months: 0,
+      day_of_week: 1,
+      day_of_month: 0,
+      run_time: "09:30",
+      time_range_type: 2,
+      sources: [source],
+      participants: [{ user_id: "e2e-user-1" }],
+      is_active: true,
+      next_run_at: "2026-08-11T01:30:00Z",
+      created_at: now,
+      updated_at: now,
+      confirm_policy: 0,
+      participant_config: { participants: [{ user_id: "e2e-user-1", confirmed: true }], confirm_gate_passed: true },
+    };
+
+    (window as unknown as { __s7State__: { listCalls: number; detailCalls: number; scheduleCalls: number } }).__s7State__ = {
+      listCalls: 0,
+      detailCalls: 0,
+      scheduleCalls: 0,
+    };
+
+    worker.use(
+      http.get("*/summary/api/v1/summaries", () => {
+        const state = (window as unknown as { __s7State__: { listCalls: number } }).__s7State__;
+        state.listCalls += 1;
+        return env({ items: [item], total: 1, attention_count: 0, unread_count: 0, pending_invitation_count: 0 });
+      }),
+      http.get("*/summary/api/v1/summaries/9701", () => {
+        const state = (window as unknown as { __s7State__: { detailCalls: number } }).__s7State__;
+        state.detailCalls += 1;
+        return env(detail);
+      }),
+      http.get("*/summary/api/v1/summary-schedules/9701", () => {
+        const state = (window as unknown as { __s7State__: { scheduleCalls: number } }).__s7State__;
+        state.scheduleCalls += 1;
+        return env(schedule);
+      }),
+      http.post("*/summary/api/v1/summaries/9701/read", () =>
+        env({ is_unread: false, has_pending_invitation: false, needs_attention: false })
+      ),
+      http.get("*/summary/api/v1/summaries/9701/versions", () =>
+        env({ versions: [], keep_limit: 3 })
+      ),
+      http.get("*/summary/api/v1/summary-templates", () =>
+        env({ templates: [], custom_template_limit: 30 })
+      )
+    );
+  });
+}

--- a/apps/web/e2e-kit/msw-handlers/s8-summary-create-participants.ts
+++ b/apps/web/e2e-kit/msw-handlers/s8-summary-create-participants.ts
@@ -1,0 +1,117 @@
+/* eslint-disable no-undef -- e2e code runs in Node */
+/* eslint-disable @typescript-eslint/no-explicit-any -- msw resolver types */
+import type { Page } from "@playwright/test";
+
+/** S8: Summary 创建时选择参与者. */
+export async function registerS8SummaryCreateParticipants(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    type MSW = {
+      worker: { use: (...h: unknown[]) => void };
+      http: {
+        get: (path: string, resolver: (info: any) => unknown) => unknown;
+        post: (path: string, resolver: (info: any) => unknown) => unknown;
+      };
+      HttpResponse: { json: (body: unknown, init?: unknown) => unknown };
+    };
+    const msw = (window as unknown as { __msw?: MSW }).__msw;
+    if (!msw) throw new Error("[S8] MSW worker 未就绪 (等 __MSW_READY__).");
+    const { worker, http, HttpResponse } = msw;
+    const env = (data: unknown) => HttpResponse.json({ code: 0, message: "ok", data });
+    const taskId = 9801;
+    const now = "2026-08-05T10:30:00Z";
+    const source = { source_type: 1, source_id: "s8-project-group", source_name: "S8 项目群" };
+    const detail = {
+      task_id: taskId,
+      task_no: "S8-TASK-9801",
+      title: "S8 多人协作总结",
+      topic: "S8 多人协作总结",
+      summary_mode: 1,
+      status: 3,
+      trigger_type: 1,
+      schedule_id: null,
+      creator_id: "e2e-user-1",
+      time_range_start: "2026-08-04T00:00:00Z",
+      time_range_end: "2026-08-05T00:00:00Z",
+      sources: [source],
+      participants: [
+        { user_id: "e2e-user-1", user_name: "E2E Tester", status: 1, confirmed_at: now },
+        { user_id: "s8-member-a", user_name: "S8 Alice", status: 1, confirmed_at: now },
+      ],
+      total_msg_count: 18,
+      creator_name: "E2E Tester",
+      origin_channel_id: "s8-project-group",
+      origin_channel_type: 2,
+      created_at: now,
+      updated_at: "2026-08-05T10:35:00Z",
+      completed_at: "2026-08-05T10:35:00Z",
+      is_unread: true,
+      has_pending_invitation: false,
+      has_pending_submission: false,
+      needs_attention: false,
+      current_result_id: 8801,
+      current_personal_version_id: null,
+      activity_at: "2026-08-05T10:35:00Z",
+      result_id: 8801,
+      error_message: null,
+      result_edited_at: null,
+      result_is_edited: false,
+      permissions: {
+        can_edit: true,
+        can_schedule: true,
+        can_edit_team: true,
+        can_edit_personal: false,
+        can_view_schedule: true,
+        can_add_member: true,
+        can_remove_member: true,
+      },
+      result: {
+        content: "## S8 多人协作结果\n\n- 已邀请 S8 Alice 参与总结\n",
+        abstract: "S8 多人协作创建完成，参与者已带入总结任务。",
+        total_msg_count: 18,
+        total_token_used: 1024,
+        model_version: "e2e-summary-model",
+        version: 1,
+        operation_type: "generate",
+        operation_note: "",
+        parent_result_id: null,
+        generated_at: "2026-08-05T10:35:00Z",
+        citations: [],
+        team_citations: [],
+      },
+    };
+
+    (window as unknown as { __s8State__: { listCalls: number; createCalls: number } }).__s8State__ = {
+      listCalls: 0,
+      createCalls: 0,
+    };
+
+    worker.use(
+      http.get("*/summary/api/v1/summaries", () => {
+        const state = (window as unknown as { __s8State__: { listCalls: number } }).__s8State__;
+        state.listCalls += 1;
+        return env({ items: [], total: 0, attention_count: 0, unread_count: 0, pending_invitation_count: 0 });
+      }),
+      http.get("*/summary/api/v1/summary-templates", () =>
+        env({ templates: [], custom_template_limit: 30 })
+      ),
+      http.get("*/summary/api/v1/summary-chat-candidates", () =>
+        env([{ chat_id: "s8-project-group", chat_type: "group", name: "S8 项目群", member_count: 3, is_archived: false }])
+      ),
+      http.post("*/sidebar/sync", () =>
+        HttpResponse.json({ items: [], version: 0, follow_version: 0 })
+      ),
+      http.post("*/summary/api/v1/summaries", () => {
+        const state = (window as unknown as { __s8State__: { createCalls: number } }).__s8State__;
+        state.createCalls += 1;
+        return env({ task_id: taskId });
+      }),
+      http.get("*/summary/api/v1/summaries/9801", () => env(detail)),
+      http.post("*/summary/api/v1/summaries/9801/read", () =>
+        env({ is_unread: false, has_pending_invitation: false, needs_attention: false })
+      ),
+      http.get("*/summary/api/v1/summaries/9801/versions", () =>
+        env({ versions: [], keep_limit: 3 })
+      )
+    );
+  });
+}

--- a/apps/web/e2e-kit/tests/summary/create/S5-summary-create-basic.spec.ts
+++ b/apps/web/e2e-kit/tests/summary/create/S5-summary-create-basic.spec.ts
@@ -1,0 +1,55 @@
+/* eslint-disable no-undef -- e2e code runs in Node */
+/**
+ * spec: e2e-kit/case-specs/summary/create/S5-summary-create-basic.md
+ *
+ * S5: Summary 选择聊天 + 输入主题 + 创建成功.
+ */
+import { test, expect } from "../../../fixtures-authed";
+import { registerS5SummaryCreateBasic } from "../../../msw-handlers/s5-summary-create-basic";
+import { startRequestMonitor, sanityCheck } from "../../../_lib/sanity";
+
+const sanityConfig = {
+  // CI leak target plus legacy mock host marker; workflow proxy-error grep remains the fail-closed guard.
+  realHosts: ["127.0.0.1:9", "mock.e2e.local"],
+  apiPrefixRe: /^\/(api|summary\/api)(\/|$)/,
+  loginPathRe: /\/login(\?|$)/,
+};
+
+test.describe("@S5 @p1 @summary @create @summary-create S5 — Summary 创建主流程", () => {
+  test("选择聊天并输入主题后创建总结", async ({ authedPage }) => {
+    await registerS5SummaryCreateBasic(authedPage);
+    const ctx = startRequestMonitor(authedPage, sanityConfig);
+
+    await authedPage.getByRole("button", { name: "智能总结" }).click();
+    await expect(authedPage.getByText("暂无总结记录")).toBeVisible({ timeout: 15_000 });
+    await authedPage.getByRole("button", { name: "创建第一份总结" }).click();
+
+    await expect(authedPage.getByText("邀请同事一起总结信息")).toBeVisible({ timeout: 15_000 });
+    const startButton = authedPage.getByRole("button", { name: "开始总结" }).nth(1);
+    await expect(startButton).toBeDisabled();
+
+    await authedPage.getByRole("button", { name: "选择聊天" }).click();
+    await expect(authedPage.getByText("选择聊天").last()).toBeVisible({ timeout: 15_000 });
+    await authedPage.getByRole("button", { name: "全部群聊" }).click();
+    await authedPage.getByText("S5 项目群", { exact: true }).click();
+    await expect(authedPage.getByText("已选 1 / 30")).toBeVisible();
+    await authedPage.getByRole("button", { name: "确定" }).click();
+
+    await expect(authedPage.getByText("S5 项目群", { exact: true })).toBeVisible();
+    await authedPage
+      .getByPlaceholder("请输入你想总结的主题，例如：总结本周项目进展、整理客户反馈要点")
+      .fill("S5 项目复盘总结");
+    await expect(startButton).toBeEnabled();
+    await startButton.click();
+
+    await expect(authedPage.getByText("总结任务已创建")).toBeVisible({ timeout: 15_000 });
+    await expect(
+      authedPage.getByRole("heading", { name: "S5 项目复盘总结", level: 2 })
+    ).toBeVisible({ timeout: 15_000 });
+    await expect(authedPage.getByText("S5 创建流程已完成")).toBeVisible();
+    await expect(authedPage.getByText("创建失败")).toHaveCount(0);
+    await expect(authedPage.getByText("加载失败")).toHaveCount(0);
+
+    await sanityCheck(authedPage, ctx);
+  });
+});

--- a/apps/web/e2e-kit/tests/summary/create/S8-summary-create-participants.spec.ts
+++ b/apps/web/e2e-kit/tests/summary/create/S8-summary-create-participants.spec.ts
@@ -1,0 +1,78 @@
+/* eslint-disable no-undef -- e2e code runs in Node */
+/**
+ * spec: e2e-kit/case-specs/summary/create/S8-summary-create-participants.md
+ *
+ * S8: Summary 创建时选择参与者.
+ */
+import { test, expect } from "../../../fixtures-authed";
+import { installMockImRuntime } from "../../../_kit/mock-im-runtime";
+import { registerS8SummaryCreateParticipants } from "../../../msw-handlers/s8-summary-create-participants";
+import { startRequestMonitor, sanityCheck } from "../../../_lib/sanity";
+
+const sanityConfig = {
+  // CI leak target plus legacy mock host marker; workflow proxy-error grep remains the fail-closed guard.
+  realHosts: ["127.0.0.1:9", "mock.e2e.local"],
+  apiPrefixRe: /^\/(api|summary\/api)(\/|$)/,
+  loginPathRe: /\/login(\?|$)/,
+};
+
+test.describe("@S8 @p1 @summary @create @summary-create @member-select S8 — Summary 创建参与者", () => {
+  test("选择聊天成员作为参与者后创建总结", async ({ authedPage }) => {
+    await registerS8SummaryCreateParticipants(authedPage);
+    await installMockImRuntime(authedPage, {
+      currentUid: "e2e-user-1",
+      spaceId: "e2e-space-001",
+      users: [
+        { uid: "e2e-user-1", name: "E2E Tester", robot: 0 },
+        { uid: "s8-member-a", name: "S8 Alice", robot: 0 },
+        { uid: "s8-member-b", name: "S8 Bob", robot: 0 },
+      ],
+      groups: [{ group_no: "s8-project-group", name: "S8 项目群" }],
+      conversations: [{ channelId: "s8-project-group", channelType: 2, unread: 0 }],
+      subscribers: [
+        { uid: "e2e-user-1", name: "E2E Tester", channelId: "s8-project-group", channelType: 2, role: 1, robot: 0 },
+        { uid: "s8-member-a", name: "S8 Alice", channelId: "s8-project-group", channelType: 2, role: 0, robot: 0 },
+        { uid: "s8-member-b", name: "S8 Bob", channelId: "s8-project-group", channelType: 2, role: 0, robot: 0 },
+      ],
+    });
+    const ctx = startRequestMonitor(authedPage, sanityConfig);
+
+    await authedPage.getByRole("button", { name: "智能总结" }).click();
+    await expect(authedPage.getByText("暂无总结记录")).toBeVisible({ timeout: 15_000 });
+    await authedPage.getByRole("button", { name: "创建第一份总结" }).click();
+
+    await expect(authedPage.getByText("邀请同事一起总结信息")).toBeVisible({ timeout: 15_000 });
+    const startButton = authedPage.getByRole("button", { name: "开始总结" }).nth(1);
+    await expect(startButton).toBeDisabled();
+
+    await authedPage.getByRole("button", { name: "选择聊天" }).click();
+    await authedPage.getByRole("button", { name: "全部群聊" }).click();
+    await authedPage.getByText("S8 项目群", { exact: true }).click();
+    await expect(authedPage.getByText("已选 1 / 30")).toBeVisible();
+    await authedPage.getByRole("button", { name: "确定" }).click();
+    await expect(authedPage.getByText("S8 项目群", { exact: true })).toBeVisible();
+
+    await authedPage.getByRole("button", { name: "选择参与者" }).click();
+    await expect(authedPage.getByText("选择参与者").last()).toBeVisible({ timeout: 15_000 });
+    await authedPage.getByText("S8 Alice", { exact: true }).click();
+    await expect(authedPage.getByText("已选 1 / 30")).toBeVisible();
+    await authedPage.getByRole("button", { name: "确定" }).click();
+    await expect(authedPage.getByText("S8 Alice", { exact: true })).toBeVisible();
+
+    await authedPage
+      .getByPlaceholder("请输入你想总结的主题，例如：总结本周项目进展、整理客户反馈要点")
+      .fill("S8 多人协作总结");
+    await expect(startButton).toBeEnabled();
+    await startButton.click();
+
+    await expect(authedPage.getByText("总结任务已创建")).toBeVisible({ timeout: 15_000 });
+    await expect(
+      authedPage.getByRole("heading", { name: "S8 多人协作总结", level: 2 })
+    ).toBeVisible({ timeout: 15_000 });
+    await expect(authedPage.getByText("S8 多人协作创建完成")).toBeVisible();
+    await expect(authedPage.getByText("创建失败")).toHaveCount(0);
+    await expect(authedPage.getByText("加载失败")).toHaveCount(0);
+
+    await sanityCheck(authedPage, ctx);
+  });
+});

--- a/apps/web/e2e-kit/tests/summary/detail/S6-summary-detail-failed.spec.ts
+++ b/apps/web/e2e-kit/tests/summary/detail/S6-summary-detail-failed.spec.ts
@@ -1,0 +1,42 @@
+/* eslint-disable no-undef -- e2e code runs in Node */
+/**
+ * spec: e2e-kit/case-specs/summary/detail/S6-summary-detail-failed.md
+ *
+ * S6: Summary 失败详情态.
+ */
+import { test, expect } from "../../../fixtures-authed";
+import { registerS6SummaryDetailFailed } from "../../../msw-handlers/s6-summary-detail-failed";
+import { startRequestMonitor, sanityCheck } from "../../../_lib/sanity";
+
+const sanityConfig = {
+  // CI leak target plus legacy mock host marker; workflow proxy-error grep remains the fail-closed guard.
+  realHosts: ["127.0.0.1:9", "mock.e2e.local"],
+  apiPrefixRe: /^\/(api|summary\/api)(\/|$)/,
+  loginPathRe: /\/login(\?|$)/,
+};
+
+test.describe("@S6 @p1 @summary @detail @summary-detail S6 — Summary 失败详情", () => {
+  test("打开失败总结后显示失败原因", async ({ authedPage }) => {
+    await registerS6SummaryDetailFailed(authedPage);
+    const ctx = startRequestMonitor(authedPage, sanityConfig);
+
+    await authedPage.getByRole("button", { name: "智能总结" }).click();
+
+    await expect(authedPage.getByText("S6 失败总结")).toBeVisible({ timeout: 15_000 });
+    await expect(authedPage.getByText("失败", { exact: true })).toBeVisible();
+    await expect(authedPage.getByText("S6 异常群")).toBeVisible();
+
+    await authedPage.getByText("S6 失败总结").click();
+
+    await expect(
+      authedPage.getByRole("heading", { name: "S6 失败总结", level: 2 })
+    ).toBeVisible({ timeout: 15_000 });
+    await expect(authedPage.getByRole("heading", { name: "总结生成失败", level: 3 })).toBeVisible();
+    await expect(authedPage.getByText("S6 模拟生成失败：模型服务暂不可用")).toBeVisible();
+    await expect(authedPage.getByText("📝 总结内容")).toHaveCount(0);
+    await expect(authedPage.getByText("AI 摘要")).toHaveCount(0);
+    await expect(authedPage.getByText("加载失败")).toHaveCount(0);
+
+    await sanityCheck(authedPage, ctx);
+  });
+});

--- a/apps/web/e2e-kit/tests/summary/schedule/S7-summary-schedule-list.spec.ts
+++ b/apps/web/e2e-kit/tests/summary/schedule/S7-summary-schedule-list.spec.ts
@@ -1,0 +1,43 @@
+/* eslint-disable no-undef -- e2e code runs in Node */
+/**
+ * spec: e2e-kit/case-specs/summary/schedule/S7-summary-schedule-list.md
+ *
+ * S7: Summary 详情页定时信息展示.
+ */
+import { test, expect } from "../../../fixtures-authed";
+import { registerS7SummaryScheduleList } from "../../../msw-handlers/s7-summary-schedule-list";
+import { startRequestMonitor, sanityCheck } from "../../../_lib/sanity";
+
+const sanityConfig = {
+  // CI leak target plus legacy mock host marker; workflow proxy-error grep remains the fail-closed guard.
+  realHosts: ["127.0.0.1:9", "mock.e2e.local"],
+  apiPrefixRe: /^\/(api|summary\/api)(\/|$)/,
+  loginPathRe: /\/login(\?|$)/,
+};
+
+test.describe("@S7 @p1 @summary @schedule @summary-detail @summary-schedule S7 — Summary 详情定时信息", () => {
+  test("打开带定时配置的总结后显示定时说明", async ({ authedPage }) => {
+    await registerS7SummaryScheduleList(authedPage);
+    const ctx = startRequestMonitor(authedPage, sanityConfig);
+
+    await authedPage.getByRole("button", { name: "智能总结" }).click();
+
+    await expect(authedPage.getByText("S7 定时项目总结")).toBeVisible({ timeout: 15_000 });
+    await expect(authedPage.getByText("S7 项目群")).toBeVisible();
+    await authedPage.getByText("S7 定时项目总结").click();
+
+    await expect(
+      authedPage.getByRole("heading", { name: "S7 定时项目总结", level: 2 })
+    ).toBeVisible({ timeout: 15_000 });
+    await expect(authedPage.getByText(/定时：.*每周.*周一.*09:30/)).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(authedPage.getByText(/下次/)).toBeVisible();
+    await expect(authedPage.getByText("S7 定时信息已展示")).toBeVisible();
+    await expect(authedPage.getByText("定时已关闭")).toHaveCount(0);
+    await expect(authedPage.getByText("加载失败")).toHaveCount(0);
+    await expect(authedPage.getByText("网络连接异常，请检查网络后重试")).toHaveCount(0);
+
+    await sanityCheck(authedPage, ctx);
+  });
+});


### PR DESCRIPTION
## Summary
- add S5 Summary create flow e2e
- add S6 Summary failed-detail e2e
- add S7 Summary detail schedule-info e2e
- add S8 Summary create-with-participants e2e using mock IM subscribers

## Verification
- node e2e-kit/_lib/lint-spec-format.mjs --files e2e-kit/case-specs/summary/create/S5-summary-create-basic.md e2e-kit/case-specs/summary/detail/S6-summary-detail-failed.md
- pnpm exec playwright test --config=e2e-kit/playwright.config.ts --grep "@S5|@S6" --workers=1
- pnpm exec playwright test --config=e2e-kit/playwright.config.ts --grep "@S5|@S6" --repeat-each=3 --workers=1
- node e2e-kit/_lib/lint-spec-format.mjs --files e2e-kit/case-specs/summary/schedule/S7-summary-schedule-list.md
- pnpm exec playwright test --config=e2e-kit/playwright.config.ts --grep "@S7" --repeat-each=3 --workers=1
- node e2e-kit/_lib/lint-spec-format.mjs --files e2e-kit/case-specs/summary/create/S8-summary-create-participants.md
- pnpm exec playwright test --config=e2e-kit/playwright.config.ts --grep "@S8" --workers=1
- pnpm exec playwright test --config=e2e-kit/playwright.config.ts --grep "@S8" --repeat-each=3 --workers=1

🤖 Generated with [Claude Code](https://claude.com/claude-code)