### PR TITLE
feat(base): add cached, cancellable space member roster

### DIFF
--- a/packages/dmworkbase/src/Service/SpaceService.tsx
+++ b/packages/dmworkbase/src/Service/SpaceService.tsx
@@ -4,6 +4,7 @@ import { hasSpacePrefix } from "./SpacePrefix"
 import { ChannelTypeCommunityTopic } from "./Const"
 import { parseThreadChannelId } from "./Thread"
 import { getImChannelInfo, getImChannelSubscribers } from "../im-runtime/channelRuntime"
+import { createAsyncCache } from "../Utils/asyncCache"
 
 export type JoinSpaceStatus = "NEED_APPROVAL" | "PENDING"
 
@@ -256,6 +257,23 @@ export interface InviteResp {
     invite_url: string
 }
 
+/**
+ * 名册缓存的存活时长。30s 量级足以覆盖「打开转发面板 → 关闭 → 再打开」以及
+ * 多个消费面在同一屏内并发拉取，同时把成员变动的可见延迟控制在可接受范围。
+ * 本 Service 内的写操作会主动失效，所以这个窗口只对外部来源的变更生效。
+ */
+const SPACE_ROSTER_TTL_MS = 30_000
+/**
+ * 单页条数。取 10000（与 Contacts / docs octoweb 既有实现一致），大多数空间
+ * 一趟拉完。不用 getAllMembers 的默认 100：那会退化成 800 人 8 趟串行请求，
+ * 且 100×50 的上限只有 5000，低于已知的 5760 人空间。
+ */
+const SPACE_ROSTER_PAGE_LIMIT = 10_000
+/** 兜底防异常空间无限循环（20×10000 = 20 万，远超任何真实空间）。 */
+const SPACE_ROSTER_MAX_PAGES = 20
+
+const rosterCache = createAsyncCache<SpaceMember[]>({ ttlMs: SPACE_ROSTER_TTL_MS })
+
 export class SpaceService {
     static shared = new SpaceService()
 
@@ -272,23 +290,65 @@ export class SpaceService {
         return WKApp.apiClient.get(`space/${spaceId}`)
     }
 
-    async getMembers(spaceId: string, page: number = 1, limit: number = 50): Promise<SpaceMember[]> {
-        const resp = await WKApp.apiClient.get(`space/${spaceId}/members?page=${page}&limit=${limit}`)
+    async getMembers(spaceId: string, page: number = 1, limit: number = 50, signal?: AbortSignal): Promise<SpaceMember[]> {
+        const path = `space/${spaceId}/members?page=${page}&limit=${limit}`
+        // 仅在调用方给了 signal 时才带 config，保持既有调用形态不变。
+        const resp = signal ? await WKApp.apiClient.get(path, { signal }) : await WKApp.apiClient.get(path)
         return resp || []
     }
 
     // 拉取一个 space 的全部成员（分页循环到取空/达上限）。收敛此前散落在
     // dmloop directory / SettingsPage 各自复制的分页逻辑，
     // 避免翻页上限相互漂移。
-    async getAllMembers(spaceId: string, pageLimit: number = 100, maxPages: number = 50): Promise<SpaceMember[]> {
+    //
+    // 注意默认上限是 100×50 = 5000。已知有 5760 人的空间（见 packages/docs
+    // octoweb 的 picker 截断修复），所以需要完整名册的调用方应改用 getRoster，
+    // 或显式传更大的 pageLimit。
+    async getAllMembers(spaceId: string, pageLimit: number = 100, maxPages: number = 50, signal?: AbortSignal): Promise<SpaceMember[]> {
         if (!spaceId) return []
         const acc: SpaceMember[] = []
         for (let page = 1; page <= maxPages; page++) {
-            const batch = await this.getMembers(spaceId, page, pageLimit)
+            const batch = await this.getMembers(spaceId, page, pageLimit, signal)
             acc.push(...batch)
+            // 取消检查放在 await 之后并抛错，而不是 break 返回半份名册——
+            // 半份名册会被上层当成完整结果，静默丢人。
+            if (signal?.aborted) {
+                const err = new Error("Aborted")
+                err.name = "AbortError"
+                throw err
+            }
             if (!batch || batch.length < pageLimit) break
         }
         return acc
+    }
+
+    /**
+     * 带缓存的全量成员名册。
+     *
+     * 与 getAllMembers 的区别：结果按 spaceId 缓存，TTL 内的并发/重复调用共享
+     * 同一次请求。`space/{id}/members` 目前被转发面板、通讯录、Chat 侧栏、docs
+     * 成员选择器和企业模块各自全量拉取且互不复用，此方法是它们的统一入口。
+     *
+     * 翻页参数用 10000×20（与 Contacts / docs 既有实现一致），而非
+     * getAllMembers 的 100×50 —— 后者上限 5000，低于已知的 5760 人空间。
+     */
+    async getRoster(spaceId: string, options?: { maxAgeMs?: number; signal?: AbortSignal }): Promise<SpaceMember[]> {
+        if (!spaceId) return []
+        return rosterCache.get(
+            spaceId,
+            () => this.getAllMembers(spaceId, SPACE_ROSTER_PAGE_LIMIT, SPACE_ROSTER_MAX_PAGES),
+            options,
+        )
+    }
+
+    /** 同步读已缓存的名册（不触发请求），用于首帧兜底。 */
+    peekRoster(spaceId: string): SpaceMember[] | undefined {
+        return rosterCache.peek(spaceId)
+    }
+
+    /** 失效名册缓存。不传 spaceId 则清空全部（例如登出）。 */
+    invalidateRoster(spaceId?: string): void {
+        rosterCache.invalidate(spaceId)
     }
 
     async createInvite(spaceId: string): Promise<InviteResp> {
@@ -318,14 +378,21 @@ export class SpaceService {
     }
 
     async removeMembers(spaceId: string, uids: string[]): Promise<void> {
-        return WKApp.apiClient.delete(`space/${spaceId}/members`, { data: { uids } })
+        const result = await WKApp.apiClient.delete(`space/${spaceId}/members`, { data: { uids } })
+        // 写后失效：否则 TTL 窗口内会读回自己刚移除的成员。
+        rosterCache.invalidate(spaceId)
+        return result
     }
 
     async disbandSpace(spaceId: string): Promise<void> {
-        return WKApp.apiClient.delete(`space/${spaceId}`, {})
+        const result = await WKApp.apiClient.delete(`space/${spaceId}`, {})
+        rosterCache.invalidate(spaceId)
+        return result
     }
 
     async updateMemberRole(spaceId: string, uid: string, role: number): Promise<void> {
-        return WKApp.apiClient.put(`space/${spaceId}/members/${uid}/role`, { role })
+        const result = await WKApp.apiClient.put(`space/${spaceId}/members/${uid}/role`, { role })
+        rosterCache.invalidate(spaceId)
+        return result
     }
 }

--- a/packages/dmworkbase/src/Service/SpaceService.tsx
+++ b/packages/dmworkbase/src/Service/SpaceService.tsx
@@ -272,7 +272,10 @@ const SPACE_ROSTER_PAGE_LIMIT = 10_000
 /** 兜底防异常空间无限循环（20×10000 = 20 万，远超任何真实空间）。 */
 const SPACE_ROSTER_MAX_PAGES = 20
 
-const rosterCache = createAsyncCache<SpaceMember[]>({ ttlMs: SPACE_ROSTER_TTL_MS })
+const rosterCache = createAsyncCache<SpaceMember[]>({
+    ttlMs: SPACE_ROSTER_TTL_MS,
+    clone: (members) => [...members],
+})
 
 export class SpaceService {
     static shared = new SpaceService()

--- a/packages/dmworkbase/src/Service/SpaceService.tsx
+++ b/packages/dmworkbase/src/Service/SpaceService.tsx
@@ -4,7 +4,7 @@ import { hasSpacePrefix } from "./SpacePrefix"
 import { ChannelTypeCommunityTopic } from "./Const"
 import { parseThreadChannelId } from "./Thread"
 import { getImChannelInfo, getImChannelSubscribers } from "../im-runtime/channelRuntime"
-import { createAsyncCache } from "../Utils/asyncCache"
+import { abortError, createAsyncCache } from "../Utils/asyncCache"
 
 export type JoinSpaceStatus = "NEED_APPROVAL" | "PENDING"
 
@@ -292,9 +292,19 @@ export class SpaceService {
 
     async getMembers(spaceId: string, page: number = 1, limit: number = 50, signal?: AbortSignal): Promise<SpaceMember[]> {
         const path = `space/${spaceId}/members?page=${page}&limit=${limit}`
-        // 仅在调用方给了 signal 时才带 config，保持既有调用形态不变。
-        const resp = signal ? await WKApp.apiClient.get(path, { signal }) : await WKApp.apiClient.get(path)
-        return resp || []
+        try {
+            // 仅在调用方给了 signal 时才带 config，保持既有调用形态不变。
+            const resp = signal ? await WKApp.apiClient.get(path, { signal }) : await WKApp.apiClient.get(path)
+            return resp || []
+        } catch (err) {
+            // 请求进行中被取消时，axios 抛 ERR_CANCELED，而 normalizeApiError
+            // （apiError.ts:96-109）只归类 ECONNABORTED / ERR_NETWORK，取消会被
+            // 包装成「未知错误」——调用方无从识别，还会弹错误提示。这里按
+            // signal.aborted 判定而非匹配错误码：请求被取消时该标志必然为真，
+            // 不依赖 APIClient 包装后的错误形状。
+            if (signal?.aborted) throw abortError()
+            throw err
+        }
     }
 
     // 拉取一个 space 的全部成员（分页循环到取空/达上限）。收敛此前散落在
@@ -308,15 +318,12 @@ export class SpaceService {
         if (!spaceId) return []
         const acc: SpaceMember[] = []
         for (let page = 1; page <= maxPages; page++) {
+            // 请求进行中被取消由 getMembers 翻译成 AbortError 抛出。
             const batch = await this.getMembers(spaceId, page, pageLimit, signal)
             acc.push(...batch)
-            // 取消检查放在 await 之后并抛错，而不是 break 返回半份名册——
-            // 半份名册会被上层当成完整结果，静默丢人。
-            if (signal?.aborted) {
-                const err = new Error("Aborted")
-                err.name = "AbortError"
-                throw err
-            }
+            // 这一层只兜「abort 落在两页之间」（无请求在飞）的窗口。抛错而不是
+            // break 返回半份名册——半份会被上层当成完整结果，静默丢人。
+            if (signal?.aborted) throw abortError()
             if (!batch || batch.length < pageLimit) break
         }
         return acc
@@ -370,7 +377,12 @@ export class SpaceService {
     }
 
     async leaveSpace(spaceId: string): Promise<void> {
-        return WKApp.apiClient.post(`space/${spaceId}/leave`, {})
+        const result = await WKApp.apiClient.post(`space/${spaceId}/leave`, {})
+        // 自己退出是 removeMembers 的对称操作，同样要失效名册，否则 TTL 窗口内
+        // 还能读到把自己算在内的旧名册。（joinSpace 只有邀请码，拿不到 spaceId，
+        // 无法在此失效。）
+        rosterCache.invalidate(spaceId)
+        return result
     }
 
     async updateSpace(spaceId: string, data: { name?: string; description?: string }): Promise<void> {

--- a/packages/dmworkbase/src/Service/__tests__/SpaceService.members.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/SpaceService.members.test.ts
@@ -1,10 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const api = vi.hoisted(() => ({ get: vi.fn(), put: vi.fn(), delete: vi.fn() }));
+const api = vi.hoisted(() => ({ get: vi.fn(), put: vi.fn(), post: vi.fn(), delete: vi.fn() }));
 
 vi.mock("../../App", () => ({
   default: {
-    apiClient: { get: api.get, put: api.put, delete: api.delete },
+    apiClient: { get: api.get, put: api.put, post: api.post, delete: api.delete },
     shared: {},
     loginInfo: {},
   },
@@ -32,6 +32,7 @@ describe("SpaceService member pagination", () => {
   beforeEach(() => {
     api.get.mockReset();
     api.put.mockReset();
+    api.post.mockReset();
     api.delete.mockReset();
     SpaceService.shared.invalidateRoster();
   });
@@ -84,12 +85,51 @@ describe("SpaceService member pagination", () => {
     await expect(SpaceService.shared.getAllMembers("")).resolves.toEqual([]);
     expect(api.get).not.toHaveBeenCalled();
   });
+
+  it("translates an in-flight cancellation into AbortError", async () => {
+    const controller = new AbortController();
+    // 复刻 APIClient 的真实行为：axios 取消抛 ERR_CANCELED，而
+    // normalizeApiError（apiError.ts:96-109）只归类 ECONNABORTED / ERR_NETWORK，
+    // 于是取消被包装成通用「未知错误」。调用方必须仍看到 AbortError。
+    api.get.mockImplementation(async () => {
+      controller.abort();
+      throw { code: "err.shared.unknown", message: "unknown error", normalized: {} };
+    });
+
+    await expect(
+      SpaceService.shared.getMembers("space-1", 1, 10, controller.signal)
+    ).rejects.toMatchObject({ name: "AbortError" });
+  });
+
+  it("surfaces AbortError through getAllMembers on an in-flight cancellation", async () => {
+    const controller = new AbortController();
+    api.get.mockImplementation(async () => {
+      controller.abort();
+      throw { code: "err.shared.unknown", message: "unknown error" };
+    });
+
+    await expect(
+      SpaceService.shared.getAllMembers("space-1", 2, 50, controller.signal)
+    ).rejects.toMatchObject({ name: "AbortError" });
+    expect(api.get).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not mask a genuine failure as a cancellation", async () => {
+    const controller = new AbortController();
+    api.get.mockRejectedValue(new Error("boom"));
+
+    // signal 未触发 → 原始错误必须原样抛出，不能被翻译成 AbortError。
+    await expect(
+      SpaceService.shared.getMembers("space-1", 1, 10, controller.signal)
+    ).rejects.toThrow("boom");
+  });
 });
 
 describe("SpaceService.getRoster", () => {
   beforeEach(() => {
     api.get.mockReset();
     api.put.mockReset();
+    api.post.mockReset();
     api.delete.mockReset();
     SpaceService.shared.invalidateRoster();
   });
@@ -153,6 +193,29 @@ describe("SpaceService.getRoster", () => {
 
     await SpaceService.shared.getRoster("space-1");
     await SpaceService.shared.updateMemberRole("space-1", "u1", 2);
+    await SpaceService.shared.getRoster("space-1");
+
+    expect(api.get).toHaveBeenCalledTimes(2);
+  });
+
+  it("refetches after disbandSpace invalidates the roster", async () => {
+    api.get.mockResolvedValue([member("u1")]);
+    api.delete.mockResolvedValue(undefined);
+
+    await SpaceService.shared.getRoster("space-1");
+    await SpaceService.shared.disbandSpace("space-1");
+    await SpaceService.shared.getRoster("space-1");
+
+    expect(api.get).toHaveBeenCalledTimes(2);
+  });
+
+  it("refetches after leaveSpace invalidates the roster", async () => {
+    api.get.mockResolvedValue([member("u1")]);
+    api.post.mockResolvedValue(undefined);
+
+    await SpaceService.shared.getRoster("space-1");
+    // 自己退出后名册里不该还有自己——与 removeMembers 对称。
+    await SpaceService.shared.leaveSpace("space-1");
     await SpaceService.shared.getRoster("space-1");
 
     expect(api.get).toHaveBeenCalledTimes(2);

--- a/packages/dmworkbase/src/Service/__tests__/SpaceService.members.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/SpaceService.members.test.ts
@@ -149,7 +149,26 @@ describe("SpaceService.getRoster", () => {
     const first = await SpaceService.shared.getRoster("space-1");
     const second = await SpaceService.shared.getRoster("space-1");
 
-    expect(second).toBe(first);
+    expect(second).toEqual(first);
+    expect(second).not.toBe(first);
+    expect(api.get).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not let one caller mutate the cached roster array", async () => {
+    api.get.mockResolvedValue([member("u1"), member("u2")]);
+
+    const first = await SpaceService.shared.getRoster("space-1");
+    first.reverse();
+    first.push(member("injected"));
+
+    await expect(SpaceService.shared.getRoster("space-1")).resolves.toEqual([
+      member("u1"),
+      member("u2"),
+    ]);
+    expect(SpaceService.shared.peekRoster("space-1")).toEqual([
+      member("u1"),
+      member("u2"),
+    ]);
     expect(api.get).toHaveBeenCalledTimes(1);
   });
 

--- a/packages/dmworkbase/src/Service/__tests__/SpaceService.members.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/SpaceService.members.test.ts
@@ -1,0 +1,184 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const api = vi.hoisted(() => ({ get: vi.fn(), put: vi.fn(), delete: vi.fn() }));
+
+vi.mock("../../App", () => ({
+  default: {
+    apiClient: { get: api.get, put: api.put, delete: api.delete },
+    shared: {},
+    loginInfo: {},
+  },
+}));
+
+import { SpaceService, type SpaceMember } from "../SpaceService";
+
+function member(uid: string): SpaceMember {
+  return {
+    uid,
+    name: uid,
+    avatar: "",
+    role: 3,
+    robot: 0,
+    created_at: "",
+  };
+}
+
+/** 造一页刚好等于 pageLimit 的返回，迫使分页循环继续。 */
+function fullPage(size: number): SpaceMember[] {
+  return Array.from({ length: size }, (_, i) => member(`u${i}`));
+}
+
+describe("SpaceService member pagination", () => {
+  beforeEach(() => {
+    api.get.mockReset();
+    api.put.mockReset();
+    api.delete.mockReset();
+    SpaceService.shared.invalidateRoster();
+  });
+
+  it("omits the request config when no signal is given", async () => {
+    api.get.mockResolvedValue([]);
+
+    await SpaceService.shared.getMembers("space-1", 2, 25);
+
+    expect(api.get).toHaveBeenCalledWith("space/space-1/members?page=2&limit=25");
+  });
+
+  it("forwards the cancellation signal to member requests", async () => {
+    const controller = new AbortController();
+    api.get.mockResolvedValue([]);
+
+    await SpaceService.shared.getMembers("space-1", 2, 25, controller.signal);
+
+    expect(api.get).toHaveBeenCalledWith(
+      "space/space-1/members?page=2&limit=25",
+      { signal: controller.signal }
+    );
+  });
+
+  it("stops paginating after the signal is aborted", async () => {
+    const controller = new AbortController();
+    api.get.mockImplementation(async () => {
+      controller.abort();
+      return [member("u1"), member("u2")];
+    });
+
+    await expect(
+      SpaceService.shared.getAllMembers("space-1", 2, 50, controller.signal)
+    ).rejects.toMatchObject({ name: "AbortError" });
+    expect(api.get).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps paginating until a short page arrives", async () => {
+    api.get
+      .mockResolvedValueOnce(fullPage(2))
+      .mockResolvedValueOnce([member("last")]);
+
+    const all = await SpaceService.shared.getAllMembers("space-1", 2, 50);
+
+    expect(api.get).toHaveBeenCalledTimes(2);
+    expect(all).toHaveLength(3);
+  });
+
+  it("returns an empty list without a request when spaceId is empty", async () => {
+    await expect(SpaceService.shared.getAllMembers("")).resolves.toEqual([]);
+    expect(api.get).not.toHaveBeenCalled();
+  });
+});
+
+describe("SpaceService.getRoster", () => {
+  beforeEach(() => {
+    api.get.mockReset();
+    api.put.mockReset();
+    api.delete.mockReset();
+    SpaceService.shared.invalidateRoster();
+  });
+
+  it("uses a page limit above the known 5760-member space", async () => {
+    api.get.mockResolvedValue([member("u1")]);
+
+    await SpaceService.shared.getRoster("space-1");
+
+    // getAllMembers 的默认 100×50 上限是 5000，会截断 5760 人的空间。
+    expect(api.get).toHaveBeenCalledWith("space/space-1/members?page=1&limit=10000");
+  });
+
+  it("serves repeat calls from cache within the ttl", async () => {
+    api.get.mockResolvedValue([member("u1")]);
+
+    const first = await SpaceService.shared.getRoster("space-1");
+    const second = await SpaceService.shared.getRoster("space-1");
+
+    expect(second).toBe(first);
+    expect(api.get).toHaveBeenCalledTimes(1);
+  });
+
+  it("collapses concurrent callers into a single request", async () => {
+    api.get.mockResolvedValue([member("u1")]);
+
+    await Promise.all([
+      SpaceService.shared.getRoster("space-1"),
+      SpaceService.shared.getRoster("space-1"),
+      SpaceService.shared.getRoster("space-1"),
+    ]);
+
+    expect(api.get).toHaveBeenCalledTimes(1);
+  });
+
+  it("caches per space so switching space refetches", async () => {
+    api.get.mockResolvedValue([member("u1")]);
+
+    await SpaceService.shared.getRoster("space-1");
+    await SpaceService.shared.getRoster("space-2");
+
+    expect(api.get).toHaveBeenCalledTimes(2);
+    expect(api.get).toHaveBeenNthCalledWith(1, "space/space-1/members?page=1&limit=10000");
+    expect(api.get).toHaveBeenNthCalledWith(2, "space/space-2/members?page=1&limit=10000");
+  });
+
+  it("refetches after removeMembers invalidates the roster", async () => {
+    api.get.mockResolvedValue([member("u1")]);
+    api.delete.mockResolvedValue(undefined);
+
+    await SpaceService.shared.getRoster("space-1");
+    await SpaceService.shared.removeMembers("space-1", ["u1"]);
+    await SpaceService.shared.getRoster("space-1");
+
+    expect(api.get).toHaveBeenCalledTimes(2);
+  });
+
+  it("refetches after updateMemberRole invalidates the roster", async () => {
+    api.get.mockResolvedValue([member("u1")]);
+    api.put.mockResolvedValue(undefined);
+
+    await SpaceService.shared.getRoster("space-1");
+    await SpaceService.shared.updateMemberRole("space-1", "u1", 2);
+    await SpaceService.shared.getRoster("space-1");
+
+    expect(api.get).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not cache a failed roster load", async () => {
+    api.get.mockRejectedValueOnce(new Error("boom"));
+
+    await expect(SpaceService.shared.getRoster("space-1")).rejects.toThrow("boom");
+    expect(SpaceService.shared.peekRoster("space-1")).toBeUndefined();
+
+    api.get.mockResolvedValue([member("u1")]);
+    await expect(SpaceService.shared.getRoster("space-1")).resolves.toHaveLength(1);
+  });
+
+  it("bypasses the cache when maxAgeMs is 0", async () => {
+    api.get.mockResolvedValue([member("u1")]);
+
+    await SpaceService.shared.getRoster("space-1");
+    await SpaceService.shared.getRoster("space-1", { maxAgeMs: 0 });
+
+    expect(api.get).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns an empty list without a request when spaceId is empty", async () => {
+    await expect(SpaceService.shared.getRoster("")).resolves.toEqual([]);
+    expect(api.get).not.toHaveBeenCalled();
+  });
+});

--- a/packages/dmworkbase/src/Utils/__tests__/asyncCache.test.ts
+++ b/packages/dmworkbase/src/Utils/__tests__/asyncCache.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createAsyncCache } from "../asyncCache";
+
+/** 手动控制 resolve/reject 时机，用于断言合流与取消语义。 */
+function deferred<T>() {
+    let resolve!: (v: T) => void;
+    let reject!: (e: unknown) => void;
+    const promise = new Promise<T>((res, rej) => {
+        resolve = res;
+        reject = rej;
+    });
+    return { promise, resolve, reject };
+}
+
+/** 可推进的假时钟，避免依赖真实计时器。 */
+function clock(start = 0) {
+    let t = start;
+    return {
+        now: () => t,
+        advance: (ms: number) => {
+            t += ms;
+        },
+    };
+}
+
+describe("createAsyncCache", () => {
+    it("serves a fresh hit without calling the loader again", async () => {
+        const time = clock();
+        const cache = createAsyncCache<string>({ ttlMs: 1000, now: time.now });
+        const loader = vi.fn(async () => "v1");
+
+        await expect(cache.get("k", loader)).resolves.toBe("v1");
+        time.advance(999);
+        await expect(cache.get("k", loader)).resolves.toBe("v1");
+
+        expect(loader).toHaveBeenCalledTimes(1);
+    });
+
+    it("reloads once the entry is older than the ttl", async () => {
+        const time = clock();
+        const cache = createAsyncCache<string>({ ttlMs: 1000, now: time.now });
+        const loader = vi.fn().mockResolvedValueOnce("v1").mockResolvedValueOnce("v2");
+
+        await cache.get("k", loader);
+        time.advance(1001);
+
+        await expect(cache.get("k", loader)).resolves.toBe("v2");
+        expect(loader).toHaveBeenCalledTimes(2);
+    });
+
+    it("rides concurrent callers along a single in-flight load", async () => {
+        const cache = createAsyncCache<string>({ ttlMs: 1000 });
+        const d = deferred<string>();
+        const loader = vi.fn(() => d.promise);
+
+        const a = cache.get("k", loader);
+        const b = cache.get("k", loader);
+        d.resolve("shared");
+
+        await expect(a).resolves.toBe("shared");
+        await expect(b).resolves.toBe("shared");
+        expect(loader).toHaveBeenCalledTimes(1);
+    });
+
+    it("keeps separate keys independent", async () => {
+        const cache = createAsyncCache<string>({ ttlMs: 1000 });
+        const loader = vi.fn(async (v: string) => v);
+
+        await cache.get("a", () => loader("a"));
+        await cache.get("b", () => loader("b"));
+
+        expect(cache.peek("a")).toBe("a");
+        expect(cache.peek("b")).toBe("b");
+    });
+
+    it("does not cache a failed load and retries on the next get", async () => {
+        const cache = createAsyncCache<string>({ ttlMs: 1000 });
+        const loader = vi
+            .fn()
+            .mockRejectedValueOnce(new Error("boom"))
+            .mockResolvedValueOnce("v1");
+
+        await expect(cache.get("k", loader)).rejects.toThrow("boom");
+        expect(cache.peek("k")).toBeUndefined();
+
+        await expect(cache.get("k", loader)).resolves.toBe("v1");
+        expect(loader).toHaveBeenCalledTimes(2);
+    });
+
+    it("propagates a rejection to every concurrent waiter", async () => {
+        const cache = createAsyncCache<string>({ ttlMs: 1000 });
+        const d = deferred<string>();
+        const loader = vi.fn(() => d.promise);
+
+        const a = cache.get("k", loader);
+        const b = cache.get("k", loader);
+        d.reject(new Error("boom"));
+
+        await expect(a).rejects.toThrow("boom");
+        await expect(b).rejects.toThrow("boom");
+        expect(loader).toHaveBeenCalledTimes(1);
+    });
+
+    it("discards the result of a load that was invalidated while in flight", async () => {
+        const cache = createAsyncCache<string>({ ttlMs: 1000 });
+        const d = deferred<string>();
+        const loader = vi.fn(() => d.promise);
+
+        const pending = cache.get("k", loader);
+        cache.invalidate("k");
+        d.resolve("stale");
+
+        // 等待方仍拿到该次返回值，但缓存不保留已知过期的数据。
+        await expect(pending).resolves.toBe("stale");
+        expect(cache.peek("k")).toBeUndefined();
+    });
+
+    it("discards an in-flight result after a keyless invalidate", async () => {
+        const cache = createAsyncCache<string>({ ttlMs: 1000 });
+        const d = deferred<string>();
+
+        const pending = cache.get("k", () => d.promise);
+        cache.invalidate();
+        d.resolve("stale");
+
+        await expect(pending).resolves.toBe("stale");
+        expect(cache.peek("k")).toBeUndefined();
+    });
+
+    it("drops cached entries on invalidate", async () => {
+        const cache = createAsyncCache<string>({ ttlMs: 1000 });
+        const loader = vi.fn().mockResolvedValueOnce("v1").mockResolvedValueOnce("v2");
+
+        await cache.get("k", loader);
+        cache.invalidate("k");
+
+        await expect(cache.get("k", loader)).resolves.toBe("v2");
+        expect(loader).toHaveBeenCalledTimes(2);
+    });
+
+    it("bypasses the cache when maxAgeMs is 0", async () => {
+        const cache = createAsyncCache<string>({ ttlMs: 1000 });
+        const loader = vi.fn().mockResolvedValueOnce("v1").mockResolvedValueOnce("v2");
+
+        await cache.get("k", loader);
+        await expect(cache.get("k", loader, { maxAgeMs: 0 })).resolves.toBe("v2");
+    });
+
+    it("rejects an aborted caller but still commits the shared load", async () => {
+        const cache = createAsyncCache<string>({ ttlMs: 1000 });
+        const d = deferred<string>();
+        const loader = vi.fn(() => d.promise);
+        const controller = new AbortController();
+
+        const cancelled = cache.get("k", loader, { signal: controller.signal });
+        const other = cache.get("k", loader);
+        controller.abort();
+
+        await expect(cancelled).rejects.toMatchObject({ name: "AbortError" });
+
+        d.resolve("v1");
+        // 取消一个等待方不影响其余等待方，底层加载照常填充缓存。
+        await expect(other).resolves.toBe("v1");
+        expect(cache.peek("k")).toBe("v1");
+        expect(loader).toHaveBeenCalledTimes(1);
+    });
+
+    it("rejects immediately when the signal is already aborted", async () => {
+        const cache = createAsyncCache<string>({ ttlMs: 1000 });
+        const loader = vi.fn(async () => "v1");
+        const controller = new AbortController();
+        controller.abort();
+
+        await expect(
+            cache.get("k", loader, { signal: controller.signal })
+        ).rejects.toMatchObject({ name: "AbortError" });
+        expect(loader).not.toHaveBeenCalled();
+    });
+});

--- a/packages/dmworkbase/src/Utils/__tests__/asyncCache.test.ts
+++ b/packages/dmworkbase/src/Utils/__tests__/asyncCache.test.ts
@@ -116,6 +116,27 @@ describe("createAsyncCache", () => {
         expect(cache.peek("k")).toBeUndefined();
     });
 
+    it("starts a fresh load for callers arriving after keyed invalidation", async () => {
+        const cache = createAsyncCache<string>({ ttlMs: 1000 });
+        const stale = deferred<string>();
+        const fresh = deferred<string>();
+        const loader = vi.fn()
+            .mockImplementationOnce(() => stale.promise)
+            .mockImplementationOnce(() => fresh.promise);
+
+        const existingWaiter = cache.get("k", loader);
+        cache.invalidate("k");
+        const postInvalidation = cache.get("k", loader);
+
+        expect(loader).toHaveBeenCalledTimes(2);
+        stale.resolve("stale");
+        fresh.resolve("fresh");
+
+        await expect(existingWaiter).resolves.toBe("stale");
+        await expect(postInvalidation).resolves.toBe("fresh");
+        expect(cache.peek("k")).toBe("fresh");
+    });
+
     it("discards an in-flight result after a keyless invalidate", async () => {
         const cache = createAsyncCache<string>({ ttlMs: 1000 });
         const d = deferred<string>();
@@ -126,6 +147,32 @@ describe("createAsyncCache", () => {
 
         await expect(pending).resolves.toBe("stale");
         expect(cache.peek("k")).toBeUndefined();
+    });
+
+    it("starts fresh loads after keyless invalidation", async () => {
+        const cache = createAsyncCache<string>({ ttlMs: 1000 });
+        const staleA = deferred<string>();
+        const staleB = deferred<string>();
+        const freshA = deferred<string>();
+        const loaderA = vi.fn()
+            .mockImplementationOnce(() => staleA.promise)
+            .mockImplementationOnce(() => freshA.promise);
+
+        const existingA = cache.get("a", loaderA);
+        const existingB = cache.get("b", () => staleB.promise);
+        cache.invalidate();
+        const postInvalidationA = cache.get("a", loaderA);
+
+        expect(loaderA).toHaveBeenCalledTimes(2);
+        staleA.resolve("stale-a");
+        staleB.resolve("stale-b");
+        freshA.resolve("fresh-a");
+
+        await expect(existingA).resolves.toBe("stale-a");
+        await expect(existingB).resolves.toBe("stale-b");
+        await expect(postInvalidationA).resolves.toBe("fresh-a");
+        expect(cache.peek("a")).toBe("fresh-a");
+        expect(cache.peek("b")).toBeUndefined();
     });
 
     it("drops cached entries on invalidate", async () => {
@@ -145,6 +192,27 @@ describe("createAsyncCache", () => {
 
         await cache.get("k", loader);
         await expect(cache.get("k", loader, { maxAgeMs: 0 })).resolves.toBe("v2");
+    });
+
+    it("clones mutable values for every get and peek", async () => {
+        const cache = createAsyncCache<string[]>({
+            ttlMs: 1000,
+            clone: (value) => [...value],
+        });
+        const loader = vi.fn(async () => ["a", "b"]);
+
+        const first = await cache.get("k", loader);
+        first.reverse();
+        first.push("injected");
+
+        const second = await cache.get("k", loader);
+        const peeked = cache.peek("k");
+
+        expect(second).toEqual(["a", "b"]);
+        expect(peeked).toEqual(["a", "b"]);
+        expect(second).not.toBe(first);
+        expect(peeked).not.toBe(second);
+        expect(loader).toHaveBeenCalledTimes(1);
     });
 
     it("rejects an aborted caller but still commits the shared load", async () => {

--- a/packages/dmworkbase/src/Utils/asyncCache.ts
+++ b/packages/dmworkbase/src/Utils/asyncCache.ts
@@ -14,8 +14,14 @@
  *     天然 miss，无需监听 `space-changed`，也无需在 Service 层 import WKApp。
  */
 
-/** 调用方传入的取消信号被触发时抛出的错误。名字对齐 DOMException 的约定。 */
-function abortError(): Error {
+/**
+ * 调用方传入的取消信号被触发时抛出的错误。名字对齐 DOMException 的约定。
+ *
+ * 导出供 Service 层复用：axios 取消后经 APIClient 包装成 `ERR_CANCELED`，而
+ * `normalizeApiError`（apiError.ts）只归类 `ECONNABORTED` / `ERR_NETWORK`，
+ * 取消会退化成「未知错误」。转发 signal 的 Service 需要把它翻译回 AbortError。
+ */
+export function abortError(): Error {
     const err = new Error("Aborted");
     err.name = "AbortError";
     return err;
@@ -59,7 +65,13 @@ export interface AsyncCacheOptions {
 }
 
 export interface AsyncCacheGetOptions {
-    /** 本次可接受的最大陈旧时长（严格小于才算命中）；省略则用 `ttlMs`，传 0 强制绕过缓存。 */
+    /**
+     * 本次可接受的最大陈旧时长（严格小于才算命中）；省略则用 `ttlMs`。
+     *
+     * 传 0 会跳过任何已完成的缓存值，但**仍会合流到正在进行的加载**——否则并发
+     * 的「强制刷新」会各自打一个请求。要真正拿到一次独立的新请求，请先
+     * `invalidate(key)` 再 get。
+     */
     maxAgeMs?: number;
     /** 取消本次等待（不影响底层加载与其他等待方）。 */
     signal?: AbortSignal;

--- a/packages/dmworkbase/src/Utils/asyncCache.ts
+++ b/packages/dmworkbase/src/Utils/asyncCache.ts
@@ -1,0 +1,157 @@
+/**
+ * 通用异步缓存原语：TTL + 并发合流 + 代际守卫。
+ *
+ * 解决的问题：同一份远端数据在一次会话内被多处重复拉取。典型例子是
+ * `space/{id}/members`——它被转发面板、通讯录、Chat 侧栏、docs 成员选择器
+ * 以及企业模块各自调用，彼此不共享结果。
+ *
+ * 刻意不做的事：
+ *   - 不持久化（不落 IndexedDB / localStorage）。TTL 是秒级量级，数据活不过
+ *     一次刷新，持久化只会换来 schema 迁移、跨标签页一致性和把人员名册落盘的
+ *     隐私面。全仓库唯一用 IndexedDB 的是 docs 离线编辑，那是真需要跨会话。
+ *   - 不缓存失败。loader reject 时条目不写入，下次 get 会重新尝试。
+ *   - 不读全局状态。key 由调用方给（对 Space 数据就用 spaceId），所以切 Space
+ *     天然 miss，无需监听 `space-changed`，也无需在 Service 层 import WKApp。
+ */
+
+/** 调用方传入的取消信号被触发时抛出的错误。名字对齐 DOMException 的约定。 */
+function abortError(): Error {
+    const err = new Error("Aborted");
+    err.name = "AbortError";
+    return err;
+}
+
+/**
+ * 把 `signal` 挂到一个已经在跑的 promise 上。
+ *
+ * 关键语义：signal 只中止**调用方自己的等待**，不中止底层加载。因为同一次加载
+ * 可能有多个等待方合流，其中一方取消不该让其余等待方拿到 AbortError；底层请求
+ * 继续跑完并正常填充缓存，后来者仍能命中。
+ */
+function withAbort<T>(promise: Promise<T>, signal?: AbortSignal): Promise<T> {
+    if (!signal) {
+        return promise;
+    }
+    if (signal.aborted) {
+        return Promise.reject(abortError());
+    }
+    return new Promise<T>((resolve, reject) => {
+        const onAbort = () => reject(abortError());
+        signal.addEventListener("abort", onAbort, { once: true });
+        promise.then(
+            (value) => {
+                signal.removeEventListener("abort", onAbort);
+                resolve(value);
+            },
+            (err) => {
+                signal.removeEventListener("abort", onAbort);
+                reject(err);
+            }
+        );
+    });
+}
+
+export interface AsyncCacheOptions {
+    /** 条目默认存活时长（毫秒）。单次 get 可用 `maxAgeMs` 覆盖。 */
+    ttlMs: number;
+    /** 时间源，仅为测试注入；默认 `Date.now`。 */
+    now?: () => number;
+}
+
+export interface AsyncCacheGetOptions {
+    /** 本次可接受的最大陈旧时长（严格小于才算命中）；省略则用 `ttlMs`，传 0 强制绕过缓存。 */
+    maxAgeMs?: number;
+    /** 取消本次等待（不影响底层加载与其他等待方）。 */
+    signal?: AbortSignal;
+}
+
+export interface AsyncCache<V> {
+    /**
+     * 取值：新鲜命中直接返回；否则调 `loader`。同一 key 的并发调用只会触发一次
+     * `loader`，其余调用合流到同一个 promise。
+     */
+    get(key: string, loader: () => Promise<V>, options?: AsyncCacheGetOptions): Promise<V>;
+    /** 同步读已缓存值，不触发加载，不判新鲜度。用于渲染首帧兜底。 */
+    peek(key: string): V | undefined;
+    /**
+     * 失效。传 key 只失效该条；不传清空全部。
+     *
+     * 对 in-flight 的加载同样生效：失效时被推进的代际会让那次加载的结果**不被
+     * 提交**（等待方仍拿到该次返回值，但缓存不留下已知过期的数据）。写操作后
+     * 调用它，避免 TTL 窗口内读到自己刚改掉的旧值。
+     */
+    invalidate(key?: string): void;
+}
+
+export function createAsyncCache<V>(options: AsyncCacheOptions): AsyncCache<V> {
+    const { ttlMs } = options;
+    const now = options.now ?? (() => Date.now());
+
+    const entries = new Map<string, { value: V; at: number }>();
+    const inflight = new Map<string, Promise<V>>();
+    // 每个 key 一个代际计数。invalidate 时 +1，加载完成时比对——不等就丢弃写入。
+    const generations = new Map<string, number>();
+
+    return {
+        get(key, loader, getOptions) {
+            // 入口短路：已取消就不要启动加载，否则 `signal` 形同虚设。
+            if (getOptions?.signal?.aborted) {
+                return Promise.reject(abortError());
+            }
+
+            const maxAge = getOptions?.maxAgeMs ?? ttlMs;
+            const hit = entries.get(key);
+            // 严格小于：`maxAgeMs: 0` 必须总是 miss（刚写入的条目 age 也是 0）。
+            if (hit && now() - hit.at < maxAge) {
+                return withAbort(Promise.resolve(hit.value), getOptions?.signal);
+            }
+
+            const existing = inflight.get(key);
+            if (existing) {
+                return withAbort(existing, getOptions?.signal);
+            }
+
+            const startedAt = generations.get(key) ?? 0;
+            // `tracked` 在两个回调真正执行前就已赋值（它们都是异步的），所以
+            // finally 里的自引用是安全的。
+            let tracked: Promise<V>;
+            tracked = loader()
+                .then((value) => {
+                    if ((generations.get(key) ?? 0) === startedAt) {
+                        entries.set(key, { value, at: now() });
+                    }
+                    return value;
+                })
+                .finally(() => {
+                    // 只清自己那条，避免误删后续已经重开的加载。
+                    if (inflight.get(key) === tracked) {
+                        inflight.delete(key);
+                    }
+                });
+            inflight.set(key, tracked);
+            return withAbort(tracked, getOptions?.signal);
+        },
+
+        peek(key) {
+            return entries.get(key)?.value;
+        },
+
+        invalidate(key) {
+            if (key === undefined) {
+                entries.clear();
+                for (const k of generations.keys()) {
+                    generations.set(k, (generations.get(k) ?? 0) + 1);
+                }
+                // in-flight 的 key 可能还没进 generations，补上代际推进。
+                for (const k of inflight.keys()) {
+                    if (!generations.has(k)) {
+                        generations.set(k, 1);
+                    }
+                }
+                return;
+            }
+            entries.delete(key);
+            generations.set(key, (generations.get(key) ?? 0) + 1);
+        },
+    };
+}

--- a/packages/dmworkbase/src/Utils/asyncCache.ts
+++ b/packages/dmworkbase/src/Utils/asyncCache.ts
@@ -15,16 +15,20 @@
  */
 
 /**
- * 调用方传入的取消信号被触发时抛出的错误。名字对齐 DOMException 的约定。
+ * 调用方传入的取消信号被触发时抛出的错误。
+ *
+ * 用 DOMException 而非 `new Error()` 改 name：仓库里已有多处消费方以
+ * `err instanceof DOMException && err.name === "AbortError"` 判取消
+ * （dmworkskillmarket/src/hooks/useSkills.ts、dmworkmcp 的 McpMarketListPage
+ * 等），普通 Error 不会命中那些 instanceof 检查。构造方式对齐
+ * dmworkmcp/src/api/mcpService.ts:920。
  *
  * 导出供 Service 层复用：axios 取消后经 APIClient 包装成 `ERR_CANCELED`，而
  * `normalizeApiError`（apiError.ts）只归类 `ECONNABORTED` / `ERR_NETWORK`，
  * 取消会退化成「未知错误」。转发 signal 的 Service 需要把它翻译回 AbortError。
  */
-export function abortError(): Error {
-    const err = new Error("Aborted");
-    err.name = "AbortError";
-    return err;
+export function abortError(): DOMException {
+    return new DOMException("Aborted", "AbortError");
 }
 
 /**
@@ -57,9 +61,16 @@ function withAbort<T>(promise: Promise<T>, signal?: AbortSignal): Promise<T> {
     });
 }
 
-export interface AsyncCacheOptions {
+export interface AsyncCacheOptions<V> {
     /** 条目默认存活时长（毫秒）。单次 get 可用 `maxAgeMs` 覆盖。 */
     ttlMs: number;
+    /**
+     * 每次交付前复制缓存值。**强烈建议为可变值（数组/对象）传入。**
+     *
+     * 不传时 `get` / `peek` 交付的是同一个引用：任一消费方就地 sort/splice 会
+     * 污染之后所有读者，而且故障现场离本文件很远。数组传 `(v) => [...v]` 即可。
+     */
+    clone?: (value: V) => V;
     /** 时间源，仅为测试注入；默认 `Date.now`。 */
     now?: () => number;
 }
@@ -70,7 +81,7 @@ export interface AsyncCacheGetOptions {
      *
      * 传 0 会跳过任何已完成的缓存值，但**仍会合流到正在进行的加载**——否则并发
      * 的「强制刷新」会各自打一个请求。要真正拿到一次独立的新请求，请先
-     * `invalidate(key)` 再 get。
+     * `invalidate(key)` 再 get：invalidate 会把在飞的加载移出可合流集合。
      */
     maxAgeMs?: number;
     /** 取消本次等待（不影响底层加载与其他等待方）。 */
@@ -89,20 +100,27 @@ export interface AsyncCache<V> {
      * 失效。传 key 只失效该条；不传清空全部。
      *
      * 对 in-flight 的加载同样生效：失效时被推进的代际会让那次加载的结果**不被
-     * 提交**（等待方仍拿到该次返回值，但缓存不留下已知过期的数据）。写操作后
-     * 调用它，避免 TTL 窗口内读到自己刚改掉的旧值。
+     * 提交**，同时将它移出可合流集合。已有等待方仍拿到该次返回值，但失效后的
+     * 新调用会启动新加载。写操作后调用它，避免读到自己刚改掉的旧值。
      */
     invalidate(key?: string): void;
 }
 
-export function createAsyncCache<V>(options: AsyncCacheOptions): AsyncCache<V> {
-    const { ttlMs } = options;
+export function createAsyncCache<V>(options: AsyncCacheOptions<V>): AsyncCache<V> {
+    const { clone, ttlMs } = options;
     const now = options.now ?? (() => Date.now());
 
     const entries = new Map<string, { value: V; at: number }>();
     const inflight = new Map<string, Promise<V>>();
     // 每个 key 一个代际计数。invalidate 时 +1，加载完成时比对——不等就丢弃写入。
     const generations = new Map<string, number>();
+
+    const deliver = (promise: Promise<V>, signal?: AbortSignal): Promise<V> => {
+        const value = withAbort(promise, signal);
+        return clone ? value.then(clone) : value;
+    };
+
+    const copy = (value: V): V => clone ? clone(value) : value;
 
     return {
         get(key, loader, getOptions) {
@@ -115,12 +133,12 @@ export function createAsyncCache<V>(options: AsyncCacheOptions): AsyncCache<V> {
             const hit = entries.get(key);
             // 严格小于：`maxAgeMs: 0` 必须总是 miss（刚写入的条目 age 也是 0）。
             if (hit && now() - hit.at < maxAge) {
-                return withAbort(Promise.resolve(hit.value), getOptions?.signal);
+                return deliver(Promise.resolve(hit.value), getOptions?.signal);
             }
 
             const existing = inflight.get(key);
             if (existing) {
-                return withAbort(existing, getOptions?.signal);
+                return deliver(existing, getOptions?.signal);
             }
 
             const startedAt = generations.get(key) ?? 0;
@@ -141,11 +159,12 @@ export function createAsyncCache<V>(options: AsyncCacheOptions): AsyncCache<V> {
                     }
                 });
             inflight.set(key, tracked);
-            return withAbort(tracked, getOptions?.signal);
+            return deliver(tracked, getOptions?.signal);
         },
 
         peek(key) {
-            return entries.get(key)?.value;
+            const value = entries.get(key)?.value;
+            return value === undefined ? undefined : copy(value);
         },
 
         invalidate(key) {
@@ -160,10 +179,13 @@ export function createAsyncCache<V>(options: AsyncCacheOptions): AsyncCache<V> {
                         generations.set(k, 1);
                     }
                 }
+                // 已有等待方仍持有原 promise；这里只阻止失效后的调用继续合流。
+                inflight.clear();
                 return;
             }
             entries.delete(key);
             generations.set(key, (generations.get(key) ?? 0) + 1);
+            inflight.delete(key);
         },
     };
 }

--- a/packages/dmworkbase/src/index.tsx
+++ b/packages/dmworkbase/src/index.tsx
@@ -65,6 +65,7 @@ export { NotificationUtil, notificationUtil } from './Utils/NotificationUtil'
 export * from './Utils/NotificationUtil'
 export * from './Utils/clipboard'
 export * from './Utils/docLink'
+export * from './Utils/asyncCache'
 export * from './features/documentTitle'
 export * from './features/notifications'
 


### PR DESCRIPTION
## 问题

`GET space/{id}/members` 是开源 Web 与私有模块共同依赖的 Space 成员名册接口。目前开源仓库中有 **6 处独立调用，彼此不共享缓存**：

| 调用点 | 形态 | 请求数 |
|---|---|---|
| `dmworkdatasource/src/datasource.ts:668` `contactsSync` | `page=1&limit=10000` | 1 |
| `dmworkdatasource/src/datasource.ts:748` `searchFriends` | `page=1&limit=10000` | 1 |
| `dmworkbase/src/Pages/Chat/vm.ts:139` `loadSpaceMembers` | `getMembers(spaceId,1,10000)` | 1 |
| `dmworkcontacts/src/Contacts/index.tsx:350` | 自建循环 `10000 x 20` | N |
| `docs/src/octoweb/index.ts:186` `fetchAllSpaceMembers` | `10000 x 20` | N |
| `SpaceService.getAllMembers` | `page=N&limit=100` x <=50 | N |

同一份数据在一次会话内会被反复拉取，`APIClient`、datasource 和现有 `getAllMembers` 均没有共享 dedupe/TTL。

## 能力边界

- Space 名册属于开源和私有模块共同使用的公共能力，因此统一封装在开源 `@octo/base` 的 `SpaceService` 中。
- 私有 Loop 模块后续直接调用 `SpaceService.getRoster`，不再重复拼 Space 成员接口或维护第二套名册缓存。
- Loop 独有的 workspace、agent、squad、project 等接口仍留在私有模块，本 PR 不将其上移到开源仓库。

## 本 PR 做什么

只提供后续迁移所需的公共能力，**不改动任何既有调用点**。

- **`Utils/asyncCache.ts`** - TTL、并发合流、代际守卫及按需防御性复制。
  - 纯内存，失败不入缓存。
  - key 由调用方提供；Space 数据按 `spaceId` 隔离。
  - `invalidate` 会推进代际并移除旧 in-flight 合流入口：已有等待者可完成，失效后的新调用会启动新 loader，旧结果不会重新写入缓存。
  - 可变值可配置 `clone`；Roster 为每个 `get`/`peek` 调用返回独立数组，避免一个消费方原地 `sort`/`splice` 污染其他消费方。
- **公共导出** - `createAsyncCache`、`abortError` 及相关类型从 `@octo/base` barrel 导出，供下游模块复用。
- **`SpaceService.getMembers` / `getAllMembers`** - 增加可选尾参 `signal`。请求取消统一抛标准 `DOMException("Aborted", "AbortError")`，不返回半份名册。
- **`SpaceService.getRoster`** - 带 30 秒 TTL 的全量名册入口，并提供 `peekRoster` / `invalidateRoster`。
- **写后失效** - `leaveSpace` / `removeMembers` / `updateMemberRole` / `disbandSpace` 成功后主动失效。

## 一个值得注意的上限问题

`getRoster` 使用 `10000 x 20`，而不是 `getAllMembers` 默认的 `100 x 50`。后者最多返回 5000 人，低于已知的 5760 人空间；`packages/docs/src/octoweb/index.ts:113-118` 记录过该截断问题。

## 不做什么

- 不迁移现有调用点；迁移拆到后续 PR。
- 不把 Loop 独有接口放进开源 `SpaceService`。
- 不碰 `group/my?limit=100000`，该接口需要后端分页/搜索支持。
- 不重写 `ForwardModal` / `useForwardCandidates` 的业务合并逻辑。

## 兼容性

既有方法签名只增加可选参数。新增方法和工具均为加法，不改变现有调用方行为。

## 验证

```bash
pnpm --dir packages/dmworkbase exec vitest run
# 278 test files / 2410 tests passed

pnpm --filter @octo/web build
# passed
```

两个新增测试文件共 **35 个用例**，覆盖 TTL、并发合流、失败重试、keyed/keyless in-flight 失效后重新加载、取消隔离、标准 AbortError、按 Space 分 key、写后失效、`maxAgeMs: 0`、10000 page limit，以及调用方修改数组不会污染缓存。
