### PR TITLE
feat(docs): live New Slides create flow with four-template picker (html_ppt)

### DIFF
--- a/packages/docs/src/config.ts
+++ b/packages/docs/src/config.ts
@@ -178,6 +178,19 @@ export const FONT_FAMILY_ENABLED = envOr(import.meta.env?.VITE_DOCS_FONT_FAMILY,
  */
 export const LINE_SPACING_ENABLED = envOr(import.meta.env?.VITE_DOCS_LINE_SPACING, 'true') === 'true'
 
+/**
+ * Feature flag for the live "New slides" create + four-template picker (R2-F1, XIN-1495).
+ *
+ * R1 (XIN-1501) shipped the html_ppt entry + routing shell only; the caret-menu "New slides" item
+ * opened a "coming soon" notice. R2-F1 replaces that notice with the real template picker that
+ * POSTs to `/api/v1/ppt/docs`. This flag gates ONLY that upgrade — it never touches the html_ppt
+ * routing / read-only view, so an OFF build cleanly falls back to the R1 coming-soon notice with no
+ * regression to the R1 entry, filter, or no-fallthrough routing. DEFAULT ON now that the R2-B1
+ * backend (`POST /api/v1/ppt/docs` + 4 templates + atomic idempotent create) is merged upstream; an
+ * explicit `VITE_DOCS_PPT_CREATE=false` build restores the coming-soon behaviour (rollback intact).
+ */
+export const PPT_CREATE_ENABLED = envOr(import.meta.env?.VITE_DOCS_PPT_CREATE, 'true') === 'true'
+
 // ── Default document addressing (frontend-design §7.2) ───────────────────────
 //
 // The docs-backend currently exposes only per-doc endpoints (`/docs/:docId/...`)

--- a/packages/docs/src/i18n/en-US.json
+++ b/packages/docs/src/i18n/en-US.json
@@ -885,7 +885,37 @@
     "createComingSoon": "Slides (Bento PPT) creation is coming soon.",
     "createComingSoonOk": "Got it",
     "viewTitle": "Slides",
-    "previewComingSoon": "Slides preview is coming soon."
+    "previewComingSoon": "Slides preview is coming soon.",
+    "create": {
+      "title": "New slides",
+      "templateLabel": "Choose a template",
+      "titleLabel": "Title",
+      "titlePlaceholder": "Untitled slides",
+      "titleTooLong": "The title is too long.",
+      "submit": "Create",
+      "cancel": "Cancel",
+      "loading": "Creating…",
+      "error": "Couldn't create the slides. Please try again.",
+      "validationError": "Please check the title and template, then try again."
+    },
+    "template": {
+      "blank": {
+        "name": "Blank",
+        "desc": "Start from scratch"
+      },
+      "pitch": {
+        "name": "Pitch",
+        "desc": "Investor and sales pitch decks"
+      },
+      "report": {
+        "name": "Report",
+        "desc": "Weekly and quarterly data reports"
+      },
+      "lesson": {
+        "name": "Lesson",
+        "desc": "Courseware and teaching slides"
+      }
+    }
   },
   "onboarding": {
     "helpTitle": "Agent CLI onboarding help",

--- a/packages/docs/src/i18n/en-US.json
+++ b/packages/docs/src/i18n/en-US.json
@@ -896,7 +896,8 @@
       "cancel": "Cancel",
       "loading": "Creating…",
       "error": "Couldn't create the slides. Please try again.",
-      "validationError": "Please check the title and template, then try again."
+      "validationError": "Please check the title and template, then try again.",
+      "unavailable": "The slides were created but can't be opened from here. Please contact support."
     },
     "template": {
       "blank": {

--- a/packages/docs/src/i18n/zh-CN.json
+++ b/packages/docs/src/i18n/zh-CN.json
@@ -896,7 +896,8 @@
       "cancel": "取消",
       "loading": "创建中…",
       "error": "创建幻灯片失败，请重试。",
-      "validationError": "请检查标题和模板后重试。"
+      "validationError": "请检查标题和模板后重试。",
+      "unavailable": "幻灯片已创建，但无法在此打开，请联系管理员。"
     },
     "template": {
       "blank": {

--- a/packages/docs/src/i18n/zh-CN.json
+++ b/packages/docs/src/i18n/zh-CN.json
@@ -885,7 +885,37 @@
     "createComingSoon": "幻灯片（Bento PPT）创建即将上线，敬请期待。",
     "createComingSoonOk": "知道了",
     "viewTitle": "幻灯片",
-    "previewComingSoon": "幻灯片预览即将上线。"
+    "previewComingSoon": "幻灯片预览即将上线。",
+    "create": {
+      "title": "新建幻灯片",
+      "templateLabel": "选择模板",
+      "titleLabel": "标题",
+      "titlePlaceholder": "无标题幻灯片",
+      "titleTooLong": "标题过长。",
+      "submit": "创建",
+      "cancel": "取消",
+      "loading": "创建中…",
+      "error": "创建幻灯片失败，请重试。",
+      "validationError": "请检查标题和模板后重试。"
+    },
+    "template": {
+      "blank": {
+        "name": "空白",
+        "desc": "从零开始"
+      },
+      "pitch": {
+        "name": "路演",
+        "desc": "融资与对外演示"
+      },
+      "report": {
+        "name": "汇报",
+        "desc": "周报季报数据汇报"
+      },
+      "lesson": {
+        "name": "课程",
+        "desc": "教学讲义与课件"
+      }
+    }
   },
   "onboarding": {
     "helpTitle": "Agent CLI 上手帮助",

--- a/packages/docs/src/pages/DocsHome.pptFlagOff.test.tsx
+++ b/packages/docs/src/pages/DocsHome.pptFlagOff.test.tsx
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, waitFor, cleanup, fireEvent } from '@testing-library/react'
+import { setWKApp } from '../octoweb/index.ts'
+import { createMockWKApp } from '../octoweb/mock.ts'
+
+// ── R2-F1 P2-4: the PPT_CREATE_ENABLED rollback branch has coverage ──────────
+// The flag is read once at module scope in config.ts. With it OFF, DocsHome must fall back to the R1
+// "coming soon" notice (an acceptance item) and must NOT mount the live four-template picker — that
+// is the emergency rollback path, and it was previously untested. This file mocks config.ts with the
+// flag OFF (keeping every other config export real via importActual) so the whole file exercises the
+// OFF build without disturbing the flag-ON assertions in DocsHome.test.tsx.
+vi.mock('../config.ts', async () => {
+  const actual = await vi.importActual<typeof import('../config.ts')>('../config.ts')
+  return { ...actual, PPT_CREATE_ENABLED: false }
+})
+
+// Heavy child boundaries replaced with markers (same rationale as DocsHome.test.tsx): the editor /
+// board / sheet / html / ppt shells pull Tiptap/Yjs/Univer/WebSocket runtimes we do not need for a
+// list-only render.
+vi.mock('../editor/EditorShell.tsx', () => ({
+  EditorShell: (props: { docId: string }) => <div data-testid="editor-shell">{props.docId}</div>,
+}))
+vi.mock('../board/BoardSession.tsx', () => ({
+  BoardSession: (props: { docId: string }) => <div data-testid="board-shell">{props.docId}</div>,
+}))
+vi.mock('../sheet/SheetView.tsx', () => ({
+  SheetView: (props: { docId: string }) => <div data-testid="sheet-view">{props.docId}</div>,
+}))
+vi.mock('../html/HtmlDocView.tsx', () => ({
+  HtmlDocView: (props: { docId: string }) => <div data-testid="html-doc-view">{props.docId}</div>,
+}))
+vi.mock('../ppt/PptDocView.tsx', () => ({
+  PptDocView: (props: { docId: string }) => <div data-testid="ppt-doc-view">{props.docId}</div>,
+}))
+vi.mock('../html-create/DocsBotConversation.tsx', () => ({
+  DocsBotConversation: () => <div data-testid="bot-chat" />,
+}))
+
+// Imported AFTER the config mock is registered so DocsHome closes over the OFF flag.
+import { DocsHome } from './DocsHome.tsx'
+
+const realLocation = window.location
+
+describe('DocsHome — PPT_CREATE_ENABLED OFF (R1 coming-soon rollback, P2-4)', () => {
+  beforeEach(() => {
+    window.sessionStorage.clear()
+    window.localStorage.clear()
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      writable: true,
+      value: { search: '', assign: vi.fn() },
+    })
+    vi.spyOn(window.history, 'replaceState').mockImplementation(() => {})
+    vi.spyOn(window.history, 'pushState').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    cleanup()
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      writable: true,
+      value: realLocation,
+    })
+    vi.restoreAllMocks()
+    window.sessionStorage.clear()
+  })
+
+  it('opens the R1 "coming soon" notice — never the live template picker — when the flag is OFF', async () => {
+    const wk = createMockWKApp()
+    wk.apiClient.responder = (method: string, url: string) => {
+      if (method === 'get' && url.startsWith('/docs')) return { data: { total: 0, items: [] }, status: 200 }
+      return { data: {}, status: 200 }
+    }
+    setWKApp(wk)
+
+    render(<DocsHome />)
+
+    // Open the split "New" dropdown and choose "New slides".
+    fireEvent.click(screen.getByLabelText('docs.list.newMenu'))
+    fireEvent.click(screen.getByText('docs.list.newPpt'))
+
+    // Flag OFF → the coming-soon notice shows and the create endpoint is never hit.
+    await waitFor(() => expect(screen.getByText('docs.ppt.createComingSoon')).toBeTruthy())
+    // The live picker (radiogroup of four template cards) must NOT render.
+    expect(screen.queryByRole('radiogroup')).toBeNull()
+    expect(screen.queryAllByRole('radio')).toHaveLength(0)
+    // Nothing is created server-side either.
+    expect(wk.apiClient.calls.some((c) => c.method === 'post' && c.url === '/ppt/docs')).toBe(false)
+  })
+})

--- a/packages/docs/src/pages/DocsHome.test.tsx
+++ b/packages/docs/src/pages/DocsHome.test.tsx
@@ -1436,7 +1436,7 @@ describe('DocsHome — sheet open path restored (XIN-520)', () => {
     expect(screen.queryByTestId('editor-shell')).toBeNull()
   })
 
-  it('shows the "new slides" caret-menu entry that opens the R1 coming-soon notice without creating a doc', async () => {
+  it('shows the "new slides" caret-menu entry that opens the R2 template picker without precreating a doc', async () => {
     const wk = createMockWKApp()
     setWKApp(wk)
     const calls: Array<{ method: string; url: string }> = []
@@ -1454,12 +1454,15 @@ describe('DocsHome — sheet open path restored (XIN-520)', () => {
     fireEvent.click(screen.getByLabelText('docs.list.newMenu'))
     fireEvent.click(screen.getByText('docs.list.newPpt'))
 
-    // R1: a "coming soon" notice appears — no doc is created and no editor/PPT surface opens.
-    await waitFor(() => expect(screen.getByText('docs.ppt.createComingSoon')).toBeTruthy())
+    // R2 (flag ON): the four-template picker opens — no doc is created and no editor/PPT surface
+    // opens (the deck is minted only on submit, via POST /api/v1/ppt/docs, never here).
+    await waitFor(() => expect(screen.getByRole('radiogroup')).toBeTruthy())
+    expect(screen.getAllByRole('radio')).toHaveLength(4)
     expect(screen.queryByTestId('editor-shell')).toBeNull()
     expect(screen.queryByTestId('ppt-doc-view')).toBeNull()
-    // The entry must NOT call createDoc (a Bento deck is never minted through the rich-doc path).
+    // Opening the picker must NOT call createDoc or the ppt create endpoint — nothing is precreated.
     expect(calls.some((c) => c.method === 'post' && c.url === '/docs')).toBe(false)
+    expect(calls.some((c) => c.method === 'post' && c.url === '/ppt/docs')).toBe(false)
   })
 
   it('re-pushes an open html doc WITH its slug when the docs nav menu is re-activated', async () => {

--- a/packages/docs/src/pages/DocsHome.test.tsx
+++ b/packages/docs/src/pages/DocsHome.test.tsx
@@ -1531,6 +1531,70 @@ describe('DocsHome — sheet open path restored (XIN-520)', () => {
     await waitFor(() => expect(document.activeElement).toBe(caret))
   })
 
+  // ── R2-F1 P1-1: open-redirect — a backend editorUrl is gated before navigation ─────────────
+  // onPptCreated fed window.location.assign the backend editorUrl after only an emptiness check, so
+  // a compromised/misbehaving backend could bounce the user to a `javascript:` or cross-origin URL.
+  // The create flow now runs the returned route through the repo's same-origin guard before assign.
+  it('R2-F1 P1-1: does NOT navigate when the backend returns an unsafe (cross-origin) editorUrl', async () => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      writable: true,
+      value: { origin: 'https://app.example.com', search: '', assign: assignSpy },
+    })
+    const wk = createMockWKApp()
+    wk.apiClient.responder = (method: string, url: string) => {
+      if (method === 'get' && url.startsWith('/docs')) return { data: { total: 0, items: [] }, status: 200 }
+      // A hostile absolute cross-origin route — must be rejected, never navigated to.
+      if (method === 'post' && url === '/ppt/docs') {
+        return { data: { data: { editorUrl: 'https://evil.example.com/steal' } }, status: 201 }
+      }
+      return { data: {}, status: 200 }
+    }
+    setWKApp(wk)
+
+    render(<DocsHome />)
+    await openPickerFromCaretMenu()
+    fireEvent.change(screen.getByLabelText('docs.ppt.create.titleLabel'), {
+      target: { value: 'My deck' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'docs.ppt.create.submit' }))
+
+    // The create round-trip completes, but the unsafe route is refused: no navigation happens and
+    // the picker stays open with an inline error (retriable), never a silent soft-lock.
+    await waitFor(() =>
+      expect(wk.apiClient.calls.some((c) => c.method === 'post' && c.url === '/ppt/docs')).toBe(true),
+    )
+    await waitFor(() => expect(screen.getByText('docs.ppt.create.error')).toBeTruthy())
+    expect(assignSpy).not.toHaveBeenCalled()
+    expect(screen.getByRole('dialog')).toBeTruthy()
+  })
+
+  it('R2-F1 P1-1: navigates for a safe same-origin editorUrl (happy path preserved)', async () => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      writable: true,
+      value: { origin: 'https://app.example.com', search: '', assign: assignSpy },
+    })
+    const wk = createMockWKApp()
+    wk.apiClient.responder = (method: string, url: string) => {
+      if (method === 'get' && url.startsWith('/docs')) return { data: { total: 0, items: [] }, status: 200 }
+      if (method === 'post' && url === '/ppt/docs') {
+        return { data: { data: { editorUrl: '/ppt/d/new_deck' } }, status: 201 }
+      }
+      return { data: {}, status: 200 }
+    }
+    setWKApp(wk)
+
+    render(<DocsHome />)
+    await openPickerFromCaretMenu()
+    fireEvent.change(screen.getByLabelText('docs.ppt.create.titleLabel'), {
+      target: { value: 'My deck' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'docs.ppt.create.submit' }))
+
+    await waitFor(() => expect(assignSpy).toHaveBeenCalledWith('/ppt/d/new_deck'))
+  })
+
   it('re-pushes an open html doc WITH its slug when the docs nav menu is re-activated', async () => {
     // Repro of the "open html → click the 文档 nav button → 出错了" bug: the nav-reactivation
     // re-push must carry octoDocSlug, else HtmlDocView falls back to docId and 404s against octo-doc.

--- a/packages/docs/src/pages/DocsHome.test.tsx
+++ b/packages/docs/src/pages/DocsHome.test.tsx
@@ -1465,6 +1465,72 @@ describe('DocsHome — sheet open path restored (XIN-520)', () => {
     expect(calls.some((c) => c.method === 'post' && c.url === '/ppt/docs')).toBe(false)
   })
 
+  // ── R2-F1: focus returns to the PERSISTENT caret after the picker closes ───
+  // Drives the REAL wiring — DocsList caret → dropdown menu → 新建幻灯片 menu item → CreatePptModal →
+  // close — not a hand-focused trigger. This is the path the previous CreatePptModal unit tests never
+  // exercised: they mounted a persistent trigger and focused it directly, so restore always "worked",
+  // while the real app captured `document.activeElement` — the dropdown menu item, which UNMOUNTS the
+  // instant it is clicked (the menu closes as it opens the modal). Restoring to that detached node
+  // silently no-ops and focus is stranded on <body>. The fix hands the modal the persistent caret to
+  // restore to instead; these tests assert focus lands back on that caret after Esc and after Cancel.
+  async function openPickerFromCaretMenu(): Promise<HTMLElement> {
+    const caret = screen.getByLabelText('docs.list.newMenu')
+    caret.focus() // the real user/AT focuses the caret before it is activated
+    fireEvent.click(caret)
+    // The dropdown menu item takes focus when activated (real browsers focus a clicked button); mirror
+    // that so document.activeElement is the menu item at click time — the exact pre-condition of the
+    // R2-F1 defect. jsdom's fireEvent.click does NOT move focus, so we set it explicitly.
+    const item = screen.getByRole('button', { name: 'docs.list.newPpt' })
+    item.focus()
+    expect(document.activeElement).toBe(item)
+    fireEvent.click(item)
+    await waitFor(() => expect(screen.getByRole('radiogroup')).toBeTruthy())
+    // The menu item that opened the modal is now gone — it can never be a valid restore target, and
+    // (with it detached) document.activeElement has fallen back to <body>.
+    expect(screen.queryByText('docs.list.newPpt')).toBeNull()
+    expect(item.isConnected).toBe(false)
+    return caret
+  }
+
+  const pptListResponder = (method: string, url: string) => {
+    if (method === 'get' && url.startsWith('/docs')) return { data: { total: 0, items: [] }, status: 200 }
+    return { data: {}, status: 200 }
+  }
+
+  it('R2-F1: restores focus to the persistent caret after the picker is closed with Esc', async () => {
+    const wk = createMockWKApp()
+    wk.apiClient.responder = pptListResponder
+    setWKApp(wk)
+
+    const { container } = render(<DocsHome />)
+    const caret = await openPickerFromCaretMenu()
+
+    // Esc on the native <dialog> fires a cancel event, routed to onClose (modal closes).
+    const dialogEl = container.querySelector('dialog') as HTMLDialogElement
+    fireEvent(dialogEl, new Event('cancel', { bubbles: false, cancelable: true }))
+    // Reproduce the real-browser race: focus falls to <body> after the close, before the restore lands.
+    ;(document.activeElement as HTMLElement | null)?.blur()
+    expect(document.activeElement).not.toBe(caret)
+
+    // The post-close restore lands on the PERSISTENT caret — not the detached menu item, not <body>.
+    await waitFor(() => expect(document.activeElement).toBe(caret))
+  })
+
+  it('R2-F1: restores focus to the persistent caret after the picker is closed with Cancel', async () => {
+    const wk = createMockWKApp()
+    wk.apiClient.responder = pptListResponder
+    setWKApp(wk)
+
+    render(<DocsHome />)
+    const caret = await openPickerFromCaretMenu()
+
+    fireEvent.click(screen.getByRole('button', { name: 'docs.ppt.create.cancel' }))
+    ;(document.activeElement as HTMLElement | null)?.blur()
+    expect(document.activeElement).not.toBe(caret)
+
+    await waitFor(() => expect(document.activeElement).toBe(caret))
+  })
+
   it('re-pushes an open html doc WITH its slug when the docs nav menu is re-activated', async () => {
     // Repro of the "open html → click the 文档 nav button → 出错了" bug: the nav-reactivation
     // re-push must carry octoDocSlug, else HtmlDocView falls back to docId and 404s against octo-doc.

--- a/packages/docs/src/pages/DocsHome.test.tsx
+++ b/packages/docs/src/pages/DocsHome.test.tsx
@@ -1560,13 +1560,18 @@ describe('DocsHome — sheet open path restored (XIN-520)', () => {
     fireEvent.click(screen.getByRole('button', { name: 'docs.ppt.create.submit' }))
 
     // The create round-trip completes, but the unsafe route is refused: no navigation happens and
-    // the picker stays open with an inline error (retriable), never a silent soft-lock.
+    // the picker stays open. Because the cross-origin route is NON-retriable (a retry reuses the same
+    // Idempotency-Key → the backend returns the same refused route), the modal shows its distinct
+    // non-retriable message and DISABLES Create — not the generic retriable error (P2-1).
     await waitFor(() =>
       expect(wk.apiClient.calls.some((c) => c.method === 'post' && c.url === '/ppt/docs')).toBe(true),
     )
-    await waitFor(() => expect(screen.getByText('docs.ppt.create.error')).toBeTruthy())
+    await waitFor(() => expect(screen.getByText('docs.ppt.create.unavailable')).toBeTruthy())
     expect(assignSpy).not.toHaveBeenCalled()
     expect(screen.getByRole('dialog')).toBeTruthy()
+    expect(
+      (screen.getByRole('button', { name: 'docs.ppt.create.submit' }) as HTMLButtonElement).disabled,
+    ).toBe(true)
   })
 
   it('R2-F1 P1-1: navigates for a safe same-origin editorUrl (happy path preserved)', async () => {
@@ -1593,6 +1598,50 @@ describe('DocsHome — sheet open path restored (XIN-520)', () => {
     fireEvent.click(screen.getByRole('button', { name: 'docs.ppt.create.submit' }))
 
     await waitFor(() => expect(assignSpy).toHaveBeenCalledWith('/ppt/d/new_deck'))
+  })
+
+  // ── R2-F1 P2-2: navigate BEFORE closing the picker ─────────────────────────
+  // onPptCreated used to setPptModalOpen(false) and THEN window.location.assign(editorUrl). When
+  // assign throws (a sandboxed embed can forbid top-level navigation), the exception propagates into
+  // CreatePptModal.onSubmit's catch, which calls setError — but on an ALREADY-CLOSED modal, so the
+  // error never renders and the user is soft-locked on a silent no-op. Assigning FIRST keeps the
+  // modal open when assign throws, so the failure surfaces and the create stays retriable.
+  it('R2-F1 P2-2: keeps the picker open and surfaces the error when navigation throws (assign before close)', async () => {
+    const throwingAssign = vi.fn(() => {
+      throw new Error('navigation blocked (sandboxed embed)')
+    })
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      writable: true,
+      value: { origin: 'https://app.example.com', search: '', assign: throwingAssign },
+    })
+    const wk = createMockWKApp()
+    wk.apiClient.responder = (method: string, url: string) => {
+      if (method === 'get' && url.startsWith('/docs')) return { data: { total: 0, items: [] }, status: 200 }
+      // A perfectly safe same-origin route — the only failure here is that assign itself throws.
+      if (method === 'post' && url === '/ppt/docs') {
+        return { data: { data: { editorUrl: '/ppt/d/new_deck' } }, status: 201 }
+      }
+      return { data: {}, status: 200 }
+    }
+    setWKApp(wk)
+
+    render(<DocsHome />)
+    await openPickerFromCaretMenu()
+    fireEvent.change(screen.getByLabelText('docs.ppt.create.titleLabel'), {
+      target: { value: 'My deck' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'docs.ppt.create.submit' }))
+
+    // assign was attempted (navigate-first), but it threw…
+    await waitFor(() => expect(throwingAssign).toHaveBeenCalledWith('/ppt/d/new_deck'))
+    // …and because the close runs only AFTER a successful assign, the picker is still open and the
+    // error is visible + retriable — not a silently-closed soft-lock.
+    await waitFor(() => expect(screen.getByText('docs.ppt.create.error')).toBeTruthy())
+    expect(screen.getByRole('dialog')).toBeTruthy()
+    expect(
+      (screen.getByRole('button', { name: 'docs.ppt.create.submit' }) as HTMLButtonElement).disabled,
+    ).toBe(false)
   })
 
   it('re-pushes an open html doc WITH its slug when the docs nav menu is re-activated', async () => {

--- a/packages/docs/src/pages/DocsHome.tsx
+++ b/packages/docs/src/pages/DocsHome.tsx
@@ -7,6 +7,7 @@ import { parseXlsxToMatrix, pendingSheetImports } from '../sheet/xlsxImport.ts'
 import { BoardSession } from '../board/BoardSession.tsx'
 import { HtmlDocView } from '../html/HtmlDocView.tsx'
 import { PptDocView } from '../ppt/PptDocView.tsx'
+import { isSameOriginPath } from './StandaloneDocPage.tsx'
 import { ConfirmModal } from '../editor/ConfirmModal.tsx'
 import { CreateHtmlModal } from '../html-create/CreateHtmlModal.tsx'
 import { CreatePptModal } from '../ppt/CreatePptModal.tsx'
@@ -1653,11 +1654,17 @@ export function DocsHome() {
   // NOWHERE else. We deliberately do NOT build a route, open the doc through openDoc, or fall
   // through to any editor shell — trusting the backend route verbatim preserves the R1
   // no-fallthrough contract (a Bento deck never reaches the Tiptap editor / Hocuspocus path).
-  const onPptCreated = useCallback((editorUrl: string) => {
+  //
+  // Open-redirect guard (P1-1): the route is attacker-influenceable (a compromised/misbehaving
+  // backend could return a `javascript:` or cross-origin `editorUrl`), and it is fed straight to
+  // window.location.assign. Gate it through the repo's existing same-origin guard (isSameOriginPath,
+  // the XIN-392 open-redirect core) BEFORE navigating. On an unsafe route we do NOT navigate and do
+  // NOT close the picker; returning false lets the modal surface an inline error and stay retriable.
+  const onPptCreated = useCallback((editorUrl: string): boolean => {
+    if (typeof window === 'undefined' || !isSameOriginPath(editorUrl)) return false
     setPptModalOpen(false)
-    if (typeof window !== 'undefined' && editorUrl) {
-      window.location.assign(editorUrl)
-    }
+    window.location.assign(editorUrl)
+    return true
   }, [])
 
   const backToList = useCallback(() => {

--- a/packages/docs/src/pages/DocsHome.tsx
+++ b/packages/docs/src/pages/DocsHome.tsx
@@ -7,7 +7,7 @@ import { parseXlsxToMatrix, pendingSheetImports } from '../sheet/xlsxImport.ts'
 import { BoardSession } from '../board/BoardSession.tsx'
 import { HtmlDocView } from '../html/HtmlDocView.tsx'
 import { PptDocView } from '../ppt/PptDocView.tsx'
-import { isSameOriginPath } from './StandaloneDocPage.tsx'
+import { resolveSameOriginPath } from './StandaloneDocPage.tsx'
 import { ConfirmModal } from '../editor/ConfirmModal.tsx'
 import { CreateHtmlModal } from '../html-create/CreateHtmlModal.tsx'
 import { CreatePptModal } from '../ppt/CreatePptModal.tsx'
@@ -1655,15 +1655,23 @@ export function DocsHome() {
   // through to any editor shell — trusting the backend route verbatim preserves the R1
   // no-fallthrough contract (a Bento deck never reaches the Tiptap editor / Hocuspocus path).
   //
-  // Open-redirect guard (P1-1): the route is attacker-influenceable (a compromised/misbehaving
-  // backend could return a `javascript:` or cross-origin `editorUrl`), and it is fed straight to
-  // window.location.assign. Gate it through the repo's existing same-origin guard (isSameOriginPath,
-  // the XIN-392 open-redirect core) BEFORE navigating. On an unsafe route we do NOT navigate and do
-  // NOT close the picker; returning false lets the modal surface an inline error and stay retriable.
+  // Open-redirect guard (P1-1) + same-origin NORMALISE (P2-1): the route is attacker-influenceable
+  // (a compromised/misbehaving backend could return a `javascript:` or cross-origin `editorUrl`), and
+  // it is fed straight to window.location.assign. resolveSameOriginPath resolves it against the
+  // current origin and returns a clean rooted path for a same-origin ABSOLUTE or relative url — so a
+  // backend that returns `http://<origin>/ppt/d/x` (or `d/x`) is accepted instead of dead-ending —
+  // while cross-origin / scheme-relative / `javascript:` still return null. On null we do NOT navigate
+  // and do NOT close the picker; returning false lets the modal surface its non-retriable message.
+  //
+  // Ordering (P2-2): navigate FIRST, close AFTER. If assign throws (e.g. a sandboxed embed forbids
+  // top-level navigation), the exception propagates into onSubmit's catch and the still-OPEN modal can
+  // show it. Closing first would setError on an unmounted modal — a silent no-op / soft-lock.
   const onPptCreated = useCallback((editorUrl: string): boolean => {
-    if (typeof window === 'undefined' || !isSameOriginPath(editorUrl)) return false
+    if (typeof window === 'undefined') return false
+    const target = resolveSameOriginPath(editorUrl)
+    if (target === null) return false
+    window.location.assign(target)
     setPptModalOpen(false)
-    window.location.assign(editorUrl)
     return true
   }, [])
 

--- a/packages/docs/src/pages/DocsHome.tsx
+++ b/packages/docs/src/pages/DocsHome.tsx
@@ -9,6 +9,7 @@ import { HtmlDocView } from '../html/HtmlDocView.tsx'
 import { PptDocView } from '../ppt/PptDocView.tsx'
 import { ConfirmModal } from '../editor/ConfirmModal.tsx'
 import { CreateHtmlModal } from '../html-create/CreateHtmlModal.tsx'
+import { CreatePptModal } from '../ppt/CreatePptModal.tsx'
 import { DocsBotConversation } from '../html-create/DocsBotConversation.tsx'
 import { docsApiBaseUrl, type HtmlCreationDraft } from '../html-create/createHtmlTask.ts'
 import { isBoardDoc, isBoardIdLocally, persistBoardScene, rememberBoard } from '../board/boardStore.ts'
@@ -20,6 +21,7 @@ import {
   DEFAULT_DOC_FOLDER,
   DEFAULT_DOC_ID,
   DOC_TARGET_STORAGE_KEY,
+  PPT_CREATE_ENABLED,
 } from '../config.ts'
 import { createDoc, deleteDoc, getDoc, recordDocView, type DocListItem } from './docsApi.ts'
 import { useMemberNames } from '../members/useMemberNames.ts'
@@ -524,8 +526,8 @@ function DocsList({
   /** Open the "new HTML (embedded bot DM)" flow (plan Task 6). Menu-only; never calls createDoc. */
   onCreateHtml: () => void
   /**
-   * Open the "new slides (html_ppt)" flow. R1 (XIN-1501) is entry-only: this opens a "coming soon"
-   * notice — live create + template picker land in R2 with `POST /api/v1/ppt/docs`. Menu-only;
+   * Open the "new slides (html_ppt)" flow. Behind the R2 flag this opens the four-template picker
+   * (POST /api/v1/ppt/docs); with the flag off it opens the R1 "coming soon" notice. Menu-only;
    * never calls createDoc (a Bento deck is not a rich-text doc).
    */
   onCreatePpt: () => void
@@ -1054,9 +1056,10 @@ function DocsList({
               <span className="octo-docs-new-menu-icon" aria-hidden="true"><HtmlRowIcon /></span>
               {t('docs.list.newHtml')}
             </button>
-            {/* New slides (html_ppt). R1 (XIN-1501) is entry + routing shell only: this opens a
-                "coming soon" notice rather than creating a deck. Live create + the 4-template picker
-                (POST /api/v1/ppt/docs) land in R2 — like the HTML entry, it NEVER calls createDoc. */}
+            {/* New slides (html_ppt). Independent peer AFTER "HTML" — opens the four-template
+                picker (POST /api/v1/ppt/docs) behind the R2 flag, or the R1 coming-soon notice when
+                off. Like the HTML entry it only closes the menu + calls onCreatePpt; it NEVER
+                calls createDoc, so no empty deck is precreated. */}
             <button
               type="button"
               className="octo-docs-new-menu-item"
@@ -1472,10 +1475,10 @@ export function DocsHome() {
   // closes the other). A ref mirrors the draft so the NavRail re-entry handler can re-mount the
   // SAME chat (same requestId) without a stale closure and without re-sending (§5 risk 1).
   const [htmlModalOpen, setHtmlModalOpen] = useState(false)
-  // R1 (XIN-1501) "new slides" entry: the caret-menu item is wired but live create + the template
-  // picker land in R2 (POST /api/v1/ppt/docs). Until then the entry opens this "coming soon" notice
-  // — it NEVER creates a doc, so a Bento deck is never mis-minted as a rich-text placeholder.
-  const [pptComingSoonOpen, setPptComingSoonOpen] = useState(false)
+  // "New slides" (html_ppt) entry. When the R2 flag is ON this opens the real four-template picker
+  // (POST /api/v1/ppt/docs); when OFF it falls back to the R1 "coming soon" notice (no regression).
+  // Either way it NEVER calls createDoc — a Bento deck is never mis-minted as a rich-text placeholder.
+  const [pptModalOpen, setPptModalOpen] = useState(false)
   const [htmlChatDraft, setHtmlChatDraft] = useState<HtmlCreationDraft | null>(null)
   const htmlChatDraftRef = useRef<HtmlCreationDraft | null>(null)
   useEffect(() => {
@@ -1633,6 +1636,17 @@ export function DocsHome() {
     [openHtmlChat],
   )
 
+  // "New slides" create succeeded: navigate to the PPT editor route the BACKEND returned, and
+  // NOWHERE else. We deliberately do NOT build a route, open the doc through openDoc, or fall
+  // through to any editor shell — trusting the backend route verbatim preserves the R1
+  // no-fallthrough contract (a Bento deck never reaches the Tiptap editor / Hocuspocus path).
+  const onPptCreated = useCallback((editorUrl: string) => {
+    setPptModalOpen(false)
+    if (typeof window !== 'undefined' && editorUrl) {
+      window.location.assign(editorUrl)
+    }
+  }, [])
+
   const backToList = useCallback(() => {
     setSelectedDocId(null)
     setSelectedDocType(undefined)
@@ -1645,6 +1659,7 @@ export function DocsHome() {
     setHtmlChatDraft(null)
     htmlChatDraftRef.current = null
     setHtmlModalOpen(false)
+    setPptModalOpen(false)
     // Invalidate any in-flight unknown-kind open (openDoc → getDoc still pending). Without this,
     // a Space switch (this is also the onSpaceChanged reconciler) leaves latestOpenRef pointing at
     // the previous Space's docId, so a late getDoc resolve would pass the `latestOpenRef === docId`
@@ -2078,6 +2093,29 @@ export function DocsHome() {
   // Production (routeRight present): the editor lives in the host's main pane; this route
   // slot renders ONLY the resident list (left). Tests / standalone (no routeRight): render
   // the inline CSS split-pane (left list + right editor) so the layout still works.
+  //
+  // The "New slides" modal is built once and reused across both layouts (only one renders at a
+  // time). Behind the R2 flag it is the live four-template picker; with the flag off it is the R1
+  // "coming soon" notice, so an OFF build never regresses the R1 entry.
+  const pptModal = PPT_CREATE_ENABLED ? (
+    <CreatePptModal
+      open={pptModalOpen}
+      spaceId={space}
+      folderId={folder}
+      onClose={() => setPptModalOpen(false)}
+      onCreated={onPptCreated}
+    />
+  ) : (
+    <ConfirmModal
+      open={pptModalOpen}
+      title={t('docs.ppt.createTitle')}
+      message={t('docs.ppt.createComingSoon')}
+      confirmLabel={t('docs.ppt.createComingSoonOk')}
+      cancelLabel={t('docs.ppt.createComingSoonOk')}
+      onConfirm={() => setPptModalOpen(false)}
+      onCancel={() => setPptModalOpen(false)}
+    />
+  )
   if (routeRight) {
     return (
       <div className="octo-doc octo-docs-list-only octo-theme">
@@ -2088,7 +2126,7 @@ export function DocsHome() {
           selectedDocId={selectedDocId}
           onSelect={openDoc}
           onCreateHtml={() => setHtmlModalOpen(true)}
-          onCreatePpt={() => setPptComingSoonOpen(true)}
+          onCreatePpt={() => setPptModalOpen(true)}
           reloadToken={listReloadToken}
           botUids={botUids}
         />
@@ -2099,15 +2137,7 @@ export function DocsHome() {
           onClose={() => setHtmlModalOpen(false)}
           onSubmit={onSubmitHtml}
         />
-        <ConfirmModal
-          open={pptComingSoonOpen}
-          title={t('docs.ppt.createTitle')}
-          message={t('docs.ppt.createComingSoon')}
-          confirmLabel={t('docs.ppt.createComingSoonOk')}
-          cancelLabel={t('docs.ppt.createComingSoonOk')}
-          onConfirm={() => setPptComingSoonOpen(false)}
-          onCancel={() => setPptComingSoonOpen(false)}
-        />
+        {pptModal}
       </div>
     )
   }
@@ -2122,7 +2152,7 @@ export function DocsHome() {
           selectedDocId={selectedDocId}
           onSelect={openDoc}
           onCreateHtml={() => setHtmlModalOpen(true)}
-          onCreatePpt={() => setPptComingSoonOpen(true)}
+          onCreatePpt={() => setPptModalOpen(true)}
           reloadToken={listReloadToken}
           botUids={botUids}
         />
@@ -2145,15 +2175,7 @@ export function DocsHome() {
         onClose={() => setHtmlModalOpen(false)}
         onSubmit={onSubmitHtml}
       />
-      <ConfirmModal
-        open={pptComingSoonOpen}
-        title={t('docs.ppt.createTitle')}
-        message={t('docs.ppt.createComingSoon')}
-        confirmLabel={t('docs.ppt.createComingSoonOk')}
-        cancelLabel={t('docs.ppt.createComingSoonOk')}
-        onConfirm={() => setPptComingSoonOpen(false)}
-        onCancel={() => setPptComingSoonOpen(false)}
-      />
+      {pptModal}
     </div>
   )
 }

--- a/packages/docs/src/pages/DocsHome.tsx
+++ b/packages/docs/src/pages/DocsHome.tsx
@@ -528,15 +528,21 @@ function DocsList({
   /**
    * Open the "new slides (html_ppt)" flow. Behind the R2 flag this opens the four-template picker
    * (POST /api/v1/ppt/docs); with the flag off it opens the R1 "coming soon" notice. Menu-only;
-   * never calls createDoc (a Bento deck is not a rich-text doc).
+   * never calls createDoc (a Bento deck is not a rich-text doc). Receives the PERSISTENT caret button
+   * that opened the menu so the modal can restore focus to it on close (the menu item itself unmounts
+   * on click, so it is not a valid restore target — R2-F1).
    */
-  onCreatePpt: () => void
+  onCreatePpt: (opener?: HTMLElement | null) => void
   reloadToken?: number
   /** uids of every bot in the space; a row whose ownerId is here shows a bot badge. */
   botUids: Set<string>
 }): React.ReactElement {
   const [creating, setCreating] = useState(false)
   const [newMenuAt, setNewMenuAt] = useState<{ left: number; top: number } | null>(null)
+  // The persistent "new" split-button caret. Handed to onCreatePpt so the picker restores focus HERE
+  // on close: the dropdown menu item that fires onCreatePpt unmounts the instant it is clicked, so it
+  // cannot be the restore target — the caret persists across the menu open/close and can (R2-F1).
+  const caretRef = useRef<HTMLButtonElement>(null)
   const importInputRef = useRef<HTMLInputElement>(null)
   const boardImportInputRef = useRef<HTMLInputElement>(null)
   // Client-side pin (置顶) — persisted in localStorage; pinned docs sort to the top. Pin is a
@@ -1002,6 +1008,7 @@ function DocsList({
             </button>
             <button
               type="button"
+              ref={caretRef}
               aria-label={t('docs.list.newMenu')}
               title={t('docs.list.newMenu')}
               disabled={creating}
@@ -1066,7 +1073,9 @@ function DocsList({
               disabled={creating}
               onClick={() => {
                 setNewMenuAt(null)
-                onCreatePpt()
+                // Hand the picker the PERSISTENT caret (not this menu item, which unmounts as the menu
+                // closes on the line above) as its focus-restore target — R2-F1.
+                onCreatePpt(caretRef.current)
               }}
             >
               <span className="octo-docs-new-menu-icon" aria-hidden="true"><PptRowIcon /></span>
@@ -1479,6 +1488,10 @@ export function DocsHome() {
   // (POST /api/v1/ppt/docs); when OFF it falls back to the R1 "coming soon" notice (no regression).
   // Either way it NEVER calls createDoc — a Bento deck is never mis-minted as a rich-text placeholder.
   const [pptModalOpen, setPptModalOpen] = useState(false)
+  // The persistent element that opened the PPT picker (the DocsList caret button), handed in via
+  // onCreatePpt and forwarded to CreatePptModal as its focus-restore target (R2-F1). A ref, not state:
+  // it only needs to be readable inside the modal's open/close effects, and must not trigger a render.
+  const pptOpenerRef = useRef<HTMLElement | null>(null)
   const [htmlChatDraft, setHtmlChatDraft] = useState<HtmlCreationDraft | null>(null)
   const htmlChatDraftRef = useRef<HtmlCreationDraft | null>(null)
   useEffect(() => {
@@ -2102,6 +2115,7 @@ export function DocsHome() {
       open={pptModalOpen}
       spaceId={space}
       folderId={folder}
+      triggerRef={pptOpenerRef}
       onClose={() => setPptModalOpen(false)}
       onCreated={onPptCreated}
     />
@@ -2126,7 +2140,10 @@ export function DocsHome() {
           selectedDocId={selectedDocId}
           onSelect={openDoc}
           onCreateHtml={() => setHtmlModalOpen(true)}
-          onCreatePpt={() => setPptModalOpen(true)}
+          onCreatePpt={(opener) => {
+            pptOpenerRef.current = opener ?? null
+            setPptModalOpen(true)
+          }}
           reloadToken={listReloadToken}
           botUids={botUids}
         />
@@ -2152,7 +2169,10 @@ export function DocsHome() {
           selectedDocId={selectedDocId}
           onSelect={openDoc}
           onCreateHtml={() => setHtmlModalOpen(true)}
-          onCreatePpt={() => setPptModalOpen(true)}
+          onCreatePpt={(opener) => {
+            pptOpenerRef.current = opener ?? null
+            setPptModalOpen(true)
+          }}
           reloadToken={listReloadToken}
           botUids={botUids}
         />

--- a/packages/docs/src/pages/StandaloneDocPage.test.tsx
+++ b/packages/docs/src/pages/StandaloneDocPage.test.tsx
@@ -831,6 +831,34 @@ describe('resolveSameOriginPath — PPT editorUrl normalise (P2-1)', () => {
     expect(resolveSameOriginPath(null)).toBeNull()
     expect(resolveSameOriginPath(undefined)).toBeNull()
   })
+
+  it('collapses leading-slash runs so a normalised path can never be scheme-relative (P1-1)', () => {
+    // Each input parses same-origin, but its pathname begins with `//` (or resolves to one via
+    // dot-segments / backslash smuggling). Handing that back verbatim lets location.assign()
+    // re-parse it as SCHEME-RELATIVE and bounce cross-origin. The guard must return a single-rooted
+    // path that stays same-origin when re-parsed.
+    const rows = [
+      `${origin}//evil.example.com/steal`, // absolute same-origin, pathname `//evil…`
+      `${origin}/\\/evil.example.com/steal`, // backslash → `/` in special schemes → `//evil…`
+      '/..//evil.example.com/steal', // rooted; `/..` clamps to root, leaving `//evil…`
+      '/a/../..//evil.example.com', // rooted; dot-segments collapse to `//evil…`
+    ]
+    for (const raw of rows) {
+      const result = resolveSameOriginPath(raw)
+      expect(result).not.toBeNull()
+      // Exactly one leading slash — not scheme-relative.
+      expect(result!.startsWith('//')).toBe(false)
+      expect(result!.startsWith('/')).toBe(true)
+      // Re-parsing the returned value (as location.assign would) stays on the current origin.
+      expect(new URL(result!, origin).origin).toBe(origin)
+    }
+  })
+
+  it('rejects non-http(s) same-origin protocols (e.g. blob:) whose pathname is not a real page path', () => {
+    // blob:<origin>/… reports a matching origin, but its pathname is the whole inner URL, so it is
+    // not a navigable rooted path. Only http/https page schemes are accepted.
+    expect(resolveSameOriginPath(`blob:${origin}/550e8400-e29b-41d4-a716-446655440000`)).toBeNull()
+  })
 })
 
 describe('standalone return target — open-redirect-safe post-login bounce (blocker 4)', () => {

--- a/packages/docs/src/pages/StandaloneDocPage.test.tsx
+++ b/packages/docs/src/pages/StandaloneDocPage.test.tsx
@@ -77,6 +77,7 @@ import {
   persistStandaloneReturn,
   consumeStandaloneReturn,
   withReturnSid,
+  resolveSameOriginPath,
   STANDALONE_RETURN_KEY,
 } from './StandaloneDocPage.tsx'
 
@@ -798,6 +799,37 @@ describe('XIN-501 — preflight addresses the doc space from the link ?sp, never
     expect(wk.shared.currentSpaceId).toBe('space-doc')
     const preflight = wk.apiClient.calls.find((c) => c.method === 'get' && c.url === '/docs/d_ok')
     expect(preflight!.config?.headers?.['X-Space-Id']).toBe('space-doc')
+  })
+})
+
+describe('resolveSameOriginPath — PPT editorUrl normalise (P2-1)', () => {
+  const origin = window.location.origin
+
+  it('normalises a same-origin ABSOLUTE url to a rooted path (the P2-1 accept case)', () => {
+    expect(resolveSameOriginPath(`${origin}/ppt/d/abc`)).toBe('/ppt/d/abc')
+    // query + hash are preserved.
+    expect(resolveSameOriginPath(`${origin}/ppt/d/abc?sp=1#s2`)).toBe('/ppt/d/abc?sp=1#s2')
+  })
+
+  it('accepts a rooted-relative path and a bare-relative path (resolved against origin root)', () => {
+    expect(resolveSameOriginPath('/ppt/d/abc?sp=1')).toBe('/ppt/d/abc?sp=1')
+    // A bare-relative value that isSameOriginPath would REJECT is normalised to a rooted path here.
+    expect(resolveSameOriginPath('d/abc')).toBe('/d/abc')
+  })
+
+  it('rejects cross-origin / scheme-relative / javascript / control-char / empty values', () => {
+    for (const bad of [
+      'https://evil.example.com/steal', // cross-origin absolute
+      '//evil.example.com', // scheme-relative → off-origin
+      'javascript:alert(1)', // script payload (opaque origin)
+      '/\n/evil.example.com', // newline smuggles //host past the URL parser
+      '/\t/evil.example.com', // tab → same
+      '', // empty
+    ]) {
+      expect(resolveSameOriginPath(bad)).toBeNull()
+    }
+    expect(resolveSameOriginPath(null)).toBeNull()
+    expect(resolveSameOriginPath(undefined)).toBeNull()
   })
 })
 

--- a/packages/docs/src/pages/StandaloneDocPage.tsx
+++ b/packages/docs/src/pages/StandaloneDocPage.tsx
@@ -125,10 +125,11 @@ export function isSameOriginPath(path: string | null | undefined): path is strin
  * the same refused url — the user can never reach a deck the server already made.
  *
  * So for the trusted-route path we NORMALISE instead of reject: resolve against the current origin
- * and, when the resolved origin matches, hand back `pathname + search + hash` (a clean rooted path,
- * regardless of whether the input was absolute or relative). Cross-origin, scheme-relative
- * (`//host`), backslash-smuggled, and non-http(s) (`javascript:`) values still resolve off-origin (or
- * fail to parse) and return `null` — the open-redirect protection is intact; only same-origin
+ * and, when the resolved origin matches AND the scheme is http(s), hand back a single-rooted
+ * `pathname + search + hash` (leading slash runs collapsed to one, so the value can never be re-read
+ * as scheme-relative). Cross-origin, scheme-relative (`//host`), backslash-smuggled, and non-http(s)
+ * (`javascript:`, `blob:`) values still resolve off-origin, fail the scheme gate, or fail to parse,
+ * and return `null` — the open-redirect protection is intact; only same-origin http(s)
  * absolute/relative inputs are additionally accepted. Control chars are rejected up front for the
  * same reason as gate 1 above (the URL parser silently strips tab/newline/CR, smuggling `//host`).
  */
@@ -146,7 +147,15 @@ export function resolveSameOriginPath(raw: string | null | undefined): string | 
     return null
   }
   if (url.origin !== origin) return null
-  return url.pathname + url.search + url.hash
+  // Only real page schemes: blob:<origin>/… also reports a matching origin, but its pathname is the
+  // whole inner URL, so it would be handed back as a non-navigable, non-rooted value.
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') return null
+  // url.pathname can itself begin with `//` — from an absolute input (`https://<origin>//evil…`),
+  // a backslash-smuggled one, or a rooted `/..//evil…` whose dot-segments clamp to the root and
+  // leave a doubled slash. location.assign() re-parses `//host…` as SCHEME-RELATIVE and bounces
+  // cross-origin, re-opening the redirect this guard closes. Collapse the leading slash run so the
+  // result is a single rooted path.
+  return url.pathname.replace(/^\/+/, '/') + url.search + url.hash
 }
 
 /**

--- a/packages/docs/src/pages/StandaloneDocPage.tsx
+++ b/packages/docs/src/pages/StandaloneDocPage.tsx
@@ -114,6 +114,42 @@ export function isSameOriginPath(path: string | null | undefined): path is strin
 }
 
 /**
+ * Resolve `raw` to a same-origin path to navigate to, or `null` when it is not same-origin (P2-1).
+ *
+ * The difference from `isSameOriginPath` is deliberate: that guard REJECTS anything that is not a
+ * rooted RELATIVE path — correct for the post-login return target, where the value is user-tamperable
+ * and must be a bare `/…` path. But a backend-supplied PPT `editorUrl` may legitimately arrive as a
+ * same-origin ABSOLUTE url (`http://localhost:3000/ppt/d/abc`) or a bare-relative (`d/abc`), and
+ * rejecting those makes the whole create flow a dead-end: the deck exists server-side, the frontend
+ * refuses to navigate, and an unedited retry reuses the same Idempotency-Key so the backend returns
+ * the same refused url — the user can never reach a deck the server already made.
+ *
+ * So for the trusted-route path we NORMALISE instead of reject: resolve against the current origin
+ * and, when the resolved origin matches, hand back `pathname + search + hash` (a clean rooted path,
+ * regardless of whether the input was absolute or relative). Cross-origin, scheme-relative
+ * (`//host`), backslash-smuggled, and non-http(s) (`javascript:`) values still resolve off-origin (or
+ * fail to parse) and return `null` — the open-redirect protection is intact; only same-origin
+ * absolute/relative inputs are additionally accepted. Control chars are rejected up front for the
+ * same reason as gate 1 above (the URL parser silently strips tab/newline/CR, smuggling `//host`).
+ */
+export function resolveSameOriginPath(raw: string | null | undefined): string | null {
+  if (typeof raw !== 'string' || raw.length === 0) return null
+  // eslint-disable-next-line no-control-regex
+  if (/[\x00-\x1f\x7f]/.test(raw)) return null
+  if (typeof window === 'undefined') return null
+  const origin = window.location.origin
+  if (!origin) return null
+  let url: URL
+  try {
+    url = new URL(raw, origin)
+  } catch {
+    return null
+  }
+  if (url.origin !== origin) return null
+  return url.pathname + url.search + url.hash
+}
+
+/**
  * Whether a stashed return target is a SAFE same-origin STANDALONE link.
  *
  * Layers the standalone-target gate (P2-2) on top of the shared same-origin core: even a same-origin

--- a/packages/docs/src/pages/StandaloneDocPage.tsx
+++ b/packages/docs/src/pages/StandaloneDocPage.tsx
@@ -71,11 +71,10 @@ export function persistStandaloneReturn(): void {
 }
 
 /**
- * Whether a stashed return target is a SAFE same-origin standalone link.
+ * Whether `path` is a SAFE same-origin absolute path — the reusable open-redirect core.
  *
- * Open-redirect guard (hardened, XIN-392). The value lives in sessionStorage, so it is
- * attacker-influenceable, and it is later fed to `window.location.assign` — it must clear three
- * gates, in order:
+ * Open-redirect guard (hardened, XIN-392). A value that will later be fed to
+ * `window.location.assign` must clear these gates, in order:
  *
  *   1. No control characters. The WHATWG URL parser SILENTLY STRIPS tab / newline / CR mid-string,
  *      so a value like `/` + "\n" + `/evil.example.com` parses to the scheme-relative
@@ -83,31 +82,49 @@ export function persistStandaloneReturn(): void {
  *      (only path[0]/path[1]) never saw the smuggled `//host` because the control char sat between
  *      them. Rejecting any C0 control char (and DEL) up front closes that whole class of bypass
  *      before parsing can mask it.
- *   2. Same origin. Resolve against the current origin and require `url.origin === origin`. This
+ *   2. Rooted absolute path. Rejecting relative values (`d/relative`) up front stops them from
+ *      resolving against whatever the current document URL happens to be when the assign runs
+ *      (e.g. `/login/` → `/login/d/relative`) instead of a clean `/…` route.
+ *   3. Same origin. Resolve against the current origin and require `url.origin === origin`. This
  *      rejects absolute (`https://evil`), scheme-relative (`//host`), and backslash-smuggled
- *      (`/\host`) targets structurally, instead of hand-checking leading characters.
- *   3. Standalone target only (P2-2). Even a same-origin path must resolve to `/d/:docId` or the
- *      summary notification target `/s/:taskNo`, so a tampered value can't bounce the user to another
- *      same-origin page (`/settings`, `/oidc/bind`, …) after login.
+ *      (`/\host`) targets structurally, instead of hand-checking leading characters. A `javascript:`
+ *      value fails gate 2 (no leading `/`) and never reaches parsing.
+ *
+ * This is the shared same-origin check reused by both the post-login return-path guard
+ * (isSafeReturnPath, which adds a stricter standalone-target gate on top) and the live PPT-create
+ * navigation guard (DocsHome onPptCreated) — a backend-returned editor route is trusted only when it
+ * resolves same-origin.
  */
-function isSafeReturnPath(path: string | null): path is string {
+export function isSameOriginPath(path: string | null | undefined): path is string {
   if (typeof path !== 'string' || path.length === 0) return false
-  // A return target must be a rooted absolute path. Rejecting relative values (`d/relative`) up
-  // front stops them from resolving against whatever the current document URL happens to be when
-  // window.location.assign runs (e.g. `/login/` → `/login/d/relative`) instead of a clean `/d/:id`.
   if (path[0] !== '/') return false
   // Reject ANY control character before parsing — see gate 1 above.
   // eslint-disable-next-line no-control-regex
   if (/[\x00-\x1f\x7f]/.test(path)) return false
   if (typeof window === 'undefined') return false
   const origin = window.location.origin
+  if (!origin) return false
   let url: URL
   try {
     url = new URL(path, origin)
   } catch {
     return false
   }
-  if (url.origin !== origin) return false
+  return url.origin === origin
+}
+
+/**
+ * Whether a stashed return target is a SAFE same-origin STANDALONE link.
+ *
+ * Layers the standalone-target gate (P2-2) on top of the shared same-origin core: even a same-origin
+ * path must resolve to `/d/:docId` or the summary notification target `/s/:taskNo`, so a tampered
+ * value can't bounce the user to another same-origin page (`/settings`, `/oidc/bind`, …) after login.
+ */
+function isSafeReturnPath(path: string | null): path is string {
+  if (!isSameOriginPath(path)) return false
+  // Same-origin already proven; re-parse to inspect the pathname. `path` is a rooted same-origin
+  // value here, so this parse cannot throw.
+  const url = new URL(path, window.location.origin)
   return parseStandaloneDocId(url.pathname) !== null || STANDALONE_SUMMARY_PATH.test(url.pathname)
 }
 

--- a/packages/docs/src/ppt/CreatePptModal.css
+++ b/packages/docs/src/ppt/CreatePptModal.css
@@ -1,0 +1,176 @@
+/* Create-slides template picker (R2-F1). Mirrors the html-create modal shell so the two create
+   dialogs read as peers; colours are `--wk-*` tokens only (no hardcoded values, R1 CSS discipline). */
+
+.octo-ppt-create-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1300;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 16px;
+  background: transparent;
+}
+.octo-ppt-create-modal::backdrop {
+  background: color-mix(in srgb, var(--wk-text-primary) 36%, transparent);
+}
+.octo-ppt-create-modal {
+  width: 100%;
+  max-width: 640px;
+  min-height: 232px;
+  display: flex;
+  flex-direction: column;
+  background: var(--wk-bg-surface);
+  color: var(--wk-text-primary);
+  border: none;
+  padding: 0;
+  border-radius: 12px;
+  box-shadow: var(--wk-shadow-lg);
+  box-sizing: border-box;
+}
+.octo-ppt-create-header {
+  min-height: 56px;
+  display: flex;
+  align-items: center;
+  padding: 16px;
+  border-bottom: 1px solid var(--wk-border-default);
+}
+.octo-ppt-create-title {
+  margin: 0;
+  font-size: 16px;
+  line-height: 24px;
+  font-weight: 600;
+  color: var(--wk-brand-primary);
+}
+.octo-ppt-create-body {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 16px;
+}
+.octo-ppt-create-field {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.octo-ppt-create-label {
+  font-size: 14px;
+  line-height: 20px;
+  font-weight: 600;
+  color: var(--wk-text-primary);
+}
+
+/* Four 16:9 template cards, 2×2 → 1 column on a narrow modal (design §2). */
+.octo-ppt-create-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+@media (max-width: 520px) {
+  .octo-ppt-create-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+.octo-ppt-tpl-card {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 10px;
+  text-align: left;
+  cursor: pointer;
+  background: var(--wk-bg-surface);
+  border: 1px solid var(--wk-border-default);
+  border-radius: 8px;
+  color: inherit;
+  font: inherit;
+}
+.octo-ppt-tpl-card:hover {
+  background: var(--wk-bg-hover);
+}
+.octo-ppt-tpl-card-selected {
+  background: var(--wk-bg-selected);
+  border-color: var(--wk-border-glow);
+}
+/* Visible focus ring on every focusable control (hard metric #1 / §3). */
+.octo-ppt-tpl-card:focus-visible,
+.octo-ppt-create-input:focus-visible,
+.octo-ppt-create-submit:focus-visible,
+.octo-ppt-create-footer .octo-tb-btn:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px var(--wk-brand-primary-ring);
+}
+.octo-ppt-tpl-card:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+.octo-ppt-tpl-thumb {
+  display: block;
+  aspect-ratio: 16 / 9;
+  width: 100%;
+  border-radius: 6px;
+  overflow: hidden;
+  background: var(--wk-bg-elevated);
+  color: var(--wk-text-tertiary);
+}
+.octo-ppt-tpl-preview {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+.octo-ppt-tpl-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+.octo-ppt-tpl-name {
+  font-size: 14px;
+  line-height: 20px;
+  font-weight: 600;
+  color: var(--wk-text-primary);
+}
+.octo-ppt-tpl-desc {
+  font-size: 12px;
+  line-height: 18px;
+  color: var(--wk-text-secondary);
+}
+
+.octo-ppt-create-input {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 8px 12px;
+  font: inherit;
+  font-size: 14px;
+  line-height: 21px;
+  color: var(--wk-text-primary);
+  background: var(--wk-bg-surface);
+  border: 1px solid var(--wk-border-strong);
+  border-radius: 8px;
+}
+.octo-ppt-create-input::placeholder {
+  color: var(--wk-text-tertiary);
+}
+.octo-ppt-create-input:focus-visible {
+  border-color: var(--wk-text-tertiary);
+}
+.octo-ppt-create-error {
+  margin: 0;
+  font-size: 12px;
+  line-height: 18px;
+  color: var(--wk-color-danger);
+}
+.octo-ppt-create-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  padding-top: 4px;
+}
+/* Primary Create button: filled with the brand colour so it reads as the main action. */
+.octo-ppt-create-submit {
+  background: var(--wk-brand-primary);
+  color: var(--wk-color-white);
+}
+.octo-ppt-create-submit:hover:not(:disabled) {
+  background: var(--wk-brand-primary);
+  opacity: 0.9;
+}

--- a/packages/docs/src/ppt/CreatePptModal.test.tsx
+++ b/packages/docs/src/ppt/CreatePptModal.test.tsx
@@ -411,4 +411,64 @@ describe('CreatePptModal', () => {
     expect(keys[0]).toBe(keys[1])
     expect(keys[0]).toBeTruthy()
   })
+
+  // P1-2: a CONTENT-CHANGED resubmit must mint a FRESH idempotency key. Reusing the open-time key
+  // across a title change lets the backend dedup the second submit and return the first (stale-title)
+  // deck — the user changed the title but gets the old-title deck.
+  it('re-mints the idempotency key when the title changes between submits (no stale-title dedup)', async () => {
+    let attempt = 0
+    const wk = mountApi(() => {
+      attempt += 1
+      if (attempt === 1) return Promise.reject({ response: { status: 500 } })
+      return { data: { data: { editorUrl: '/ppt/d/deck' } }, status: 201 }
+    })
+    const onCreated = vi.fn()
+    render(<CreatePptModal open spaceId="s_1" onClose={() => {}} onCreated={onCreated} />)
+
+    const titleInput = screen.getByLabelText('docs.ppt.create.titleLabel')
+    fireEvent.change(titleInput, { target: { value: 'AAA' } })
+    fireEvent.click(screen.getByRole('button', { name: 'docs.ppt.create.submit' }))
+    await waitFor(() => expect(screen.getByText('docs.ppt.create.error')).toBeTruthy())
+
+    // The user edits the title, then resubmits — this is NOT an identical retry.
+    fireEvent.change(titleInput, { target: { value: 'BBB' } })
+    fireEvent.click(screen.getByRole('button', { name: 'docs.ppt.create.submit' }))
+    await waitFor(() => expect(onCreated).toHaveBeenCalledWith('/ppt/d/deck'))
+
+    const calls = wk.apiClient.calls.filter((c) => c.url === '/ppt/docs')
+    expect(calls).toHaveLength(2)
+    expect(calls[0].body).toMatchObject({ title: 'AAA' })
+    expect(calls[1].body).toMatchObject({ title: 'BBB' })
+    const keys = calls.map((c) => c.config?.headers?.['Idempotency-Key'])
+    expect(keys[0]).toBeTruthy()
+    expect(keys[1]).toBeTruthy()
+    // Content changed → the second submit must carry a DIFFERENT key.
+    expect(keys[0]).not.toBe(keys[1])
+  })
+
+  // P1-3: if the user switches space while a create is in flight, the late-resolving space-A create
+  // must NOT navigate — it would drop the user into the wrong-space deck. A generation token captured
+  // at submit start is invalidated by the space-change reset, so the post-await handoff is skipped.
+  it('does NOT complete/navigate when the space changes mid-submit (cross-space late-resolve guard)', async () => {
+    let resolve!: (v: unknown) => void
+    mountApi(() => new Promise((r) => { resolve = r as (v: unknown) => void }))
+    const onCreated = vi.fn()
+    const { rerender } = render(
+      <CreatePptModal open spaceId="s_A" onClose={() => {}} onCreated={onCreated} />,
+    )
+    fireEvent.change(screen.getByLabelText('docs.ppt.create.titleLabel'), {
+      target: { value: 'Deck A' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'docs.ppt.create.submit' }))
+    await waitFor(() => expect(screen.getByText('docs.ppt.create.loading')).toBeTruthy())
+
+    // User switches to space B while the space-A create is still awaiting.
+    rerender(<CreatePptModal open spaceId="s_B" onClose={() => {}} onCreated={onCreated} />)
+
+    // The space-A create finally resolves — but its generation is stale now, so no handoff/navigation.
+    await act(async () => {
+      resolve({ data: { data: { editorUrl: '/ppt/d/deck_A' } }, status: 201 })
+    })
+    expect(onCreated).not.toHaveBeenCalled()
+  })
 })

--- a/packages/docs/src/ppt/CreatePptModal.test.tsx
+++ b/packages/docs/src/ppt/CreatePptModal.test.tsx
@@ -136,41 +136,63 @@ describe('CreatePptModal', () => {
     trigger.remove()
   })
 
-  // ── R2-F1 defect 1: Esc/close restores focus on the close route itself ────
-  // The parent-driven unmount cleanup is not enough: in a real browser the
-  // native dialog steals focus to BODY on the Esc route before the parent flips
-  // `open`. Focus must be restored synchronously by the close handler, without
-  // relying on the caller re-rendering with open={false}.
-  it('restores focus to the trigger synchronously on the Esc/cancel route', () => {
+  // ── R2-F1 defect 1: Esc/close restores focus to the trigger AFTER close ───
+  // Faithful to the real DOM race: a native <dialog> moves focus to <body> as it
+  // unwinds the Esc/close, AFTER any synchronous restore our handler ran. So the
+  // restore must happen on a post-close animation frame, not synchronously inside
+  // the cancel/keydown handler. These tests mount a real trigger element and assert
+  // document.activeElement === trigger AFTER the close + the browser's focus-to-body,
+  // which is exactly what the old synchronous-only implementation failed on.
+  it('restores focus to the trigger after Esc, surviving the browser moving focus to <body>', async () => {
+    const onClose = vi.fn()
     const trigger = document.createElement('button')
     document.body.appendChild(trigger)
     trigger.focus()
+    expect(document.activeElement).toBe(trigger)
 
-    const { container } = render(
-      <CreatePptModal open spaceId="s_1" onClose={() => {}} onCreated={() => {}} />,
+    const { container, rerender } = render(
+      <CreatePptModal open spaceId="s_1" onClose={onClose} onCreated={() => {}} />,
     )
     const dialogEl = container.querySelector('dialog') as HTMLDialogElement
-    // Simulate the browser having moved focus off the trigger (dialog took it).
-    ;(cards()[0] as HTMLButtonElement).focus()
+    // The open effect moves focus into the dialog (default card).
+    await waitFor(() => expect(document.activeElement).toBe(cards()[0]))
+
+    // Esc on a native <dialog> fires a cancel event, which our handler routes to onClose.
+    fireEvent(dialogEl, new Event('cancel', { bubbles: false, cancelable: true }))
+    expect(onClose).toHaveBeenCalledTimes(1)
+    // Parent closes the modal in response.
+    rerender(<CreatePptModal open={false} spaceId="s_1" onClose={onClose} onCreated={() => {}} />)
+
+    // Reproduce the real-browser race: focus lands on <body> AFTER the close handler ran.
+    ;(document.activeElement as HTMLElement | null)?.blur()
     expect(document.activeElement).not.toBe(trigger)
 
-    // Esc → cancel event. Focus must return to the trigger WITHOUT any rerender.
-    fireEvent(dialogEl, new Event('cancel', { bubbles: false, cancelable: true }))
-    expect(document.activeElement).toBe(trigger)
+    // The post-close restore must still win and return focus to the trigger.
+    await waitFor(() => expect(document.activeElement).toBe(trigger))
     trigger.remove()
   })
 
-  it('restores focus to the trigger synchronously when Cancel is clicked', () => {
+  it('restores focus to the trigger after Cancel is clicked, surviving focus-to-body', async () => {
+    const onClose = vi.fn()
     const trigger = document.createElement('button')
     document.body.appendChild(trigger)
     trigger.focus()
 
-    render(<CreatePptModal open spaceId="s_1" onClose={() => {}} onCreated={() => {}} />)
+    const { rerender } = render(
+      <CreatePptModal open spaceId="s_1" onClose={onClose} onCreated={() => {}} />,
+    )
     ;(cards()[0] as HTMLButtonElement).focus()
     expect(document.activeElement).not.toBe(trigger)
 
     fireEvent.click(screen.getByRole('button', { name: 'docs.ppt.create.cancel' }))
-    expect(document.activeElement).toBe(trigger)
+    expect(onClose).toHaveBeenCalledTimes(1)
+    rerender(<CreatePptModal open={false} spaceId="s_1" onClose={onClose} onCreated={() => {}} />)
+
+    // Browser drops focus to <body> as the dialog closes, after our handler ran.
+    ;(document.activeElement as HTMLElement | null)?.blur()
+    expect(document.activeElement).not.toBe(trigger)
+
+    await waitFor(() => expect(document.activeElement).toBe(trigger))
     trigger.remove()
   })
 

--- a/packages/docs/src/ppt/CreatePptModal.test.tsx
+++ b/packages/docs/src/ppt/CreatePptModal.test.tsx
@@ -1,0 +1,253 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, waitFor, cleanup, fireEvent, act } from '@testing-library/react'
+import { setWKApp } from '../octoweb/index.ts'
+import { createMockWKApp, type MockApiClient } from '../octoweb/mock.ts'
+import { CreatePptModal } from './CreatePptModal.tsx'
+
+// Drive the POST /ppt/docs response through the mock apiClient responder.
+function mountApi(
+  responder: MockApiClient['responder'],
+): ReturnType<typeof createMockWKApp> {
+  const wk = createMockWKApp()
+  wk.apiClient.responder = responder
+  setWKApp(wk)
+  return wk
+}
+
+const okResponder: MockApiClient['responder'] = (_m, url) => {
+  if (url === '/ppt/docs') return { data: { data: { editorUrl: '/ppt/d/new_deck' } }, status: 201 }
+  return { data: {}, status: 200 }
+}
+
+/** All four template cards, in DOM order. */
+function cards(): HTMLElement[] {
+  return screen.getAllByRole('radio')
+}
+
+describe('CreatePptModal', () => {
+  beforeEach(() => {
+    Object.defineProperty(HTMLDialogElement.prototype, 'showModal', {
+      configurable: true,
+      value: vi.fn(function (this: HTMLDialogElement) {
+        this.setAttribute('open', '')
+      }),
+    })
+    Object.defineProperty(HTMLDialogElement.prototype, 'close', {
+      configurable: true,
+      value: vi.fn(function (this: HTMLDialogElement) {
+        this.removeAttribute('open')
+      }),
+    })
+    mountApi(okResponder)
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+  })
+
+  it('renders nothing when closed', () => {
+    const { container } = render(
+      <CreatePptModal open={false} spaceId="s_1" onClose={() => {}} onCreated={() => {}} />,
+    )
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders a native <dialog> with dialog a11y semantics', () => {
+    const { container } = render(
+      <CreatePptModal open spaceId="s_1" onClose={() => {}} onCreated={() => {}} />,
+    )
+    const dialogEl = container.querySelector('dialog.octo-ppt-create-modal')
+    expect(dialogEl?.tagName).toBe('DIALOG')
+    const byRole = screen.getByRole('dialog')
+    expect(byRole.getAttribute('aria-modal')).toBe('true')
+    expect(byRole.getAttribute('aria-labelledby')).toBeTruthy()
+  })
+
+  // ── PPT-UI-001: keyboard semantics ───────────────────────────────────────
+  it('exposes a radiogroup of four radio cards with blank selected by default', () => {
+    render(<CreatePptModal open spaceId="s_1" onClose={() => {}} onCreated={() => {}} />)
+    expect(screen.getByRole('radiogroup')).toBeTruthy()
+    const radios = cards()
+    expect(radios).toHaveLength(4)
+    // First card = blank, selected by default (aria-checked + roving tabindex 0).
+    expect(radios[0].getAttribute('aria-checked')).toBe('true')
+    expect(radios[0].getAttribute('tabindex')).toBe('0')
+    for (const r of radios.slice(1)) {
+      expect(r.getAttribute('aria-checked')).toBe('false')
+      expect(r.getAttribute('tabindex')).toBe('-1')
+    }
+  })
+
+  it('focuses the default template card on open (clear keyboard start point)', async () => {
+    render(<CreatePptModal open spaceId="s_1" onClose={() => {}} onCreated={() => {}} />)
+    await waitFor(() => expect(document.activeElement).toBe(cards()[0]))
+  })
+
+  it('arrow keys move selection AND focus across the cards; Space/Enter confirm', () => {
+    render(<CreatePptModal open spaceId="s_1" onClose={() => {}} onCreated={() => {}} />)
+    const radios = cards()
+    fireEvent.keyDown(radios[0], { key: 'ArrowRight' })
+    expect(radios[1].getAttribute('aria-checked')).toBe('true')
+    expect(document.activeElement).toBe(radios[1])
+    expect(radios[0].getAttribute('aria-checked')).toBe('false')
+
+    // Wrap-around backwards from the first card lands on the last.
+    fireEvent.keyDown(radios[1], { key: 'ArrowLeft' })
+    expect(radios[0].getAttribute('aria-checked')).toBe('true')
+
+    // Space/Enter confirm the focused card (native button click → onSelect).
+    fireEvent.click(radios[2])
+    expect(radios[2].getAttribute('aria-checked')).toBe('true')
+  })
+
+  it('keeps focus order group → title → Create → Cancel in the DOM', () => {
+    render(<CreatePptModal open spaceId="s_1" onClose={() => {}} onCreated={() => {}} />)
+    const group = screen.getByRole('radiogroup')
+    const titleInput = screen.getByLabelText('docs.ppt.create.titleLabel')
+    const create = screen.getByRole('button', { name: 'docs.ppt.create.submit' })
+    const cancel = screen.getByRole('button', { name: 'docs.ppt.create.cancel' })
+    // DOCUMENT_POSITION_FOLLOWING === 4: b follows a.
+    const follows = (a: Node, b: Node) =>
+      Boolean(a.compareDocumentPosition(b) & Node.DOCUMENT_POSITION_FOLLOWING)
+    expect(follows(group, titleInput)).toBe(true)
+    expect(follows(titleInput, create)).toBe(true)
+    expect(follows(create, cancel)).toBe(true)
+  })
+
+  it('closes and restores focus to the trigger on Esc (dialog cancel)', async () => {
+    const onClose = vi.fn()
+    const trigger = document.createElement('button')
+    document.body.appendChild(trigger)
+    trigger.focus()
+    expect(document.activeElement).toBe(trigger)
+
+    const { container, rerender } = render(
+      <CreatePptModal open spaceId="s_1" onClose={onClose} onCreated={() => {}} />,
+    )
+    const dialogEl = container.querySelector('dialog') as HTMLDialogElement
+    // Esc on a native <dialog> fires a cancel event, which our handler routes to onClose.
+    fireEvent(dialogEl, new Event('cancel', { bubbles: false, cancelable: true }))
+    expect(onClose).toHaveBeenCalledTimes(1)
+
+    // Parent closes the modal → focus is returned to the trigger.
+    rerender(<CreatePptModal open={false} spaceId="s_1" onClose={onClose} onCreated={() => {}} />)
+    await waitFor(() => expect(document.activeElement).toBe(trigger))
+    trigger.remove()
+  })
+
+  // ── PPT-HUMAN-001: create → land on the backend editor route ─────────────
+  it('creates the deck and hands the caller the backend editorUrl (no fabricated route)', async () => {
+    const wk = mountApi(okResponder)
+    const onCreated = vi.fn()
+    render(
+      <CreatePptModal open spaceId="s_1" folderId="f_1" onClose={() => {}} onCreated={onCreated} />,
+    )
+    // Pick the "report" template (3rd card) and type a title.
+    fireEvent.click(cards()[2])
+    fireEvent.change(screen.getByLabelText('docs.ppt.create.titleLabel'), {
+      target: { value: 'Quarterly review' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'docs.ppt.create.submit' }))
+
+    await waitFor(() => expect(onCreated).toHaveBeenCalledWith('/ppt/d/new_deck'))
+    const call = wk.apiClient.calls.find((c) => c.url === '/ppt/docs')
+    expect(call?.body).toEqual({ title: 'Quarterly review', templateId: 'report', folderId: 'f_1' })
+    expect(call?.config?.headers?.['Idempotency-Key']).toBeTruthy()
+  })
+
+  // ── PPT-HUMAN-002: empty / invalid title, 400 handling ───────────────────
+  it('disables Create until a non-empty title is entered', () => {
+    render(<CreatePptModal open spaceId="s_1" onClose={() => {}} onCreated={() => {}} />)
+    const create = screen.getByRole('button', { name: 'docs.ppt.create.submit' }) as HTMLButtonElement
+    expect(create.disabled).toBe(true)
+    fireEvent.change(screen.getByLabelText('docs.ppt.create.titleLabel'), {
+      target: { value: '   ' },
+    })
+    expect(create.disabled).toBe(true) // whitespace-only is still empty
+    fireEvent.change(screen.getByLabelText('docs.ppt.create.titleLabel'), {
+      target: { value: 'Deck' },
+    })
+    expect(create.disabled).toBe(false)
+  })
+
+  it('on 400 shows an inline error, does NOT navigate, and keeps the modal open', async () => {
+    mountApi(() => Promise.reject({ response: { status: 400, data: { error: 'VALIDATION_ERROR' } } }))
+    const onCreated = vi.fn()
+    const onClose = vi.fn()
+    render(<CreatePptModal open spaceId="s_1" onClose={onClose} onCreated={onCreated} />)
+    fireEvent.change(screen.getByLabelText('docs.ppt.create.titleLabel'), {
+      target: { value: 'Deck' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'docs.ppt.create.submit' }))
+
+    await waitFor(() => expect(screen.getByText('docs.ppt.create.validationError')).toBeTruthy())
+    expect(onCreated).not.toHaveBeenCalled()
+    expect(onClose).not.toHaveBeenCalled()
+    // Modal still mounted + retriable.
+    expect(screen.getByRole('dialog')).toBeTruthy()
+    expect((screen.getByRole('button', { name: 'docs.ppt.create.submit' }) as HTMLButtonElement).disabled).toBe(false)
+  })
+
+  it('a non-400 failure shows the generic error and keeps the modal open', async () => {
+    mountApi(() => Promise.reject({ response: { status: 500 } }))
+    const onCreated = vi.fn()
+    render(<CreatePptModal open spaceId="s_1" onClose={() => {}} onCreated={onCreated} />)
+    fireEvent.change(screen.getByLabelText('docs.ppt.create.titleLabel'), {
+      target: { value: 'Deck' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'docs.ppt.create.submit' }))
+    await waitFor(() => expect(screen.getByText('docs.ppt.create.error')).toBeTruthy())
+    expect(onCreated).not.toHaveBeenCalled()
+  })
+
+  // ── Double-submit + idempotency ──────────────────────────────────────────
+  it('prevents double-submit: Create shows loading + disabled, and only ONE request is sent', async () => {
+    let resolve!: (v: unknown) => void
+    const wk = mountApi(
+      () => new Promise((r) => { resolve = r as (v: unknown) => void }),
+    )
+    render(<CreatePptModal open spaceId="s_1" onClose={() => {}} onCreated={() => {}} />)
+    fireEvent.change(screen.getByLabelText('docs.ppt.create.titleLabel'), {
+      target: { value: 'Deck' },
+    })
+    const create = () => screen.getByRole('button', { name: /docs\.ppt\.create\.(submit|loading)/ }) as HTMLButtonElement
+    fireEvent.click(create())
+    // In-flight: label flips to loading and the button is disabled.
+    await waitFor(() => expect(screen.getByText('docs.ppt.create.loading')).toBeTruthy())
+    expect(create().disabled).toBe(true)
+    // A second click while loading is a no-op.
+    fireEvent.click(create())
+    fireEvent.click(create())
+    expect(wk.apiClient.calls.filter((c) => c.url === '/ppt/docs')).toHaveLength(1)
+    await act(async () => {
+      resolve({ data: { data: { editorUrl: '/ppt/d/x' } }, status: 201 })
+    })
+  })
+
+  it('retry after a failure reuses the SAME idempotency key (no duplicate deck)', async () => {
+    let attempt = 0
+    const wk = mountApi(() => {
+      attempt += 1
+      if (attempt === 1) return Promise.reject({ response: { status: 500 } })
+      return { data: { data: { editorUrl: '/ppt/d/deck' } }, status: 201 }
+    })
+    const onCreated = vi.fn()
+    render(<CreatePptModal open spaceId="s_1" onClose={() => {}} onCreated={onCreated} />)
+    fireEvent.change(screen.getByLabelText('docs.ppt.create.titleLabel'), {
+      target: { value: 'Deck' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'docs.ppt.create.submit' }))
+    await waitFor(() => expect(screen.getByText('docs.ppt.create.error')).toBeTruthy())
+    // Retry the same submit.
+    fireEvent.click(screen.getByRole('button', { name: 'docs.ppt.create.submit' }))
+    await waitFor(() => expect(onCreated).toHaveBeenCalledWith('/ppt/d/deck'))
+
+    const keys = wk.apiClient.calls
+      .filter((c) => c.url === '/ppt/docs')
+      .map((c) => c.config?.headers?.['Idempotency-Key'])
+    expect(keys).toHaveLength(2)
+    expect(keys[0]).toBe(keys[1])
+    expect(keys[0]).toBeTruthy()
+  })
+})

--- a/packages/docs/src/ppt/CreatePptModal.test.tsx
+++ b/packages/docs/src/ppt/CreatePptModal.test.tsx
@@ -446,10 +446,100 @@ describe('CreatePptModal', () => {
     expect(keys[0]).not.toBe(keys[1])
   })
 
-  // P1-3: if the user switches space while a create is in flight, the late-resolving space-A create
-  // must NOT navigate — it would drop the user into the wrong-space deck. A generation token captured
-  // at submit start is invalidated by the space-change reset, so the post-await handoff is skipped.
-  it('does NOT complete/navigate when the space changes mid-submit (cross-space late-resolve guard)', async () => {
+  // P2-3: a WHITESPACE-ONLY title edit is NOT a content change — the body carries `title.trim()`, so
+  // "AAA" and "AAA " POST byte-identical payloads. The idempotency key must therefore stay STABLE
+  // across such an edit; re-minting it (the bug: the effect keyed on the raw title) would let the
+  // backend treat the second submit as a distinct create and, if the first actually succeeded
+  // server-side, mint a duplicate deck. Keying the effect on the trimmed title fixes it.
+  it('does NOT re-mint the idempotency key when only trailing whitespace is added to the title (same trimmed payload)', async () => {
+    let attempt = 0
+    const wk = mountApi(() => {
+      attempt += 1
+      if (attempt === 1) return Promise.reject({ response: { status: 500 } })
+      return { data: { data: { editorUrl: '/ppt/d/deck' } }, status: 201 }
+    })
+    const onCreated = vi.fn()
+    render(<CreatePptModal open spaceId="s_1" onClose={() => {}} onCreated={onCreated} />)
+
+    const titleInput = screen.getByLabelText('docs.ppt.create.titleLabel')
+    fireEvent.change(titleInput, { target: { value: 'AAA' } })
+    fireEvent.click(screen.getByRole('button', { name: 'docs.ppt.create.submit' }))
+    await waitFor(() => expect(screen.getByText('docs.ppt.create.error')).toBeTruthy())
+
+    // Add a trailing space — the trimmed payload is unchanged, so this is an identical retry.
+    fireEvent.change(titleInput, { target: { value: 'AAA ' } })
+    fireEvent.click(screen.getByRole('button', { name: 'docs.ppt.create.submit' }))
+    await waitFor(() => expect(onCreated).toHaveBeenCalledWith('/ppt/d/deck'))
+
+    const calls = wk.apiClient.calls.filter((c) => c.url === '/ppt/docs')
+    expect(calls).toHaveLength(2)
+    // Both bodies carry the trimmed title, so they are byte-identical…
+    expect(calls[0].body).toMatchObject({ title: 'AAA' })
+    expect(calls[1].body).toMatchObject({ title: 'AAA' })
+    // …and MUST reuse the same key so the backend dedups instead of minting a duplicate deck.
+    const keys = calls.map((c) => c.config?.headers?.['Idempotency-Key'])
+    expect(keys[0]).toBeTruthy()
+    expect(keys[0]).toBe(keys[1])
+  })
+
+  // P2-1: a NON-retriable failure (the caller refused the backend route, onCreated → false) must show
+  // its own message and DISABLE Create — retrying reuses the same key and re-dedups to the same dead
+  // route. Editing the payload mints a fresh key and re-enables Create.
+  it('P2-1: on a refused (unsafe) route shows the non-retriable message + disables Create, re-enabled after a payload edit', async () => {
+    mountApi(okResponder)
+    // onCreated returns false → the caller refused to navigate (unsafe/cross-origin route).
+    const onCreated = vi.fn(() => false as const)
+    render(<CreatePptModal open spaceId="s_1" onClose={() => {}} onCreated={onCreated} />)
+
+    const titleInput = screen.getByLabelText('docs.ppt.create.titleLabel')
+    fireEvent.change(titleInput, { target: { value: 'Deck' } })
+    fireEvent.click(screen.getByRole('button', { name: 'docs.ppt.create.submit' }))
+
+    await waitFor(() => expect(screen.getByText('docs.ppt.create.unavailable')).toBeTruthy())
+    const submit = () => screen.getByRole('button', { name: 'docs.ppt.create.submit' }) as HTMLButtonElement
+    expect(submit().disabled).toBe(true)
+
+    // A genuine payload edit mints a fresh key → distinct create → Create is usable again.
+    fireEvent.change(titleInput, { target: { value: 'Deck v2' } })
+    expect(submit().disabled).toBe(false)
+    expect(screen.queryByText('docs.ppt.create.unavailable')).toBeNull()
+  })
+
+  // P2-1: a 201 with no editorUrl (MissingEditorUrlError) is likewise non-retriable — same distinct
+  // message + disabled Create, never the generic retriable error.
+  it('P2-1: a 201 with no editorUrl shows the non-retriable message + disables Create', async () => {
+    mountApi((_m, url) => {
+      if (url === '/ppt/docs') return { data: { data: {} }, status: 201 } // no editorUrl
+      return { data: {}, status: 200 }
+    })
+    const onCreated = vi.fn()
+    render(<CreatePptModal open spaceId="s_1" onClose={() => {}} onCreated={onCreated} />)
+    fireEvent.change(screen.getByLabelText('docs.ppt.create.titleLabel'), {
+      target: { value: 'Deck' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'docs.ppt.create.submit' }))
+
+    await waitFor(() => expect(screen.getByText('docs.ppt.create.unavailable')).toBeTruthy())
+    expect(onCreated).not.toHaveBeenCalled()
+    expect(
+      (screen.getByRole('button', { name: 'docs.ppt.create.submit' }) as HTMLButtonElement).disabled,
+    ).toBe(true)
+  })
+
+  // P1-3 (fix #5): if the user switches space while a create is in flight, the late-resolving
+  // space-A create must NOT navigate — it would drop the user into the wrong-space deck. A
+  // generation token captured at submit start is invalidated by the open/space-change bump, so the
+  // post-await handoff is skipped.
+  //
+  // This drives the REAL app transition, not the earlier open-held rerender. In DocsHome the
+  // Space-switch reconciler (onSpaceChanged → setSpace(next) + backToList()) flips BOTH props in ONE
+  // React batch: `open` → false AND `spaceId` → the new id. `spaceId` never changes while `open`
+  // stays true — the picker is always closed in the same batch. The prior test held `open` true
+  // (`rerender(<CreatePptModal open spaceId="s_B" />)`), a state that cannot occur in the app, so it
+  // passed even while the generation bump lived inside the reset effect that early-returns on
+  // `!open` (the shipped bug). Bumping the token in its own open-guard-free effect is what makes the
+  // real close+space-change transition invalidate the in-flight submit.
+  it('does NOT navigate when a space switch closes the picker mid-submit (open→false AND spaceId→new in one update)', async () => {
     let resolve!: (v: unknown) => void
     mountApi(() => new Promise((r) => { resolve = r as (v: unknown) => void }))
     const onCreated = vi.fn()
@@ -462,10 +552,12 @@ describe('CreatePptModal', () => {
     fireEvent.click(screen.getByRole('button', { name: 'docs.ppt.create.submit' }))
     await waitFor(() => expect(screen.getByText('docs.ppt.create.loading')).toBeTruthy())
 
-    // User switches to space B while the space-A create is still awaiting.
-    rerender(<CreatePptModal open spaceId="s_B" onClose={() => {}} onCreated={onCreated} />)
+    // The Space switch closes the picker (open→false) AND moves to space B in the SAME update — the
+    // exact DocsHome batch. The picker is never left open across a spaceId change.
+    rerender(<CreatePptModal open={false} spaceId="s_B" onClose={() => {}} onCreated={onCreated} />)
 
-    // The space-A create finally resolves — but its generation is stale now, so no handoff/navigation.
+    // The space-A create finally resolves — but its generation is stale now, so no handoff/navigation
+    // into the previous space's deck.
     await act(async () => {
       resolve({ data: { data: { editorUrl: '/ppt/d/deck_A' } }, status: 201 })
     })

--- a/packages/docs/src/ppt/CreatePptModal.test.tsx
+++ b/packages/docs/src/ppt/CreatePptModal.test.tsx
@@ -196,6 +196,62 @@ describe('CreatePptModal', () => {
     trigger.remove()
   })
 
+  // ── R2-F1 root cause: restore target must be the PERSISTENT trigger, not a detached opener ──
+  // The picker is opened from a caret dropdown MENU ITEM that unmounts the instant it is clicked.
+  // document.activeElement at open time is therefore a node that will detach; restoring to it no-ops
+  // onto <body> (the observed defect). When a triggerRef pointing at a PERSISTENT element (the caret)
+  // is supplied, the modal must restore focus to THAT, ignoring the detached opener.
+  it('restores focus to the persistent triggerRef target even when the captured opener has detached (R2-F1)', async () => {
+    const persistent = document.createElement('button')
+    persistent.textContent = 'caret'
+    document.body.appendChild(persistent)
+    const triggerRef = { current: persistent as HTMLElement | null }
+
+    // The transient opener (a menu item) had focus when the modal opened.
+    const transientOpener = document.createElement('button')
+    document.body.appendChild(transientOpener)
+    transientOpener.focus()
+    expect(document.activeElement).toBe(transientOpener)
+
+    const { rerender } = render(
+      <CreatePptModal open spaceId="s_1" triggerRef={triggerRef} onClose={() => {}} onCreated={() => {}} />,
+    )
+    // The opener detaches while the modal is up (the dropdown menu has closed).
+    transientOpener.remove()
+    expect(transientOpener.isConnected).toBe(false)
+
+    rerender(
+      <CreatePptModal open={false} spaceId="s_1" triggerRef={triggerRef} onClose={() => {}} onCreated={() => {}} />,
+    )
+    ;(document.activeElement as HTMLElement | null)?.blur()
+
+    // Focus lands on the persistent caret, never on the detached opener or <body>.
+    await waitFor(() => expect(document.activeElement).toBe(persistent))
+    persistent.remove()
+  })
+
+  // Control: with NO triggerRef and the captured opener detached, the old document.activeElement path
+  // cannot restore focus — it strands on <body>. This is the R2-F1 defect the triggerRef fix removes.
+  it('control: without triggerRef, a detached opener leaves focus on <body> (the R2-F1 defect)', async () => {
+    const transientOpener = document.createElement('button')
+    document.body.appendChild(transientOpener)
+    transientOpener.focus()
+
+    const { rerender } = render(
+      <CreatePptModal open spaceId="s_1" onClose={() => {}} onCreated={() => {}} />,
+    )
+    transientOpener.remove()
+    rerender(<CreatePptModal open={false} spaceId="s_1" onClose={() => {}} onCreated={() => {}} />)
+    ;(document.activeElement as HTMLElement | null)?.blur()
+
+    // No connected restore target → focus cannot return; it stays on <body>.
+    await act(async () => {
+      await new Promise((r) => requestAnimationFrame(() => r(null)))
+    })
+    expect(document.activeElement).toBe(document.body)
+  })
+
+
   // ── R2-F1 defect 2: Tab focus is trapped inside the dialog ────────────────
   it('traps Tab focus inside the dialog (Tab from the last control wraps to the first)', () => {
     const { container } = render(

--- a/packages/docs/src/ppt/CreatePptModal.test.tsx
+++ b/packages/docs/src/ppt/CreatePptModal.test.tsx
@@ -136,6 +136,89 @@ describe('CreatePptModal', () => {
     trigger.remove()
   })
 
+  // ── R2-F1 defect 1: Esc/close restores focus on the close route itself ────
+  // The parent-driven unmount cleanup is not enough: in a real browser the
+  // native dialog steals focus to BODY on the Esc route before the parent flips
+  // `open`. Focus must be restored synchronously by the close handler, without
+  // relying on the caller re-rendering with open={false}.
+  it('restores focus to the trigger synchronously on the Esc/cancel route', () => {
+    const trigger = document.createElement('button')
+    document.body.appendChild(trigger)
+    trigger.focus()
+
+    const { container } = render(
+      <CreatePptModal open spaceId="s_1" onClose={() => {}} onCreated={() => {}} />,
+    )
+    const dialogEl = container.querySelector('dialog') as HTMLDialogElement
+    // Simulate the browser having moved focus off the trigger (dialog took it).
+    ;(cards()[0] as HTMLButtonElement).focus()
+    expect(document.activeElement).not.toBe(trigger)
+
+    // Esc → cancel event. Focus must return to the trigger WITHOUT any rerender.
+    fireEvent(dialogEl, new Event('cancel', { bubbles: false, cancelable: true }))
+    expect(document.activeElement).toBe(trigger)
+    trigger.remove()
+  })
+
+  it('restores focus to the trigger synchronously when Cancel is clicked', () => {
+    const trigger = document.createElement('button')
+    document.body.appendChild(trigger)
+    trigger.focus()
+
+    render(<CreatePptModal open spaceId="s_1" onClose={() => {}} onCreated={() => {}} />)
+    ;(cards()[0] as HTMLButtonElement).focus()
+    expect(document.activeElement).not.toBe(trigger)
+
+    fireEvent.click(screen.getByRole('button', { name: 'docs.ppt.create.cancel' }))
+    expect(document.activeElement).toBe(trigger)
+    trigger.remove()
+  })
+
+  // ── R2-F1 defect 2: Tab focus is trapped inside the dialog ────────────────
+  it('traps Tab focus inside the dialog (Tab from the last control wraps to the first)', () => {
+    const { container } = render(
+      <CreatePptModal open spaceId="s_1" onClose={() => {}} onCreated={() => {}} />,
+    )
+    const dialogEl = container.querySelector('dialog') as HTMLDialogElement
+    // Enable Create so all four tab stops (radio → title → Create → Cancel) exist.
+    fireEvent.change(screen.getByLabelText('docs.ppt.create.titleLabel'), {
+      target: { value: 'Deck' },
+    })
+    const selectedRadio = cards()[0] // blank, tabindex 0
+    const cancel = screen.getByRole('button', { name: 'docs.ppt.create.cancel' })
+
+    // Tab from the last control (Cancel) wraps forward to the first (selected radio).
+    cancel.focus()
+    fireEvent.keyDown(dialogEl, { key: 'Tab' })
+    expect(document.activeElement).toBe(selectedRadio)
+
+    // Shift+Tab from the first control wraps backward to the last (Cancel).
+    selectedRadio.focus()
+    fireEvent.keyDown(dialogEl, { key: 'Tab', shiftKey: true })
+    expect(document.activeElement).toBe(cancel)
+  })
+
+  // ── R2-F1 defect 3: Create disables synchronously on the first click ──────
+  // Two clicks dispatched within a single React batch (before `submitting`
+  // state flushes) must still fire only ONE request — a synchronous guard, not
+  // just the state-derived `disabled` attribute.
+  it('sends only ONE request when Create is double-clicked within one batch', () => {
+    const wk = mountApi(() => new Promise(() => {})) // never resolves; stays in-flight
+    render(<CreatePptModal open spaceId="s_1" onClose={() => {}} onCreated={() => {}} />)
+    fireEvent.change(screen.getByLabelText('docs.ppt.create.titleLabel'), {
+      target: { value: 'Deck' },
+    })
+    const create = screen.getByRole('button', {
+      name: /docs\.ppt\.create\.(submit|loading)/,
+    }) as HTMLButtonElement
+    // Both clicks in ONE act() batch → state has not re-rendered between them.
+    act(() => {
+      create.click()
+      create.click()
+    })
+    expect(wk.apiClient.calls.filter((c) => c.url === '/ppt/docs')).toHaveLength(1)
+  })
+
   // ── PPT-HUMAN-001: create → land on the backend editor route ─────────────
   it('creates the deck and hands the caller the backend editorUrl (no fabricated route)', async () => {
     const wk = mountApi(okResponder)

--- a/packages/docs/src/ppt/CreatePptModal.tsx
+++ b/packages/docs/src/ppt/CreatePptModal.tsx
@@ -12,7 +12,7 @@
 // and double-submit prevention with idempotency-key reuse on retry.
 
 import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react'
-import { t } from '../octoweb/index.ts'
+import { t, useI18n } from '../octoweb/index.ts'
 import {
   createPptDoc,
   DEFAULT_PPT_TEMPLATE,
@@ -115,6 +115,12 @@ export function CreatePptModal({
   onCreated,
   triggerRef,
 }: CreatePptModalProps): React.ReactElement | null {
+  // Subscribe to the host locale (P2-2). The modal stays mounted (returns null when closed), so a
+  // one-shot module-level t() would freeze every label — and the template names/aria-labels below —
+  // at first-render language. useI18n() re-renders the component on a live zh/en switch; `locale`
+  // also keys the template memo so it recomputes. Imperative submit-time error strings keep using
+  // the module `t()` (read once, at submit) to avoid re-keying the verified cross-space closure.
+  const { locale } = useI18n()
   const [selected, setSelected] = useState<PptTemplateId>(DEFAULT_PPT_TEMPLATE)
   const [title, setTitle] = useState('')
   const [submitting, setSubmitting] = useState(false)
@@ -152,7 +158,8 @@ export function CreatePptModal({
   const titleFieldId = useId()
   const errorId = useId()
 
-  // Template metadata (name + scene) resolved from i18n; memoised on locale-stable keys.
+  // Template metadata (name + scene) resolved from i18n; recomputed when the active locale changes
+  // so card names and their aria-labels follow a live zh/en switch (P2-2).
   const templates = useMemo(
     () =>
       PPT_TEMPLATES.map((id) => ({
@@ -160,7 +167,7 @@ export function CreatePptModal({
         name: t(`docs.ppt.template.${id}.name`),
         desc: t(`docs.ppt.template.${id}.desc`),
       })),
-    [],
+    [locale],
   )
 
   // The submitted title (P2-3): the request body carries `title.trim()`, so the idempotency key and
@@ -411,7 +418,16 @@ export function CreatePptModal({
           requestClose()
         }}
         onKeyDown={onDialogKeyDown}
-        onMouseDown={(e) => e.stopPropagation()}
+        onMouseDown={(e) => {
+          // A press on the ::backdrop (which showModal() promotes to the top layer) or on the
+          // dialog's own margin reports the <dialog> itself as the event target; a press inside the
+          // content reports a descendant. Close only on the former, so a real-browser backdrop click
+          // dismisses (P2-1) — the outer overlay wrapper never receives the event once the dialog is
+          // in the top layer. Content presses stop here so they don't bubble to the wrapper's
+          // requestClose on the no-top-layer (jsdom) fallback path.
+          if (e.target === dialogRef.current) requestClose()
+          else e.stopPropagation()
+        }}
       >
         <header className="octo-ppt-create-header">
           <h3 id={titleId} className="octo-ppt-create-title">

--- a/packages/docs/src/ppt/CreatePptModal.tsx
+++ b/packages/docs/src/ppt/CreatePptModal.tsx
@@ -30,8 +30,13 @@ export interface CreatePptModalProps {
   /** Optional target folder passed straight through to the create call. */
   folderId?: string
   onClose(): void
-  /** Called with the backend-returned editor route after a successful create. NOT called on cancel. */
-  onCreated(editorUrl: string): void
+  /**
+   * Called with the backend-returned editor route after a successful create. NOT called on cancel.
+   * Returns `false` when the caller REFUSED to navigate (e.g. the route failed the open-redirect
+   * guard, P1-1); the modal then surfaces an inline error and stays open/retriable instead of
+   * silently soft-locking. `void`/`true` mean the caller took over navigation and the modal unmounts.
+   */
+  onCreated(editorUrl: string): boolean | void
   /**
    * The PERSISTENT element that opened the picker (the DocsHome "new" caret button), to restore focus
    * to on close. Supplied explicitly because the picker is launched from a caret dropdown MENU ITEM
@@ -118,14 +123,22 @@ export function CreatePptModal({
   const cardRefs = useRef<Array<HTMLButtonElement | null>>([])
   // The element focused before the modal opened, restored on close (design §3 focus trap + restore).
   const restoreFocusRef = useRef<HTMLElement | null>(null)
-  // Idempotency key for the CURRENT submit session: minted once per open and REUSED across retries
-  // so a lost-response retry never mints a duplicate deck (hard metric #3). Reset on each open.
+  // Idempotency key for the CURRENT submit session. It must be REUSED across an identical retry (so
+  // a lost-response retry dedups to the same deck, hard metric #3) but RE-MINTED whenever the payload
+  // (title/template) changes — otherwise a content-changed resubmit reuses the key, the backend
+  // dedups on it, and the user gets the FIRST (stale-title) deck back (P1-2). Minted by the
+  // payload-keyed effect below, not just on open.
   const idempotencyKeyRef = useRef<string>('')
   // Synchronous double-submit latch: flipped true the instant a create starts, BEFORE React
   // re-renders the disabled button. Two clicks in the same tick can both observe `submitting`
   // state as false, so the state-derived `disabled` alone can leak a second HTTP request; this ref
   // closes that window (belt-and-suspenders over idempotency-key reuse). Reset on each open/failure.
   const submittingRef = useRef(false)
+  // Generation token for the in-flight submit (P1-3). The open/space reset effect bumps this, so if
+  // the user switches space (or the modal reopens) mid-await, the submit's captured token goes stale
+  // and its late resolve must NOT navigate to the wrong-space deck. Same idiom as useDocComments'
+  // reqRef / SummaryListPage's loadDataSeq generation guards.
+  const submitSeqRef = useRef(0)
 
   const titleId = useId()
   const groupId = useId()
@@ -143,8 +156,9 @@ export function CreatePptModal({
     [],
   )
 
-  // Reset the draft whenever the modal opens or the space changes; mint a fresh idempotency key for
-  // the new submit session and remember what to restore focus to.
+  // Reset the draft whenever the modal opens or the space changes; remember what to restore focus to.
+  // Bumping submitSeqRef here invalidates any in-flight submit's generation token, so a create that
+  // was fired before a space switch cannot navigate after it resolves (P1-3).
   useEffect(() => {
     if (!open) return
     setSelected(DEFAULT_PPT_TEMPLATE)
@@ -152,7 +166,7 @@ export function CreatePptModal({
     setSubmitting(false)
     setError(null)
     submittingRef.current = false
-    idempotencyKeyRef.current = newIdempotencyKey()
+    submitSeqRef.current += 1
     // Capture the restore target. Prefer the caller-supplied PERSISTENT trigger (the caret button that
     // opened the picker) over document.activeElement: the picker is launched from a caret DROPDOWN menu
     // item that unmounts the instant it is clicked (the menu closes as it fires onCreatePpt), so by the
@@ -169,6 +183,16 @@ export function CreatePptModal({
           ? document.activeElement
           : null
   }, [open, spaceId, triggerRef])
+
+  // Mint the idempotency key for the current payload (P1-2). Keyed on the payload (title + template)
+  // as well as open/space so the key is STABLE across an identical retry — a plain retry re-runs
+  // onSubmit without changing title/selected, so no new key is minted and the backend dedups to the
+  // same deck — but a FRESH key is minted the moment the user edits the title or picks another
+  // template, so a content-changed resubmit is a distinct create (never a stale-title dedup).
+  useEffect(() => {
+    if (!open) return
+    idempotencyKeyRef.current = newIdempotencyKey()
+  }, [open, spaceId, title, selected])
 
   // Restore focus to the element that had it before the modal opened (the trigger caret).
   // This MUST run AFTER the native <dialog> has finished closing. On the Esc/close route the
@@ -292,6 +316,9 @@ export function CreatePptModal({
     submittingRef.current = true
     setSubmitting(true)
     setError(null)
+    // Capture the submit generation (P1-3). The open/space reset effect bumps submitSeqRef, so if the
+    // user switches space (or the modal resets) mid-await, this captured token goes stale.
+    const token = submitSeqRef.current
     try {
       const result = await createPptDoc({
         title: trimmed,
@@ -299,9 +326,22 @@ export function CreatePptModal({
         folderId,
         idempotencyKey: idempotencyKeyRef.current,
       })
-      // Trust the backend route ONLY — no frontend fallback (preserves R1 no-fallthrough).
-      onCreated(result.editorUrl)
+      // Cross-space late-resolve guard (P1-3): if the space changed (or the modal reset) during the
+      // await, this create belongs to a stale context — do NOT navigate to its wrong-space deck.
+      if (submitSeqRef.current !== token) return
+      // Trust the backend route ONLY — no frontend fallback (preserves R1 no-fallthrough). The caller
+      // gates the route through the open-redirect guard; a `false` return means it REFUSED to navigate
+      // (unsafe route, P1-1) — surface an inline error and keep the modal open/retriable instead of
+      // soft-locking on a dead "success".
+      if (onCreated(result.editorUrl) === false) {
+        setError(t('docs.ppt.create.error'))
+        submittingRef.current = false
+        setSubmitting(false)
+      }
     } catch (err) {
+      // A superseded submit (space switched mid-await) must not clobber the fresh draft with its late
+      // error either — bail on a stale generation (P1-3).
+      if (submitSeqRef.current !== token) return
       const status = (err as { response?: { status?: number } })?.response?.status
       // 400 → inline validation error, modal stays open, no navigation (hard metric #2).
       // Everything else (401/409/5xx/missing editorUrl/network) → generic error, modal stays open

--- a/packages/docs/src/ppt/CreatePptModal.tsx
+++ b/packages/docs/src/ppt/CreatePptModal.tsx
@@ -32,6 +32,15 @@ export interface CreatePptModalProps {
   onClose(): void
   /** Called with the backend-returned editor route after a successful create. NOT called on cancel. */
   onCreated(editorUrl: string): void
+  /**
+   * The PERSISTENT element that opened the picker (the DocsHome "new" caret button), to restore focus
+   * to on close. Supplied explicitly because the picker is launched from a caret dropdown MENU ITEM
+   * that unmounts the instant it is clicked — so `document.activeElement` at open time is already a
+   * detached node / `<body>` and cannot be a reliable restore target (R2-F1). The caret persists across
+   * the menu open/close, so restoring to it lands focus correctly. Optional: falls back to
+   * `document.activeElement` when omitted (e.g. programmatic opens in tests).
+   */
+  triggerRef?: React.RefObject<HTMLElement | null>
 }
 
 /**
@@ -98,6 +107,7 @@ export function CreatePptModal({
   folderId,
   onClose,
   onCreated,
+  triggerRef,
 }: CreatePptModalProps): React.ReactElement | null {
   const [selected, setSelected] = useState<PptTemplateId>(DEFAULT_PPT_TEMPLATE)
   const [title, setTitle] = useState('')
@@ -143,11 +153,22 @@ export function CreatePptModal({
     setError(null)
     submittingRef.current = false
     idempotencyKeyRef.current = newIdempotencyKey()
+    // Capture the restore target. Prefer the caller-supplied PERSISTENT trigger (the caret button that
+    // opened the picker) over document.activeElement: the picker is launched from a caret DROPDOWN menu
+    // item that unmounts the instant it is clicked (the menu closes as it fires onCreatePpt), so by the
+    // time this open effect runs the previously-focused element is a DETACHED menu item and
+    // document.activeElement has already fallen back to <body>. Restoring to either silently no-ops and
+    // focus is stranded on <body> (the R2-F1 defect). The caret persists across the menu open/close, so
+    // it is the correct, still-connected restore target. Fall back to document.activeElement only when
+    // no trigger is supplied (e.g. programmatic opens in tests).
+    const trigger = triggerRef?.current
     restoreFocusRef.current =
-      typeof document !== 'undefined' && document.activeElement instanceof HTMLElement
-        ? document.activeElement
-        : null
-  }, [open, spaceId])
+      trigger && trigger.isConnected
+        ? trigger
+        : typeof document !== 'undefined' && document.activeElement instanceof HTMLElement
+          ? document.activeElement
+          : null
+  }, [open, spaceId, triggerRef])
 
   // Restore focus to the element that had it before the modal opened (the trigger caret).
   // This MUST run AFTER the native <dialog> has finished closing. On the Esc/close route the
@@ -157,17 +178,20 @@ export function CreatePptModal({
   // fallback) lets us run after the browser's own focus move and reliably land on the trigger
   // (design §3 focus restore, PPT-UI-001).
   const scheduleFocusRestore = useCallback(() => {
-    const el = restoreFocusRef.current
-    if (!el) return
     const run = () => {
-      // Only reclaim focus if the dialog close dropped it to <body> (or nowhere); never yank it
-      // away if the app has meanwhile placed it somewhere deliberate.
+      // Prefer the LIVE persistent trigger (the caret) — it survives the menu close, whereas the element
+      // captured on open may have detached. Only reclaim focus if the dialog close dropped it to <body>
+      // (or nowhere); never yank it away if the app has meanwhile placed it somewhere deliberate. Never
+      // focus a detached node: el.focus() on a node not in the document silently no-ops and leaves focus
+      // on <body> (the observed R2-F1 failure), so guard on isConnected.
+      const target = triggerRef?.current ?? restoreFocusRef.current
+      if (!target || target.isConnected === false) return
       const active = typeof document !== 'undefined' ? document.activeElement : null
-      if (!active || active === document.body) el.focus?.()
+      if (!active || active === document.body) target.focus?.()
     }
     if (typeof requestAnimationFrame === 'function') requestAnimationFrame(run)
     else setTimeout(run, 0)
-  }, [])
+  }, [triggerRef])
 
   // Open the native dialog and, on close, restore focus to the trigger (caret menu item).
   useEffect(() => {

--- a/packages/docs/src/ppt/CreatePptModal.tsx
+++ b/packages/docs/src/ppt/CreatePptModal.tsx
@@ -11,7 +11,7 @@
 // + Esc-restores-focus + visible focus ring, PPT-UI-001), trust-the-backend-route + inline 400,
 // and double-submit prevention with idempotency-key reuse on retry.
 
-import { useEffect, useId, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react'
 import { t } from '../octoweb/index.ts'
 import {
   createPptDoc,
@@ -149,6 +149,26 @@ export function CreatePptModal({
         : null
   }, [open, spaceId])
 
+  // Restore focus to the element that had it before the modal opened (the trigger caret).
+  // This MUST run AFTER the native <dialog> has finished closing. On the Esc/close route the
+  // browser moves focus to <body> asynchronously relative to our React handlers, so a synchronous
+  // focus() inside the cancel/keydown handler is immediately overwritten and focus ends up on
+  // <body> (the observed R2-F1 defect). Deferring to the next animation frame (with a timeout
+  // fallback) lets us run after the browser's own focus move and reliably land on the trigger
+  // (design §3 focus restore, PPT-UI-001).
+  const scheduleFocusRestore = useCallback(() => {
+    const el = restoreFocusRef.current
+    if (!el) return
+    const run = () => {
+      // Only reclaim focus if the dialog close dropped it to <body> (or nowhere); never yank it
+      // away if the app has meanwhile placed it somewhere deliberate.
+      const active = typeof document !== 'undefined' ? document.activeElement : null
+      if (!active || active === document.body) el.focus?.()
+    }
+    if (typeof requestAnimationFrame === 'function') requestAnimationFrame(run)
+    else setTimeout(run, 0)
+  }, [])
+
   // Open the native dialog and, on close, restore focus to the trigger (caret menu item).
   useEffect(() => {
     const dialog = dialogRef.current
@@ -165,9 +185,9 @@ export function CreatePptModal({
         if (typeof dialog.close === 'function') dialog.close()
         else dialog.removeAttribute('open')
       }
-      restoreFocusRef.current?.focus?.()
+      scheduleFocusRestore()
     }
-  }, [open])
+  }, [open, scheduleFocusRestore])
 
   if (!open) return null
 
@@ -177,12 +197,12 @@ export function CreatePptModal({
 
   // Cancel/Esc/overlay dismissal — blocked while a create is in flight so the request can't be
   // orphaned mid-submit (the retry would otherwise mint under a fresh key on reopen). Focus is
-  // restored to the trigger synchronously on THIS route: the native dialog moves focus to BODY on
-  // the Esc/close path in real browsers, and the parent-driven unmount cleanup fires too late to
-  // catch that (design §3 focus restore, PPT-UI-001).
+  // restored to the trigger on a post-close animation frame (see scheduleFocusRestore): the native
+  // dialog moves focus to BODY on the Esc/close path in real browsers, so a synchronous restore
+  // here would be overwritten (design §3 focus restore, PPT-UI-001).
   const requestClose = () => {
     if (submitting) return
-    restoreFocusRef.current?.focus?.()
+    scheduleFocusRestore()
     onClose()
   }
 

--- a/packages/docs/src/ppt/CreatePptModal.tsx
+++ b/packages/docs/src/ppt/CreatePptModal.tsx
@@ -1,0 +1,358 @@
+// Create-slides template picker (R2-F1 / design appendix §2–§4).
+//
+// A self-contained, keyboard-accessible modal: a real native <dialog>, a `role="radiogroup"` of
+// four `role="radio"` template cards (16:9 preview + name + scene), a required title input, and a
+// Create / Cancel footer. It ONLY collects a {template, title} choice and POSTs it to
+// `POST /api/v1/ppt/docs` with a client `Idempotency-Key`; on success it hands the caller the
+// BACKEND-returned editor route to navigate to (never a frontend-built route — no-fallthrough
+// contract). No empty deck is precreated before submit.
+//
+// Hard acceptance bars (design appendix): keyboard semantics (radiogroup + arrow keys + Space/Enter
+// + Esc-restores-focus + visible focus ring, PPT-UI-001), trust-the-backend-route + inline 400,
+// and double-submit prevention with idempotency-key reuse on retry.
+
+import { useEffect, useId, useMemo, useRef, useState } from 'react'
+import { t } from '../octoweb/index.ts'
+import {
+  createPptDoc,
+  DEFAULT_PPT_TEMPLATE,
+  newIdempotencyKey,
+  PPT_TEMPLATES,
+  PPT_TITLE_MAX,
+  type PptTemplateId,
+} from './createPptTask.ts'
+import './CreatePptModal.css'
+
+export interface CreatePptModalProps {
+  open: boolean
+  /** Active space — resets the draft when it changes (mirrors CreateHtmlModal). */
+  spaceId: string
+  /** Optional target folder passed straight through to the create call. */
+  folderId?: string
+  onClose(): void
+  /** Called with the backend-returned editor route after a successful create. NOT called on cancel. */
+  onCreated(editorUrl: string): void
+}
+
+/**
+ * Distinct 16:9 line-drawn preview per template (no bespoke colours — inherits currentColor so it
+ * themes with the card). Purely decorative: the accessible name of the card is its aria-label
+ * (template name + scene), so the SVG is aria-hidden.
+ */
+function TemplatePreview({ id }: { id: PptTemplateId }): React.ReactElement {
+  const common = {
+    width: '100%',
+    viewBox: '0 0 160 90',
+    fill: 'none',
+    'aria-hidden': true as const,
+    preserveAspectRatio: 'xMidYMid meet',
+  }
+  const frame = (
+    <rect x="1" y="1" width="158" height="88" rx="6" stroke="currentColor" strokeWidth="1.5" />
+  )
+  switch (id) {
+    case 'blank':
+      return (
+        <svg {...common} className="octo-ppt-tpl-preview">
+          {frame}
+        </svg>
+      )
+    case 'pitch':
+      return (
+        <svg {...common} className="octo-ppt-tpl-preview">
+          {frame}
+          <rect x="18" y="24" width="70" height="10" rx="2" fill="currentColor" opacity="0.85" />
+          <rect x="18" y="42" width="52" height="6" rx="2" fill="currentColor" opacity="0.5" />
+          <rect x="18" y="54" width="44" height="6" rx="2" fill="currentColor" opacity="0.5" />
+          <circle cx="122" cy="45" r="20" stroke="currentColor" strokeWidth="1.5" />
+          <path d="M122 45 122 25 A20 20 0 0 1 139 55 Z" fill="currentColor" opacity="0.6" />
+        </svg>
+      )
+    case 'report':
+      return (
+        <svg {...common} className="octo-ppt-tpl-preview">
+          {frame}
+          <rect x="18" y="18" width="60" height="8" rx="2" fill="currentColor" opacity="0.85" />
+          <rect x="20" y="66" width="14" height="8" fill="currentColor" opacity="0.5" />
+          <rect x="42" y="54" width="14" height="20" fill="currentColor" opacity="0.6" />
+          <rect x="64" y="44" width="14" height="30" fill="currentColor" opacity="0.7" />
+          <rect x="86" y="34" width="14" height="40" fill="currentColor" opacity="0.85" />
+          <path d="M112 60 L124 48 L134 54 L144 38" stroke="currentColor" strokeWidth="1.5" />
+        </svg>
+      )
+    case 'lesson':
+      return (
+        <svg {...common} className="octo-ppt-tpl-preview">
+          {frame}
+          <rect x="16" y="16" width="128" height="42" rx="3" stroke="currentColor" strokeWidth="1.5" opacity="0.7" />
+          <path d="M30 30 H120 M30 38 H110 M30 46 H96" stroke="currentColor" strokeWidth="1.5" opacity="0.6" />
+          <rect x="60" y="66" width="40" height="6" rx="2" fill="currentColor" opacity="0.5" />
+        </svg>
+      )
+  }
+}
+
+export function CreatePptModal({
+  open,
+  spaceId,
+  folderId,
+  onClose,
+  onCreated,
+}: CreatePptModalProps): React.ReactElement | null {
+  const [selected, setSelected] = useState<PptTemplateId>(DEFAULT_PPT_TEMPLATE)
+  const [title, setTitle] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const dialogRef = useRef<HTMLDialogElement>(null)
+  const cardRefs = useRef<Array<HTMLButtonElement | null>>([])
+  // The element focused before the modal opened, restored on close (design §3 focus trap + restore).
+  const restoreFocusRef = useRef<HTMLElement | null>(null)
+  // Idempotency key for the CURRENT submit session: minted once per open and REUSED across retries
+  // so a lost-response retry never mints a duplicate deck (hard metric #3). Reset on each open.
+  const idempotencyKeyRef = useRef<string>('')
+
+  const titleId = useId()
+  const groupId = useId()
+  const titleFieldId = useId()
+  const errorId = useId()
+
+  // Template metadata (name + scene) resolved from i18n; memoised on locale-stable keys.
+  const templates = useMemo(
+    () =>
+      PPT_TEMPLATES.map((id) => ({
+        id,
+        name: t(`docs.ppt.template.${id}.name`),
+        desc: t(`docs.ppt.template.${id}.desc`),
+      })),
+    [],
+  )
+
+  // Reset the draft whenever the modal opens or the space changes; mint a fresh idempotency key for
+  // the new submit session and remember what to restore focus to.
+  useEffect(() => {
+    if (!open) return
+    setSelected(DEFAULT_PPT_TEMPLATE)
+    setTitle('')
+    setSubmitting(false)
+    setError(null)
+    idempotencyKeyRef.current = newIdempotencyKey()
+    restoreFocusRef.current =
+      typeof document !== 'undefined' && document.activeElement instanceof HTMLElement
+        ? document.activeElement
+        : null
+  }, [open, spaceId])
+
+  // Open the native dialog and, on close, restore focus to the trigger (caret menu item).
+  useEffect(() => {
+    const dialog = dialogRef.current
+    if (!open || !dialog) return
+    if (!dialog.open) {
+      if (typeof dialog.showModal === 'function') dialog.showModal()
+      else dialog.setAttribute('open', '')
+    }
+    // Focus the default-selected template card so keyboard/SR users get a clear start point (§2.2).
+    const startIdx = PPT_TEMPLATES.indexOf(DEFAULT_PPT_TEMPLATE)
+    cardRefs.current[startIdx]?.focus()
+    return () => {
+      if (dialog.open) {
+        if (typeof dialog.close === 'function') dialog.close()
+        else dialog.removeAttribute('open')
+      }
+      restoreFocusRef.current?.focus?.()
+    }
+  }, [open])
+
+  if (!open) return null
+
+  const trimmed = title.trim()
+  const tooLong = title.length > PPT_TITLE_MAX
+  const canSubmit = trimmed.length > 0 && !tooLong && !submitting
+
+  // Cancel/Esc/overlay dismissal — blocked while a create is in flight so the request can't be
+  // orphaned mid-submit (the retry would otherwise mint under a fresh key on reopen).
+  const requestClose = () => {
+    if (submitting) return
+    onClose()
+  }
+
+  // Roving-tabindex arrow navigation across the 4 radio cards. Arrows move selection AND focus
+  // (selection-follows-focus); Home/End jump to the ends. Space/Enter confirm via the button's
+  // native click → onSelect (handled below), so they need no special-casing here.
+  const onCardKeyDown = (e: React.KeyboardEvent, index: number) => {
+    let next = index
+    switch (e.key) {
+      case 'ArrowRight':
+      case 'ArrowDown':
+        next = (index + 1) % PPT_TEMPLATES.length
+        break
+      case 'ArrowLeft':
+      case 'ArrowUp':
+        next = (index - 1 + PPT_TEMPLATES.length) % PPT_TEMPLATES.length
+        break
+      case 'Home':
+        next = 0
+        break
+      case 'End':
+        next = PPT_TEMPLATES.length - 1
+        break
+      default:
+        return
+    }
+    e.preventDefault()
+    setSelected(PPT_TEMPLATES[next])
+    cardRefs.current[next]?.focus()
+  }
+
+  const onSubmit = async () => {
+    if (!canSubmit) return
+    setSubmitting(true)
+    setError(null)
+    try {
+      const result = await createPptDoc({
+        title: trimmed,
+        templateId: selected,
+        folderId,
+        idempotencyKey: idempotencyKeyRef.current,
+      })
+      // Trust the backend route ONLY — no frontend fallback (preserves R1 no-fallthrough).
+      onCreated(result.editorUrl)
+    } catch (err) {
+      const status = (err as { response?: { status?: number } })?.response?.status
+      // 400 → inline validation error, modal stays open, no navigation (hard metric #2).
+      // Everything else (401/409/5xx/missing editorUrl/network) → generic error, modal stays open
+      // and retriable; the same idempotency key is reused so a retry never duplicates a deck.
+      setError(status === 400 ? t('docs.ppt.create.validationError') : t('docs.ppt.create.error'))
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div
+      className="octo-ppt-create-overlay"
+      role="presentation"
+      onMouseDown={requestClose}
+      data-screen-label="docs-create-ppt"
+    >
+      <dialog
+        ref={dialogRef}
+        className="octo-ppt-create-modal"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        onCancel={(e) => {
+          e.preventDefault()
+          requestClose()
+        }}
+        onMouseDown={(e) => e.stopPropagation()}
+      >
+        <header className="octo-ppt-create-header">
+          <h3 id={titleId} className="octo-ppt-create-title">
+            {t('docs.ppt.create.title')}
+          </h3>
+        </header>
+
+        <form
+          className="octo-ppt-create-body"
+          onSubmit={(e) => {
+            e.preventDefault()
+            void onSubmit()
+          }}
+        >
+          {/* Template picker — radiogroup with roving tabindex (§3). */}
+          <div className="octo-ppt-create-field">
+            <span id={groupId} className="octo-ppt-create-label">
+              {t('docs.ppt.create.templateLabel')}
+            </span>
+            <div
+              className="octo-ppt-create-grid"
+              role="radiogroup"
+              aria-labelledby={groupId}
+            >
+              {templates.map((tpl, i) => {
+                const isSelected = selected === tpl.id
+                return (
+                  <button
+                    key={tpl.id}
+                    type="button"
+                    ref={(el) => {
+                      cardRefs.current[i] = el
+                    }}
+                    role="radio"
+                    aria-checked={isSelected}
+                    aria-label={`${tpl.name} — ${tpl.desc}`}
+                    tabIndex={isSelected ? 0 : -1}
+                    className={
+                      isSelected
+                        ? 'octo-ppt-tpl-card octo-ppt-tpl-card-selected'
+                        : 'octo-ppt-tpl-card'
+                    }
+                    disabled={submitting}
+                    onClick={() => setSelected(tpl.id)}
+                    onKeyDown={(e) => onCardKeyDown(e, i)}
+                  >
+                    <span className="octo-ppt-tpl-thumb" aria-hidden="true">
+                      <TemplatePreview id={tpl.id} />
+                    </span>
+                    <span className="octo-ppt-tpl-text">
+                      <span className="octo-ppt-tpl-name">{tpl.name}</span>
+                      <span className="octo-ppt-tpl-desc">{tpl.desc}</span>
+                    </span>
+                  </button>
+                )
+              })}
+            </div>
+          </div>
+
+          {/* Title (required). */}
+          <div className="octo-ppt-create-field">
+            <label className="octo-ppt-create-label" htmlFor={titleFieldId}>
+              {t('docs.ppt.create.titleLabel')}
+            </label>
+            <input
+              id={titleFieldId}
+              type="text"
+              className="octo-ppt-create-input"
+              value={title}
+              maxLength={PPT_TITLE_MAX + 1}
+              placeholder={t('docs.ppt.create.titlePlaceholder')}
+              aria-describedby={error ? errorId : undefined}
+              aria-invalid={tooLong || undefined}
+              disabled={submitting}
+              onChange={(e) => setTitle(e.target.value)}
+            />
+            {tooLong && (
+              <p className="octo-ppt-create-error" role="alert">
+                {t('docs.ppt.create.titleTooLong')}
+              </p>
+            )}
+          </div>
+
+          {error && (
+            <p id={errorId} className="octo-ppt-create-error" role="alert">
+              {error}
+            </p>
+          )}
+
+          <footer className="octo-ppt-create-footer">
+            {/* Focus order group→title→Create→Cancel: Create precedes Cancel in the DOM (§3). */}
+            <button
+              type="submit"
+              className="octo-tb-btn octo-ppt-create-submit"
+              disabled={!canSubmit}
+            >
+              {submitting ? t('docs.ppt.create.loading') : t('docs.ppt.create.submit')}
+            </button>
+            <button
+              type="button"
+              className="octo-tb-btn"
+              disabled={submitting}
+              onClick={requestClose}
+            >
+              {t('docs.ppt.create.cancel')}
+            </button>
+          </footer>
+        </form>
+      </dialog>
+    </div>
+  )
+}

--- a/packages/docs/src/ppt/CreatePptModal.tsx
+++ b/packages/docs/src/ppt/CreatePptModal.tsx
@@ -111,6 +111,11 @@ export function CreatePptModal({
   // Idempotency key for the CURRENT submit session: minted once per open and REUSED across retries
   // so a lost-response retry never mints a duplicate deck (hard metric #3). Reset on each open.
   const idempotencyKeyRef = useRef<string>('')
+  // Synchronous double-submit latch: flipped true the instant a create starts, BEFORE React
+  // re-renders the disabled button. Two clicks in the same tick can both observe `submitting`
+  // state as false, so the state-derived `disabled` alone can leak a second HTTP request; this ref
+  // closes that window (belt-and-suspenders over idempotency-key reuse). Reset on each open/failure.
+  const submittingRef = useRef(false)
 
   const titleId = useId()
   const groupId = useId()
@@ -136,6 +141,7 @@ export function CreatePptModal({
     setTitle('')
     setSubmitting(false)
     setError(null)
+    submittingRef.current = false
     idempotencyKeyRef.current = newIdempotencyKey()
     restoreFocusRef.current =
       typeof document !== 'undefined' && document.activeElement instanceof HTMLElement
@@ -170,10 +176,43 @@ export function CreatePptModal({
   const canSubmit = trimmed.length > 0 && !tooLong && !submitting
 
   // Cancel/Esc/overlay dismissal — blocked while a create is in flight so the request can't be
-  // orphaned mid-submit (the retry would otherwise mint under a fresh key on reopen).
+  // orphaned mid-submit (the retry would otherwise mint under a fresh key on reopen). Focus is
+  // restored to the trigger synchronously on THIS route: the native dialog moves focus to BODY on
+  // the Esc/close path in real browsers, and the parent-driven unmount cleanup fires too late to
+  // catch that (design §3 focus restore, PPT-UI-001).
   const requestClose = () => {
     if (submitting) return
+    restoreFocusRef.current?.focus?.()
     onClose()
+  }
+
+  // Focus trap (design §3, PPT-UI-001): keep Tab/Shift+Tab cycling within the dialog. Only the
+  // boundary transitions are intercepted — the browser handles intermediate Tabs natively. The
+  // tabbable set follows the roving radiogroup (only the selected card is tabbable) plus the title
+  // input and the enabled footer buttons, in DOM order: radio → title → Create → Cancel.
+  const onDialogKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key !== 'Tab') return
+    const dialog = dialogRef.current
+    if (!dialog) return
+    const tabbable = Array.from(
+      dialog.querySelectorAll<HTMLElement>(
+        'button:not([disabled]), input:not([disabled]), [tabindex]:not([tabindex="-1"])',
+      ),
+    ).filter((el) => el.tabIndex !== -1)
+    if (tabbable.length === 0) return
+    const first = tabbable[0]
+    const last = tabbable[tabbable.length - 1]
+    const active = document.activeElement
+    const inside = active instanceof HTMLElement && dialog.contains(active)
+    if (e.shiftKey) {
+      if (!inside || active === first) {
+        e.preventDefault()
+        last.focus()
+      }
+    } else if (!inside || active === last) {
+      e.preventDefault()
+      first.focus()
+    }
   }
 
   // Roving-tabindex arrow navigation across the 4 radio cards. Arrows move selection AND focus
@@ -205,7 +244,8 @@ export function CreatePptModal({
   }
 
   const onSubmit = async () => {
-    if (!canSubmit) return
+    if (!canSubmit || submittingRef.current) return
+    submittingRef.current = true
     setSubmitting(true)
     setError(null)
     try {
@@ -223,6 +263,7 @@ export function CreatePptModal({
       // Everything else (401/409/5xx/missing editorUrl/network) → generic error, modal stays open
       // and retriable; the same idempotency key is reused so a retry never duplicates a deck.
       setError(status === 400 ? t('docs.ppt.create.validationError') : t('docs.ppt.create.error'))
+      submittingRef.current = false
       setSubmitting(false)
     }
   }
@@ -243,6 +284,7 @@ export function CreatePptModal({
           e.preventDefault()
           requestClose()
         }}
+        onKeyDown={onDialogKeyDown}
         onMouseDown={(e) => e.stopPropagation()}
       >
         <header className="octo-ppt-create-header">

--- a/packages/docs/src/ppt/CreatePptModal.tsx
+++ b/packages/docs/src/ppt/CreatePptModal.tsx
@@ -16,6 +16,7 @@ import { t } from '../octoweb/index.ts'
 import {
   createPptDoc,
   DEFAULT_PPT_TEMPLATE,
+  MissingEditorUrlError,
   newIdempotencyKey,
   PPT_TEMPLATES,
   PPT_TITLE_MAX,
@@ -118,6 +119,12 @@ export function CreatePptModal({
   const [title, setTitle] = useState('')
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  // Non-retriable failure latch (P2-1). Set when the create can never succeed under the SAME payload:
+  // the backend returned a route the caller refused (unsafe/cross-origin), or a 201 carried no
+  // editorUrl (MissingEditorUrlError). Retrying reuses the same idempotency key → the backend dedups
+  // → the same dead result, so a generic "please try again" is futile. When true we show a distinct
+  // message and disable Create; editing the payload (title/template) mints a fresh key and clears it.
+  const [fatal, setFatal] = useState(false)
 
   const dialogRef = useRef<HTMLDialogElement>(null)
   const cardRefs = useRef<Array<HTMLButtonElement | null>>([])
@@ -156,17 +163,33 @@ export function CreatePptModal({
     [],
   )
 
+  // The submitted title (P2-3): the request body carries `title.trim()`, so the idempotency key and
+  // the enable/disable gate must both key on the TRIMMED value, not the raw input — otherwise a
+  // whitespace-only edit ("AAA" → "AAA ") re-mints the key for a byte-identical payload and can
+  // create a second deck. Hoisted above the effects so the idem-key effect can depend on it.
+  const trimmed = title.trim()
+
+  // Invalidate any in-flight submit on EVERY open/space transition — including open → false (P1-3).
+  // In the app a Space switch closes the picker in the SAME React batch that changes spaceId
+  // (DocsHome onSpaceChanged → setSpace(next) + backToList() → setPptModalOpen(false)), so the guard
+  // MUST bump on the open → false edge too. Keeping the bump inside the reset effect below (which
+  // early-returns on `!open`) missed exactly that edge: the in-flight space-A create kept a matching
+  // token and its late resolve navigated into the previous space's deck. `backToList` is also the
+  // reconciler for doc-delete and nav-menu reactivation, so this open-guard-free bump covers those
+  // closes too.
+  useEffect(() => {
+    submitSeqRef.current += 1
+  }, [open, spaceId])
+
   // Reset the draft whenever the modal opens or the space changes; remember what to restore focus to.
-  // Bumping submitSeqRef here invalidates any in-flight submit's generation token, so a create that
-  // was fired before a space switch cannot navigate after it resolves (P1-3).
   useEffect(() => {
     if (!open) return
     setSelected(DEFAULT_PPT_TEMPLATE)
     setTitle('')
     setSubmitting(false)
     setError(null)
+    setFatal(false)
     submittingRef.current = false
-    submitSeqRef.current += 1
     // Capture the restore target. Prefer the caller-supplied PERSISTENT trigger (the caret button that
     // opened the picker) over document.activeElement: the picker is launched from a caret DROPDOWN menu
     // item that unmounts the instant it is clicked (the menu closes as it fires onCreatePpt), so by the
@@ -184,15 +207,21 @@ export function CreatePptModal({
           : null
   }, [open, spaceId, triggerRef])
 
-  // Mint the idempotency key for the current payload (P1-2). Keyed on the payload (title + template)
-  // as well as open/space so the key is STABLE across an identical retry — a plain retry re-runs
-  // onSubmit without changing title/selected, so no new key is minted and the backend dedups to the
-  // same deck — but a FRESH key is minted the moment the user edits the title or picks another
-  // template, so a content-changed resubmit is a distinct create (never a stale-title dedup).
+  // Mint the idempotency key for the current payload (P1-2 / P2-3). Keyed on the SUBMITTED payload
+  // (trimmed title + template) as well as open/space so the key is STABLE across an identical retry
+  // — a plain retry re-runs onSubmit without changing the trimmed title/selected, so no new key is
+  // minted and the backend dedups to the same deck — but a FRESH key is minted the moment the user
+  // changes the submitted content, so a content-changed resubmit is a distinct create. Keying on the
+  // TRIMMED title (not the raw input) closes P2-3: a whitespace-only edit ("AAA" → "AAA ") sends a
+  // byte-identical body, so it must NOT re-mint the key and risk a duplicate deck.
   useEffect(() => {
     if (!open) return
     idempotencyKeyRef.current = newIdempotencyKey()
-  }, [open, spaceId, title, selected])
+    // A genuine payload change is a distinct create — clear any prior error (P2-3), including the
+    // non-retriable one (P2-1), so Create becomes usable again for the new content.
+    setError(null)
+    setFatal(false)
+  }, [open, spaceId, trimmed, selected])
 
   // Restore focus to the element that had it before the modal opened (the trigger caret).
   // This MUST run AFTER the native <dialog> has finished closing. On the Esc/close route the
@@ -239,9 +268,9 @@ export function CreatePptModal({
 
   if (!open) return null
 
-  const trimmed = title.trim()
   const tooLong = title.length > PPT_TITLE_MAX
-  const canSubmit = trimmed.length > 0 && !tooLong && !submitting
+  // `fatal` (P2-1) keeps Create disabled after a non-retriable failure until the payload changes.
+  const canSubmit = trimmed.length > 0 && !tooLong && !submitting && !fatal
 
   // Cancel/Esc/overlay dismissal — blocked while a create is in flight so the request can't be
   // orphaned mid-submit (the retry would otherwise mint under a fresh key on reopen). Focus is
@@ -330,11 +359,13 @@ export function CreatePptModal({
       // await, this create belongs to a stale context — do NOT navigate to its wrong-space deck.
       if (submitSeqRef.current !== token) return
       // Trust the backend route ONLY — no frontend fallback (preserves R1 no-fallthrough). The caller
-      // gates the route through the open-redirect guard; a `false` return means it REFUSED to navigate
-      // (unsafe route, P1-1) — surface an inline error and keep the modal open/retriable instead of
-      // soft-locking on a dead "success".
+      // gates the route through the same-origin guard; a `false` return means it REFUSED to navigate
+      // (unsafe / cross-origin route, P1-1 / P2-1). That is NON-retriable: retrying reuses the same
+      // idempotency key so the backend returns the same dead route — surface a distinct message and
+      // disable Create (the user recovers by changing the title/template, which mints a fresh key).
       if (onCreated(result.editorUrl) === false) {
-        setError(t('docs.ppt.create.error'))
+        setError(t('docs.ppt.create.unavailable'))
+        setFatal(true)
         submittingRef.current = false
         setSubmitting(false)
       }
@@ -342,10 +373,21 @@ export function CreatePptModal({
       // A superseded submit (space switched mid-await) must not clobber the fresh draft with its late
       // error either — bail on a stale generation (P1-3).
       if (submitSeqRef.current !== token) return
+      // A 201 with no editorUrl (MissingEditorUrlError) is NON-retriable for the same reason as an
+      // unsafe route (P2-1): the same key re-dedups to the same routeless deck. Distinct message +
+      // disable Create instead of the generic retriable error.
+      if (err instanceof MissingEditorUrlError) {
+        setError(t('docs.ppt.create.unavailable'))
+        setFatal(true)
+        submittingRef.current = false
+        setSubmitting(false)
+        return
+      }
       const status = (err as { response?: { status?: number } })?.response?.status
       // 400 → inline validation error, modal stays open, no navigation (hard metric #2).
-      // Everything else (401/409/5xx/missing editorUrl/network) → generic error, modal stays open
-      // and retriable; the same idempotency key is reused so a retry never duplicates a deck.
+      // Everything else (401/409/5xx/network) → generic error, modal stays open and retriable; the
+      // same idempotency key is reused so a retry never duplicates a deck. (A routeless 201 is the
+      // MissingEditorUrlError handled above — non-retriable, not this generic branch.)
       setError(status === 400 ? t('docs.ppt.create.validationError') : t('docs.ppt.create.error'))
       submittingRef.current = false
       setSubmitting(false)

--- a/packages/docs/src/ppt/createPptTask.test.ts
+++ b/packages/docs/src/ppt/createPptTask.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { setWKApp } from '../octoweb/index.ts'
+import { createMockWKApp } from '../octoweb/mock.ts'
+import {
+  createPptDoc,
+  isPptTemplate,
+  MissingEditorUrlError,
+  newIdempotencyKey,
+  PPT_TEMPLATES,
+  PPT_TITLE_MAX,
+} from './createPptTask.ts'
+
+describe('createPptTask', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('exposes exactly the four fixed v1 templates', () => {
+    expect(PPT_TEMPLATES).toEqual(['blank', 'pitch', 'report', 'lesson'])
+    expect(isPptTemplate('pitch')).toBe(true)
+    expect(isPptTemplate('nope')).toBe(false)
+  })
+
+  it('newIdempotencyKey returns a non-empty, unique-per-call key', () => {
+    const a = newIdempotencyKey()
+    const b = newIdempotencyKey()
+    expect(a.length).toBeGreaterThan(0)
+    expect(a).not.toBe(b)
+  })
+
+  describe('createPptDoc', () => {
+    beforeEach(() => {
+      const wk = createMockWKApp()
+      setWKApp(wk)
+    })
+
+    it('POSTs to /ppt/docs with the template body and the Idempotency-Key header', async () => {
+      const wk = createMockWKApp()
+      wk.apiClient.responder = (_m, url) => {
+        if (url === '/ppt/docs') {
+          return { data: { data: { editorUrl: '/ppt/d/deck_1', docId: 'deck_1' } }, status: 201 }
+        }
+        return { data: {}, status: 200 }
+      }
+      setWKApp(wk)
+
+      const result = await createPptDoc({
+        title: 'Q3 review',
+        templateId: 'report',
+        folderId: 'f_1',
+        idempotencyKey: 'key-abc',
+      })
+
+      expect(result.editorUrl).toBe('/ppt/d/deck_1')
+      expect(result.docId).toBe('deck_1')
+      const call = wk.apiClient.calls.find((c) => c.url === '/ppt/docs')
+      expect(call).toBeTruthy()
+      expect(call?.method).toBe('post')
+      expect(call?.body).toEqual({ title: 'Q3 review', templateId: 'report', folderId: 'f_1' })
+      expect(call?.config?.headers?.['Idempotency-Key']).toBe('key-abc')
+    })
+
+    it('omits folderId from the body when not provided', async () => {
+      const wk = createMockWKApp()
+      wk.apiClient.responder = () => ({ data: { data: { editorUrl: '/ppt/d/x' } }, status: 201 })
+      setWKApp(wk)
+      await createPptDoc({ title: 'T', templateId: 'blank', idempotencyKey: 'k' })
+      const call = wk.apiClient.calls.find((c) => c.url === '/ppt/docs')
+      expect(call?.body).toEqual({ title: 'T', templateId: 'blank' })
+      expect((call?.body as Record<string, unknown>).folderId).toBeUndefined()
+    })
+
+    it('reads editorUrl from a flat (un-enveloped) body too', async () => {
+      const wk = createMockWKApp()
+      wk.apiClient.responder = () => ({ data: { editorUrl: '/ppt/d/flat' }, status: 201 })
+      setWKApp(wk)
+      const result = await createPptDoc({ title: 'T', templateId: 'pitch', idempotencyKey: 'k' })
+      expect(result.editorUrl).toBe('/ppt/d/flat')
+    })
+
+    it('throws MissingEditorUrlError when a 201 carries no editorUrl (never fabricates a route)', async () => {
+      const wk = createMockWKApp()
+      wk.apiClient.responder = () => ({ data: { data: { docId: 'deck_2' } }, status: 201 })
+      setWKApp(wk)
+      await expect(
+        createPptDoc({ title: 'T', templateId: 'lesson', idempotencyKey: 'k' }),
+      ).rejects.toBeInstanceOf(MissingEditorUrlError)
+    })
+
+    it('propagates the API error so the caller can branch on status (400/etc.)', async () => {
+      const wk = createMockWKApp()
+      wk.apiClient.responder = () => Promise.reject({ response: { status: 400, data: { error: 'VALIDATION_ERROR' } } })
+      setWKApp(wk)
+      await expect(
+        createPptDoc({ title: '', templateId: 'blank', idempotencyKey: 'k' }),
+      ).rejects.toMatchObject({ response: { status: 400 } })
+    })
+
+    it('a retry reusing the same key sends the same Idempotency-Key (no duplicate deck)', async () => {
+      const wk = createMockWKApp()
+      let attempt = 0
+      wk.apiClient.responder = () => {
+        attempt += 1
+        if (attempt === 1) return Promise.reject({ response: { status: 500 } })
+        return { data: { data: { editorUrl: '/ppt/d/deck_9' } }, status: 201 }
+      }
+      setWKApp(wk)
+
+      const key = 'stable-key'
+      await expect(
+        createPptDoc({ title: 'Deck', templateId: 'blank', idempotencyKey: key }),
+      ).rejects.toBeTruthy()
+      const ok = await createPptDoc({ title: 'Deck', templateId: 'blank', idempotencyKey: key })
+      expect(ok.editorUrl).toBe('/ppt/d/deck_9')
+
+      const keys = wk.apiClient.calls
+        .filter((c) => c.url === '/ppt/docs')
+        .map((c) => c.config?.headers?.['Idempotency-Key'])
+      expect(keys).toEqual([key, key])
+    })
+  })
+
+  it('caps the client title pre-check at a sane bound', () => {
+    expect(PPT_TITLE_MAX).toBeGreaterThan(0)
+  })
+})

--- a/packages/docs/src/ppt/createPptTask.ts
+++ b/packages/docs/src/ppt/createPptTask.ts
@@ -1,0 +1,118 @@
+// Create-slides (html_ppt) task helpers — the R2-F1 live create path.
+//
+// A Bento slide-deck is a first-class, B-owned document type created through its OWN endpoint
+// (`POST /api/v1/ppt/docs`), NOT the generic `POST /api/v1/docs` seam and NOT a Tiptap rich doc.
+// The create call is minted atomically server-side (strip template marker + new docId + drop
+// collab), so the front end only chooses a fixed template + title, POSTs once with a client
+// idempotency key, and then navigates to the editor route the BACKEND returns — it never builds a
+// PPT route itself (no-fallthrough contract, XIN-1501 / R1).
+
+import { apiClient } from '../octoweb/index.ts'
+import { HTML_PPT_DOC_TYPE } from '../pages/docsApi.ts'
+
+/** Re-exported so guards never re-hardcode the wire value. */
+export { HTML_PPT_DOC_TYPE }
+
+/**
+ * The four fixed v1 templates (gate3 D6: no CRUD, no admin-extensible registry). Authored in
+ * lockstep with the backend's accepted `templateId` set (blank/pitch/report/lesson). Order is the
+ * 2×2 grid reading order used by the picker.
+ */
+export const PPT_TEMPLATES = ['blank', 'pitch', 'report', 'lesson'] as const
+export type PptTemplateId = (typeof PPT_TEMPLATES)[number]
+
+/** The template selected by default when the picker opens (design §2.2 — a clear focus start). */
+export const DEFAULT_PPT_TEMPLATE: PptTemplateId = 'blank'
+
+/**
+ * Client-side title bound, a pre-check aligned with the backend's PPT-HUMAN-002 validation. The
+ * BACKEND is authoritative — a `400 VALIDATION_ERROR` is surfaced inline regardless — so this only
+ * spares an obviously-invalid round-trip (empty / absurdly long) and never widens what the server
+ * accepts.
+ */
+export const PPT_TITLE_MAX = 200
+
+/** Narrow a free string to a known template id (defensive; the picker only ever passes valid ids). */
+export function isPptTemplate(id: string): id is PptTemplateId {
+  return (PPT_TEMPLATES as readonly string[]).includes(id)
+}
+
+export interface CreatePptInput {
+  title: string
+  templateId: PptTemplateId
+  /** Optional target folder; space is carried by the global `X-Space-Id` interceptor, not the body. */
+  folderId?: string
+  /**
+   * Client-generated idempotency key (e.g. crypto.randomUUID). The SAME key must be reused across a
+   * retry of the same submit so a lost-response retry reuses the server-side result instead of
+   * minting a duplicate deck (hard metric #3).
+   */
+  idempotencyKey: string
+}
+
+export interface CreatePptResult {
+  /** The PPT editor route to navigate to — taken verbatim from the backend, never built here. */
+  editorUrl: string
+  docId?: string
+  title?: string
+}
+
+/** Shape of the `POST /ppt/docs` success body — the doc fields wrapped in the C-style `{ data }`. */
+interface PptCreateEnvelope {
+  editorUrl?: string
+  docId?: string
+  title?: string
+  data?: {
+    editorUrl?: string
+    docId?: string
+    title?: string
+  }
+}
+
+/**
+ * Generate a one-shot idempotency key. Prefers crypto.randomUUID; falls back to a
+ * timestamp+random string on the rare host without it (same pattern as the HTML create flow).
+ */
+export function newIdempotencyKey(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID()
+  }
+  return `ppt-${Date.now()}-${Math.random().toString(16).slice(2)}`
+}
+
+/**
+ * Thrown when a `201` create response carries no `editorUrl`. We refuse to navigate to an
+ * undefined route (that would be the exact frontend-fabricated fallback the no-fallthrough
+ * contract forbids), so the caller shows a generic error and keeps the modal open.
+ */
+export class MissingEditorUrlError extends Error {
+  constructor() {
+    super('ppt create succeeded but the response carried no editorUrl')
+    this.name = 'MissingEditorUrlError'
+  }
+}
+
+/**
+ * POST /api/v1/ppt/docs — create a Bento slide-deck from one of the four fixed templates.
+ *
+ * Body `{ title, templateId, folderId? }`; the required `Idempotency-Key` header carries the
+ * client key so a retry of the same submit is deduped server-side. Success (`201`) resolves with
+ * the backend-returned `editorUrl`; the caller navigates there and NOWHERE else. Errors propagate
+ * unchanged so the caller can branch on `err.response?.status` (400 → inline, else → generic).
+ */
+export async function createPptDoc(input: CreatePptInput): Promise<CreatePptResult> {
+  const body: { title: string; templateId: PptTemplateId; folderId?: string } = {
+    title: input.title,
+    templateId: input.templateId,
+  }
+  if (input.folderId) body.folderId = input.folderId
+  const { data } = await apiClient().post<PptCreateEnvelope>('/ppt/docs', body, {
+    headers: { 'Idempotency-Key': input.idempotencyKey },
+  })
+  // The backend wraps the doc in the C-style `{ data }` envelope; the host apiClient unwraps one
+  // transport layer, so read `data.data.*` first and fall back to a flat body for resilience.
+  const payload = data?.data ?? data ?? {}
+  const editorUrl = (payload.editorUrl ?? '').trim()
+  if (!editorUrl) throw new MissingEditorUrlError()
+  return { editorUrl, docId: payload.docId, title: payload.title }
+}


### PR DESCRIPTION
Closes #1252

## Summary

R2-F1 turns the R1 "coming soon" placeholder into a real **create flow** for Bento slide-decks (`html_ppt`). The caret-menu **New slides** entry now opens a keyboard-accessible four-template picker that mints a deck through the live `POST /api/v1/ppt/docs` endpoint (R2-B1, already merged) and navigates to the editor route the backend returns.

Builds against the live backend contract — no stub:
- `POST /api/v1/ppt/docs` body `{ title, folderId?, templateId }`; headers: octo identity token + `X-Space-Id` (global interceptor) + required `Idempotency-Key` (client-generated).
- Success `201 { data }` with an `editorUrl`; errors are the C-style envelope (`400 VALIDATION_ERROR`, `409 CONFLICT`, `401 AUTH_REQUIRED`).

## What changed
- **`ppt/createPptTask.ts`** — `createPptDoc()` (POST + `Idempotency-Key` header + editorUrl extraction), the four fixed template ids (`blank`/`pitch`/`report`/`lesson`), and `newIdempotencyKey()`.
- **`ppt/CreatePptModal.tsx` / `.css`** — the picker modal (native `<dialog>`, `--wk-*` tokens only).
- **`pages/DocsHome.tsx`** — wire the picker into the existing caret menu; navigate to the backend `editorUrl` only.
- **`config.ts`** — `PPT_CREATE_ENABLED` flag (`VITE_DOCS_PPT_CREATE`, default ON, kill-switch → falls back to the R1 coming-soon notice).
- **i18n** — `docs.ppt.create.*` + `docs.ppt.template.*` in en-US and zh-CN (parity guard green).

## Acceptance (the three hard bars)
1. **Keyboard (PPT-UI-001):** group `role=radiogroup`, cards `role=radio`; arrow keys move selection + focus; Space/Enter confirm; focus order group → title → Create → Cancel; Esc closes and restores focus to the trigger; visible focus ring (`--wk-brand-primary-ring`).
2. **Trust the backend route:** navigate to the returned `editorUrl` only — no frontend fallback route; `400` shows an inline modal error, no navigation, modal stays open (preserves the R1 no-fallthrough contract).
3. **Double-submit:** Create loads + disables on submit; a retry reuses the same client `Idempotency-Key`, so a lost-response retry never mints a duplicate deck.

Also honored: independent **Slides** peer entry after HTML (never precreates an empty deck); four 16:9 cards, 2×2 → 1 column; v1 = 4 fixed templates (no CRUD, no Hocuspocus in the create flow); flag-gated entry; R1 entry/filter/no-fallback routing untouched.

## Tests
- `ppt/createPptTask.test.ts` — body/header shape, envelope + flat `editorUrl` extraction, `MissingEditorUrlError`, error propagation, same-key retry.
- `ppt/CreatePptModal.test.tsx` — PPT-UI-001 (radiogroup/roles, arrows, Space/Enter, focus order, Esc + focus restore), PPT-HUMAN-001 (create → backend `editorUrl`), PPT-HUMAN-002 (empty title disables Create; `400` → inline error, no nav, modal open), double-submit (one request), idempotency-key reuse on retry.
- `pages/DocsHome.test.tsx` — the caret entry opens the picker and precreates nothing (no `POST /docs`, no `POST /ppt/docs`).

`pnpm test` (docs): all PPT + DocsHome (100) + i18n parity tests pass. Typecheck clean for the touched files. (One unrelated pre-existing failure in `editor/TableReorderInterrupt.test.ts` reproduces on upstream `main` in this environment.)

---

## Security hardening round — open-redirect fix in `resolveSameOriginPath`

The previous round's open-redirect guard normalised into a **protocol-relative** path, re-opening the redirect it was meant to close: the origin check ran on the parsed URL, but the value handed back to `location.assign` was `url.pathname`, which can itself begin with `//` — via an absolute `https://<origin>//evil…`, a backslash-smuggled input, or a rooted `/..//evil…` whose dot-segments clamp to the root. `location.assign('//host/x')` re-parses that as scheme-relative and bounces cross-origin.

**Fix** (`packages/docs/src/pages/StandaloneDocPage.tsx`): after the origin check, reject non-`http(s)` schemes (`blob:<origin>/…` also reports a matching origin but its pathname is the whole inner URL) and collapse the leading slash run to a single `/`, so the returned value is always one rooted same-origin path.

### What changed (additions to the list above)
- **`pages/StandaloneDocPage.tsx`** — `resolveSameOriginPath` now gates on `http:`/`https:` and collapses leading `/` runs (`url.pathname.replace(/^\/+/, '/')`); docstring updated.
- **`pages/StandaloneDocPage.test.tsx`** — four bypass rows (`<origin>//evil…`, backslash-smuggled, `/..//evil…`, `/a/../..//evil…`) each asserting the result is single-rooted and re-parses same-origin, plus a `blob:<origin>/…` rejection row. All four were **red at head `511ec320`** and are green after the fix.
- **`ppt/CreatePptModal.tsx`** — P2-2: template names/`aria-label`s now follow a live locale switch (component subscribes via `useI18n()`; the template memo keys on `locale`). P2-1: a real-browser backdrop click now dismisses the modal (detect the `<dialog>` as the `mousedown` target rather than relying on the dead overlay wrapper, which never receives the event once `showModal()` promotes the dialog to the top layer).

### P2 items deferred (with rationale)
- **P2-3 (pending-create navigates after full unmount)** — deferred. The reviewer confirmed this is latent, not a live defect (no host path unmounts DocsHome mid-submit), and folding the three submit-liveness guards into one predicate risks regressing the verified cross-space late-resolve fix. Not worth that risk for a non-reproducible path.
- **P2-4 (`/ppt/d/…` fixture route the SPA does not serve)** — deferred, **needs human verification**. The only route rendering an `html_ppt` deck is `/d/:docId`; nothing registers `/ppt`. Since create does a full-page `location.assign`, a returned `/ppt/d/:id` would land on the SPA fallback. This depends on what `POST /api/v1/ppt/docs` actually returns for `editorUrl` — align the fixtures once the backend contract is confirmed rather than guessing now.

### Self-test (at new head `6f721b8b`)
- `vitest run src/ppt src/pages/DocsHome.test.tsx src/pages/DocsHome.pptFlagOff.test.tsx src/pages/StandaloneDocPage.test.tsx` → **199 passed** (197 baseline + 2 new).
- `tsc --noEmit -p tsconfig.typecheck.json` → clean for all touched files (only the pre-existing, unrelated `packages/dmworkbase/src/i18n/format.ts:38` error remains).
- `stylelint packages/docs/src/ppt/CreatePptModal.css` → clean.
- `node scripts/i18n-scan.mjs check` → 0 candidates, locale keys healthy (en-US/zh-CN parity preserved).

The three already-fixed prior P1s (cross-space late resolve, idempotency-key-on-edited-retry, close/assign ordering) and `isSafeReturnPath` were not touched.

Draft PR — not for merge yet.
