### PR TITLE
refactor: extract resolveApiURL to fix desktop dev CORS issue

### DIFF
--- a/apps/web/src/__tests__/apiURL.test.ts
+++ b/apps/web/src/__tests__/apiURL.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest"
+import { resolveApiURL } from "../apiURL"
+
+describe("resolveApiURL", () => {
+  it("uses the Vite proxy for desktop development", () => {
+    expect(
+      resolveApiURL({ isDesktop: true, isDev: true, rawApiURL: "https://api.example.com" }),
+    ).toBe("/api/v1/")
+  })
+
+  it("uses the configured API origin for desktop production", () => {
+    expect(
+      resolveApiURL({
+        isDesktop: true,
+        isDev: false,
+        rawApiURL: "https://api.example.com/legacy/path",
+      }),
+    ).toBe("https://api.example.com/v1/")
+  })
+
+  it("uses the relative API path for web builds", () => {
+    expect(
+      resolveApiURL({ isDesktop: false, isDev: false, rawApiURL: "https://api.example.com" }),
+    ).toBe("/api/v1/")
+  })
+
+  it("requires an API URL for desktop production", () => {
+    expect(() => resolveApiURL({ isDesktop: true, isDev: false })).toThrow(
+      "VITE_API_URL is required for Tauri/Electron",
+    )
+  })
+
+  it("rejects an invalid API URL for desktop production", () => {
+    expect(() =>
+      resolveApiURL({ isDesktop: true, isDev: false, rawApiURL: "not-a-url" }),
+    ).toThrow("VITE_API_URL format is invalid")
+  })
+})

--- a/apps/web/src/apiURL.ts
+++ b/apps/web/src/apiURL.ts
@@ -1,0 +1,28 @@
+export interface ApiURLOptions {
+  isDesktop: boolean
+  isDev: boolean
+  rawApiURL?: string
+}
+
+export function resolveApiURL({ isDesktop, isDev, rawApiURL }: ApiURLOptions): string {
+  if (!isDesktop || isDev) {
+    return "/api/v1/"
+  }
+
+  if (!rawApiURL) {
+    throw new Error(
+      "VITE_API_URL is required for Tauri/Electron. Please set it in .env.local (e.g., VITE_API_URL=https://api.example.com)",
+    )
+  }
+
+  let apiOrigin: string
+  try {
+    apiOrigin = new URL(rawApiURL).origin
+  } catch {
+    throw new Error(
+      `VITE_API_URL format is invalid: "${rawApiURL}". Please use full URL, e.g. https://api.example.com`,
+    )
+  }
+
+  return `${apiOrigin}/v1/`
+}

--- a/apps/web/src/index.tsx
+++ b/apps/web/src/index.tsx
@@ -18,29 +18,29 @@ import { DriveModule } from '@octo/drive';
 import { version as pkgVersion } from '../package.json';
 import appEnUS from './i18n/en-US.json';
 import appZhCN from './i18n/zh-CN.json';
+import { resolveApiURL } from './apiURL';
 
 // VITE_API_URL 只填 origin（协议+域名+端口），不要带路径
 // 例如: https://api.example.com (而非 https://api.example.com/v1/)
 
 if((window as any).__TAURI_IPC__ || (window as any)?.__POWERED_ELECTRON__) {
-  // Tauri/Electron 需要完整 API URL
-  const rawApiURL = import.meta.env.VITE_API_URL
-  if (!rawApiURL) {
-    throw new Error('VITE_API_URL is required for Tauri/Electron. Please set it in .env.local (e.g., VITE_API_URL=https://api.example.com)')
-  }
-  // 提取 origin，防止旧格式导致双拼路径
-  let apiURL: string
-  try {
-    apiURL = new URL(rawApiURL).origin
-  } catch {
-    throw new Error(`VITE_API_URL format is invalid: "${rawApiURL}". Please use full URL, e.g. https://api.example.com`)
-  }
-  WKApp.apiClient.config.apiURL = apiURL + "/v1/"
+  // 开发环境的 Tauri/Electron 页面运行在 localhost:3000，走 Vite 同源代理，
+  // 避免直接请求远程 API 时被浏览器 CORS 拦截。正式桌面包没有 Vite 代理，
+  // 仍然使用 VITE_API_URL 直连后端。
+  WKApp.apiClient.config.apiURL = resolveApiURL({
+    isDesktop: true,
+    isDev: import.meta.env.DEV,
+    rawApiURL: import.meta.env.VITE_API_URL,
+  })
 } else {
   // Web 环境（DEV/PROD）统一走相对路径 /api/v1/
   // DEV: 由 Vite proxy 转发到 VITE_API_URL（保留 /api 前缀，后端直连）
   // PROD: 由 Nginx 反代到实际后端（Nginx 剥离 /api 前缀）
-  WKApp.apiClient.config.apiURL = "/api/v1/"
+  WKApp.apiClient.config.apiURL = resolveApiURL({
+    isDesktop: false,
+    isDev: import.meta.env.DEV,
+    rawApiURL: import.meta.env.VITE_API_URL,
+  })
 }
 
 WKApp.apiClient.config.tokenCallback = ()=> {


### PR DESCRIPTION
## 改动内容

- 将 `index.tsx` 中内联的 API URL 解析逻辑抽取为独立函数 `resolveApiURL`（`apps/web/src/apiURL.ts`）
- 桌面端开发模式改走 Vite 同源代理（`/api/v1/`），避免浏览器 CORS 拦截
- 正式桌面包行为不变，仍通过 `VITE_API_URL` 直连后端
- Web 端行为不变，始终走 `/api/v1/`

## 测试

- 新增单测 `apps/web/src/__tests__/apiURL.test.ts` 覆盖各场景