### PR TITLE
feat(navrail): add resizable sidebar layout

### DIFF
--- a/packages/dmworkbase/src/Components/NavRail/NavBottom.tsx
+++ b/packages/dmworkbase/src/Components/NavRail/NavBottom.tsx
@@ -68,6 +68,7 @@ export default class NavBottom extends Component<NavBottomProps, NavBottomState>
                         onClick={onSettingsClick}
                     >
                         <IconSettings />
+                        <span className="wk-navrail__item-label">{t("base.navRail.settings")}</span>
                     </button>
 
                     {/* 版本更新气泡 */}

--- a/packages/dmworkbase/src/Components/NavRail/NavItem.tsx
+++ b/packages/dmworkbase/src/Components/NavRail/NavItem.tsx
@@ -21,6 +21,7 @@ export default function NavItem({ icon, label, active, badge, onClick }: NavItem
             onClick={onClick}
         >
             {icon}
+            <span className="wk-navrail__item-label">{label}</span>
             {!!badge && (
                 <span className="wk-navrail__badge">{badgeLabel}</span>
             )}

--- a/packages/dmworkbase/src/Components/NavRail/NavLanguageSwitcher.tsx
+++ b/packages/dmworkbase/src/Components/NavRail/NavLanguageSwitcher.tsx
@@ -66,6 +66,7 @@ export default function NavLanguageSwitcher() {
         onClick={() => setOpen((value) => !value)}
       >
         <IconLanguage aria-hidden="true" />
+        <span className="wk-navrail__item-label">{t("base.navRail.language.label")}</span>
       </button>
 
       <NavFlyout

--- a/packages/dmworkbase/src/Components/NavRail/NavSpaceSwitcher.tsx
+++ b/packages/dmworkbase/src/Components/NavRail/NavSpaceSwitcher.tsx
@@ -80,6 +80,9 @@ export default class NavSpaceSwitcher extends Component<NavSpaceSwitcherProps, N
                     onClick={this.handleToggle}
                 >
                     <IconBuilding />
+                    <span className="wk-navrail__item-label">
+                        {current?.name ?? t("base.navRail.spaceSwitcher.switch")}
+                    </span>
                 </button>
 
                 <NavFlyout

--- a/packages/dmworkbase/src/Components/NavRail/index.css
+++ b/packages/dmworkbase/src/Components/NavRail/index.css
@@ -37,7 +37,6 @@
 }
 
 .wk-navrail__user-wrap {
-    position: relative;
     cursor: pointer;
     margin-bottom: 0;
 }
@@ -47,6 +46,13 @@
     align-items: center;
     gap: var(--wk-sp-2, 8px);
     min-width: 0;
+}
+
+.wk-navrail__user-avatar-wrap {
+    position: relative;
+    width: 40px;
+    height: 40px;
+    flex-shrink: 0;
 }
 
 .wk-navrail__user-avatar {

--- a/packages/dmworkbase/src/Components/NavRail/index.css
+++ b/packages/dmworkbase/src/Components/NavRail/index.css
@@ -1,6 +1,7 @@
 /* ── NavRail wrapper ── */
 .wk-navrail {
-    width: 56px;
+    width: 100%;
+    min-width: 0;
     flex-shrink: 0;
     height: 100%;
     background: var(--wk-bg-navrail);
@@ -15,6 +16,10 @@
     overflow: visible; /* dropdown 需要溢出 */
 }
 
+.wk-layout-tab-expanded .wk-navrail {
+    align-items: stretch;
+}
+
 /* ── Top user avatar ── */
 .wk-navrail__top {
     display: flex;
@@ -25,10 +30,23 @@
     padding-top: 16px;                 /* 头像顶部留白 */
 }
 
+.wk-layout-tab-expanded .wk-navrail__top {
+    align-items: stretch;
+    padding: var(--wk-sp-4, 16px) var(--wk-sp-3, 12px) 0;
+    margin-bottom: var(--wk-sp-2, 8px);
+}
+
 .wk-navrail__user-wrap {
     position: relative;
     cursor: pointer;
     margin-bottom: 0;
+}
+
+.wk-layout-tab-expanded .wk-navrail__user-wrap {
+    display: flex;
+    align-items: center;
+    gap: var(--wk-sp-2, 8px);
+    min-width: 0;
 }
 
 .wk-navrail__user-avatar {
@@ -54,6 +72,22 @@
     height: 40px;
 }
 
+.wk-navrail__user-name {
+    display: none;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    color: var(--wk-text-primary);
+    font-size: var(--wk-text-size-md);
+    font-weight: var(--wk-font-semibold);
+    line-height: 1.4;
+}
+
+.wk-layout-tab-expanded .wk-navrail__user-name {
+    display: block;
+}
+
 /* ── Online status dot ── */
 .wk-navrail__user-status {
     position: absolute;
@@ -74,6 +108,11 @@
     background: var(--wk-border-subtle);
     margin: var(--wk-sp-2, 8px) 0;
     flex-shrink: 0;
+}
+
+.wk-layout-tab-expanded .wk-navrail__sep {
+    width: auto;
+    margin: var(--wk-sp-2, 8px) var(--wk-sp-3, 12px);
 }
 
 /* ── Space switcher ── */
@@ -238,23 +277,46 @@
     flex: 1;
     justify-content: flex-start;
     padding: 8px 0;                    /* Figma: Frame 5 pad top:8 bottom:8 */
+    min-height: 0;
+    overflow-y: auto;
+    overflow-x: hidden;
+}
+
+.wk-layout-tab-expanded .wk-navrail__items {
+    align-items: stretch;
+    gap: var(--wk-sp-1, 4px);
+    padding: var(--wk-sp-2, 8px);
 }
 
 /* ── NavItem button ── */
 .wk-navrail__item {
     position: relative;
     width: 56px;                       /* Figma: IconItem 56x44 */
-    height: 44px;
+    height: 54px;
     border-radius: 0;
     border: none;
     background: transparent;
     color: var(--wk-icon-muted);       /* Figma: 未选中 30% 透明 */
     cursor: pointer;
     display: flex;
+    flex-direction: column;
     align-items: center;
     justify-content: center;
+    gap: var(--wk-sp-1, 4px);
+    min-width: 0;
+    padding: var(--wk-sp-1, 4px) var(--wk-sp-0-5, 2px);
     transition: background var(--wk-dur-fast, 200ms) var(--wk-ease, cubic-bezier(0.16,1,0.3,1)),
                 color var(--wk-dur-fast, 200ms) var(--wk-ease, cubic-bezier(0.16,1,0.3,1));
+}
+
+.wk-layout-tab-expanded .wk-navrail__item {
+    width: 100%;
+    height: 38px;
+    flex-direction: row;
+    justify-content: flex-start;
+    gap: var(--wk-sp-2, 8px);
+    padding: 0 var(--wk-sp-3, 12px);
+    border-radius: var(--wk-r-md, 10px);
 }
 
 /* svg 图标统一 20×20，对齐设计稿 */
@@ -262,6 +324,33 @@
     width: 20px;
     height: 20px;
     flex-shrink: 0;
+}
+
+.wk-navrail__item-label {
+    display: block;
+    box-sizing: border-box;
+    width: 100%;
+    max-width: 100%;
+    min-width: 0;
+    padding-inline: var(--wk-sp-1, 4px);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    color: inherit;
+    font-size: var(--wk-text-size-tiny);
+    font-weight: var(--wk-font-medium);
+    line-height: 1.1;
+    text-align: center;
+}
+
+.wk-layout-tab-expanded .wk-navrail__item-label {
+    display: inline-flex;
+    width: auto;
+    max-width: none;
+    padding-inline: 0;
+    font-size: var(--wk-text-size-md);
+    line-height: 1;
+    text-align: left;
 }
 
 .wk-navrail__item:hover {
@@ -435,6 +524,12 @@
     line-height: 1;
 }
 
+.wk-layout-tab-expanded .wk-navrail__badge {
+    top: 50%;
+    right: var(--wk-sp-2, 8px);
+    transform: translateY(-50%);
+}
+
 /* ── Bottom area ── */
 .wk-navrail__bottom {
     display: flex;
@@ -444,25 +539,42 @@
     padding-bottom: 16px;
 }
 
+.wk-layout-tab-expanded .wk-navrail__bottom {
+    align-items: stretch;
+    padding: 0 var(--wk-sp-2, 8px) var(--wk-sp-4, 16px);
+}
+
 .wk-navrail__bottom > .wk-navrail__sep {
     margin: 0;
 }
 
 /* ── Space icon button (bottom) ── */
 .wk-navrail__space-icon-btn {
-    width: 32px;                       /* Figma: 32x32 */
-    height: 32px;
+    width: 56px;
+    height: 54px;
     border-radius: 0;
     border: none;                      /* Figma: 无边框 */
     background: transparent;           /* Figma: 无底色 */
     color: var(--wk-icon-muted);       /* Figma: 同未选中态 */
     cursor: pointer;
     display: flex;
+    flex-direction: column;
     align-items: center;
     justify-content: center;
+    gap: var(--wk-sp-1, 4px);
     transition: background var(--wk-dur-fast, 200ms) var(--wk-ease, cubic-bezier(0.16,1,0.3,1)),
                 border-color var(--wk-dur-fast, 200ms) var(--wk-ease, cubic-bezier(0.16,1,0.3,1));
-    padding: 0;
+    padding: var(--wk-sp-1, 4px) var(--wk-sp-0-5, 2px);
+}
+
+.wk-layout-tab-expanded .wk-navrail__space-icon-btn {
+    width: 100%;
+    height: 38px;
+    flex-direction: row;
+    justify-content: flex-start;
+    gap: var(--wk-sp-2, 8px);
+    padding: 0 var(--wk-sp-3, 12px);
+    border-radius: var(--wk-r-md, 10px);
 }
 
 .wk-navrail__space-icon-btn:hover {

--- a/packages/dmworkbase/src/Components/NavRail/index.tsx
+++ b/packages/dmworkbase/src/Components/NavRail/index.tsx
@@ -90,16 +90,18 @@ export default class NavRail extends Component<NavRailProps> {
                     {/* 顶部：用户头像（含在线状态点） */}
                     <div className="wk-navrail__top">
                         <div className="wk-navrail__user-wrap">
-                            <button
-                                type="button"
-                                className="wk-navrail__user-avatar"
-                                title={t("base.navRail.me")}
-                                aria-label={t("base.navRail.me")}
-                                onClick={onAvatarClick}
-                            >
-                                <WKAvatar channel={userChannel} />
-                            </button>
-                            {isOnline && <div className="wk-navrail__user-status" />}
+                            <div className="wk-navrail__user-avatar-wrap">
+                                <button
+                                    type="button"
+                                    className="wk-navrail__user-avatar"
+                                    title={t("base.navRail.me")}
+                                    aria-label={t("base.navRail.me")}
+                                    onClick={onAvatarClick}
+                                >
+                                    <WKAvatar channel={userChannel} />
+                                </button>
+                                {isOnline && <div className="wk-navrail__user-status" />}
+                            </div>
                             <span className="wk-navrail__user-name">{userName}</span>
                         </div>
                     </div>

--- a/packages/dmworkbase/src/Components/NavRail/index.tsx
+++ b/packages/dmworkbase/src/Components/NavRail/index.tsx
@@ -82,6 +82,7 @@ export default class NavRail extends Component<NavRailProps> {
             canManageSpace = false,
         } = this.props;
         const userChannel = new Channel(WKApp.loginInfo.uid || "", ChannelTypePerson);
+        const userName = WKApp.loginInfo.name || WKApp.loginInfo.uid || t("base.navRail.me");
 
         return (
             <>
@@ -99,6 +100,7 @@ export default class NavRail extends Component<NavRailProps> {
                                 <WKAvatar channel={userChannel} />
                             </button>
                             {isOnline && <div className="wk-navrail__user-status" />}
+                            <span className="wk-navrail__user-name">{userName}</span>
                         </div>
                     </div>
 

--- a/packages/dmworkbase/src/Components/WKLayout/__tests__/layoutWidth.test.ts
+++ b/packages/dmworkbase/src/Components/WKLayout/__tests__/layoutWidth.test.ts
@@ -133,16 +133,6 @@ describe('layoutWidth', () => {
                 expect(restoreNavRailWidth()).toBe(NAV_RAIL_EXPANDED_WIDTH)
             })
 
-            it('normalizes legacy intermediate stored values', () => {
-                localStorage.setItem(NAV_RAIL_STORAGE_KEY, '160')
-                expect(restoreNavRailWidth()).toBe(NAV_RAIL_EXPANDED_WIDTH)
-            })
-
-            it('normalizes legacy expanded stored values above the new max width', () => {
-                localStorage.setItem(NAV_RAIL_STORAGE_KEY, '220')
-                expect(restoreNavRailWidth()).toBe(NAV_RAIL_EXPANDED_WIDTH)
-            })
-
             it('returns default for out-of-range stored values', () => {
                 localStorage.setItem(NAV_RAIL_STORAGE_KEY, '9999')
                 expect(restoreNavRailWidth()).toBe(NAV_RAIL_DEFAULT_WIDTH)

--- a/packages/dmworkbase/src/Components/WKLayout/__tests__/layoutWidth.test.ts
+++ b/packages/dmworkbase/src/Components/WKLayout/__tests__/layoutWidth.test.ts
@@ -15,10 +15,19 @@ import {
     SUMMARY_MAX_WIDTH,
     SUMMARY_DEFAULT_WIDTH,
     SUMMARY_STORAGE_KEY,
+    NAV_RAIL_MIN_WIDTH,
+    NAV_RAIL_MAX_WIDTH,
+    NAV_RAIL_EXPANDED_WIDTH,
+    NAV_RAIL_DEFAULT_WIDTH,
+    NAV_RAIL_STORAGE_KEY,
     getMaxLeftWidth,
     clampWidth,
     restoreWidth,
     persistWidth,
+    clampNavRailWidth,
+    getNavRailDragWidth,
+    restoreNavRailWidth,
+    persistNavRailWidth,
     clampThreadWidth,
     restoreThreadWidth,
     persistThreadWidth,
@@ -82,6 +91,62 @@ describe('layoutWidth', () => {
         it('returns default for non-numeric stored values', () => {
             localStorage.setItem(SPLITTER_STORAGE_KEY, 'abc')
             expect(restoreWidth()).toBe(SPLITTER_DEFAULT_WIDTH)
+        })
+    })
+
+    describe('nav rail', () => {
+        describe('clampNavRailWidth', () => {
+            it('snaps below threshold to collapsed width', () => {
+                expect(clampNavRailWidth(40, 1200)).toBe(NAV_RAIL_MIN_WIDTH)
+            })
+
+            it('snaps above threshold to expanded width', () => {
+                expect(clampNavRailWidth(400, 1200)).toBe(NAV_RAIL_MAX_WIDTH)
+            })
+
+            it('does not return intermediate widths', () => {
+                expect(clampNavRailWidth(120, 1200)).toBe(NAV_RAIL_EXPANDED_WIDTH)
+            })
+        })
+
+        describe('getNavRailDragWidth', () => {
+            it('expands when dragging right', () => {
+                expect(getNavRailDragWidth(NAV_RAIL_MIN_WIDTH, 1)).toBe(NAV_RAIL_EXPANDED_WIDTH)
+            })
+
+            it('collapses when dragging left', () => {
+                expect(getNavRailDragWidth(NAV_RAIL_EXPANDED_WIDTH, -1)).toBe(NAV_RAIL_MIN_WIDTH)
+            })
+        })
+
+        describe('restoreNavRailWidth / persistNavRailWidth', () => {
+            beforeEach(() => {
+                localStorage.clear()
+            })
+
+            it('returns default when nothing stored', () => {
+                expect(restoreNavRailWidth()).toBe(NAV_RAIL_DEFAULT_WIDTH)
+            })
+
+            it('restores a previously persisted value', () => {
+                persistNavRailWidth(NAV_RAIL_EXPANDED_WIDTH)
+                expect(restoreNavRailWidth()).toBe(NAV_RAIL_EXPANDED_WIDTH)
+            })
+
+            it('normalizes legacy intermediate stored values', () => {
+                localStorage.setItem(NAV_RAIL_STORAGE_KEY, '160')
+                expect(restoreNavRailWidth()).toBe(NAV_RAIL_EXPANDED_WIDTH)
+            })
+
+            it('normalizes legacy expanded stored values above the new max width', () => {
+                localStorage.setItem(NAV_RAIL_STORAGE_KEY, '220')
+                expect(restoreNavRailWidth()).toBe(NAV_RAIL_EXPANDED_WIDTH)
+            })
+
+            it('returns default for out-of-range stored values', () => {
+                localStorage.setItem(NAV_RAIL_STORAGE_KEY, '9999')
+                expect(restoreNavRailWidth()).toBe(NAV_RAIL_DEFAULT_WIDTH)
+            })
         })
     })
 

--- a/packages/dmworkbase/src/Components/WKLayout/index.css
+++ b/packages/dmworkbase/src/Components/WKLayout/index.css
@@ -9,11 +9,14 @@
     height: 100%;
     display: flex;
     overflow: hidden;
+    position: relative;
 }
 
 .wk-layout-tab {
     width: var(--wk-width-layout-tab);
     height: 100%;
+    flex-shrink: 0;
+    min-width: 0;
 }
 
 .wk-layout-content {
@@ -71,6 +74,34 @@
     border-radius: var(--wk-r-full);
 }
 
+.wk-layout-nav-splitter {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: var(--wk-width-layout-tab);
+    width: 12px;
+    margin-left: -6px;
+    cursor: col-resize;
+    z-index: 30;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.wk-layout-nav-splitter-line {
+    width: 0;
+    height: 100%;
+    transition: width var(--wk-dur-fast) var(--wk-ease),
+                background var(--wk-dur-fast) var(--wk-ease);
+}
+
+.wk-layout-nav-splitter:hover .wk-layout-nav-splitter-line,
+.wk-layout-nav-splitter-active .wk-layout-nav-splitter-line {
+    width: 3px;
+    background: var(--wk-brand-primary);
+    border-radius: var(--wk-r-full);
+}
+
 /* Overlay during drag to prevent content from stealing mouse events */
 .wk-layout-drag-overlay {
     position: fixed;
@@ -110,6 +141,10 @@
     }
 
     .wk-layout-splitter {
+        display: none;
+    }
+
+    .wk-layout-nav-splitter {
         display: none;
     }
 

--- a/packages/dmworkbase/src/Components/WKLayout/index.tsx
+++ b/packages/dmworkbase/src/Components/WKLayout/index.tsx
@@ -90,11 +90,7 @@ export class WKLayout extends Component<WKLayoutProps, WKLayoutState>{
 
     resize = throttle(() => {
         this.updateContainerWidth()
-        const nextNavRailWidth = clampNavRailWidth(this.lastNavRailWidth, this.cachedLayoutWidth)
-        const nextWidth = clampWidth(this.lastWidth, this.cachedContainerWidth)
-        this.lastNavRailWidth = nextNavRailWidth
-        this.lastWidth = nextWidth
-        this.setState({ leftWidth: nextWidth, navRailWidth: nextNavRailWidth })
+        this.setState({})
     }, 100)
 
     private updateContainerWidth() {
@@ -156,7 +152,6 @@ export class WKLayout extends Component<WKLayoutProps, WKLayoutState>{
             if (layout) {
                 const px = newWidth + 'px'
                 layout.style.setProperty('--wk-width-layout-tab', px)
-                layout.classList.toggle('wk-layout-nav-expanded', newWidth >= NAV_RAIL_EXPANDED_THRESHOLD)
                 const tab = layout.querySelector('.wk-layout-tab') as HTMLElement
                 if (tab) {
                     tab.style.width = px
@@ -204,6 +199,7 @@ export class WKLayout extends Component<WKLayoutProps, WKLayoutState>{
         }
         // Commit final width to React state (single re-render)
         if (draggingTarget === "nav") {
+            this.updateContainerWidth()
             this.setState({ navRailWidth: this.lastNavRailWidth, isDragging: false, draggingTarget: undefined })
             persistNavRailWidth(this.lastNavRailWidth)
             return
@@ -289,7 +285,7 @@ export class WKLayout extends Component<WKLayoutProps, WKLayoutState>{
         </div>
 
         return <div
-            className={classNames("wk-layout", isNavRailExpanded && "wk-layout-nav-expanded")}
+            className="wk-layout"
             ref={this.layoutRef}
             style={isSmallScreen ? undefined : { '--wk-width-layout-tab': navRailWidthPx } as React.CSSProperties}
         >

--- a/packages/dmworkbase/src/Components/WKLayout/index.tsx
+++ b/packages/dmworkbase/src/Components/WKLayout/index.tsx
@@ -8,9 +8,16 @@ import {
     SMALL_SCREEN_WIDTH,
     SPLITTER_MIN_WIDTH,
     SPLITTER_DEFAULT_WIDTH,
+    NAV_RAIL_MIN_WIDTH,
+    NAV_RAIL_DEFAULT_WIDTH,
+    NAV_RAIL_EXPANDED_THRESHOLD,
     clampWidth,
     restoreWidth,
     persistWidth,
+    clampNavRailWidth,
+    getNavRailDragWidth,
+    restoreNavRailWidth,
+    persistNavRailWidth,
 } from "./layoutWidth";
 import "./index.css"
 
@@ -29,7 +36,9 @@ export interface WKLayoutProps {
 
 interface WKLayoutState {
     leftWidth: number
+    navRailWidth: number
     isDragging: boolean
+    draggingTarget?: "nav" | "content"
 }
 
 export class WKLayout extends Component<WKLayoutProps, WKLayoutState>{
@@ -40,16 +49,21 @@ export class WKLayout extends Component<WKLayoutProps, WKLayoutState>{
     private dragStartX = 0
     private dragStartWidth = 0
     private lastWidth = SPLITTER_DEFAULT_WIDTH
+    private lastNavRailWidth = NAV_RAIL_DEFAULT_WIDTH
     private cachedContainerWidth = 1200  // updated in mount + resize
+    private cachedLayoutWidth = 1200
 
     constructor(props: any) {
         super(props)
         this.gResize = this.resize
 
         const savedWidth = restoreWidth()
+        const savedNavRailWidth = restoreNavRailWidth()
         this.lastWidth = savedWidth
+        this.lastNavRailWidth = savedNavRailWidth
         this.state = {
             leftWidth: savedWidth,
+            navRailWidth: savedNavRailWidth,
             isDragging: false,
         }
     }
@@ -69,40 +83,89 @@ export class WKLayout extends Component<WKLayoutProps, WKLayoutState>{
         this.rightContext.removeRouteListener(this.routeLister)
         document.removeEventListener('mousemove', this.onDragMove)
         document.removeEventListener('mouseup', this.onDragEnd)
+        document.removeEventListener('mouseout', this.onDocumentMouseOut)
+        window.removeEventListener('mouseup', this.onDragEnd)
+        window.removeEventListener('blur', this.onDragEnd)
     }
 
     resize = throttle(() => {
         this.updateContainerWidth()
-        this.setState({})
+        const nextNavRailWidth = clampNavRailWidth(this.lastNavRailWidth, this.cachedLayoutWidth)
+        const nextWidth = clampWidth(this.lastWidth, this.cachedContainerWidth)
+        this.lastNavRailWidth = nextNavRailWidth
+        this.lastWidth = nextWidth
+        this.setState({ leftWidth: nextWidth, navRailWidth: nextNavRailWidth })
     }, 100)
 
     private updateContainerWidth() {
         if (!this.layoutRef.current) return
+        this.cachedLayoutWidth = this.layoutRef.current.clientWidth || this.cachedLayoutWidth
         const contentEl = this.layoutRef.current.querySelector('.wk-layout-content') as HTMLElement
         if (contentEl) {
             this.cachedContainerWidth = contentEl.clientWidth
         }
     }
 
-    private onDoubleClick = () => {
+    private onContentDoubleClick = () => {
         this.lastWidth = SPLITTER_DEFAULT_WIDTH
         this.setState({ leftWidth: SPLITTER_DEFAULT_WIDTH })
         persistWidth(SPLITTER_DEFAULT_WIDTH)
     }
 
-    private onDragStart = (e: React.MouseEvent) => {
+    private onContentDragStart = (e: React.MouseEvent) => {
         e.preventDefault()
         this.dragStartX = e.clientX
         this.dragStartWidth = this.lastWidth
-        this.setState({ isDragging: true })
+        this.setState({ isDragging: true, draggingTarget: "content" })
         document.addEventListener('mousemove', this.onDragMove)
         document.addEventListener('mouseup', this.onDragEnd)
+        document.addEventListener('mouseout', this.onDocumentMouseOut)
+        window.addEventListener('mouseup', this.onDragEnd)
+        window.addEventListener('blur', this.onDragEnd)
+        document.body.style.cursor = 'col-resize'
+        document.body.style.userSelect = 'none'
+    }
+
+    private onNavDoubleClick = () => {
+        this.lastNavRailWidth = NAV_RAIL_DEFAULT_WIDTH
+        this.setState({ navRailWidth: NAV_RAIL_DEFAULT_WIDTH })
+        persistNavRailWidth(NAV_RAIL_DEFAULT_WIDTH)
+    }
+
+    private onNavDragStart = (e: React.MouseEvent) => {
+        e.preventDefault()
+        this.dragStartX = e.clientX
+        this.dragStartWidth = this.lastNavRailWidth
+        this.setState({ isDragging: true, draggingTarget: "nav" })
+        document.addEventListener('mousemove', this.onDragMove)
+        document.addEventListener('mouseup', this.onDragEnd)
+        document.addEventListener('mouseout', this.onDocumentMouseOut)
+        window.addEventListener('mouseup', this.onDragEnd)
+        window.addEventListener('blur', this.onDragEnd)
         document.body.style.cursor = 'col-resize'
         document.body.style.userSelect = 'none'
     }
 
     private onDragMove = (e: MouseEvent) => {
         const delta = e.clientX - this.dragStartX
+        if (this.state.draggingTarget === "nav") {
+            const newWidth = clampNavRailWidth(getNavRailDragWidth(this.dragStartWidth, delta), this.cachedLayoutWidth)
+            this.lastNavRailWidth = newWidth
+
+            const layout = this.layoutRef.current
+            if (layout) {
+                const px = newWidth + 'px'
+                layout.style.setProperty('--wk-width-layout-tab', px)
+                layout.classList.toggle('wk-layout-nav-expanded', newWidth >= NAV_RAIL_EXPANDED_THRESHOLD)
+                const tab = layout.querySelector('.wk-layout-tab') as HTMLElement
+                if (tab) {
+                    tab.style.width = px
+                    tab.classList.toggle('wk-layout-tab-expanded', newWidth >= NAV_RAIL_EXPANDED_THRESHOLD)
+                }
+            }
+            return
+        }
+
         const containerWidth = this.cachedContainerWidth
         const newWidth = clampWidth(this.dragStartWidth + delta, containerWidth)
         this.lastWidth = newWidth
@@ -120,13 +183,32 @@ export class WKLayout extends Component<WKLayoutProps, WKLayoutState>{
         }
     }
 
+    private onDocumentMouseOut = (e: MouseEvent) => {
+        if (!e.relatedTarget) {
+            this.onDragEnd()
+        }
+    }
+
     private onDragEnd = () => {
         document.removeEventListener('mousemove', this.onDragMove)
         document.removeEventListener('mouseup', this.onDragEnd)
+        document.removeEventListener('mouseout', this.onDocumentMouseOut)
+        window.removeEventListener('mouseup', this.onDragEnd)
+        window.removeEventListener('blur', this.onDragEnd)
         document.body.style.cursor = ''
         document.body.style.userSelect = ''
+        const { draggingTarget } = this.state
+        if (!draggingTarget) {
+            this.setState({ isDragging: false })
+            return
+        }
         // Commit final width to React state (single re-render)
-        this.setState({ leftWidth: this.lastWidth, isDragging: false })
+        if (draggingTarget === "nav") {
+            this.setState({ navRailWidth: this.lastNavRailWidth, isDragging: false, draggingTarget: undefined })
+            persistNavRailWidth(this.lastNavRailWidth)
+            return
+        }
+        this.setState({ leftWidth: this.lastWidth, isDragging: false, draggingTarget: undefined })
         persistWidth(this.lastWidth)
     }
 
@@ -134,9 +216,16 @@ export class WKLayout extends Component<WKLayoutProps, WKLayoutState>{
         const { onRenderTab, contentLeft,contentRight,onLeftContext,onRightContext } = this.props
         const isExtension = (window as any).__POWERED_EXTENSION__
         const isSmallScreen = window.innerWidth <= SMALL_SCREEN_WIDTH
-        const { leftWidth, isDragging } = this.state
+        const { leftWidth, navRailWidth, isDragging, draggingTarget } = this.state
 
-        const tabElement = <div className="wk-layout-tab">
+        const clampedNavRailWidth = isSmallScreen ? NAV_RAIL_DEFAULT_WIDTH : clampNavRailWidth(navRailWidth, this.cachedLayoutWidth)
+        const navRailWidthPx = `${clampedNavRailWidth}px`
+        const isNavRailExpanded = clampedNavRailWidth >= NAV_RAIL_EXPANDED_THRESHOLD
+
+        const tabElement = <div
+            className={classNames("wk-layout-tab", isNavRailExpanded && "wk-layout-tab-expanded")}
+            style={isSmallScreen ? undefined : { width: navRailWidthPx }}
+        >
             {
                 onRenderTab && onRenderTab(isSmallScreen ? ScreenSize.small : ScreenSize.normal)
             }
@@ -152,6 +241,7 @@ export class WKLayout extends Component<WKLayoutProps, WKLayoutState>{
         const contentStyle = isSmallScreen ? undefined : {
             '--wk-width-layout-content-left': widthPx,
             '--wk-wdith-conversation-list': widthPx,
+            '--wk-width-layout-tab': navRailWidthPx,
         } as React.CSSProperties
 
         const leftStyle = isSmallScreen ? undefined : {
@@ -186,16 +276,37 @@ export class WKLayout extends Component<WKLayoutProps, WKLayoutState>{
             </div>
             {/* Draggable splitter — absolutely positioned, hidden on small screens */}
             <div
-                className={classNames("wk-layout-splitter", isDragging && "wk-layout-splitter-active")}
-                onMouseDown={this.onDragStart}
-                onDoubleClick={this.onDoubleClick}
+                className={classNames("wk-layout-splitter", isDragging && draggingTarget === "content" && "wk-layout-splitter-active")}
+                onMouseDown={this.onContentDragStart}
+                onDoubleClick={this.onContentDoubleClick}
+                role="separator"
+                aria-orientation="vertical"
+                aria-valuemin={SPLITTER_MIN_WIDTH}
+                aria-valuenow={clampedWidth}
             >
                 <div className="wk-layout-splitter-line" />
             </div>
         </div>
 
-        return <div className="wk-layout" ref={this.layoutRef}>
+        return <div
+            className={classNames("wk-layout", isNavRailExpanded && "wk-layout-nav-expanded")}
+            ref={this.layoutRef}
+            style={isSmallScreen ? undefined : { '--wk-width-layout-tab': navRailWidthPx } as React.CSSProperties}
+        >
             {isExtension ? <>{contentElement}{tabElement}</> : <>{tabElement}{contentElement}</>}
+            {!isSmallScreen && !isExtension && (
+                <div
+                    className={classNames("wk-layout-nav-splitter", isDragging && draggingTarget === "nav" && "wk-layout-nav-splitter-active")}
+                    onMouseDown={this.onNavDragStart}
+                    onDoubleClick={this.onNavDoubleClick}
+                    role="separator"
+                    aria-orientation="vertical"
+                    aria-valuemin={NAV_RAIL_MIN_WIDTH}
+                    aria-valuenow={clampedNavRailWidth}
+                >
+                    <div className="wk-layout-nav-splitter-line" />
+                </div>
+            )}
             {isDragging && <div className="wk-layout-drag-overlay" />}
         </div>
     }

--- a/packages/dmworkbase/src/Components/WKLayout/layoutWidth.ts
+++ b/packages/dmworkbase/src/Components/WKLayout/layoutWidth.ts
@@ -14,6 +14,16 @@ export const SPLITTER_MAX_WIDTH = 360
 export const SPLITTER_DEFAULT_WIDTH = 300
 export const SPLITTER_STORAGE_KEY = 'wk-layout-left-width'
 
+// ── Global NavRail ──
+export const NAV_RAIL_COLLAPSED_WIDTH = 56
+export const NAV_RAIL_MIN_WIDTH = 56
+export const NAV_RAIL_EXPANDED_WIDTH = 180
+export const NAV_RAIL_MAX_WIDTH = NAV_RAIL_EXPANDED_WIDTH
+export const NAV_RAIL_DEFAULT_WIDTH = 56
+export const NAV_RAIL_EXPANDED_THRESHOLD = NAV_RAIL_EXPANDED_WIDTH
+export const NAV_RAIL_STORAGE_KEY = 'wk-layout-navrail-width'
+const NAV_RAIL_LEGACY_MAX_WIDTH = 260
+
 // ── Right panel (thread panel) ──
 export const THREAD_MIN_WIDTH = 432
 export const THREAD_MAX_WIDTH = 1600  // effective max is clamped by screen ratio
@@ -53,6 +63,36 @@ export function restoreWidth(): number {
 
 export function persistWidth(width: number): void {
     persistStoredWidth(SPLITTER_STORAGE_KEY, width)
+}
+
+// ── Global NavRail helpers ──
+
+export function clampNavRailWidth(width: number, containerWidth: number): number {
+    const max = getMaxWidth(containerWidth, NAV_RAIL_MIN_WIDTH, NAV_RAIL_MAX_WIDTH, 0.3)
+    const snapThreshold = (NAV_RAIL_COLLAPSED_WIDTH + NAV_RAIL_EXPANDED_WIDTH) / 2
+    return width >= snapThreshold ? max : NAV_RAIL_COLLAPSED_WIDTH
+}
+
+export function getNavRailDragWidth(startWidth: number, delta: number): number {
+    if (delta === 0) return clampNavRailWidth(startWidth, Number.POSITIVE_INFINITY)
+    return delta > 0 ? NAV_RAIL_EXPANDED_WIDTH : NAV_RAIL_COLLAPSED_WIDTH
+}
+
+export function restoreNavRailWidth(): number {
+    try {
+        const stored = localStorage.getItem(NAV_RAIL_STORAGE_KEY)
+        if (stored) {
+            const parsed = parseInt(stored, 10)
+            if (!isNaN(parsed) && parsed >= NAV_RAIL_MIN_WIDTH && parsed <= NAV_RAIL_LEGACY_MAX_WIDTH) {
+                return clampNavRailWidth(parsed, Number.POSITIVE_INFINITY)
+            }
+        }
+    } catch (_) {}
+    return NAV_RAIL_DEFAULT_WIDTH
+}
+
+export function persistNavRailWidth(width: number): void {
+    persistStoredWidth(NAV_RAIL_STORAGE_KEY, clampNavRailWidth(width, Number.POSITIVE_INFINITY))
 }
 
 // ── Right (thread) panel helpers ──

--- a/packages/dmworkbase/src/Components/WKLayout/layoutWidth.ts
+++ b/packages/dmworkbase/src/Components/WKLayout/layoutWidth.ts
@@ -22,7 +22,6 @@ export const NAV_RAIL_MAX_WIDTH = NAV_RAIL_EXPANDED_WIDTH
 export const NAV_RAIL_DEFAULT_WIDTH = 56
 export const NAV_RAIL_EXPANDED_THRESHOLD = NAV_RAIL_EXPANDED_WIDTH
 export const NAV_RAIL_STORAGE_KEY = 'wk-layout-navrail-width'
-const NAV_RAIL_LEGACY_MAX_WIDTH = 260
 
 // ── Right panel (thread panel) ──
 export const THREAD_MIN_WIDTH = 432
@@ -79,16 +78,10 @@ export function getNavRailDragWidth(startWidth: number, delta: number): number {
 }
 
 export function restoreNavRailWidth(): number {
-    try {
-        const stored = localStorage.getItem(NAV_RAIL_STORAGE_KEY)
-        if (stored) {
-            const parsed = parseInt(stored, 10)
-            if (!isNaN(parsed) && parsed >= NAV_RAIL_MIN_WIDTH && parsed <= NAV_RAIL_LEGACY_MAX_WIDTH) {
-                return clampNavRailWidth(parsed, Number.POSITIVE_INFINITY)
-            }
-        }
-    } catch (_) {}
-    return NAV_RAIL_DEFAULT_WIDTH
+    return clampNavRailWidth(
+        restoreStoredWidth(NAV_RAIL_STORAGE_KEY, NAV_RAIL_MIN_WIDTH, NAV_RAIL_MAX_WIDTH, NAV_RAIL_DEFAULT_WIDTH),
+        Number.POSITIVE_INFINITY,
+    )
 }
 
 export function persistNavRailWidth(width: number): void {

--- a/packages/dmworkbase/src/i18n/locales/en-US.json
+++ b/packages/dmworkbase/src/i18n/locales/en-US.json
@@ -1230,6 +1230,7 @@
   "uploadCredentials.failed": "Upload failed",
   "uploadCredentials.missingFields": "Credential fields are missing from the response",
   "navRail.ariaLabel": "Main navigation",
+  "navRail.language.label": "Language",
   "navRail.language.name.en": "English",
   "navRail.language.name.zh": "简体中文",
   "navRail.language.switchToChinese": "Switch to 简体中文",

--- a/packages/dmworkbase/src/i18n/locales/zh-CN.json
+++ b/packages/dmworkbase/src/i18n/locales/zh-CN.json
@@ -1230,6 +1230,7 @@
   "uploadCredentials.failed": "上传失败",
   "uploadCredentials.missingFields": "响应缺少凭证字段",
   "navRail.ariaLabel": "主导航",
+  "navRail.language.label": "语言",
   "navRail.language.name.en": "English",
   "navRail.language.name.zh": "简体中文",
   "navRail.language.switchToChinese": "切换到简体中文",


### PR DESCRIPTION
## Summary
- Add a two-state resizable NavRail layout: collapsed at 56px and expanded at 180px.
- Show NavRail labels below icons when collapsed and to the right when expanded, including bottom language/settings/space actions.
- Preserve existing menu source, Chat search/add button placement, and conversation list resizing behavior.
- Normalize legacy intermediate NavRail widths and ensure drag state is cleared when the pointer leaves the page/window.

## Validation
- git diff --check
- pnpm i18n:check
- pnpm --dir packages/dmworkbase test -- layoutWidth (277 files / 2396 tests passed)
- pnpm lint:css (0 errors; existing warnings only; WKModal check passed)
