### PR TITLE
feat(docs): html_ppt viewer preview, editor route, and present route (R3-F1)

### DIFF
--- a/apps/web/src/Layout/__tests__/standaloneReturn.test.ts
+++ b/apps/web/src/Layout/__tests__/standaloneReturn.test.ts
@@ -80,6 +80,36 @@ describe("standalone return target", () => {
         ).toBeNull();
     });
 
+    it("accepts the html_ppt peer surface deep-links so they replay after login (XIN-1608)", () => {
+        for (const good of [
+            "/ppt/d/d_abc",
+            "/ppt/d/d_abc/",
+            "/ppt/d/d_abc?foo=bar",
+            "/docs/d_abc/present",
+            "/docs/d_abc/present/",
+            "/docs/d_abc/present?version=3",
+        ]) {
+            window.sessionStorage.setItem(KEY, good);
+            expect(consumeStandaloneReturn()).toBe(good);
+        }
+    });
+
+    it("rejects docs paths that are not the exact /docs/:id/present shape (keeps the shell)", () => {
+        for (const bad of [
+            "/docs", // list namespace
+            "/docs/d_abc", // editor route, not a return target
+            "/docs/d_abc/edit", // wrong tail
+            "/docs/d_abc/present/extra", // extra segment
+            "/ppt/d", // no id
+            "/ppt/d/", // empty id
+            "/ppt/x/d_abc", // wrong shape
+        ]) {
+            window.sessionStorage.setItem(KEY, bad);
+            expect(consumeStandaloneReturn()).toBeNull();
+            expect(window.sessionStorage.getItem(KEY)).toBeNull();
+        }
+    });
+
     it("clearStandaloneReturn deletes the key without navigating or consuming (R9 P1)", () => {
         const href = window.location.href;
         window.sessionStorage.setItem(KEY, "/drive/invite/tok_1");

--- a/apps/web/src/Layout/index.tsx
+++ b/apps/web/src/Layout/index.tsx
@@ -13,7 +13,7 @@ import { toJoinApprovalStatus } from "@octo/base";
 import InviteLanding from "../Components/InviteLanding";
 import JoinSpacePage from "../Components/JoinSpacePage";
 import JoinApprovalResult from "../Components/JoinApprovalResult";
-import { StandaloneDocPage, parseStandaloneDocId, isStandaloneDocPath } from "@octo/docs";
+import { StandaloneDocPage, parseStandaloneDocId, isStandaloneDocPath, PptEditorPage, PptPresentPage, parsePptEditorDocId, isPptEditorPath, parsePptPresentDocId, isPptPresentPath, parsePresentVersion } from "@octo/docs";
 import { getEnterpriseStandaloneHandlers } from "virtual:octo-enterprise-modules";
 import { SummaryDetailPage, SummaryShareDetailPage } from "@dmwork/summary";
 import { adoptStoredSession, findSidForToken, clearSessionsWithToken } from "./recoverSession";
@@ -467,6 +467,42 @@ export default class AppLayout extends Component<{}, AppLayoutState> {
             // written for a first-time visitor — onLogin consumes it via consumeStandaloneReturn.
             persistStandaloneReturn();
             // Anonymous: fall through to the login screen (below) without navigating away.
+        }
+
+        // html_ppt peer surfaces (R3-F1, XIN-1495): two full-window Bento routes that live OUTSIDE
+        // the app shell and are intercepted exactly like `/d/:docId` above — so a PPT deep link
+        // lands on the PPT surface and NEVER falls through to the rich-text editor / app-shell list
+        // (the R1 no-fallthrough contract). Both consume live backend source, so the pages keep that
+        // behind PPT_SOURCE_ENABLED (default OFF until backend R3-B1 merges) and show a gated shell
+        // meanwhile; the host still routes to them. Session handling mirrors the standalone branch:
+        // load/recover the octo session, render when signed in, else stash the return target and fall
+        // through to login so the user bounces back after sign-in.
+        //
+        //   - `/ppt/d/:docId`         → peer editor route (namespace-claimed; a malformed id renders
+        //                               the PPT not-found shell, not the app shell).
+        //   - `/docs/:docId/present`  → present route (`?version=latest|N`); only this exact shape is
+        //                               claimed, so every other `/docs...` path keeps the app shell.
+        const isPptEditor = isPptEditorPath(window.location.pathname);
+        const isPptPresent = isPptPresentPath(window.location.pathname);
+        if (isPptEditor || isPptPresent) {
+            if (!WKApp.loginInfo.token) {
+                WKApp.loginInfo.load();
+            }
+            if (!WKApp.loginInfo.token) {
+                recoverOctoSessionFromStorage(true);
+            }
+            if (WKApp.loginInfo.token) {
+                if (isPptEditor) {
+                    const pptDocId = parsePptEditorDocId(window.location.pathname);
+                    return <PptEditorPage docId={pptDocId} onSessionExpired={clearExpiredStandaloneSessionAndReload} />;
+                }
+                const presentDocId = parsePptPresentDocId(window.location.pathname);
+                const presentVersion = parsePresentVersion(window.location.search);
+                return <PptPresentPage docId={presentDocId} version={presentVersion} onSessionExpired={clearExpiredStandaloneSessionAndReload} />;
+            }
+            // Anonymous: stash the exact target so the post-login flow bounces the user back to the
+            // PPT surface, then fall through to the login screen without navigating away.
+            persistStandaloneReturn();
         }
 
         // Drive share landing (`/drive/s/:token`, PR#1146 N2). Access requires a

--- a/apps/web/src/Layout/standaloneReturn.ts
+++ b/apps/web/src/Layout/standaloneReturn.ts
@@ -8,6 +8,15 @@ const STANDALONE_DOC_PATH = /^\/d\/([A-Za-z0-9_-]+)\/?$/;
 const STANDALONE_SUMMARY_PATH = /^\/s\/([A-Za-z0-9_-]+)\/?$/;
 const STANDALONE_SUMMARY_SHARE_PATH = /^\/s\/share\/([A-Za-z0-9_-]+)\/?$/;
 
+// html_ppt peer surfaces (R3-F1, XIN-1495 / XIN-1608). Layout persists a return target for these two
+// full-window PPT routes on the anonymous deep-link path (index.tsx ~L505), but they are NOT
+// registered enterprise standalone handlers, so without an allowlist entry consumeStandaloneReturn
+// discarded the stored target and the user landed on the app root after sign-in. Mirror the docId
+// safety of the standalone doc path (`A-Z a-z 0-9 _ -`, single segment) and match the exact route
+// shapes parsed in packages/docs/src/ppt/pptRoutes.ts, so only a real PPT deep-link replays.
+const STANDALONE_PPT_EDITOR_PATH = /^\/ppt\/d\/([A-Za-z0-9_-]+)\/?$/;
+const STANDALONE_PPT_PRESENT_PATH = /^\/docs\/([A-Za-z0-9_-]+)\/present\/?$/;
+
 // `/drive/s/:token` and `/drive/invite/:token` — drive share / space-invite landings
 // (PR#1146 N2). Both require login: a signed-in user who opens the link while logged
 // out is bounced back here after sign-in. Matches a SINGLE path segment before decode
@@ -51,6 +60,8 @@ function isSafeReturnPath(path: string | null, handlers: readonly ReturnHandler[
     if (STANDALONE_DOC_PATH.test(url.pathname)) return true;
     if (STANDALONE_SUMMARY_PATH.test(url.pathname)) return true;
     if (STANDALONE_SUMMARY_SHARE_PATH.test(url.pathname)) return true;
+    if (STANDALONE_PPT_EDITOR_PATH.test(url.pathname)) return true;
+    if (STANDALONE_PPT_PRESENT_PATH.test(url.pathname)) return true;
     if (isSafeDriveLandingPath(url.pathname)) return true;
     return handlers.some((handler) => handler.persistReturnOnAnonymous && handler.match(url.pathname));
 }

--- a/packages/docs/src/config.ts
+++ b/packages/docs/src/config.ts
@@ -196,9 +196,9 @@ export const PPT_CREATE_ENABLED = envOr(import.meta.env?.VITE_DOCS_PPT_CREATE, '
  * source (R3-F1, XIN-1495 / XIN-1583).
  *
  * R3-F1 builds the static shell and wires the routes (read-only PptDocView preview, the peer
- * `/ppt/d/:docId` editor route with its same-origin Bento container, and the `/docs/:docId/present`
- * present route), but the payloads those surfaces load — the origin-checked bootstrap and the
- * published/live HTML — are produced by the backend R3-B1 source/bootstrap layer
+ * `/ppt/d/:docId` editor route with its isolated opaque-origin Bento container, and the
+ * `/docs/:docId/present` present route), but the payloads those surfaces load — the rendered
+ * published/live HTML — are produced by the backend R3-B1 source layer
  * (`feature/xin-1495-ppt-r3-source-bootstrap`), which is NOT yet merged to main. Wiring the
  * frontend to consume live source against an unmerged / mock contract would let a reader or
  * commenter reach draft/live HTML before the backend enforces published-only access — the exact

--- a/packages/docs/src/config.ts
+++ b/packages/docs/src/config.ts
@@ -191,6 +191,30 @@ export const LINE_SPACING_ENABLED = envOr(import.meta.env?.VITE_DOCS_LINE_SPACIN
  */
 export const PPT_CREATE_ENABLED = envOr(import.meta.env?.VITE_DOCS_PPT_CREATE, 'true') === 'true'
 
+/**
+ * Exposure gate for the html_ppt viewer / editor / present surfaces that consume LIVE backend
+ * source (R3-F1, XIN-1495 / XIN-1583).
+ *
+ * R3-F1 builds the static shell and wires the routes (read-only PptDocView preview, the peer
+ * `/ppt/d/:docId` editor route with its same-origin Bento container, and the `/docs/:docId/present`
+ * present route), but the payloads those surfaces load — the origin-checked bootstrap and the
+ * published/live HTML — are produced by the backend R3-B1 source/bootstrap layer
+ * (`feature/xin-1495-ppt-r3-source-bootstrap`), which is NOT yet merged to main. Wiring the
+ * frontend to consume live source against an unmerged / mock contract would let a reader or
+ * commenter reach draft/live HTML before the backend enforces published-only access — the exact
+ * thing R3-B1 exists to prevent. So this flag DEFAULTS OFF: every live-source consumer renders a
+ * gated "not yet available" shell (fetching nothing, opening no frame, requesting no token) until a
+ * deployment whose backend carries R3-B1 flips `VITE_DOCS_PPT_SOURCE=true`.
+ *
+ * This gate is deliberately SEPARATE from PPT_CREATE_ENABLED: create (R2, backend merged) is already
+ * live, while source/bootstrap (R3-B1) is not. It never touches the R1 entry / filter /
+ * no-fallthrough routing or the R2 create picker — an OFF build leaves the placeholder behaviour and
+ * the create flow exactly as they are on main, so there is no regression to the shipped rounds. When
+ * OFF, the routes still exist (so a deep link lands on the PPT shell, never the rich-text editor),
+ * they simply show the gated state instead of loading source.
+ */
+export const PPT_SOURCE_ENABLED = envOr(import.meta.env?.VITE_DOCS_PPT_SOURCE, 'false') === 'true'
+
 // ── Default document addressing (frontend-design §7.2) ───────────────────────
 //
 // The docs-backend currently exposes only per-doc endpoints (`/docs/:docId/...`)

--- a/packages/docs/src/i18n/en-US.json
+++ b/packages/docs/src/i18n/en-US.json
@@ -948,6 +948,8 @@
     "editorComingSoon": "The slides editor is coming soon.",
     "presentComingSoon": "Slides presentation is coming soon.",
     "frameOriginError": "Couldn't load the slides: the source must be same-origin.",
+    "loading": "Loading slides…",
+    "loadError": "Couldn't load the slides. Please try again.",
     "create": {
       "title": "New slides",
       "templateLabel": "Choose a template",

--- a/packages/docs/src/i18n/en-US.json
+++ b/packages/docs/src/i18n/en-US.json
@@ -947,7 +947,6 @@
     "previewComingSoon": "Slides preview is coming soon.",
     "editorComingSoon": "The slides editor is coming soon.",
     "presentComingSoon": "Slides presentation is coming soon.",
-    "frameOriginError": "Couldn't load the slides: the source must be same-origin.",
     "loading": "Loading slides…",
     "loadError": "Couldn't load the slides. Please try again.",
     "create": {

--- a/packages/docs/src/i18n/en-US.json
+++ b/packages/docs/src/i18n/en-US.json
@@ -945,6 +945,9 @@
     "createComingSoonOk": "Got it",
     "viewTitle": "Slides",
     "previewComingSoon": "Slides preview is coming soon.",
+    "editorComingSoon": "The slides editor is coming soon.",
+    "presentComingSoon": "Slides presentation is coming soon.",
+    "frameOriginError": "Couldn't load the slides: the source must be same-origin.",
     "create": {
       "title": "New slides",
       "templateLabel": "Choose a template",

--- a/packages/docs/src/i18n/zh-CN.json
+++ b/packages/docs/src/i18n/zh-CN.json
@@ -947,7 +947,6 @@
     "previewComingSoon": "幻灯片预览即将上线。",
     "editorComingSoon": "幻灯片编辑器即将上线。",
     "presentComingSoon": "幻灯片放映即将上线。",
-    "frameOriginError": "无法加载幻灯片：来源必须同源。",
     "loading": "正在加载幻灯片…",
     "loadError": "加载幻灯片失败，请重试。",
     "create": {

--- a/packages/docs/src/i18n/zh-CN.json
+++ b/packages/docs/src/i18n/zh-CN.json
@@ -945,6 +945,9 @@
     "createComingSoonOk": "知道了",
     "viewTitle": "幻灯片",
     "previewComingSoon": "幻灯片预览即将上线。",
+    "editorComingSoon": "幻灯片编辑器即将上线。",
+    "presentComingSoon": "幻灯片放映即将上线。",
+    "frameOriginError": "无法加载幻灯片：来源必须同源。",
     "create": {
       "title": "新建幻灯片",
       "templateLabel": "选择模板",

--- a/packages/docs/src/i18n/zh-CN.json
+++ b/packages/docs/src/i18n/zh-CN.json
@@ -948,6 +948,8 @@
     "editorComingSoon": "幻灯片编辑器即将上线。",
     "presentComingSoon": "幻灯片放映即将上线。",
     "frameOriginError": "无法加载幻灯片：来源必须同源。",
+    "loading": "正在加载幻灯片…",
+    "loadError": "加载幻灯片失败，请重试。",
     "create": {
       "title": "新建幻灯片",
       "templateLabel": "选择模板",

--- a/packages/docs/src/index.ts
+++ b/packages/docs/src/index.ts
@@ -8,6 +8,17 @@ export { DocsModule } from './module.tsx'
 export { EditorShell } from './editor/EditorShell.tsx'
 export { StandaloneDocPage, parseStandaloneDocId, isStandaloneDocPath, persistStandaloneReturn, consumeStandaloneReturn, withReturnSid } from './pages/StandaloneDocPage.tsx'
 export { BoardShell } from './board/BoardShell.tsx'
+// html_ppt peer surfaces (R3-F1, XIN-1495): the editor + present route pages the host Layout mounts,
+// and the pure route parsers it intercepts with (mirroring the standalone `/d/:docId` wiring).
+export { PptEditorPage } from './ppt/PptEditorPage.tsx'
+export { PptPresentPage } from './ppt/PptPresentPage.tsx'
+export {
+  parsePptEditorDocId,
+  isPptEditorPath,
+  parsePptPresentDocId,
+  isPptPresentPath,
+  parsePresentVersion,
+} from './ppt/pptRoutes.ts'
 export { buildDocumentName, parseDocumentName } from './documentName/index.ts'
 export { COLLAB_FIELD, SCHEMA_VERSION } from './schema/index.ts'
 export type { Role } from './auth/roles.ts'

--- a/packages/docs/src/pages/DocsHome.test.tsx
+++ b/packages/docs/src/pages/DocsHome.test.tsx
@@ -1597,7 +1597,7 @@ describe('DocsHome — sheet open path restored (XIN-520)', () => {
     })
     fireEvent.click(screen.getByRole('button', { name: 'docs.ppt.create.submit' }))
 
-    await waitFor(() => expect(assignSpy).toHaveBeenCalledWith('/ppt/d/new_deck'))
+    await waitFor(() => expect(assignSpy).toHaveBeenCalledWith('/ppt/d/new_deck?sp=demo'))
   })
 
   // ── R2-F1 P2-2: navigate BEFORE closing the picker ─────────────────────────
@@ -1634,7 +1634,7 @@ describe('DocsHome — sheet open path restored (XIN-520)', () => {
     fireEvent.click(screen.getByRole('button', { name: 'docs.ppt.create.submit' }))
 
     // assign was attempted (navigate-first), but it threw…
-    await waitFor(() => expect(throwingAssign).toHaveBeenCalledWith('/ppt/d/new_deck'))
+    await waitFor(() => expect(throwingAssign).toHaveBeenCalledWith('/ppt/d/new_deck?sp=demo'))
     // …and because the close runs only AFTER a successful assign, the picker is still open and the
     // error is visible + retriable — not a silently-closed soft-lock.
     await waitFor(() => expect(screen.getByText('docs.ppt.create.error')).toBeTruthy())

--- a/packages/docs/src/pages/DocsHome.tsx
+++ b/packages/docs/src/pages/DocsHome.tsx
@@ -11,6 +11,7 @@ import { resolveSameOriginPath } from './StandaloneDocPage.tsx'
 import { ConfirmModal } from '../editor/ConfirmModal.tsx'
 import { CreateHtmlModal } from '../html-create/CreateHtmlModal.tsx'
 import { CreatePptModal } from '../ppt/CreatePptModal.tsx'
+import { withDeckSpace } from '../ppt/pptLink.ts'
 import { DocsBotConversation } from '../html-create/DocsBotConversation.tsx'
 import { docsApiBaseUrl, type HtmlCreationDraft } from '../html-create/createHtmlTask.ts'
 import { isBoardDoc, isBoardIdLocally, persistBoardScene, rememberBoard } from '../board/boardStore.ts'
@@ -1666,11 +1667,18 @@ export function DocsHome() {
   // Ordering (P2-2): navigate FIRST, close AFTER. If assign throws (e.g. a sandboxed embed forbids
   // top-level navigation), the exception propagates into onSubmit's catch and the still-OPEN modal can
   // show it. Closing first would setError on an unmounted modal — a silent no-op / soft-lock.
+  //
+  // Space carrier (P1-1, XIN-1621): the created deck lives in the active DocsHome space, so we stamp
+  // that space onto the forwarded editor link as `?sp=` (withDeckSpace) — the same carrier the PPT
+  // routes read first (resolveDeckSpace). Without it the peer editor link carried no space and a
+  // cross-space cold open fell to the recipient's last-visited space (backend cross-space guard →
+  // not-found). We read spaceRef (the authoritative current space id) so the callback stays deps-free,
+  // exactly like onOpenInNewPage. A backend editorUrl that already carries `?sp=` is left intact.
   const onPptCreated = useCallback((editorUrl: string): boolean => {
     if (typeof window === 'undefined') return false
     const target = resolveSameOriginPath(editorUrl)
     if (target === null) return false
-    window.location.assign(target)
+    window.location.assign(withDeckSpace(target, spaceRef.current))
     setPptModalOpen(false)
     return true
   }, [])

--- a/packages/docs/src/ppt/BentoContainer.css
+++ b/packages/docs/src/ppt/BentoContainer.css
@@ -1,0 +1,26 @@
+/* Same-origin Bento frame + frame-state styling (R3-F1, XIN-1495). Colours use --wk-* tokens only
+   (repo discipline); the frame itself is chromeless and fills its host container. */
+.octo-ppt-frame {
+  display: block;
+  width: 100%;
+  height: 100%;
+  border: 0;
+  background: var(--wk-bg-base, transparent);
+}
+
+.octo-ppt-frame-state {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  min-height: calc(var(--wk-sp-12) * 4);
+  padding: var(--wk-sp-8);
+  text-align: center;
+  font-size: var(--wk-text-size-md);
+  color: var(--wk-text-secondary);
+}
+
+.octo-ppt-frame-state--error {
+  color: var(--wk-color-danger);
+}

--- a/packages/docs/src/ppt/BentoContainer.tsx
+++ b/packages/docs/src/ppt/BentoContainer.tsx
@@ -1,0 +1,113 @@
+// Same-origin Bento container for the html_ppt peer surfaces (R3-F1, XIN-1495 / XIN-1583).
+//
+// Bento is a single-HTML slide engine that runs its own JS. We host it in a SAME-ORIGIN iframe and
+// hand it its bootstrap over an origin-checked `postMessage` handshake (bootstrapTransfer.ts) rather
+// than baking source or asset credentials into the frame `src`. This component is the peer mount
+// point — it is deliberately NOT wired through EditorShell (a Bento deck has no Yjs/ProseMirror
+// payload and no Hocuspocus room; mounting it through the rich-text host would mint a collab token
+// against a PPT documentName the backend rejects) and it requests NO Hocuspocus token.
+//
+// EXPOSURE GATE: this container consumes LIVE backend source, so it is only ever mounted by a caller
+// that has already checked PPT_SOURCE_ENABLED. Until the backend R3-B1 source/bootstrap layer merges
+// that flag defaults OFF and this component does not mount; the gated shell is shown instead. As
+// defense in depth the container still re-validates that `frameSrc` is same-origin before rendering
+// the iframe, so a misconfigured caller can never point the frame at a cross-origin document.
+
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { t } from '../octoweb/index.ts'
+import {
+  serveBootstrap,
+  currentOrigin,
+  type PptBootstrap,
+  type PptBootstrapMode,
+} from './bootstrapTransfer.ts'
+import './BentoContainer.css'
+
+export interface BentoContainerProps {
+  /** The bootstrap payload served to the frame when it requests it (origin-checked handshake). */
+  bootstrap: PptBootstrap
+  /**
+   * Same-origin URL of the Bento host document to load into the iframe. Validated same-origin here;
+   * a cross-origin / malformed value renders the error state instead of the frame.
+   */
+  frameSrc: string
+  /** Accessible frame title (deck title when known). */
+  title: string
+  className?: string
+}
+
+/** Whether `url` resolves to the current document's own origin (defense-in-depth frame-src gate). */
+function isSameOriginUrl(url: string): boolean {
+  const origin = currentOrigin()
+  if (origin.length === 0) return false
+  try {
+    return new URL(url, origin).origin === origin
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Per-mode iframe sandbox. Bento needs `allow-scripts` to run and `allow-same-origin` to reach the
+ * same-origin bootstrap channel; `present` additionally needs `allow-fullscreen` for the fullscreen
+ * present affordance. The editor additionally allows same-origin form/clipboard interactions Bento
+ * uses for text editing. No `allow-top-navigation` — the deck can never navigate the host away.
+ */
+function sandboxForMode(mode: PptBootstrapMode): string {
+  const base = 'allow-scripts allow-same-origin'
+  if (mode === 'present') return `${base} allow-fullscreen`
+  return base
+}
+
+/**
+ * Mount a same-origin Bento frame and answer its origin-checked bootstrap request with `bootstrap`.
+ *
+ * The `serveBootstrap` listener is attached for this container's lifetime and only ever replies to a
+ * SAME-ORIGIN request whose docId matches this deck — a cross-origin message is dropped without a
+ * reply (see bootstrapTransfer.ts). The bootstrap is also pushed proactively once the frame's
+ * `onLoad` fires, covering a frame that renders before it wires its own request listener.
+ */
+export function BentoContainer({
+  bootstrap,
+  frameSrc,
+  title,
+  className,
+}: BentoContainerProps): React.ReactElement {
+  const iframeRef = useRef<HTMLIFrameElement>(null)
+  const [rejectedCount, setRejectedCount] = useState(0)
+  const sameOrigin = useMemo(() => isSameOriginUrl(frameSrc), [frameSrc])
+
+  useEffect(() => {
+    if (!sameOrigin) return
+    const dispose = serveBootstrap({
+      provide: (request) => (request.docId === bootstrap.docId ? bootstrap : null),
+      // Surface cross-origin/malformed attempts for observability; the count is diagnostic only.
+      onReject: () => setRejectedCount((n) => n + 1),
+    })
+    return dispose
+  }, [bootstrap, sameOrigin])
+
+  if (!sameOrigin) {
+    return (
+      <div className="octo-ppt-frame-state octo-ppt-frame-state--error" role="alert">
+        {t('docs.ppt.frameOriginError')}
+      </div>
+    )
+  }
+
+  return (
+    <iframe
+      ref={iframeRef}
+      className={className ?? 'octo-ppt-frame'}
+      // Same-origin, first-party Bento host. Scripts + same-origin are required for the engine and
+      // the bootstrap channel; present adds fullscreen. See sandboxForMode.
+      sandbox={sandboxForMode(bootstrap.mode)}
+      allow="fullscreen"
+      title={title}
+      src={frameSrc}
+      // Diagnostic attribute only (never read by the frame) so a test / debugger can see whether any
+      // cross-origin handshake was rejected during this mount.
+      data-ppt-rejected={rejectedCount}
+    />
+  )
+}

--- a/packages/docs/src/ppt/BentoContainer.tsx
+++ b/packages/docs/src/ppt/BentoContainer.tsx
@@ -1,96 +1,123 @@
 // Same-origin Bento container for the html_ppt peer surfaces (R3-F1, XIN-1495 / XIN-1583).
 //
-// Bento is a single-HTML slide engine that runs its own JS. We host it in a SAME-ORIGIN iframe and
-// hand it its bootstrap over an origin-checked `postMessage` handshake (bootstrapTransfer.ts) rather
-// than baking source or asset credentials into the frame `src`. This component is the peer mount
-// point — it is deliberately NOT wired through EditorShell (a Bento deck has no Yjs/ProseMirror
-// payload and no Hocuspocus room; mounting it through the rich-text host would mint a collab token
-// against a PPT documentName the backend rejects) and it requests NO Hocuspocus token.
+// Bento is a single-HTML slide engine that runs its own JS. The backend (octo-docs-backend #161)
+// serves a deck's rendered source at `GET /api/v1/ppt/docs/:docId/source` and mounts NO
+// `/ppt/frame/:id` host page — so we do NOT navigate an iframe at a bespoke host route. Instead we
+// FETCH the rendered single-file source through the shared apiClient (pptSourceClient.ts), so the
+// app's auth / `X-Space-Id` / language interceptors apply, and host that HTML in a SAME-ORIGIN
+// iframe via `srcdoc` (a srcdoc document inherits the embedder's origin, so it is same-origin by
+// construction — no cross-origin host page, no baked-in credentials in a frame `src`).
+//
+// The bootstrap payload (source mode/version + any short-lived asset metadata) is still handed to
+// the frame over the origin-checked `postMessage` handshake (bootstrapTransfer.ts): a srcdoc frame
+// with `allow-same-origin` reports `event.origin === window.location.origin`, so the same trust gate
+// — and its cross-origin negative control — holds unchanged.
+//
+// This component is the peer mount point — it is deliberately NOT wired through EditorShell (a Bento
+// deck has no Yjs/ProseMirror payload and no Hocuspocus room; mounting it through the rich-text host
+// would mint a collab token against a PPT documentName the backend rejects) and it requests NO
+// Hocuspocus token.
 //
 // EXPOSURE GATE: this container consumes LIVE backend source, so it is only ever mounted by a caller
-// that has already checked PPT_SOURCE_ENABLED. Until the backend R3-B1 source/bootstrap layer merges
-// that flag defaults OFF and this component does not mount; the gated shell is shown instead. As
-// defense in depth the container still re-validates that `frameSrc` is same-origin before rendering
-// the iframe, so a misconfigured caller can never point the frame at a cross-origin document.
+// that has already checked PPT_SOURCE_ENABLED. While the flag is OFF the caller renders the gated
+// shell and this component never mounts (no fetch, no frame, no token).
 
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { t } from '../octoweb/index.ts'
-import {
-  serveBootstrap,
-  currentOrigin,
-  type PptBootstrap,
-  type PptBootstrapMode,
-} from './bootstrapTransfer.ts'
+import { serveBootstrap, type PptBootstrap } from './bootstrapTransfer.ts'
+import { fetchPptSourceHtml } from './pptSourceClient.ts'
 import './BentoContainer.css'
 
 export interface BentoContainerProps {
   /** The bootstrap payload served to the frame when it requests it (origin-checked handshake). */
   bootstrap: PptBootstrap
-  /**
-   * Same-origin URL of the Bento host document to load into the iframe. Validated same-origin here;
-   * a cross-origin / malformed value renders the error state instead of the frame.
-   */
-  frameSrc: string
+  /** Owning space, forwarded as `X-Space-Id` on the source fetch (parity with getDoc). */
+  space?: string
   /** Accessible frame title (deck title when known). */
   title: string
   className?: string
 }
 
-/** Whether `url` resolves to the current document's own origin (defense-in-depth frame-src gate). */
-function isSameOriginUrl(url: string): boolean {
-  const origin = currentOrigin()
-  if (origin.length === 0) return false
-  try {
-    return new URL(url, origin).origin === origin
-  } catch {
-    return false
-  }
-}
+type SourceState =
+  | { status: 'loading' }
+  | { status: 'ready'; html: string }
+  | { status: 'error' }
 
 /**
  * Per-mode iframe sandbox. Bento needs `allow-scripts` to run and `allow-same-origin` to reach the
  * same-origin bootstrap channel; `present` additionally needs `allow-fullscreen` for the fullscreen
- * present affordance. The editor additionally allows same-origin form/clipboard interactions Bento
- * uses for text editing. No `allow-top-navigation` — the deck can never navigate the host away.
+ * present affordance. No `allow-top-navigation` — the deck can never navigate the host away.
  */
-function sandboxForMode(mode: PptBootstrapMode): string {
+function sandboxForMode(mode: PptBootstrap['mode']): string {
   const base = 'allow-scripts allow-same-origin'
   if (mode === 'present') return `${base} allow-fullscreen`
   return base
 }
 
 /**
- * Mount a same-origin Bento frame and answer its origin-checked bootstrap request with `bootstrap`.
+ * Mount a same-origin Bento frame (srcdoc) with the deck's fetched source and answer its
+ * origin-checked bootstrap request with `bootstrap`.
  *
  * The `serveBootstrap` listener is attached for this container's lifetime and only ever replies to a
  * SAME-ORIGIN request whose docId matches this deck — a cross-origin message is dropped without a
- * reply (see bootstrapTransfer.ts). The bootstrap is also pushed proactively once the frame's
- * `onLoad` fires, covering a frame that renders before it wires its own request listener.
+ * reply (see bootstrapTransfer.ts).
  */
 export function BentoContainer({
   bootstrap,
-  frameSrc,
+  space,
   title,
   className,
 }: BentoContainerProps): React.ReactElement {
   const iframeRef = useRef<HTMLIFrameElement>(null)
   const [rejectedCount, setRejectedCount] = useState(0)
-  const sameOrigin = useMemo(() => isSameOriginUrl(frameSrc), [frameSrc])
+  const [source, setSource] = useState<SourceState>({ status: 'loading' })
 
+  // Fetch the rendered single-file source through the shared apiClient (interceptors applied). Bento
+  // decks are self-contained HTML, so `format=html` returns the whole renderable deck.
   useEffect(() => {
-    if (!sameOrigin) return
+    let cancelled = false
+    setSource({ status: 'loading' })
+    fetchPptSourceHtml({
+      docId: bootstrap.docId,
+      mode: bootstrap.mode,
+      version: bootstrap.version,
+      space,
+    })
+      .then((html) => {
+        if (!cancelled) setSource({ status: 'ready', html })
+      })
+      .catch(() => {
+        if (!cancelled) setSource({ status: 'error' })
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [bootstrap.docId, bootstrap.mode, bootstrap.version, space])
+
+  // Origin-checked handshake: answer only a same-origin request for this deck; drop everything else.
+  // Attached once the frame is on the page (source ready) so the srcdoc frame is present to reply to.
+  useEffect(() => {
+    if (source.status !== 'ready') return
     const dispose = serveBootstrap({
       provide: (request) => (request.docId === bootstrap.docId ? bootstrap : null),
       // Surface cross-origin/malformed attempts for observability; the count is diagnostic only.
       onReject: () => setRejectedCount((n) => n + 1),
     })
     return dispose
-  }, [bootstrap, sameOrigin])
+  }, [bootstrap, source.status])
 
-  if (!sameOrigin) {
+  if (source.status === 'loading') {
+    return (
+      <div className="octo-ppt-frame-state" role="status">
+        {t('docs.ppt.loading')}
+      </div>
+    )
+  }
+
+  if (source.status === 'error') {
     return (
       <div className="octo-ppt-frame-state octo-ppt-frame-state--error" role="alert">
-        {t('docs.ppt.frameOriginError')}
+        {t('docs.ppt.loadError')}
       </div>
     )
   }
@@ -99,12 +126,13 @@ export function BentoContainer({
     <iframe
       ref={iframeRef}
       className={className ?? 'octo-ppt-frame'}
-      // Same-origin, first-party Bento host. Scripts + same-origin are required for the engine and
-      // the bootstrap channel; present adds fullscreen. See sandboxForMode.
+      // Same-origin, first-party Bento host: the source is fetched through the app's own apiClient and
+      // rendered from `srcdoc`, which inherits this document's origin. Scripts + same-origin are
+      // required for the engine and the bootstrap channel; present adds fullscreen. See sandboxForMode.
       sandbox={sandboxForMode(bootstrap.mode)}
       allow="fullscreen"
       title={title}
-      src={frameSrc}
+      srcDoc={source.html}
       // Diagnostic attribute only (never read by the frame) so a test / debugger can see whether any
       // cross-origin handshake was rejected during this mount.
       data-ppt-rejected={rejectedCount}

--- a/packages/docs/src/ppt/BentoContainer.tsx
+++ b/packages/docs/src/ppt/BentoContainer.tsx
@@ -1,17 +1,29 @@
-// Same-origin Bento container for the html_ppt peer surfaces (R3-F1, XIN-1495 / XIN-1583).
+// Isolated Bento container for the html_ppt peer surfaces (R3-F1, XIN-1495 / XIN-1583).
 //
 // Bento is a single-HTML slide engine that runs its own JS. The backend (octo-docs-backend #161)
 // serves a deck's rendered source at `GET /api/v1/ppt/docs/:docId/source` and mounts NO
 // `/ppt/frame/:id` host page — so we do NOT navigate an iframe at a bespoke host route. Instead we
 // FETCH the rendered single-file source through the shared apiClient (pptSourceClient.ts), so the
-// app's auth / `X-Space-Id` / language interceptors apply, and host that HTML in a SAME-ORIGIN
-// iframe via `srcdoc` (a srcdoc document inherits the embedder's origin, so it is same-origin by
-// construction — no cross-origin host page, no baked-in credentials in a frame `src`).
+// app's auth / `X-Space-Id` / language interceptors apply, and host that HTML in a sandboxed iframe
+// via `srcdoc`.
 //
-// The bootstrap payload (source mode/version + any short-lived asset metadata) is still handed to
-// the frame over the origin-checked `postMessage` handshake (bootstrapTransfer.ts): a srcdoc frame
-// with `allow-same-origin` reports `event.origin === window.location.origin`, so the same trust gate
-// — and its cross-origin negative control — holds unchanged.
+// SECURITY (XIN-1608 P0): the deck HTML is user-authored and NOT end-to-end sanitized, so it may
+// carry <script>, on* handlers, or javascript: URLs. A srcdoc document inherits the embedder's
+// origin, so granting `allow-same-origin` alongside `allow-scripts` would let the deck's scripts run
+// AS the parent origin with full access to parent-origin cookies / localStorage / DOM (a stored-XSS
+// escalation). We therefore run the frame WITHOUT `allow-same-origin` (see sandboxForMode): the
+// srcdoc loads in an OPAQUE origin where Bento's scripts still execute against the frame's own
+// document but can touch nothing in the parent origin. This mirrors the intent of the sibling
+// `packages/docs/src/html/HtmlDocView.tsx` (which isolates its unsanitized fetched HTML) while still
+// letting the engine run. The deck's rendered source is delivered by the `srcdoc` injection itself —
+// that is the load-bearing delivery path.
+//
+// The origin-checked `postMessage` handshake (bootstrapTransfer.ts) is retained UNCHANGED and stays
+// fail-closed: it only ever trusts an EXACT same-origin match, so an opaque-origin frame's request
+// (`event.origin === 'null'`) is rejected without a reply — the same negative control the acceptance
+// matrix pins. It is forward scaffolding (a future same-origin-served host page) and issues NO
+// Hocuspocus token; the P0 isolation change does not weaken its origin gate (verified by
+// bootstrapTransfer.test.ts, which is sandbox-independent).
 //
 // This component is the peer mount point — it is deliberately NOT wired through EditorShell (a Bento
 // deck has no Yjs/ProseMirror payload and no Hocuspocus room; mounting it through the rich-text host
@@ -44,23 +56,28 @@ type SourceState =
   | { status: 'error' }
 
 /**
- * Per-mode iframe sandbox. Bento needs `allow-scripts` to run and `allow-same-origin` to reach the
- * same-origin bootstrap channel; `present` additionally needs `allow-fullscreen` for the fullscreen
- * present affordance. No `allow-top-navigation` — the deck can never navigate the host away.
+ * Per-mode iframe sandbox. The deck source is user-authored and NOT end-to-end sanitized, so the
+ * frame runs Bento's scripts (`allow-scripts`) but DELIBERATELY WITHOUT `allow-same-origin`: the
+ * srcdoc document therefore loads in an OPAQUE origin, and its scripts cannot read the parent
+ * origin's cookies / localStorage / DOM (XIN-1608 P0 — Option A). Granting both `allow-scripts` and
+ * `allow-same-origin` over unsanitized HTML would let the deck execute AS the parent origin, so the
+ * two are never combined here. `present` additionally needs `allow-fullscreen`. No
+ * `allow-top-navigation` — the deck can never navigate the host away.
  */
 function sandboxForMode(mode: PptBootstrap['mode']): string {
-  const base = 'allow-scripts allow-same-origin'
+  const base = 'allow-scripts'
   if (mode === 'present') return `${base} allow-fullscreen`
   return base
 }
 
 /**
- * Mount a same-origin Bento frame (srcdoc) with the deck's fetched source and answer its
- * origin-checked bootstrap request with `bootstrap`.
+ * Mount an isolated (opaque-origin) Bento frame (srcdoc) with the deck's fetched source and answer
+ * any origin-checked bootstrap request with `bootstrap`.
  *
- * The `serveBootstrap` listener is attached for this container's lifetime and only ever replies to a
- * SAME-ORIGIN request whose docId matches this deck — a cross-origin message is dropped without a
- * reply (see bootstrapTransfer.ts).
+ * The `serveBootstrap` listener is attached for this container's lifetime and only ever replies to an
+ * EXACT same-origin request whose docId matches this deck — every other message (including the
+ * opaque-origin frame's own `event.origin === 'null'`) is dropped without a reply (see
+ * bootstrapTransfer.ts). The handshake is thus fail-closed under the isolated sandbox.
  */
 export function BentoContainer({
   bootstrap,
@@ -126,9 +143,10 @@ export function BentoContainer({
     <iframe
       ref={iframeRef}
       className={className ?? 'octo-ppt-frame'}
-      // Same-origin, first-party Bento host: the source is fetched through the app's own apiClient and
-      // rendered from `srcdoc`, which inherits this document's origin. Scripts + same-origin are
-      // required for the engine and the bootstrap channel; present adds fullscreen. See sandboxForMode.
+      // First-party Bento host: the source is fetched through the app's own apiClient and rendered
+      // from `srcdoc`. The sandbox grants `allow-scripts` (the engine needs to run) but NOT
+      // `allow-same-origin`, so the deck loads in an OPAQUE origin and its scripts cannot touch the
+      // parent origin (XIN-1608 P0); present adds fullscreen. See sandboxForMode.
       sandbox={sandboxForMode(bootstrap.mode)}
       allow="fullscreen"
       title={title}

--- a/packages/docs/src/ppt/BentoContainer.tsx
+++ b/packages/docs/src/ppt/BentoContainer.tsx
@@ -8,22 +8,22 @@
 // via `srcdoc`.
 //
 // SECURITY (XIN-1608 P0): the deck HTML is user-authored and NOT end-to-end sanitized, so it may
-// carry <script>, on* handlers, or javascript: URLs. A srcdoc document inherits the embedder's
+// carry <script>, on* handlers, or javascript: URLs. A srcdoc document would inherit the embedder's
 // origin, so granting `allow-same-origin` alongside `allow-scripts` would let the deck's scripts run
 // AS the parent origin with full access to parent-origin cookies / localStorage / DOM (a stored-XSS
 // escalation). We therefore run the frame WITHOUT `allow-same-origin` (see sandboxForMode): the
 // srcdoc loads in an OPAQUE origin where Bento's scripts still execute against the frame's own
 // document but can touch nothing in the parent origin. This mirrors the intent of the sibling
 // `packages/docs/src/html/HtmlDocView.tsx` (which isolates its unsanitized fetched HTML) while still
-// letting the engine run. The deck's rendered source is delivered by the `srcdoc` injection itself —
-// that is the load-bearing delivery path.
+// letting the engine run.
 //
-// The origin-checked `postMessage` handshake (bootstrapTransfer.ts) is retained UNCHANGED and stays
-// fail-closed: it only ever trusts an EXACT same-origin match, so an opaque-origin frame's request
-// (`event.origin === 'null'`) is rejected without a reply — the same negative control the acceptance
-// matrix pins. It is forward scaffolding (a future same-origin-served host page) and issues NO
-// Hocuspocus token; the P0 isolation change does not weaken its origin gate (verified by
-// bootstrapTransfer.test.ts, which is sandbox-independent).
+// DELIVERY PATH: the deck's rendered source is delivered by the `srcdoc` injection ITSELF — that is
+// the single, load-bearing delivery path here. There is NO postMessage bootstrap handshake in the
+// live container: an opaque-origin frame's message arrives with `event.origin === 'null'`, which the
+// origin gate (bootstrapTransfer.ts) can never trust, so a handshake is structurally impossible under
+// this sandbox. The origin-gated bootstrap module is retained as DEFERRED scaffolding for a future
+// separate-origin host page (see the P1-A discussion on XIN-1615); it is intentionally NOT wired
+// here, so nothing in this component depends on a channel that cannot run.
 //
 // This component is the peer mount point — it is deliberately NOT wired through EditorShell (a Bento
 // deck has no Yjs/ProseMirror payload and no Hocuspocus room; mounting it through the rich-text host
@@ -34,15 +34,23 @@
 // that has already checked PPT_SOURCE_ENABLED. While the flag is OFF the caller renders the gated
 // shell and this component never mounts (no fetch, no frame, no token).
 
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { t } from '../octoweb/index.ts'
-import { serveBootstrap, type PptBootstrap } from './bootstrapTransfer.ts'
+import type { PptBootstrapMode } from './bootstrapTransfer.ts'
 import { fetchPptSourceHtml } from './pptSourceClient.ts'
 import './BentoContainer.css'
 
 export interface BentoContainerProps {
-  /** The bootstrap payload served to the frame when it requests it (origin-checked handshake). */
-  bootstrap: PptBootstrap
+  /** Deck id whose rendered source is fetched and hosted. */
+  docId: string
+  /**
+   * Resolved source mode driving the backend `mode` mapping and the sandbox. A reader/commenter is
+   * given a read-only mode (`preview`/`present` → `published`); only a writer/admin editor context
+   * resolves to `editor` (→ `live`). The container never decides this — the caller does.
+   */
+  mode: PptBootstrapMode
+  /** `'latest'` or a published `version_seq`; only serialized for the published modes. */
+  version: 'latest' | number
   /** Owning space, forwarded as `X-Space-Id` on the source fetch (parity with getDoc). */
   space?: string
   /** Accessible frame title (deck title when known). */
@@ -64,29 +72,27 @@ type SourceState =
  * two are never combined here. `present` additionally needs `allow-fullscreen`. No
  * `allow-top-navigation` — the deck can never navigate the host away.
  */
-function sandboxForMode(mode: PptBootstrap['mode']): string {
+function sandboxForMode(mode: PptBootstrapMode): string {
   const base = 'allow-scripts'
   if (mode === 'present') return `${base} allow-fullscreen`
   return base
 }
 
 /**
- * Mount an isolated (opaque-origin) Bento frame (srcdoc) with the deck's fetched source and answer
- * any origin-checked bootstrap request with `bootstrap`.
+ * Mount an isolated (opaque-origin) Bento frame (srcdoc) with the deck's fetched source.
  *
- * The `serveBootstrap` listener is attached for this container's lifetime and only ever replies to an
- * EXACT same-origin request whose docId matches this deck — every other message (including the
- * opaque-origin frame's own `event.origin === 'null'`) is dropped without a reply (see
- * bootstrapTransfer.ts). The handshake is thus fail-closed under the isolated sandbox.
+ * The deck HTML is fetched through the shared apiClient (interceptors applied) and injected via
+ * `srcdoc`; the frame renders entirely from that. No postMessage handshake runs here — see the file
+ * header for why the opaque origin forecloses it.
  */
 export function BentoContainer({
-  bootstrap,
+  docId,
+  mode,
+  version,
   space,
   title,
   className,
 }: BentoContainerProps): React.ReactElement {
-  const iframeRef = useRef<HTMLIFrameElement>(null)
-  const [rejectedCount, setRejectedCount] = useState(0)
   const [source, setSource] = useState<SourceState>({ status: 'loading' })
 
   // Fetch the rendered single-file source through the shared apiClient (interceptors applied). Bento
@@ -94,12 +100,7 @@ export function BentoContainer({
   useEffect(() => {
     let cancelled = false
     setSource({ status: 'loading' })
-    fetchPptSourceHtml({
-      docId: bootstrap.docId,
-      mode: bootstrap.mode,
-      version: bootstrap.version,
-      space,
-    })
+    fetchPptSourceHtml({ docId, mode, version, space })
       .then((html) => {
         if (!cancelled) setSource({ status: 'ready', html })
       })
@@ -109,19 +110,7 @@ export function BentoContainer({
     return () => {
       cancelled = true
     }
-  }, [bootstrap.docId, bootstrap.mode, bootstrap.version, space])
-
-  // Origin-checked handshake: answer only a same-origin request for this deck; drop everything else.
-  // Attached once the frame is on the page (source ready) so the srcdoc frame is present to reply to.
-  useEffect(() => {
-    if (source.status !== 'ready') return
-    const dispose = serveBootstrap({
-      provide: (request) => (request.docId === bootstrap.docId ? bootstrap : null),
-      // Surface cross-origin/malformed attempts for observability; the count is diagnostic only.
-      onReject: () => setRejectedCount((n) => n + 1),
-    })
-    return dispose
-  }, [bootstrap, source.status])
+  }, [docId, mode, version, space])
 
   if (source.status === 'loading') {
     return (
@@ -141,19 +130,15 @@ export function BentoContainer({
 
   return (
     <iframe
-      ref={iframeRef}
       className={className ?? 'octo-ppt-frame'}
       // First-party Bento host: the source is fetched through the app's own apiClient and rendered
       // from `srcdoc`. The sandbox grants `allow-scripts` (the engine needs to run) but NOT
       // `allow-same-origin`, so the deck loads in an OPAQUE origin and its scripts cannot touch the
       // parent origin (XIN-1608 P0); present adds fullscreen. See sandboxForMode.
-      sandbox={sandboxForMode(bootstrap.mode)}
+      sandbox={sandboxForMode(mode)}
       allow="fullscreen"
       title={title}
       srcDoc={source.html}
-      // Diagnostic attribute only (never read by the frame) so a test / debugger can see whether any
-      // cross-origin handshake was rejected during this mount.
-      data-ppt-rejected={rejectedCount}
     />
   )
 }

--- a/packages/docs/src/ppt/BentoContainer.tsx
+++ b/packages/docs/src/ppt/BentoContainer.tsx
@@ -17,6 +17,13 @@
 // `packages/docs/src/html/HtmlDocView.tsx` (which isolates its unsanitized fetched HTML) while still
 // letting the engine run.
 //
+// DEFENCE-IN-DEPTH (XIN-1621 P1-2): the opaque origin stops the deck touching the PARENT origin, but
+// not the frame opening OUTBOUND requests. Since an R3 deck is self-contained (needs no network at
+// render time), we inject a CSP `<meta>` into the srcdoc (pptFrameCsp.ts) that denies `connect-src`
+// (and form/base exfil side-channels) while still allowing Bento's inline/eval/`data:`/`blob:`
+// runtime — FE-side only, no global nginx change. The complementary parent-document `frame-src` (in
+// the app's top-level CSP) is deferred to a follow-up because it needs the global nginx config.
+//
 // DELIVERY PATH: the deck's rendered source is delivered by the `srcdoc` injection ITSELF — that is
 // the single, load-bearing delivery path here. There is NO postMessage bootstrap handshake in the
 // live container: an opaque-origin frame's message arrives with `event.origin === 'null'`, which the
@@ -38,6 +45,7 @@ import { useEffect, useState } from 'react'
 import { t } from '../octoweb/index.ts'
 import type { PptBootstrapMode } from './bootstrapTransfer.ts'
 import { fetchPptSourceHtml } from './pptSourceClient.ts'
+import { withFrameCsp } from './pptFrameCsp.ts'
 import './BentoContainer.css'
 
 export interface BentoContainerProps {
@@ -69,13 +77,14 @@ type SourceState =
  * srcdoc document therefore loads in an OPAQUE origin, and its scripts cannot read the parent
  * origin's cookies / localStorage / DOM (XIN-1608 P0 — Option A). Granting both `allow-scripts` and
  * `allow-same-origin` over unsanitized HTML would let the deck execute AS the parent origin, so the
- * two are never combined here. `present` additionally needs `allow-fullscreen`. No
- * `allow-top-navigation` — the deck can never navigate the host away.
+ * two are never combined here. Fullscreen for `present` is granted by the `allow="fullscreen"`
+ * permission-policy attribute on the iframe, NOT a sandbox token — `allow-fullscreen` is not a valid
+ * sandbox keyword and the browser silently ignores it, so it is deliberately absent here. No
+ * `allow-top-navigation` — the deck can never navigate the host away. The sandbox is therefore the
+ * same for every mode today; kept as a function so a future per-mode token has one seam.
  */
-function sandboxForMode(mode: PptBootstrapMode): string {
-  const base = 'allow-scripts'
-  if (mode === 'present') return `${base} allow-fullscreen`
-  return base
+function sandboxForMode(_mode: PptBootstrapMode): string {
+  return 'allow-scripts'
 }
 
 /**
@@ -95,8 +104,9 @@ export function BentoContainer({
 }: BentoContainerProps): React.ReactElement {
   const [source, setSource] = useState<SourceState>({ status: 'loading' })
 
-  // Fetch the rendered single-file source through the shared apiClient (interceptors applied). Bento
-  // decks are self-contained HTML, so `format=html` returns the whole renderable deck.
+  // Fetch the rendered single-file source through the shared apiClient (interceptors applied). R3
+  // supports only self-contained rendered HTML, so `format=html` returns a deck whose bytes are
+  // complete at the frame boundary and the opaque-origin `srcdoc` needs no further network to render.
   useEffect(() => {
     let cancelled = false
     setSource({ status: 'loading' })
@@ -134,11 +144,15 @@ export function BentoContainer({
       // First-party Bento host: the source is fetched through the app's own apiClient and rendered
       // from `srcdoc`. The sandbox grants `allow-scripts` (the engine needs to run) but NOT
       // `allow-same-origin`, so the deck loads in an OPAQUE origin and its scripts cannot touch the
-      // parent origin (XIN-1608 P0); present adds fullscreen. See sandboxForMode.
+      // parent origin (XIN-1608 P0). Fullscreen (for present) comes from the `allow="fullscreen"`
+      // permission-policy attribute below, not a sandbox token. See sandboxForMode.
       sandbox={sandboxForMode(mode)}
       allow="fullscreen"
       title={title}
-      srcDoc={source.html}
+      // Defence-in-depth (P1-2): inject a CSP meta that denies `connect-src` so the opaque frame
+      // cannot exfiltrate over fetch/XHR/WebSocket, while still allowing Bento's inline/blob/data
+      // runtime for the self-contained render. See pptFrameCsp.ts.
+      srcDoc={withFrameCsp(source.html)}
     />
   )
 }

--- a/packages/docs/src/ppt/PptDocView.sourceOn.test.tsx
+++ b/packages/docs/src/ppt/PptDocView.sourceOn.test.tsx
@@ -1,12 +1,13 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { render, screen, cleanup } from '@testing-library/react'
+import { render, screen, waitFor, cleanup } from '@testing-library/react'
 import { setWKApp } from '../octoweb/index.ts'
-import { createMockWKApp } from '../octoweb/mock.ts'
+import { createMockWKApp, type MockApiClient } from '../octoweb/mock.ts'
 
-// Flag-ON build: a deployment whose backend carries R3-B1 flips PPT_SOURCE_ENABLED on. The preview
-// then mounts the same-origin Bento container (an iframe) instead of the coming-soon placeholder.
-// Mock config.ts with the flag ON (every other export real via importActual), mirroring the
-// DocsHome.pptFlagOff.test.tsx pattern.
+// Flag-ON build: a deployment whose backend carries R3-B1 (octo-docs-backend #161) flips
+// PPT_SOURCE_ENABLED on. The preview then fetches the deck's rendered source through the shared
+// apiClient and mounts it in a same-origin Bento container (srcdoc iframe) instead of the
+// coming-soon placeholder. Mock config.ts with the flag ON (every other export real via
+// importActual), mirroring the DocsHome.pptFlagOff.test.tsx pattern.
 vi.mock('../config.ts', async () => {
   const actual = await vi.importActual<typeof import('../config.ts')>('../config.ts')
   return { ...actual, PPT_SOURCE_ENABLED: true }
@@ -15,20 +16,43 @@ vi.mock('../config.ts', async () => {
 // Imported AFTER the config mock so the module closes over the ON flag.
 import { PptDocView } from './PptDocView.tsx'
 
+const DECK_HTML = '<html><body>Q3 deck</body></html>'
+let api: MockApiClient
+
 describe('PptDocView — source gated ON', () => {
   beforeEach(() => {
-    setWKApp(createMockWKApp())
+    const wk = createMockWKApp()
+    api = wk.apiClient
+    api.responder = () => ({ data: DECK_HTML, status: 200 })
+    setWKApp(wk)
   })
   afterEach(() => cleanup())
 
-  it('mounts the same-origin Bento preview frame (read-only)', () => {
+  it('fetches the real published source and mounts the same-origin Bento preview (read-only)', async () => {
     const { container } = render(<PptDocView docId="d_1" title="Q3 deck" />)
+    await waitFor(() => expect(container.querySelector('iframe')).not.toBeNull())
     const frame = container.querySelector('iframe')
-    expect(frame).not.toBeNull()
-    // Same-origin frame src, addressed by docId, in preview mode.
-    expect(frame?.getAttribute('src')).toContain('/ppt/frame/d_1')
-    expect(frame?.getAttribute('src')).toContain('mode=preview')
+    // srcdoc-hosted deck source (same-origin by construction); no bespoke /ppt/frame host route.
+    expect(frame?.getAttribute('srcdoc')).toContain('Q3 deck')
+    expect(frame?.getAttribute('src')).toBeNull()
+    // Fetched the real backend source endpoint with the mapped mode + format.
+    expect(api.calls).toHaveLength(1)
+    const { url } = api.calls[0]
+    expect(url).toContain('/ppt/docs/d_1/source')
+    expect(url).not.toContain('/ppt/frame')
+    const q = new URL(url, 'http://local').searchParams
+    expect(q.get('mode')).toBe('published')
+    expect(q.get('format')).toBe('html')
     // No placeholder hint in the mounted state.
     expect(screen.queryByText('docs.ppt.previewComingSoon')).toBeNull()
+  })
+
+  it('renders the load-error state (no frame) when the source fetch fails', async () => {
+    api.responder = () => {
+      throw { response: { status: 500 } }
+    }
+    const { container } = render(<PptDocView docId="d_1" title="Q3 deck" />)
+    await waitFor(() => expect(screen.getByText('docs.ppt.loadError')).toBeTruthy())
+    expect(container.querySelector('iframe')).toBeNull()
   })
 })

--- a/packages/docs/src/ppt/PptDocView.sourceOn.test.tsx
+++ b/packages/docs/src/ppt/PptDocView.sourceOn.test.tsx
@@ -5,8 +5,8 @@ import { createMockWKApp, type MockApiClient } from '../octoweb/mock.ts'
 
 // Flag-ON build: a deployment whose backend carries R3-B1 (octo-docs-backend #161) flips
 // PPT_SOURCE_ENABLED on. The preview then fetches the deck's rendered source through the shared
-// apiClient and mounts it in a same-origin Bento container (srcdoc iframe) instead of the
-// coming-soon placeholder. Mock config.ts with the flag ON (every other export real via
+// apiClient and mounts it in an isolated (opaque-origin) Bento container (srcdoc iframe) instead of
+// the coming-soon placeholder. Mock config.ts with the flag ON (every other export real via
 // importActual), mirroring the DocsHome.pptFlagOff.test.tsx pattern.
 vi.mock('../config.ts', async () => {
   const actual = await vi.importActual<typeof import('../config.ts')>('../config.ts')
@@ -32,7 +32,7 @@ describe('PptDocView — source gated ON', () => {
     const { container } = render(<PptDocView docId="d_1" title="Q3 deck" />)
     await waitFor(() => expect(container.querySelector('iframe')).not.toBeNull())
     const frame = container.querySelector('iframe')
-    // srcdoc-hosted deck source (same-origin by construction); no bespoke /ppt/frame host route.
+    // srcdoc-hosted deck source (opaque origin — no allow-same-origin); no bespoke /ppt/frame route.
     expect(frame?.getAttribute('srcdoc')).toContain('Q3 deck')
     expect(frame?.getAttribute('src')).toBeNull()
     // Fetched the real backend source endpoint with the mapped mode + format.

--- a/packages/docs/src/ppt/PptDocView.sourceOn.test.tsx
+++ b/packages/docs/src/ppt/PptDocView.sourceOn.test.tsx
@@ -1,0 +1,34 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import { setWKApp } from '../octoweb/index.ts'
+import { createMockWKApp } from '../octoweb/mock.ts'
+
+// Flag-ON build: a deployment whose backend carries R3-B1 flips PPT_SOURCE_ENABLED on. The preview
+// then mounts the same-origin Bento container (an iframe) instead of the coming-soon placeholder.
+// Mock config.ts with the flag ON (every other export real via importActual), mirroring the
+// DocsHome.pptFlagOff.test.tsx pattern.
+vi.mock('../config.ts', async () => {
+  const actual = await vi.importActual<typeof import('../config.ts')>('../config.ts')
+  return { ...actual, PPT_SOURCE_ENABLED: true }
+})
+
+// Imported AFTER the config mock so the module closes over the ON flag.
+import { PptDocView } from './PptDocView.tsx'
+
+describe('PptDocView — source gated ON', () => {
+  beforeEach(() => {
+    setWKApp(createMockWKApp())
+  })
+  afterEach(() => cleanup())
+
+  it('mounts the same-origin Bento preview frame (read-only)', () => {
+    const { container } = render(<PptDocView docId="d_1" title="Q3 deck" />)
+    const frame = container.querySelector('iframe')
+    expect(frame).not.toBeNull()
+    // Same-origin frame src, addressed by docId, in preview mode.
+    expect(frame?.getAttribute('src')).toContain('/ppt/frame/d_1')
+    expect(frame?.getAttribute('src')).toContain('mode=preview')
+    // No placeholder hint in the mounted state.
+    expect(screen.queryByText('docs.ppt.previewComingSoon')).toBeNull()
+  })
+})

--- a/packages/docs/src/ppt/PptDocView.test.tsx
+++ b/packages/docs/src/ppt/PptDocView.test.tsx
@@ -1,0 +1,22 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import { setWKApp } from '../octoweb/index.ts'
+import { createMockWKApp } from '../octoweb/mock.ts'
+import { PptDocView } from './PptDocView.tsx'
+
+// Default build: PPT_SOURCE_ENABLED is OFF (pending backend R3-B1), so the read-only preview must
+// render the R1 "coming soon" placeholder and mount NO iframe / open no network — the gated state
+// that ships until source lands. (The flag-ON branch is covered in PptDocView.sourceOn.test.tsx.)
+describe('PptDocView — source gated OFF (default)', () => {
+  beforeEach(() => {
+    setWKApp(createMockWKApp())
+  })
+  afterEach(() => cleanup())
+
+  it('renders the coming-soon placeholder and no Bento frame', () => {
+    const { container } = render(<PptDocView docId="d_1" title="Q3 deck" />)
+    expect(screen.getByText('docs.ppt.previewComingSoon')).toBeTruthy()
+    expect(screen.getByText('Q3 deck')).toBeTruthy()
+    expect(container.querySelector('iframe')).toBeNull()
+  })
+})

--- a/packages/docs/src/ppt/PptDocView.tsx
+++ b/packages/docs/src/ppt/PptDocView.tsx
@@ -2,9 +2,10 @@
 //
 // R1 (XIN-1501) shipped this as the routing shell only — a static "coming soon" placeholder — so a
 // PPT row / deep-link / right-pane had a concrete surface to land on instead of silently defaulting
-// to the rich-text editor. R3-F1 (XIN-1583) turns it into the real routeRight read-only PREVIEW: a
-// same-origin Bento container that loads the deck's PUBLISHED source through the origin-checked
-// bootstrap handshake — read-only, so `canEdit` is always false here.
+// to the rich-text editor. R3-F1 (XIN-1583) turns it into the real routeRight read-only PREVIEW: an
+// isolated (opaque-origin) Bento container that fetches the deck's PUBLISHED source through the
+// shared apiClient and hosts it in a sandboxed `srcdoc` frame — read-only, so this always requests
+// the `published` source (FE `preview` mode).
 //
 // WHY A DEDICATED COMPONENT (no-fallback contract): an `html_ppt` row must NEVER fall through to the
 // Tiptap `EditorShell` — a Bento deck has no Yjs/ProseMirror payload and no Hocuspocus collab room,
@@ -21,7 +22,6 @@
 import { t } from '../octoweb/index.ts'
 import { PPT_SOURCE_ENABLED } from '../config.ts'
 import { BentoContainer } from './BentoContainer.tsx'
-import { buildPptBootstrap } from './pptSource.ts'
 import './PptDocView.css'
 
 export interface PptDocViewProps {
@@ -48,15 +48,17 @@ function PptPreviewPlaceholder({ title }: { title?: string }): React.ReactElemen
 
 /**
  * Read-only PPT preview. Renders the gated placeholder when source is off (default, pending R3-B1)
- * and the same-origin Bento preview container when it is on. Either way it opens no collab socket
- * and mints no Hocuspocus token.
+ * and the isolated (opaque-origin) Bento preview container when it is on. Either way it opens no
+ * collab socket and mints no Hocuspocus token.
  */
 export function PptDocView({ docId, space, title }: PptDocViewProps): React.ReactElement {
   return (
     <div className="octo-doc octo-ppt-view octo-theme" role="region" aria-label={t('docs.ppt.viewTitle')}>
       {PPT_SOURCE_ENABLED ? (
         <BentoContainer
-          bootstrap={buildPptBootstrap({ docId, mode: 'preview', version: 'latest', canEdit: false })}
+          docId={docId}
+          mode="preview"
+          version="latest"
           space={space}
           title={title?.trim() || t('docs.ppt.viewTitle')}
         />

--- a/packages/docs/src/ppt/PptDocView.tsx
+++ b/packages/docs/src/ppt/PptDocView.tsx
@@ -1,44 +1,68 @@
-// Read-only placeholder view for a `docType==='html_ppt'` (Bento slide-deck) document.
+// Read-only preview for a `docType==='html_ppt'` (Bento slide-deck) document.
 //
-// R1 SCOPE (XIN-1501): this is the routing shell only. `html_ppt` is a first-class, B-owned
-// document type whose editor/preview/present surfaces and `/api/v1/ppt/**` source endpoints land
-// in later rings (R2+). Until those endpoints are deployed this component renders a static,
-// self-contained "coming soon" placeholder.
+// R1 (XIN-1501) shipped this as the routing shell only — a static "coming soon" placeholder — so a
+// PPT row / deep-link / right-pane had a concrete surface to land on instead of silently defaulting
+// to the rich-text editor. R3-F1 (XIN-1583) turns it into the real routeRight read-only PREVIEW: a
+// same-origin Bento container that loads the deck's PUBLISHED source through the origin-checked
+// bootstrap handshake — read-only, so `canEdit` is always false here.
 //
-// WHY A DEDICATED COMPONENT (no-fallback contract): an `html_ppt` row must NEVER fall through to
-// the Tiptap `EditorShell` — a Bento deck has no Yjs/ProseMirror payload and no Hocuspocus collab
-// room, so the rich-text editor would report "not found" and, worse, could mint a Hocuspocus token
-// against a PPT documentName (which the backend rejects with 422, see octo-docs-backend #152). This
-// component is the explicit peer branch that keeps PPT off both the editor and the collab-token
-// path. It fetches nothing and opens no socket.
+// WHY A DEDICATED COMPONENT (no-fallback contract): an `html_ppt` row must NEVER fall through to the
+// Tiptap `EditorShell` — a Bento deck has no Yjs/ProseMirror payload and no Hocuspocus collab room,
+// so the rich-text editor would report "not found" and, worse, could mint a Hocuspocus token against
+// a PPT documentName (which the backend rejects with 422). This is the explicit peer branch that
+// keeps PPT off both the editor and the collab-token path.
+//
+// EXPOSURE GATE (R3-B1): the preview consumes LIVE backend source, so it is gated behind
+// PPT_SOURCE_ENABLED. Until the backend R3-B1 source/bootstrap layer merges, the flag defaults OFF
+// and this component renders the R1 placeholder exactly as before (fetching nothing, opening no
+// frame, requesting no token) — no regression to the shipped R1/R2 behaviour. When a deployment
+// whose backend carries R3-B1 flips the flag on, the same component mounts the Bento preview.
 
 import { t } from '../octoweb/index.ts'
+import { PPT_SOURCE_ENABLED } from '../config.ts'
+import { BentoContainer } from './BentoContainer.tsx'
+import { buildFrameSrc, buildPptBootstrap } from './pptSource.ts'
 import './PptDocView.css'
 
 export interface PptDocViewProps {
-  /** Doc id of the slide deck (used only for the stable React key at the call site today). */
+  /** Doc id of the slide deck. */
   docId: string
   /** Owning space — carried for parity with HtmlDocView / SheetView and future source scoping. */
   space?: string
-  /** octo-doc slug when it differs from docId; unused in the R1 placeholder. */
+  /** octo-doc slug when it differs from docId; unused today. */
   slug?: string
   /** Deck title, when the caller resolved one. */
   title?: string
 }
 
+/** The R1 "coming soon" placeholder — the gated state shown until PPT_SOURCE_ENABLED (R3-B1) is on. */
+function PptPreviewPlaceholder({ title }: { title?: string }): React.ReactElement {
+  return (
+    <div className="octo-ppt-view-state">
+      <p className="octo-ppt-view-kind">{t('docs.ppt.viewTitle')}</p>
+      {title && title.trim() && <p className="octo-ppt-view-title">{title.trim()}</p>}
+      <p className="octo-ppt-view-hint">{t('docs.ppt.previewComingSoon')}</p>
+    </div>
+  )
+}
+
 /**
- * R1 read-only placeholder. Intentionally free of any editing chrome, collab wiring, or network
- * calls — it exists so the docs list / deep-link / right-pane routing has a concrete PPT surface to
- * land on instead of silently defaulting to the rich-text editor.
+ * Read-only PPT preview. Renders the gated placeholder when source is off (default, pending R3-B1)
+ * and the same-origin Bento preview container when it is on. Either way it opens no collab socket
+ * and mints no Hocuspocus token.
  */
-export function PptDocView({ title }: PptDocViewProps): React.ReactElement {
+export function PptDocView({ docId, title }: PptDocViewProps): React.ReactElement {
   return (
     <div className="octo-doc octo-ppt-view octo-theme" role="region" aria-label={t('docs.ppt.viewTitle')}>
-      <div className="octo-ppt-view-state">
-        <p className="octo-ppt-view-kind">{t('docs.ppt.viewTitle')}</p>
-        {title && title.trim() && <p className="octo-ppt-view-title">{title.trim()}</p>}
-        <p className="octo-ppt-view-hint">{t('docs.ppt.previewComingSoon')}</p>
-      </div>
+      {PPT_SOURCE_ENABLED ? (
+        <BentoContainer
+          bootstrap={buildPptBootstrap({ docId, mode: 'preview', version: 'latest', canEdit: false })}
+          frameSrc={buildFrameSrc(docId, 'preview', 'latest')}
+          title={title?.trim() || t('docs.ppt.viewTitle')}
+        />
+      ) : (
+        <PptPreviewPlaceholder title={title} />
+      )}
     </div>
   )
 }

--- a/packages/docs/src/ppt/PptDocView.tsx
+++ b/packages/docs/src/ppt/PptDocView.tsx
@@ -21,7 +21,7 @@
 import { t } from '../octoweb/index.ts'
 import { PPT_SOURCE_ENABLED } from '../config.ts'
 import { BentoContainer } from './BentoContainer.tsx'
-import { buildFrameSrc, buildPptBootstrap } from './pptSource.ts'
+import { buildPptBootstrap } from './pptSource.ts'
 import './PptDocView.css'
 
 export interface PptDocViewProps {
@@ -51,13 +51,13 @@ function PptPreviewPlaceholder({ title }: { title?: string }): React.ReactElemen
  * and the same-origin Bento preview container when it is on. Either way it opens no collab socket
  * and mints no Hocuspocus token.
  */
-export function PptDocView({ docId, title }: PptDocViewProps): React.ReactElement {
+export function PptDocView({ docId, space, title }: PptDocViewProps): React.ReactElement {
   return (
     <div className="octo-doc octo-ppt-view octo-theme" role="region" aria-label={t('docs.ppt.viewTitle')}>
       {PPT_SOURCE_ENABLED ? (
         <BentoContainer
           bootstrap={buildPptBootstrap({ docId, mode: 'preview', version: 'latest', canEdit: false })}
-          frameSrc={buildFrameSrc(docId, 'preview', 'latest')}
+          space={space}
           title={title?.trim() || t('docs.ppt.viewTitle')}
         />
       ) : (

--- a/packages/docs/src/ppt/PptEditorPage.tsx
+++ b/packages/docs/src/ppt/PptEditorPage.tsx
@@ -1,0 +1,20 @@
+// Peer PPT editor route page (`/ppt/d/:docId`). R3-F1, XIN-1495 / XIN-1583.
+//
+// A backend `editorUrl` from the R2 create flow resolves to this same-origin path; the host Layout
+// intercepts the `/ppt/d` namespace (like `/d/:docId`) and mounts this page OUTSIDE the app shell.
+// It is a thin wrapper over the shared PptSurfacePage in `editor` mode — deliberately NOT the Tiptap
+// EditorShell, and it requests no Hocuspocus token. Live source is gated behind PPT_SOURCE_ENABLED
+// (default OFF pending backend R3-B1); until then this renders the gated "not yet available" shell.
+
+import { type ReactElement } from 'react'
+import { PptSurfacePage } from './PptSurfacePage.tsx'
+
+export function PptEditorPage({
+  docId,
+  onSessionExpired,
+}: {
+  docId: string | null
+  onSessionExpired?: () => void
+}): ReactElement {
+  return <PptSurfacePage docId={docId} mode="editor" onSessionExpired={onSessionExpired} />
+}

--- a/packages/docs/src/ppt/PptPresentPage.tsx
+++ b/packages/docs/src/ppt/PptPresentPage.tsx
@@ -1,0 +1,25 @@
+// Present route page (`/docs/:docId/present?version=latest|N`). R3-F1, XIN-1495 / XIN-1583.
+//
+// A top-level, full-window present surface the host Layout intercepts (only the exact
+// `/docs/:docId/present` shape — every other `/docs...` path stays with the app shell). Read-only:
+// present always loads the PUBLISHED version the `?version=` query selects (default latest), never a
+// draft, and mounts the Bento container in `present` mode with fullscreen allowed. Live source is
+// gated behind PPT_SOURCE_ENABLED (default OFF pending backend R3-B1); until then this renders the
+// gated "not yet available" shell.
+
+import { type ReactElement } from 'react'
+import { PptSurfacePage } from './PptSurfacePage.tsx'
+
+export function PptPresentPage({
+  docId,
+  version,
+  onSessionExpired,
+}: {
+  docId: string | null
+  version: 'latest' | number
+  onSessionExpired?: () => void
+}): ReactElement {
+  return (
+    <PptSurfacePage docId={docId} mode="present" version={version} onSessionExpired={onSessionExpired} />
+  )
+}

--- a/packages/docs/src/ppt/PptSurface.css
+++ b/packages/docs/src/ppt/PptSurface.css
@@ -1,0 +1,57 @@
+/* Full-window html_ppt peer surfaces — editor route (/ppt/d/:docId) and present route
+   (/docs/:docId/present). R3-F1, XIN-1495. Colours use --wk-* tokens only (repo discipline).
+   These pages mount OUTSIDE the app shell, so they own the full viewport. */
+.octo-ppt-surface {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  background: var(--wk-bg-base);
+  color: var(--wk-text-primary);
+}
+
+/* The present surface uses the darkest neutral token so slide letterboxing reads as a projector,
+   not a page — a solid --wk-* token (repo discipline forbids raw hex). */
+.octo-ppt-surface--present {
+  background: var(--wk-neutral-950);
+}
+
+.octo-ppt-surface-body {
+  flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
+}
+
+/* Centered state card for loading / gated / terminal states, mirroring the standalone doc card. */
+.octo-ppt-surface-state {
+  margin: auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--wk-sp-2);
+  text-align: center;
+  padding: var(--wk-sp-8);
+  max-width: calc(var(--wk-sp-12) * 8);
+}
+
+.octo-ppt-surface-state-kind {
+  font-size: var(--wk-text-size-base);
+  font-weight: var(--wk-font-semibold);
+  letter-spacing: 0.02em;
+  opacity: 0.6;
+  margin: 0;
+}
+
+.octo-ppt-surface-state-title {
+  font-size: var(--wk-text-size-2xl);
+  font-weight: var(--wk-font-semibold);
+  margin: 0;
+}
+
+.octo-ppt-surface-state-hint {
+  font-size: var(--wk-text-size-md);
+  opacity: 0.7;
+  margin: 0;
+}

--- a/packages/docs/src/ppt/PptSurfacePage.sourceOn.test.tsx
+++ b/packages/docs/src/ppt/PptSurfacePage.sourceOn.test.tsx
@@ -1,11 +1,13 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { render, screen, waitFor, cleanup } from '@testing-library/react'
+import { render, waitFor, cleanup } from '@testing-library/react'
 import { setWKApp } from '../octoweb/index.ts'
-import { createMockWKApp } from '../octoweb/mock.ts'
+import { createMockWKApp, type MockApiClient } from '../octoweb/mock.ts'
 import type { DocMeta } from '../pages/docsApi.ts'
 
-// Flag-ON build (backend R3-B1 present): the peer routes run the reader preflight and mount the
-// Bento container for a confirmed html_ppt deck. Mock config.ts with PPT_SOURCE_ENABLED ON.
+// Flag-ON build (backend R3-B1 present, octo-docs-backend #161): the peer routes run the reader
+// preflight (getDoc) and mount the Bento container for a confirmed html_ppt deck. The container then
+// fetches the deck's rendered source through the shared apiClient and hosts it same-origin (srcdoc).
+// Mock config.ts with PPT_SOURCE_ENABLED ON.
 vi.mock('../config.ts', async () => {
   const actual = await vi.importActual<typeof import('../config.ts')>('../config.ts')
   return { ...actual, PPT_SOURCE_ENABLED: true }
@@ -21,34 +23,46 @@ vi.mock('../pages/docsApi.ts', async () => {
 
 import { PptSurfacePage } from './PptSurfacePage.tsx'
 
+const DECK_HTML = '<html><body>deck source</body></html>'
+let api: MockApiClient
+
 function meta(over: Partial<DocMeta>): DocMeta {
   return { docId: 'd_1', title: 'Deck', docType: 'html_ppt', role: 'writer', ...over } as DocMeta
 }
 
 describe('PptSurfacePage — source gated ON', () => {
   beforeEach(() => {
-    setWKApp(createMockWKApp())
+    const wk = createMockWKApp()
+    api = wk.apiClient
+    api.responder = () => ({ data: DECK_HTML, status: 200 })
+    setWKApp(wk)
     getDoc.mockReset()
   })
   afterEach(() => cleanup())
 
-  it('mounts the Bento container for a confirmed html_ppt deck (editor mode)', async () => {
+  it('mounts the Bento container and fetches the live editor source (editor mode)', async () => {
     getDoc.mockResolvedValue(meta({ docId: 'd_1' }))
     const { container } = render(<PptSurfacePage docId="d_1" mode="editor" />)
     await waitFor(() => expect(container.querySelector('iframe')).not.toBeNull())
     const frame = container.querySelector('iframe')
-    expect(frame?.getAttribute('src')).toContain('/ppt/frame/d_1')
-    expect(frame?.getAttribute('src')).toContain('mode=editor')
+    expect(frame?.getAttribute('srcdoc')).toContain('deck source')
     expect(getDoc).toHaveBeenCalledWith('d_1')
+    const url = api.calls[0]?.url ?? ''
+    expect(url).toContain('/ppt/docs/d_1/source')
+    expect(url).not.toContain('/ppt/frame')
+    const q = new URL(url, 'http://local').searchParams
+    expect(q.get('mode')).toBe('live')
+    expect(q.get('format')).toBe('html')
   })
 
-  it('addresses the requested published version in present mode', async () => {
+  it('fetches the requested published version in present mode', async () => {
     getDoc.mockResolvedValue(meta({ docId: 'd_1', role: 'reader' }))
     const { container } = render(<PptSurfacePage docId="d_1" mode="present" version={3} />)
     await waitFor(() => expect(container.querySelector('iframe')).not.toBeNull())
-    const src = container.querySelector('iframe')?.getAttribute('src') ?? ''
-    expect(src).toContain('mode=present')
-    expect(src).toContain('version=3')
+    const q = new URL(api.calls[0]?.url ?? '', 'http://local').searchParams
+    expect(q.get('mode')).toBe('published')
+    expect(q.get('version')).toBe('3')
+    expect(q.get('format')).toBe('html')
   })
 
   it('never falls through to a frame for a non-html_ppt doc (no-fallthrough contract)', async () => {
@@ -56,6 +70,8 @@ describe('PptSurfacePage — source gated ON', () => {
     const { container } = render(<PptSurfacePage docId="d_1" mode="editor" />)
     await waitFor(() => expect(getDoc).toHaveBeenCalled())
     expect(container.querySelector('iframe')).toBeNull()
+    // No-fallthrough: a non-deck never triggers a source fetch.
+    expect(api.calls).toHaveLength(0)
   })
 
   it('renders the not-found shell (no frame) for a null id', () => {

--- a/packages/docs/src/ppt/PptSurfacePage.sourceOn.test.tsx
+++ b/packages/docs/src/ppt/PptSurfacePage.sourceOn.test.tsx
@@ -33,6 +33,10 @@ function meta(over: Partial<DocMeta>): DocMeta {
 describe('PptSurfacePage — source gated ON', () => {
   beforeEach(() => {
     const wk = createMockWKApp()
+    // Cross-space cold deep-link: the surface mounts via the Layout early-return before the shell
+    // restores currentSpaceId, but the standalone branch seeds it from the cached localStorage key.
+    // Pin a resolved space here so the test can assert BOTH hops carry X-Space-Id (XIN-1608 P1).
+    wk.shared.currentSpaceId = 'sp_1'
     api = wk.apiClient
     api.responder = () => ({ data: DECK_HTML, status: 200 })
     setWKApp(wk)
@@ -40,19 +44,48 @@ describe('PptSurfacePage — source gated ON', () => {
   })
   afterEach(() => cleanup())
 
-  it('mounts the Bento container and fetches the live editor source (editor mode)', async () => {
+  it('mounts the Bento container and forwards X-Space-Id on both hops (editor mode)', async () => {
     getDoc.mockResolvedValue(meta({ docId: 'd_1' }))
     const { container } = render(<PptSurfacePage docId="d_1" mode="editor" />)
     await waitFor(() => expect(container.querySelector('iframe')).not.toBeNull())
     const frame = container.querySelector('iframe')
     expect(frame?.getAttribute('srcdoc')).toContain('deck source')
-    expect(getDoc).toHaveBeenCalledWith('d_1')
+    // P1: the preflight is space-scoped (getDoc `{ spaceId }`), not a bare id call that pins the bug.
+    expect(getDoc).toHaveBeenCalledWith('d_1', { spaceId: 'sp_1' })
     const url = api.calls[0]?.url ?? ''
     expect(url).toContain('/ppt/docs/d_1/source')
     expect(url).not.toContain('/ppt/frame')
     const q = new URL(url, 'http://local').searchParams
     expect(q.get('mode')).toBe('live')
     expect(q.get('format')).toBe('html')
+    // P1: the source fetch is scoped too — BentoContainer received `space` and forwarded the header.
+    const headers = (api.calls[0]?.config?.headers ?? {}) as Record<string, string>
+    expect(headers['X-Space-Id']).toBe('sp_1')
+  })
+
+  // P0 (XIN-1608): the deck source is user-authored and NOT end-to-end sanitized, so the frame must
+  // never run scripts in the parent origin. Pin the isolation: the sandbox may grant allow-scripts
+  // but must NOT also grant allow-same-origin (Option A — opaque origin). This asserted red on head
+  // 8fb959db (sandbox was `allow-scripts allow-same-origin`).
+  it('isolates the deck in an opaque origin: never both allow-scripts and allow-same-origin', async () => {
+    getDoc.mockResolvedValue(meta({ docId: 'd_1' }))
+    const { container } = render(<PptSurfacePage docId="d_1" mode="editor" />)
+    await waitFor(() => expect(container.querySelector('iframe')).not.toBeNull())
+    const sandbox = container.querySelector('iframe')?.getAttribute('sandbox') ?? ''
+    const tokens = sandbox.split(/\s+/).filter(Boolean)
+    expect(tokens).toContain('allow-scripts')
+    expect(tokens).not.toContain('allow-same-origin')
+  })
+
+  it('present mode also isolates the frame in an opaque origin (keeps allow-fullscreen)', async () => {
+    getDoc.mockResolvedValue(meta({ docId: 'd_1', role: 'reader' }))
+    const { container } = render(<PptSurfacePage docId="d_1" mode="present" version={2} />)
+    await waitFor(() => expect(container.querySelector('iframe')).not.toBeNull())
+    const sandbox = container.querySelector('iframe')?.getAttribute('sandbox') ?? ''
+    const tokens = sandbox.split(/\s+/).filter(Boolean)
+    expect(tokens).toContain('allow-scripts')
+    expect(tokens).toContain('allow-fullscreen')
+    expect(tokens).not.toContain('allow-same-origin')
   })
 
   it('fetches the requested published version in present mode', async () => {

--- a/packages/docs/src/ppt/PptSurfacePage.sourceOn.test.tsx
+++ b/packages/docs/src/ppt/PptSurfacePage.sourceOn.test.tsx
@@ -50,6 +50,9 @@ describe('PptSurfacePage — source gated ON', () => {
     await waitFor(() => expect(container.querySelector('iframe')).not.toBeNull())
     const frame = container.querySelector('iframe')
     expect(frame?.getAttribute('srcdoc')).toContain('deck source')
+    // P1-2: the srcdoc is hardened with a CSP meta that denies outbound connections.
+    expect(frame?.getAttribute('srcdoc')).toContain('Content-Security-Policy')
+    expect(frame?.getAttribute('srcdoc')).toContain("connect-src 'none'")
     // P1: the preflight is space-scoped (getDoc `{ spaceId }`), not a bare id call that pins the bug.
     expect(getDoc).toHaveBeenCalledWith('d_1', { spaceId: 'sp_1' })
     const url = api.calls[0]?.url ?? ''
@@ -107,15 +110,19 @@ describe('PptSurfacePage — source gated ON', () => {
     expect(tokens).not.toContain('allow-same-origin')
   })
 
-  it('present mode also isolates the frame in an opaque origin (keeps allow-fullscreen)', async () => {
+  it('present mode also isolates the frame in an opaque origin', async () => {
     getDoc.mockResolvedValue(meta({ docId: 'd_1', role: 'reader' }))
     const { container } = render(<PptSurfacePage docId="d_1" mode="present" version={2} />)
     await waitFor(() => expect(container.querySelector('iframe')).not.toBeNull())
-    const sandbox = container.querySelector('iframe')?.getAttribute('sandbox') ?? ''
+    const frame = container.querySelector('iframe')
+    const sandbox = frame?.getAttribute('sandbox') ?? ''
     const tokens = sandbox.split(/\s+/).filter(Boolean)
     expect(tokens).toContain('allow-scripts')
-    expect(tokens).toContain('allow-fullscreen')
     expect(tokens).not.toContain('allow-same-origin')
+    // Fullscreen is granted via the permission-policy `allow` attribute, NOT a sandbox token
+    // (`allow-fullscreen` is not a valid sandbox keyword and would be silently ignored).
+    expect(tokens).not.toContain('allow-fullscreen')
+    expect(frame?.getAttribute('allow') ?? '').toContain('fullscreen')
   })
 
   it('fetches the requested published version in present mode', async () => {

--- a/packages/docs/src/ppt/PptSurfacePage.sourceOn.test.tsx
+++ b/packages/docs/src/ppt/PptSurfacePage.sourceOn.test.tsx
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, waitFor, cleanup } from '@testing-library/react'
+import { setWKApp } from '../octoweb/index.ts'
+import { createMockWKApp } from '../octoweb/mock.ts'
+import type { DocMeta } from '../pages/docsApi.ts'
+
+// Flag-ON build (backend R3-B1 present): the peer routes run the reader preflight and mount the
+// Bento container for a confirmed html_ppt deck. Mock config.ts with PPT_SOURCE_ENABLED ON.
+vi.mock('../config.ts', async () => {
+  const actual = await vi.importActual<typeof import('../config.ts')>('../config.ts')
+  return { ...actual, PPT_SOURCE_ENABLED: true }
+})
+vi.mock('../collab/useCollabEditor.ts', () => ({
+  terminalForCreateError: () => 'not-found',
+}))
+const { getDoc } = vi.hoisted(() => ({ getDoc: vi.fn() }))
+vi.mock('../pages/docsApi.ts', async () => {
+  const actual = await vi.importActual<typeof import('../pages/docsApi.ts')>('../pages/docsApi.ts')
+  return { ...actual, getDoc }
+})
+
+import { PptSurfacePage } from './PptSurfacePage.tsx'
+
+function meta(over: Partial<DocMeta>): DocMeta {
+  return { docId: 'd_1', title: 'Deck', docType: 'html_ppt', role: 'writer', ...over } as DocMeta
+}
+
+describe('PptSurfacePage — source gated ON', () => {
+  beforeEach(() => {
+    setWKApp(createMockWKApp())
+    getDoc.mockReset()
+  })
+  afterEach(() => cleanup())
+
+  it('mounts the Bento container for a confirmed html_ppt deck (editor mode)', async () => {
+    getDoc.mockResolvedValue(meta({ docId: 'd_1' }))
+    const { container } = render(<PptSurfacePage docId="d_1" mode="editor" />)
+    await waitFor(() => expect(container.querySelector('iframe')).not.toBeNull())
+    const frame = container.querySelector('iframe')
+    expect(frame?.getAttribute('src')).toContain('/ppt/frame/d_1')
+    expect(frame?.getAttribute('src')).toContain('mode=editor')
+    expect(getDoc).toHaveBeenCalledWith('d_1')
+  })
+
+  it('addresses the requested published version in present mode', async () => {
+    getDoc.mockResolvedValue(meta({ docId: 'd_1', role: 'reader' }))
+    const { container } = render(<PptSurfacePage docId="d_1" mode="present" version={3} />)
+    await waitFor(() => expect(container.querySelector('iframe')).not.toBeNull())
+    const src = container.querySelector('iframe')?.getAttribute('src') ?? ''
+    expect(src).toContain('mode=present')
+    expect(src).toContain('version=3')
+  })
+
+  it('never falls through to a frame for a non-html_ppt doc (no-fallthrough contract)', async () => {
+    getDoc.mockResolvedValue(meta({ docType: 'doc' }))
+    const { container } = render(<PptSurfacePage docId="d_1" mode="editor" />)
+    await waitFor(() => expect(getDoc).toHaveBeenCalled())
+    expect(container.querySelector('iframe')).toBeNull()
+  })
+
+  it('renders the not-found shell (no frame) for a null id', () => {
+    const { container } = render(<PptSurfacePage docId={null} mode="present" version="latest" />)
+    expect(container.querySelector('iframe')).toBeNull()
+    expect(getDoc).not.toHaveBeenCalled()
+  })
+})

--- a/packages/docs/src/ppt/PptSurfacePage.sourceOn.test.tsx
+++ b/packages/docs/src/ppt/PptSurfacePage.sourceOn.test.tsx
@@ -6,8 +6,8 @@ import type { DocMeta } from '../pages/docsApi.ts'
 
 // Flag-ON build (backend R3-B1 present, octo-docs-backend #161): the peer routes run the reader
 // preflight (getDoc) and mount the Bento container for a confirmed html_ppt deck. The container then
-// fetches the deck's rendered source through the shared apiClient and hosts it same-origin (srcdoc).
-// Mock config.ts with PPT_SOURCE_ENABLED ON.
+// fetches the deck's rendered source through the shared apiClient and hosts it in an isolated
+// (opaque-origin) srcdoc frame. Mock config.ts with PPT_SOURCE_ENABLED ON.
 vi.mock('../config.ts', async () => {
   const actual = await vi.importActual<typeof import('../config.ts')>('../config.ts')
   return { ...actual, PPT_SOURCE_ENABLED: true }
@@ -21,7 +21,7 @@ vi.mock('../pages/docsApi.ts', async () => {
   return { ...actual, getDoc }
 })
 
-import { PptSurfacePage } from './PptSurfacePage.tsx'
+import { PptSurfacePage, resolveDeckSpace } from './PptSurfacePage.tsx'
 
 const DECK_HTML = '<html><body>deck source</body></html>'
 let api: MockApiClient
@@ -61,6 +61,36 @@ describe('PptSurfacePage — source gated ON', () => {
     // P1: the source fetch is scoped too — BentoContainer received `space` and forwarded the header.
     const headers = (api.calls[0]?.config?.headers ?? {}) as Record<string, string>
     expect(headers['X-Space-Id']).toBe('sp_1')
+  })
+
+  // P1-3 (XIN-1615): a reader/commenter following the editor link lands on `/ppt/d/:docId` too, but
+  // must NOT fetch the editable `live` source — only a writer/admin does. A non-writer here requests
+  // the `published` source instead (FE preview → published), consistent with the role model. This
+  // asserted red on head 6620f95b (editor mode always mapped to `live`, regardless of role).
+  it('a reader on the editor route requests published, never live (P1-3)', async () => {
+    getDoc.mockResolvedValue(meta({ docId: 'd_1', role: 'reader' }))
+    const { container } = render(<PptSurfacePage docId="d_1" mode="editor" />)
+    await waitFor(() => expect(container.querySelector('iframe')).not.toBeNull())
+    const q = new URL(api.calls[0]?.url ?? '', 'http://local').searchParams
+    expect(q.get('mode')).toBe('published')
+    expect(q.get('mode')).not.toBe('live')
+    expect(q.get('format')).toBe('html')
+  })
+
+  it('a commenter on the editor route also requests published, never live (P1-3)', async () => {
+    getDoc.mockResolvedValue(meta({ docId: 'd_1', role: 'commenter' }))
+    const { container } = render(<PptSurfacePage docId="d_1" mode="editor" />)
+    await waitFor(() => expect(container.querySelector('iframe')).not.toBeNull())
+    const q = new URL(api.calls[0]?.url ?? '', 'http://local').searchParams
+    expect(q.get('mode')).toBe('published')
+  })
+
+  it('a writer on the editor route still loads the editable live source', async () => {
+    getDoc.mockResolvedValue(meta({ docId: 'd_1', role: 'admin' }))
+    const { container } = render(<PptSurfacePage docId="d_1" mode="editor" />)
+    await waitFor(() => expect(container.querySelector('iframe')).not.toBeNull())
+    const q = new URL(api.calls[0]?.url ?? '', 'http://local').searchParams
+    expect(q.get('mode')).toBe('live')
   })
 
   // P0 (XIN-1608): the deck source is user-authored and NOT end-to-end sanitized, so the frame must
@@ -111,5 +141,48 @@ describe('PptSurfacePage — source gated ON', () => {
     const { container } = render(<PptSurfacePage docId={null} mode="present" version="latest" />)
     expect(container.querySelector('iframe')).toBeNull()
     expect(getDoc).not.toHaveBeenCalled()
+  })
+})
+
+// P1-1 (XIN-1615): the PPT deep-link carries the deck's real space in a dedicated `?sp=` query param
+// — the same carrier the standalone doc route reads — so a cross-space COLD deep-link (opened before
+// the shell restores currentSpaceId) resolves the right X-Space-Id instead of an empty/wrong space.
+describe('resolveDeckSpace — cross-space deep-link space carrier', () => {
+  const originalSearch = window.location.search
+
+  beforeEach(() => {
+    const wk = createMockWKApp()
+    // Cold deep-link: shell has not restored currentSpaceId yet, and nothing cached.
+    wk.shared.currentSpaceId = ''
+    setWKApp(wk)
+    try {
+      window.localStorage.removeItem('currentSpaceId')
+    } catch {
+      /* ignore */
+    }
+  })
+  afterEach(() => {
+    window.history.replaceState({}, '', `/${originalSearch}`)
+  })
+
+  it('reads the deck space from the link `?sp=` even when currentSpaceId is empty', () => {
+    window.history.replaceState({}, '', '/ppt/d/d_1?sp=sp_link')
+    expect(resolveDeckSpace()).toBe('sp_link')
+  })
+
+  it('prefers the link `?sp=` over the live currentSpaceId (authoritative for cross-space opens)', () => {
+    const wk = createMockWKApp()
+    wk.shared.currentSpaceId = 'sp_current'
+    setWKApp(wk)
+    window.history.replaceState({}, '', '/ppt/d/d_1?sp=sp_link')
+    expect(resolveDeckSpace()).toBe('sp_link')
+  })
+
+  it('falls back to the live currentSpaceId when the link carries no `?sp=`', () => {
+    const wk = createMockWKApp()
+    wk.shared.currentSpaceId = 'sp_current'
+    setWKApp(wk)
+    window.history.replaceState({}, '', '/ppt/d/d_1')
+    expect(resolveDeckSpace()).toBe('sp_current')
   })
 })

--- a/packages/docs/src/ppt/PptSurfacePage.test.tsx
+++ b/packages/docs/src/ppt/PptSurfacePage.test.tsx
@@ -38,4 +38,22 @@ describe('PptSurfacePage — source gated OFF (default)', () => {
     expect(screen.getByText('docs.ppt.presentComingSoon')).toBeTruthy()
     expect(getDoc).not.toHaveBeenCalled()
   })
+
+  // Branch-order (XIN-1621): a malformed/empty link (docId=null) is a terminal NOT-FOUND in every
+  // build — it must NOT render the "coming soon" gated shell, which is reserved for a well-formed
+  // deck link whose live source is not yet exposed. The null-id branch is checked BEFORE the gate.
+  // Still zero-I/O: the effect returns early when gated, so no preflight fires.
+  it('malformed id (docId=null) renders the not-found shell, not the gated notice, and runs no preflight', () => {
+    render(<PptSurfacePage docId={null} mode="editor" />)
+    expect(screen.getByText('docs.error.permission.notFound')).toBeTruthy()
+    expect(screen.queryByText('docs.ppt.editorComingSoon')).toBeNull()
+    expect(getDoc).not.toHaveBeenCalled()
+  })
+
+  it('malformed id (docId=null) in present mode also renders not-found, not the gated notice', () => {
+    render(<PptSurfacePage docId={null} mode="present" version="latest" />)
+    expect(screen.getByText('docs.error.permission.notFound')).toBeTruthy()
+    expect(screen.queryByText('docs.ppt.presentComingSoon')).toBeNull()
+    expect(getDoc).not.toHaveBeenCalled()
+  })
 })

--- a/packages/docs/src/ppt/PptSurfacePage.test.tsx
+++ b/packages/docs/src/ppt/PptSurfacePage.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import { setWKApp } from '../octoweb/index.ts'
+import { createMockWKApp } from '../octoweb/mock.ts'
+
+// Keep the heavy collab runtime out of this render: PptSurfacePage only needs terminalForCreateError.
+vi.mock('../collab/useCollabEditor.ts', () => ({
+  terminalForCreateError: () => 'not-found',
+}))
+
+// Spy getDoc so the gated path can be asserted to perform NO preflight; keep the other exports real.
+const { getDoc } = vi.hoisted(() => ({ getDoc: vi.fn() }))
+vi.mock('../pages/docsApi.ts', async () => {
+  const actual = await vi.importActual<typeof import('../pages/docsApi.ts')>('../pages/docsApi.ts')
+  return { ...actual, getDoc }
+})
+
+import { PptSurfacePage } from './PptSurfacePage.tsx'
+
+// Default build: PPT_SOURCE_ENABLED OFF. Both peer routes render the gated "coming soon" shell and
+// perform NO network I/O (no preflight) — the state that ships until backend R3-B1 merges.
+describe('PptSurfacePage — source gated OFF (default)', () => {
+  beforeEach(() => {
+    setWKApp(createMockWKApp())
+    getDoc.mockReset()
+  })
+  afterEach(() => cleanup())
+
+  it('editor mode shows the gated editor notice, mounts no frame, and runs no preflight', () => {
+    const { container } = render(<PptSurfacePage docId="d_1" mode="editor" />)
+    expect(screen.getByText('docs.ppt.editorComingSoon')).toBeTruthy()
+    expect(container.querySelector('iframe')).toBeNull()
+    expect(getDoc).not.toHaveBeenCalled()
+  })
+
+  it('present mode shows the gated present notice', () => {
+    render(<PptSurfacePage docId="d_1" mode="present" version="latest" />)
+    expect(screen.getByText('docs.ppt.presentComingSoon')).toBeTruthy()
+    expect(getDoc).not.toHaveBeenCalled()
+  })
+})

--- a/packages/docs/src/ppt/PptSurfacePage.tsx
+++ b/packages/docs/src/ppt/PptSurfacePage.tsx
@@ -21,7 +21,7 @@ import { getDoc, HTML_PPT_DOC_TYPE, type DocMeta } from '../pages/docsApi.ts'
 import { DocTerminal, type TerminalKind } from '../editor/DocTerminal.tsx'
 import { terminalForCreateError } from '../collab/useCollabEditor.ts'
 import { BentoContainer } from './BentoContainer.tsx'
-import { buildFrameSrc, buildPptBootstrap } from './pptSource.ts'
+import { buildPptBootstrap } from './pptSource.ts'
 import type { PptBootstrapMode } from './bootstrapTransfer.ts'
 import './PptSurface.css'
 
@@ -159,7 +159,6 @@ export function PptSurfacePage({ docId, mode, version, onSessionExpired }: PptSu
       <div className="octo-ppt-surface-body">
         <BentoContainer
           bootstrap={buildPptBootstrap({ docId: deckId, mode, version: resolvedVersion, canEdit })}
-          frameSrc={buildFrameSrc(deckId, mode, resolvedVersion)}
           title={meta.title || t('docs.ppt.viewTitle')}
         />
       </div>

--- a/packages/docs/src/ppt/PptSurfacePage.tsx
+++ b/packages/docs/src/ppt/PptSurfacePage.tsx
@@ -21,7 +21,6 @@ import { getDoc, HTML_PPT_DOC_TYPE, type DocMeta } from '../pages/docsApi.ts'
 import { DocTerminal, type TerminalKind } from '../editor/DocTerminal.tsx'
 import { terminalForCreateError } from '../collab/useCollabEditor.ts'
 import { BentoContainer } from './BentoContainer.tsx'
-import { buildPptBootstrap } from './pptSource.ts'
 import type { PptBootstrapMode } from './bootstrapTransfer.ts'
 import './PptSurface.css'
 
@@ -67,12 +66,22 @@ function SurfaceState({
  *
  * The PPT surfaces mount via the host Layout's EARLY RETURN, before the app-shell logic that
  * restores `currentSpaceId` from localStorage runs — so on a cross-space cold deep-link the live
- * `WKApp.shared.currentSpaceId` is still empty. Mirror the standalone branches: prefer the live
- * value, else the cached `currentSpaceId` localStorage key the shell persists. Returns '' when there
- * is no signal at all, in which case the caller omits the explicit header and lets the global request
- * interceptor decide (exactly as an in-shell entry does) rather than forcing a wrong space.
+ * `WKApp.shared.currentSpaceId` is still empty. Priority mirrors the standalone doc page
+ * (StandaloneDocPage.standaloneLinkSpace + standaloneFallbackSpace):
+ *
+ *   1. the deep-link's dedicated `?sp=` carrier — the doc's REAL space, embedded by the share/deep
+ *      link (32-hex docs-backend space_id), authoritative for a CROSS-SPACE cold open because it is
+ *      the only signal that survives before the shell restores currentSpaceId;
+ *   2. the live `WKApp.shared.currentSpaceId`;
+ *   3. the cached `currentSpaceId` localStorage key the shell persists.
+ *
+ * Returns '' when there is no signal at all, in which case the caller omits the explicit header and
+ * lets the global request interceptor decide (exactly as an in-shell entry does) rather than forcing
+ * a wrong space.
  */
 export function resolveDeckSpace(): string {
+  const link = linkSpace()
+  if (link) return link
   const live = getWKApp().shared?.currentSpaceId
   if (live) return live
   if (typeof window !== 'undefined') {
@@ -86,14 +95,30 @@ export function resolveDeckSpace(): string {
   return ''
 }
 
+/**
+ * The deck's own space as carried by the deep-link's dedicated `?sp=` query param — the same carrier
+ * the standalone doc route reads (StandaloneDocPage.standaloneLinkSpace). buildDocLink embeds the
+ * document's REAL space id as `?sp=`, so a cross-space cold deep-link resolves the right
+ * `X-Space-Id` before the shell restores currentSpaceId. Returns '' when the link carries no `?sp=`
+ * (older links, or SSR); the caller then falls back to live/cached currentSpaceId.
+ */
+function linkSpace(): string {
+  if (typeof window === 'undefined') return ''
+  try {
+    return (new URLSearchParams(window.location.search).get('sp') || '').trim()
+  } catch {
+    return ''
+  }
+}
+
 export function PptSurfacePage({ docId, mode, version, onSessionExpired }: PptSurfacePageProps): ReactElement {
   const gated = !PPT_SOURCE_ENABLED
   // Resolve the owning space for the cross-space cold deep-link. Both PPT routes mount via the
   // Layout EARLY RETURN — before the app shell restores currentSpaceId — so the live value is often
-  // empty on a fresh tab. Mirror the standalone branches (Layout ~L421 / StandaloneDocPage) by
-  // falling back to the cached `currentSpaceId` localStorage key the shell persists, so the by-space
-  // reads below are scoped instead of unscoped (XIN-1608 P1). '' → omit the header and let the global
-  // interceptor decide, exactly as an in-shell entry would.
+  // empty on a fresh tab. resolveDeckSpace reads the link's dedicated `?sp=` carrier first (the same
+  // one the standalone route uses), then falls back to live / cached currentSpaceId, so the by-space
+  // reads below are scoped even on a cross-space cold open (XIN-1608 P1). '' → omit the header and
+  // let the global interceptor decide, exactly as an in-shell entry would.
   const space = resolveDeckSpace()
   const [phase, setPhase] = useState<Phase>({ status: 'loading' })
 
@@ -177,9 +202,15 @@ export function PptSurfacePage({ docId, mode, version, onSessionExpired }: PptSu
 
   const deckId = meta.docId || docId
   const resolvedVersion: 'latest' | number = mode === 'present' ? version ?? 'latest' : 'latest'
-  // Editor edits the live/draft the caller's role permits (backend enforces what that role may load);
-  // present is always read-only published, so canEdit is false there.
+  // Editor edits the live/draft the caller's role permits; present is always read-only published.
   const canEdit = mode === 'editor' ? Boolean(meta.role && roleCanEdit(meta.role)) : false
+  // P1-3 (role model): the editor route `/ppt/d/:docId` is a WRITER surface, but a reader/commenter
+  // following an editor link lands here too — and must NOT fetch the editable `live` source. Only a
+  // writer/admin (canEdit) loads `live` (FE `editor` mode); a non-writer on the editor route loads
+  // the `published` source instead (FE `preview` mode → published), exactly like the read-only
+  // preview surface. `present` is unaffected (always published). The backend still enforces access;
+  // this stops the FE from even ASKING for `live` on behalf of a non-writer.
+  const sourceMode: PptBootstrapMode = mode === 'editor' && !canEdit ? 'preview' : mode
 
   return (
     <div
@@ -189,7 +220,9 @@ export function PptSurfacePage({ docId, mode, version, onSessionExpired }: PptSu
     >
       <div className="octo-ppt-surface-body">
         <BentoContainer
-          bootstrap={buildPptBootstrap({ docId: deckId, mode, version: resolvedVersion, canEdit })}
+          docId={deckId}
+          mode={sourceMode}
+          version={resolvedVersion}
           space={space || undefined}
           title={meta.title || t('docs.ppt.viewTitle')}
         />

--- a/packages/docs/src/ppt/PptSurfacePage.tsx
+++ b/packages/docs/src/ppt/PptSurfacePage.tsx
@@ -97,10 +97,14 @@ export function resolveDeckSpace(): string {
 
 /**
  * The deck's own space as carried by the deep-link's dedicated `?sp=` query param — the same carrier
- * the standalone doc route reads (StandaloneDocPage.standaloneLinkSpace). buildDocLink embeds the
- * document's REAL space id as `?sp=`, so a cross-space cold deep-link resolves the right
- * `X-Space-Id` before the shell restores currentSpaceId. Returns '' when the link carries no `?sp=`
- * (older links, or SSR); the caller then falls back to live/cached currentSpaceId.
+ * the standalone doc route reads (StandaloneDocPage.standaloneLinkSpace). On the PPT routes this `?sp=`
+ * is minted by the PPT link builders (pptLink.ts): the create flow stamps the deck's space onto the
+ * forwarded editor link (`/ppt/d/:docId?sp=`), and `buildPptPresentLink` stamps it onto a present
+ * link, so a cross-space cold deep-link resolves the right `X-Space-Id` before the shell restores
+ * currentSpaceId. (Note `buildDocLink` mints `?sp=` for the STANDALONE `/d/:docId` route only, a
+ * different route — it does NOT produce these PPT paths.) Returns '' when the link carries no `?sp=`
+ * (an editor link the backend forwarded without one, an older/hand-built link, or SSR); the caller
+ * then falls back to live/cached currentSpaceId.
  */
 function linkSpace(): string {
   if (typeof window === 'undefined') return ''
@@ -149,7 +153,21 @@ export function PptSurfacePage({ docId, mode, version, onSessionExpired }: PptSu
     }
   }, [gated, docId, space, onSessionExpired])
 
-  // Gated shell — the only state that ships until R3-B1 merges.
+  // Null id (route claimed a malformed link): not-found shell, never the app shell / rich editor.
+  // Checked BEFORE the gate so a malformed link is a terminal not-found in every build — the gated
+  // "coming soon" shell is for a WELL-FORMED deck link whose live source is not yet exposed, not for
+  // a broken id. (The effect above already returns early when gated, so this reorder is render-only
+  // and preserves the gated-OFF zero-I/O invariant.)
+  if (!docId) {
+    return (
+      <SurfaceState mode={mode}>
+        <DocTerminal title={t('docs.state.untitled')} kind="not-found" />
+      </SurfaceState>
+    )
+  }
+
+  // Gated (well-formed id, live source not yet exposed): the "not yet available" shell that ships
+  // until R3-B1 merges.
   if (gated) {
     return (
       <SurfaceState mode={mode}>
@@ -157,15 +175,6 @@ export function PptSurfacePage({ docId, mode, version, onSessionExpired }: PptSu
         <p className="octo-ppt-surface-state-hint">
           {mode === 'present' ? t('docs.ppt.presentComingSoon') : t('docs.ppt.editorComingSoon')}
         </p>
-      </SurfaceState>
-    )
-  }
-
-  // Null id (route claimed a malformed link): not-found shell, never the app shell / rich editor.
-  if (!docId) {
-    return (
-      <SurfaceState mode={mode}>
-        <DocTerminal title={t('docs.state.untitled')} kind="not-found" />
       </SurfaceState>
     )
   }

--- a/packages/docs/src/ppt/PptSurfacePage.tsx
+++ b/packages/docs/src/ppt/PptSurfacePage.tsx
@@ -14,7 +14,7 @@
 // container.
 
 import { useEffect, useState, type ReactElement } from 'react'
-import { t } from '../octoweb/index.ts'
+import { getWKApp, t } from '../octoweb/index.ts'
 import { PPT_SOURCE_ENABLED } from '../config.ts'
 import { canEdit as roleCanEdit } from '../auth/roles.ts'
 import { getDoc, HTML_PPT_DOC_TYPE, type DocMeta } from '../pages/docsApi.ts'
@@ -62,8 +62,39 @@ function SurfaceState({
   )
 }
 
+/**
+ * Resolve the owning space for a PPT deep-link's by-space reads (getDoc preflight + source fetch).
+ *
+ * The PPT surfaces mount via the host Layout's EARLY RETURN, before the app-shell logic that
+ * restores `currentSpaceId` from localStorage runs — so on a cross-space cold deep-link the live
+ * `WKApp.shared.currentSpaceId` is still empty. Mirror the standalone branches: prefer the live
+ * value, else the cached `currentSpaceId` localStorage key the shell persists. Returns '' when there
+ * is no signal at all, in which case the caller omits the explicit header and lets the global request
+ * interceptor decide (exactly as an in-shell entry does) rather than forcing a wrong space.
+ */
+export function resolveDeckSpace(): string {
+  const live = getWKApp().shared?.currentSpaceId
+  if (live) return live
+  if (typeof window !== 'undefined') {
+    try {
+      const cached = window.localStorage.getItem('currentSpaceId')
+      if (cached) return cached
+    } catch {
+      // localStorage unavailable (private mode / disabled): no signal → '' (omit the header).
+    }
+  }
+  return ''
+}
+
 export function PptSurfacePage({ docId, mode, version, onSessionExpired }: PptSurfacePageProps): ReactElement {
   const gated = !PPT_SOURCE_ENABLED
+  // Resolve the owning space for the cross-space cold deep-link. Both PPT routes mount via the
+  // Layout EARLY RETURN — before the app shell restores currentSpaceId — so the live value is often
+  // empty on a fresh tab. Mirror the standalone branches (Layout ~L421 / StandaloneDocPage) by
+  // falling back to the cached `currentSpaceId` localStorage key the shell persists, so the by-space
+  // reads below are scoped instead of unscoped (XIN-1608 P1). '' → omit the header and let the global
+  // interceptor decide, exactly as an in-shell entry would.
+  const space = resolveDeckSpace()
   const [phase, setPhase] = useState<Phase>({ status: 'loading' })
 
   useEffect(() => {
@@ -75,7 +106,7 @@ export function PptSurfacePage({ docId, mode, version, onSessionExpired }: PptSu
       return
     }
     setPhase({ status: 'loading' })
-    getDoc(docId)
+    getDoc(docId, space ? { spaceId: space } : undefined)
       .then((meta) => {
         if (!cancelled) setPhase({ status: 'ready', meta })
       })
@@ -91,7 +122,7 @@ export function PptSurfacePage({ docId, mode, version, onSessionExpired }: PptSu
     return () => {
       cancelled = true
     }
-  }, [gated, docId, onSessionExpired])
+  }, [gated, docId, space, onSessionExpired])
 
   // Gated shell — the only state that ships until R3-B1 merges.
   if (gated) {
@@ -159,6 +190,7 @@ export function PptSurfacePage({ docId, mode, version, onSessionExpired }: PptSu
       <div className="octo-ppt-surface-body">
         <BentoContainer
           bootstrap={buildPptBootstrap({ docId: deckId, mode, version: resolvedVersion, canEdit })}
+          space={space || undefined}
           title={meta.title || t('docs.ppt.viewTitle')}
         />
       </div>

--- a/packages/docs/src/ppt/PptSurfacePage.tsx
+++ b/packages/docs/src/ppt/PptSurfacePage.tsx
@@ -1,0 +1,168 @@
+// Full-window html_ppt peer surface — the shared engine behind the editor route (`/ppt/d/:docId`)
+// and the present route (`/docs/:docId/present`). R3-F1, XIN-1495 / XIN-1583.
+//
+// Both routes mount OUTSIDE the app shell (like the standalone `/d/:docId` page) and both must honor
+// the no-fallthrough contract: a Bento deck never reaches the Tiptap `EditorShell` and never mints a
+// Hocuspocus token. This component is that peer host.
+//
+// EXPOSURE GATE (R3-B1): the surface consumes LIVE backend source, so it is gated behind
+// PPT_SOURCE_ENABLED. While the flag is OFF (default, until the backend R3-B1 source/bootstrap layer
+// merges) it renders a "not yet available" shell and performs NO network I/O — no preflight, no
+// source fetch, no token. The route still resolves here (so a deep link lands on the PPT shell, never
+// the rich-text editor), it simply shows the gated state. When a deployment whose backend carries
+// R3-B1 flips the flag on, the SAME component runs the reader preflight and mounts the Bento
+// container.
+
+import { useEffect, useState, type ReactElement } from 'react'
+import { t } from '../octoweb/index.ts'
+import { PPT_SOURCE_ENABLED } from '../config.ts'
+import { canEdit as roleCanEdit } from '../auth/roles.ts'
+import { getDoc, HTML_PPT_DOC_TYPE, type DocMeta } from '../pages/docsApi.ts'
+import { DocTerminal, type TerminalKind } from '../editor/DocTerminal.tsx'
+import { terminalForCreateError } from '../collab/useCollabEditor.ts'
+import { BentoContainer } from './BentoContainer.tsx'
+import { buildFrameSrc, buildPptBootstrap } from './pptSource.ts'
+import type { PptBootstrapMode } from './bootstrapTransfer.ts'
+import './PptSurface.css'
+
+type Phase =
+  | { status: 'loading' }
+  | { status: 'ready'; meta: DocMeta }
+  | { status: 'terminal'; kind: TerminalKind }
+
+export interface PptSurfacePageProps {
+  /** Deck id, or null when the route claimed a malformed/empty id (→ not-found shell). */
+  docId: string | null
+  /** `'editor'` for `/ppt/d/:docId`, `'present'` for `/docs/:docId/present`. */
+  mode: Extract<PptBootstrapMode, 'editor' | 'present'>
+  /** Present-route version; ignored for the editor (which always edits latest). */
+  version?: 'latest' | number
+  /** Called on a 401 with a token loaded (expired session) — host clears + reloads into login. */
+  onSessionExpired?: () => void
+}
+
+/** Centered state card (loading / gated / terminal), inside the full-window surface chrome. */
+function SurfaceState({
+  mode,
+  children,
+}: {
+  mode: PptSurfacePageProps['mode']
+  children: ReactElement | ReactElement[]
+}): ReactElement {
+  return (
+    <div
+      className={`octo-ppt-surface octo-theme${mode === 'present' ? ' octo-ppt-surface--present' : ''}`}
+      role="region"
+      aria-label={t('docs.ppt.viewTitle')}
+    >
+      <div className="octo-ppt-surface-body">
+        <div className="octo-ppt-surface-state">{children}</div>
+      </div>
+    </div>
+  )
+}
+
+export function PptSurfacePage({ docId, mode, version, onSessionExpired }: PptSurfacePageProps): ReactElement {
+  const gated = !PPT_SOURCE_ENABLED
+  const [phase, setPhase] = useState<Phase>({ status: 'loading' })
+
+  useEffect(() => {
+    // Gated (default) or malformed id: no preflight, no network. Render the shell directly.
+    if (gated) return
+    let cancelled = false
+    if (!docId) {
+      setPhase({ status: 'terminal', kind: 'not-found' })
+      return
+    }
+    setPhase({ status: 'loading' })
+    getDoc(docId)
+      .then((meta) => {
+        if (!cancelled) setPhase({ status: 'ready', meta })
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return
+        const kind = terminalForCreateError(err)
+        if (kind === 'login' && onSessionExpired) {
+          onSessionExpired()
+          return
+        }
+        setPhase({ status: 'terminal', kind })
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [gated, docId, onSessionExpired])
+
+  // Gated shell — the only state that ships until R3-B1 merges.
+  if (gated) {
+    return (
+      <SurfaceState mode={mode}>
+        <p className="octo-ppt-surface-state-kind">{t('docs.ppt.viewTitle')}</p>
+        <p className="octo-ppt-surface-state-hint">
+          {mode === 'present' ? t('docs.ppt.presentComingSoon') : t('docs.ppt.editorComingSoon')}
+        </p>
+      </SurfaceState>
+    )
+  }
+
+  // Null id (route claimed a malformed link): not-found shell, never the app shell / rich editor.
+  if (!docId) {
+    return (
+      <SurfaceState mode={mode}>
+        <DocTerminal title={t('docs.state.untitled')} kind="not-found" />
+      </SurfaceState>
+    )
+  }
+
+  if (phase.status === 'loading') {
+    return (
+      <SurfaceState mode={mode}>
+        <p className="octo-ppt-surface-state-hint" role="status">
+          {t('docs.state.loading')}
+        </p>
+      </SurfaceState>
+    )
+  }
+
+  if (phase.status === 'terminal') {
+    return (
+      <SurfaceState mode={mode}>
+        <DocTerminal title={t('docs.state.untitled')} kind={phase.kind} />
+      </SurfaceState>
+    )
+  }
+
+  const meta = phase.meta
+  // No-fallthrough guard: only a confirmed Bento deck mounts the container. Any other kind (a link
+  // that resolved to a plain doc/sheet/board/html) renders an error rather than silently opening the
+  // rich-text editor — the R1 contract the whole PPT branch defends.
+  if (meta.docType !== HTML_PPT_DOC_TYPE) {
+    return (
+      <SurfaceState mode={mode}>
+        <DocTerminal title={meta.title || t('docs.state.untitled')} kind="not-found" />
+      </SurfaceState>
+    )
+  }
+
+  const deckId = meta.docId || docId
+  const resolvedVersion: 'latest' | number = mode === 'present' ? version ?? 'latest' : 'latest'
+  // Editor edits the live/draft the caller's role permits (backend enforces what that role may load);
+  // present is always read-only published, so canEdit is false there.
+  const canEdit = mode === 'editor' ? Boolean(meta.role && roleCanEdit(meta.role)) : false
+
+  return (
+    <div
+      className={`octo-ppt-surface octo-theme${mode === 'present' ? ' octo-ppt-surface--present' : ''}`}
+      role="region"
+      aria-label={meta.title || t('docs.ppt.viewTitle')}
+    >
+      <div className="octo-ppt-surface-body">
+        <BentoContainer
+          bootstrap={buildPptBootstrap({ docId: deckId, mode, version: resolvedVersion, canEdit })}
+          frameSrc={buildFrameSrc(deckId, mode, resolvedVersion)}
+          title={meta.title || t('docs.ppt.viewTitle')}
+        />
+      </div>
+    </div>
+  )
+}

--- a/packages/docs/src/ppt/PptSurfacePage.tsx
+++ b/packages/docs/src/ppt/PptSurfacePage.tsx
@@ -98,13 +98,14 @@ export function resolveDeckSpace(): string {
 /**
  * The deck's own space as carried by the deep-link's dedicated `?sp=` query param — the same carrier
  * the standalone doc route reads (StandaloneDocPage.standaloneLinkSpace). On the PPT routes this `?sp=`
- * is minted by the PPT link builders (pptLink.ts): the create flow stamps the deck's space onto the
- * forwarded editor link (`/ppt/d/:docId?sp=`), and `buildPptPresentLink` stamps it onto a present
- * link, so a cross-space cold deep-link resolves the right `X-Space-Id` before the shell restores
- * currentSpaceId. (Note `buildDocLink` mints `?sp=` for the STANDALONE `/d/:docId` route only, a
- * different route — it does NOT produce these PPT paths.) Returns '' when the link carries no `?sp=`
- * (an editor link the backend forwarded without one, an older/hand-built link, or SSR); the caller
- * then falls back to live/cached currentSpaceId.
+ * is minted by `withDeckSpace` (pptLink.ts): the create flow stamps the deck's space onto the
+ * forwarded editor link (`/ppt/d/:docId?sp=`), so a cross-space cold deep-link resolves the right
+ * `X-Space-Id` before the shell restores currentSpaceId. (Note `buildDocLink` mints `?sp=` for the
+ * STANDALONE `/d/:docId` route only, a different route — it does NOT produce these PPT paths. The
+ * present route has no `?sp=` minter yet, so cross-space present-share is not resolved — see
+ * pptLink.ts.) Returns '' when the link carries no `?sp=` (an editor link the backend forwarded
+ * without one, an older/hand-built link, or SSR); the caller then falls back to live/cached
+ * currentSpaceId.
  */
 function linkSpace(): string {
   if (typeof window === 'undefined') return ''

--- a/packages/docs/src/ppt/bootstrapTransfer.test.ts
+++ b/packages/docs/src/ppt/bootstrapTransfer.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi } from 'vitest'
+import {
+  PPT_BOOTSTRAP_PROTOCOL,
+  isTrustedOrigin,
+  isBootstrapRequest,
+  isBootstrapDeliver,
+  deliverBootstrap,
+  serveBootstrap,
+  currentOrigin,
+  type PptBootstrap,
+  type BootstrapRequestMessage,
+} from './bootstrapTransfer.ts'
+
+const SAME = () => window.location.origin
+const CROSS = 'https://evil.example.com'
+
+function bootstrap(docId = 'd_1'): PptBootstrap {
+  return { mode: 'editor', docId, version: 'latest', sourceUrl: `/ppt/frame/${docId}/source`, canEdit: true }
+}
+
+function request(docId = 'd_1', mode: BootstrapRequestMessage['mode'] = 'editor'): BootstrapRequestMessage {
+  return { protocol: PPT_BOOTSTRAP_PROTOCOL, type: 'request', docId, mode }
+}
+
+/** Injectable event target that captures the single message handler so a test can dispatch to it. */
+function makeTarget() {
+  let handler: ((e: MessageEvent) => void) | undefined
+  return {
+    addEventListener: vi.fn((_type: string, h: EventListener) => {
+      handler = h as unknown as (e: MessageEvent) => void
+    }),
+    removeEventListener: vi.fn(() => {
+      handler = undefined
+    }),
+    dispatch(evt: Partial<MessageEvent>) {
+      handler?.(evt as MessageEvent)
+    },
+    get hasHandler() {
+      return Boolean(handler)
+    },
+  }
+}
+
+/** A fake same-origin frame window whose postMessage is a spy. */
+function fakeSource() {
+  return { postMessage: vi.fn() } as unknown as Window & { postMessage: ReturnType<typeof vi.fn> }
+}
+
+describe('isTrustedOrigin', () => {
+  it('trusts only the current document origin', () => {
+    expect(isTrustedOrigin(SAME())).toBe(true)
+    expect(currentOrigin()).toBe(SAME())
+  })
+  it('rejects a different origin, the wildcard, empty, and null', () => {
+    expect(isTrustedOrigin(CROSS)).toBe(false)
+    expect(isTrustedOrigin('*')).toBe(false)
+    expect(isTrustedOrigin('')).toBe(false)
+    expect(isTrustedOrigin('null')).toBe(false)
+    expect(isTrustedOrigin(null)).toBe(false)
+    expect(isTrustedOrigin(undefined)).toBe(false)
+  })
+})
+
+describe('message type guards', () => {
+  it('accepts well-formed request / deliver and rejects malformed', () => {
+    expect(isBootstrapRequest(request())).toBe(true)
+    expect(isBootstrapRequest({ protocol: PPT_BOOTSTRAP_PROTOCOL, type: 'request', docId: '', mode: 'editor' })).toBe(false)
+    expect(isBootstrapRequest({ protocol: 'other', type: 'request', docId: 'd', mode: 'editor' })).toBe(false)
+    expect(isBootstrapRequest({ protocol: PPT_BOOTSTRAP_PROTOCOL, type: 'request', docId: 'd', mode: 'bogus' })).toBe(false)
+    expect(isBootstrapRequest(null)).toBe(false)
+    expect(isBootstrapDeliver({ protocol: PPT_BOOTSTRAP_PROTOCOL, type: 'deliver', bootstrap: bootstrap() })).toBe(true)
+    expect(isBootstrapDeliver({ protocol: PPT_BOOTSTRAP_PROTOCOL, type: 'deliver', bootstrap: null })).toBe(false)
+  })
+})
+
+describe('deliverBootstrap', () => {
+  it('posts to a same-origin target pinned to that origin (never a wildcard)', () => {
+    const target = fakeSource()
+    deliverBootstrap(target, SAME(), bootstrap())
+    expect(target.postMessage).toHaveBeenCalledTimes(1)
+    const [msg, origin] = target.postMessage.mock.calls[0]
+    expect(origin).toBe(SAME())
+    expect(origin).not.toBe('*')
+    expect(msg).toMatchObject({ protocol: PPT_BOOTSTRAP_PROTOCOL, type: 'deliver' })
+  })
+  it('throws rather than deliver to a cross-origin target or the wildcard', () => {
+    const target = fakeSource()
+    expect(() => deliverBootstrap(target, CROSS, bootstrap())).toThrow()
+    expect(() => deliverBootstrap(target, '*', bootstrap())).toThrow()
+    expect(target.postMessage).not.toHaveBeenCalled()
+  })
+})
+
+describe('serveBootstrap — origin-checked handshake', () => {
+  it('answers a same-origin, well-formed request by delivering the bootstrap to event.source', () => {
+    const target = makeTarget()
+    const provide = vi.fn(() => bootstrap())
+    serveBootstrap({ provide, eventTarget: target })
+    const source = fakeSource()
+    target.dispatch({ origin: SAME(), data: request(), source })
+    expect(provide).toHaveBeenCalledTimes(1)
+    expect(source.postMessage).toHaveBeenCalledTimes(1)
+    const [, origin] = source.postMessage.mock.calls[0]
+    expect(origin).toBe(SAME())
+  })
+
+  // NEGATIVE CONTROL (acceptance): a cross-origin handoff is rejected — no provide, no reply.
+  it('rejects a cross-origin request: no bootstrap is produced and no reply is posted', () => {
+    const target = makeTarget()
+    const provide = vi.fn(() => bootstrap())
+    const onReject = vi.fn()
+    serveBootstrap({ provide, onReject, eventTarget: target })
+    const source = fakeSource()
+    target.dispatch({ origin: CROSS, data: request(), source })
+    expect(provide).not.toHaveBeenCalled()
+    expect(source.postMessage).not.toHaveBeenCalled()
+    expect(onReject).toHaveBeenCalledTimes(1)
+  })
+
+  it('ignores a same-origin message that is not a well-formed request (no reply)', () => {
+    const target = makeTarget()
+    const provide = vi.fn(() => bootstrap())
+    const onReject = vi.fn()
+    serveBootstrap({ provide, onReject, eventTarget: target })
+    const source = fakeSource()
+    target.dispatch({ origin: SAME(), data: { hello: 'world' }, source })
+    expect(provide).not.toHaveBeenCalled()
+    expect(source.postMessage).not.toHaveBeenCalled()
+    expect(onReject).toHaveBeenCalledTimes(1)
+  })
+
+  it('sends no reply when provide declines (returns null)', () => {
+    const target = makeTarget()
+    serveBootstrap({ provide: () => null, eventTarget: target })
+    const source = fakeSource()
+    target.dispatch({ origin: SAME(), data: request(), source })
+    expect(source.postMessage).not.toHaveBeenCalled()
+  })
+
+  it('disposer detaches the listener', () => {
+    const target = makeTarget()
+    const dispose = serveBootstrap({ provide: () => bootstrap(), eventTarget: target })
+    expect(target.hasHandler).toBe(true)
+    dispose()
+    expect(target.removeEventListener).toHaveBeenCalledTimes(1)
+    expect(target.hasHandler).toBe(false)
+  })
+})

--- a/packages/docs/src/ppt/bootstrapTransfer.test.ts
+++ b/packages/docs/src/ppt/bootstrapTransfer.test.ts
@@ -15,7 +15,7 @@ const SAME = () => window.location.origin
 const CROSS = 'https://evil.example.com'
 
 function bootstrap(docId = 'd_1'): PptBootstrap {
-  return { mode: 'editor', docId, version: 'latest', sourceUrl: `/ppt/frame/${docId}/source`, canEdit: true }
+  return { mode: 'editor', docId, version: 'latest', sourceUrl: `/ppt/docs/${docId}/source?format=bento`, canEdit: true }
 }
 
 function request(docId = 'd_1', mode: BootstrapRequestMessage['mode'] = 'editor'): BootstrapRequestMessage {

--- a/packages/docs/src/ppt/bootstrapTransfer.ts
+++ b/packages/docs/src/ppt/bootstrapTransfer.ts
@@ -41,7 +41,7 @@ export interface PptBootstrap {
   docId: string
   /** `'latest'` or a published `version_seq` (>= 1). */
   version: 'latest' | number
-  /** Backend-rendered source URL (same-origin) the frame should load. */
+  /** Backend rendered-source URL (bare-relative on the shared apiClient) the frame should load. */
   sourceUrl: string
   /** Signed short-lived asset bootstrap metadata from R3-B1; opaque to the transfer layer. */
   assets?: Record<string, unknown>

--- a/packages/docs/src/ppt/bootstrapTransfer.ts
+++ b/packages/docs/src/ppt/bootstrapTransfer.ts
@@ -1,0 +1,198 @@
+// Origin-checked bootstrap transfer for the html_ppt peer surfaces (R3-F1, XIN-1495 / XIN-1583).
+//
+// The PPT editor / preview / present surfaces mount a SAME-ORIGIN Bento container (an iframe served
+// from the page's own origin). Before Bento can render it needs its bootstrap payload — the source
+// mode, the version to load, and the short-lived signed asset metadata the backend R3-B1 layer
+// produces. That payload is handed to the frame over `postMessage`, which is a CROSS-DOCUMENT channel
+// even when both documents share an origin, so every hop MUST be origin-checked:
+//
+//   1. Host → frame delivery pins an explicit `targetOrigin` and REFUSES to post with the `'*'`
+//      wildcard. A wildcard would let the payload (which may carry signed, if short-lived, asset
+//      access) leak to whatever document happens to occupy the frame if its src is ever navigated
+//      cross-origin. We only ever deliver to `window.location.origin`.
+//   2. Frame → host requests are accepted ONLY when `event.origin === window.location.origin`. A
+//      message from any other origin is dropped without a reply (the negative control): a
+//      cross-origin document embedding or being embedded by this page can neither trigger a
+//      bootstrap delivery nor observe one.
+//
+// This module is pure and framework-free so the origin gate can be unit-tested directly, including
+// the cross-origin rejection path the acceptance matrix calls out (reject cross-origin handoff —
+// negative-control test). It performs NO network I/O and issues NO Hocuspocus token; the bootstrap
+// object is supplied by the caller (gated behind PPT_SOURCE_ENABLED until R3-B1 merges).
+
+/**
+ * Protocol tag carried on every bootstrap message. Bumped only on a breaking envelope change so a
+ * stale frame/host pair fails closed (unrecognized protocol → ignored) instead of misreading a
+ * differently-shaped payload.
+ */
+export const PPT_BOOTSTRAP_PROTOCOL = 'octo-ppt-bootstrap/1' as const
+
+/** The three consumption modes whose bootstrap payloads the backend R3-B1 layer distinguishes. */
+export type PptBootstrapMode = 'preview' | 'editor' | 'present'
+
+/**
+ * The bootstrap payload delivered to the same-origin Bento frame. Shape mirrors the R3-B1 source
+ * contract; it is treated as opaque transport here (this module only guards the ORIGIN of the hop,
+ * never interprets the source). `version` is `'latest'` or a positive integer version sequence;
+ * `assets` is the signed, short-lived asset bootstrap metadata (no long-lived auth material).
+ */
+export interface PptBootstrap {
+  mode: PptBootstrapMode
+  docId: string
+  /** `'latest'` or a published `version_seq` (>= 1). */
+  version: 'latest' | number
+  /** Backend-rendered source URL (same-origin) the frame should load. */
+  sourceUrl: string
+  /** Signed short-lived asset bootstrap metadata from R3-B1; opaque to the transfer layer. */
+  assets?: Record<string, unknown>
+  /** Whether the caller resolved a writer/admin (editor) vs reader/commenter (read-only) context. */
+  canEdit?: boolean
+}
+
+/** Frame → host: "I'm ready, send me the bootstrap for this doc/mode." */
+export interface BootstrapRequestMessage {
+  protocol: typeof PPT_BOOTSTRAP_PROTOCOL
+  type: 'request'
+  docId: string
+  mode: PptBootstrapMode
+}
+
+/** Host → frame: the bootstrap payload (or an explicit refusal the frame can surface). */
+export interface BootstrapDeliverMessage {
+  protocol: typeof PPT_BOOTSTRAP_PROTOCOL
+  type: 'deliver'
+  bootstrap: PptBootstrap
+}
+
+/**
+ * The current document's origin, or `''` under SSR / a non-browser test host. Centralized so every
+ * gate reads the SAME value and a missing `window` fails closed (empty origin never equals a real
+ * `event.origin`, so nothing is trusted).
+ */
+export function currentOrigin(): string {
+  if (typeof window === 'undefined') return ''
+  return window.location?.origin ?? ''
+}
+
+/**
+ * Whether `origin` is this document's own origin — the single trust predicate for both hops.
+ *
+ * Rejects the empty string explicitly: a `MessageEvent` from a `srcdoc` / sandboxed frame without
+ * `allow-same-origin` reports `origin === ''` (an opaque origin), and `file:`/data documents report
+ * `'null'`. Neither is our origin, so both fail here; only a byte-for-byte match with a non-empty
+ * `window.location.origin` is trusted. There is no wildcard and no substring match.
+ */
+export function isTrustedOrigin(origin: string | null | undefined): boolean {
+  if (typeof origin !== 'string' || origin.length === 0) return false
+  const self = currentOrigin()
+  if (self.length === 0) return false
+  return origin === self
+}
+
+/** Type guard for a well-formed inbound bootstrap request (frame → host). */
+export function isBootstrapRequest(data: unknown): data is BootstrapRequestMessage {
+  if (data === null || typeof data !== 'object') return false
+  const m = data as Record<string, unknown>
+  return (
+    m.protocol === PPT_BOOTSTRAP_PROTOCOL &&
+    m.type === 'request' &&
+    typeof m.docId === 'string' &&
+    m.docId.length > 0 &&
+    (m.mode === 'preview' || m.mode === 'editor' || m.mode === 'present')
+  )
+}
+
+/** Type guard for a well-formed inbound bootstrap delivery (host → frame). */
+export function isBootstrapDeliver(data: unknown): data is BootstrapDeliverMessage {
+  if (data === null || typeof data !== 'object') return false
+  const m = data as Record<string, unknown>
+  return (
+    m.protocol === PPT_BOOTSTRAP_PROTOCOL &&
+    m.type === 'deliver' &&
+    typeof m.bootstrap === 'object' &&
+    m.bootstrap !== null
+  )
+}
+
+/**
+ * Deliver a bootstrap payload to the same-origin Bento frame.
+ *
+ * `targetOrigin` MUST be this document's own origin — the call throws otherwise, and it NEVER falls
+ * back to the `'*'` wildcard. Passing `'*'` (or any cross-origin value) is a programming error that
+ * would defeat the whole gate, so it is rejected loudly rather than silently downgraded. This is the
+ * only function that calls `postMessage` toward the frame.
+ */
+export function deliverBootstrap(
+  target: Pick<Window, 'postMessage'>,
+  targetOrigin: string,
+  bootstrap: PptBootstrap,
+): void {
+  if (!isTrustedOrigin(targetOrigin)) {
+    throw new Error(
+      `refusing to deliver PPT bootstrap to a non-same-origin target (${String(targetOrigin)}); ` +
+        'the Bento container is same-origin and the payload is never posted with a wildcard origin',
+    )
+  }
+  const message: BootstrapDeliverMessage = {
+    protocol: PPT_BOOTSTRAP_PROTOCOL,
+    type: 'deliver',
+    bootstrap,
+  }
+  target.postMessage(message, targetOrigin)
+}
+
+export interface ServeBootstrapOptions {
+  /**
+   * Produce the bootstrap for a validated same-origin request, or `null` to decline (e.g. the docId
+   * does not match this host, or source is gated off). Declining sends no reply.
+   */
+  provide: (request: BootstrapRequestMessage) => PptBootstrap | null
+  /**
+   * Observe a REJECTED cross-origin / malformed message (test + telemetry hook). Never receives a
+   * trusted request. Optional.
+   */
+  onReject?: (event: MessageEvent) => void
+  /** Injectable event target for tests; defaults to `window`. */
+  eventTarget?: Pick<Window, 'addEventListener' | 'removeEventListener'>
+}
+
+/**
+ * Host-side listener that answers same-origin bootstrap requests from the Bento frame and rejects
+ * everything else. Returns a disposer that detaches the listener.
+ *
+ * The origin gate is the FIRST thing checked on every inbound message: a request whose
+ * `event.origin` is not `window.location.origin` is dropped (routed to `onReject`) before its
+ * payload is even shape-checked, and no reply is posted — so a cross-origin frame can neither pull a
+ * bootstrap nor learn whether one exists (the negative-control requirement). A trusted, well-formed
+ * request is answered by posting the bootstrap back through `event.source`, pinned to the SAME
+ * validated `event.origin` (which equals our own origin here) — never `'*'`.
+ */
+export function serveBootstrap(options: ServeBootstrapOptions): () => void {
+  const target: Pick<Window, 'addEventListener' | 'removeEventListener'> =
+    options.eventTarget ?? (typeof window !== 'undefined' ? window : undefined as never)
+  if (!target) return () => {}
+
+  const handler = (event: MessageEvent): void => {
+    // Gate 1 — ORIGIN. Reject anything not from our own origin before touching the payload.
+    if (!isTrustedOrigin(event.origin)) {
+      options.onReject?.(event)
+      return
+    }
+    // Gate 2 — SHAPE. A same-origin message that is not a well-formed request is ignored (it may be
+    // unrelated same-origin postMessage traffic); route it to onReject for visibility but never reply.
+    if (!isBootstrapRequest(event.data)) {
+      options.onReject?.(event)
+      return
+    }
+    const bootstrap = options.provide(event.data)
+    if (bootstrap === null) return
+    const source = event.source
+    if (!source || typeof (source as Window).postMessage !== 'function') return
+    // Reply pinned to the validated origin (== our origin). Deliver re-asserts the trust gate as
+    // defense in depth, so a future refactor of `event.origin` handling cannot open a wildcard hole.
+    deliverBootstrap(source as Window, event.origin, bootstrap)
+  }
+
+  target.addEventListener('message', handler as EventListener)
+  return () => target.removeEventListener('message', handler as EventListener)
+}

--- a/packages/docs/src/ppt/bootstrapTransfer.ts
+++ b/packages/docs/src/ppt/bootstrapTransfer.ts
@@ -90,9 +90,13 @@ export function currentOrigin(): string {
 /**
  * Whether `origin` is this document's own origin — the single trust predicate for both hops.
  *
- * Rejects the empty string explicitly: a `MessageEvent` from a `srcdoc` / sandboxed frame without
- * `allow-same-origin` reports `origin === ''` (an opaque origin), and `file:`/data documents report
- * `'null'`. Neither is our origin, so both fail here; only a byte-for-byte match with a non-empty
+ * Rejects the empty string explicitly AND never trusts the opaque-origin sentinel: per the HTML spec
+ * an opaque origin (a `srcdoc` / sandboxed frame without `allow-same-origin`, or a `file:`/`data:`
+ * document) serializes to the string `'null'` — the same value `BentoContainer.tsx` documents — so a
+ * message from our opaque Bento frame arrives with `event.origin === 'null'`, which is not our origin
+ * and fails here. The empty string is the separate SSR / non-browser case (`currentOrigin()` returns
+ * `''` when `window` is absent). Neither `'null'` nor `''` equals a real origin, so both fail; only a
+ * byte-for-byte match with a non-empty
  * `window.location.origin` is trusted. There is no wildcard and no substring match.
  */
 export function isTrustedOrigin(origin: string | null | undefined): boolean {

--- a/packages/docs/src/ppt/bootstrapTransfer.ts
+++ b/packages/docs/src/ppt/bootstrapTransfer.ts
@@ -1,24 +1,36 @@
 // Origin-checked bootstrap transfer for the html_ppt peer surfaces (R3-F1, XIN-1495 / XIN-1583).
 //
-// The PPT editor / preview / present surfaces mount a SAME-ORIGIN Bento container (an iframe served
-// from the page's own origin). Before Bento can render it needs its bootstrap payload — the source
-// mode, the version to load, and the short-lived signed asset metadata the backend R3-B1 layer
-// produces. That payload is handed to the frame over `postMessage`, which is a CROSS-DOCUMENT channel
-// even when both documents share an origin, so every hop MUST be origin-checked:
+// STATUS — DEFERRED SCAFFOLDING (XIN-1615 P1-A, Option 2). The live Bento container isolates the
+// unsanitized deck HTML in an OPAQUE origin (iframe `srcdoc`, `allow-scripts` WITHOUT
+// `allow-same-origin` — see BentoContainer.tsx), and delivers the deck by the srcdoc injection
+// itself. An opaque-origin frame's postMessage arrives with `event.origin === 'null'`, which the
+// origin gate below can never trust (trusting `'null'` would trust EVERY sandboxed frame). So the
+// postMessage handshake and the opaque-origin isolation are mutually exclusive by construction: this
+// module is NOT wired into the live container and no live code path depends on it.
+//
+// It is retained (not deleted) as scaffolding for a FUTURE separate-origin Bento host page — the
+// round-3 reviewer's Option 1 — where the frame is served from a distinct, NAMED origin that CAN be
+// allowlisted in `isTrustedOrigin`, keeping both the postMessage channel and the isolation. Standing
+// up that named origin is a deploy/nginx topology change out of R3 frontend scope, so it is deferred;
+// until it lands, everything here is dormant. The pure origin gate stays unit-tested
+// (bootstrapTransfer.test.ts) so the deferred channel keeps its fail-closed guarantees.
+//
+// When that channel IS built, Bento can be handed its bootstrap payload — the source mode, the
+// version to load, and the short-lived signed asset metadata the backend R3-B1 layer produces — over
+// `postMessage`, which is a CROSS-DOCUMENT channel even when both documents share an origin, so every
+// hop MUST be origin-checked:
 //
 //   1. Host → frame delivery pins an explicit `targetOrigin` and REFUSES to post with the `'*'`
 //      wildcard. A wildcard would let the payload (which may carry signed, if short-lived, asset
 //      access) leak to whatever document happens to occupy the frame if its src is ever navigated
-//      cross-origin. We only ever deliver to `window.location.origin`.
-//   2. Frame → host requests are accepted ONLY when `event.origin === window.location.origin`. A
-//      message from any other origin is dropped without a reply (the negative control): a
-//      cross-origin document embedding or being embedded by this page can neither trigger a
-//      bootstrap delivery nor observe one.
+//      cross-origin. We only ever deliver to a trusted (own) origin.
+//   2. Frame → host requests are accepted ONLY when `event.origin` is the trusted origin. A message
+//      from any other origin is dropped without a reply (the negative control): a cross-origin
+//      document embedding or being embedded by this page can neither trigger a bootstrap delivery nor
+//      observe one.
 //
 // This module is pure and framework-free so the origin gate can be unit-tested directly, including
-// the cross-origin rejection path the acceptance matrix calls out (reject cross-origin handoff —
-// negative-control test). It performs NO network I/O and issues NO Hocuspocus token; the bootstrap
-// object is supplied by the caller (gated behind PPT_SOURCE_ENABLED until R3-B1 merges).
+// the cross-origin rejection path. It performs NO network I/O and issues NO Hocuspocus token.
 
 /**
  * Protocol tag carried on every bootstrap message. Bumped only on a breaking envelope change so a
@@ -31,10 +43,11 @@ export const PPT_BOOTSTRAP_PROTOCOL = 'octo-ppt-bootstrap/1' as const
 export type PptBootstrapMode = 'preview' | 'editor' | 'present'
 
 /**
- * The bootstrap payload delivered to the same-origin Bento frame. Shape mirrors the R3-B1 source
- * contract; it is treated as opaque transport here (this module only guards the ORIGIN of the hop,
- * never interprets the source). `version` is `'latest'` or a positive integer version sequence;
- * `assets` is the signed, short-lived asset bootstrap metadata (no long-lived auth material).
+ * The bootstrap payload for the DEFERRED separate-origin Bento frame (see file header). Shape mirrors
+ * the R3-B1 source contract; it is treated as opaque transport here (this module only guards the
+ * ORIGIN of the hop, never interprets the source). `version` is `'latest'` or a positive integer
+ * version sequence; `assets` is the signed, short-lived asset bootstrap metadata (no long-lived auth
+ * material).
  */
 export interface PptBootstrap {
   mode: PptBootstrapMode
@@ -115,12 +128,12 @@ export function isBootstrapDeliver(data: unknown): data is BootstrapDeliverMessa
 }
 
 /**
- * Deliver a bootstrap payload to the same-origin Bento frame.
+ * Deliver a bootstrap payload to the (deferred) trusted-origin Bento frame.
  *
- * `targetOrigin` MUST be this document's own origin — the call throws otherwise, and it NEVER falls
- * back to the `'*'` wildcard. Passing `'*'` (or any cross-origin value) is a programming error that
- * would defeat the whole gate, so it is rejected loudly rather than silently downgraded. This is the
- * only function that calls `postMessage` toward the frame.
+ * `targetOrigin` MUST be a trusted origin — the call throws otherwise, and it NEVER falls back to the
+ * `'*'` wildcard. Passing `'*'` (or any untrusted value) is a programming error that would defeat the
+ * whole gate, so it is rejected loudly rather than silently downgraded. This is the only function
+ * that calls `postMessage` toward the frame.
  */
 export function deliverBootstrap(
   target: Pick<Window, 'postMessage'>,
@@ -129,8 +142,8 @@ export function deliverBootstrap(
 ): void {
   if (!isTrustedOrigin(targetOrigin)) {
     throw new Error(
-      `refusing to deliver PPT bootstrap to a non-same-origin target (${String(targetOrigin)}); ` +
-        'the Bento container is same-origin and the payload is never posted with a wildcard origin',
+      `refusing to deliver PPT bootstrap to an untrusted target origin (${String(targetOrigin)}); ` +
+        'the payload is never posted with a wildcard origin',
     )
   }
   const message: BootstrapDeliverMessage = {

--- a/packages/docs/src/ppt/pptFrameCsp.test.ts
+++ b/packages/docs/src/ppt/pptFrameCsp.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest'
+import { PPT_FRAME_CSP, withFrameCsp } from './pptFrameCsp.ts'
+
+// P1-2 (XIN-1621): the opaque Bento frame is hardened with a srcdoc CSP meta that denies outbound
+// connections (fetch-exfiltration containment) while still allowing the self-contained Bento runtime.
+describe('PPT_FRAME_CSP — the srcdoc frame policy', () => {
+  it('denies connect-src (the exfiltration containment)', () => {
+    expect(PPT_FRAME_CSP).toContain("connect-src 'none'")
+  })
+
+  it('allows the self-contained Bento runtime (inline/eval scripts, data/blob media & fonts)', () => {
+    expect(PPT_FRAME_CSP).toContain("script-src 'unsafe-inline' 'unsafe-eval' blob:")
+    expect(PPT_FRAME_CSP).toContain('img-src data: blob:')
+    expect(PPT_FRAME_CSP).toContain('font-src data: blob:')
+    expect(PPT_FRAME_CSP).toContain('media-src data: blob:')
+  })
+
+  it('closes the base-tag and form-POST exfil side-channels', () => {
+    expect(PPT_FRAME_CSP).toContain("base-uri 'none'")
+    expect(PPT_FRAME_CSP).toContain("form-action 'none'")
+  })
+})
+
+describe('withFrameCsp — inject the CSP meta at the head of the deck', () => {
+  const cspMeta = /<meta http-equiv="Content-Security-Policy"/i
+
+  it('inserts the meta just inside an existing <head>', () => {
+    const out = withFrameCsp('<html><head><title>Deck</title></head><body>slides</body></html>')
+    expect(out).toMatch(cspMeta)
+    // The meta must precede the deck's own head content so it governs before any script runs.
+    expect(out.indexOf('Content-Security-Policy')).toBeLessThan(out.indexOf('<title>'))
+    expect(out).toContain('slides')
+  })
+
+  it('opens a <head> right after <html> when the deck has none', () => {
+    const out = withFrameCsp('<html><body>slides</body></html>')
+    expect(out).toMatch(cspMeta)
+    expect(out.indexOf('Content-Security-Policy')).toBeLessThan(out.indexOf('<body>'))
+    expect(out).toContain('slides')
+  })
+
+  it('prepends the meta for a bare fragment (implicit head)', () => {
+    const out = withFrameCsp('<section>just a fragment</section>')
+    expect(out).toMatch(cspMeta)
+    expect(out.indexOf('Content-Security-Policy')).toBeLessThan(out.indexOf('<section>'))
+    expect(out).toContain('just a fragment')
+  })
+
+  it('does not treat `$` sequences in the deck HTML as replacement patterns', () => {
+    const out = withFrameCsp('<html><head></head><body>price $1 & $&$`</body></html>')
+    expect(out).toContain('price $1 & $&$`')
+  })
+})

--- a/packages/docs/src/ppt/pptFrameCsp.test.ts
+++ b/packages/docs/src/ppt/pptFrameCsp.test.ts
@@ -21,7 +21,18 @@ describe('PPT_FRAME_CSP — the srcdoc frame policy', () => {
   })
 })
 
-describe('withFrameCsp — inject the CSP meta at the head of the deck', () => {
+// Re-parse withFrameCsp's OUTPUT exactly as the browser would parse the srcdoc, and assert the CSP meta
+// is the FIRST element child of the real <head>. That is the only placement that governs the document
+// before any deck script runs; a control that is not first-in-head is not a control.
+const CSP_SELECTOR = 'meta[http-equiv="Content-Security-Policy" i]'
+function reparse(out: string): Document {
+  return new DOMParser().parseFromString(out, 'text/html')
+}
+function cspMetas(doc: Document): NodeListOf<HTMLMetaElement> {
+  return doc.querySelectorAll<HTMLMetaElement>(CSP_SELECTOR)
+}
+
+describe('withFrameCsp — inject the CSP meta as the first real-head child', () => {
   const cspMeta = /<meta http-equiv="Content-Security-Policy"/i
 
   it('inserts the meta just inside an existing <head>', () => {
@@ -30,6 +41,9 @@ describe('withFrameCsp — inject the CSP meta at the head of the deck', () => {
     // The meta must precede the deck's own head content so it governs before any script runs.
     expect(out.indexOf('Content-Security-Policy')).toBeLessThan(out.indexOf('<title>'))
     expect(out).toContain('slides')
+    const doc = reparse(out)
+    expect(cspMetas(doc)).toHaveLength(1)
+    expect(doc.head.firstElementChild).toBe(cspMetas(doc)[0])
   })
 
   it('opens a <head> right after <html> when the deck has none', () => {
@@ -37,6 +51,8 @@ describe('withFrameCsp — inject the CSP meta at the head of the deck', () => {
     expect(out).toMatch(cspMeta)
     expect(out.indexOf('Content-Security-Policy')).toBeLessThan(out.indexOf('<body>'))
     expect(out).toContain('slides')
+    const doc = reparse(out)
+    expect(doc.head.firstElementChild).toBe(cspMetas(doc)[0])
   })
 
   it('prepends the meta for a bare fragment (implicit head)', () => {
@@ -44,10 +60,69 @@ describe('withFrameCsp — inject the CSP meta at the head of the deck', () => {
     expect(out).toMatch(cspMeta)
     expect(out.indexOf('Content-Security-Policy')).toBeLessThan(out.indexOf('<section>'))
     expect(out).toContain('just a fragment')
+    const doc = reparse(out)
+    expect(doc.head.firstElementChild).toBe(cspMetas(doc)[0])
   })
 
-  it('does not treat `$` sequences in the deck HTML as replacement patterns', () => {
-    const out = withFrameCsp('<html><head></head><body>price $1 & $&$`</body></html>')
-    expect(out).toContain('price $1 & $&$`')
+  it('preserves the deck doctype (no quirks-mode regression on re-serialization)', () => {
+    const out = withFrameCsp('<!DOCTYPE html><html><head></head><body>slides</body></html>')
+    expect(out.toLowerCase().startsWith('<!doctype html>')).toBe(true)
+    expect(reparse(out).compatMode).toBe('CSS1Compat') // standards mode, not quirks
+  })
+
+  it('does not treat `$` sequences in deck content as replacement patterns', () => {
+    // The parse-based injection never runs String.prototype.replace over the deck, so `$&`/`$\`` — the
+    // sequences that were special to a replacer — are inert plain text here.
+    const out = withFrameCsp('<html><head></head><body>cost $1 $$ $` done</body></html>')
+    expect(out).toContain('cost $1 $$ $` done')
+  })
+
+  // P1-1 (XIN-1630): the CSP is a containment against the DECK AUTHOR, so it must survive an author who
+  // crafts the HTML to displace a naive textual `<head>` injection. Each vector below fails OPEN under
+  // regex surgery (the meta lands in a comment / after a hoisted script / inside an attribute); the
+  // parse-based injection makes each fail CLOSED — the meta re-parses as the first real-head child.
+  describe('adversarial: fails CLOSED against deck-author bypass vectors', () => {
+    it('(a) a <head> inside a leading comment does not displace the meta', () => {
+      // A textual match on the earliest `<head>` — here inside the comment — would inject the meta INTO
+      // the comment (commented out, no CSP). Parsing treats the comment as a comment.
+      const out = withFrameCsp(
+        '<!-- <head> --><html><head><title>T</title></head><body>slides</body></html>',
+      )
+      const doc = reparse(out)
+      expect(cspMetas(doc)).toHaveLength(1)
+      expect(doc.head.firstElementChild).toBe(cspMetas(doc)[0])
+      expect(doc.body.textContent).toContain('slides')
+    })
+
+    it('(b) a <script> before <head> is hoisted into head AFTER the meta', () => {
+      // HTML tree construction hoists a pre-<head> <script> into an implicit head and ignores the later
+      // literal <head>. A textual injection into that later <head> lands after the running script (fail
+      // OPEN); parsing puts the meta first, so the hoisted script is governed (fail CLOSED).
+      const out = withFrameCsp(
+        '<html><script>window.__exfil=1</script><head><title>T</title></head><body>x</body></html>',
+      )
+      const doc = reparse(out)
+      const meta = cspMetas(doc)[0]
+      expect(cspMetas(doc)).toHaveLength(1)
+      expect(doc.head.firstElementChild).toBe(meta)
+      const script = doc.head.querySelector('script')
+      expect(script).not.toBeNull()
+      // The meta precedes the deck script in the head, so the CSP is installed before it could run.
+      expect(meta.compareDocumentPosition(script!) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    })
+
+    it('(c) a <head` inside a quoted attribute value does not displace the meta', () => {
+      // A textual match on the `<head>` inside the attribute value would inject the meta into the
+      // attribute (no CSP + corrupted tag). Parsing keeps it as attribute text.
+      const out = withFrameCsp(
+        '<html><head></head><body><div title="<head>">hi</div></body></html>',
+      )
+      const doc = reparse(out)
+      expect(cspMetas(doc)).toHaveLength(1)
+      expect(doc.head.firstElementChild).toBe(cspMetas(doc)[0])
+      // The attribute-embedded `<head>` stayed text on the div; it never became a second head/meta site.
+      expect(doc.querySelector('div')?.getAttribute('title')).toBe('<head>')
+      expect(doc.body.textContent).toContain('hi')
+    })
   })
 })

--- a/packages/docs/src/ppt/pptFrameCsp.ts
+++ b/packages/docs/src/ppt/pptFrameCsp.ts
@@ -1,0 +1,67 @@
+// PPT-frame Content-Security-Policy for the html_ppt peer surfaces (R3-F1, XIN-1495 / XIN-1621).
+//
+// P1-2 (round-5, defence-in-depth). The Bento deck runs in an OPAQUE-origin `srcdoc` frame with
+// `allow-scripts` but NOT `allow-same-origin` (BentoContainer.tsx / XIN-1608 P0), so the deck's
+// scripts can already touch nothing in the parent origin. What the opaque sandbox does NOT stop is the
+// frame's own scripts opening OUTBOUND connections — `fetch`/XHR/WebSocket/EventSource/`sendBeacon` to
+// an attacker endpoint — i.e. exfiltrating whatever the deck can read (its own bytes, referrer, etc.).
+//
+// R3's contract is that a rendered deck is SELF-CONTAINED at the byte boundary (pptSourceClient.ts):
+// fonts/media inline as `data:`/`blob:`, charts/morph run on Bento's bundled engine, and nothing
+// legitimate needs the network at render time. So we can inject a restrictive CSP `<meta>` into the
+// srcdoc that DENIES `connect-src` (and form submission / base-tag tricks) while still allowing the
+// inline/eval/`data:`/`blob:` runtime Bento needs. This is FULLY FE-wireable — it lives in the srcdoc
+// bytes we already control — and needs no change to the global nginx / index.html CSP.
+//
+// NOT covered here (filed as a follow-up, see the PR body / issue): the PARENT-document `frame-src`
+// that would allowlist exactly this frame in the app's TOP-LEVEL CSP. A meta CSP cannot set another
+// document's policy, and the app shell's CSP is delivered by the global nginx config the architect
+// scoped OUT of R3 (no global nginx `connect-src`/`frame-src` tightening). That half is deferred with
+// rationale rather than silently dropped.
+
+/**
+ * The CSP enforced inside the opaque Bento `srcdoc` frame. Permits the self-contained Bento runtime
+ * (inline + eval scripts, inline styles, `data:`/`blob:` media/fonts/images) but sets
+ * `connect-src 'none'` so the frame cannot open any outbound request — the fetch-exfiltration
+ * containment. `base-uri 'none'` and `form-action 'none'` close the base-tag and form-POST exfil
+ * side-channels a self-contained deck never needs. `http-equiv` meta supports these directives (it
+ * does not support `frame-ancestors`/`sandbox`, which is why the sandbox attribute stays on the
+ * iframe element).
+ */
+export const PPT_FRAME_CSP = [
+  "default-src 'unsafe-inline' 'unsafe-eval' data: blob:",
+  "script-src 'unsafe-inline' 'unsafe-eval' blob:",
+  "style-src 'unsafe-inline' data: blob:",
+  'img-src data: blob:',
+  'font-src data: blob:',
+  'media-src data: blob:',
+  'frame-src blob: data:',
+  "connect-src 'none'",
+  "base-uri 'none'",
+  "form-action 'none'",
+].join('; ')
+
+/** The CSP meta element injected at the head of the deck document. */
+const CSP_META = `<meta http-equiv="Content-Security-Policy" content="${PPT_FRAME_CSP}">`
+
+/**
+ * Inject the PPT-frame CSP `<meta>` into a deck's rendered HTML so it governs the srcdoc document
+ * BEFORE any deck script runs. Inserts just inside `<head>` when present; otherwise opens a `<head>`
+ * right after `<html>`; otherwise prepends the meta (a srcdoc fragment gets an implicit head and the
+ * meta still applies before body content is parsed). A deck that already ships its own CSP meta keeps
+ * it — the browser enforces the INTERSECTION, so our `connect-src 'none'` still binds. The tag is
+ * matched with a function replacer so no `$`-sequence in the deck HTML is treated as a replacement
+ * pattern.
+ */
+export function withFrameCsp(html: string): string {
+  if (typeof html !== 'string') return html
+  const headOpen = /<head\b[^>]*>/i
+  if (headOpen.test(html)) {
+    return html.replace(headOpen, (m) => `${m}${CSP_META}`)
+  }
+  const htmlOpen = /<html\b[^>]*>/i
+  if (htmlOpen.test(html)) {
+    return html.replace(htmlOpen, (m) => `${m}<head>${CSP_META}</head>`)
+  }
+  return `${CSP_META}${html}`
+}

--- a/packages/docs/src/ppt/pptFrameCsp.ts
+++ b/packages/docs/src/ppt/pptFrameCsp.ts
@@ -13,6 +13,17 @@
 // inline/eval/`data:`/`blob:` runtime Bento needs. This is FULLY FE-wireable — it lives in the srcdoc
 // bytes we already control — and needs no change to the global nginx / index.html CSP.
 //
+// P1-1 (round-6, XIN-1630 — the containment must not be bypassable by the deck author it contains).
+// The deck HTML is attacker-controlled and NOT sanitized. A meta CSP only governs the document if the
+// browser parses it as the FIRST directive of the real `<head>` before any deck script runs, so the
+// injection MUST land there under the HTML5 tree-construction rules — not merely at the first textual
+// `<head>` match. Regex surgery over untrusted HTML cannot guarantee that: a `<head>` inside a leading
+// comment, a `<script>` hoisted into an implicit head ahead of a later literal `<head>`, or a `<head`
+// inside a quoted attribute all displace a textual-match injection so the deck ends up ungoverned
+// (fail OPEN). We therefore PARSE the HTML with the browser's own HTML parser, insert the meta as the
+// first child of the real `<head>` via the DOM, and re-serialize — so those vectors fail CLOSED. See
+// `withFrameCsp` and the adversarial cases in pptFrameCsp.test.ts.
+//
 // NOT covered here (filed as a follow-up, see the PR body / issue): the PARENT-document `frame-src`
 // that would allowlist exactly this frame in the app's TOP-LEVEL CSP. A meta CSP cannot set another
 // document's policy, and the app shell's CSP is delivered by the global nginx config the architect
@@ -41,27 +52,43 @@ export const PPT_FRAME_CSP = [
   "form-action 'none'",
 ].join('; ')
 
-/** The CSP meta element injected at the head of the deck document. */
-const CSP_META = `<meta http-equiv="Content-Security-Policy" content="${PPT_FRAME_CSP}">`
+/** Serialize a parsed DocumentType back to source so re-serialization does not drop the deck's doctype
+ *  (a missing `<!DOCTYPE html>` would force quirks mode and change how Bento lays the deck out). */
+function serializeDoctype(dt: DocumentType): string {
+  let s = `<!DOCTYPE ${dt.name}`
+  if (dt.publicId) s += ` PUBLIC "${dt.publicId}"`
+  if (dt.systemId) s += dt.publicId ? ` "${dt.systemId}"` : ` SYSTEM "${dt.systemId}"`
+  return `${s}>`
+}
 
 /**
- * Inject the PPT-frame CSP `<meta>` into a deck's rendered HTML so it governs the srcdoc document
- * BEFORE any deck script runs. Inserts just inside `<head>` when present; otherwise opens a `<head>`
- * right after `<html>`; otherwise prepends the meta (a srcdoc fragment gets an implicit head and the
- * meta still applies before body content is parsed). A deck that already ships its own CSP meta keeps
- * it — the browser enforces the INTERSECTION, so our `connect-src 'none'` still binds. The tag is
- * matched with a function replacer so no `$`-sequence in the deck HTML is treated as a replacement
- * pattern.
+ * Inject the PPT-frame CSP `<meta>` so it governs the srcdoc document BEFORE any deck script runs.
+ *
+ * The deck HTML is attacker-controlled and unsanitized, so the injection must survive an adversarial
+ * author (P1-1, XIN-1630). Rather than a textual `<head>` match — which a comment / pre-head script /
+ * attribute-embedded `<head>` can displace so the meta lands somewhere inert (fail OPEN) — we parse
+ * the HTML with the platform HTML parser (`DOMParser`, `text/html`, which follows the HTML5
+ * tree-construction algorithm and never executes scripts), insert the meta as the FIRST child of the
+ * parser's real `<head>`, and re-serialize. Because the browser re-parses our output the same way, the
+ * meta is guaranteed to be the head's first directive — ahead of any deck `<script>`, including one
+ * the parser hoists into an implicit head — so the (a) leading-comment, (b) pre-head-script, and
+ * (c) `<head`-in-attribute vectors all fail CLOSED. A deck that ships its own CSP meta keeps it; ours
+ * precedes it and the browser enforces the INTERSECTION, so `connect-src 'none'` still binds.
+ *
+ * `DOMParser` is a browser platform API and this surface only ever renders in an iframe, so it is
+ * always present in production. Should it somehow be unavailable, we return the HTML unchanged rather
+ * than fall back to a bypassable textual injection: the opaque-origin sandbox (P0) remains the primary
+ * containment, and a control that cannot be placed reliably must not masquerade as one.
  */
 export function withFrameCsp(html: string): string {
   if (typeof html !== 'string') return html
-  const headOpen = /<head\b[^>]*>/i
-  if (headOpen.test(html)) {
-    return html.replace(headOpen, (m) => `${m}${CSP_META}`)
-  }
-  const htmlOpen = /<html\b[^>]*>/i
-  if (htmlOpen.test(html)) {
-    return html.replace(htmlOpen, (m) => `${m}<head>${CSP_META}</head>`)
-  }
-  return `${CSP_META}${html}`
+  if (typeof DOMParser === 'undefined') return html
+  const doc = new DOMParser().parseFromString(html, 'text/html')
+  const head = doc.head || doc.documentElement
+  const meta = doc.createElement('meta')
+  meta.setAttribute('http-equiv', 'Content-Security-Policy')
+  meta.setAttribute('content', PPT_FRAME_CSP)
+  head.insertBefore(meta, head.firstChild)
+  const doctype = doc.doctype ? serializeDoctype(doc.doctype) : ''
+  return `${doctype}${doc.documentElement.outerHTML}`
 }

--- a/packages/docs/src/ppt/pptLink.test.ts
+++ b/packages/docs/src/ppt/pptLink.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect } from 'vitest'
-import { withDeckSpace, buildPptPresentLink } from './pptLink.ts'
+import { withDeckSpace } from './pptLink.ts'
 
-// P1-1 (XIN-1621): these builders are the FE producers of PPT links that carry the deck's owning
-// space as `?sp=` — the carrier resolveDeckSpace reads first on a cross-space cold open. The bug the
-// round-5 reviewer flagged was that NOTHING produced such a link, so these tests assert the produced
-// link actually carries `?sp=`, not merely that a hand-placed `?sp=` is read back.
+// P1-1 (XIN-1621): withDeckSpace is the FE producer of a PPT link that carries the deck's owning space
+// as `?sp=` — the carrier resolveDeckSpace reads first on a cross-space cold open. The bug the round-5
+// reviewer flagged was that NOTHING produced such a link, so these tests assert the produced link
+// actually carries `?sp=`, not merely that a hand-placed `?sp=` is read back.
 describe('withDeckSpace — stamp the deck space onto the forwarded editor link', () => {
   it('appends `?sp=` to a bare rooted editor path', () => {
     expect(withDeckSpace('/ppt/d/new_deck', '105d4a60d0fc4d55a5cfc3c2d0501361')).toBe(
@@ -37,32 +37,3 @@ describe('withDeckSpace — stamp the deck space onto the forwarded editor link'
   })
 })
 
-describe('buildPptPresentLink — present-route share link carries the deck space', () => {
-  const origin = window.location.origin
-
-  it('builds an absolute present link carrying `?sp=`', () => {
-    const link = buildPptPresentLink({ docId: 'd_1', space: 'sp_1' })
-    expect(link).toBe(`${origin}/docs/d_1/present?sp=sp_1`)
-    // The produced link is read back by the same carrier resolveDeckSpace uses.
-    expect(new URL(link).searchParams.get('sp')).toBe('sp_1')
-  })
-
-  it('adds `?version=` only for a pinned published version, not for latest', () => {
-    const pinned = buildPptPresentLink({ docId: 'd_1', space: 'sp_1', version: 3 })
-    const q = new URL(pinned).searchParams
-    expect(q.get('sp')).toBe('sp_1')
-    expect(q.get('version')).toBe('3')
-
-    const latest = buildPptPresentLink({ docId: 'd_1', space: 'sp_1', version: 'latest' })
-    expect(new URL(latest).searchParams.has('version')).toBe(false)
-  })
-
-  it('omits `?sp=` when no space is known (degrades to the route default)', () => {
-    expect(buildPptPresentLink({ docId: 'd_1' })).toBe(`${origin}/docs/d_1/present`)
-  })
-
-  it('percent-encodes the docId in the path', () => {
-    const link = buildPptPresentLink({ docId: 'a b', space: 'sp_1' })
-    expect(link).toBe(`${origin}/docs/a%20b/present?sp=sp_1`)
-  })
-})

--- a/packages/docs/src/ppt/pptLink.test.ts
+++ b/packages/docs/src/ppt/pptLink.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest'
+import { withDeckSpace, buildPptPresentLink } from './pptLink.ts'
+
+// P1-1 (XIN-1621): these builders are the FE producers of PPT links that carry the deck's owning
+// space as `?sp=` — the carrier resolveDeckSpace reads first on a cross-space cold open. The bug the
+// round-5 reviewer flagged was that NOTHING produced such a link, so these tests assert the produced
+// link actually carries `?sp=`, not merely that a hand-placed `?sp=` is read back.
+describe('withDeckSpace — stamp the deck space onto the forwarded editor link', () => {
+  it('appends `?sp=` to a bare rooted editor path', () => {
+    expect(withDeckSpace('/ppt/d/new_deck', '105d4a60d0fc4d55a5cfc3c2d0501361')).toBe(
+      '/ppt/d/new_deck?sp=105d4a60d0fc4d55a5cfc3c2d0501361',
+    )
+  })
+
+  it('preserves an existing query param and appends `sp` alongside it', () => {
+    const out = withDeckSpace('/ppt/d/new_deck?foo=1', 'sp_1')
+    const q = new URL(out, 'http://local').searchParams
+    expect(q.get('foo')).toBe('1')
+    expect(q.get('sp')).toBe('sp_1')
+  })
+
+  it('preserves a hash fragment after the appended query', () => {
+    expect(withDeckSpace('/ppt/d/new_deck#slide-2', 'sp_1')).toBe('/ppt/d/new_deck?sp=sp_1#slide-2')
+  })
+
+  it('never overrides an `sp` the path already carries (backend authority wins)', () => {
+    expect(withDeckSpace('/ppt/d/new_deck?sp=backend_space', 'sp_local')).toBe(
+      '/ppt/d/new_deck?sp=backend_space',
+    )
+  })
+
+  it('leaves the path unchanged when the space is empty / whitespace', () => {
+    expect(withDeckSpace('/ppt/d/new_deck', '')).toBe('/ppt/d/new_deck')
+    expect(withDeckSpace('/ppt/d/new_deck', '   ')).toBe('/ppt/d/new_deck')
+    expect(withDeckSpace('/ppt/d/new_deck', null)).toBe('/ppt/d/new_deck')
+    expect(withDeckSpace('/ppt/d/new_deck', undefined)).toBe('/ppt/d/new_deck')
+  })
+})
+
+describe('buildPptPresentLink — present-route share link carries the deck space', () => {
+  const origin = window.location.origin
+
+  it('builds an absolute present link carrying `?sp=`', () => {
+    const link = buildPptPresentLink({ docId: 'd_1', space: 'sp_1' })
+    expect(link).toBe(`${origin}/docs/d_1/present?sp=sp_1`)
+    // The produced link is read back by the same carrier resolveDeckSpace uses.
+    expect(new URL(link).searchParams.get('sp')).toBe('sp_1')
+  })
+
+  it('adds `?version=` only for a pinned published version, not for latest', () => {
+    const pinned = buildPptPresentLink({ docId: 'd_1', space: 'sp_1', version: 3 })
+    const q = new URL(pinned).searchParams
+    expect(q.get('sp')).toBe('sp_1')
+    expect(q.get('version')).toBe('3')
+
+    const latest = buildPptPresentLink({ docId: 'd_1', space: 'sp_1', version: 'latest' })
+    expect(new URL(latest).searchParams.has('version')).toBe(false)
+  })
+
+  it('omits `?sp=` when no space is known (degrades to the route default)', () => {
+    expect(buildPptPresentLink({ docId: 'd_1' })).toBe(`${origin}/docs/d_1/present`)
+  })
+
+  it('percent-encodes the docId in the path', () => {
+    const link = buildPptPresentLink({ docId: 'a b', space: 'sp_1' })
+    expect(link).toBe(`${origin}/docs/a%20b/present?sp=sp_1`)
+  })
+})

--- a/packages/docs/src/ppt/pptLink.ts
+++ b/packages/docs/src/ppt/pptLink.ts
@@ -1,4 +1,4 @@
-// Link minting for the html_ppt peer surfaces (R3-F1, XIN-1495 / XIN-1583 / XIN-1621).
+// Link minting for the html_ppt peer surfaces (R3-F1, XIN-1495 / XIN-1583 / XIN-1621 / XIN-1630).
 //
 // P1-1 (round-5): `resolveDeckSpace()` (PptSurfacePage.tsx) reads a deep-link's dedicated `?sp=`
 // carrier FIRST so a cross-space cold open resolves the deck's REAL space before the app shell has
@@ -8,17 +8,18 @@
 // `editorUrl` verbatim, and the present route had no minting site at all. So a cross-space share fell
 // through to the recipient's last-visited space and 404'd on the backend cross-space guard.
 //
-// These builders are the PPT-route analogue of `buildDocLink`: they stamp the deck's owning space
-// onto the `?sp=` carrier the PPT routes read, so a link the FE produces resolves the right
-// `X-Space-Id` on a cross-space cold open. They are pure (only read `window.location.origin`) so they
-// are unit-testable and reusable from any producer (the create flow's forwarded editor link today; a
-// present-link share affordance when one lands). They mint the SAME `?sp=` param the standalone route
-// uses (docs-backend space_id), never the octo `?sid` token-bucket key.
-
-/** Origin for a PPT link; empty under SSR / tests so the link degrades to a bare rooted path. */
-function origin(): string {
-  return typeof window !== 'undefined' && window.location?.origin ? window.location.origin : ''
-}
+// `withDeckSpace` is the PPT-route analogue of `buildDocLink`: it stamps the deck's owning space onto
+// the `?sp=` carrier the PPT routes read, so a link the FE produces resolves the right `X-Space-Id` on
+// a cross-space cold open. It is pure (only rewrites the query string) so it is unit-testable and
+// reusable from any producer. It mints the SAME `?sp=` param the standalone route uses (docs-backend
+// space_id), never the octo `?sid` token-bucket key.
+//
+// SCOPE (round-6, XIN-1630 — honesty): the ONLY wired producer today is the create flow, which stamps
+// the deck's space onto the backend-forwarded editor link (`/ppt/d/:docId?sp=`) via `withDeckSpace`
+// (DocsHome.tsx). There is deliberately NO present-route link minter here: the present route
+// (`/docs/:docId/present`) has no share affordance yet, so cross-space PRESENT-share remains
+// unresolved and is left to a follow-up rather than shipped as a dead, uncalled builder described as
+// wired. When a present-share affordance lands it should mint through a builder added here.
 
 /**
  * Stamp the deck's owning space onto a rooted same-origin PPT path as `?sp=<space>`, preserving any
@@ -43,29 +44,4 @@ export function withDeckSpace(path: string, space: string | null | undefined): s
   if (params.has('sp')) return path
   params.set('sp', sp)
   return `${base}?${params.toString()}${hash}`
-}
-
-export interface PptPresentLinkTarget {
-  docId: string
-  /** The deck's REAL owning space (docs-backend space_id), embedded as `?sp=` (optional). */
-  space?: string
-  /** Published version to present; omitted from the link when `'latest'` or absent (route defaults). */
-  version?: 'latest' | number
-}
-
-/**
- * Build `${origin}/docs/:docId/present` — the present-route share form — carrying the deck's owning
- * space as `?sp=<space>` (so a cross-space recipient's cold open resolves the right `X-Space-Id`) and
- * an explicit `?version=<N>` only when a specific published version is pinned (`'latest'`/absent maps
- * to the route's own default, so it is left off). This is the present-route analogue of
- * `buildDocLink`; a present-link share affordance mints its link through here.
- */
-export function buildPptPresentLink({ docId, space, version }: PptPresentLinkTarget): string {
-  const path = `/docs/${encodeURIComponent(docId)}/present`
-  const params = new URLSearchParams()
-  const sp = (space ?? '').trim()
-  if (sp) params.set('sp', sp)
-  if (version !== undefined && version !== 'latest') params.set('version', String(version))
-  const q = params.toString()
-  return `${origin()}${path}${q ? `?${q}` : ''}`
 }

--- a/packages/docs/src/ppt/pptLink.ts
+++ b/packages/docs/src/ppt/pptLink.ts
@@ -1,0 +1,71 @@
+// Link minting for the html_ppt peer surfaces (R3-F1, XIN-1495 / XIN-1583 / XIN-1621).
+//
+// P1-1 (round-5): `resolveDeckSpace()` (PptSurfacePage.tsx) reads a deep-link's dedicated `?sp=`
+// carrier FIRST so a cross-space cold open resolves the deck's REAL space before the app shell has
+// restored `currentSpaceId`. That read is only useful if something on the FE actually PRODUCES a PPT
+// link carrying `?sp=` — and until this module, nothing did: `buildDocLink` mints `/d/:docId?sp=` for
+// the STANDALONE rich-text route (a different route), the peer editor link arrives from the backend
+// `editorUrl` verbatim, and the present route had no minting site at all. So a cross-space share fell
+// through to the recipient's last-visited space and 404'd on the backend cross-space guard.
+//
+// These builders are the PPT-route analogue of `buildDocLink`: they stamp the deck's owning space
+// onto the `?sp=` carrier the PPT routes read, so a link the FE produces resolves the right
+// `X-Space-Id` on a cross-space cold open. They are pure (only read `window.location.origin`) so they
+// are unit-testable and reusable from any producer (the create flow's forwarded editor link today; a
+// present-link share affordance when one lands). They mint the SAME `?sp=` param the standalone route
+// uses (docs-backend space_id), never the octo `?sid` token-bucket key.
+
+/** Origin for a PPT link; empty under SSR / tests so the link degrades to a bare rooted path. */
+function origin(): string {
+  return typeof window !== 'undefined' && window.location?.origin ? window.location.origin : ''
+}
+
+/**
+ * Stamp the deck's owning space onto a rooted same-origin PPT path as `?sp=<space>`, preserving any
+ * existing query params and hash. Used to append the space to the backend-forwarded editor link
+ * (`/ppt/d/:docId`) so a created deck's link carries its space.
+ *
+ * - Returns `path` unchanged when `space` is empty/whitespace (no signal → let the interceptor decide,
+ *   exactly as an in-shell entry does).
+ * - Never OVERRIDES an `sp` the path already carries: if the backend already scoped the link, that
+ *   authority wins and we leave it intact.
+ */
+export function withDeckSpace(path: string, space: string | null | undefined): string {
+  const sp = (space ?? '').trim()
+  if (!sp) return path
+  const hashIdx = path.indexOf('#')
+  const hash = hashIdx >= 0 ? path.slice(hashIdx) : ''
+  const beforeHash = hashIdx >= 0 ? path.slice(0, hashIdx) : path
+  const qIdx = beforeHash.indexOf('?')
+  const base = qIdx >= 0 ? beforeHash.slice(0, qIdx) : beforeHash
+  const query = qIdx >= 0 ? beforeHash.slice(qIdx + 1) : ''
+  const params = new URLSearchParams(query)
+  if (params.has('sp')) return path
+  params.set('sp', sp)
+  return `${base}?${params.toString()}${hash}`
+}
+
+export interface PptPresentLinkTarget {
+  docId: string
+  /** The deck's REAL owning space (docs-backend space_id), embedded as `?sp=` (optional). */
+  space?: string
+  /** Published version to present; omitted from the link when `'latest'` or absent (route defaults). */
+  version?: 'latest' | number
+}
+
+/**
+ * Build `${origin}/docs/:docId/present` — the present-route share form — carrying the deck's owning
+ * space as `?sp=<space>` (so a cross-space recipient's cold open resolves the right `X-Space-Id`) and
+ * an explicit `?version=<N>` only when a specific published version is pinned (`'latest'`/absent maps
+ * to the route's own default, so it is left off). This is the present-route analogue of
+ * `buildDocLink`; a present-link share affordance mints its link through here.
+ */
+export function buildPptPresentLink({ docId, space, version }: PptPresentLinkTarget): string {
+  const path = `/docs/${encodeURIComponent(docId)}/present`
+  const params = new URLSearchParams()
+  const sp = (space ?? '').trim()
+  if (sp) params.set('sp', sp)
+  if (version !== undefined && version !== 'latest') params.set('version', String(version))
+  const q = params.toString()
+  return `${origin()}${path}${q ? `?${q}` : ''}`
+}

--- a/packages/docs/src/ppt/pptRoutes.test.ts
+++ b/packages/docs/src/ppt/pptRoutes.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest'
+import {
+  parsePptEditorDocId,
+  isPptEditorPath,
+  parsePptPresentDocId,
+  isPptPresentPath,
+  parsePresentVersion,
+} from './pptRoutes.ts'
+
+describe('parsePptEditorDocId / isPptEditorPath', () => {
+  it('extracts the docId from a well-formed editor path', () => {
+    expect(parsePptEditorDocId('/ppt/d/d_abc123')).toBe('d_abc123')
+    expect(parsePptEditorDocId('/ppt/d/d_abc123/')).toBe('d_abc123')
+    expect(parsePptEditorDocId('/ppt/d/DECK-9_x')).toBe('DECK-9_x')
+  })
+  it('returns null for malformed / non-editor paths', () => {
+    expect(parsePptEditorDocId('/ppt/d/')).toBeNull()
+    expect(parsePptEditorDocId('/ppt/d/a:b')).toBeNull()
+    expect(parsePptEditorDocId('/ppt/d/a/b')).toBeNull()
+    expect(parsePptEditorDocId('/docs')).toBeNull()
+    expect(parsePptEditorDocId('/d/d_abc')).toBeNull()
+  })
+  it('claims the whole /ppt/d namespace regardless of id validity', () => {
+    expect(isPptEditorPath('/ppt/d/d_abc')).toBe(true)
+    expect(isPptEditorPath('/ppt/d/')).toBe(true)
+    expect(isPptEditorPath('/ppt/d')).toBe(true)
+    expect(isPptEditorPath('/ppt/d/a:b')).toBe(true)
+    expect(isPptEditorPath('/ppt/deck')).toBe(false)
+    expect(isPptEditorPath('/pptx/d/a')).toBe(false)
+    expect(isPptEditorPath('/docs/x/present')).toBe(false)
+  })
+})
+
+describe('parsePptPresentDocId / isPptPresentPath', () => {
+  it('matches only the exact /docs/:docId/present shape', () => {
+    expect(parsePptPresentDocId('/docs/d_abc/present')).toBe('d_abc')
+    expect(parsePptPresentDocId('/docs/d_abc/present/')).toBe('d_abc')
+    expect(isPptPresentPath('/docs/d_abc/present')).toBe(true)
+  })
+  it('does NOT claim other /docs paths (app shell keeps them)', () => {
+    expect(parsePptPresentDocId('/docs')).toBeNull()
+    expect(parsePptPresentDocId('/docs/d_abc')).toBeNull()
+    expect(parsePptPresentDocId('/docs/d_abc/present/extra')).toBeNull()
+    expect(parsePptPresentDocId('/docs/a:b/present')).toBeNull()
+    expect(isPptPresentPath('/docs')).toBe(false)
+    expect(isPptPresentPath('/docs/d_abc')).toBe(false)
+  })
+})
+
+describe('parsePresentVersion', () => {
+  it('defaults to latest when absent or blank', () => {
+    expect(parsePresentVersion('')).toBe('latest')
+    expect(parsePresentVersion(undefined)).toBe('latest')
+    expect(parsePresentVersion('?foo=bar')).toBe('latest')
+    expect(parsePresentVersion('?version=latest')).toBe('latest')
+  })
+  it('accepts a positive integer version', () => {
+    expect(parsePresentVersion('?version=1')).toBe(1)
+    expect(parsePresentVersion('?version=42')).toBe(42)
+  })
+  it('falls back to latest for out-of-range / malformed versions', () => {
+    expect(parsePresentVersion('?version=0')).toBe('latest')
+    expect(parsePresentVersion('?version=-3')).toBe('latest')
+    expect(parsePresentVersion('?version=1.5')).toBe('latest')
+    expect(parsePresentVersion('?version=abc')).toBe('latest')
+    expect(parsePresentVersion('?version=99999999999999999999')).toBe('latest')
+    expect(parsePresentVersion('?version= 2 ')).toBe(2)
+  })
+})

--- a/packages/docs/src/ppt/pptRoutes.ts
+++ b/packages/docs/src/ppt/pptRoutes.ts
@@ -1,0 +1,90 @@
+// Top-level route parsing for the html_ppt peer surfaces (R3-F1, XIN-1495 / XIN-1583).
+//
+// Two full-window PPT routes live OUTSIDE the app shell and are intercepted by the host Layout the
+// same way `/d/:docId` (StandaloneDocPage) is — they must never fall through to the rich-text editor
+// or the app-shell doc list:
+//
+//   - `/ppt/d/:docId`            — the peer PPT editor route. A backend `editorUrl` from the R2
+//                                  create flow resolves to this same-origin path; the frontend
+//                                  navigates there and mounts the Bento container (no EditorShell,
+//                                  no Hocuspocus token).
+//   - `/docs/:docId/present`     — the present route, `?version=latest|N`.
+//
+// Parsers here are pure (no `window`) so they are unit-testable and reusable by both the host Layout
+// interception and the page components. docId shares the same single-segment safety as the
+// standalone doc id (`A-Z a-z 0-9 _ -`), so a malformed id is claimed by the namespace but resolves
+// to `null` and lands on the PPT not-available shell rather than silently escaping to the app shell.
+
+/** `/ppt/d/:docId` — the peer PPT editor route (optional trailing slash). */
+const PPT_EDITOR_PATH = /^\/ppt\/d\/([A-Za-z0-9_-]+)\/?$/
+
+/** The editor URL namespace: `/ppt/d`, `/ppt/d/`, or `/ppt/d/<anything>` (top-level only). */
+const PPT_EDITOR_NAMESPACE = /^\/ppt\/d(?:\/|$)/
+
+/** `/docs/:docId/present` — the present route (optional trailing slash). */
+const PPT_PRESENT_PATH = /^\/docs\/([A-Za-z0-9_-]+)\/present\/?$/
+
+/**
+ * Extract the docId from a peer editor path (`/ppt/d/:docId`), or `null` when the path is not a
+ * well-formed editor link.
+ */
+export function parsePptEditorDocId(pathname: string): string | null {
+  if (typeof pathname !== 'string') return null
+  const m = PPT_EDITOR_PATH.exec(pathname)
+  return m ? m[1] : null
+}
+
+/**
+ * Whether `pathname` lives in the editor namespace (`/ppt/d`, `/ppt/d/`, `/ppt/d/<id>`), regardless
+ * of whether the id is well-formed. The host Layout claims the whole namespace — a malformed/empty
+ * id renders the PPT not-available shell instead of falling through to the app shell (mirroring the
+ * `/d` standalone-namespace treatment).
+ */
+export function isPptEditorPath(pathname: string): boolean {
+  return typeof pathname === 'string' && PPT_EDITOR_NAMESPACE.test(pathname)
+}
+
+/**
+ * Extract the docId from a present path (`/docs/:docId/present`), or `null` when the path is not a
+ * present link. Unlike the editor route this does NOT claim a whole namespace: `/docs` itself is the
+ * app-shell doc list, so only the exact `/docs/:docId/present` shape is a present route — every other
+ * `/docs...` path must keep falling through to the shell.
+ */
+export function parsePptPresentDocId(pathname: string): string | null {
+  if (typeof pathname !== 'string') return null
+  const m = PPT_PRESENT_PATH.exec(pathname)
+  return m ? m[1] : null
+}
+
+/** Whether `pathname` is a present route (`/docs/:docId/present`). */
+export function isPptPresentPath(pathname: string): boolean {
+  return parsePptPresentDocId(pathname) !== null
+}
+
+/**
+ * Resolve the `?version=` query for the present route to `'latest'` or a positive integer version
+ * sequence.
+ *
+ * Defaults to `'latest'` whenever the param is absent, blank, or not a clean positive integer — so a
+ * hand-edited `?version=0`, `?version=-3`, `?version=1.5`, `?version=abc`, or `?version=99999999999…`
+ * (beyond a safe integer) falls back to the newest published version rather than requesting a
+ * nonsensical one. Accepts a bare decimal integer only (no signs, no leading zeros beyond a single
+ * digit is fine, no `0x`/exponent), matching the backend `version_seq` contract.
+ */
+export function parsePresentVersion(search: string | null | undefined): 'latest' | number {
+  if (typeof search !== 'string' || search.length === 0) return 'latest'
+  let raw: string | null
+  try {
+    raw = new URLSearchParams(search).get('version')
+  } catch {
+    return 'latest'
+  }
+  if (raw === null) return 'latest'
+  const trimmed = raw.trim()
+  if (trimmed === 'latest') return 'latest'
+  // Bare positive integer only: reject signs, decimals, whitespace-embedded, and non-digit input.
+  if (!/^[0-9]+$/.test(trimmed)) return 'latest'
+  const n = Number(trimmed)
+  if (!Number.isSafeInteger(n) || n < 1) return 'latest'
+  return n
+}

--- a/packages/docs/src/ppt/pptSource.test.ts
+++ b/packages/docs/src/ppt/pptSource.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest'
+import {
+  backendModeFor,
+  buildSourceUrl,
+  buildPptBootstrap,
+  PPT_SOURCE_BASE,
+} from './pptSource.ts'
+
+// Reconciliation with octo-docs-backend #161's real contract:
+//   GET /api/v1/ppt/docs/:docId/source?mode=<published|live|draft>&version=<latest|N>&format=<bootstrap|bento|html>
+// addressed BARE-RELATIVE on the shared apiClient (`/api/v1/` baseURL). These assert the finalized
+// path + params and the FE→BE mode mapping, replacing the provisional `/ppt/frame` shape.
+
+describe('backendModeFor — FE surface mode → backend mode vocabulary', () => {
+  it('maps preview and present (read-only) to published, editor (writer/admin) to live', () => {
+    expect(backendModeFor('preview')).toBe('published')
+    expect(backendModeFor('present')).toBe('published')
+    expect(backendModeFor('editor')).toBe('live')
+  })
+})
+
+describe('buildSourceUrl — real backend source endpoint', () => {
+  it('builds the bare-relative /ppt/docs/:id/source path with mode/version/format', () => {
+    const url = buildSourceUrl({ docId: 'd_1', mode: 'preview', version: 'latest', format: 'html' })
+    expect(url.startsWith(`${PPT_SOURCE_BASE}/d_1/source?`)).toBe(true)
+    // No bespoke /ppt/frame host route anywhere in the URL.
+    expect(url).not.toContain('/ppt/frame')
+    const q = new URL(url, 'http://local').searchParams
+    expect(q.get('mode')).toBe('published')
+    expect(q.get('version')).toBe('latest')
+    expect(q.get('format')).toBe('html')
+  })
+
+  it('carries the editor→live mapping and a numeric version', () => {
+    const q = new URL(buildSourceUrl({ docId: 'd_1', mode: 'editor', version: 7, format: 'bento' }), 'http://local')
+      .searchParams
+    expect(q.get('mode')).toBe('live')
+    expect(q.get('version')).toBe('7')
+    expect(q.get('format')).toBe('bento')
+  })
+
+  it('defaults format to the bootstrap container-handshake payload', () => {
+    const q = new URL(buildSourceUrl({ docId: 'd_1', mode: 'present', version: 'latest' }), 'http://local')
+      .searchParams
+    expect(q.get('format')).toBe('bootstrap')
+    expect(q.get('mode')).toBe('published')
+  })
+
+  it('percent-encodes the docId', () => {
+    const url = buildSourceUrl({ docId: 'a/b?c', mode: 'preview', version: 'latest' })
+    expect(url).toContain(`${PPT_SOURCE_BASE}/a%2Fb%3Fc/source`)
+  })
+})
+
+describe('buildPptBootstrap — payload for the origin-checked handshake', () => {
+  it('carries the FE mode and a real backend rendered-source URL (format=bento)', () => {
+    const bootstrap = buildPptBootstrap({ docId: 'd_1', mode: 'editor', version: 'latest', canEdit: true })
+    expect(bootstrap.mode).toBe('editor')
+    expect(bootstrap.docId).toBe('d_1')
+    expect(bootstrap.canEdit).toBe(true)
+    expect(bootstrap.sourceUrl).toContain(`${PPT_SOURCE_BASE}/d_1/source`)
+    expect(bootstrap.sourceUrl).not.toContain('/ppt/frame')
+    const q = new URL(bootstrap.sourceUrl, 'http://local').searchParams
+    expect(q.get('mode')).toBe('live')
+    expect(q.get('format')).toBe('bento')
+  })
+
+  it('defaults canEdit to false for a read-only context', () => {
+    expect(buildPptBootstrap({ docId: 'd_1', mode: 'preview', version: 'latest' }).canEdit).toBe(false)
+  })
+})

--- a/packages/docs/src/ppt/pptSource.test.ts
+++ b/packages/docs/src/ppt/pptSource.test.ts
@@ -31,11 +31,13 @@ describe('buildSourceUrl — real backend source endpoint', () => {
     expect(q.get('format')).toBe('html')
   })
 
-  it('carries the editor→live mapping and a numeric version', () => {
+  it('carries the editor→live mapping but omits version (published-only per backend #161)', () => {
     const q = new URL(buildSourceUrl({ docId: 'd_1', mode: 'editor', version: 7, format: 'bento' }), 'http://local')
       .searchParams
     expect(q.get('mode')).toBe('live')
-    expect(q.get('version')).toBe('7')
+    // Backend #161 rejects an explicit `version` unless mode=published, so editor→live must not send it,
+    // even when a concrete version is passed in.
+    expect(q.has('version')).toBe(false)
     expect(q.get('format')).toBe('bento')
   })
 
@@ -49,6 +51,35 @@ describe('buildSourceUrl — real backend source endpoint', () => {
   it('percent-encodes the docId', () => {
     const url = buildSourceUrl({ docId: 'a/b?c', mode: 'preview', version: 'latest' })
     expect(url).toContain(`${PPT_SOURCE_BASE}/a%2Fb%3Fc/source`)
+  })
+
+  // Backend octo-docs-backend #161 (deployed) rejects any explicit `version` unless mode=published
+  // (parseVersion throws VALIDATION_ERROR/400). So the FE must serialize `version` ONLY for the
+  // published modes (preview/present); editor→live must omit it entirely.
+  describe('version is gated to published mode only (backend #161 "version is published-only")', () => {
+    it('published modes (preview/present) DO carry version', () => {
+      const preview = new URL(buildSourceUrl({ docId: 'd_1', mode: 'preview', version: 'latest' }), 'http://local')
+        .searchParams
+      expect(preview.get('mode')).toBe('published')
+      expect(preview.get('version')).toBe('latest')
+
+      const present = new URL(buildSourceUrl({ docId: 'd_1', mode: 'present', version: 3 }), 'http://local')
+        .searchParams
+      expect(present.get('mode')).toBe('published')
+      expect(present.get('version')).toBe('3')
+    })
+
+    it('editor→live NEVER carries version, regardless of the version passed', () => {
+      const latest = new URL(buildSourceUrl({ docId: 'd_1', mode: 'editor', version: 'latest' }), 'http://local')
+        .searchParams
+      expect(latest.get('mode')).toBe('live')
+      expect(latest.has('version')).toBe(false)
+
+      const numeric = new URL(buildSourceUrl({ docId: 'd_1', mode: 'editor', version: 9 }), 'http://local')
+        .searchParams
+      expect(numeric.get('mode')).toBe('live')
+      expect(numeric.has('version')).toBe(false)
+    })
   })
 })
 

--- a/packages/docs/src/ppt/pptSource.test.ts
+++ b/packages/docs/src/ppt/pptSource.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect } from 'vitest'
 import {
   backendModeFor,
   buildSourceUrl,
-  buildPptBootstrap,
   PPT_SOURCE_BASE,
 } from './pptSource.ts'
 
@@ -41,10 +40,10 @@ describe('buildSourceUrl — real backend source endpoint', () => {
     expect(q.get('format')).toBe('bento')
   })
 
-  it('defaults format to the bootstrap container-handshake payload', () => {
+  it('defaults format to html (the rendered source the live opaque-origin container mounts)', () => {
     const q = new URL(buildSourceUrl({ docId: 'd_1', mode: 'present', version: 'latest' }), 'http://local')
       .searchParams
-    expect(q.get('format')).toBe('bootstrap')
+    expect(q.get('format')).toBe('html')
     expect(q.get('mode')).toBe('published')
   })
 
@@ -80,23 +79,5 @@ describe('buildSourceUrl — real backend source endpoint', () => {
       expect(numeric.get('mode')).toBe('live')
       expect(numeric.has('version')).toBe(false)
     })
-  })
-})
-
-describe('buildPptBootstrap — payload for the origin-checked handshake', () => {
-  it('carries the FE mode and a real backend rendered-source URL (format=bento)', () => {
-    const bootstrap = buildPptBootstrap({ docId: 'd_1', mode: 'editor', version: 'latest', canEdit: true })
-    expect(bootstrap.mode).toBe('editor')
-    expect(bootstrap.docId).toBe('d_1')
-    expect(bootstrap.canEdit).toBe(true)
-    expect(bootstrap.sourceUrl).toContain(`${PPT_SOURCE_BASE}/d_1/source`)
-    expect(bootstrap.sourceUrl).not.toContain('/ppt/frame')
-    const q = new URL(bootstrap.sourceUrl, 'http://local').searchParams
-    expect(q.get('mode')).toBe('live')
-    expect(q.get('format')).toBe('bento')
-  })
-
-  it('defaults canEdit to false for a read-only context', () => {
-    expect(buildPptBootstrap({ docId: 'd_1', mode: 'preview', version: 'latest' }).canEdit).toBe(false)
   })
 })

--- a/packages/docs/src/ppt/pptSource.ts
+++ b/packages/docs/src/ppt/pptSource.ts
@@ -1,56 +1,100 @@
-// Bootstrap builders for the html_ppt peer surfaces (R3-F1, XIN-1495 / XIN-1583).
+// Source-URL and bootstrap builders for the html_ppt peer surfaces (R3-F1, XIN-1495 / XIN-1583).
 //
-// These assemble the same-origin frame `src` and the `PptBootstrap` payload handed to the Bento
-// container over the origin-checked handshake. They are invoked ONLY when PPT_SOURCE_ENABLED is on
-// — i.e. on a deployment whose backend carries the R3-B1 source/bootstrap layer.
+// These assemble the backend source-endpoint URL and the `PptBootstrap` payload handed to the Bento
+// container over the origin-checked handshake. They are invoked ONLY when PPT_SOURCE_ENABLED is on —
+// i.e. on a deployment whose backend carries the R3-B1 source/bootstrap layer (octo-docs-backend
+// #161, deployed).
 //
-// ⚠️ PROVISIONAL CONTRACT (pending R3-B1 merge): the backend R3-B1 ticket
-// (`feature/xin-1495-ppt-r3-source-bootstrap`) is the authority for the exact source URL shape,
-// signed asset metadata, and cache semantics of the preview / editor / present payloads. It is NOT
-// yet merged to main, so the URL conventions below are the frontend's best-effort placeholders
-// derived from the merged R1/R2 `/api/v1/ppt/**` prefix. They are deliberately quarantined behind
-// PPT_SOURCE_ENABLED (default OFF) so nothing here ships until R3-B1 lands; when it does, reconcile
-// these builders with the finalized contract before flipping the flag on. Do NOT enable the flag
-// against a mock/unmerged contract.
+// CONTRACT (finalized against octo-docs-backend #161, deployed and verified):
+//   GET /api/v1/ppt/docs/:docId/source?mode=<published|live|draft>&version=<latest|N>&format=<bootstrap|bento|html>
+// The endpoint is addressed BARE-RELATIVE on the shared apiClient (baseURL `/api/v1/`), so it
+// resolves to `/api/v1/ppt/docs/:docId/source` and inherits the app's auth / `X-Space-Id` / language
+// interceptors — the same seam every other docs REST call uses. The backend PPT router mounts only
+// `/docs` and `/docs/:docId/source`; there is NO `/ppt/frame/:id` host page, so the container fetches
+// the rendered source through this endpoint (via the shared apiClient) and mounts it same-origin
+// rather than navigating an iframe at a bespoke host route. See BentoContainer.tsx for the mount.
+//
+// The backend is the authority on what source a role may load — it enforces published-only access
+// for reader/commenter contexts. The frontend never bypasses that: it only resolves the FE surface
+// mode to the backend `mode` vocabulary below and passes it through.
 
-import type { PptBootstrap } from './bootstrapTransfer.ts'
+import type { PptBootstrap, PptBootstrapMode } from './bootstrapTransfer.ts'
 
 /**
- * Same-origin path of the Bento host document loaded into the container iframe. Served by the
- * backend (B, Node) at the page's own origin so the origin-checked handshake and the same-origin
- * source fetch both resolve to `window.location.origin`. Provisional — see the file header.
+ * Bare-relative base for the PPT source endpoint on the shared apiClient (baseURL `/api/v1/`), so it
+ * resolves to `/api/v1/ppt/docs`. Kept as a constant so the URL builder and the fetch client (and
+ * their tests) address the exact same path.
  */
-export const PPT_FRAME_PATH = '/ppt/frame'
+export const PPT_SOURCE_BASE = '/ppt/docs'
+
+/** Backend `mode` vocabulary for the source endpoint (octo-docs-backend #161). */
+export type PptBackendMode = 'published' | 'live' | 'draft'
 
 /**
- * Bare-relative source endpoint for a deck, addressed on the docs API base (`/api/v1/ppt/...`),
- * mirroring the R2 create path convention. The backend R3-B1 layer enforces published-only access
- * for reader/commenter here; the frontend never bypasses it. Provisional — see the file header.
+ * Backend `format` vocabulary for the source endpoint (octo-docs-backend #161):
+ * - `bootstrap` — the container handshake payload (default on the backend).
+ * - `bento` / `html` — the rendered single-file Bento source the surface mounts.
  */
-function sourcePath(docId: string, mode: PptBootstrap['mode'], version: 'latest' | number): string {
-  const v = version === 'latest' ? 'latest' : String(version)
-  const id = encodeURIComponent(docId)
-  return `/ppt/frame/${id}/source?mode=${mode}&version=${encodeURIComponent(v)}`
+export type PptSourceFormat = 'bootstrap' | 'bento' | 'html'
+
+/**
+ * Map an FE surface mode to the backend `mode` vocabulary.
+ *
+ * Rationale (reconciled with the R3 design):
+ * - `preview`  → `published` — the read-only routeRight preview is a reader/commenter surface, so it
+ *   loads the published source. The backend enforces published-only for that role regardless; this
+ *   simply asks for the right one.
+ * - `present`  → `published` — the present route is always read-only and shows a published version
+ *   (the `?version=` query selects which), never a draft.
+ * - `editor`   → `live` — the writer/admin editor loads the current editable working copy (`live`).
+ *   R3 exposes a single editable source; `draft` is reserved for the R5 publish/version flow (out of
+ *   scope here), so the editor maps to `live` rather than `draft`. The backend still gates whether
+ *   the caller's role may load it.
+ */
+export function backendModeFor(mode: PptBootstrapMode): PptBackendMode {
+  switch (mode) {
+    case 'editor':
+      return 'live'
+    case 'preview':
+    case 'present':
+    default:
+      return 'published'
+  }
 }
 
 /**
- * Build the frame `src` for a deck's Bento host. Same-origin by construction (a rooted path resolved
- * against the current origin); the container re-validates same-origin as defense in depth.
+ * Build the bare-relative source URL for a deck, addressed on the shared apiClient (`/api/v1/`
+ * baseURL → `/api/v1/ppt/docs/:id/source`). Emits the finalized `mode`/`version`/`format` params:
+ * `mode` is the backend vocabulary resolved from the FE surface mode, `version` is `latest` or a
+ * positive version sequence, `format` is sent explicitly (defaults to `bootstrap`, the container
+ * handshake payload; pass `bento`/`html` for rendered source).
  */
-export function buildFrameSrc(docId: string, mode: PptBootstrap['mode'], version: 'latest' | number): string {
+export function buildSourceUrl(params: {
+  docId: string
+  mode: PptBootstrapMode
+  version: 'latest' | number
+  format?: PptSourceFormat
+}): string {
+  const { docId, mode, version, format = 'bootstrap' } = params
   const id = encodeURIComponent(docId)
-  const v = version === 'latest' ? 'latest' : String(version)
-  return `${PPT_FRAME_PATH}/${id}?mode=${mode}&version=${encodeURIComponent(v)}`
+  const q = new URLSearchParams({
+    mode: backendModeFor(mode),
+    version: version === 'latest' ? 'latest' : String(version),
+    format,
+  })
+  return `${PPT_SOURCE_BASE}/${id}/source?${q.toString()}`
 }
 
 /**
- * Assemble the bootstrap payload served to the frame. `canEdit` distinguishes a writer/admin editor
- * context from a reader/commenter read-only one; the backend is the authority on what source that
- * role may load (draft/live vs published-only), the frontend only passes the resolved context.
+ * Assemble the bootstrap payload served to the same-origin Bento frame over the origin-checked
+ * handshake. `canEdit` distinguishes a writer/admin editor context from a reader/commenter read-only
+ * one; the backend is the authority on what source that role may load (published vs live/draft), the
+ * frontend only passes the resolved context. `sourceUrl` is the real backend rendered-source URL
+ * (`format=bento`) so the frame can (re-)fetch the deck source through the shared apiClient.
  */
 export function buildPptBootstrap(params: {
   docId: string
-  mode: PptBootstrap['mode']
+  mode: PptBootstrapMode
   version: 'latest' | number
   canEdit?: boolean
 }): PptBootstrap {
@@ -59,7 +103,7 @@ export function buildPptBootstrap(params: {
     mode,
     docId,
     version,
-    sourceUrl: sourcePath(docId, mode, version),
+    sourceUrl: buildSourceUrl({ docId, mode, version, format: 'bento' }),
     canEdit: canEdit ?? false,
   }
 }

--- a/packages/docs/src/ppt/pptSource.ts
+++ b/packages/docs/src/ppt/pptSource.ts
@@ -65,9 +65,15 @@ export function backendModeFor(mode: PptBootstrapMode): PptBackendMode {
 /**
  * Build the bare-relative source URL for a deck, addressed on the shared apiClient (`/api/v1/`
  * baseURL → `/api/v1/ppt/docs/:id/source`). Emits the finalized `mode`/`version`/`format` params:
- * `mode` is the backend vocabulary resolved from the FE surface mode, `version` is `latest` or a
- * positive version sequence, `format` is sent explicitly (defaults to `bootstrap`, the container
- * handshake payload; pass `bento`/`html` for rendered source).
+ * `mode` is the backend vocabulary resolved from the FE surface mode, `format` is sent explicitly
+ * (defaults to `bootstrap`, the container handshake payload; pass `bento`/`html` for rendered
+ * source).
+ *
+ * `version` is PUBLISHED-ONLY: octo-docs-backend #161 rejects an explicit `version` unless
+ * `mode==='published'` (`parseVersion()` throws VALIDATION_ERROR/400 otherwise — the R3-B1
+ * "version is published-only" rule). So it is serialized only for the published modes
+ * (FE `preview`/`present`); for `editor`→`live` (and any `draft`) it is omitted entirely, which
+ * is why an enabled editor source fetch no longer 400s.
  */
 export function buildSourceUrl(params: {
   docId: string
@@ -77,11 +83,15 @@ export function buildSourceUrl(params: {
 }): string {
   const { docId, mode, version, format = 'bootstrap' } = params
   const id = encodeURIComponent(docId)
+  const backendMode = backendModeFor(mode)
   const q = new URLSearchParams({
-    mode: backendModeFor(mode),
-    version: version === 'latest' ? 'latest' : String(version),
+    mode: backendMode,
     format,
   })
+  // Only published sources accept a `version`; live/draft must not send it (backend #161).
+  if (backendMode === 'published') {
+    q.set('version', version === 'latest' ? 'latest' : String(version))
+  }
   return `${PPT_SOURCE_BASE}/${id}/source?${q.toString()}`
 }
 

--- a/packages/docs/src/ppt/pptSource.ts
+++ b/packages/docs/src/ppt/pptSource.ts
@@ -57,8 +57,14 @@ export function backendModeFor(mode: PptBootstrapMode): PptBackendMode {
       return 'live'
     case 'preview':
     case 'present':
-    default:
       return 'published'
+    default: {
+      // Exhaustiveness guard: this function decides published-vs-live, so a NEW PptBootstrapMode
+      // must be mapped deliberately rather than silently defaulting to 'published'. A future member
+      // makes `mode` non-`never` here and fails typecheck until it is handled above.
+      const exhaustive: never = mode
+      return exhaustive
+    }
   }
 }
 

--- a/packages/docs/src/ppt/pptSource.ts
+++ b/packages/docs/src/ppt/pptSource.ts
@@ -4,10 +4,16 @@
 // when PPT_SOURCE_ENABLED is on — i.e. on a deployment whose backend carries the R3-B1
 // source/bootstrap layer (octo-docs-backend #161).
 //
-// CONTRACT (finalized against octo-docs-backend #161, NOT yet merged — PR open, mergedAt null; the
-// PPT_SOURCE_ENABLED gate stays OFF until a deployment carries it, see config.ts):
+// CONTRACT — the R3 LIVE path is `format=html` ONLY. Against octo-docs-backend #161 (PR open,
+// mergedAt null; the PPT_SOURCE_ENABLED gate stays OFF until a deployment carries it, see config.ts)
+// the endpoint shape is:
 //   GET /api/v1/ppt/docs/:docId/source?mode=<published|live|draft>&version=<latest|N>&format=<bootstrap|bento|html>
-// The endpoint is addressed BARE-RELATIVE on the shared apiClient (baseURL `/api/v1/`), so it
+// but R3 exercises only `format=html` (self-contained rendered HTML — see pptSourceClient.ts). The
+// `format=bootstrap` + signed short-lived asset half is a DORMANT FORWARD CONTRACT: it is NOT
+// delivered by R3, no live R3 code path requests it, and the backend PR documents it as forward
+// scaffolding for a future separate-origin host page rather than a live origin-checked delivery
+// channel. It stays in the vocabulary (below) so the deferred channel has a name, not because it is
+// wired. The endpoint is addressed BARE-RELATIVE on the shared apiClient (baseURL `/api/v1/`), so it
 // resolves to `/api/v1/ppt/docs/:docId/source` and inherits the app's auth / `X-Space-Id` / language
 // interceptors — the same seam every other docs REST call uses. The backend PPT router mounts only
 // `/docs` and `/docs/:docId/source`; there is NO `/ppt/frame/:id` host page, so the container fetches

--- a/packages/docs/src/ppt/pptSource.ts
+++ b/packages/docs/src/ppt/pptSource.ts
@@ -1,0 +1,65 @@
+// Bootstrap builders for the html_ppt peer surfaces (R3-F1, XIN-1495 / XIN-1583).
+//
+// These assemble the same-origin frame `src` and the `PptBootstrap` payload handed to the Bento
+// container over the origin-checked handshake. They are invoked ONLY when PPT_SOURCE_ENABLED is on
+// — i.e. on a deployment whose backend carries the R3-B1 source/bootstrap layer.
+//
+// ⚠️ PROVISIONAL CONTRACT (pending R3-B1 merge): the backend R3-B1 ticket
+// (`feature/xin-1495-ppt-r3-source-bootstrap`) is the authority for the exact source URL shape,
+// signed asset metadata, and cache semantics of the preview / editor / present payloads. It is NOT
+// yet merged to main, so the URL conventions below are the frontend's best-effort placeholders
+// derived from the merged R1/R2 `/api/v1/ppt/**` prefix. They are deliberately quarantined behind
+// PPT_SOURCE_ENABLED (default OFF) so nothing here ships until R3-B1 lands; when it does, reconcile
+// these builders with the finalized contract before flipping the flag on. Do NOT enable the flag
+// against a mock/unmerged contract.
+
+import type { PptBootstrap } from './bootstrapTransfer.ts'
+
+/**
+ * Same-origin path of the Bento host document loaded into the container iframe. Served by the
+ * backend (B, Node) at the page's own origin so the origin-checked handshake and the same-origin
+ * source fetch both resolve to `window.location.origin`. Provisional — see the file header.
+ */
+export const PPT_FRAME_PATH = '/ppt/frame'
+
+/**
+ * Bare-relative source endpoint for a deck, addressed on the docs API base (`/api/v1/ppt/...`),
+ * mirroring the R2 create path convention. The backend R3-B1 layer enforces published-only access
+ * for reader/commenter here; the frontend never bypasses it. Provisional — see the file header.
+ */
+function sourcePath(docId: string, mode: PptBootstrap['mode'], version: 'latest' | number): string {
+  const v = version === 'latest' ? 'latest' : String(version)
+  const id = encodeURIComponent(docId)
+  return `/ppt/frame/${id}/source?mode=${mode}&version=${encodeURIComponent(v)}`
+}
+
+/**
+ * Build the frame `src` for a deck's Bento host. Same-origin by construction (a rooted path resolved
+ * against the current origin); the container re-validates same-origin as defense in depth.
+ */
+export function buildFrameSrc(docId: string, mode: PptBootstrap['mode'], version: 'latest' | number): string {
+  const id = encodeURIComponent(docId)
+  const v = version === 'latest' ? 'latest' : String(version)
+  return `${PPT_FRAME_PATH}/${id}?mode=${mode}&version=${encodeURIComponent(v)}`
+}
+
+/**
+ * Assemble the bootstrap payload served to the frame. `canEdit` distinguishes a writer/admin editor
+ * context from a reader/commenter read-only one; the backend is the authority on what source that
+ * role may load (draft/live vs published-only), the frontend only passes the resolved context.
+ */
+export function buildPptBootstrap(params: {
+  docId: string
+  mode: PptBootstrap['mode']
+  version: 'latest' | number
+  canEdit?: boolean
+}): PptBootstrap {
+  const { docId, mode, version, canEdit } = params
+  return {
+    mode,
+    docId,
+    version,
+    sourceUrl: sourcePath(docId, mode, version),
+    canEdit: canEdit ?? false,
+  }
+}

--- a/packages/docs/src/ppt/pptSource.ts
+++ b/packages/docs/src/ppt/pptSource.ts
@@ -1,24 +1,26 @@
-// Source-URL and bootstrap builders for the html_ppt peer surfaces (R3-F1, XIN-1495 / XIN-1583).
+// Source-URL builder for the html_ppt peer surfaces (R3-F1, XIN-1495 / XIN-1583).
 //
-// These assemble the backend source-endpoint URL and the `PptBootstrap` payload handed to the Bento
-// container over the origin-checked handshake. They are invoked ONLY when PPT_SOURCE_ENABLED is on —
-// i.e. on a deployment whose backend carries the R3-B1 source/bootstrap layer (octo-docs-backend
-// #161, deployed).
+// This assembles the backend source-endpoint URL the Bento container fetches. It is invoked ONLY
+// when PPT_SOURCE_ENABLED is on — i.e. on a deployment whose backend carries the R3-B1
+// source/bootstrap layer (octo-docs-backend #161).
 //
-// CONTRACT (finalized against octo-docs-backend #161, deployed and verified):
+// CONTRACT (finalized against octo-docs-backend #161, NOT yet merged — PR open, mergedAt null; the
+// PPT_SOURCE_ENABLED gate stays OFF until a deployment carries it, see config.ts):
 //   GET /api/v1/ppt/docs/:docId/source?mode=<published|live|draft>&version=<latest|N>&format=<bootstrap|bento|html>
 // The endpoint is addressed BARE-RELATIVE on the shared apiClient (baseURL `/api/v1/`), so it
 // resolves to `/api/v1/ppt/docs/:docId/source` and inherits the app's auth / `X-Space-Id` / language
 // interceptors — the same seam every other docs REST call uses. The backend PPT router mounts only
 // `/docs` and `/docs/:docId/source`; there is NO `/ppt/frame/:id` host page, so the container fetches
-// the rendered source through this endpoint (via the shared apiClient) and mounts it same-origin
-// rather than navigating an iframe at a bespoke host route. See BentoContainer.tsx for the mount.
+// the rendered source through this endpoint (via the shared apiClient) and hosts it in a sandboxed
+// opaque-origin `srcdoc` frame rather than navigating an iframe at a bespoke host route. See
+// BentoContainer.tsx for the mount.
 //
 // The backend is the authority on what source a role may load — it enforces published-only access
-// for reader/commenter contexts. The frontend never bypasses that: it only resolves the FE surface
-// mode to the backend `mode` vocabulary below and passes it through.
+// for reader/commenter contexts. The frontend never bypasses that: it resolves the FE surface mode
+// to the backend `mode` vocabulary below and passes it through (and, per XIN-1615 P1-3, never asks
+// for `live` on behalf of a non-writer — see PptSurfacePage).
 
-import type { PptBootstrap, PptBootstrapMode } from './bootstrapTransfer.ts'
+import type { PptBootstrapMode } from './bootstrapTransfer.ts'
 
 /**
  * Bare-relative base for the PPT source endpoint on the shared apiClient (baseURL `/api/v1/`), so it
@@ -32,8 +34,12 @@ export type PptBackendMode = 'published' | 'live' | 'draft'
 
 /**
  * Backend `format` vocabulary for the source endpoint (octo-docs-backend #161):
- * - `bootstrap` — the container handshake payload (default on the backend).
- * - `bento` / `html` — the rendered single-file Bento source the surface mounts.
+ * - `bento` / `html` — the rendered single-file Bento source the surface mounts (the live path uses
+ *   `html`).
+ * - `bootstrap` — the container handshake payload. The live opaque-origin container does NOT use
+ *   this (see BentoContainer.tsx / bootstrapTransfer.ts: the postMessage handshake is deferred
+ *   scaffolding for a future separate-origin host page), so the FE never requests `format=bootstrap`
+ *   today; it stays in the vocabulary for that deferred channel.
  */
 export type PptSourceFormat = 'bootstrap' | 'bento' | 'html'
 
@@ -72,8 +78,8 @@ export function backendModeFor(mode: PptBootstrapMode): PptBackendMode {
  * Build the bare-relative source URL for a deck, addressed on the shared apiClient (`/api/v1/`
  * baseURL → `/api/v1/ppt/docs/:id/source`). Emits the finalized `mode`/`version`/`format` params:
  * `mode` is the backend vocabulary resolved from the FE surface mode, `format` is sent explicitly
- * (defaults to `bootstrap`, the container handshake payload; pass `bento`/`html` for rendered
- * source).
+ * (defaults to `html`, the rendered single-file source the live container mounts; the backend also
+ * accepts `bento`/`bootstrap`).
  *
  * `version` is PUBLISHED-ONLY: octo-docs-backend #161 rejects an explicit `version` unless
  * `mode==='published'` (`parseVersion()` throws VALIDATION_ERROR/400 otherwise — the R3-B1
@@ -87,7 +93,7 @@ export function buildSourceUrl(params: {
   version: 'latest' | number
   format?: PptSourceFormat
 }): string {
-  const { docId, mode, version, format = 'bootstrap' } = params
+  const { docId, mode, version, format = 'html' } = params
   const id = encodeURIComponent(docId)
   const backendMode = backendModeFor(mode)
   const q = new URLSearchParams({
@@ -99,27 +105,4 @@ export function buildSourceUrl(params: {
     q.set('version', version === 'latest' ? 'latest' : String(version))
   }
   return `${PPT_SOURCE_BASE}/${id}/source?${q.toString()}`
-}
-
-/**
- * Assemble the bootstrap payload served to the same-origin Bento frame over the origin-checked
- * handshake. `canEdit` distinguishes a writer/admin editor context from a reader/commenter read-only
- * one; the backend is the authority on what source that role may load (published vs live/draft), the
- * frontend only passes the resolved context. `sourceUrl` is the real backend rendered-source URL
- * (`format=bento`) so the frame can (re-)fetch the deck source through the shared apiClient.
- */
-export function buildPptBootstrap(params: {
-  docId: string
-  mode: PptBootstrapMode
-  version: 'latest' | number
-  canEdit?: boolean
-}): PptBootstrap {
-  const { docId, mode, version, canEdit } = params
-  return {
-    mode,
-    docId,
-    version,
-    sourceUrl: buildSourceUrl({ docId, mode, version, format: 'bento' }),
-    canEdit: canEdit ?? false,
-  }
 }

--- a/packages/docs/src/ppt/pptSourceClient.test.ts
+++ b/packages/docs/src/ppt/pptSourceClient.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { setWKApp } from '../octoweb/index.ts'
+import { createMockWKApp, type MockApiClient } from '../octoweb/mock.ts'
+import { fetchPptSourceHtml } from './pptSourceClient.ts'
+
+// The container fetches the rendered source THROUGH the shared apiClient (so the app's auth /
+// X-Space-Id / language interceptors apply), against octo-docs-backend #161's real endpoint — never
+// a bespoke /ppt/frame host route.
+
+let api: MockApiClient
+
+beforeEach(() => {
+  const wk = createMockWKApp()
+  api = wk.apiClient
+  setWKApp(wk)
+})
+
+describe('fetchPptSourceHtml — real source endpoint through the shared apiClient', () => {
+  it('GETs /ppt/docs/:id/source with the mapped mode, version and format=html', async () => {
+    api.responder = () => ({ data: '<html><body>deck</body></html>', status: 200 })
+    const html = await fetchPptSourceHtml({ docId: 'd_1', mode: 'preview', version: 'latest' })
+    expect(html).toBe('<html><body>deck</body></html>')
+    expect(api.calls).toHaveLength(1)
+    const { method, url } = api.calls[0]
+    expect(method).toBe('get')
+    expect(url).toContain('/ppt/docs/d_1/source')
+    expect(url).not.toContain('/ppt/frame')
+    const q = new URL(url, 'http://local').searchParams
+    expect(q.get('mode')).toBe('published')
+    expect(q.get('version')).toBe('latest')
+    expect(q.get('format')).toBe('html')
+  })
+
+  it('maps editor→live, forwards X-Space-Id, and addresses a numeric version', async () => {
+    api.responder = () => ({ data: '<html></html>', status: 200 })
+    await fetchPptSourceHtml({ docId: 'd_1', mode: 'editor', version: 4, space: 's_9' })
+    const { url, config } = api.calls[0]
+    const q = new URL(url, 'http://local').searchParams
+    expect(q.get('mode')).toBe('live')
+    expect(q.get('version')).toBe('4')
+    expect(config?.headers?.['X-Space-Id']).toBe('s_9')
+  })
+})

--- a/packages/docs/src/ppt/pptSourceClient.test.ts
+++ b/packages/docs/src/ppt/pptSourceClient.test.ts
@@ -31,13 +31,14 @@ describe('fetchPptSourceHtml — real source endpoint through the shared apiClie
     expect(q.get('format')).toBe('html')
   })
 
-  it('maps editor→live, forwards X-Space-Id, and addresses a numeric version', async () => {
+  it('maps editor→live, forwards X-Space-Id, and omits version (published-only per backend #161)', async () => {
     api.responder = () => ({ data: '<html></html>', status: 200 })
     await fetchPptSourceHtml({ docId: 'd_1', mode: 'editor', version: 4, space: 's_9' })
     const { url, config } = api.calls[0]
     const q = new URL(url, 'http://local').searchParams
     expect(q.get('mode')).toBe('live')
-    expect(q.get('version')).toBe('4')
+    // editor→live must not send `version`; backend #161 400s an explicit version on non-published modes.
+    expect(q.has('version')).toBe(false)
     expect(config?.headers?.['X-Space-Id']).toBe('s_9')
   })
 })

--- a/packages/docs/src/ppt/pptSourceClient.ts
+++ b/packages/docs/src/ppt/pptSourceClient.ts
@@ -7,9 +7,14 @@
 // through the shared apiClient here and then injected by the container into a sandboxed opaque-origin
 // `srcdoc` frame, rather than navigating a frame at a bespoke route the backend does not serve.
 //
-// Bento decks are single self-contained HTML files, so `format=html` returns the whole renderable
-// deck; the container hosts it in an isolated (opaque-origin) `srcdoc` document. This module performs
-// the ONLY network I/O of the PPT source path and issues NO Hocuspocus token.
+// R3 supports only SELF-CONTAINED rendered HTML: `format=html` returns a deck whose bytes are already
+// complete at the frame boundary — decorative fonts / assets inlined via `doc.assets`, charts and
+// morph transitions driven by Bento's bundled engine — so the opaque-origin `srcdoc` document needs
+// no further network to render. This is deliberately narrower than Bento's full authoring model, where
+// a media `src` may be a data URI, an `asset:<key>` reference, an external URL, or a relative path;
+// decks that are NOT self-contained (needing signed-asset resolution or external fetches) are a
+// later-round concern and are not delivered by R3. This module performs the ONLY network I/O of the
+// R3 PPT source path and issues NO Hocuspocus token.
 
 import { apiClient } from '../octoweb/index.ts'
 import { buildSourceUrl } from './pptSource.ts'

--- a/packages/docs/src/ppt/pptSourceClient.ts
+++ b/packages/docs/src/ppt/pptSourceClient.ts
@@ -4,12 +4,12 @@
 // `GET /api/v1/ppt/docs/:docId/source` and mounts NO `/ppt/frame/:id` host page. Because that
 // endpoint sits behind the app's auth / `X-Space-Id` / language interceptors (a header-token auth
 // scheme — an iframe `src` navigation would carry none of them and 401), the source is FETCHED
-// through the shared apiClient here and then mounted same-origin by the container (iframe `srcdoc`),
-// rather than navigating a frame at a bespoke same-origin route the backend does not serve.
+// through the shared apiClient here and then injected by the container into a sandboxed opaque-origin
+// `srcdoc` frame, rather than navigating a frame at a bespoke route the backend does not serve.
 //
 // Bento decks are single self-contained HTML files, so `format=html` returns the whole renderable
-// deck; the container hosts it in a same-origin `srcdoc` document. This module performs the ONLY
-// network I/O of the PPT source path and issues NO Hocuspocus token.
+// deck; the container hosts it in an isolated (opaque-origin) `srcdoc` document. This module performs
+// the ONLY network I/O of the PPT source path and issues NO Hocuspocus token.
 
 import { apiClient } from '../octoweb/index.ts'
 import { buildSourceUrl } from './pptSource.ts'
@@ -26,8 +26,8 @@ export interface FetchPptSourceParams {
 /**
  * Fetch a deck's rendered single-file Bento source (`format=html`) through the shared apiClient, so
  * the app's auth / `X-Space-Id` / language interceptors apply. Returns the HTML string the container
- * mounts same-origin. The backend enforces what source the caller's role may load; this never
- * bypasses that.
+ * injects into its opaque-origin `srcdoc` frame. The backend enforces what source the caller's role
+ * may load; this never bypasses that.
  */
 export async function fetchPptSourceHtml(params: FetchPptSourceParams): Promise<string> {
   const { docId, mode, version, space } = params

--- a/packages/docs/src/ppt/pptSourceClient.ts
+++ b/packages/docs/src/ppt/pptSourceClient.ts
@@ -1,0 +1,38 @@
+// Source fetch client for the html_ppt peer surfaces (R3-F1, XIN-1495 / XIN-1583).
+//
+// The backend PPT router (octo-docs-backend #161) serves the rendered deck source at
+// `GET /api/v1/ppt/docs/:docId/source` and mounts NO `/ppt/frame/:id` host page. Because that
+// endpoint sits behind the app's auth / `X-Space-Id` / language interceptors (a header-token auth
+// scheme — an iframe `src` navigation would carry none of them and 401), the source is FETCHED
+// through the shared apiClient here and then mounted same-origin by the container (iframe `srcdoc`),
+// rather than navigating a frame at a bespoke same-origin route the backend does not serve.
+//
+// Bento decks are single self-contained HTML files, so `format=html` returns the whole renderable
+// deck; the container hosts it in a same-origin `srcdoc` document. This module performs the ONLY
+// network I/O of the PPT source path and issues NO Hocuspocus token.
+
+import { apiClient } from '../octoweb/index.ts'
+import { buildSourceUrl } from './pptSource.ts'
+import type { PptBootstrapMode } from './bootstrapTransfer.ts'
+
+export interface FetchPptSourceParams {
+  docId: string
+  mode: PptBootstrapMode
+  version: 'latest' | number
+  /** Owning space, forwarded as `X-Space-Id` for source scoping (parity with getDoc). */
+  space?: string
+}
+
+/**
+ * Fetch a deck's rendered single-file Bento source (`format=html`) through the shared apiClient, so
+ * the app's auth / `X-Space-Id` / language interceptors apply. Returns the HTML string the container
+ * mounts same-origin. The backend enforces what source the caller's role may load; this never
+ * bypasses that.
+ */
+export async function fetchPptSourceHtml(params: FetchPptSourceParams): Promise<string> {
+  const { docId, mode, version, space } = params
+  const url = buildSourceUrl({ docId, mode, version, format: 'html' })
+  const config = space ? { headers: { 'X-Space-Id': space } } : undefined
+  const { data } = await apiClient().get<string>(url, config)
+  return typeof data === 'string' ? data : String(data ?? '')
+}


### PR DESCRIPTION
## Summary

R3-F1 of XIN-1495 (bring the Bento slide-deck `html_ppt` doc type into octo-docs). Adds the frontend PPT peer surfaces — the read-only preview, the peer editor route, and the present route — building on the R1 routing shell and the R2 create + template picker already on main.

- **`PptDocView`** is upgraded from the R1 "coming soon" placeholder into the routeRight **read-only preview**, mounting the isolated Bento container.
- **Peer editor route `/ppt/d/:docId`** and top-level **present route `/docs/:docId/present?version=latest|N`**, both intercepted by the host `Layout` outside the app shell (mirroring the standalone `/d/:docId` interception) and deliberately **not** mounted through `EditorShell`.
- **No Hocuspocus token** is requested on preview / edit / present.

## Source delivery — opaque-origin `srcdoc`, `format=html` only

The deck HTML is user-authored and **not** end-to-end sanitized, so it may carry `<script>`, `on*` handlers, or `javascript:` URLs. The container isolates it by:

- Fetching the rendered single-file source through the shared apiClient (`GET /api/v1/ppt/docs/:docId/source?format=html`) so the app's auth / `X-Space-Id` / language interceptors apply — the backend mounts no `/ppt/frame/:id` host page, so we do not navigate a frame at a bespoke route.
- Injecting that HTML into an **opaque-origin `srcdoc` iframe**: `sandbox="allow-scripts"` **without** `allow-same-origin`, so Bento's scripts run against the frame's own document but can touch nothing in the parent origin (no parent cookies / localStorage / DOM). This is the stored-XSS tradeoff R3 ships.
- **The `srcdoc` injection is the single delivery path.** There is **no** postMessage bootstrap handshake in the live container: an opaque-origin frame's message arrives with `event.origin === 'null'`, which the origin gate can never trust, so a handshake is structurally impossible under this sandbox.

**R3 supports only self-contained rendered HTML** — `format=html` returns a deck whose bytes are complete at the frame boundary (fonts/media inlined via `data:`/`blob:` or `doc.assets`, charts/morph on Bento's bundled engine). Non-self-contained decks (external/`asset:<key>`/relative `src`) are a later-round concern and are **not** delivered by R3.

## Deferred forward contracts (retained, NOT live in R3)

- **`bootstrapTransfer.ts`** (origin-checked postMessage handshake) is retained as **deferred scaffolding** for a future separate-origin Bento host page (the round-3 reviewer's Option 1), where a distinct **named** origin could be allowlisted. It is **not wired** into the live container; its pure origin gate stays unit-tested so the deferred channel keeps its fail-closed guarantee.
- **`format=bootstrap` + signed short-lived asset** delivery is a **dormant forward contract** in `pptSource.ts`: it stays in the vocabulary, but no live R3 code path requests it and R3 exercises `format=html` only. It is **not** an active origin-checked delivery channel.

## Exposure gate (depends on backend R3-B1 — not yet merged)

Everything that consumes **live backend source** is gated behind `PPT_SOURCE_ENABLED` (`VITE_DOCS_PPT_SOURCE`), which **defaults OFF**. The backend R3-B1 source layer (`octo-docs-backend` #161) is **not yet merged**, so this PR ships the static shell + route wiring only:

- While the flag is OFF (the shipping state), every surface renders a gated "not yet available" shell and performs **no network I/O** — no preflight, no source fetch, no token. Routes still resolve, so a deep link lands on the PPT surface instead of the rich-text editor.
- When a deployment whose backend carries R3-B1 flips the flag on, the same components run the reader preflight and mount the Bento container.
- No regression to R1 entry/filter/no-fallthrough routing or the R2 create picker; the gate is independent of `PPT_CREATE_ENABLED`.

**This PR must not be marked ready / merged until backend R3-B1 is merged and the source contract reconciled.**

## Round-5 fixes (this revision)

- **Contract honesty** — narrowed the "self-contained" claim to R3's `format=html` path; restated the `format=bootstrap` / signed-asset half as a dormant forward contract; every bootstrap comment now agrees it is deferred, not live.
- **P1-1 `?sp=` minting** — `resolveDeckSpace()` reads a deep-link's `?sp=` carrier first, but nothing on the FE previously *produced* a PPT link carrying it. Added `pptLink.ts`'s `withDeckSpace`: the create flow now stamps the deck's space onto the backend-forwarded editor link (`/ppt/d/:docId?sp=`). Tests prove a *produced* link carries `?sp=`. (Present-route share-link minting is deferred — see round-6 below. The parent-document `frame-src` in the global CSP is a separate follow-up, below.)
- **P1-2 CSP (defence-in-depth)** — the opaque frame is now hardened with a `<meta http-equiv="Content-Security-Policy">` injected into the `srcdoc` (`pptFrameCsp.ts`): `connect-src 'none'` (fetch-exfiltration containment) plus `base-uri`/`form-action 'none'`, while allowing Bento's inline/eval/`data:`/`blob:` runtime. This is fully FE-side. **Deferred follow-up (rationale):** the complementary parent-document `frame-src` that would allowlist this frame in the app's top-level CSP needs the **global nginx** config, which the architect scoped out of R3 — filed, not silently dropped.
- **Malformed-id branch order** — the null-id not-found branch is now checked **before** the gated shell, so a malformed link is a terminal not-found in every build (flag-OFF `docId={null}` test added).
- **`allow-fullscreen`** — dropped the inert `allow-fullscreen` *sandbox token* (not a valid sandbox keyword; silently ignored); real fullscreen is granted by the `allow="fullscreen"` permission-policy attribute. The test assertion pinning the token was dropped.
- **Opaque-origin comment** — fixed the `bootstrapTransfer.ts` comment that said an opaque frame reports `origin === ''`; per spec an opaque origin serializes to the string `'null'` (consistent with `BentoContainer.tsx`).

## Round-6 fixes (XIN-1630)

- **P1-1 frame CSP now fails CLOSED against the deck author (was bypassable).** The `srcdoc` CSP meta is the egress containment against the *deck author*, but the round-5 implementation injected it at the first textual `<head>` match on **unsanitized, attacker-controlled** HTML — bypassable by the very author it must contain: (a) a `<head>` inside a leading comment, (b) a `<script>` the parser hoists into an implicit head ahead of a later literal `<head>`, and (c) a `<head` inside a quoted attribute value each displaced the meta so the frame inherited the parent CSP (wholesale `connect-src http:/https:`) and the control silently no-op'd.
  - **Approach + rationale:** `withFrameCsp` no longer does regex surgery. It **parses** the deck HTML with the platform HTML parser (`DOMParser`, `text/html` — the HTML5 tree-construction algorithm, which never executes scripts), inserts the CSP meta as the **first child of the real `<head>`** via the DOM, and re-serializes (doctype preserved so re-serialization cannot force a quirks-mode layout regression). Because the browser re-parses the srcdoc by the same algorithm, the meta is guaranteed to be the head's first directive — ahead of any deck `<script>`, including a hoisted one — so vectors (a)/(b)/(c) fail **CLOSED**. Chosen over the `<iframe csp="…">` attribute (browser support is limited/inconsistent) and over hardening the regex (unwinnable on untrusted HTML). If `DOMParser` were ever unavailable (it is a browser platform API and this surface only renders in an iframe, so this is unreachable in prod), the function returns the HTML unchanged rather than fall back to a bypassable injection — the opaque-origin sandbox (P0) stays the primary containment. The complementary parent-document `frame-src` remains the deferred nginx-side follow-up.
  - **Adversarial tests:** three new cases in `pptFrameCsp.test.ts` re-parse `withFrameCsp`'s output and assert the CSP meta is the first real-`<head>` element for each of (a)/(b)/(c) — and for (b) that the deck script sits *after* the meta in the head.
- **Dead present-link export removed (honesty).** `buildPptPresentLink` had no production caller (tests only) yet comments described it as wired — the third "described-as-wired-but-no-caller" instance on this branch. Removed the export + its interface and corrected the `pptLink.ts` / `PptSurfacePage.tsx` comments: the only wired `?sp=` producer is the create flow (`withDeckSpace`); the present route has no share affordance yet, so cross-space **present**-share is honestly left as a follow-up rather than shipped as a dead builder. Branch re-audited — the postMessage handshake (`bootstrapTransfer.ts`) is already labeled deferred/not-wired and the `?sp=` reader is wired via the create flow, so no other stale "wired" comments remain.
- **PR description reconciled** to the shipped opaque-origin `format=html` head (the round-5 `buildPptPresentLink` claim above corrected) and the self-test counts refreshed below.

## Self-tests

Run in `packages/docs`:

- **Unit** — `pnpm exec vitest run`: **2664 passed** (212 files). 1 pre-existing unrelated failure in `editor/TableReorderInterrupt.test.ts`, confirmed failing identically on clean `main`; untouched by this PR.
- **PPT + i18n** — `pnpm exec vitest run src/ppt src/i18n` → **13 files, 100 tests passed**, covering the opaque-origin isolation, the srcdoc CSP (`connect-src 'none'`) **including the three adversarial deck-author bypass vectors now failing CLOSED**, the produced-link `?sp=` minting, the malformed-id branch order, route parsers, gated/enabled rendering of every surface, and the deferred origin gate + its cross-origin negative control.
- **apps/web** — `pnpm exec vitest run src/Layout/__tests__/standaloneReturn.test.ts src/__tests__/layoutStandaloneDocPath.test.ts` → **20 passed** (post-login return allowlist + PPT route interception).
- **Typecheck (touched files)** — `pnpm -C packages/docs exec tsc --noEmit -p tsconfig.typecheck.json`: no errors in any touched file. (One pre-existing error in `dmworkbase/src/i18n/format.ts`, present on clean `main`.)
- **Stylelint** — `pnpm exec stylelint 'packages/docs/src/ppt/*.css' --config stylelint.config.mjs`: **0 problems**.
- **i18n parity** — `src/i18n/i18n.test.ts` green; en-US/zh-CN key shapes identical.

## Acceptance (tester matrix)

- `PPT-UI-002`, `PPT-UI-003`, `PPT-UI-004` — preview / editor / present surfaces implemented; browser evidence (present desktop/mobile, keyboard/touch/fullscreen, chart/morph rendering, no rich-doc fallback) is demonstrable once source is enabled.
- Reader/commenter cannot see unpublished live/draft — enforced by backend R3-B1; the frontend never bypasses it (no token, published-version addressing in present, role-gated editor context; a reader/commenter on the editor route requests `published`, never `live`).
- **Deferred origin gate** — the origin-checked bootstrap module keeps its cross-origin-rejection negative control under unit test, guarding the **deferred** separate-origin channel, not a live prod path. The live container has no wired handshake (opaque origin).

## Related

- Ticket: XIN-1495 R3-F1. Architect source-delivery decision: #1619.
- Depends on: backend R3-B1 source (`octo-docs-backend` #161 — not yet merged).
- Follows: R1 (#1235) and R2 (#1251), both merged.

