### PR TITLE
fix(messages): preserve long link text

### DIFF
--- a/packages/dmworkbase/src/Components/ForwardModal/forwardMessageText.ts
+++ b/packages/dmworkbase/src/Components/ForwardModal/forwardMessageText.ts
@@ -42,10 +42,9 @@ export function escapeForwardLinkDestination(link: string): string {
  * #511 problem 1 (option A, boss-approved): the recipient must be able to *see*
  * the true destination URL on the card and click it, not just a title-labelled
  * anchor that hides the URL behind the `href`. So the link label is the real URL
- * (host + path + query), which stays clickable to the same destination and, being
- * a bare-URL link (visible text === href), is middle-ellipsized for compactness by
- * MarkdownContent's `a` renderer while the full URL remains in the href + title
- * tooltip (AC-13b). The bold title is retained on the line above.
+ * (host + path + query), which stays clickable to the same destination and remains
+ * complete in visible text so selecting/copying the rendered message preserves the
+ * full URL. The bold title is retained on the line above.
  *
  * The URL is app-generated (buildDocLink) and carries no Markdown-structural
  * characters, so it is safe to use verbatim as the link label; only the

--- a/packages/dmworkbase/src/Messages/Text/MarkdownContent.tsx
+++ b/packages/dmworkbase/src/Messages/Text/MarkdownContent.tsx
@@ -23,8 +23,6 @@ import { t } from "../../i18n";
 import { getMentionRenderState } from "./mentionRenderState";
 import {
   isForwardDocCard,
-  middleEllipsizeUrl,
-  shouldEllipsizeLinkText,
   type ParagraphChildKind,
 } from "./forwardClamp";
 
@@ -370,22 +368,6 @@ const MarkdownCodeBlock: React.FC<{
 
 const baseComponents: any = {
   a: ({ href, children, ...props }: any) => {
-    // AC-13b (feature #511): middle-ellipsize the DISPLAY text only when it is itself a long bare
-    // URL (visible text === href). A normal `[title](link)` keeps its title untouched; the href is
-    // never modified. `title` tooltip carries the full URL so hover/copy still gets the whole link.
-    const text =
-      typeof children === "string"
-        ? children
-        : Array.isArray(children) && children.length === 1 && typeof children[0] === "string"
-          ? (children[0] as string)
-          : null;
-    if (text != null && shouldEllipsizeLinkText(text, href)) {
-      return (
-        <a href={href} target="_blank" rel="noopener noreferrer" title={text} {...props}>
-          {middleEllipsizeUrl(text)}
-        </a>
-      );
-    }
     return (
       <a href={href} target="_blank" rel="noopener noreferrer" {...props}>
         {children}

--- a/packages/dmworkbase/src/Messages/Text/__tests__/MarkdownContentForwardClamp.test.tsx
+++ b/packages/dmworkbase/src/Messages/Text/__tests__/MarkdownContentForwardClamp.test.tsx
@@ -51,6 +51,8 @@ function renderContent(element: React.ReactElement) {
 
 describe("MarkdownContent — forwarded-doc title clamp gate (B3)", () => {
   const url = "https://octo.example.com/docs?space=demo&doc=d_1";
+  const longUrl =
+    "https://octo.example.com/docs?space=demo&folder=f_default&doc=d_verylongidentifier12345&token=abcdefghijklmnopqrstuvwxyz";
 
   it("clamps a genuine forward card `**title**\\n[title](link)`", () => {
     // remark-breaks turns the single newline into a <br>, so this is strong + break + link with the
@@ -97,5 +99,37 @@ describe("MarkdownContent — forwarded-doc title clamp gate (B3)", () => {
       <MarkdownContent content={`**Heading**\n[open here](${url})`} />
     );
     expect(root.querySelector(".wk-markdown-forward-card")).toBeNull();
+  });
+
+  it("renders a long bare-URL markdown link with complete visible text", () => {
+    const root = renderContent(
+      <MarkdownContent content={`[${longUrl}](${longUrl})`} />
+    );
+    const link = root.querySelector("a");
+    expect(link?.textContent).toBe(longUrl);
+    expect(link?.textContent).not.toContain("…");
+    expect(link?.getAttribute("href")).toBe(longUrl);
+  });
+
+  it("renders a plain-text long URL link with complete visible text", () => {
+    const root = renderContent(
+      <MarkdownContent content={longUrl} enableMarkdown={false} />
+    );
+    const link = root.querySelector("a");
+    expect(link?.textContent).toBe(longUrl);
+    expect(link?.textContent).not.toContain("…");
+    expect(link?.getAttribute("href")).toBe(longUrl);
+  });
+
+  it("keeps forward-card title clamp while showing the full URL label", () => {
+    const root = renderContent(
+      <MarkdownContent content={`**Quarterly plan**\n[${longUrl}](${longUrl})`} />
+    );
+    const card = root.querySelector(".wk-markdown-forward-card");
+    const link = root.querySelector("a");
+    expect(card).not.toBeNull();
+    expect(root.querySelector(".wk-markdown-forward-title")).not.toBeNull();
+    expect(link?.textContent).toBe(longUrl);
+    expect(link?.textContent).not.toContain("…");
   });
 });

--- a/packages/dmworkbase/src/Messages/Text/__tests__/forwardClamp.test.ts
+++ b/packages/dmworkbase/src/Messages/Text/__tests__/forwardClamp.test.ts
@@ -1,46 +1,16 @@
 import { describe, it, expect } from "vitest"
 import {
-  URL_ELLIPSIS_THRESHOLD,
   isUrlLike,
-  middleEllipsizeUrl,
-  shouldEllipsizeLinkText,
   isForwardDocCard,
   type ParagraphChildKind,
 } from "../forwardClamp"
 
-describe("forwardClamp — URL middle-ellipsis (AC-13b, contract 5)", () => {
-  it("leaves text at or below the threshold untouched", () => {
-    const short = "https://octo.example.com/docs?doc=d_1"
-    expect(short.length).toBeLessThanOrEqual(URL_ELLIPSIS_THRESHOLD)
-    expect(middleEllipsizeUrl(short)).toBe(short)
-  })
-
-  it("middle-ellipsizes a long URL as head30…tail20 (href-length preserving semantics)", () => {
-    const long = "https://octo.example.com/docs?space=demo&folder=f_default&doc=d_verylongidentifier12345"
-    expect(long.length).toBeGreaterThan(URL_ELLIPSIS_THRESHOLD)
-    const out = middleEllipsizeUrl(long)
-    expect(out).toBe(`${long.slice(0, 30)}…${long.slice(long.length - 20)}`)
-    expect(out).toContain("…")
-    // The ellipsized text is shorter than the source but keeps the recognizable head + tail.
-    expect(out.startsWith(long.slice(0, 30))).toBe(true)
-    expect(out.endsWith(long.slice(long.length - 20))).toBe(true)
-  })
-
+describe("forwardClamp — URL recognition", () => {
   it("isUrlLike accepts http(s) URLs and rejects plain titles", () => {
     expect(isUrlLike("https://a.com/x")).toBe(true)
     expect(isUrlLike("http://a.com")).toBe(true)
     expect(isUrlLike("Quarterly planning doc")).toBe(false)
     expect(isUrlLike("ftp://a.com")).toBe(false)
-  })
-
-  it("only ellipsizes when the visible text IS the (long) href — a titled link is untouched", () => {
-    const longUrl = "https://octo.example.com/docs?space=demo&folder=f_default&doc=d_verylongidentifier12345"
-    // Bare URL link: text === href → ellipsize.
-    expect(shouldEllipsizeLinkText(longUrl, longUrl)).toBe(true)
-    // Titled link `[title](link)`: visible text is the title, not the URL → never ellipsize.
-    expect(shouldEllipsizeLinkText("My document", longUrl)).toBe(false)
-    // Short bare URL: no ellipsis.
-    expect(shouldEllipsizeLinkText("https://a.com", "https://a.com")).toBe(false)
   })
 })
 

--- a/packages/dmworkbase/src/Messages/Text/forwardClamp.ts
+++ b/packages/dmworkbase/src/Messages/Text/forwardClamp.ts
@@ -1,44 +1,16 @@
-// AC-13b truncation helpers for forwarded doc messages (feature #511 §3.2, contract 5).
+// AC-13b title-clamp helper for forwarded doc messages (feature #511 §3.2, contract 5).
 //
 // A forwarded doc message is a plain Text/Markdown message `**title**\n[title](link)` — there is
 // NO contentType or side-channel to single it out, so any render-layer change must be safe for ALL
-// markdown messages. These two helpers keep that safety:
+// markdown messages. This helper keeps that safety:
 //
-//   1) middleEllipsizeUrl — shortens ONLY link text that is itself a long URL (visible text ===
-//      href). For a normal `[title](link)` the visible text is the title (≠ href) so this is a
-//      no-op; it only ever improves bare-URL / degraded rendering. The href is never touched.
-//   2) title clamp is done in CSS (2 lines + ellipsis); these helpers detect the exact forward
-//      structure (strong + line-break + link) so the clamp class is applied ONLY to that shape,
-//      never to arbitrary bold text (structure heuristic, contract 5 — no字符数 assertion).
-
-/** URL display text longer than this is middle-ellipsized (contract 5: head 30 … tail 20). */
-export const URL_ELLIPSIS_THRESHOLD = 64
-const URL_HEAD = 30
-const URL_TAIL = 20
+//   title clamp is done in CSS (2 lines + ellipsis); this helper detects the exact forward
+//   structure (strong + line-break + link) so the clamp class is applied ONLY to that shape,
+//   never to arbitrary bold text (structure heuristic, contract 5 — no字符数 assertion).
 
 /** Whether a string looks like an http(s) URL (used to decide if link text is a bare URL). */
 export function isUrlLike(text: string): boolean {
   return /^https?:\/\/\S+$/i.test(text.trim())
-}
-
-/**
- * Middle-ellipsize a long URL's DISPLAY text: `head30…tail20`. Leaves anything at or below the
- * threshold untouched. Never applied to the href — only the visible text (contract 5, E-15).
- */
-export function middleEllipsizeUrl(text: string): string {
-  if (text.length <= URL_ELLIPSIS_THRESHOLD) return text
-  return `${text.slice(0, URL_HEAD)}…${text.slice(text.length - URL_TAIL)}`
-}
-
-/**
- * True when a link's visible text is a long bare URL that should be middle-ellipsized (the text
- * equals the href AND it is a long URL). For a `[title](link)` link the text is the title, so this
- * is false and the link renders unchanged.
- */
-export function shouldEllipsizeLinkText(displayText: string, href: string | undefined): boolean {
-  if (!href) return false
-  const text = displayText.trim()
-  return text === href.trim() && isUrlLike(text) && text.length > URL_ELLIPSIS_THRESHOLD
 }
 
 /** Lightweight, framework-agnostic descriptor of a paragraph child (for structure detection/tests). */
@@ -89,4 +61,3 @@ export function isForwardDocCard(children: ParagraphChildKind[]): boolean {
   // differing label (a bare word, prose) is NOT a forward card and stays a plain paragraph.
   return label === title || isUrlLike(label)
 }
-


### PR DESCRIPTION
## Background

Long URL links in rendered message content were being middle-ellipsized when the visible text matched the href. The href stayed intact, but selecting and copying the rendered text copied the shortened display string instead of the full URL.

## Changes

- Preserve full visible text for Markdown and plain-text auto-linked long URLs.
- Keep forwarded document title clamp detection in place while removing the URL display ellipsis helper.
- Update forwarded document link comments to reflect that visible URLs remain complete.
- Add regression coverage for Markdown long URLs, plain-text linked URLs, and forwarded document cards with full URL labels.

## Verification

- `./node_modules/.bin/vitest run packages/dmworkbase/src/Messages/Text/__tests__/forwardClamp.test.ts packages/dmworkbase/src/Messages/Text/__tests__/MarkdownContentForwardClamp.test.tsx packages/dmworkbase/src/Components/ForwardModal/__tests__/forwardMessageText.test.ts` passed: 3 files / 23 tests.
- `git diff --check` passed.
- Manual validation completed on the local online-configured environment before handoff.

## Risks

- Forwarded document card URLs may take more vertical space because the full URL is visible, but existing message wrapping handles long text and this was manually validated.
- This does not change message sending, document share card copy behavior, or input paste handling.
