### PR TITLE
feat: one-time DMWork -> OCTO userData migration with retryable failure modes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,8 @@ jobs:
           src/comments
           src/sheet/SheetCommentPanel.test.ts
           src/board/boardImport.test.ts
+      - name: Electron main-process unit tests
+        run: pnpm --filter @octo/web exec vitest run src-election
       - name: Build
         run: pnpm build
       - name: Verify Excalidraw production bundle

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,8 @@ jobs:
           src/board/boardImport.test.ts
       - name: Electron main-process unit tests
         run: pnpm --filter @octo/web exec vitest run src-election
+      - name: Type-check Electron main-process tests
+        run: pnpm --filter @octo/web exec tsc -p tsconfig.e.tests.json
       - name: Build
         run: pnpm build
       - name: Verify Excalidraw production bundle

--- a/apps/web/src-election/main/__tests__/userDataMigration.test.ts
+++ b/apps/web/src-election/main/__tests__/userDataMigration.test.ts
@@ -60,12 +60,12 @@ describe("planUserDataMigration", () => {
     expect(planUserDataMigration(appDataDir, BRAND).action).toBe("none");
   });
 
-  it("re-migrates a torn publish: marker present but no profile sentinel (P1-2)", () => {
-    makeLegacyProfile(appDataDir);
+  it("re-migrates a torn publish: marker present but no profile sentinel, legacy had data (P1-2/P0-1)", () => {
+    makeLegacyProfile(appDataDir); // has Preferences -> real data to carry
     const newDir = path.join(appDataDir, BRAND);
     fs.mkdirSync(newDir, { recursive: true });
     // Power loss between rename and any data flush: a bare marker with no
-    // real profile files must NOT be trusted.
+    // real profile files must NOT be trusted when the legacy had data.
     fs.writeFileSync(path.join(newDir, MIGRATION_MARKER), "2026-08-06T00:00:00Z");
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
     try {
@@ -75,6 +75,28 @@ describe("planUserDataMigration", () => {
     } finally {
       warnSpy.mockRestore();
     }
+  });
+
+  it("round-trip invariant: a marker-only destination with a data-less legacy counts as migrated (P0-1, no relaunch loop)", () => {
+    // Legacy profile with ONLY regenerable caches (no sentinel): the copy
+    // prunes everything, so re-migrating would loop forever. The marker-only
+    // result must plan "none" on the next launch.
+    const profile = path.join(appDataDir, "DMWork");
+    fs.mkdirSync(path.join(profile, "Cache"), { recursive: true });
+    fs.writeFileSync(path.join(profile, "Cache", "data"), "x");
+
+    const plan = planUserDataMigration(appDataDir, BRAND);
+    expect(plan.action).toBe("migrate");
+
+    // Simulate execute()'s publish: staging -> newDir with only a marker.
+    const newDir = path.join(appDataDir, BRAND);
+    const staging = path.join(appDataDir, `${BRAND}.migrating`);
+    fs.mkdirSync(staging, { recursive: true });
+    fs.writeFileSync(path.join(staging, MIGRATION_MARKER), new Date().toISOString());
+    fs.renameSync(staging, newDir);
+
+    // Next launch: marker present, no sentinel anywhere -> "none", loop broken.
+    expect(planUserDataMigration(appDataDir, BRAND).action).toBe("none");
   });
 
   it("plans none (occupied) when the destination has a real profile without a marker — permanent, loud (P2-1)", () => {
@@ -136,20 +158,37 @@ describe("planUserDataMigration", () => {
     expect(plan.action).toBe("none");
   });
 
-  it("never throws: an unstatable legacy path degrades to none, not an exception (P0-2)", () => {
+  it("plans none when the legacy path does not exist (ENOENT -> none, normal fresh install)", () => {
+    const statSpy = vi.spyOn(fs, "statSync").mockImplementationOnce(() => {
+      const err = new Error("ENOENT: no such file or directory") as NodeJS.ErrnoException;
+      err.code = "ENOENT";
+      throw err;
+    });
+    try {
+      const plan = planUserDataMigration(appDataDir, BRAND);
+      expect(plan.action).toBe("none");
+    } finally {
+      statSpy.mockRestore();
+    }
+  });
+
+  it("plans legacy (not none) when the legacy path cannot be inspected for other reasons (P1-1 round-5)", () => {
     makeLegacyProfile(appDataDir);
     const statSpy = vi.spyOn(fs, "statSync").mockImplementationOnce(() => {
       const err = new Error("EACCES: permission denied") as NodeJS.ErrnoException;
       err.code = "EACCES";
       throw err;
     });
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
     try {
-      // Cannot stat the legacy path -> treated as "no legacy profile":
-      // no exception escapes plan() (the internal guard swallows it).
+      // EACCES must NOT degrade to "none" (which would silently start a fresh
+      // OCTO profile and strand DMWork forever via destination-occupied).
       const plan = planUserDataMigration(appDataDir, BRAND);
-      expect(plan.action).toBe("none");
+      expect(plan.action).toBe("legacy");
+      expect(errorSpy).toHaveBeenCalled();
     } finally {
       statSpy.mockRestore();
+      errorSpy.mockRestore();
     }
   });
 });
@@ -193,8 +232,13 @@ describe("executeUserDataMigration", () => {
     return profile;
   };
 
-  it("(a) migrates atomically, keeps source, writes marker, leaks no Singleton artifacts (F3), prunes top-level caches case-insensitively (P2-3)", () => {
+  it("(a) migrates atomically, keeps source, writes marker, leaks no Singleton artifacts (F3), prunes top-level caches case-insensitively (P2-3), leaves the breadcrumb behind (round-5 P2)", () => {
     makeLegacyProfile();
+    // Migration bookkeeping must stay behind (never copied).
+    fs.writeFileSync(
+      path.join(appDataDir, "DMWork", ".migration-failed.json"),
+      JSON.stringify({ attempts: 2, lastError: "x" })
+    );
     const plan = planUserDataMigration(appDataDir, BRAND);
     expect(plan.action).toBe("migrate");
 
@@ -209,6 +253,8 @@ describe("executeUserDataMigration", () => {
     expect(fs.existsSync(path.join(newDir, "SingletonLock"))).toBe(false);
     expect(fs.existsSync(path.join(newDir, "SingletonCookie"))).toBe(false);
     expect(fs.existsSync(path.join(newDir, "SingletonSocket"))).toBe(false);
+    // Round-5 P2: the breadcrumb is migration bookkeeping, never copied.
+    expect(fs.existsSync(path.join(newDir, ".migration-failed.json"))).toBe(false);
     // Top-level caches skipped, including the lowercase variant.
     expect(fs.existsSync(path.join(newDir, "Cache"))).toBe(false);
     expect(fs.existsSync(path.join(newDir, "cache"))).toBe(false);

--- a/apps/web/src-election/main/__tests__/userDataMigration.test.ts
+++ b/apps/web/src-election/main/__tests__/userDataMigration.test.ts
@@ -6,6 +6,7 @@ import {
   MIGRATION_MARKER,
   STAGING_OWNER_FILE,
   executeUserDataMigration,
+  isLegacyProcessRunningOutput,
   planUserDataMigration,
   type MigrationRuntime,
 } from "../userDataMigration";
@@ -14,6 +15,17 @@ const BRAND = "OCTO";
 // A pid that is guaranteed not to exist on this machine (any process.kill
 // against it must throw ESRCH), for stale-lock fixtures.
 const DEAD_PID = 2_147_483_647;
+
+// isLegacyInstanceRunning branches on process.platform; the test host is
+// Windows, so POSIX-lock fixtures need the platform forced to linux.
+function withPlatform(platform: string, fn: () => void): void {
+  const spy = vi.spyOn(process, "platform", "get").mockReturnValue(platform as NodeJS.Platform);
+  try {
+    fn();
+  } finally {
+    spy.mockRestore();
+  }
+}
 
 describe("planUserDataMigration", () => {
   let appDataDir: string;
@@ -85,12 +97,14 @@ describe("planUserDataMigration", () => {
     const readlinkSpy = vi
       .spyOn(fs, "readlinkSync")
       .mockReturnValue(`${os.hostname()}-${process.pid}`);
-    try {
-      expect(planUserDataMigration(appDataDir, BRAND).action).toBe("defer-legacy");
-    } finally {
-      lstatSpy.mockRestore();
-      readlinkSpy.mockRestore();
-    }
+    withPlatform("linux", () => {
+      try {
+        expect(planUserDataMigration(appDataDir, BRAND).action).toBe("defer-legacy");
+      } finally {
+        lstatSpy.mockRestore();
+        readlinkSpy.mockRestore();
+      }
+    });
   });
 
   it("does NOT defer for a stale lock with a dead pid (F1)", () => {
@@ -101,12 +115,14 @@ describe("planUserDataMigration", () => {
     const readlinkSpy = vi
       .spyOn(fs, "readlinkSync")
       .mockReturnValue(`${os.hostname()}-${DEAD_PID}`);
-    try {
-      expect(planUserDataMigration(appDataDir, BRAND).action).toBe("migrate");
-    } finally {
-      lstatSpy.mockRestore();
-      readlinkSpy.mockRestore();
-    }
+    withPlatform("linux", () => {
+      try {
+        expect(planUserDataMigration(appDataDir, BRAND).action).toBe("migrate");
+      } finally {
+        lstatSpy.mockRestore();
+        readlinkSpy.mockRestore();
+      }
+    });
   });
 
   it("does NOT defer for a lock from a foreign hostname (F1)", () => {
@@ -117,24 +133,58 @@ describe("planUserDataMigration", () => {
     const readlinkSpy = vi
       .spyOn(fs, "readlinkSync")
       .mockReturnValue(`other-host-${process.pid}`);
-    try {
-      expect(planUserDataMigration(appDataDir, BRAND).action).toBe("migrate");
-    } finally {
-      lstatSpy.mockRestore();
-      readlinkSpy.mockRestore();
-    }
+    withPlatform("linux", () => {
+      try {
+        expect(planUserDataMigration(appDataDir, BRAND).action).toBe("migrate");
+      } finally {
+        lstatSpy.mockRestore();
+        readlinkSpy.mockRestore();
+      }
+    });
   });
 
   it("does NOT defer for an unparseable lock file (F1: never trap users on garbage)", () => {
     const profile = makeLegacyProfile(appDataDir);
     fs.writeFileSync(path.join(profile, "SingletonLock"), "not-a-hostname-pid");
-    expect(planUserDataMigration(appDataDir, BRAND).action).toBe("migrate");
+    withPlatform("linux", () => {
+      expect(planUserDataMigration(appDataDir, BRAND).action).toBe("migrate");
+    });
   });
 
   it("defers for a plain-file lock with a live pid (F1 fallback parse)", () => {
     const profile = makeLegacyProfile(appDataDir);
     fs.writeFileSync(path.join(profile, "SingletonLock"), `${os.hostname()}-${process.pid}`);
-    expect(planUserDataMigration(appDataDir, BRAND).action).toBe("defer-legacy");
+    withPlatform("linux", () => {
+      expect(planUserDataMigration(appDataDir, BRAND).action).toBe("defer-legacy");
+    });
+  });
+
+  it("parses tasklist output: running DMWork.exe defers, no match does not (Windows probe)", () => {
+    expect(
+      isLegacyProcessRunningOutput("DMWork.exe                     1234 Console                    1     45,678 K")
+    ).toBe(true);
+    expect(
+      isLegacyProcessRunningOutput("INFO: No tasks are running which match the specified criteria.")
+    ).toBe(false);
+    expect(isLegacyProcessRunningOutput("")).toBe(false);
+  });
+
+  it("defers on Windows when a legacy DMWork process is running (tasklist probe, no SingletonLock file there)", () => {
+    makeLegacyProfile(appDataDir);
+    withPlatform("win32", () => {
+      // The real tasklist on this machine has no DMWork.exe; the probe's
+      // decision logic is covered by isLegacyProcessRunningOutput above.
+      const plan = planUserDataMigration(appDataDir, BRAND);
+      expect(["migrate", "defer-legacy"]).toContain(plan.action);
+    });
+  });
+
+  it("migrates on Windows when no legacy process is running", () => {
+    makeLegacyProfile(appDataDir);
+    withPlatform("win32", () => {
+      // Runs the real tasklist probe: no DMWork.exe on this machine / CI.
+      expect(planUserDataMigration(appDataDir, BRAND).action).toBe("migrate");
+    });
   });
 });
 
@@ -191,6 +241,8 @@ describe("executeUserDataMigration", () => {
     expect(fs.existsSync(path.join(newDir, "SingletonLock"))).toBe(false);
     expect(fs.existsSync(path.join(newDir, "SingletonCookie"))).toBe(false);
     expect(fs.existsSync(path.join(newDir, "SingletonSocket"))).toBe(false);
+    // Migration-internal owner metadata is not published.
+    expect(fs.existsSync(path.join(newDir, STAGING_OWNER_FILE))).toBe(false);
     // Regenerable caches skipped.
     expect(fs.existsSync(path.join(newDir, "Cache"))).toBe(false);
     // No staging residue (owner file included).
@@ -236,12 +288,14 @@ describe("executeUserDataMigration", () => {
       .spyOn(fs, "readlinkSync")
       .mockReturnValue(`${os.hostname()}-${process.pid}`);
     let plan;
-    try {
-      plan = planUserDataMigration(appDataDir, BRAND);
-    } finally {
-      lstatSpy.mockRestore();
-      readlinkSpy.mockRestore();
-    }
+    withPlatform("linux", () => {
+      try {
+        plan = planUserDataMigration(appDataDir, BRAND);
+      } finally {
+        lstatSpy.mockRestore();
+        readlinkSpy.mockRestore();
+      }
+    });
     expect(plan.action).toBe("defer-legacy");
 
     const result = executeUserDataMigration(plan, runtime);
@@ -276,6 +330,39 @@ describe("executeUserDataMigration", () => {
     expect(fs.existsSync(path.join(plan.stagingDir, STAGING_OWNER_FILE))).toBe(true);
     // Nothing copied to the destination.
     expect(fs.existsSync(path.join(appDataDir, BRAND, "Preferences"))).toBe(false);
+  });
+
+  it("claims an ownerless staging dir atomically — no stale misjudgment mid-claim (F2 race)", () => {
+    makeLegacyProfile();
+    const plan = planUserDataMigration(appDataDir, BRAND);
+    // Process A mkdir'd the staging dir but was preempted before writing its
+    // owner file. Process B must NOT treat this as stale (deleting A's live
+    // dir); it claims by writing the owner file exclusively and proceeds.
+    fs.mkdirSync(plan.stagingDir, { recursive: true });
+
+    const result = executeUserDataMigration(plan, runtime);
+
+    expect(result).toBe("done");
+    expect(fs.existsSync(path.join(appDataDir, BRAND, MIGRATION_MARKER))).toBe(true);
+    expect(fs.existsSync(path.join(appDataDir, BRAND, "Preferences"))).toBe(true);
+    expect(fs.existsSync(plan.stagingDir)).toBe(false);
+  });
+
+  it("falls back to the legacy profile when claiming the staging mutex itself fails (e.g. EACCES)", () => {
+    makeLegacyProfile();
+    const plan = planUserDataMigration(appDataDir, BRAND);
+    const mkdirSpy = vi.spyOn(fs, "mkdirSync").mockImplementationOnce(() => {
+      const err = new Error("EACCES: permission denied") as NodeJS.ErrnoException;
+      err.code = "EACCES";
+      throw err;
+    });
+
+    const result = executeUserDataMigration(plan, runtime);
+    mkdirSpy.mockRestore();
+
+    expect(result).toBe("failed");
+    expect(setUserDataDir).toHaveBeenCalledWith(path.join(appDataDir, "DMWork"));
+    expect(fs.existsSync(path.join(appDataDir, BRAND))).toBe(false);
   });
 
   it("claims and retries a stale staging dir whose owner pid is dead (F2)", () => {

--- a/apps/web/src-election/main/__tests__/userDataMigration.test.ts
+++ b/apps/web/src-election/main/__tests__/userDataMigration.test.ts
@@ -4,28 +4,12 @@ import path from "path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   MIGRATION_MARKER,
-  STAGING_OWNER_FILE,
   executeUserDataMigration,
-  isLegacyProcessRunningOutput,
   planUserDataMigration,
   type MigrationRuntime,
 } from "../userDataMigration";
 
 const BRAND = "OCTO";
-// A pid that is guaranteed not to exist on this machine (any process.kill
-// against it must throw ESRCH), for stale-lock fixtures.
-const DEAD_PID = 2_147_483_647;
-
-// isLegacyInstanceRunning branches on process.platform; the test host is
-// Windows, so POSIX-lock fixtures need the platform forced to linux.
-function withPlatform(platform: string, fn: () => void): void {
-  const spy = vi.spyOn(process, "platform", "get").mockReturnValue(platform as NodeJS.Platform);
-  try {
-    fn();
-  } finally {
-    spy.mockRestore();
-  }
-}
 
 describe("planUserDataMigration", () => {
   let appDataDir: string;
@@ -80,124 +64,50 @@ describe("planUserDataMigration", () => {
     const newDir = path.join(appDataDir, BRAND);
     fs.mkdirSync(newDir, { recursive: true });
     fs.writeFileSync(path.join(newDir, "Preferences"), '{"account":"someone-else"}');
-    // First decision: keep both profiles.
-    expect(planUserDataMigration(appDataDir, BRAND).action).toBe("none");
-    // Re-running must NOT flip back to migrate: the decision is idempotent,
-    // no per-launch re-decision loop.
-    expect(planUserDataMigration(appDataDir, BRAND).action).toBe("none");
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    try {
+      expect(planUserDataMigration(appDataDir, BRAND).action).toBe("none");
+      expect(planUserDataMigration(appDataDir, BRAND).action).toBe("none");
+      // The skip is surfaced loudly (P2-1).
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("keeping both profiles"));
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 
-  it("defers when a live legacy SingletonLock symlink exists (F1: POSIX dangling symlink, pid alive)", () => {
+  it("never throws: a plan-time I/O failure degrades to legacy, not an exception (P0-2)", () => {
     makeLegacyProfile(appDataDir);
-    // Chromium's POSIX SingletonLock is a symlink to a non-existent target
-    // "<hostname>-<pid>"; existsSync follows links and would never see it.
-    const lstatSpy = vi
-      .spyOn(fs, "lstatSync")
-      .mockReturnValue({ isSymbolicLink: () => true } as fs.Stats);
-    const readlinkSpy = vi
-      .spyOn(fs, "readlinkSync")
-      .mockReturnValue(`${os.hostname()}-${process.pid}`);
-    withPlatform("linux", () => {
-      try {
-        expect(planUserDataMigration(appDataDir, BRAND).action).toBe("defer-legacy");
-      } finally {
-        lstatSpy.mockRestore();
-        readlinkSpy.mockRestore();
-      }
+    // Make the destination inspection reachable (plan reads <newDir> only
+    // when it exists), then force that read to fail (e.g. unreadable dir).
+    const newDir = path.join(appDataDir, BRAND);
+    fs.mkdirSync(newDir, { recursive: true });
+    const readdirSpy = vi.spyOn(fs, "readdirSync").mockImplementationOnce(() => {
+      const err = new Error("EACCES: permission denied") as NodeJS.ErrnoException;
+      err.code = "EACCES";
+      throw err;
     });
-  });
-
-  it("does NOT defer for a stale lock with a dead pid (F1)", () => {
-    makeLegacyProfile(appDataDir);
-    const lstatSpy = vi
-      .spyOn(fs, "lstatSync")
-      .mockReturnValue({ isSymbolicLink: () => true } as fs.Stats);
-    const readlinkSpy = vi
-      .spyOn(fs, "readlinkSync")
-      .mockReturnValue(`${os.hostname()}-${DEAD_PID}`);
-    withPlatform("linux", () => {
-      try {
-        expect(planUserDataMigration(appDataDir, BRAND).action).toBe("migrate");
-      } finally {
-        lstatSpy.mockRestore();
-        readlinkSpy.mockRestore();
-      }
-    });
-  });
-
-  it("does NOT defer for a lock from a foreign hostname (F1)", () => {
-    makeLegacyProfile(appDataDir);
-    const lstatSpy = vi
-      .spyOn(fs, "lstatSync")
-      .mockReturnValue({ isSymbolicLink: () => true } as fs.Stats);
-    const readlinkSpy = vi
-      .spyOn(fs, "readlinkSync")
-      .mockReturnValue(`other-host-${process.pid}`);
-    withPlatform("linux", () => {
-      try {
-        expect(planUserDataMigration(appDataDir, BRAND).action).toBe("migrate");
-      } finally {
-        lstatSpy.mockRestore();
-        readlinkSpy.mockRestore();
-      }
-    });
-  });
-
-  it("does NOT defer for an unparseable lock file (F1: never trap users on garbage)", () => {
-    const profile = makeLegacyProfile(appDataDir);
-    fs.writeFileSync(path.join(profile, "SingletonLock"), "not-a-hostname-pid");
-    withPlatform("linux", () => {
-      expect(planUserDataMigration(appDataDir, BRAND).action).toBe("migrate");
-    });
-  });
-
-  it("defers for a plain-file lock with a live pid (F1 fallback parse)", () => {
-    const profile = makeLegacyProfile(appDataDir);
-    fs.writeFileSync(path.join(profile, "SingletonLock"), `${os.hostname()}-${process.pid}`);
-    withPlatform("linux", () => {
-      expect(planUserDataMigration(appDataDir, BRAND).action).toBe("defer-legacy");
-    });
-  });
-
-  it("parses tasklist output: running DMWork.exe defers, no match does not (Windows probe)", () => {
-    expect(
-      isLegacyProcessRunningOutput("DMWork.exe                     1234 Console                    1     45,678 K")
-    ).toBe(true);
-    expect(
-      isLegacyProcessRunningOutput("INFO: No tasks are running which match the specified criteria.")
-    ).toBe(false);
-    expect(isLegacyProcessRunningOutput("")).toBe(false);
-  });
-
-  it("defers on Windows when a legacy DMWork process is running (tasklist probe, no SingletonLock file there)", () => {
-    makeLegacyProfile(appDataDir);
-    withPlatform("win32", () => {
-      // The real tasklist on this machine has no DMWork.exe; the probe's
-      // decision logic is covered by isLegacyProcessRunningOutput above.
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    try {
       const plan = planUserDataMigration(appDataDir, BRAND);
-      expect(["migrate", "defer-legacy"]).toContain(plan.action);
-    });
-  });
-
-  it("migrates on Windows when no legacy process is running", () => {
-    makeLegacyProfile(appDataDir);
-    withPlatform("win32", () => {
-      // Runs the real tasklist probe: no DMWork.exe on this machine / CI.
-      expect(planUserDataMigration(appDataDir, BRAND).action).toBe("migrate");
-    });
+      expect(plan.action).toBe("legacy");
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("planUserDataMigration failed"),
+        expect.anything()
+      );
+    } finally {
+      readdirSpy.mockRestore();
+      errorSpy.mockRestore();
+    }
   });
 });
 
 describe("executeUserDataMigration", () => {
   let appDataDir: string;
-  let setUserDataDir: ReturnType<typeof vi.fn<(dir: string) => void>>;
   let runtime: MigrationRuntime;
 
   beforeEach(() => {
     appDataDir = fs.mkdtempSync(path.join(os.tmpdir(), "octo-mig-exec-"));
-    setUserDataDir = vi.fn<(dir: string) => void>();
     runtime = {
-      setUserDataDir,
       log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
     };
   });
@@ -217,13 +127,19 @@ describe("executeUserDataMigration", () => {
     fs.writeFileSync(path.join(profile, "IndexedDB"), "indexed-db-content");
     // A stale legacy instance's singleton artifacts must never leak into the
     // new profile (F3).
-    fs.writeFileSync(path.join(profile, "SingletonLock"), `${os.hostname()}-${DEAD_PID}`);
+    fs.writeFileSync(path.join(profile, "SingletonLock"), "hostname-pid");
     fs.writeFileSync(path.join(profile, "SingletonCookie"), "cookie");
     fs.writeFileSync(path.join(profile, "SingletonSocket"), "socket");
+    // Nested dirs whose names collide with the top-level skip sets must NOT
+    // be pruned (P2-3: the filter is anchored to top-level entries).
+    fs.mkdirSync(path.join(profile, "Partitions", "persist_octo", "Cache"), { recursive: true });
+    fs.writeFileSync(path.join(profile, "Partitions", "persist_octo", "Cache", "nested-cache"), "keep");
+    fs.mkdirSync(path.join(profile, "Sync Data", "Cache"), { recursive: true });
+    fs.writeFileSync(path.join(profile, "Sync Data", "Cache", "keep-me"), "keep");
     return profile;
   };
 
-  it("(a) migrates atomically via staging, keeps the source, writes the marker, leaks no Singleton artifacts (F3)", () => {
+  it("(a) migrates atomically via staging, keeps the source, writes the marker, leaks no Singleton artifacts (F3), prunes only top-level caches (P2-3)", () => {
     makeLegacyProfile();
     const plan = planUserDataMigration(appDataDir, BRAND);
     expect(plan.action).toBe("migrate");
@@ -231,7 +147,6 @@ describe("executeUserDataMigration", () => {
     const result = executeUserDataMigration(plan, runtime);
 
     expect(result).toBe("done");
-    expect(setUserDataDir).not.toHaveBeenCalled();
     const newDir = path.join(appDataDir, BRAND);
     expect(fs.existsSync(path.join(newDir, "Preferences"))).toBe(true);
     expect(fs.readFileSync(path.join(newDir, "Preferences"), "utf8")).toBe('{"account":"user"}');
@@ -241,11 +156,12 @@ describe("executeUserDataMigration", () => {
     expect(fs.existsSync(path.join(newDir, "SingletonLock"))).toBe(false);
     expect(fs.existsSync(path.join(newDir, "SingletonCookie"))).toBe(false);
     expect(fs.existsSync(path.join(newDir, "SingletonSocket"))).toBe(false);
-    // Migration-internal owner metadata is not published.
-    expect(fs.existsSync(path.join(newDir, STAGING_OWNER_FILE))).toBe(false);
-    // Regenerable caches skipped.
+    // Top-level regenerable caches skipped.
     expect(fs.existsSync(path.join(newDir, "Cache"))).toBe(false);
-    // No staging residue (owner file included).
+    // P2-3: nested dirs named like caches are preserved.
+    expect(fs.existsSync(path.join(newDir, "Partitions", "persist_octo", "Cache", "nested-cache"))).toBe(true);
+    expect(fs.existsSync(path.join(newDir, "Sync Data", "Cache", "keep-me"))).toBe(true);
+    // No staging residue.
     expect(fs.existsSync(path.join(appDataDir, `${BRAND}.migrating`))).toBe(false);
     // Source kept (rollback safety / retryability).
     expect(fs.existsSync(path.join(appDataDir, "DMWork", "Preferences"))).toBe(true);
@@ -253,7 +169,7 @@ describe("executeUserDataMigration", () => {
     expect(planUserDataMigration(appDataDir, BRAND).action).toBe("none");
   });
 
-  it("(b) falls back to the legacy profile when the rename fails, then succeeds on retry", () => {
+  it("(b) fails and keeps the legacy profile when the rename fails, then succeeds on retry", () => {
     makeLegacyProfile();
     const plan = planUserDataMigration(appDataDir, BRAND);
 
@@ -267,7 +183,10 @@ describe("executeUserDataMigration", () => {
     renameSpy.mockRestore();
 
     expect(first).toBe("failed");
-    expect(setUserDataDir).toHaveBeenCalledWith(path.join(appDataDir, "DMWork"));
+    expect(runtime.log.error).toHaveBeenCalledWith(
+      expect.stringContaining("migration failed"),
+      expect.anything()
+    );
     expect(fs.existsSync(path.join(appDataDir, `${BRAND}.migrating`))).toBe(false);
     expect(fs.existsSync(path.join(appDataDir, "DMWork", "Preferences"))).toBe(true);
 
@@ -279,144 +198,20 @@ describe("executeUserDataMigration", () => {
     expect(fs.existsSync(path.join(appDataDir, BRAND, "Preferences"))).toBe(true);
   });
 
-  it("(c) defer-legacy is reachable through execute and emits the user-actionable message (F7)", () => {
+  it("clears a stale staging dir from an interrupted previous attempt and retries", () => {
     makeLegacyProfile();
-    const lstatSpy = vi
-      .spyOn(fs, "lstatSync")
-      .mockReturnValue({ isSymbolicLink: () => true } as fs.Stats);
-    const readlinkSpy = vi
-      .spyOn(fs, "readlinkSync")
-      .mockReturnValue(`${os.hostname()}-${process.pid}`);
-    let plan;
-    withPlatform("linux", () => {
-      try {
-        plan = planUserDataMigration(appDataDir, BRAND);
-      } finally {
-        lstatSpy.mockRestore();
-        readlinkSpy.mockRestore();
-      }
-    });
-    expect(plan.action).toBe("defer-legacy");
+    const stale = path.join(appDataDir, `${BRAND}.migrating`);
+    fs.mkdirSync(path.join(stale, "Local Storage", "leveldb"), { recursive: true });
+    fs.writeFileSync(path.join(stale, "Local Storage", "leveldb", "CURRENT"), "partial");
 
-    const result = executeUserDataMigration(plan, runtime);
-
-    expect(result).toBe("deferred");
-    expect(setUserDataDir).toHaveBeenCalledWith(path.join(appDataDir, "DMWork"));
-    expect(runtime.log.warn).toHaveBeenCalledWith(
-      expect.stringContaining("Quit the old app and relaunch to migrate")
-    );
-    // Nothing was copied.
-    expect(fs.existsSync(path.join(appDataDir, BRAND))).toBe(false);
-    expect(fs.existsSync(path.join(appDataDir, `${BRAND}.migrating`))).toBe(false);
-  });
-
-  it("defers when another launch is mid-migration (live staging owner, F2) and leaves its staging alone", () => {
-    makeLegacyProfile();
     const plan = planUserDataMigration(appDataDir, BRAND);
     expect(plan.action).toBe("migrate");
-
-    // Simulate a concurrent launch that claimed the staging mutex first.
-    fs.mkdirSync(plan.stagingDir, { recursive: true });
-    fs.writeFileSync(
-      path.join(plan.stagingDir, STAGING_OWNER_FILE),
-      JSON.stringify({ hostname: os.hostname(), pid: process.pid, startedAt: "x" })
-    );
-
-    const result = executeUserDataMigration(plan, runtime);
-
-    expect(result).toBe("deferred");
-    expect(setUserDataDir).toHaveBeenCalledWith(path.join(appDataDir, "DMWork"));
-    // The concurrent migration's staging dir is untouched.
-    expect(fs.existsSync(path.join(plan.stagingDir, STAGING_OWNER_FILE))).toBe(true);
-    // Nothing copied to the destination.
-    expect(fs.existsSync(path.join(appDataDir, BRAND, "Preferences"))).toBe(false);
-  });
-
-  it("claims an ownerless staging dir atomically — no stale misjudgment mid-claim (F2 race)", () => {
-    makeLegacyProfile();
-    const plan = planUserDataMigration(appDataDir, BRAND);
-    // Process A mkdir'd the staging dir but was preempted before writing its
-    // owner file. Process B must NOT treat this as stale (deleting A's live
-    // dir); it claims by writing the owner file exclusively and proceeds.
-    fs.mkdirSync(plan.stagingDir, { recursive: true });
-
     const result = executeUserDataMigration(plan, runtime);
 
     expect(result).toBe("done");
     expect(fs.existsSync(path.join(appDataDir, BRAND, MIGRATION_MARKER))).toBe(true);
     expect(fs.existsSync(path.join(appDataDir, BRAND, "Preferences"))).toBe(true);
-    expect(fs.existsSync(plan.stagingDir)).toBe(false);
-  });
-
-  it("falls back to the legacy profile when claiming the staging mutex itself fails (e.g. EACCES)", () => {
-    makeLegacyProfile();
-    const plan = planUserDataMigration(appDataDir, BRAND);
-    const mkdirSpy = vi.spyOn(fs, "mkdirSync").mockImplementationOnce(() => {
-      const err = new Error("EACCES: permission denied") as NodeJS.ErrnoException;
-      err.code = "EACCES";
-      throw err;
-    });
-
-    const result = executeUserDataMigration(plan, runtime);
-    mkdirSpy.mockRestore();
-
-    expect(result).toBe("failed");
-    expect(setUserDataDir).toHaveBeenCalledWith(path.join(appDataDir, "DMWork"));
-    expect(fs.existsSync(path.join(appDataDir, BRAND))).toBe(false);
-  });
-
-  it("claims and retries a stale staging dir whose owner pid is dead (F2)", () => {
-    makeLegacyProfile();
-    const plan = planUserDataMigration(appDataDir, BRAND);
-
-    fs.mkdirSync(plan.stagingDir, { recursive: true });
-    fs.writeFileSync(
-      path.join(plan.stagingDir, STAGING_OWNER_FILE),
-      JSON.stringify({ hostname: os.hostname(), pid: DEAD_PID, startedAt: "x" })
-    );
-
-    const result = executeUserDataMigration(plan, runtime);
-
-    expect(result).toBe("done");
-    expect(fs.existsSync(path.join(appDataDir, BRAND, MIGRATION_MARKER))).toBe(true);
-    expect(fs.existsSync(path.join(appDataDir, BRAND, "Preferences"))).toBe(true);
-    expect(fs.existsSync(plan.stagingDir)).toBe(false);
-  });
-
-  it("claims a stale staging dir with no owner file (pre-upgrade crash residue, F2)", () => {
-    makeLegacyProfile();
-    const plan = planUserDataMigration(appDataDir, BRAND);
-
-    fs.mkdirSync(path.join(plan.stagingDir, "Local Storage", "leveldb"), { recursive: true });
-    fs.writeFileSync(path.join(plan.stagingDir, "Local Storage", "leveldb", "CURRENT"), "partial");
-
-    const result = executeUserDataMigration(plan, runtime);
-
-    expect(result).toBe("done");
-    expect(fs.existsSync(path.join(appDataDir, BRAND, MIGRATION_MARKER))).toBe(true);
-    expect(fs.existsSync(path.join(appDataDir, BRAND, "Preferences"))).toBe(true);
-  });
-
-  it("a marker-write failure fails the migration BEFORE the rename publishes anything (F5)", () => {
-    makeLegacyProfile();
-    const plan = planUserDataMigration(appDataDir, BRAND);
-    const originalWriteFileSync = fs.writeFileSync.bind(fs);
-    const writeSpy = vi.spyOn(fs, "writeFileSync").mockImplementation(((p: fs.PathOrFileDescriptor, ...args: unknown[]) => {
-      if (String(p).endsWith(MIGRATION_MARKER)) {
-        throw new Error("ENOSPC: simulated marker write failure");
-      }
-      return (originalWriteFileSync as (p: fs.PathOrFileDescriptor, ...a: unknown[]) => unknown)(p, ...args);
-    }) as never);
-
-    const result = executeUserDataMigration(plan, runtime);
-    writeSpy.mockRestore();
-
-    expect(result).toBe("failed");
-    expect(setUserDataDir).toHaveBeenCalledWith(path.join(appDataDir, "DMWork"));
-    // The rename never ran, so a markerless destination can never exist:
-    // profile+marker publish as one atomic step.
-    expect(fs.existsSync(path.join(appDataDir, BRAND))).toBe(false);
-    expect(fs.existsSync(plan.stagingDir)).toBe(false);
+    expect(fs.existsSync(stale)).toBe(false);
   });
 
   it("clears a destination that contains only lock files before the rename lands", () => {
@@ -437,20 +232,65 @@ describe("executeUserDataMigration", () => {
     expect(fs.existsSync(path.join(newDir, "SingletonLock"))).toBe(false);
   });
 
-  it("does not clobber a destination with non-lock data (plan already returned none, F6)", () => {
+  it("re-asserts the lock-only invariant before deleting the destination (P2-6)", () => {
     makeLegacyProfile();
     const newDir = path.join(appDataDir, BRAND);
     fs.mkdirSync(newDir, { recursive: true });
     fs.writeFileSync(path.join(newDir, "Preferences"), '{"account":"someone-else"}');
 
+    // plan() would return "none" for this state; drive execute() directly to
+    // prove the re-check protects against the plan→execute gap.
     const plan = planUserDataMigration(appDataDir, BRAND);
-    expect(plan.action).toBe("none");
+    plan.action = "migrate";
     const result = executeUserDataMigration(plan, runtime);
 
     expect(result).toBe("done");
+    expect(runtime.log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("gained non-lock data")
+    );
     expect(fs.readFileSync(path.join(newDir, "Preferences"), "utf8")).toBe('{"account":"someone-else"}');
-    expect(fs.existsSync(path.join(appDataDir, "DMWork", "Preferences"))).toBe(true);
     expect(fs.existsSync(path.join(newDir, MIGRATION_MARKER))).toBe(false);
+  });
+
+  it("a marker-write failure fails the migration BEFORE the rename publishes anything (F5)", () => {
+    makeLegacyProfile();
+    const plan = planUserDataMigration(appDataDir, BRAND);
+    const originalWriteFileSync = fs.writeFileSync.bind(fs);
+    const writeSpy = vi.spyOn(fs, "writeFileSync").mockImplementation(((p: fs.PathOrFileDescriptor, ...args: unknown[]) => {
+      if (String(p).endsWith(MIGRATION_MARKER)) {
+        throw new Error("ENOSPC: simulated marker write failure");
+      }
+      return (originalWriteFileSync as (p: fs.PathOrFileDescriptor, ...a: unknown[]) => unknown)(p, ...args);
+    }) as never);
+
+    const result = executeUserDataMigration(plan, runtime);
+    writeSpy.mockRestore();
+
+    expect(result).toBe("failed");
+    expect(runtime.log.error).toHaveBeenCalled();
+    // The rename never ran, so a markerless destination can never exist.
+    expect(fs.existsSync(path.join(appDataDir, BRAND))).toBe(false);
+    expect(fs.existsSync(plan.stagingDir)).toBe(false);
+  });
+
+  it("never throws: an execution-phase I/O failure degrades to failed, not an exception (P0-2)", () => {
+    makeLegacyProfile();
+    const plan = planUserDataMigration(appDataDir, BRAND);
+    const mkdirSpy = vi.spyOn(fs, "mkdirSync").mockImplementationOnce(() => {
+      const err = new Error("EACCES: permission denied") as NodeJS.ErrnoException;
+      err.code = "EACCES";
+      throw err;
+    });
+
+    const result = executeUserDataMigration(plan, runtime);
+    mkdirSpy.mockRestore();
+
+    expect(result).toBe("failed");
+    expect(runtime.log.error).toHaveBeenCalledWith(
+      expect.stringContaining("migration failed"),
+      expect.anything()
+    );
+    expect(fs.existsSync(path.join(appDataDir, BRAND))).toBe(false);
   });
 
   it("no-op for a none plan (no side effects)", () => {
@@ -458,6 +298,15 @@ describe("executeUserDataMigration", () => {
     expect(plan.action).toBe("none");
     const result = executeUserDataMigration(plan, runtime);
     expect(result).toBe("done");
-    expect(setUserDataDir).not.toHaveBeenCalled();
+    expect(runtime.log.info).not.toHaveBeenCalled();
+    expect(fs.existsSync(path.join(appDataDir, BRAND))).toBe(false);
+  });
+
+  it("legacy plan defers (caller already pointed userData at DMWork before the lock)", () => {
+    const plan = planUserDataMigration(appDataDir, BRAND);
+    plan.action = "legacy";
+    const result = executeUserDataMigration(plan, runtime);
+    expect(result).toBe("deferred");
+    expect(runtime.log.warn).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src-election/main/__tests__/userDataMigration.test.ts
+++ b/apps/web/src-election/main/__tests__/userDataMigration.test.ts
@@ -4,12 +4,16 @@ import path from "path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   MIGRATION_MARKER,
+  STAGING_OWNER_FILE,
   executeUserDataMigration,
   planUserDataMigration,
   type MigrationRuntime,
 } from "../userDataMigration";
 
 const BRAND = "OCTO";
+// A pid that is guaranteed not to exist on this machine (any process.kill
+// against it must throw ESRCH), for stale-lock fixtures.
+const DEAD_PID = 2_147_483_647;
 
 describe("planUserDataMigration", () => {
   let appDataDir: string;
@@ -22,7 +26,7 @@ describe("planUserDataMigration", () => {
     fs.rmSync(appDataDir, { recursive: true, force: true });
   });
 
-  const makeLegacyProfile = (dir: string, extra = {}) => {
+  const makeLegacyProfile = (dir: string, extra: Record<string, string> = {}) => {
     const profile = path.join(dir, "DMWork");
     fs.mkdirSync(profile, { recursive: true });
     fs.writeFileSync(path.join(profile, "Preferences"), "{}");
@@ -51,7 +55,6 @@ describe("planUserDataMigration", () => {
 
   it("plans none when migration is already complete (marker exists) — even if <newDir> exists from startup", () => {
     makeLegacyProfile(appDataDir);
-    // Simulate the single-instance lock having created <appData>/OCTO already.
     const newDir = path.join(appDataDir, BRAND);
     fs.mkdirSync(newDir, { recursive: true });
     fs.writeFileSync(path.join(newDir, "SingletonLock"), "");
@@ -60,22 +63,89 @@ describe("planUserDataMigration", () => {
     expect(plan.action).toBe("none");
   });
 
-  it("defers to the legacy profile when a legacy instance holds SingletonLock", () => {
+  it("plans none when the destination already holds real data without a marker, permanently (F6)", () => {
+    makeLegacyProfile(appDataDir);
+    const newDir = path.join(appDataDir, BRAND);
+    fs.mkdirSync(newDir, { recursive: true });
+    fs.writeFileSync(path.join(newDir, "Preferences"), '{"account":"someone-else"}');
+    // First decision: keep both profiles.
+    expect(planUserDataMigration(appDataDir, BRAND).action).toBe("none");
+    // Re-running must NOT flip back to migrate: the decision is idempotent,
+    // no per-launch re-decision loop.
+    expect(planUserDataMigration(appDataDir, BRAND).action).toBe("none");
+  });
+
+  it("defers when a live legacy SingletonLock symlink exists (F1: POSIX dangling symlink, pid alive)", () => {
+    makeLegacyProfile(appDataDir);
+    // Chromium's POSIX SingletonLock is a symlink to a non-existent target
+    // "<hostname>-<pid>"; existsSync follows links and would never see it.
+    const lstatSpy = vi
+      .spyOn(fs, "lstatSync")
+      .mockReturnValue({ isSymbolicLink: () => true } as fs.Stats);
+    const readlinkSpy = vi
+      .spyOn(fs, "readlinkSync")
+      .mockReturnValue(`${os.hostname()}-${process.pid}`);
+    try {
+      expect(planUserDataMigration(appDataDir, BRAND).action).toBe("defer-legacy");
+    } finally {
+      lstatSpy.mockRestore();
+      readlinkSpy.mockRestore();
+    }
+  });
+
+  it("does NOT defer for a stale lock with a dead pid (F1)", () => {
+    makeLegacyProfile(appDataDir);
+    const lstatSpy = vi
+      .spyOn(fs, "lstatSync")
+      .mockReturnValue({ isSymbolicLink: () => true } as fs.Stats);
+    const readlinkSpy = vi
+      .spyOn(fs, "readlinkSync")
+      .mockReturnValue(`${os.hostname()}-${DEAD_PID}`);
+    try {
+      expect(planUserDataMigration(appDataDir, BRAND).action).toBe("migrate");
+    } finally {
+      lstatSpy.mockRestore();
+      readlinkSpy.mockRestore();
+    }
+  });
+
+  it("does NOT defer for a lock from a foreign hostname (F1)", () => {
+    makeLegacyProfile(appDataDir);
+    const lstatSpy = vi
+      .spyOn(fs, "lstatSync")
+      .mockReturnValue({ isSymbolicLink: () => true } as fs.Stats);
+    const readlinkSpy = vi
+      .spyOn(fs, "readlinkSync")
+      .mockReturnValue(`other-host-${process.pid}`);
+    try {
+      expect(planUserDataMigration(appDataDir, BRAND).action).toBe("migrate");
+    } finally {
+      lstatSpy.mockRestore();
+      readlinkSpy.mockRestore();
+    }
+  });
+
+  it("does NOT defer for an unparseable lock file (F1: never trap users on garbage)", () => {
     const profile = makeLegacyProfile(appDataDir);
-    fs.writeFileSync(path.join(profile, "SingletonLock"), "hostname-pid");
-    const plan = planUserDataMigration(appDataDir, BRAND);
-    expect(plan.action).toBe("defer-legacy");
+    fs.writeFileSync(path.join(profile, "SingletonLock"), "not-a-hostname-pid");
+    expect(planUserDataMigration(appDataDir, BRAND).action).toBe("migrate");
+  });
+
+  it("defers for a plain-file lock with a live pid (F1 fallback parse)", () => {
+    const profile = makeLegacyProfile(appDataDir);
+    fs.writeFileSync(path.join(profile, "SingletonLock"), `${os.hostname()}-${process.pid}`);
+    expect(planUserDataMigration(appDataDir, BRAND).action).toBe("defer-legacy");
   });
 });
 
 describe("executeUserDataMigration", () => {
   let appDataDir: string;
-  let setUserDataDir: ReturnType<typeof vi.fn>;
+  let setUserDataDir: ReturnType<typeof vi.fn<(dir: string) => void>>;
   let runtime: MigrationRuntime;
 
   beforeEach(() => {
     appDataDir = fs.mkdtempSync(path.join(os.tmpdir(), "octo-mig-exec-"));
-    setUserDataDir = vi.fn();
+    setUserDataDir = vi.fn<(dir: string) => void>();
     runtime = {
       setUserDataDir,
       log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
@@ -86,7 +156,7 @@ describe("executeUserDataMigration", () => {
     fs.rmSync(appDataDir, { recursive: true, force: true });
   });
 
-  const makeLegacyProfile = (withLock = false) => {
+  const makeLegacyProfile = () => {
     const profile = path.join(appDataDir, "DMWork");
     fs.mkdirSync(profile, { recursive: true });
     fs.writeFileSync(path.join(profile, "Preferences"), '{"account":"user"}');
@@ -95,13 +165,15 @@ describe("executeUserDataMigration", () => {
     fs.mkdirSync(path.join(profile, "Cache"), { recursive: true });
     fs.writeFileSync(path.join(profile, "Cache", "data_0"), "cache-bytes");
     fs.writeFileSync(path.join(profile, "IndexedDB"), "indexed-db-content");
-    if (withLock) {
-      fs.writeFileSync(path.join(profile, "SingletonLock"), "hostname-pid");
-    }
+    // A stale legacy instance's singleton artifacts must never leak into the
+    // new profile (F3).
+    fs.writeFileSync(path.join(profile, "SingletonLock"), `${os.hostname()}-${DEAD_PID}`);
+    fs.writeFileSync(path.join(profile, "SingletonCookie"), "cookie");
+    fs.writeFileSync(path.join(profile, "SingletonSocket"), "socket");
     return profile;
   };
 
-  it("(a) migrates a populated legacy profile atomically via staging, keeps the source, writes the marker", () => {
+  it("(a) migrates atomically via staging, keeps the source, writes the marker, leaks no Singleton artifacts (F3)", () => {
     makeLegacyProfile();
     const plan = planUserDataMigration(appDataDir, BRAND);
     expect(plan.action).toBe("migrate");
@@ -110,15 +182,18 @@ describe("executeUserDataMigration", () => {
 
     expect(result).toBe("done");
     expect(setUserDataDir).not.toHaveBeenCalled();
-    // New profile complete, marker present.
     const newDir = path.join(appDataDir, BRAND);
     expect(fs.existsSync(path.join(newDir, "Preferences"))).toBe(true);
     expect(fs.readFileSync(path.join(newDir, "Preferences"), "utf8")).toBe('{"account":"user"}');
     expect(fs.existsSync(path.join(newDir, "Local Storage", "leveldb", "CURRENT"))).toBe(true);
     expect(fs.existsSync(path.join(newDir, MIGRATION_MARKER))).toBe(true);
+    // F3: singleton artifacts are not copied.
+    expect(fs.existsSync(path.join(newDir, "SingletonLock"))).toBe(false);
+    expect(fs.existsSync(path.join(newDir, "SingletonCookie"))).toBe(false);
+    expect(fs.existsSync(path.join(newDir, "SingletonSocket"))).toBe(false);
     // Regenerable caches skipped.
     expect(fs.existsSync(path.join(newDir, "Cache"))).toBe(false);
-    // No staging residue.
+    // No staging residue (owner file included).
     expect(fs.existsSync(path.join(appDataDir, `${BRAND}.migrating`))).toBe(false);
     // Source kept (rollback safety / retryability).
     expect(fs.existsSync(path.join(appDataDir, "DMWork", "Preferences"))).toBe(true);
@@ -140,14 +215,10 @@ describe("executeUserDataMigration", () => {
     renameSpy.mockRestore();
 
     expect(first).toBe("failed");
-    // This session keeps the user on their data.
     expect(setUserDataDir).toHaveBeenCalledWith(path.join(appDataDir, "DMWork"));
-    // Staging cleaned up so the next launch retries from scratch.
     expect(fs.existsSync(path.join(appDataDir, `${BRAND}.migrating`))).toBe(false);
-    // Legacy profile untouched.
     expect(fs.existsSync(path.join(appDataDir, "DMWork", "Preferences"))).toBe(true);
 
-    // Next launch: still no marker -> the migration retries and now succeeds.
     const secondPlan = planUserDataMigration(appDataDir, BRAND);
     expect(secondPlan.action).toBe("migrate");
     const second = executeUserDataMigration(secondPlan, runtime);
@@ -156,29 +227,81 @@ describe("executeUserDataMigration", () => {
     expect(fs.existsSync(path.join(appDataDir, BRAND, "Preferences"))).toBe(true);
   });
 
-  it("(c) defers to the legacy profile when the legacy SingletonLock is held and copies nothing", () => {
-    makeLegacyProfile(true);
-    const plan = planUserDataMigration(appDataDir, BRAND);
+  it("(c) defer-legacy is reachable through execute and emits the user-actionable message (F7)", () => {
+    makeLegacyProfile();
+    const lstatSpy = vi
+      .spyOn(fs, "lstatSync")
+      .mockReturnValue({ isSymbolicLink: () => true } as fs.Stats);
+    const readlinkSpy = vi
+      .spyOn(fs, "readlinkSync")
+      .mockReturnValue(`${os.hostname()}-${process.pid}`);
+    let plan;
+    try {
+      plan = planUserDataMigration(appDataDir, BRAND);
+    } finally {
+      lstatSpy.mockRestore();
+      readlinkSpy.mockRestore();
+    }
     expect(plan.action).toBe("defer-legacy");
 
     const result = executeUserDataMigration(plan, runtime);
 
     expect(result).toBe("deferred");
     expect(setUserDataDir).toHaveBeenCalledWith(path.join(appDataDir, "DMWork"));
+    expect(runtime.log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("Quit the old app and relaunch to migrate")
+    );
     // Nothing was copied.
     expect(fs.existsSync(path.join(appDataDir, BRAND))).toBe(false);
     expect(fs.existsSync(path.join(appDataDir, `${BRAND}.migrating`))).toBe(false);
   });
 
-  it("cleans up a stale staging dir from an interrupted previous attempt and retries", () => {
+  it("defers when another launch is mid-migration (live staging owner, F2) and leaves its staging alone", () => {
     makeLegacyProfile();
-    // Simulate a crash mid-copy: partial staging dir left behind.
-    const stale = path.join(appDataDir, `${BRAND}.migrating`);
-    fs.mkdirSync(path.join(stale, "Local Storage", "leveldb"), { recursive: true });
-    fs.writeFileSync(path.join(stale, "Local Storage", "leveldb", "CURRENT"), "partial");
-
     const plan = planUserDataMigration(appDataDir, BRAND);
     expect(plan.action).toBe("migrate");
+
+    // Simulate a concurrent launch that claimed the staging mutex first.
+    fs.mkdirSync(plan.stagingDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(plan.stagingDir, STAGING_OWNER_FILE),
+      JSON.stringify({ hostname: os.hostname(), pid: process.pid, startedAt: "x" })
+    );
+
+    const result = executeUserDataMigration(plan, runtime);
+
+    expect(result).toBe("deferred");
+    expect(setUserDataDir).toHaveBeenCalledWith(path.join(appDataDir, "DMWork"));
+    // The concurrent migration's staging dir is untouched.
+    expect(fs.existsSync(path.join(plan.stagingDir, STAGING_OWNER_FILE))).toBe(true);
+    // Nothing copied to the destination.
+    expect(fs.existsSync(path.join(appDataDir, BRAND, "Preferences"))).toBe(false);
+  });
+
+  it("claims and retries a stale staging dir whose owner pid is dead (F2)", () => {
+    makeLegacyProfile();
+    const plan = planUserDataMigration(appDataDir, BRAND);
+
+    fs.mkdirSync(plan.stagingDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(plan.stagingDir, STAGING_OWNER_FILE),
+      JSON.stringify({ hostname: os.hostname(), pid: DEAD_PID, startedAt: "x" })
+    );
+
+    const result = executeUserDataMigration(plan, runtime);
+
+    expect(result).toBe("done");
+    expect(fs.existsSync(path.join(appDataDir, BRAND, MIGRATION_MARKER))).toBe(true);
+    expect(fs.existsSync(path.join(appDataDir, BRAND, "Preferences"))).toBe(true);
+    expect(fs.existsSync(plan.stagingDir)).toBe(false);
+  });
+
+  it("claims a stale staging dir with no owner file (pre-upgrade crash residue, F2)", () => {
+    makeLegacyProfile();
+    const plan = planUserDataMigration(appDataDir, BRAND);
+
+    fs.mkdirSync(path.join(plan.stagingDir, "Local Storage", "leveldb"), { recursive: true });
+    fs.writeFileSync(path.join(plan.stagingDir, "Local Storage", "leveldb", "CURRENT"), "partial");
 
     const result = executeUserDataMigration(plan, runtime);
 
@@ -187,9 +310,30 @@ describe("executeUserDataMigration", () => {
     expect(fs.existsSync(path.join(appDataDir, BRAND, "Preferences"))).toBe(true);
   });
 
-  it("removes only Electron lock files from <newDir> before the rename lands", () => {
+  it("a marker-write failure fails the migration BEFORE the rename publishes anything (F5)", () => {
     makeLegacyProfile();
-    // requestSingleInstanceLock() ran first: <appData>/OCTO exists with lock files.
+    const plan = planUserDataMigration(appDataDir, BRAND);
+    const originalWriteFileSync = fs.writeFileSync.bind(fs);
+    const writeSpy = vi.spyOn(fs, "writeFileSync").mockImplementation(((p: fs.PathOrFileDescriptor, ...args: unknown[]) => {
+      if (String(p).endsWith(MIGRATION_MARKER)) {
+        throw new Error("ENOSPC: simulated marker write failure");
+      }
+      return (originalWriteFileSync as (p: fs.PathOrFileDescriptor, ...a: unknown[]) => unknown)(p, ...args);
+    }) as never);
+
+    const result = executeUserDataMigration(plan, runtime);
+    writeSpy.mockRestore();
+
+    expect(result).toBe("failed");
+    expect(setUserDataDir).toHaveBeenCalledWith(path.join(appDataDir, "DMWork"));
+    // The rename never ran, so a markerless destination can never exist:
+    // profile+marker publish as one atomic step.
+    expect(fs.existsSync(path.join(appDataDir, BRAND))).toBe(false);
+    expect(fs.existsSync(plan.stagingDir)).toBe(false);
+  });
+
+  it("clears a destination that contains only lock files before the rename lands", () => {
+    makeLegacyProfile();
     const newDir = path.join(appDataDir, BRAND);
     fs.mkdirSync(newDir, { recursive: true });
     fs.writeFileSync(path.join(newDir, "SingletonLock"), "");
@@ -197,26 +341,36 @@ describe("executeUserDataMigration", () => {
     fs.writeFileSync(path.join(newDir, "SingletonSocket"), "");
 
     const plan = planUserDataMigration(appDataDir, BRAND);
+    expect(plan.action).toBe("migrate");
     const result = executeUserDataMigration(plan, runtime);
 
     expect(result).toBe("done");
     expect(fs.existsSync(path.join(newDir, "Preferences"))).toBe(true);
     expect(fs.existsSync(path.join(newDir, MIGRATION_MARKER))).toBe(true);
+    expect(fs.existsSync(path.join(newDir, "SingletonLock"))).toBe(false);
   });
 
-  it("does not clobber <newDir> when it contains non-lock data and no marker (both profiles kept)", () => {
+  it("does not clobber a destination with non-lock data (plan already returned none, F6)", () => {
     makeLegacyProfile();
     const newDir = path.join(appDataDir, BRAND);
     fs.mkdirSync(newDir, { recursive: true });
     fs.writeFileSync(path.join(newDir, "Preferences"), '{"account":"someone-else"}');
 
     const plan = planUserDataMigration(appDataDir, BRAND);
+    expect(plan.action).toBe("none");
     const result = executeUserDataMigration(plan, runtime);
 
     expect(result).toBe("done");
-    // The pre-existing data is untouched, and the legacy profile was not consumed.
     expect(fs.readFileSync(path.join(newDir, "Preferences"), "utf8")).toBe('{"account":"someone-else"}');
     expect(fs.existsSync(path.join(appDataDir, "DMWork", "Preferences"))).toBe(true);
     expect(fs.existsSync(path.join(newDir, MIGRATION_MARKER))).toBe(false);
+  });
+
+  it("no-op for a none plan (no side effects)", () => {
+    const plan = planUserDataMigration(appDataDir, BRAND);
+    expect(plan.action).toBe("none");
+    const result = executeUserDataMigration(plan, runtime);
+    expect(result).toBe("done");
+    expect(setUserDataDir).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src-election/main/__tests__/userDataMigration.test.ts
+++ b/apps/web/src-election/main/__tests__/userDataMigration.test.ts
@@ -141,25 +141,31 @@ describe("planUserDataMigration", () => {
     }
   });
 
-  it("round-trip invariant: a marker-only destination with a data-less legacy counts as migrated (P0-1, no relaunch loop)", () => {
-    // Legacy profile with ONLY regenerable caches (no sentinel): the copy
-    // prunes everything, so re-migrating would loop forever. The marker-only
-    // result must plan "none" on the next launch.
+  it("round-trip invariant: a legacy with nothing copyable plans none — no useless marker-only migrate+relaunch (P0-1 / round-8 nit)", () => {
+    // Legacy profile with ONLY regenerable caches: the copy would prune
+    // everything, so migrating would publish nothing and loop forever. The
+    // short-circuit (same hasCopyableData rule as the marker branch) plans
+    // "none" directly, and a marker-only destination from a previous version
+    // still plans "none" on the next launch (marker branch).
     const profile = path.join(appDataDir, "DMWork");
     fs.mkdirSync(path.join(profile, "Cache"), { recursive: true });
     fs.writeFileSync(path.join(profile, "Cache", "data"), "x");
 
     const plan = planUserDataMigration(appDataDir, BRAND);
-    expect(plan.action).toBe("migrate");
+    expect(plan.action).toBe("none");
 
-    // Simulate execute()'s publish: staging -> newDir with only a marker.
+    // Legacy marker-only publish (e.g. produced by an older build): still none.
     const newDir = path.join(appDataDir, BRAND);
     const staging = path.join(appDataDir, `${BRAND}.migrating`);
     fs.mkdirSync(staging, { recursive: true });
     fs.writeFileSync(path.join(staging, MIGRATION_MARKER), new Date().toISOString());
     fs.renameSync(staging, newDir);
 
-    // Next launch: marker present, no residual data anywhere -> "none", loop broken.
+    expect(planUserDataMigration(appDataDir, BRAND).action).toBe("none");
+  });
+
+  it("an EMPTY legacy dir plans none (round-8 nit: nothing to copy)", () => {
+    fs.mkdirSync(path.join(appDataDir, "DMWork"), { recursive: true });
     expect(planUserDataMigration(appDataDir, BRAND).action).toBe("none");
   });
 
@@ -204,6 +210,7 @@ describe("planUserDataMigration", () => {
     fs.writeFileSync(path.join(newDir, ".DS_Store"), "x");
     fs.writeFileSync(path.join(newDir, "Thumbs.db"), "x");
     fs.writeFileSync(path.join(newDir, "desktop.ini"), "x");
+    fs.writeFileSync(path.join(newDir, ".localized"), "x");
     const plan = planUserDataMigration(appDataDir, BRAND);
     expect(plan.action).toBe("migrate");
   });

--- a/apps/web/src-election/main/__tests__/userDataMigration.test.ts
+++ b/apps/web/src-election/main/__tests__/userDataMigration.test.ts
@@ -8,6 +8,8 @@ import {
   MIGRATION_MARKER,
   executeUserDataMigration,
   planUserDataMigration,
+  recordMigrationNotice,
+  shouldShowMigrationNotice,
   type MigrationRuntime,
 } from "../userDataMigration";
 
@@ -51,7 +53,7 @@ describe("planUserDataMigration", () => {
     expect(plan.action).toBe("none");
   });
 
-  it("plans none when migration is complete (marker + profile sentinel present)", () => {
+  it("plans none when migration is complete (marker + residual data present)", () => {
     makeLegacyProfile(appDataDir);
     const newDir = path.join(appDataDir, BRAND);
     fs.mkdirSync(newDir, { recursive: true });
@@ -60,21 +62,33 @@ describe("planUserDataMigration", () => {
     expect(planUserDataMigration(appDataDir, BRAND).action).toBe("none");
   });
 
-  it("re-migrates a torn publish: marker present but no profile sentinel, legacy had data (P1-2/P0-1)", () => {
+  it("re-migrates a torn publish: marker present over an EMPTY destination, legacy had data (P0-1)", () => {
     makeLegacyProfile(appDataDir); // has Preferences -> real data to carry
     const newDir = path.join(appDataDir, BRAND);
     fs.mkdirSync(newDir, { recursive: true });
     // Power loss between rename and any data flush: a bare marker with no
-    // real profile files must NOT be trusted when the legacy had data.
+    // residual data must NOT be trusted when the legacy had data.
     fs.writeFileSync(path.join(newDir, MIGRATION_MARKER), "2026-08-06T00:00:00Z");
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
     try {
       const plan = planUserDataMigration(appDataDir, BRAND);
       expect(plan.action).toBe("migrate");
-      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("no profile sentinel"));
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("torn publish"));
     } finally {
       warnSpy.mockRestore();
     }
+  });
+
+  it("trusts a marker whose destination lost Preferences but kept residual data (round-6 P1-1 scenario A)", () => {
+    // The user deleted OCTO/Preferences to reset UI state. The profile still
+    // holds Local Storage — re-migrating over it would destroy every byte
+    // written since the migration. The marker + residual data must win.
+    makeLegacyProfile(appDataDir); // legacy still has its sentinel
+    const newDir = path.join(appDataDir, BRAND);
+    fs.mkdirSync(path.join(newDir, "Local Storage", "leveldb"), { recursive: true });
+    fs.writeFileSync(path.join(newDir, "Local Storage", "leveldb", "CURRENT"), "MANIFEST-000001");
+    fs.writeFileSync(path.join(newDir, MIGRATION_MARKER), "2026-08-06T00:00:00Z");
+    expect(planUserDataMigration(appDataDir, BRAND).action).toBe("none");
   });
 
   it("round-trip invariant: a marker-only destination with a data-less legacy counts as migrated (P0-1, no relaunch loop)", () => {
@@ -95,11 +109,11 @@ describe("planUserDataMigration", () => {
     fs.writeFileSync(path.join(staging, MIGRATION_MARKER), new Date().toISOString());
     fs.renameSync(staging, newDir);
 
-    // Next launch: marker present, no sentinel anywhere -> "none", loop broken.
+    // Next launch: marker present, no residual data anywhere -> "none", loop broken.
     expect(planUserDataMigration(appDataDir, BRAND).action).toBe("none");
   });
 
-  it("plans none (occupied) when the destination has a real profile without a marker — permanent, loud (P2-1)", () => {
+  it("plans legacy (occupied) when the destination has a real profile without a marker — permanent, loud (round-6 P1-2)", () => {
     makeLegacyProfile(appDataDir);
     const newDir = path.join(appDataDir, BRAND);
     fs.mkdirSync(newDir, { recursive: true });
@@ -107,21 +121,37 @@ describe("planUserDataMigration", () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
     try {
       const plan = planUserDataMigration(appDataDir, BRAND);
-      expect(plan.action).toBe("none");
+      // Stay on the established legacy profile; index.ts dialogs about both dirs.
+      expect(plan.action).toBe("legacy");
       expect(plan.reason).toBe("destination-occupied");
-      expect(planUserDataMigration(appDataDir, BRAND).action).toBe("none");
+      expect(planUserDataMigration(appDataDir, BRAND).action).toBe("legacy");
       expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("keeping both profiles"));
     } finally {
       warnSpy.mockRestore();
     }
   });
 
-  it("a destination with only lock/crash files does NOT block migration (P2-1 polarity)", () => {
+  it("plans legacy (occupied) for a live profile inside Chromium's ~10 s sentinel blind spot (round-6 P1-1)", () => {
+    // Measured on a real Electron 26 binary: Local Storage appears ~120 ms
+    // after launch, Preferences only ~10 s later, Local State not at all on
+    // some platforms. A sentinel-only probe would classify this as deletable.
+    makeLegacyProfile(appDataDir);
+    const newDir = path.join(appDataDir, BRAND);
+    fs.mkdirSync(path.join(newDir, "Local Storage", "leveldb"), { recursive: true });
+    fs.writeFileSync(path.join(newDir, "Local Storage", "leveldb", "CURRENT"), "MANIFEST-000001");
+    const plan = planUserDataMigration(appDataDir, BRAND);
+    expect(plan.action).toBe("legacy");
+    expect(plan.reason).toBe("destination-occupied");
+  });
+
+  it("a destination with only lock/crash files does NOT block migration (allowlist polarity)", () => {
     makeLegacyProfile(appDataDir);
     const newDir = path.join(appDataDir, BRAND);
     fs.mkdirSync(newDir, { recursive: true });
     fs.writeFileSync(path.join(newDir, "SingletonLock"), "");
     fs.mkdirSync(path.join(newDir, "Crashpad"), { recursive: true });
+    fs.writeFileSync(path.join(newDir, "Dictionaries"), "dict");
+    fs.writeFileSync(path.join(newDir, "Network Persistent State"), "{}");
     const plan = planUserDataMigration(appDataDir, BRAND);
     expect(plan.action).toBe("migrate");
   });
@@ -303,6 +333,39 @@ describe("executeUserDataMigration", () => {
     expect(fs.existsSync(path.join(appDataDir, "DMWork", MIGRATION_BREADCRUMB))).toBe(false);
   });
 
+  it("falls back to the appData breadcrumb when the legacy dir is unwritable, and plan() reads it (round-6 P2-1)", () => {
+    makeLegacyProfile();
+    const plan = planUserDataMigration(appDataDir, BRAND);
+
+    const renameSpy = vi.spyOn(fs, "renameSync").mockImplementationOnce(() => {
+      throw new Error("EPERM: simulated rename failure");
+    });
+    const originalWriteFileSync = fs.writeFileSync.bind(fs);
+    const writeSpy = vi.spyOn(fs, "writeFileSync").mockImplementation(((p: fs.PathOrFileDescriptor, ...args: unknown[]) => {
+      const target = String(p);
+      if (target.endsWith(MIGRATION_BREADCRUMB) && target.includes(`${path.sep}DMWork${path.sep}`)) {
+        throw new Error("EACCES: read-only legacy dir");
+      }
+      return (originalWriteFileSync as (p: fs.PathOrFileDescriptor, ...a: unknown[]) => unknown)(p, ...args);
+    }) as never);
+
+    const result = executeUserDataMigration(plan, runtime);
+    renameSpy.mockRestore();
+    writeSpy.mockRestore();
+
+    expect(result).toBe("failed");
+    // The retry bound must survive an unwritable legacy dir.
+    expect(fs.existsSync(path.join(appDataDir, "DMWork", MIGRATION_BREADCRUMB))).toBe(false);
+    const fallback = JSON.parse(fs.readFileSync(path.join(appDataDir, MIGRATION_BREADCRUMB), "utf8"));
+    expect(fallback.attempts).toBe(1);
+    // plan() reads the fallback location when bounding retries.
+    fs.writeFileSync(
+      path.join(appDataDir, MIGRATION_BREADCRUMB),
+      JSON.stringify({ attempts: MAX_MIGRATION_ATTEMPTS, lastError: "EACCES" })
+    );
+    expect(planUserDataMigration(appDataDir, BRAND).reason).toBe("too-many-failures");
+  });
+
   it("clears a stale staging dir from an interrupted attempt and retries", () => {
     makeLegacyProfile();
     const stale = path.join(appDataDir, `${BRAND}.migrating`);
@@ -333,7 +396,7 @@ describe("executeUserDataMigration", () => {
     expect(fs.existsSync(path.join(newDir, "SingletonLock"))).toBe(false);
   });
 
-  it("returns skipped (not done) when the destination gained a real profile since planning (P2-2/P2-6)", () => {
+  it("returns skipped (not done) when the destination gained a real profile since planning", () => {
     makeLegacyProfile();
     const newDir = path.join(appDataDir, BRAND);
     fs.mkdirSync(newDir, { recursive: true });
@@ -346,10 +409,29 @@ describe("executeUserDataMigration", () => {
 
     expect(result).toBe("skipped");
     expect(runtime.log.warn).toHaveBeenCalledWith(
-      expect.stringContaining("gained a real profile")
+      expect.stringContaining("unexpected entries")
     );
     expect(fs.readFileSync(path.join(newDir, "Preferences"), "utf8")).toBe('{"account":"someone-else"}');
     expect(fs.existsSync(path.join(newDir, MIGRATION_MARKER))).toBe(false);
+  });
+
+  it("never deletes a destination that has data but no sentinel (round-6 P1-1 allowlist)", () => {
+    // The fixture that fails under a sentinel denylist: Local Storage present,
+    // Preferences absent (live profile inside Chromium's ~10 s blind spot, or
+    // a first-run crash). execute() must refuse the delete.
+    makeLegacyProfile();
+    const newDir = path.join(appDataDir, BRAND);
+    fs.mkdirSync(path.join(newDir, "Local Storage", "leveldb"), { recursive: true });
+    fs.writeFileSync(path.join(newDir, "Local Storage", "leveldb", "CURRENT"), "MANIFEST-000001");
+
+    const plan = planUserDataMigration(appDataDir, BRAND);
+    plan.action = "migrate"; // force the execute-side re-check path
+    const result = executeUserDataMigration(plan, runtime);
+
+    expect(result).toBe("skipped");
+    expect(fs.existsSync(path.join(newDir, "Local Storage", "leveldb", "CURRENT"))).toBe(true);
+    expect(fs.existsSync(path.join(newDir, MIGRATION_MARKER))).toBe(false);
+    expect(fs.existsSync(path.join(appDataDir, "DMWork", "Preferences"))).toBe(true);
   });
 
   it("a marker-write failure fails the migration BEFORE the rename publishes anything (F5)", () => {
@@ -392,5 +474,27 @@ describe("executeUserDataMigration", () => {
     expect(plan.action).toBe("none");
     expect(executeUserDataMigration(plan, runtime)).toBe("done");
     expect(fs.existsSync(path.join(appDataDir, BRAND))).toBe(false);
+  });
+});
+
+describe("migration notices", () => {
+  let appDataDir: string;
+
+  beforeEach(() => {
+    appDataDir = fs.mkdtempSync(path.join(os.tmpdir(), "octo-mig-notice-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(appDataDir, { recursive: true, force: true });
+  });
+
+  it("one-shot per key: a recorded notice suppresses only its own key (round-6 P2)", () => {
+    expect(shouldShowMigrationNotice(appDataDir, "retry-exhausted")).toBe(true);
+    recordMigrationNotice(appDataDir, "retry-exhausted");
+    expect(shouldShowMigrationNotice(appDataDir, "retry-exhausted")).toBe(false);
+    expect(shouldShowMigrationNotice(appDataDir, "destination-occupied")).toBe(true);
+    // Recording is idempotent.
+    recordMigrationNotice(appDataDir, "retry-exhausted");
+    expect(shouldShowMigrationNotice(appDataDir, "retry-exhausted")).toBe(false);
   });
 });

--- a/apps/web/src-election/main/__tests__/userDataMigration.test.ts
+++ b/apps/web/src-election/main/__tests__/userDataMigration.test.ts
@@ -8,8 +8,10 @@ import {
   MIGRATION_MARKER,
   MIGRATION_NOTICES,
   actualBreadcrumbFile,
+  cleanupStaleStaging,
   decideLockLostAction,
   executeUserDataMigration,
+  isCopyableSource,
   planUserDataMigration,
   recordMigrationNotice,
   shouldShowMigrationNotice,
@@ -124,6 +126,7 @@ describe("planUserDataMigration", () => {
   it("keeps the legacy profile when the marker destination cannot be inspected (round-8 P2-3 tri-state)", () => {
     // Fail-closed: an unreadable destination is neither "complete" (none) nor
     // safely re-migratable — never start a session on an unverified OCTO dir.
+    // Round-10 P2-6: the plan carries a distinct reason for the right dialog.
     makeLegacyProfile(appDataDir);
     const newDir = path.join(appDataDir, BRAND);
     fs.mkdirSync(newDir, { recursive: true });
@@ -136,6 +139,7 @@ describe("planUserDataMigration", () => {
     try {
       const plan = planUserDataMigration(appDataDir, BRAND);
       expect(plan.action).toBe("legacy");
+      expect(plan.reason).toBe("destination-unreadable");
     } finally {
       readdirSpy.mockRestore();
     }
@@ -166,6 +170,69 @@ describe("planUserDataMigration", () => {
 
   it("an EMPTY legacy dir plans none (round-8 nit: nothing to copy)", () => {
     fs.mkdirSync(path.join(appDataDir, "DMWork"), { recursive: true });
+    expect(planUserDataMigration(appDataDir, BRAND).action).toBe("none");
+  });
+
+  // Round-10 P0-1: the boot-loop regression. Each of these top-level names is
+  // "noise" — never copied, and cleanable at the destination. A legacy holding
+  // ONLY such entries must plan "none"; previously .DS_Store etc. planned
+  // "migrate" (hasCopyableData used a smaller prune set than the allowlist),
+  // published a marker-only destination, and re-planned "migrate" forever
+  // (relaunch loop, reproduced by the round-10 review harness).
+  const NOISE_ONLY_ENTRIES: Array<[string, string]> = [
+    [".DS_Store", "x"],
+    ["Thumbs.db", "x"],
+    ["desktop.ini", "x"],
+    [".localized", "x"],
+    ["Network Persistent State", "{}"],
+    ["Dictionaries", "x"],
+    ["Cache", "x"],
+    ["Crashpad", "x"],
+    ["SingletonLock", "x"],
+    ["SingletonCookie", "x"],
+    ["SingletonSocket", "x"],
+    ["LockFile", "x"],
+    ["Service Worker", "x"],
+    [MIGRATION_BREADCRUMB, "{}"],
+  ];
+  it.each(NOISE_ONLY_ENTRIES)(
+    "round-trip: a legacy holding only %s plans none — no boot loop (round-10 P0-1)",
+    (name, content) => {
+      const profile = path.join(appDataDir, "DMWork");
+      fs.mkdirSync(path.join(profile, name), { recursive: true });
+      fs.writeFileSync(path.join(profile, name, "data"), content);
+      const plan = planUserDataMigration(appDataDir, BRAND);
+      expect(plan.action).toBe("none");
+    }
+  );
+
+  it("mixed noise-only legacy (Cache + .DS_Store + Crashpad) plans none (round-10 P0-1)", () => {
+    const profile = path.join(appDataDir, "DMWork");
+    for (const name of ["Cache", ".DS_Store", "Crashpad"]) {
+      fs.mkdirSync(path.join(profile, name), { recursive: true });
+      fs.writeFileSync(path.join(profile, name, "data"), "x");
+    }
+    expect(planUserDataMigration(appDataDir, BRAND).action).toBe("none");
+  });
+
+  it("a real profile beside noise still migrates, and the noise is NOT published (round-10 P0-1)", () => {
+    makeLegacyProfile(appDataDir);
+    const profile = path.join(appDataDir, "DMWork");
+    fs.writeFileSync(path.join(profile, ".DS_Store"), "x");
+    fs.writeFileSync(path.join(profile, "Dictionaries"), "dict");
+
+    const plan = planUserDataMigration(appDataDir, BRAND);
+    expect(plan.action).toBe("migrate");
+
+    const result = executeUserDataMigration(plan, {
+      log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    });
+    expect(result).toBe("done");
+    const newDir = path.join(appDataDir, BRAND);
+    expect(fs.existsSync(path.join(newDir, ".DS_Store"))).toBe(false);
+    expect(fs.existsSync(path.join(newDir, "Dictionaries"))).toBe(false);
+    expect(fs.existsSync(path.join(newDir, "Preferences"))).toBe(true);
+    // Round-trip: next launch plans none (Preferences is residual data).
     expect(planUserDataMigration(appDataDir, BRAND).action).toBe("none");
   });
 
@@ -262,6 +329,24 @@ describe("planUserDataMigration", () => {
       JSON.stringify({ attempts: MAX_MIGRATION_ATTEMPTS - 1, lastError: "ENOSPC" })
     );
     expect(planUserDataMigration(appDataDir, BRAND).action).toBe("migrate");
+  });
+
+  it("retry bound reads the MAX of primary and fallback — a stale readable primary cannot shadow the newer fallback (round-10 P1-1)", () => {
+    // Primary became readable-but-unwritable after the breadcrumb was written
+    // there; the fallback holds the real (newer) count. Old logic (primary ??
+    // fallback) would read 1 and keep retrying past the bound.
+    const profile = makeLegacyProfile(appDataDir);
+    fs.writeFileSync(
+      path.join(profile, MIGRATION_BREADCRUMB),
+      JSON.stringify({ attempts: 1, lastError: "stale" })
+    );
+    fs.writeFileSync(
+      path.join(appDataDir, MIGRATION_BREADCRUMB),
+      JSON.stringify({ attempts: MAX_MIGRATION_ATTEMPTS, lastError: "EACCES" })
+    );
+    const plan = planUserDataMigration(appDataDir, BRAND);
+    expect(plan.action).toBe("legacy");
+    expect(plan.reason).toBe("too-many-failures");
   });
 
   it("plans none when the legacy path is a regular file, not a directory (P2-6)", () => {
@@ -413,6 +498,39 @@ describe("executeUserDataMigration", () => {
     expect(fs.existsSync(path.join(appDataDir, BRAND, "Preferences"))).toBe(true);
     // Success clears the breadcrumb.
     expect(fs.existsSync(path.join(appDataDir, "DMWork", MIGRATION_BREADCRUMB))).toBe(false);
+  });
+
+  it("records the attempt BEFORE the copy starts — ENOSPC-class failures still count toward the retry bound (round-10 P1-1)", () => {
+    makeLegacyProfile();
+    const plan = planUserDataMigration(appDataDir, BRAND);
+    expect(plan.action).toBe("migrate");
+
+    const order: string[] = [];
+    const originalWriteFileSync = fs.writeFileSync.bind(fs);
+    const writeSpy = vi.spyOn(fs, "writeFileSync").mockImplementation(((p: fs.PathOrFileDescriptor, ...args: unknown[]) => {
+      if (String(p).endsWith(MIGRATION_BREADCRUMB)) order.push("breadcrumb");
+      return (originalWriteFileSync as (p: fs.PathOrFileDescriptor, ...a: unknown[]) => unknown)(p, ...args);
+    }) as never);
+    const cpSpy = vi.spyOn(fs, "cpSync").mockImplementation(((..._args: unknown[]) => {
+      order.push("cpSync");
+      const err = new Error("ENOSPC: no space left on device") as NodeJS.ErrnoException;
+      err.code = "ENOSPC";
+      throw err;
+    }) as never);
+
+    const result = executeUserDataMigration(plan, runtime);
+    writeSpy.mockRestore();
+    cpSpy.mockRestore();
+
+    expect(result).toBe("failed");
+    // The attempt counter was bumped before the copy that then failed on a
+    // full volume — the retry bound works for the failure mode it exists for.
+    expect(order.indexOf("breadcrumb")).toBeLessThan(order.indexOf("cpSync"));
+    const breadcrumb = JSON.parse(
+      fs.readFileSync(path.join(appDataDir, "DMWork", MIGRATION_BREADCRUMB), "utf8")
+    );
+    expect(breadcrumb.attempts).toBe(1);
+    expect(breadcrumb.lastError).toContain("ENOSPC");
   });
 
   it("falls back to the appData breadcrumb when the legacy dir is unwritable, and plan() reads it (round-6 P2-1)", () => {
@@ -668,5 +786,60 @@ describe("actualBreadcrumbFile", () => {
     expect(actualBreadcrumbFile(path.join(appDataDir, "DMWork"))).toBe(
       path.join(appDataDir, "DMWork", MIGRATION_BREADCRUMB)
     );
+  });
+});
+
+describe("cleanupStaleStaging", () => {
+  let appDataDir: string;
+
+  beforeEach(() => {
+    appDataDir = fs.mkdtempSync(path.join(os.tmpdir(), "octo-mig-stage-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(appDataDir, { recursive: true, force: true });
+  });
+
+  it("removes a leftover staging dir holding copied credentials (round-10 P2-1)", () => {
+    const staging = path.join(appDataDir, `${BRAND}.migrating`);
+    fs.mkdirSync(path.join(staging, "Cookies"), { recursive: true });
+    fs.writeFileSync(path.join(staging, "Cookies", "data"), "creds");
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    try {
+      cleanupStaleStaging(staging);
+      expect(fs.existsSync(staging)).toBe(false);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("is a no-op when no staging dir exists", () => {
+    cleanupStaleStaging(path.join(appDataDir, `${BRAND}.migrating`));
+    expect(fs.existsSync(path.join(appDataDir, `${BRAND}.migrating`))).toBe(false);
+  });
+});
+
+describe("isCopyableSource", () => {
+  const stat = (o: { fifo?: boolean; socket?: boolean }) => ({
+    isFIFO: () => !!o.fifo,
+    isSocket: () => !!o.socket,
+  });
+
+  it("prunes top-level noise (round-10 P0-1)", () => {
+    expect(isCopyableSource(".DS_Store", stat({}))).toBe(false);
+    expect(isCopyableSource("Cache", stat({}))).toBe(false);
+    expect(isCopyableSource("SingletonLock", stat({}))).toBe(false);
+    expect(isCopyableSource("Preferences", stat({}))).toBe(true);
+    expect(isCopyableSource("IndexedDB", stat({}))).toBe(true);
+  });
+
+  it("keeps nested entries even when their name matches noise (round-4 P2-3)", () => {
+    expect(isCopyableSource(path.join("Partitions", "persist", "Cache"), stat({}))).toBe(true);
+  });
+
+  it("skips FIFOs and sockets at any depth (round-10 P2-3)", () => {
+    expect(isCopyableSource("fifo", stat({ fifo: true }))).toBe(false);
+    expect(isCopyableSource(path.join("a", "b", "sock"), stat({ socket: true }))).toBe(false);
+    expect(isCopyableSource(path.join("a", "b", "file"), stat({}))).toBe(true);
   });
 });

--- a/apps/web/src-election/main/__tests__/userDataMigration.test.ts
+++ b/apps/web/src-election/main/__tests__/userDataMigration.test.ts
@@ -1,0 +1,222 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  MIGRATION_MARKER,
+  executeUserDataMigration,
+  planUserDataMigration,
+  type MigrationRuntime,
+} from "../userDataMigration";
+
+const BRAND = "OCTO";
+
+describe("planUserDataMigration", () => {
+  let appDataDir: string;
+
+  beforeEach(() => {
+    appDataDir = fs.mkdtempSync(path.join(os.tmpdir(), "octo-mig-test-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(appDataDir, { recursive: true, force: true });
+  });
+
+  const makeLegacyProfile = (dir: string, extra = {}) => {
+    const profile = path.join(dir, "DMWork");
+    fs.mkdirSync(profile, { recursive: true });
+    fs.writeFileSync(path.join(profile, "Preferences"), "{}");
+    fs.writeFileSync(path.join(profile, "Local State"), "{}");
+    fs.mkdirSync(path.join(profile, "Local Storage", "leveldb"), { recursive: true });
+    fs.writeFileSync(path.join(profile, "Local Storage", "leveldb", "CURRENT"), "MANIFEST-000001");
+    for (const [name, content] of Object.entries(extra)) {
+      fs.writeFileSync(path.join(profile, name), content);
+    }
+    return profile;
+  };
+
+  it("plans migration when a legacy profile exists and no marker is present", () => {
+    makeLegacyProfile(appDataDir);
+    const plan = planUserDataMigration(appDataDir, BRAND);
+    expect(plan.action).toBe("migrate");
+    expect(plan.oldDir).toBe(path.join(appDataDir, "DMWork"));
+    expect(plan.newDir).toBe(path.join(appDataDir, BRAND));
+    expect(plan.stagingDir).toBe(path.join(appDataDir, `${BRAND}.migrating`));
+  });
+
+  it("plans none when there is no legacy profile", () => {
+    const plan = planUserDataMigration(appDataDir, BRAND);
+    expect(plan.action).toBe("none");
+  });
+
+  it("plans none when migration is already complete (marker exists) — even if <newDir> exists from startup", () => {
+    makeLegacyProfile(appDataDir);
+    // Simulate the single-instance lock having created <appData>/OCTO already.
+    const newDir = path.join(appDataDir, BRAND);
+    fs.mkdirSync(newDir, { recursive: true });
+    fs.writeFileSync(path.join(newDir, "SingletonLock"), "");
+    fs.writeFileSync(path.join(newDir, MIGRATION_MARKER), "2026-08-06T00:00:00Z");
+    const plan = planUserDataMigration(appDataDir, BRAND);
+    expect(plan.action).toBe("none");
+  });
+
+  it("defers to the legacy profile when a legacy instance holds SingletonLock", () => {
+    const profile = makeLegacyProfile(appDataDir);
+    fs.writeFileSync(path.join(profile, "SingletonLock"), "hostname-pid");
+    const plan = planUserDataMigration(appDataDir, BRAND);
+    expect(plan.action).toBe("defer-legacy");
+  });
+});
+
+describe("executeUserDataMigration", () => {
+  let appDataDir: string;
+  let setUserDataDir: ReturnType<typeof vi.fn>;
+  let runtime: MigrationRuntime;
+
+  beforeEach(() => {
+    appDataDir = fs.mkdtempSync(path.join(os.tmpdir(), "octo-mig-exec-"));
+    setUserDataDir = vi.fn();
+    runtime = {
+      setUserDataDir,
+      log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    };
+  });
+
+  afterEach(() => {
+    fs.rmSync(appDataDir, { recursive: true, force: true });
+  });
+
+  const makeLegacyProfile = (withLock = false) => {
+    const profile = path.join(appDataDir, "DMWork");
+    fs.mkdirSync(profile, { recursive: true });
+    fs.writeFileSync(path.join(profile, "Preferences"), '{"account":"user"}');
+    fs.mkdirSync(path.join(profile, "Local Storage", "leveldb"), { recursive: true });
+    fs.writeFileSync(path.join(profile, "Local Storage", "leveldb", "CURRENT"), "MANIFEST-000001");
+    fs.mkdirSync(path.join(profile, "Cache"), { recursive: true });
+    fs.writeFileSync(path.join(profile, "Cache", "data_0"), "cache-bytes");
+    fs.writeFileSync(path.join(profile, "IndexedDB"), "indexed-db-content");
+    if (withLock) {
+      fs.writeFileSync(path.join(profile, "SingletonLock"), "hostname-pid");
+    }
+    return profile;
+  };
+
+  it("(a) migrates a populated legacy profile atomically via staging, keeps the source, writes the marker", () => {
+    makeLegacyProfile();
+    const plan = planUserDataMigration(appDataDir, BRAND);
+    expect(plan.action).toBe("migrate");
+
+    const result = executeUserDataMigration(plan, runtime);
+
+    expect(result).toBe("done");
+    expect(setUserDataDir).not.toHaveBeenCalled();
+    // New profile complete, marker present.
+    const newDir = path.join(appDataDir, BRAND);
+    expect(fs.existsSync(path.join(newDir, "Preferences"))).toBe(true);
+    expect(fs.readFileSync(path.join(newDir, "Preferences"), "utf8")).toBe('{"account":"user"}');
+    expect(fs.existsSync(path.join(newDir, "Local Storage", "leveldb", "CURRENT"))).toBe(true);
+    expect(fs.existsSync(path.join(newDir, MIGRATION_MARKER))).toBe(true);
+    // Regenerable caches skipped.
+    expect(fs.existsSync(path.join(newDir, "Cache"))).toBe(false);
+    // No staging residue.
+    expect(fs.existsSync(path.join(appDataDir, `${BRAND}.migrating`))).toBe(false);
+    // Source kept (rollback safety / retryability).
+    expect(fs.existsSync(path.join(appDataDir, "DMWork", "Preferences"))).toBe(true);
+    // Second launch: marker present -> no-op.
+    expect(planUserDataMigration(appDataDir, BRAND).action).toBe("none");
+  });
+
+  it("(b) falls back to the legacy profile when the rename fails, then succeeds on retry", () => {
+    makeLegacyProfile();
+    const plan = planUserDataMigration(appDataDir, BRAND);
+
+    const renameSpy = vi
+      .spyOn(fs, "renameSync")
+      .mockImplementationOnce(() => {
+        throw new Error("EPERM: operation not permitted (Windows EBUSY equivalent)");
+      });
+
+    const first = executeUserDataMigration(plan, runtime);
+    renameSpy.mockRestore();
+
+    expect(first).toBe("failed");
+    // This session keeps the user on their data.
+    expect(setUserDataDir).toHaveBeenCalledWith(path.join(appDataDir, "DMWork"));
+    // Staging cleaned up so the next launch retries from scratch.
+    expect(fs.existsSync(path.join(appDataDir, `${BRAND}.migrating`))).toBe(false);
+    // Legacy profile untouched.
+    expect(fs.existsSync(path.join(appDataDir, "DMWork", "Preferences"))).toBe(true);
+
+    // Next launch: still no marker -> the migration retries and now succeeds.
+    const secondPlan = planUserDataMigration(appDataDir, BRAND);
+    expect(secondPlan.action).toBe("migrate");
+    const second = executeUserDataMigration(secondPlan, runtime);
+    expect(second).toBe("done");
+    expect(fs.existsSync(path.join(appDataDir, BRAND, MIGRATION_MARKER))).toBe(true);
+    expect(fs.existsSync(path.join(appDataDir, BRAND, "Preferences"))).toBe(true);
+  });
+
+  it("(c) defers to the legacy profile when the legacy SingletonLock is held and copies nothing", () => {
+    makeLegacyProfile(true);
+    const plan = planUserDataMigration(appDataDir, BRAND);
+    expect(plan.action).toBe("defer-legacy");
+
+    const result = executeUserDataMigration(plan, runtime);
+
+    expect(result).toBe("deferred");
+    expect(setUserDataDir).toHaveBeenCalledWith(path.join(appDataDir, "DMWork"));
+    // Nothing was copied.
+    expect(fs.existsSync(path.join(appDataDir, BRAND))).toBe(false);
+    expect(fs.existsSync(path.join(appDataDir, `${BRAND}.migrating`))).toBe(false);
+  });
+
+  it("cleans up a stale staging dir from an interrupted previous attempt and retries", () => {
+    makeLegacyProfile();
+    // Simulate a crash mid-copy: partial staging dir left behind.
+    const stale = path.join(appDataDir, `${BRAND}.migrating`);
+    fs.mkdirSync(path.join(stale, "Local Storage", "leveldb"), { recursive: true });
+    fs.writeFileSync(path.join(stale, "Local Storage", "leveldb", "CURRENT"), "partial");
+
+    const plan = planUserDataMigration(appDataDir, BRAND);
+    expect(plan.action).toBe("migrate");
+
+    const result = executeUserDataMigration(plan, runtime);
+
+    expect(result).toBe("done");
+    expect(fs.existsSync(path.join(appDataDir, BRAND, MIGRATION_MARKER))).toBe(true);
+    expect(fs.existsSync(path.join(appDataDir, BRAND, "Preferences"))).toBe(true);
+  });
+
+  it("removes only Electron lock files from <newDir> before the rename lands", () => {
+    makeLegacyProfile();
+    // requestSingleInstanceLock() ran first: <appData>/OCTO exists with lock files.
+    const newDir = path.join(appDataDir, BRAND);
+    fs.mkdirSync(newDir, { recursive: true });
+    fs.writeFileSync(path.join(newDir, "SingletonLock"), "");
+    fs.writeFileSync(path.join(newDir, "SingletonCookie"), "");
+    fs.writeFileSync(path.join(newDir, "SingletonSocket"), "");
+
+    const plan = planUserDataMigration(appDataDir, BRAND);
+    const result = executeUserDataMigration(plan, runtime);
+
+    expect(result).toBe("done");
+    expect(fs.existsSync(path.join(newDir, "Preferences"))).toBe(true);
+    expect(fs.existsSync(path.join(newDir, MIGRATION_MARKER))).toBe(true);
+  });
+
+  it("does not clobber <newDir> when it contains non-lock data and no marker (both profiles kept)", () => {
+    makeLegacyProfile();
+    const newDir = path.join(appDataDir, BRAND);
+    fs.mkdirSync(newDir, { recursive: true });
+    fs.writeFileSync(path.join(newDir, "Preferences"), '{"account":"someone-else"}');
+
+    const plan = planUserDataMigration(appDataDir, BRAND);
+    const result = executeUserDataMigration(plan, runtime);
+
+    expect(result).toBe("done");
+    // The pre-existing data is untouched, and the legacy profile was not consumed.
+    expect(fs.readFileSync(path.join(newDir, "Preferences"), "utf8")).toBe('{"account":"someone-else"}');
+    expect(fs.existsSync(path.join(appDataDir, "DMWork", "Preferences"))).toBe(true);
+    expect(fs.existsSync(path.join(newDir, MIGRATION_MARKER))).toBe(false);
+  });
+});

--- a/apps/web/src-election/main/__tests__/userDataMigration.test.ts
+++ b/apps/web/src-election/main/__tests__/userDataMigration.test.ts
@@ -3,6 +3,8 @@ import os from "os";
 import path from "path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  MAX_MIGRATION_ATTEMPTS,
+  MIGRATION_BREADCRUMB,
   MIGRATION_MARKER,
   executeUserDataMigration,
   planUserDataMigration,
@@ -49,54 +51,105 @@ describe("planUserDataMigration", () => {
     expect(plan.action).toBe("none");
   });
 
-  it("plans none when migration is already complete (marker exists) — even if <newDir> exists from startup", () => {
+  it("plans none when migration is complete (marker + profile sentinel present)", () => {
     makeLegacyProfile(appDataDir);
     const newDir = path.join(appDataDir, BRAND);
     fs.mkdirSync(newDir, { recursive: true });
-    fs.writeFileSync(path.join(newDir, "SingletonLock"), "");
+    fs.writeFileSync(path.join(newDir, "Preferences"), "{}");
     fs.writeFileSync(path.join(newDir, MIGRATION_MARKER), "2026-08-06T00:00:00Z");
-    const plan = planUserDataMigration(appDataDir, BRAND);
-    expect(plan.action).toBe("none");
+    expect(planUserDataMigration(appDataDir, BRAND).action).toBe("none");
   });
 
-  it("plans none when the destination already holds real data without a marker, permanently (F6)", () => {
+  it("re-migrates a torn publish: marker present but no profile sentinel (P1-2)", () => {
+    makeLegacyProfile(appDataDir);
+    const newDir = path.join(appDataDir, BRAND);
+    fs.mkdirSync(newDir, { recursive: true });
+    // Power loss between rename and any data flush: a bare marker with no
+    // real profile files must NOT be trusted.
+    fs.writeFileSync(path.join(newDir, MIGRATION_MARKER), "2026-08-06T00:00:00Z");
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    try {
+      const plan = planUserDataMigration(appDataDir, BRAND);
+      expect(plan.action).toBe("migrate");
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("no profile sentinel"));
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("plans none (occupied) when the destination has a real profile without a marker — permanent, loud (P2-1)", () => {
     makeLegacyProfile(appDataDir);
     const newDir = path.join(appDataDir, BRAND);
     fs.mkdirSync(newDir, { recursive: true });
     fs.writeFileSync(path.join(newDir, "Preferences"), '{"account":"someone-else"}');
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
     try {
+      const plan = planUserDataMigration(appDataDir, BRAND);
+      expect(plan.action).toBe("none");
+      expect(plan.reason).toBe("destination-occupied");
       expect(planUserDataMigration(appDataDir, BRAND).action).toBe("none");
-      expect(planUserDataMigration(appDataDir, BRAND).action).toBe("none");
-      // The skip is surfaced loudly (P2-1).
       expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("keeping both profiles"));
     } finally {
       warnSpy.mockRestore();
     }
   });
 
-  it("never throws: a plan-time I/O failure degrades to legacy, not an exception (P0-2)", () => {
+  it("a destination with only lock/crash files does NOT block migration (P2-1 polarity)", () => {
     makeLegacyProfile(appDataDir);
-    // Make the destination inspection reachable (plan reads <newDir> only
-    // when it exists), then force that read to fail (e.g. unreadable dir).
     const newDir = path.join(appDataDir, BRAND);
     fs.mkdirSync(newDir, { recursive: true });
-    const readdirSpy = vi.spyOn(fs, "readdirSync").mockImplementationOnce(() => {
+    fs.writeFileSync(path.join(newDir, "SingletonLock"), "");
+    fs.mkdirSync(path.join(newDir, "Crashpad"), { recursive: true });
+    const plan = planUserDataMigration(appDataDir, BRAND);
+    expect(plan.action).toBe("migrate");
+  });
+
+  it("plans legacy (too-many-failures) when the breadcrumb budget is exhausted (P1-1)", () => {
+    const profile = makeLegacyProfile(appDataDir);
+    fs.writeFileSync(
+      path.join(profile, MIGRATION_BREADCRUMB),
+      JSON.stringify({ attempts: MAX_MIGRATION_ATTEMPTS, lastError: "ENOSPC", lastAttemptAt: "x" })
+    );
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    try {
+      const plan = planUserDataMigration(appDataDir, BRAND);
+      expect(plan.action).toBe("legacy");
+      expect(plan.reason).toBe("too-many-failures");
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("disabling auto-retry"));
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("migrates while the breadcrumb budget is not exhausted", () => {
+    const profile = makeLegacyProfile(appDataDir);
+    fs.writeFileSync(
+      path.join(profile, MIGRATION_BREADCRUMB),
+      JSON.stringify({ attempts: MAX_MIGRATION_ATTEMPTS - 1, lastError: "ENOSPC" })
+    );
+    expect(planUserDataMigration(appDataDir, BRAND).action).toBe("migrate");
+  });
+
+  it("plans none when the legacy path is a regular file, not a directory (P2-6)", () => {
+    fs.writeFileSync(path.join(appDataDir, "DMWork"), "not-a-directory");
+    const plan = planUserDataMigration(appDataDir, BRAND);
+    expect(plan.action).toBe("none");
+  });
+
+  it("never throws: an unstatable legacy path degrades to none, not an exception (P0-2)", () => {
+    makeLegacyProfile(appDataDir);
+    const statSpy = vi.spyOn(fs, "statSync").mockImplementationOnce(() => {
       const err = new Error("EACCES: permission denied") as NodeJS.ErrnoException;
       err.code = "EACCES";
       throw err;
     });
-    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
     try {
+      // Cannot stat the legacy path -> treated as "no legacy profile":
+      // no exception escapes plan() (the internal guard swallows it).
       const plan = planUserDataMigration(appDataDir, BRAND);
-      expect(plan.action).toBe("legacy");
-      expect(errorSpy).toHaveBeenCalledWith(
-        expect.stringContaining("planUserDataMigration failed"),
-        expect.anything()
-      );
+      expect(plan.action).toBe("none");
     } finally {
-      readdirSpy.mockRestore();
-      errorSpy.mockRestore();
+      statSpy.mockRestore();
     }
   });
 });
@@ -124,9 +177,10 @@ describe("executeUserDataMigration", () => {
     fs.writeFileSync(path.join(profile, "Local Storage", "leveldb", "CURRENT"), "MANIFEST-000001");
     fs.mkdirSync(path.join(profile, "Cache"), { recursive: true });
     fs.writeFileSync(path.join(profile, "Cache", "data_0"), "cache-bytes");
+    fs.mkdirSync(path.join(profile, "cache"), { recursive: true }); // case variant
+    fs.writeFileSync(path.join(profile, "cache", "lower"), "cache-lower");
     fs.writeFileSync(path.join(profile, "IndexedDB"), "indexed-db-content");
-    // A stale legacy instance's singleton artifacts must never leak into the
-    // new profile (F3).
+    // A stale legacy instance's singleton artifacts must never leak (F3).
     fs.writeFileSync(path.join(profile, "SingletonLock"), "hostname-pid");
     fs.writeFileSync(path.join(profile, "SingletonCookie"), "cookie");
     fs.writeFileSync(path.join(profile, "SingletonSocket"), "socket");
@@ -139,7 +193,7 @@ describe("executeUserDataMigration", () => {
     return profile;
   };
 
-  it("(a) migrates atomically via staging, keeps the source, writes the marker, leaks no Singleton artifacts (F3), prunes only top-level caches (P2-3)", () => {
+  it("(a) migrates atomically, keeps source, writes marker, leaks no Singleton artifacts (F3), prunes top-level caches case-insensitively (P2-3)", () => {
     makeLegacyProfile();
     const plan = planUserDataMigration(appDataDir, BRAND);
     expect(plan.action).toBe("migrate");
@@ -152,24 +206,21 @@ describe("executeUserDataMigration", () => {
     expect(fs.readFileSync(path.join(newDir, "Preferences"), "utf8")).toBe('{"account":"user"}');
     expect(fs.existsSync(path.join(newDir, "Local Storage", "leveldb", "CURRENT"))).toBe(true);
     expect(fs.existsSync(path.join(newDir, MIGRATION_MARKER))).toBe(true);
-    // F3: singleton artifacts are not copied.
     expect(fs.existsSync(path.join(newDir, "SingletonLock"))).toBe(false);
     expect(fs.existsSync(path.join(newDir, "SingletonCookie"))).toBe(false);
     expect(fs.existsSync(path.join(newDir, "SingletonSocket"))).toBe(false);
-    // Top-level regenerable caches skipped.
+    // Top-level caches skipped, including the lowercase variant.
     expect(fs.existsSync(path.join(newDir, "Cache"))).toBe(false);
+    expect(fs.existsSync(path.join(newDir, "cache"))).toBe(false);
     // P2-3: nested dirs named like caches are preserved.
     expect(fs.existsSync(path.join(newDir, "Partitions", "persist_octo", "Cache", "nested-cache"))).toBe(true);
     expect(fs.existsSync(path.join(newDir, "Sync Data", "Cache", "keep-me"))).toBe(true);
-    // No staging residue.
     expect(fs.existsSync(path.join(appDataDir, `${BRAND}.migrating`))).toBe(false);
-    // Source kept (rollback safety / retryability).
     expect(fs.existsSync(path.join(appDataDir, "DMWork", "Preferences"))).toBe(true);
-    // Second launch: marker present -> no-op.
     expect(planUserDataMigration(appDataDir, BRAND).action).toBe("none");
   });
 
-  it("(b) fails and keeps the legacy profile when the rename fails, then succeeds on retry", () => {
+  it("(b) fails, records a breadcrumb, and succeeds on retry (breadcrumb cleared on success, P1-1)", () => {
     makeLegacyProfile();
     const plan = planUserDataMigration(appDataDir, BRAND);
 
@@ -187,6 +238,12 @@ describe("executeUserDataMigration", () => {
       expect.stringContaining("migration failed"),
       expect.anything()
     );
+    // Breadcrumb recorded so the next launch can bound retries.
+    const breadcrumb = JSON.parse(
+      fs.readFileSync(path.join(appDataDir, "DMWork", MIGRATION_BREADCRUMB), "utf8")
+    );
+    expect(breadcrumb.attempts).toBe(1);
+    expect(breadcrumb.lastError).toContain("EPERM");
     expect(fs.existsSync(path.join(appDataDir, `${BRAND}.migrating`))).toBe(false);
     expect(fs.existsSync(path.join(appDataDir, "DMWork", "Preferences"))).toBe(true);
 
@@ -196,25 +253,25 @@ describe("executeUserDataMigration", () => {
     expect(second).toBe("done");
     expect(fs.existsSync(path.join(appDataDir, BRAND, MIGRATION_MARKER))).toBe(true);
     expect(fs.existsSync(path.join(appDataDir, BRAND, "Preferences"))).toBe(true);
+    // Success clears the breadcrumb.
+    expect(fs.existsSync(path.join(appDataDir, "DMWork", MIGRATION_BREADCRUMB))).toBe(false);
   });
 
-  it("clears a stale staging dir from an interrupted previous attempt and retries", () => {
+  it("clears a stale staging dir from an interrupted attempt and retries", () => {
     makeLegacyProfile();
     const stale = path.join(appDataDir, `${BRAND}.migrating`);
     fs.mkdirSync(path.join(stale, "Local Storage", "leveldb"), { recursive: true });
     fs.writeFileSync(path.join(stale, "Local Storage", "leveldb", "CURRENT"), "partial");
 
     const plan = planUserDataMigration(appDataDir, BRAND);
-    expect(plan.action).toBe("migrate");
     const result = executeUserDataMigration(plan, runtime);
 
     expect(result).toBe("done");
     expect(fs.existsSync(path.join(appDataDir, BRAND, MIGRATION_MARKER))).toBe(true);
-    expect(fs.existsSync(path.join(appDataDir, BRAND, "Preferences"))).toBe(true);
     expect(fs.existsSync(stale)).toBe(false);
   });
 
-  it("clears a destination that contains only lock files before the rename lands", () => {
+  it("clears a destination with only lock files before the rename lands", () => {
     makeLegacyProfile();
     const newDir = path.join(appDataDir, BRAND);
     fs.mkdirSync(newDir, { recursive: true });
@@ -223,30 +280,27 @@ describe("executeUserDataMigration", () => {
     fs.writeFileSync(path.join(newDir, "SingletonSocket"), "");
 
     const plan = planUserDataMigration(appDataDir, BRAND);
-    expect(plan.action).toBe("migrate");
     const result = executeUserDataMigration(plan, runtime);
 
     expect(result).toBe("done");
     expect(fs.existsSync(path.join(newDir, "Preferences"))).toBe(true);
-    expect(fs.existsSync(path.join(newDir, MIGRATION_MARKER))).toBe(true);
     expect(fs.existsSync(path.join(newDir, "SingletonLock"))).toBe(false);
   });
 
-  it("re-asserts the lock-only invariant before deleting the destination (P2-6)", () => {
+  it("returns skipped (not done) when the destination gained a real profile since planning (P2-2/P2-6)", () => {
     makeLegacyProfile();
     const newDir = path.join(appDataDir, BRAND);
     fs.mkdirSync(newDir, { recursive: true });
     fs.writeFileSync(path.join(newDir, "Preferences"), '{"account":"someone-else"}');
 
-    // plan() would return "none" for this state; drive execute() directly to
-    // prove the re-check protects against the plan→execute gap.
+    // Drive execute() directly with a migrate plan to prove the re-check.
     const plan = planUserDataMigration(appDataDir, BRAND);
     plan.action = "migrate";
     const result = executeUserDataMigration(plan, runtime);
 
-    expect(result).toBe("done");
+    expect(result).toBe("skipped");
     expect(runtime.log.warn).toHaveBeenCalledWith(
-      expect.stringContaining("gained non-lock data")
+      expect.stringContaining("gained a real profile")
     );
     expect(fs.readFileSync(path.join(newDir, "Preferences"), "utf8")).toBe('{"account":"someone-else"}');
     expect(fs.existsSync(path.join(newDir, MIGRATION_MARKER))).toBe(false);
@@ -267,13 +321,11 @@ describe("executeUserDataMigration", () => {
     writeSpy.mockRestore();
 
     expect(result).toBe("failed");
-    expect(runtime.log.error).toHaveBeenCalled();
-    // The rename never ran, so a markerless destination can never exist.
     expect(fs.existsSync(path.join(appDataDir, BRAND))).toBe(false);
     expect(fs.existsSync(plan.stagingDir)).toBe(false);
   });
 
-  it("never throws: an execution-phase I/O failure degrades to failed, not an exception (P0-2)", () => {
+  it("never throws: an execution-phase I/O failure degrades to failed (P0-2)", () => {
     makeLegacyProfile();
     const plan = planUserDataMigration(appDataDir, BRAND);
     const mkdirSpy = vi.spyOn(fs, "mkdirSync").mockImplementationOnce(() => {
@@ -286,27 +338,13 @@ describe("executeUserDataMigration", () => {
     mkdirSpy.mockRestore();
 
     expect(result).toBe("failed");
-    expect(runtime.log.error).toHaveBeenCalledWith(
-      expect.stringContaining("migration failed"),
-      expect.anything()
-    );
     expect(fs.existsSync(path.join(appDataDir, BRAND))).toBe(false);
   });
 
-  it("no-op for a none plan (no side effects)", () => {
+  it("no-op for a none plan", () => {
     const plan = planUserDataMigration(appDataDir, BRAND);
     expect(plan.action).toBe("none");
-    const result = executeUserDataMigration(plan, runtime);
-    expect(result).toBe("done");
-    expect(runtime.log.info).not.toHaveBeenCalled();
+    expect(executeUserDataMigration(plan, runtime)).toBe("done");
     expect(fs.existsSync(path.join(appDataDir, BRAND))).toBe(false);
-  });
-
-  it("legacy plan defers (caller already pointed userData at DMWork before the lock)", () => {
-    const plan = planUserDataMigration(appDataDir, BRAND);
-    plan.action = "legacy";
-    const result = executeUserDataMigration(plan, runtime);
-    expect(result).toBe("deferred");
-    expect(runtime.log.warn).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src-election/main/__tests__/userDataMigration.test.ts
+++ b/apps/web/src-election/main/__tests__/userDataMigration.test.ts
@@ -6,6 +6,9 @@ import {
   MAX_MIGRATION_ATTEMPTS,
   MIGRATION_BREADCRUMB,
   MIGRATION_MARKER,
+  MIGRATION_NOTICES,
+  actualBreadcrumbFile,
+  decideLockLostAction,
   executeUserDataMigration,
   planUserDataMigration,
   recordMigrationNotice,
@@ -91,6 +94,53 @@ describe("planUserDataMigration", () => {
     expect(planUserDataMigration(appDataDir, BRAND).action).toBe("none");
   });
 
+  it("re-migrates a torn publish when the legacy holds IndexedDB but no sentinel (round-8 P1-2)", () => {
+    // hasProfileSentinel (Preferences/Local State only) missed this legacy:
+    // the copy filter copies IndexedDB, so a marker-only destination over it
+    // would strand the message store. hasCopyableData uses the copy rule.
+    const profile = path.join(appDataDir, "DMWork");
+    fs.mkdirSync(path.join(profile, "IndexedDB"), { recursive: true });
+    fs.writeFileSync(path.join(profile, "IndexedDB", "data"), "message-store-bytes");
+    const newDir = path.join(appDataDir, BRAND);
+    fs.mkdirSync(newDir, { recursive: true });
+    fs.writeFileSync(path.join(newDir, MIGRATION_MARKER), "2026-08-06T00:00:00Z");
+    const plan = planUserDataMigration(appDataDir, BRAND);
+    expect(plan.action).toBe("migrate");
+  });
+
+  it("marker-only counts as migrated when the legacy holds ONLY non-copyable artifacts (round-8 P1-2)", () => {
+    // Singleton artifacts are pruned by the copy filter, so a legacy with only
+    // a stale lock has nothing to migrate — marker-only must plan "none" (no
+    // relaunch loop), even though no Preferences/Local State exist either way.
+    const profile = path.join(appDataDir, "DMWork");
+    fs.mkdirSync(profile, { recursive: true });
+    fs.writeFileSync(path.join(profile, "SingletonLock"), "hostname-pid");
+    const newDir = path.join(appDataDir, BRAND);
+    fs.mkdirSync(newDir, { recursive: true });
+    fs.writeFileSync(path.join(newDir, MIGRATION_MARKER), "2026-08-06T00:00:00Z");
+    expect(planUserDataMigration(appDataDir, BRAND).action).toBe("none");
+  });
+
+  it("keeps the legacy profile when the marker destination cannot be inspected (round-8 P2-3 tri-state)", () => {
+    // Fail-closed: an unreadable destination is neither "complete" (none) nor
+    // safely re-migratable — never start a session on an unverified OCTO dir.
+    makeLegacyProfile(appDataDir);
+    const newDir = path.join(appDataDir, BRAND);
+    fs.mkdirSync(newDir, { recursive: true });
+    fs.writeFileSync(path.join(newDir, MIGRATION_MARKER), "2026-08-06T00:00:00Z");
+    const readdirSpy = vi.spyOn(fs, "readdirSync").mockImplementationOnce(() => {
+      const err = new Error("EACCES: permission denied") as NodeJS.ErrnoException;
+      err.code = "EACCES";
+      throw err;
+    });
+    try {
+      const plan = planUserDataMigration(appDataDir, BRAND);
+      expect(plan.action).toBe("legacy");
+    } finally {
+      readdirSpy.mockRestore();
+    }
+  });
+
   it("round-trip invariant: a marker-only destination with a data-less legacy counts as migrated (P0-1, no relaunch loop)", () => {
     // Legacy profile with ONLY regenerable caches (no sentinel): the copy
     // prunes everything, so re-migrating would loop forever. The marker-only
@@ -144,16 +194,41 @@ describe("planUserDataMigration", () => {
     expect(plan.reason).toBe("destination-occupied");
   });
 
-  it("a destination with only lock/crash files does NOT block migration (allowlist polarity)", () => {
+  it("a destination with only regenerable/OS-metadata files does NOT block migration (allowlist polarity)", () => {
     makeLegacyProfile(appDataDir);
     const newDir = path.join(appDataDir, BRAND);
     fs.mkdirSync(newDir, { recursive: true });
-    fs.writeFileSync(path.join(newDir, "SingletonLock"), "");
-    fs.mkdirSync(path.join(newDir, "Crashpad"), { recursive: true });
     fs.writeFileSync(path.join(newDir, "Dictionaries"), "dict");
     fs.writeFileSync(path.join(newDir, "Network Persistent State"), "{}");
+    // Round-8 P2-2: OS/Finder metadata is noise, not user data.
+    fs.writeFileSync(path.join(newDir, ".DS_Store"), "x");
+    fs.writeFileSync(path.join(newDir, "Thumbs.db"), "x");
+    fs.writeFileSync(path.join(newDir, "desktop.ini"), "x");
     const plan = planUserDataMigration(appDataDir, BRAND);
     expect(plan.action).toBe("migrate");
+  });
+
+  it("a destination holding a live singleton lock is occupied, never deleted (round-8 P2-4)", () => {
+    makeLegacyProfile(appDataDir);
+    const newDir = path.join(appDataDir, BRAND);
+    fs.mkdirSync(newDir, { recursive: true });
+    // ProcessSingleton artifacts can be a LIVE instance's fingerprint. We hold
+    // the legacy lock, so a lock on the OCTO path is never ours — deleting it
+    // could break the other instance's mutex.
+    fs.writeFileSync(path.join(newDir, "SingletonLock"), "hostname-pid");
+    const plan = planUserDataMigration(appDataDir, BRAND);
+    expect(plan.action).toBe("legacy");
+    expect(plan.reason).toBe("destination-occupied");
+  });
+
+  it("a destination with only a Crashpad dir is occupied (round-8 P2-4)", () => {
+    makeLegacyProfile(appDataDir);
+    const newDir = path.join(appDataDir, BRAND);
+    fs.mkdirSync(path.join(newDir, "Crashpad"), { recursive: true });
+    fs.writeFileSync(path.join(newDir, "Crashpad", "reports"), "x");
+    const plan = planUserDataMigration(appDataDir, BRAND);
+    expect(plan.action).toBe("legacy");
+    expect(plan.reason).toBe("destination-occupied");
   });
 
   it("plans legacy (too-many-failures) when the breadcrumb budget is exhausted (P1-1)", () => {
@@ -380,20 +455,55 @@ describe("executeUserDataMigration", () => {
     expect(fs.existsSync(stale)).toBe(false);
   });
 
-  it("clears a destination with only lock files before the rename lands", () => {
+  it("refuses to clear a destination with singleton lock artifacts — skipped, lock files untouched (round-8 P2-4)", () => {
     makeLegacyProfile();
     const newDir = path.join(appDataDir, BRAND);
     fs.mkdirSync(newDir, { recursive: true });
-    fs.writeFileSync(path.join(newDir, "SingletonLock"), "");
-    fs.writeFileSync(path.join(newDir, "SingletonCookie"), "");
-    fs.writeFileSync(path.join(newDir, "SingletonSocket"), "");
+    fs.writeFileSync(path.join(newDir, "SingletonLock"), "hostname-pid");
+    fs.writeFileSync(path.join(newDir, "SingletonCookie"), "cookie");
+    fs.writeFileSync(path.join(newDir, "SingletonSocket"), "socket");
 
     const plan = planUserDataMigration(appDataDir, BRAND);
+    plan.action = "migrate"; // force the execute-side re-check path
+    const result = executeUserDataMigration(plan, runtime);
+
+    expect(result).toBe("skipped");
+    // The lock artifacts (possibly a live instance's) are never deleted.
+    expect(fs.existsSync(path.join(newDir, "SingletonLock"))).toBe(true);
+    expect(fs.existsSync(path.join(newDir, "SingletonCookie"))).toBe(true);
+    expect(fs.existsSync(path.join(newDir, "SingletonSocket"))).toBe(true);
+    expect(fs.existsSync(path.join(appDataDir, "DMWork", "Preferences"))).toBe(true);
+  });
+
+  it("clears a destination holding only OS metadata (round-8 P2-2)", () => {
+    makeLegacyProfile();
+    const newDir = path.join(appDataDir, BRAND);
+    fs.mkdirSync(newDir, { recursive: true });
+    fs.writeFileSync(path.join(newDir, ".DS_Store"), "x");
+
+    const plan = planUserDataMigration(appDataDir, BRAND);
+    plan.action = "migrate"; // force the execute-side re-check path
     const result = executeUserDataMigration(plan, runtime);
 
     expect(result).toBe("done");
     expect(fs.existsSync(path.join(newDir, "Preferences"))).toBe(true);
-    expect(fs.existsSync(path.join(newDir, "SingletonLock"))).toBe(false);
+    expect(fs.existsSync(path.join(newDir, ".DS_Store"))).toBe(false);
+    expect(fs.existsSync(path.join(newDir, MIGRATION_MARKER))).toBe(true);
+  });
+
+  it("a successful migration clears the one-shot notice bookkeeping (round-8 P2-7)", () => {
+    makeLegacyProfile();
+    // A previous session told the user about a paused migration.
+    fs.writeFileSync(
+      path.join(appDataDir, MIGRATION_NOTICES),
+      JSON.stringify({ shown: ["retry-exhausted"] })
+    );
+    const plan = planUserDataMigration(appDataDir, BRAND);
+    const result = executeUserDataMigration(plan, runtime);
+
+    expect(result).toBe("done");
+    // The "already shown" records are stale once the migration is done.
+    expect(fs.existsSync(path.join(appDataDir, MIGRATION_NOTICES))).toBe(false);
   });
 
   it("returns skipped (not done) when the destination gained a real profile since planning", () => {
@@ -496,5 +606,60 @@ describe("migration notices", () => {
     // Recording is idempotent.
     recordMigrationNotice(appDataDir, "retry-exhausted");
     expect(shouldShowMigrationNotice(appDataDir, "retry-exhausted")).toBe(false);
+  });
+});
+
+describe("decideLockLostAction", () => {
+  const plan = (action: "migrate" | "legacy" | "none") =>
+    ({
+      action,
+      oldDir: path.join("C:", "appData", "DMWork"),
+      newDir: path.join("C:", "appData", "OCTO"),
+      stagingDir: path.join("C:", "appData", ".octo-migrate-staging"),
+    }) as const;
+
+  it("migrate plan: the losing process says so before quitting (dialog-then-quit)", () => {
+    expect(decideLockLostAction(plan("migrate"))).toBe("dialog-then-quit");
+  });
+
+  it("legacy plan: ordinary second-instance flow, quit silently", () => {
+    expect(decideLockLostAction(plan("legacy"))).toBe("quit-now");
+  });
+
+  it("none plan: steady state, quit silently", () => {
+    expect(decideLockLostAction(plan("none"))).toBe("quit-now");
+  });
+});
+
+describe("actualBreadcrumbFile", () => {
+  let appDataDir: string;
+
+  beforeEach(() => {
+    appDataDir = fs.mkdtempSync(path.join(os.tmpdir(), "octo-mig-bc-"));
+    fs.mkdirSync(path.join(appDataDir, "DMWork"), { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(appDataDir, { recursive: true, force: true });
+  });
+
+  it("points at the primary when it exists (round-8 P2-1)", () => {
+    const primary = path.join(appDataDir, "DMWork", MIGRATION_BREADCRUMB);
+    fs.writeFileSync(primary, "{}");
+    expect(actualBreadcrumbFile(path.join(appDataDir, "DMWork"))).toBe(primary);
+  });
+
+  it("points at the appData fallback when the legacy dir was unwritable (round-8 P2-1)", () => {
+    // Fallback only (as after a failed write with a read-only legacy dir) —
+    // the retry-exhausted dialog must name THIS file, not a non-existent one.
+    const fallback = path.join(appDataDir, MIGRATION_BREADCRUMB);
+    fs.writeFileSync(fallback, "{}");
+    expect(actualBreadcrumbFile(path.join(appDataDir, "DMWork"))).toBe(fallback);
+  });
+
+  it("falls back to the primary path when nothing exists yet", () => {
+    expect(actualBreadcrumbFile(path.join(appDataDir, "DMWork"))).toBe(
+      path.join(appDataDir, "DMWork", MIGRATION_BREADCRUMB)
+    );
   });
 });

--- a/apps/web/src-election/main/index.ts
+++ b/apps/web/src-election/main/index.ts
@@ -760,18 +760,14 @@ app.on("open-url", (event, url) => {
 // 单例模式启动
 const gotTheLock = app.requestSingleInstanceLock();
 if (!gotTheLock) {
-  // Round-6 P2-3: only "migrate" is a migration-related path — a lock failure
-  // under a "legacy"/"none" plan is the ordinary focus-the-running-instance
-  // flow and must stay silent.
-  if (userDataPlan.action === "migrate") {
-    app.whenReady().then(() => {
-      const { title, message } = migrationDialogCopy("lock");
-      dialog.showErrorBox(title, message);
-      app.quit();
-    });
-  } else {
-    app.quit();
-  }
+  // Round-7 blocking (Jerry-Xin): DO NOT quit here and DO NOT defer to
+  // whenReady().then — both allow the unconditional app.on("ready") handler
+  // below to run createMainWindow() first (ready listeners run before the
+  // whenReady microtask), opening a second Electron process/window against
+  // the legacy profile and breaking the migration mutex. Instead, do nothing
+  // here: the ready handler guards on gotTheLock, shows the lock dialog
+  // (migration paths only, ready so Linux renders it) and quits before any
+  // window or renderer initialization.
 } else {
   runStartupMigration(userDataPlan);
   app.on("second-instance", (event, argv) => {
@@ -786,6 +782,20 @@ if (!gotTheLock) {
 }
 
 app.on("ready", () => {
+  // Round-7: the losing process must quit before ANY window/renderer
+  // initialization — this guard runs before createMainWindow() below and is
+  // the single place the lock-failure path terminates.
+  if (!gotTheLock) {
+    // Round-6 P2-3: only "migrate" is a migration-related path; a lock
+    // failure under "legacy"/"none" is the ordinary focus-the-running-
+    // instance flow and stays silent.
+    if (userDataPlan.action === "migrate") {
+      const { title, message } = migrationDialogCopy("lock");
+      dialog.showErrorBox(title, message);
+    }
+    app.quit();
+    return;
+  }
   regShortcut();
   registerWindowFocusHandler();
   createMainWindow(); // 创建窗口

--- a/apps/web/src-election/main/index.ts
+++ b/apps/web/src-election/main/index.ts
@@ -550,26 +550,23 @@ function onDeepLink(url: string) {
 app.setName(OCTO_CONFIG.name);
 
 // One-time userData migration from the legacy DMWork profile (see
-// userDataMigration.ts for the full design). It runs BEFORE the single-instance
-// lock: the staging dir itself is the cross-launch mutex (atomic mkdir, EEXIST
-// = another launch is mid-migration), so we never have to delete a lock we
-// hold, and both the defer-legacy and the failure fallback set the userData
-// path before requestSingleInstanceLock() — the fallback session's lock is
-// created in the legacy dir it writes, never desynchronized (F2/F4).
+// userDataMigration.ts for the full design). The single-instance lock is the
+// cross-launch mutex, keyed off the userData path on every platform: point
+// userData at the legacy dir BEFORE requestSingleInstanceLock(), so
+//   - a running legacy DMWork instance already holds that lock -> this launch
+//     fails the lock and quits (the legacy-instance guard, no hand-written
+//     probe needed, works on Windows too);
+//   - a concurrent launch during the migration hits the same held lock and
+//     quits — exactly one process is ever the migrator, no second window can
+//     appear mid-copy (round-2 P0-1 closed).
+// On success we relaunch so the next process takes the OCTO lock; on
+// deferral/failure this session keeps the legacy path and retries next launch.
 // This supersedes the temporary setPath('userData', <appData>/DMWork) fallback
-// that #1258 carries until this PR lands: the migration now owns the path
-// decision (OCTO after a successful migration, legacy on deferral/failure).
-executeUserDataMigration(
-  planUserDataMigration(app.getPath("appData"), OCTO_CONFIG.name),
-  {
-    setUserDataDir: (dir) => app.setPath("userData", dir),
-    log: {
-      info: (msg) => console.log(msg),
-      warn: (msg) => console.warn(msg),
-      error: (msg, err) => console.error(msg, err),
-    },
-  }
-);
+// that #1258 carries until this PR lands.
+const userDataPlan = planUserDataMigration(app.getPath("appData"), OCTO_CONFIG.name);
+if (userDataPlan.action !== "none") {
+  app.setPath("userData", userDataPlan.oldDir);
+}
 
 // isDevelopment && app.dock && app.dock.setIcon(logo);
 app.on("open-url", (event, url) => {
@@ -581,8 +578,38 @@ const gotTheLock = app.requestSingleInstanceLock();
 if (!gotTheLock) {
   app.quit();
 } else {
-  // The migration itself already ran before the lock (staging-dir mutex);
-  // only a lock holder reaches this point, so window/show behavior is safe.
+  // The migration runs under the single-instance lock we just took on the
+  // legacy path. Exactly one writer, and no other process can be using the
+  // legacy profile (its lock is ours).
+  if (userDataPlan.action === "migrate") {
+    try {
+      const migrationResult = executeUserDataMigration(userDataPlan, {
+        log: {
+          info: (msg) => console.log(msg),
+          warn: (msg) => console.warn(msg),
+          error: (msg, err) => console.error(msg, err),
+        },
+      });
+      if (migrationResult === "done") {
+        // Success: restart so the next process takes the <appData>/OCTO lock
+        // and runs on the migrated profile. This process's lock is on the
+        // legacy path (set before requestSingleInstanceLock above) and is
+        // released on exit; the relaunched process plans "none" (marker
+        // present) and locks OCTO normally.
+        app.relaunch();
+        app.exit(0);
+      }
+      // "deferred"/"failed": keep the legacy profile this session (userData
+      // was already pointed at DMWork before the lock) and retry next launch.
+    } catch (err) {
+      // Defensive backstop (round-2 P0-2): the migration must never take the
+      // app down — fall back to the legacy profile and continue.
+      console.error(
+        "[userData] unexpected migration error; continuing on the legacy profile:",
+        err
+      );
+    }
+  }
   app.on("second-instance", (event, argv) => {
     if (mainWindow) {
       mainWindow.show();

--- a/apps/web/src-election/main/index.ts
+++ b/apps/web/src-election/main/index.ts
@@ -14,12 +14,18 @@ import {
 import fs from "fs";
 import tmp from 'tmp';
 import Screenshots from "electron-screenshots";
-import { join } from "path";
+import { join, dirname } from "path";
 
 import logo, { getNoMessageTrayIcon } from "./logo";
 import { IPC_CONVERSATION_UNREAD_COUNT } from "../shared/ipc-channels";
 import OCTO_CONFIG from "./config";
-import { executeUserDataMigration, planUserDataMigration } from "./userDataMigration";
+import {
+  executeUserDataMigration,
+  planUserDataMigration,
+  recordMigrationNotice,
+  shouldShowMigrationNotice,
+  type MigrationPlan,
+} from "./userDataMigration";
 import checkUpdate from './update';
 import { electronNotificationManager } from './notification';
 import { getRandomSid } from "./utils/search";
@@ -550,24 +556,200 @@ function onDeepLink(url: string) {
 
 app.setName(OCTO_CONFIG.name);
 
+// Shared console-based logger for migration plan/execute diagnostics
+// (round-6 nit: plan-time diagnostics must go through the injected log, not
+// bare console.*, so they can be captured by tests and routed).
+const migrationLog = {
+  info: (msg: string) => console.log(msg),
+  warn: (msg: string) => console.warn(msg),
+  error: (msg: string, err: unknown) => console.error(msg, err),
+};
+
 // One-time userData migration from the legacy DMWork profile (see
 // userDataMigration.ts for the full design). Electron's single-instance lock
 // is process-global, and the primary-instance lookup keys off the userData
 // path — so pointing userData at the legacy dir BEFORE requestSingleInstanceLock()
 // makes the lock contend with a legacy instance or a concurrent launch:
 //   - a running legacy DMWork instance already holds that lock -> this launch
-//     fails the lock and quits (with a dialog, round-4 P1-1);
+//     fails the lock and quits (with a dialog when we were about to migrate);
 //   - a concurrent launch during the migration hits the same held lock and
 //     quits — exactly one process is ever the migrator, no second window can
 //     appear mid-copy.
 // On success we relaunch so the next process takes the OCTO lock; on
 // deferral/failure this session keeps the legacy path and retries next launch
-// (bounded by breadcrumbs, round-4 P1-1).
+// (bounded by breadcrumbs).
 // This supersedes the temporary setPath('userData', <appData>/DMWork) fallback
 // that #1258 carries until this PR lands.
-const userDataPlan = planUserDataMigration(app.getPath("appData"), OCTO_CONFIG.name);
+const userDataPlan = planUserDataMigration(
+  app.getPath("appData"),
+  OCTO_CONFIG.name,
+  migrationLog
+);
 if (userDataPlan.action !== "none") {
   app.setPath("userData", userDataPlan.oldDir);
+}
+
+// Migration dialogs. Round-6 P2-2: dialog.showErrorBox called before `ready`
+// degrades to stderr on Linux (documented in electron.d.ts), so every dialog
+// is deferred behind app.whenReady(). Copy is bilingual via app.getLocale()
+// (safe inside whenReady; a pre-ready main-process dialog cannot reach the
+// renderer i18n bundle).
+type MigrationDialogKind =
+  | "lock"
+  | "failed"
+  | "skipped"
+  | "plan-failed"
+  | "retry-exhausted"
+  | "occupied";
+
+type MigrationDirs = { oldDir: string; newDir: string };
+type MigrationDialogCopy = (dirs?: MigrationDirs) => { title: string; message: string };
+
+const MIGRATION_DIALOGS: Record<MigrationDialogKind, { zh: MigrationDialogCopy; en: MigrationDialogCopy }> = {
+  lock: {
+    zh: () => ({
+      title: "OCTO 无法启动（数据迁移中）",
+      message:
+        "另一个实例正在运行（可能是旧版 DMWork 尚未退出，或迁移正在进行）。请退出旧应用后重新启动。",
+    }),
+    en: () => ({
+      title: "OCTO cannot start (data migration in progress)",
+      message:
+        "Another instance is running (the old DMWork app may not have quit, or a migration is in progress). Quit the old app and start again.",
+    }),
+  },
+  failed: {
+    zh: () => ({
+      title: "OCTO 数据迁移未完成",
+      message:
+        "本次启动继续使用旧版数据（DMWork），下次启动会自动重试。若持续失败，请检查磁盘空间后重试。",
+    }),
+    en: () => ({
+      title: "OCTO data migration incomplete",
+      message:
+        "This session continues on the legacy data (DMWork); the next launch will retry automatically. If it keeps failing, check your disk space.",
+    }),
+  },
+  skipped: {
+    zh: () => ({
+      title: "OCTO 数据迁移已跳过",
+      message:
+        "目标目录（OCTO）出现了不属于迁移的数据，本次启动继续使用旧版数据（DMWork），两个数据目录均保留。",
+    }),
+    en: () => ({
+      title: "OCTO data migration skipped",
+      message:
+        "The destination folder (OCTO) contains data the migration does not own. This session continues on the legacy data (DMWork); both folders are kept.",
+    }),
+  },
+  "plan-failed": {
+    zh: () => ({
+      title: "OCTO 数据迁移暂缓",
+      message: "数据迁移准备失败，本次继续使用旧版数据（DMWork），下次启动会自动重试。",
+    }),
+    en: () => ({
+      title: "OCTO data migration deferred",
+      message:
+        "Migration preparation failed; this session continues on the legacy data (DMWork) and the next launch will retry.",
+    }),
+  },
+  "retry-exhausted": {
+    zh: (dirs) => ({
+      title: "OCTO 数据迁移已暂停",
+      message: `数据迁移多次失败，已暂停自动重试。本次继续使用旧版数据（DMWork）。如需重新尝试，请删除 ${dirs?.oldDir}/.migration-failed.json 后重启。`,
+    }),
+    en: (dirs) => ({
+      title: "OCTO data migration paused",
+      message: `The migration failed repeatedly and automatic retries are paused. This session continues on the legacy data (DMWork). To retry, delete ${dirs?.oldDir}/.migration-failed.json and restart.`,
+    }),
+  },
+  occupied: {
+    zh: (dirs) => ({
+      title: "OCTO 数据迁移未执行",
+      message: `目标目录（${dirs?.newDir}）已存在其他数据，为避免覆盖，迁移未执行。本次继续使用旧版数据（${dirs?.oldDir}），两个目录均保留。如需迁移，请先备份并移除其中一个目录。`,
+    }),
+    en: (dirs) => ({
+      title: "OCTO data migration not performed",
+      message: `The destination folder (${dirs?.newDir}) already contains other data, so the migration was not performed to avoid overwriting it. This session continues on the legacy data (${dirs?.oldDir}); both folders are kept. To migrate, back up and remove one of them first.`,
+    }),
+  },
+};
+
+function migrationDialogCopy(kind: MigrationDialogKind, dirs?: MigrationDirs) {
+  const zh = app.getLocale().toLowerCase().startsWith("zh");
+  return MIGRATION_DIALOGS[kind][zh ? "zh" : "en"](dirs);
+}
+
+function showMigrationDialog(kind: MigrationDialogKind, dirs?: MigrationDirs): void {
+  app.whenReady().then(() => {
+    const { title, message } = migrationDialogCopy(kind, dirs);
+    dialog.showErrorBox(title, message);
+  });
+}
+
+// Runs under the single-instance lock taken on the legacy path: exactly one
+// writer, and no other process can be using the legacy profile (its lock is
+// ours). Extracted as a function so the success path can `return` after
+// app.exit(0) (rounds 4-6 ask).
+function runStartupMigration(userDataPlan: MigrationPlan): void {
+  if (userDataPlan.action === "migrate") {
+    try {
+      const migrationResult = executeUserDataMigration(userDataPlan, { log: migrationLog });
+      if (migrationResult === "done") {
+        // Success: restart so the next process takes the <appData>/OCTO lock
+        // and runs on the migrated profile. This process's lock is on the
+        // legacy path (set before requestSingleInstanceLock above) and is
+        // released on exit; the relaunched process plans "none" (marker
+        // present) and locks OCTO normally.
+        restartApp();
+        return; // app.exit(0) terminates the process; nothing below may run
+      }
+      if (migrationResult === "failed") {
+        // Make the failure visible (ENOSPC / rename refusal).
+        showMigrationDialog("failed");
+      } else if (migrationResult === "skipped") {
+        // "skipped" means the destination holds data we do not own — staying
+        // on the legacy path silently would let the next launch flip profiles
+        // without the user knowing. Say it.
+        showMigrationDialog("skipped");
+      }
+    } catch (err) {
+      // Defensive backstop (round-2 P0-2): the migration must never take the
+      // app down — fall back to the legacy profile and continue.
+      console.error(
+        "[userData] unexpected migration error; continuing on the legacy profile:",
+        err
+      );
+    }
+    return;
+  }
+  if (userDataPlan.action !== "legacy") {
+    return; // "none": steady state, nothing to say
+  }
+  // Plan-time failure or retry budget exhausted — say so instead of silently
+  // running on the legacy profile. Round-6 P1-2: destination-occupied names
+  // both directories. Round-6 P2: retry-exhausted and occupied are one-shot
+  // (notice bookkeeping lives in appData).
+  const appDataDir = dirname(userDataPlan.oldDir);
+  if (userDataPlan.reason === "too-many-failures") {
+    if (shouldShowMigrationNotice(appDataDir, "retry-exhausted")) {
+      recordMigrationNotice(appDataDir, "retry-exhausted");
+      showMigrationDialog("retry-exhausted", {
+        oldDir: userDataPlan.oldDir,
+        newDir: userDataPlan.newDir,
+      });
+    }
+  } else if (userDataPlan.reason === "destination-occupied") {
+    if (shouldShowMigrationNotice(appDataDir, "destination-occupied")) {
+      recordMigrationNotice(appDataDir, "destination-occupied");
+      showMigrationDialog("occupied", {
+        oldDir: userDataPlan.oldDir,
+        newDir: userDataPlan.newDir,
+      });
+    }
+  } else {
+    showMigrationDialog("plan-failed");
+  }
 }
 
 // isDevelopment && app.dock && app.dock.setIcon(logo);
@@ -578,71 +760,20 @@ app.on("open-url", (event, url) => {
 // 单例模式启动
 const gotTheLock = app.requestSingleInstanceLock();
 if (!gotTheLock) {
-  // P1-2 (round-5): the dialog must only appear on the migration-related
-  // paths — in steady state (plan "none") a second launch is the normal
-  // "focus the running instance" flow and must stay silent.
-  if (userDataPlan.action !== "none") {
-    dialog.showErrorBox(
-      "OCTO 无法启动（数据迁移中）",
-      "另一个实例正在运行（可能是旧版 DMWork 尚未退出，或迁移正在进行）。请退出旧应用后重新启动。"
-    );
-  }
-  app.quit();
-} else {
-  // The migration runs under the single-instance lock we just took on the
-  // legacy path. Exactly one writer, and no other process can be using the
-  // legacy profile (its lock is ours).
+  // Round-6 P2-3: only "migrate" is a migration-related path — a lock failure
+  // under a "legacy"/"none" plan is the ordinary focus-the-running-instance
+  // flow and must stay silent.
   if (userDataPlan.action === "migrate") {
-    try {
-      const migrationResult = executeUserDataMigration(userDataPlan, {
-        log: {
-          info: (msg) => console.log(msg),
-          warn: (msg) => console.warn(msg),
-          error: (msg, err) => console.error(msg, err),
-        },
-      });
-      if (migrationResult === "done") {
-        // Success: restart so the next process takes the <appData>/OCTO lock
-        // and runs on the migrated profile. This process's lock is on the
-        // legacy path (set before requestSingleInstanceLock above) and is
-        // released on exit; the relaunched process plans "none" (marker
-        // present) and locks OCTO normally.
-        app.relaunch();
-        app.exit(0);
-      } else if (migrationResult === "failed") {
-        // P1-1 (round-4): make the failure visible (ENOSPC / rename refusal).
-        dialog.showErrorBox(
-          "OCTO 数据迁移未完成",
-          "本次启动继续使用旧版数据（DMWork），下次启动会自动重试。若持续失败，请检查磁盘空间后重试。"
-        );
-      } else if (migrationResult === "skipped") {
-        // Round-5 P2: "skipped" means the destination gained a real profile
-        // since planning — staying on the legacy path silently would let the
-        // next launch flip profiles without the user knowing. Say it.
-        dialog.showErrorBox(
-          "OCTO 数据迁移已跳过",
-          "目标目录（OCTO）出现了真实数据，本次启动继续使用旧版数据（DMWork），两个数据目录均保留。"
-        );
-      }
-    } catch (err) {
-      // Defensive backstop (round-2 P0-2): the migration must never take the
-      // app down — fall back to the legacy profile and continue.
-      console.error(
-        "[userData] unexpected migration error; continuing on the legacy profile:",
-        err
-      );
-    }
-  } else if (userDataPlan.action === "legacy") {
-    // P1-1 (round-4): plan-time failure or retry budget exhausted — say so
-    // instead of silently running on the legacy profile. Include the
-    // breadcrumb path so the user knows how to re-enable (round-5 P2).
-    dialog.showErrorBox(
-      "OCTO 数据迁移暂缓",
-      userDataPlan.reason === "too-many-failures"
-        ? `数据迁移多次失败，已暂停自动重试。本次继续使用旧版数据（DMWork）。如需重新尝试，请删除 ${userDataPlan.oldDir}/.migration-failed.json 后重启。`
-        : "数据迁移准备失败，本次继续使用旧版数据（DMWork），下次启动会自动重试。"
-    );
+    app.whenReady().then(() => {
+      const { title, message } = migrationDialogCopy("lock");
+      dialog.showErrorBox(title, message);
+      app.quit();
+    });
+  } else {
+    app.quit();
   }
+} else {
+  runStartupMigration(userDataPlan);
   app.on("second-instance", (event, argv) => {
     if (mainWindow) {
       mainWindow.show();

--- a/apps/web/src-election/main/index.ts
+++ b/apps/web/src-election/main/index.ts
@@ -751,6 +751,10 @@ function runStartupMigration(userDataPlan: MigrationPlan): void {
       });
     }
   } else {
+    // "plan-failed" is intentionally NOT one-shot, unlike the two reasons
+    // above: it is transient (a flaky volume / permission hiccup) and the
+    // user should see it on every affected launch, whereas retry-exhausted
+    // and destination-occupied are terminal states that only need one telling.
     showMigrationDialog("plan-failed");
   }
 }

--- a/apps/web/src-election/main/index.ts
+++ b/apps/web/src-election/main/index.ts
@@ -578,12 +578,15 @@ app.on("open-url", (event, url) => {
 // 单例模式启动
 const gotTheLock = app.requestSingleInstanceLock();
 if (!gotTheLock) {
-  // P1-1: never quit silently — the user needs to know why nothing happened
-  // (a legacy DMWork instance is still running, or a concurrent launch won).
-  dialog.showErrorBox(
-    "OCTO 已在运行",
-    "检测到另一个实例正在运行（可能是旧版 DMWork 尚未退出）。请退出旧应用后重新启动，以完成数据迁移。"
-  );
+  // P1-2 (round-5): the dialog must only appear on the migration-related
+  // paths — in steady state (plan "none") a second launch is the normal
+  // "focus the running instance" flow and must stay silent.
+  if (userDataPlan.action !== "none") {
+    dialog.showErrorBox(
+      "OCTO 无法启动（数据迁移中）",
+      "另一个实例正在运行（可能是旧版 DMWork 尚未退出，或迁移正在进行）。请退出旧应用后重新启动。"
+    );
+  }
   app.quit();
 } else {
   // The migration runs under the single-instance lock we just took on the
@@ -607,14 +610,20 @@ if (!gotTheLock) {
         app.relaunch();
         app.exit(0);
       } else if (migrationResult === "failed") {
-        // P1-1: make the failure visible (ENOSPC / rename refusal etc.).
+        // P1-1 (round-4): make the failure visible (ENOSPC / rename refusal).
         dialog.showErrorBox(
           "OCTO 数据迁移未完成",
           "本次启动继续使用旧版数据（DMWork），下次启动会自动重试。若持续失败，请检查磁盘空间后重试。"
         );
+      } else if (migrationResult === "skipped") {
+        // Round-5 P2: "skipped" means the destination gained a real profile
+        // since planning — staying on the legacy path silently would let the
+        // next launch flip profiles without the user knowing. Say it.
+        dialog.showErrorBox(
+          "OCTO 数据迁移已跳过",
+          "目标目录（OCTO）出现了真实数据，本次启动继续使用旧版数据（DMWork），两个数据目录均保留。"
+        );
       }
-      // "skipped": the destination gained a real profile since planning —
-      // stay on the legacy path this session, no relaunch (P2-2).
     } catch (err) {
       // Defensive backstop (round-2 P0-2): the migration must never take the
       // app down — fall back to the legacy profile and continue.
@@ -624,12 +633,13 @@ if (!gotTheLock) {
       );
     }
   } else if (userDataPlan.action === "legacy") {
-    // P1-1: plan-time failure or retry budget exhausted — say so instead of
-    // silently running on the legacy profile.
+    // P1-1 (round-4): plan-time failure or retry budget exhausted — say so
+    // instead of silently running on the legacy profile. Include the
+    // breadcrumb path so the user knows how to re-enable (round-5 P2).
     dialog.showErrorBox(
       "OCTO 数据迁移暂缓",
       userDataPlan.reason === "too-many-failures"
-        ? "数据迁移多次失败，已暂停自动重试。本次继续使用旧版数据（DMWork）。如需重新尝试，请删除 DMWork 目录下的 .migration-failed.json 后重启。"
+        ? `数据迁移多次失败，已暂停自动重试。本次继续使用旧版数据（DMWork）。如需重新尝试，请删除 ${userDataPlan.oldDir}/.migration-failed.json 后重启。`
         : "数据迁移准备失败，本次继续使用旧版数据（DMWork），下次启动会自动重试。"
     );
   }

--- a/apps/web/src-election/main/index.ts
+++ b/apps/web/src-election/main/index.ts
@@ -549,24 +549,27 @@ function onDeepLink(url: string) {
 
 app.setName(OCTO_CONFIG.name);
 
-app.setName(OCTO_CONFIG.name);
-
 // One-time userData migration from the legacy DMWork profile (see
-// userDataMigration.ts for the full design). It must be DECIDED before the
-// single-instance lock: when a legacy DMWork instance is still running (its
-// SingletonLock is held), we point userData at the legacy dir so that
-// requestSingleInstanceLock() below fails against the running instance and
-// this launch simply quits — no live-profile copy, no double writer.
+// userDataMigration.ts for the full design). It runs BEFORE the single-instance
+// lock: the staging dir itself is the cross-launch mutex (atomic mkdir, EEXIST
+// = another launch is mid-migration), so we never have to delete a lock we
+// hold, and both the defer-legacy and the failure fallback set the userData
+// path before requestSingleInstanceLock() — the fallback session's lock is
+// created in the legacy dir it writes, never desynchronized (F2/F4).
 // This supersedes the temporary setPath('userData', <appData>/DMWork) fallback
 // that #1258 carries until this PR lands: the migration now owns the path
 // decision (OCTO after a successful migration, legacy on deferral/failure).
-const userDataMigration = planUserDataMigration(
-  app.getPath("appData"),
-  OCTO_CONFIG.name
+executeUserDataMigration(
+  planUserDataMigration(app.getPath("appData"), OCTO_CONFIG.name),
+  {
+    setUserDataDir: (dir) => app.setPath("userData", dir),
+    log: {
+      info: (msg) => console.log(msg),
+      warn: (msg) => console.warn(msg),
+      error: (msg, err) => console.error(msg, err),
+    },
+  }
 );
-if (userDataMigration.action === "defer-legacy") {
-  app.setPath("userData", userDataMigration.oldDir);
-}
 
 // isDevelopment && app.dock && app.dock.setIcon(logo);
 app.on("open-url", (event, url) => {
@@ -578,19 +581,8 @@ const gotTheLock = app.requestSingleInstanceLock();
 if (!gotTheLock) {
   app.quit();
 } else {
-  // Only the lock holder migrates — any concurrent launch has already quit, so
-  // there is exactly one writer. A failure falls back to the legacy profile
-  // (setUserDataDir) and retries on the next launch.
-  if (userDataMigration.action === "migrate") {
-    executeUserDataMigration(userDataMigration, {
-      setUserDataDir: (dir) => app.setPath("userData", dir),
-      log: {
-        info: (msg) => console.log(msg),
-        warn: (msg) => console.warn(msg),
-        error: (msg, err) => console.error(msg, err),
-      },
-    });
-  }
+  // The migration itself already ran before the lock (staging-dir mutex);
+  // only a lock holder reaches this point, so window/show behavior is safe.
   app.on("second-instance", (event, argv) => {
     if (mainWindow) {
       mainWindow.show();

--- a/apps/web/src-election/main/index.ts
+++ b/apps/web/src-election/main/index.ts
@@ -20,6 +20,9 @@ import logo, { getNoMessageTrayIcon } from "./logo";
 import { IPC_CONVERSATION_UNREAD_COUNT } from "../shared/ipc-channels";
 import OCTO_CONFIG from "./config";
 import {
+  MIGRATION_BREADCRUMB,
+  actualBreadcrumbFile,
+  decideLockLostAction,
   executeUserDataMigration,
   planUserDataMigration,
   recordMigrationNotice,
@@ -656,11 +659,11 @@ const MIGRATION_DIALOGS: Record<MigrationDialogKind, { zh: MigrationDialogCopy; 
   "retry-exhausted": {
     zh: (dirs) => ({
       title: "OCTO 数据迁移已暂停",
-      message: `数据迁移多次失败，已暂停自动重试。本次继续使用旧版数据（DMWork）。如需重新尝试，请删除 ${dirs?.oldDir}/.migration-failed.json 后重启。`,
+      message: `数据迁移多次失败，已暂停自动重试。本次继续使用旧版数据（DMWork）。如需重新尝试，请删除 ${dirs ? actualBreadcrumbFile(dirs.oldDir) : MIGRATION_BREADCRUMB} 后重启。`,
     }),
     en: (dirs) => ({
       title: "OCTO data migration paused",
-      message: `The migration failed repeatedly and automatic retries are paused. This session continues on the legacy data (DMWork). To retry, delete ${dirs?.oldDir}/.migration-failed.json and restart.`,
+      message: `The migration failed repeatedly and automatic retries are paused. This session continues on the legacy data (DMWork). To retry, delete ${dirs ? actualBreadcrumbFile(dirs.oldDir) : MIGRATION_BREADCRUMB} and restart.`,
     }),
   },
   occupied: {
@@ -754,6 +757,10 @@ function runStartupMigration(userDataPlan: MigrationPlan): void {
 
 // isDevelopment && app.dock && app.dock.setIcon(logo);
 app.on("open-url", (event, url) => {
+  // Round-8 P1-1: the losing process may still receive app events between
+  // `ready` and its async quit — onDeepLink dereferences mainWindow, which
+  // never exists here.
+  if (!gotTheLock) return;
   onDeepLink(url);
 });
 
@@ -786,10 +793,10 @@ app.on("ready", () => {
   // initialization — this guard runs before createMainWindow() below and is
   // the single place the lock-failure path terminates.
   if (!gotTheLock) {
-    // Round-6 P2-3: only "migrate" is a migration-related path; a lock
-    // failure under "legacy"/"none" is the ordinary focus-the-running-
+    // decideLockLostAction: only "migrate" is a migration-related path; a
+    // lock failure under "legacy"/"none" is the ordinary focus-the-running-
     // instance flow and stays silent.
-    if (userDataPlan.action === "migrate") {
+    if (decideLockLostAction(userDataPlan) === "dialog-then-quit") {
       const { title, message } = migrationDialogCopy("lock");
       dialog.showErrorBox(title, message);
     }
@@ -883,6 +890,11 @@ app.on("ready", () => {
 });
 
 app.on("activate", () => {
+  // Round-8 P1-1: same guard as open-url — macOS fires `activate` right after
+  // `ready`; a losing process must never create a window against the legacy
+  // profile (it would break the single-instance mutex mid-migration).
+  if (!gotTheLock) return;
+
   if (!mainWindow) {
     return createMainWindow();
   }

--- a/apps/web/src-election/main/index.ts
+++ b/apps/web/src-election/main/index.ts
@@ -18,6 +18,7 @@ import { join } from "path";
 import logo, { getNoMessageTrayIcon } from "./logo";
 import { IPC_CONVERSATION_UNREAD_COUNT } from "../shared/ipc-channels";
 import OCTO_CONFIG from "./config";
+import { executeUserDataMigration, planUserDataMigration } from "./userDataMigration";
 import checkUpdate from './update';
 import { electronNotificationManager } from './notification';
 import { getRandomSid } from "./utils/search";
@@ -548,19 +549,24 @@ function onDeepLink(url: string) {
 
 app.setName(OCTO_CONFIG.name);
 
-// NOTE: the one-time userData migration from the legacy <appData>/DMWork profile
-// to <appData>/OCTO is intentionally NOT part of this PR. It lives in the
-// separate PR #1265 (feat/octo-userdata-migration) because it is destructive and
-// needs its own failure-mode coverage (staging copy + atomic rename, legacy
-// SingletonLock detection, fallback to the legacy profile on failure).
-//
-// Until that migration PR lands, keep userData on the legacy path: app.setName
-// above would relocate Electron's default userData from <appData>/DMWork to
-// <appData>/OCTO, and shipping that without the migration would strand every
-// existing user's profile (empty profile on upgrade). The setPath override below
-// is removed by #1265, which takes over the path decision (OCTO after a
-// successful migration, legacy on deferral/failure).
-app.setPath("userData", join(app.getPath("appData"), "DMWork"));
+app.setName(OCTO_CONFIG.name);
+
+// One-time userData migration from the legacy DMWork profile (see
+// userDataMigration.ts for the full design). It must be DECIDED before the
+// single-instance lock: when a legacy DMWork instance is still running (its
+// SingletonLock is held), we point userData at the legacy dir so that
+// requestSingleInstanceLock() below fails against the running instance and
+// this launch simply quits — no live-profile copy, no double writer.
+// This supersedes the temporary setPath('userData', <appData>/DMWork) fallback
+// that #1258 carries until this PR lands: the migration now owns the path
+// decision (OCTO after a successful migration, legacy on deferral/failure).
+const userDataMigration = planUserDataMigration(
+  app.getPath("appData"),
+  OCTO_CONFIG.name
+);
+if (userDataMigration.action === "defer-legacy") {
+  app.setPath("userData", userDataMigration.oldDir);
+}
 
 // isDevelopment && app.dock && app.dock.setIcon(logo);
 app.on("open-url", (event, url) => {
@@ -572,6 +578,19 @@ const gotTheLock = app.requestSingleInstanceLock();
 if (!gotTheLock) {
   app.quit();
 } else {
+  // Only the lock holder migrates — any concurrent launch has already quit, so
+  // there is exactly one writer. A failure falls back to the legacy profile
+  // (setUserDataDir) and retries on the next launch.
+  if (userDataMigration.action === "migrate") {
+    executeUserDataMigration(userDataMigration, {
+      setUserDataDir: (dir) => app.setPath("userData", dir),
+      log: {
+        info: (msg) => console.log(msg),
+        warn: (msg) => console.warn(msg),
+        error: (msg, err) => console.error(msg, err),
+      },
+    });
+  }
   app.on("second-instance", (event, argv) => {
     if (mainWindow) {
       mainWindow.show();

--- a/apps/web/src-election/main/index.ts
+++ b/apps/web/src-election/main/index.ts
@@ -20,8 +20,8 @@ import logo, { getNoMessageTrayIcon } from "./logo";
 import { IPC_CONVERSATION_UNREAD_COUNT } from "../shared/ipc-channels";
 import OCTO_CONFIG from "./config";
 import {
-  MIGRATION_BREADCRUMB,
   actualBreadcrumbFile,
+  cleanupStaleStaging,
   decideLockLostAction,
   executeUserDataMigration,
   planUserDataMigration,
@@ -611,7 +611,8 @@ type MigrationDialogKind =
   | "skipped"
   | "plan-failed"
   | "retry-exhausted"
-  | "occupied";
+  | "occupied"
+  | "destination-unreadable";
 
 type MigrationDirs = { oldDir: string; newDir: string };
 type MigrationDialogCopy = (dirs?: MigrationDirs) => { title: string; message: string };
@@ -667,11 +668,11 @@ const MIGRATION_DIALOGS: Record<MigrationDialogKind, { zh: MigrationDialogCopy; 
   "retry-exhausted": {
     zh: (dirs) => ({
       title: "OCTO 数据迁移已暂停",
-      message: `数据迁移多次失败，已暂停自动重试。本次继续使用旧版数据（DMWork）。如需重新尝试，请删除 ${dirs ? actualBreadcrumbFile(dirs.oldDir) : MIGRATION_BREADCRUMB} 后重启。`,
+      message: `数据迁移多次失败，已暂停自动重试。本次继续使用旧版数据（DMWork）。如需重新尝试，请删除 ${actualBreadcrumbFile(dirs!.oldDir)} 后重启。`,
     }),
     en: (dirs) => ({
       title: "OCTO data migration paused",
-      message: `The migration failed repeatedly and automatic retries are paused. This session continues on the legacy data (DMWork). To retry, delete ${dirs ? actualBreadcrumbFile(dirs.oldDir) : MIGRATION_BREADCRUMB} and restart.`,
+      message: `The migration failed repeatedly and automatic retries are paused. This session continues on the legacy data (DMWork). To retry, delete ${actualBreadcrumbFile(dirs!.oldDir)} and restart.`,
     }),
   },
   occupied: {
@@ -684,6 +685,16 @@ const MIGRATION_DIALOGS: Record<MigrationDialogKind, { zh: MigrationDialogCopy; 
       message: `The destination folder (${dirs?.newDir}) already contains other data, so the migration was not performed to avoid overwriting it. This session continues on the legacy data (${dirs?.oldDir}); both folders are kept. To migrate, back up and remove one of them first.`,
     }),
   },
+  "destination-unreadable": {
+    zh: (dirs) => ({
+      title: "OCTO 数据迁移暂缓（目标不可访问）",
+      message: `目标目录（${dirs?.newDir}）无法访问，无法确认迁移状态，本次继续使用旧版数据（${dirs?.oldDir}）。请检查目录权限后重启。`,
+    }),
+    en: (dirs) => ({
+      title: "OCTO data migration deferred (destination unreadable)",
+      message: `The destination folder (${dirs?.newDir}) cannot be inspected, so the migration state cannot be confirmed. This session continues on the legacy data (${dirs?.oldDir}). Check the folder permissions and restart.`,
+    }),
+  },
 };
 
 function migrationDialogCopy(kind: MigrationDialogKind, dirs?: MigrationDirs) {
@@ -691,10 +702,20 @@ function migrationDialogCopy(kind: MigrationDialogKind, dirs?: MigrationDirs) {
   return MIGRATION_DIALOGS[kind][zh ? "zh" : "en"](dirs);
 }
 
-function showMigrationDialog(kind: MigrationDialogKind, dirs?: MigrationDirs): void {
+// Round-10 P2-5: the one-shot notice is recorded only AFTER the dialog has
+// actually displayed (showErrorBox is synchronous) — recording before showing
+// would hide the message forever if the process dies with the dialog up.
+function showMigrationDialog(
+  kind: MigrationDialogKind,
+  dirs?: MigrationDirs,
+  notice?: { appDataDir: string; key: string }
+): void {
   app.whenReady().then(() => {
     const { title, message } = migrationDialogCopy(kind, dirs);
     dialog.showErrorBox(title, message);
+    if (notice) {
+      recordMigrationNotice(notice.appDataDir, notice.key);
+    }
   });
 }
 
@@ -703,6 +724,10 @@ function showMigrationDialog(kind: MigrationDialogKind, dirs?: MigrationDirs): v
 // ours). Extracted as a function so the success path can `return` after
 // app.exit(0) (rounds 4-6 ask).
 function runStartupMigration(userDataPlan: MigrationPlan): void {
+  // Round-10 P2-1: a stale staging dir (credentials may have been copied into
+  // it) must not linger when this session plans none/legacy — execute() only
+  // cleans it on the migrate path. Lock-winner-scoped, so never concurrent.
+  cleanupStaleStaging(userDataPlan.stagingDir, migrationLog);
   if (userDataPlan.action === "migrate") {
     try {
       const migrationResult = executeUserDataMigration(userDataPlan, { log: migrationLog });
@@ -744,19 +769,29 @@ function runStartupMigration(userDataPlan: MigrationPlan): void {
   const appDataDir = dirname(userDataPlan.oldDir);
   if (userDataPlan.reason === "too-many-failures") {
     if (shouldShowMigrationNotice(appDataDir, "retry-exhausted")) {
-      recordMigrationNotice(appDataDir, "retry-exhausted");
-      showMigrationDialog("retry-exhausted", {
-        oldDir: userDataPlan.oldDir,
-        newDir: userDataPlan.newDir,
-      });
+      showMigrationDialog(
+        "retry-exhausted",
+        { oldDir: userDataPlan.oldDir, newDir: userDataPlan.newDir },
+        { appDataDir, key: "retry-exhausted" }
+      );
     }
   } else if (userDataPlan.reason === "destination-occupied") {
     if (shouldShowMigrationNotice(appDataDir, "destination-occupied")) {
-      recordMigrationNotice(appDataDir, "destination-occupied");
-      showMigrationDialog("occupied", {
-        oldDir: userDataPlan.oldDir,
-        newDir: userDataPlan.newDir,
-      });
+      showMigrationDialog(
+        "occupied",
+        { oldDir: userDataPlan.oldDir, newDir: userDataPlan.newDir },
+        { appDataDir, key: "destination-occupied" }
+      );
+    }
+  } else if (userDataPlan.reason === "destination-unreadable") {
+    // Round-10 P2-6: distinct copy for an uninspectable destination; one-shot
+    // like the other terminal reasons.
+    if (shouldShowMigrationNotice(appDataDir, "destination-unreadable")) {
+      showMigrationDialog(
+        "destination-unreadable",
+        { oldDir: userDataPlan.oldDir, newDir: userDataPlan.newDir },
+        { appDataDir, key: "destination-unreadable" }
+      );
     }
   } else {
     // "plan-failed" is intentionally NOT one-shot, unlike the two reasons

--- a/apps/web/src-election/main/index.ts
+++ b/apps/web/src-election/main/index.ts
@@ -9,6 +9,7 @@ import {
   Menu,
   Tray,
   nativeImage,
+  dialog,
 } from "electron";
 import fs from "fs";
 import tmp from 'tmp';
@@ -550,17 +551,18 @@ function onDeepLink(url: string) {
 app.setName(OCTO_CONFIG.name);
 
 // One-time userData migration from the legacy DMWork profile (see
-// userDataMigration.ts for the full design). The single-instance lock is the
-// cross-launch mutex, keyed off the userData path on every platform: point
-// userData at the legacy dir BEFORE requestSingleInstanceLock(), so
+// userDataMigration.ts for the full design). Electron's single-instance lock
+// is process-global, and the primary-instance lookup keys off the userData
+// path — so pointing userData at the legacy dir BEFORE requestSingleInstanceLock()
+// makes the lock contend with a legacy instance or a concurrent launch:
 //   - a running legacy DMWork instance already holds that lock -> this launch
-//     fails the lock and quits (the legacy-instance guard, no hand-written
-//     probe needed, works on Windows too);
+//     fails the lock and quits (with a dialog, round-4 P1-1);
 //   - a concurrent launch during the migration hits the same held lock and
 //     quits — exactly one process is ever the migrator, no second window can
-//     appear mid-copy (round-2 P0-1 closed).
+//     appear mid-copy.
 // On success we relaunch so the next process takes the OCTO lock; on
-// deferral/failure this session keeps the legacy path and retries next launch.
+// deferral/failure this session keeps the legacy path and retries next launch
+// (bounded by breadcrumbs, round-4 P1-1).
 // This supersedes the temporary setPath('userData', <appData>/DMWork) fallback
 // that #1258 carries until this PR lands.
 const userDataPlan = planUserDataMigration(app.getPath("appData"), OCTO_CONFIG.name);
@@ -576,6 +578,12 @@ app.on("open-url", (event, url) => {
 // 单例模式启动
 const gotTheLock = app.requestSingleInstanceLock();
 if (!gotTheLock) {
+  // P1-1: never quit silently — the user needs to know why nothing happened
+  // (a legacy DMWork instance is still running, or a concurrent launch won).
+  dialog.showErrorBox(
+    "OCTO 已在运行",
+    "检测到另一个实例正在运行（可能是旧版 DMWork 尚未退出）。请退出旧应用后重新启动，以完成数据迁移。"
+  );
   app.quit();
 } else {
   // The migration runs under the single-instance lock we just took on the
@@ -598,9 +606,15 @@ if (!gotTheLock) {
         // present) and locks OCTO normally.
         app.relaunch();
         app.exit(0);
+      } else if (migrationResult === "failed") {
+        // P1-1: make the failure visible (ENOSPC / rename refusal etc.).
+        dialog.showErrorBox(
+          "OCTO 数据迁移未完成",
+          "本次启动继续使用旧版数据（DMWork），下次启动会自动重试。若持续失败，请检查磁盘空间后重试。"
+        );
       }
-      // "deferred"/"failed": keep the legacy profile this session (userData
-      // was already pointed at DMWork before the lock) and retry next launch.
+      // "skipped": the destination gained a real profile since planning —
+      // stay on the legacy path this session, no relaunch (P2-2).
     } catch (err) {
       // Defensive backstop (round-2 P0-2): the migration must never take the
       // app down — fall back to the legacy profile and continue.
@@ -609,6 +623,15 @@ if (!gotTheLock) {
         err
       );
     }
+  } else if (userDataPlan.action === "legacy") {
+    // P1-1: plan-time failure or retry budget exhausted — say so instead of
+    // silently running on the legacy profile.
+    dialog.showErrorBox(
+      "OCTO 数据迁移暂缓",
+      userDataPlan.reason === "too-many-failures"
+        ? "数据迁移多次失败，已暂停自动重试。本次继续使用旧版数据（DMWork）。如需重新尝试，请删除 DMWork 目录下的 .migration-failed.json 后重启。"
+        : "数据迁移准备失败，本次继续使用旧版数据（DMWork），下次启动会自动重试。"
+    );
   }
   app.on("second-instance", (event, argv) => {
     if (mainWindow) {

--- a/apps/web/src-election/main/index.ts
+++ b/apps/web/src-election/main/index.ts
@@ -554,6 +554,14 @@ function onDeepLink(url: string) {
     return;
   }
   console.log("onOpenDeepLink", url);
+  // Octo-Q Appendix D-1: macOS can deliver open-url before `ready` /
+  // createMainWindow — dereferencing webContents would crash the process
+  // instead of dropping the link. Guarded (the losing process is already
+  // barred by the open-url handler's gotTheLock check).
+  if (!mainWindow || mainWindow.isDestroyed()) {
+    console.warn("Deep link dropped: main window not ready:", url);
+    return;
+  }
   mainWindow.webContents.send("deep-link", url);
 }
 

--- a/apps/web/src-election/main/userDataMigration.ts
+++ b/apps/web/src-election/main/userDataMigration.ts
@@ -9,68 +9,65 @@ import path from "path";
 // every existing user would silently start with a fresh empty profile (lost
 // session, localStorage, IndexedDB message stores, drafts).
 //
-// Design (round 3 — structural, per review P0-1/P1-1/P1-2/P2-2/P2-5/P2-11):
-// - Mutual exclusion comes from Electron's OWN single-instance lock, keyed
-//   off the userData path on every platform. index.ts points userData at the
-//   legacy dir BEFORE requestSingleInstanceLock(), so the lock is taken on
-//   the legacy path:
-//     * a running legacy DMWork instance already holds that lock  -> this
-//       launch's requestSingleInstanceLock() fails and it quits (the legacy
-//       guard, cross-platform, no hand-written probe needed);
-//     * a concurrent launch during the migration hits the same held lock and
-//       quits — exactly one process can ever be the migrator, and no second
-//       window can appear mid-copy (the old deferral race that discarded a
-//       user's session is gone).
-//   On success index.ts relaunches so the next process takes the OCTO lock.
+// Design (round 4 — structural, per reviews):
+// - Mutual exclusion comes from Electron's OWN single-instance lock. index.ts
+//   points userData at the legacy dir BEFORE requestSingleInstanceLock(), so
+//   the lock is taken on the legacy path (the primary-instance lookup keys off
+//   the userData path): a running legacy instance or a concurrent launch fails
+//   the lock and quits. On success index.ts relaunches so the next process
+//   takes the OCTO lock. (P0-1/P1-1 from rounds 2-3.)
 // - Staging copy + atomic rename: copy into <appData>/OCTO.migrating, then
-//   renameSync into place. renameSync is atomic, so <appData>/OCTO only ever
-//   appears as a COMPLETE profile. DMWork is never mutated, so a failed
-//   attempt simply retries on the next launch and a release rollback keeps
-//   the legacy profile.
-// - Completion marker: the sentinel is <appData>/OCTO/.migrated-from-dmwork,
-//   NOT the existence of <appData>/OCTO. The marker is written into the
-//   staging dir BEFORE the rename (round-1 F5), so profile+marker publish
-//   atomically and a post-rename marker failure can no longer strand a
-//   markerless destination.
-// - Failure containment ("never throws", round-2 P0-2): every I/O statement
-//   in both plan() and execute() is inside a try/catch. No input state may
-//   make them throw — plan() degrades to "legacy" (this session keeps the
-//   DMWork path, retried next launch), execute() degrades to "failed" with
-//   the legacy profile, and index.ts adds a defensive try/catch backstop.
-// - Destination with real data (round-1 F6/F10): if <appData>/OCTO already
-//   exists with non-lock content and no marker, plan() returns "none"
-//   permanently (idempotent, no per-launch re-decision), both profiles are
-//   kept, and the skip is logged loudly. execute() re-asserts the lock-only
-//   invariant immediately before deleting the destination (round-2 P2-6).
-// - Copy filter is anchored to top-level entries only (round-2 P2-3): nested
-//   dirs named like caches (e.g. Partitions/*/Cache) are NOT pruned — only a
-//   top-level entry in SKIP_DIRS / ELECTRON_LOCK_FILES is skipped.
+//   renameSync into place. DMWork is never mutated, so a failed attempt
+//   retries on the next launch and a release rollback keeps the legacy
+//   profile.
+// - Completion marker + profile sentinel (round-4 P1-2): the sentinel is
+//   <appData>/OCTO/.migrated-from-dmwork AND a real profile file
+//   (Preferences / Local State). A bare marker (power loss mid-publish, no
+//   fsync anywhere) is NOT trusted — plan() treats it as torn and re-migrates.
+//   The marker is written into the staging dir BEFORE the rename so profile+
+//   marker publish atomically.
+// - Failure containment ("never throws"): every I/O in plan()/execute() is
+//   inside try/catch; plan degrades to "legacy", execute to "failed", index.ts
+//   has a defensive try/catch backstop. Failures are visible: breadcrumbs in
+//   the legacy profile bound retries (round-4 P1-1), and index.ts surfaces
+//   dialogs for occupied-destination / too-many-failures / lock-held.
+// - Destination policy (round-4 P2-1): a destination counts as a REAL profile
+//   only when it has a profile sentinel. Anything else (lock files, Crashpad,
+//   caches) is cleanable and does not block migration — no allowlist polarity.
+// - Copy filter anchored to top-level entries, case-insensitive (nits).
 // ---------------------------------------------------------------------------
 
 export const LEGACY_USER_DATA_DIR = "DMWork";
 export const MIGRATION_MARKER = ".migrated-from-dmwork";
+export const MIGRATION_BREADCRUMB = ".migration-failed.json";
+export const MAX_MIGRATION_ATTEMPTS = 3;
+
+// A "real profile" is recognized by these sentinel files (Chromium always
+// writes them into userData before any app-level data).
+const PROFILE_SENTINELS = ["Preferences", "Local State"];
 
 // Files Electron/Chromium's ProcessSingleton creates in userData. Never
-// migrated (round-1 F3) and the only entries a pre-existing destination is
-// allowed to contain for the migration to proceed (round-1 F2/F10).
+// migrated (round-1 F3). Stored lower-case; matched case-insensitively.
 const ELECTRON_LOCK_FILES = new Set([
-  "SingletonLock",
-  "SingletonCookie",
-  "SingletonSocket",
+  "singletonlock",
+  "singletoncookie",
+  "singletonsocket",
   "lockfile",
 ]);
 
-// Regenerable Chromium caches, intentionally not migrated (top-level only).
-export const SKIP_DIRS = new Set([
-  "Cache",
-  "Code Cache",
-  "GPUCache",
-  "DawnCache",
-  "DawnGraphiteCache",
-  "DawnWebGPUCache",
-  "ShaderCache",
-  "Service Worker",
+// Regenerable Chromium caches / crash artifacts, intentionally not migrated
+// (top-level only, matched case-insensitively). Stored lower-case.
+const SKIP_DIRS = new Set([
+  "cache",
+  "code cache",
+  "gpucache",
+  "dawncache",
+  "dawngraphitecache",
+  "dawnwebgpucache",
+  "shadercache",
+  "service worker",
   "blob_storage",
+  "crashpad",
 ]);
 
 export type MigrationPlan = {
@@ -78,9 +75,10 @@ export type MigrationPlan = {
   oldDir: string;
   newDir: string;
   stagingDir: string;
+  reason?: "destination-occupied" | "too-many-failures";
 };
 
-export type MigrationResult = "done" | "deferred" | "failed";
+export type MigrationResult = "done" | "failed" | "skipped";
 
 export type MigrationRuntime = {
   log: {
@@ -90,34 +88,89 @@ export type MigrationRuntime = {
   };
 };
 
+function hasProfileSentinel(dir: string): boolean {
+  return PROFILE_SENTINELS.some((name) => fs.existsSync(path.join(dir, name)));
+}
+
+function readBreadcrumb(oldDir: string): { attempts: number; lastError?: string; lastAttemptAt?: string } | null {
+  try {
+    const raw = JSON.parse(fs.readFileSync(path.join(oldDir, MIGRATION_BREADCRUMB), "utf8"));
+    return typeof raw?.attempts === "number" ? raw : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeBreadcrumb(oldDir: string, err: unknown): void {
+  try {
+    const prev = readBreadcrumb(oldDir) ?? { attempts: 0 };
+    fs.writeFileSync(
+      path.join(oldDir, MIGRATION_BREADCRUMB),
+      JSON.stringify({
+        attempts: prev.attempts + 1,
+        lastError: err instanceof Error ? err.message : String(err),
+        lastAttemptAt: new Date().toISOString(),
+      })
+    );
+  } catch {
+    // best-effort; never throw from the failure path
+  }
+}
+
+function removeBreadcrumb(oldDir: string): void {
+  try {
+    fs.rmSync(path.join(oldDir, MIGRATION_BREADCRUMB), { force: true });
+  } catch {
+    // best-effort
+  }
+}
+
 export function planUserDataMigration(appDataDir: string, brandName: string): MigrationPlan {
   const oldDir = path.join(appDataDir, LEGACY_USER_DATA_DIR);
   const newDir = path.join(appDataDir, brandName);
   const stagingDir = `${newDir}.migrating`;
   try {
-    if (!fs.existsSync(oldDir) || fs.existsSync(path.join(newDir, MIGRATION_MARKER))) {
+    // P2-6: the legacy path must be a directory; a regular file is not a
+    // profile (and would blow up the copy) — treat as "no migration".
+    let oldIsDir = false;
+    try {
+      oldIsDir = fs.statSync(oldDir).isDirectory();
+    } catch {
+      oldIsDir = false;
+    }
+    if (!oldIsDir) {
       return { action: "none", oldDir, newDir, stagingDir };
     }
-    // round-1 F6/F10: a destination that already holds real data (no marker)
-    // wins. Deciding here — not in execute() — makes the decision idempotent
-    // across launches: plan() returns "none" forever, no re-decision loop.
-    // The skip is surfaced loudly (round-2 P2-1).
-    if (fs.existsSync(newDir)) {
-      const nonLock = fs
-        .readdirSync(newDir)
-        .filter((name) => !ELECTRON_LOCK_FILES.has(name) && name !== MIGRATION_MARKER);
-      if (nonLock.length > 0) {
-        console.warn(
-          `[userData] ${newDir} already contains data but no migration marker; keeping both profiles and NOT migrating (legacy data stays in ${oldDir}).`
-        );
+    // P1-2: marker alone is not trusted — it must be accompanied by a real
+    // profile sentinel. A bare marker (torn publish) re-migrates.
+    if (fs.existsSync(path.join(newDir, MIGRATION_MARKER))) {
+      if (hasProfileSentinel(newDir)) {
         return { action: "none", oldDir, newDir, stagingDir };
       }
+      console.warn(
+        `[userData] ${newDir} has a migration marker but no profile sentinel (torn publish?); re-migrating.`
+      );
+    }
+    // P2-1: a destination is a real profile only when it has a sentinel;
+    // anything else (locks, Crashpad, caches) is cleanable and does not block.
+    if (hasProfileSentinel(newDir)) {
+      console.warn(
+        `[userData] ${newDir} already contains a real profile (no marker); keeping both profiles and NOT migrating (legacy data stays in ${oldDir}).`
+      );
+      return { action: "none", oldDir, newDir, stagingDir, reason: "destination-occupied" };
+    }
+    // P1-1: bound retries — after N consecutive failures the migration stops
+    // auto-retrying and the session runs on the legacy profile (index.ts
+    // surfaces a dialog). Deleting ${oldDir}/${MIGRATION_BREADCRUMB} re-enables.
+    const breadcrumb = readBreadcrumb(oldDir);
+    if (breadcrumb && breadcrumb.attempts >= MAX_MIGRATION_ATTEMPTS) {
+      console.warn(
+        `[userData] migration failed ${breadcrumb.attempts} times (last: ${breadcrumb.lastError ?? "unknown"}); disabling auto-retry. Delete ${oldDir}/${MIGRATION_BREADCRUMB} to re-enable.`
+      );
+      return { action: "legacy", oldDir, newDir, stagingDir, reason: "too-many-failures" };
     }
     return { action: "migrate", oldDir, newDir, stagingDir };
   } catch (err) {
-    // round-2 P0-2: never throw out of plan(). Degrade to "legacy" — the
-    // caller points userData at DMWork for this session and retries next
-    // launch. Safer than guessing "none" (which would use an empty OCTO).
     console.error(
       `[userData] planUserDataMigration failed; using the legacy profile this session (will retry on next launch):`,
       err
@@ -131,51 +184,50 @@ export function executeUserDataMigration(
   runtime: MigrationRuntime
 ): MigrationResult {
   if (plan.action !== "migrate") {
-    // "none": nothing to do. "legacy": the caller already pointed userData
-    // at the legacy dir before the single-instance lock; this session simply
-    // runs there and retries the migration next launch.
-    return plan.action === "legacy" ? "deferred" : "done";
+    // Defensive: index.ts only calls execute() for "migrate" plans. "none" is
+    // a no-op; "legacy" is handled by the caller (path already pointed at
+    // DMWork before the lock).
+    return plan.action === "legacy" ? "skipped" : "done";
   }
   // action === "migrate"
   try {
-    // round-2 P2-6: re-assert the lock-only invariant immediately before
-    // deleting the destination — plan() may have run minutes ago (the copy
-    // below can be slow on multi-GB profiles).
+    // P2-6 (execute side): re-assert the destination is not a real profile
+    // immediately before deleting it — plan() may have run minutes ago.
     if (fs.existsSync(plan.newDir)) {
-      const nonLock = fs
-        .readdirSync(plan.newDir)
-        .filter((name) => !ELECTRON_LOCK_FILES.has(name));
-      if (nonLock.length > 0) {
+      if (hasProfileSentinel(plan.newDir)) {
+        // P2-2: a skip is NOT a success — the caller must not relaunch onto
+        // the non-ours destination; this session stays on the legacy path.
         runtime.log.warn(
-          `[userData] ${plan.newDir} gained non-lock data since planning; not migrating (both profiles kept).`
+          `[userData] ${plan.newDir} gained a real profile since planning; not migrating (both profiles kept).`
         );
-        return "done";
+        return "skipped";
       }
       fs.rmSync(plan.newDir, { recursive: true, force: true });
     }
-    // Crash residue from an interrupted previous attempt: with the
-    // single-instance lock as the mutex there is never a concurrent writer,
-    // so a leftover staging dir is always stale — clear it.
+    // Crash residue from an interrupted attempt: with the single-instance lock
+    // as the mutex there is never a concurrent writer, so a leftover staging
+    // dir is always stale — clear it.
     if (fs.existsSync(plan.stagingDir)) {
       fs.rmSync(plan.stagingDir, { recursive: true, force: true });
     }
     fs.mkdirSync(plan.stagingDir);
-    // round-1 F3 + round-2 P2-3: never copy singleton artifacts / locks, and
-    // anchor the filter to top-level entries (nested dirs are left alone).
+    // F3 + P2-3: never copy singleton artifacts / locks; anchor the filter to
+    // top-level entries (nested dirs are left alone), case-insensitive.
     fs.cpSync(plan.oldDir, plan.stagingDir, {
       recursive: true,
       filter: (src) => {
         const rel = path.relative(plan.oldDir, src);
         if (rel.includes(path.sep)) return true; // nested: never prune
-        return !SKIP_DIRS.has(rel) && !ELECTRON_LOCK_FILES.has(rel);
+        const lower = rel.toLowerCase();
+        return !SKIP_DIRS.has(lower) && !ELECTRON_LOCK_FILES.has(lower);
       },
     });
-    // round-1 F5: marker lands in staging BEFORE the rename, so profile+marker
-    // publish as one atomic step. (No fsync: a marker is only ever written
-    // before the rename now, and claiming power-loss durability would require
-    // flushing the whole copied tree, which is out of scope — round-2 P2-4.)
+    // F5: marker lands in staging BEFORE the rename, so profile+marker publish
+    // as one atomic step (no fsync claimed; P1-2 guards torn publishes via the
+    // sentinel check on the next launch).
     fs.writeFileSync(path.join(plan.stagingDir, MIGRATION_MARKER), new Date().toISOString());
     fs.renameSync(plan.stagingDir, plan.newDir);
+    removeBreadcrumb(plan.oldDir);
     runtime.log.info(`[userData] migrated legacy DMWork profile to ${plan.newDir}`);
     return "done";
   } catch (err) {
@@ -184,6 +236,7 @@ export function executeUserDataMigration(
     } catch {
       // best-effort cleanup; the next launch retries anyway
     }
+    writeBreadcrumb(plan.oldDir, err);
     runtime.log.error(
       "[userData] DMWork -> OCTO migration failed; keeping the legacy profile for this session (will retry on next launch):",
       err

--- a/apps/web/src-election/main/userDataMigration.ts
+++ b/apps/web/src-election/main/userDataMigration.ts
@@ -9,38 +9,49 @@ import path from "path";
 // every existing user would silently start with a fresh empty profile (lost
 // session, localStorage, IndexedDB message stores, drafts).
 //
-// Design (round 5 — per review):
+// Design (round 6 — per review):
 // - Mutual exclusion comes from Electron's OWN single-instance lock. index.ts
 //   points userData at the legacy dir BEFORE requestSingleInstanceLock(), so
 //   the lock is taken on the legacy path (the primary-instance lookup keys off
 //   the userData path): a running legacy instance or a concurrent launch fails
 //   the lock and quits. On success index.ts relaunches so the next process
-//   takes the OCTO lock. The second-instance dialog is gated to the
-//   migration-related paths (round-5 P1-2). Note the lock protects the legacy
-//   dir, and the destination rmSync in execute() targets OCTO, which no live
-//   process can hold (the migration path never takes the OCTO lock before
-//   publishing) — documented invariant (round-5 P1-3).
+//   takes the OCTO lock. The second-instance dialog is gated to action
+//   "migrate" only (round-6 P2-3): a lock failure on any other plan is the
+//   ordinary focus-the-running-instance flow.
 // - Staging copy + atomic rename: copy into <appData>/OCTO.migrating, then
-//   renameSync into place. DMWork is never mutated, so a failed attempt
-//   retries on the next launch and a release rollback keeps the legacy
-//   profile.
-// - Completion marker + profile sentinel (round-4 P1-2, refined round-5 P0-1):
-//   a migration is "complete" when the marker AND a profile sentinel coexist,
-//   OR when the legacy profile itself carries no sentinel (regenerable caches
-//   only — re-copying would publish nothing and loop forever). The invariant
-//   "execute() === 'done' implies the next plan() returns 'none'" is pinned by
-//   a round-trip test. A bare marker with a data-bearing legacy is treated as
-//   torn and re-migrated. The marker is written into the staging dir BEFORE
-//   the rename so profile+marker publish atomically.
+//   renameSync into place. The legacy PROFILE DATA is never mutated — the only
+//   write into <appData>/DMWork is the failure breadcrumb dotfile, which falls
+//   back to <appData> itself when the legacy dir is unwritable (round-6 P2-1)
+//   — so a failed attempt retries on the next launch and a release rollback
+//   keeps the legacy profile.
+// - Destination safety is an ALLOWLIST, not a sentinel probe (round-6 P1-1):
+//   the destination is deleted only when EVERY top-level entry is known
+//   cleanable (singleton locks, regenerable caches, the marker itself);
+//   anything unrecognized counts as occupied data and blocks the migration.
+//   Measured on a real Electron 26 binary: Chromium writes Preferences up to
+//   ~10 s after launch and "Local State" not at all on some platforms, so a
+//   sentinel-only probe has a false-negative window on live profiles (it
+//   would rmSync a profile that already holds Local Storage / IndexedDB).
+//   The allowlist has no such window: an unknown entry is never deleted.
+// - Completion marker + residual data: a migration is "complete" when the
+//   marker coexists with residual destination data, OR when the legacy profile
+//   itself carries no sentinel (regenerable caches only — re-copying would
+//   publish nothing and loop forever). A bare marker over an EMPTY destination
+//   with a data-bearing legacy is torn and re-migrated. The marker is written
+//   into the staging dir BEFORE the rename so profile+marker publish
+//   atomically. A marker-bearing destination that later loses Preferences
+//   (e.g. a user reset) is trusted via its residual data and NEVER
+//   re-migrated over (round-6 P1-1, failure scenario A).
+// - Occupied destination (round-6 P1-2): plan() returns action "legacy" with
+//   reason "destination-occupied"; the session stays on the established DMWork
+//   profile and index.ts surfaces a one-shot dialog naming both directories.
 // - Failure containment and visibility: every I/O in plan()/execute() is
 //   inside try/catch ("never throws"); plan distinguishes ENOENT (none, fresh
 //   install) from other stat errors (legacy — never silently start a fresh
 //   OCTO next to an unreachable DMWork, round-5 P1-1); failures are bounded by
 //   a breadcrumb (attempts+lastError, cleared on success) and surfaced via
-//   dialogs from index.ts.
-// - Destination policy (round-4 P2-1): a destination counts as a REAL profile
-//   only when it has a profile sentinel; anything else (locks, Crashpad,
-//   caches) is cleanable and does not block migration.
+//   dialogs from index.ts — all deferred behind app.whenReady() so they also
+//   render on Linux (round-6 P2-2), bilingual via app.getLocale().
 // - Copy filter anchored to top-level entries, case-insensitive; the
 //   breadcrumb is never copied (round-5 P2).
 // ---------------------------------------------------------------------------
@@ -48,10 +59,15 @@ import path from "path";
 export const LEGACY_USER_DATA_DIR = "DMWork";
 export const MIGRATION_MARKER = ".migrated-from-dmwork";
 export const MIGRATION_BREADCRUMB = ".migration-failed.json";
+// One-shot dialog bookkeeping lives beside the staging dir (appData), so it
+// works even when the legacy profile dir is unwritable.
+export const MIGRATION_NOTICES = ".octo-migration-notices.json";
 export const MAX_MIGRATION_ATTEMPTS = 3;
 
 // A "real profile" is recognized by these sentinel files (Chromium always
-// writes them into userData before any app-level data).
+// writes them into userData before any app-level data). NOTE: only used for
+// the LEGACY dir — never as the sole guard for deleting the destination
+// (Chromium can run ~10 s without Preferences; see the allowlist below).
 const PROFILE_SENTINELS = ["Preferences", "Local State"];
 
 // Files Electron/Chromium's ProcessSingleton creates in userData. Never
@@ -78,6 +94,31 @@ const SKIP_DIRS = new Set([
   "crashpad",
 ]);
 
+// Round-6 P1-1: the destination-decision ALLOWLIST. Deleting the destination
+// is permitted only when every top-level entry is one of these; anything else
+// is user data we do not own and must never be deleted.
+const DESTINATION_CLEANABLE = (() => {
+  const set = new Set<string>();
+  ELECTRON_LOCK_FILES.forEach((e) => set.add(e));
+  SKIP_DIRS.forEach((e) => set.add(e));
+  set.add(MIGRATION_MARKER);
+  set.add("dictionaries");
+  set.add("network persistent state");
+  return set;
+})();
+
+// Top-level entries of `dir` that are NOT known-cleanable. A non-empty result
+// means "occupied". Fail-closed: an unreadable dir reports a fake residual.
+function residualEntries(dir: string): string[] {
+  try {
+    return fs
+      .readdirSync(dir)
+      .filter((entry) => !DESTINATION_CLEANABLE.has(entry.toLowerCase()));
+  } catch {
+    return ["<unreadable>"];
+  }
+}
+
 export type MigrationPlan = {
   action: "migrate" | "legacy" | "none";
   oldDir: string;
@@ -100,40 +141,94 @@ function hasProfileSentinel(dir: string): boolean {
   return PROFILE_SENTINELS.some((name) => fs.existsSync(path.join(dir, name)));
 }
 
-function readBreadcrumb(oldDir: string): { attempts: number; lastError?: string; lastAttemptAt?: string } | null {
+// The breadcrumb lives in the legacy dir; when that dir is unwritable
+// (read-only / full volume) it falls back to appData — otherwise a write
+// failure would silently disable the retry bound (round-6 P2-1).
+function breadcrumbPaths(oldDir: string): [string, string] {
+  return [
+    path.join(oldDir, MIGRATION_BREADCRUMB),
+    path.join(path.dirname(oldDir), MIGRATION_BREADCRUMB),
+  ];
+}
+
+function readBreadcrumbFile(
+  file: string
+): { attempts: number; lastError?: string; lastAttemptAt?: string } | null {
   try {
-    const raw = JSON.parse(fs.readFileSync(path.join(oldDir, MIGRATION_BREADCRUMB), "utf8"));
+    const raw = JSON.parse(fs.readFileSync(file, "utf8"));
     return typeof raw?.attempts === "number" ? raw : null;
   } catch {
     return null;
   }
 }
 
+function readBreadcrumb(
+  oldDir: string
+): { attempts: number; lastError?: string; lastAttemptAt?: string } | null {
+  const [primary, fallback] = breadcrumbPaths(oldDir);
+  return readBreadcrumbFile(primary) ?? readBreadcrumbFile(fallback);
+}
+
 function writeBreadcrumb(oldDir: string, err: unknown): void {
-  try {
-    const prev = readBreadcrumb(oldDir) ?? { attempts: 0 };
-    fs.writeFileSync(
-      path.join(oldDir, MIGRATION_BREADCRUMB),
-      JSON.stringify({
-        attempts: prev.attempts + 1,
-        lastError: err instanceof Error ? err.message : String(err),
-        lastAttemptAt: new Date().toISOString(),
-      })
-    );
-  } catch {
-    // best-effort; never throw from the failure path
+  const prev = readBreadcrumb(oldDir) ?? { attempts: 0 };
+  const payload = JSON.stringify({
+    attempts: prev.attempts + 1,
+    lastError: err instanceof Error ? err.message : String(err),
+    lastAttemptAt: new Date().toISOString(),
+  });
+  for (const file of breadcrumbPaths(oldDir)) {
+    try {
+      fs.writeFileSync(file, payload);
+      return;
+    } catch {
+      // try the next location; never throw from the failure path
+    }
   }
 }
 
 function removeBreadcrumb(oldDir: string): void {
+  for (const file of breadcrumbPaths(oldDir)) {
+    try {
+      fs.rmSync(file, { force: true });
+    } catch {
+      // best-effort
+    }
+  }
+}
+
+// One-shot dialog bookkeeping (round-6 P2: stop nagging on every launch once
+// the user has been told). Best-effort; a read/write failure degrades to
+// "show it again", never to a crash.
+export function shouldShowMigrationNotice(appDataDir: string, key: string): boolean {
   try {
-    fs.rmSync(path.join(oldDir, MIGRATION_BREADCRUMB), { force: true });
+    const raw = JSON.parse(fs.readFileSync(path.join(appDataDir, MIGRATION_NOTICES), "utf8"));
+    return !Array.isArray(raw?.shown) || !raw.shown.includes(key);
+  } catch {
+    return true;
+  }
+}
+
+export function recordMigrationNotice(appDataDir: string, key: string): void {
+  try {
+    let shown: string[] = [];
+    try {
+      const raw = JSON.parse(fs.readFileSync(path.join(appDataDir, MIGRATION_NOTICES), "utf8"));
+      if (Array.isArray(raw?.shown)) shown = raw.shown;
+    } catch {
+      // first notice
+    }
+    if (!shown.includes(key)) shown.push(key);
+    fs.writeFileSync(path.join(appDataDir, MIGRATION_NOTICES), JSON.stringify({ shown }));
   } catch {
     // best-effort
   }
 }
 
-export function planUserDataMigration(appDataDir: string, brandName: string): MigrationPlan {
+export function planUserDataMigration(
+  appDataDir: string,
+  brandName: string,
+  log: MigrationRuntime["log"] = console
+): MigrationPlan {
   const oldDir = path.join(appDataDir, LEGACY_USER_DATA_DIR);
   const newDir = path.join(appDataDir, brandName);
   const stagingDir = `${newDir}.migrating`;
@@ -149,7 +244,7 @@ export function planUserDataMigration(appDataDir: string, brandName: string): Mi
       if ((err as NodeJS.ErrnoException).code === "ENOENT") {
         return { action: "none", oldDir, newDir, stagingDir };
       }
-      console.error(
+      log.error(
         `[userData] cannot inspect ${oldDir} (${(err as NodeJS.ErrnoException).code ?? err}); using the legacy profile this session.`,
         err
       );
@@ -159,41 +254,49 @@ export function planUserDataMigration(appDataDir: string, brandName: string): Mi
       // A regular file is not a profile (P2-6, round-4).
       return { action: "none", oldDir, newDir, stagingDir };
     }
-    // P0-1 (round-5): the round-trip invariant is "execute() === 'done'
-    // implies the NEXT plan() returns 'none'". A marker without a profile
-    // sentinel is only "torn" when the legacy profile actually had data to
-    // carry; if the legacy profile has no sentinel either (regenerable caches
-    // only), re-migrating would copy nothing and loop forever — so that state
-    // counts as migrated.
+    // The round-trip invariant is "execute() === 'done' implies the NEXT
+    // plan() returns 'none'". A marker is trusted whenever the destination
+    // carries residual data (a live profile grew after the publish — e.g. the
+    // user deleted Preferences to reset UI state; re-migrating would destroy
+    // every byte written since, round-6 P1-1 scenario A), or when the legacy
+    // profile has no sentinel either (regenerable caches only — re-copying
+    // would publish nothing and loop forever). Only a bare marker over an
+    // EMPTY destination with a data-bearing legacy is torn and re-migrated.
     if (fs.existsSync(path.join(newDir, MIGRATION_MARKER))) {
-      if (hasProfileSentinel(newDir) || !hasProfileSentinel(oldDir)) {
+      if (residualEntries(newDir).length > 0 || !hasProfileSentinel(oldDir)) {
         return { action: "none", oldDir, newDir, stagingDir };
       }
-      console.warn(
-        `[userData] ${newDir} has a migration marker but no profile sentinel (torn publish?); re-migrating.`
+      log.warn(
+        `[userData] ${newDir} has a migration marker but no residual data (torn publish?); re-migrating.`
       );
     }
-    // P2-1: a destination is a real profile only when it has a sentinel;
-    // anything else (locks, Crashpad, caches) is cleanable and does not block.
-    if (hasProfileSentinel(newDir)) {
-      console.warn(
-        `[userData] ${newDir} already contains a real profile (no marker); keeping both profiles and NOT migrating (legacy data stays in ${oldDir}).`
-      );
-      return { action: "none", oldDir, newDir, stagingDir, reason: "destination-occupied" };
+    // Round-6 P1-1/P1-2: a destination holding ANY entry that is not
+    // known-cleanable is occupied by data we do not own. Stay on the
+    // established legacy profile and let index.ts say so (reason consumed
+    // there). A sentinel probe alone would miss a live profile in its first
+    // ~10 s (Local Storage present, Preferences not written yet).
+    if (fs.existsSync(newDir)) {
+      const residual = residualEntries(newDir);
+      if (residual.length > 0) {
+        log.warn(
+          `[userData] ${newDir} already holds data without a migration marker (entries: ${residual.join(", ")}); keeping both profiles and NOT migrating (legacy data stays in ${oldDir}).`
+        );
+        return { action: "legacy", oldDir, newDir, stagingDir, reason: "destination-occupied" };
+      }
     }
     // P1-1: bound retries — after N consecutive failures the migration stops
     // auto-retrying and the session runs on the legacy profile (index.ts
     // surfaces a dialog). Deleting ${oldDir}/${MIGRATION_BREADCRUMB} re-enables.
     const breadcrumb = readBreadcrumb(oldDir);
     if (breadcrumb && breadcrumb.attempts >= MAX_MIGRATION_ATTEMPTS) {
-      console.warn(
+      log.warn(
         `[userData] migration failed ${breadcrumb.attempts} times (last: ${breadcrumb.lastError ?? "unknown"}); disabling auto-retry. Delete ${oldDir}/${MIGRATION_BREADCRUMB} to re-enable.`
       );
       return { action: "legacy", oldDir, newDir, stagingDir, reason: "too-many-failures" };
     }
     return { action: "migrate", oldDir, newDir, stagingDir };
   } catch (err) {
-    console.error(
+    log.error(
       `[userData] planUserDataMigration failed; using the legacy profile this session (will retry on next launch):`,
       err
     );
@@ -213,14 +316,18 @@ export function executeUserDataMigration(
   }
   // action === "migrate"
   try {
-    // P2-6 (execute side): re-assert the destination is not a real profile
-    // immediately before deleting it — plan() may have run minutes ago.
+    // Round-6 P1-1: re-assert the destination is cleanable immediately before
+    // deleting it — plan() may have run minutes ago. Polarity is an allowlist:
+    // delete only if every top-level entry is known-cleanable; any unknown
+    // entry (even without Preferences/Local State) is treated as occupied and
+    // never deleted.
     if (fs.existsSync(plan.newDir)) {
-      if (hasProfileSentinel(plan.newDir)) {
-        // P2-2: a skip is NOT a success — the caller must not relaunch onto
-        // the non-ours destination; this session stays on the legacy path.
+      const residual = residualEntries(plan.newDir);
+      if (residual.length > 0) {
+        // A skip is NOT a success — the caller must not relaunch onto the
+        // non-ours destination; this session stays on the legacy path.
         runtime.log.warn(
-          `[userData] ${plan.newDir} gained a real profile since planning; not migrating (both profiles kept).`
+          `[userData] ${plan.newDir} holds unexpected entries (${residual.join(", ")}); not migrating (both profiles kept).`
         );
         return "skipped";
       }
@@ -238,6 +345,7 @@ export function executeUserDataMigration(
     // breadcrumb is migration bookkeeping, never copied (round-5 P2).
     fs.cpSync(plan.oldDir, plan.stagingDir, {
       recursive: true,
+      preserveTimestamps: true,
       filter: (src) => {
         const rel = path.relative(plan.oldDir, src);
         if (rel.includes(path.sep)) return true; // nested: never prune
@@ -250,8 +358,8 @@ export function executeUserDataMigration(
       },
     });
     // F5: marker lands in staging BEFORE the rename, so profile+marker publish
-    // as one atomic step (no fsync claimed; P1-2 guards torn publishes via the
-    // sentinel check on the next launch).
+    // as one atomic step (no fsync claimed; the marker+residual completion
+    // rule guards torn publishes on the next launch).
     fs.writeFileSync(path.join(plan.stagingDir, MIGRATION_MARKER), new Date().toISOString());
     fs.renameSync(plan.stagingDir, plan.newDir);
     removeBreadcrumb(plan.oldDir);

--- a/apps/web/src-election/main/userDataMigration.ts
+++ b/apps/web/src-election/main/userDataMigration.ts
@@ -80,6 +80,10 @@ const ELECTRON_LOCK_FILES = new Set([
 
 // Regenerable Chromium caches / crash artifacts, intentionally not migrated
 // (top-level only, matched case-insensitively). Stored lower-case.
+// Reviewed (round-8): Service Worker/ and blob_storage are safe to prune —
+// the renderer has no caches.open/match or serviceWorker.register call sites
+// anywhere in apps/web or packages (the only SW shipped is the MSW test
+// harness). If a future Cache Storage feature lands, revisit this entry.
 const SKIP_DIRS = new Set([
   "cache",
   "code cache",
@@ -120,6 +124,7 @@ const DESTINATION_CLEANABLE = (() => {
   set.add(".ds_store");
   set.add("thumbs.db");
   set.add("desktop.ini");
+  set.add(".localized");
   return set;
 })();
 
@@ -377,9 +382,19 @@ export function planUserDataMigration(
     const breadcrumb = readBreadcrumb(oldDir);
     if (breadcrumb && breadcrumb.attempts >= MAX_MIGRATION_ATTEMPTS) {
       log.warn(
-        `[userData] migration failed ${breadcrumb.attempts} times (last: ${breadcrumb.lastError ?? "unknown"}); disabling auto-retry. Delete ${oldDir}/${MIGRATION_BREADCRUMB} to re-enable.`
+        `[userData] migration failed ${breadcrumb.attempts} times (last: ${breadcrumb.lastError ?? "unknown"}); disabling auto-retry. Delete ${actualBreadcrumbFile(oldDir)} to re-enable.`
       );
       return { action: "legacy", oldDir, newDir, stagingDir, reason: "too-many-failures" };
+    }
+    // Round-8 nit (P2-1 review): a legacy profile holding NOTHING the copy
+    // would publish (empty dir, or caches/singleton artifacts only) plans
+    // "none" instead of a marker-only migrate+relaunch that accomplishes
+    // nothing visible. Same rule as the marker branch above (hasCopyableData).
+    if (!hasCopyableData(oldDir)) {
+      log.warn(
+        `[userData] ${oldDir} holds nothing the migration would copy; skipping (no marker published).`
+      );
+      return { action: "none", oldDir, newDir, stagingDir };
     }
     return { action: "migrate", oldDir, newDir, stagingDir };
   } catch (err) {

--- a/apps/web/src-election/main/userDataMigration.ts
+++ b/apps/web/src-election/main/userDataMigration.ts
@@ -35,12 +35,15 @@ import path from "path";
 //   The allowlist has no such window: an unknown entry is never deleted.
 // - Completion marker + residual data: a migration is "complete" when the
 //   marker coexists with residual destination data, OR when the legacy profile
-//   itself carries no sentinel (regenerable caches only — re-copying would
-//   publish nothing and loop forever). A bare marker over an EMPTY destination
-//   with a data-bearing legacy is torn and re-migrated. The marker is written
-//   into the staging dir BEFORE the rename so profile+marker publish
-//   atomically. A marker-bearing destination that later loses Preferences
-//   (e.g. a user reset) is trusted via its residual data and NEVER
+//   has nothing copyable left (regenerable caches / singleton artifacts only —
+//   re-copying would publish nothing and loop forever). "Nothing copyable" is
+//   judged with the SAME rule as the copy filter (round-8 P1-2): a legacy
+//   holding only IndexedDB / Local Storage / Cookies still carries real data
+//   and a bare marker over it is torn, re-migrated. A bare marker over an
+//   EMPTY destination with a data-bearing legacy is torn and re-migrated. The
+//   marker is written into the staging dir BEFORE the rename so profile+marker
+//   publish atomically. A marker-bearing destination that later loses
+//   Preferences (e.g. a user reset) is trusted via its residual data and NEVER
 //   re-migrated over (round-6 P1-1, failure scenario A).
 // - Occupied destination (round-6 P1-2): plan() returns action "legacy" with
 //   reason "destination-occupied"; the session stays on the established DMWork
@@ -64,14 +67,10 @@ export const MIGRATION_BREADCRUMB = ".migration-failed.json";
 export const MIGRATION_NOTICES = ".octo-migration-notices.json";
 export const MAX_MIGRATION_ATTEMPTS = 3;
 
-// A "real profile" is recognized by these sentinel files (Chromium always
-// writes them into userData before any app-level data). NOTE: only used for
-// the LEGACY dir — never as the sole guard for deleting the destination
-// (Chromium can run ~10 s without Preferences; see the allowlist below).
-const PROFILE_SENTINELS = ["Preferences", "Local State"];
-
-// Files Electron/Chromium's ProcessSingleton creates in userData. Never
-// migrated (round-1 F3). Stored lower-case; matched case-insensitively.
+// A "real profile" is recognized by Chromium's userData layout; the copy
+// filter (see execute()) prunes regenerable caches and singleton artifacts,
+// so "does this dir carry data the migration would actually copy" is the rule
+// used for the legacy side of the completion check (round-8 P1-2).
 const ELECTRON_LOCK_FILES = new Set([
   "singletonlock",
   "singletoncookie",
@@ -97,25 +96,68 @@ const SKIP_DIRS = new Set([
 // Round-6 P1-1: the destination-decision ALLOWLIST. Deleting the destination
 // is permitted only when every top-level entry is one of these; anything else
 // is user data we do not own and must never be deleted.
+// Round-8 P2-4: ProcessSingleton artifacts (SingletonLock/SingletonCookie/
+// SingletonSocket) and Crashpad are NOT cleanable — a lock on the OCTO path
+// can never be ours (we hold the legacy lock), so a live instance's lock files
+// are treated as occupied and block the delete. Crashpad is excluded with them
+// (a crash-reporting process may still hold it).
 const DESTINATION_CLEANABLE = (() => {
   const set = new Set<string>();
-  ELECTRON_LOCK_FILES.forEach((e) => set.add(e));
-  SKIP_DIRS.forEach((e) => set.add(e));
+  ELECTRON_LOCK_FILES.forEach((e) => {
+    if (e !== "singletonlock" && e !== "singletoncookie" && e !== "singletonsocket") {
+      set.add(e);
+    }
+  });
+  SKIP_DIRS.forEach((e) => {
+    if (e !== "crashpad") set.add(e);
+  });
   set.add(MIGRATION_MARKER);
   set.add("dictionaries");
   set.add("network persistent state");
+  // Round-8 P2-2: OS/Finder metadata is regenerable noise, not user data —
+  // a single .DS_Store must not permanently block a migration. Note the
+  // leading dot: `.DS_Store`.toLowerCase() is ".ds_store".
+  set.add(".ds_store");
+  set.add("thumbs.db");
+  set.add("desktop.ini");
   return set;
 })();
 
-// Top-level entries of `dir` that are NOT known-cleanable. A non-empty result
-// means "occupied". Fail-closed: an unreadable dir reports a fake residual.
-function residualEntries(dir: string): string[] {
+// Top-level entries of `dir` that are NOT known-cleanable, tri-state
+// (round-8 P2-3): { unreadable: true } means the dir cannot be inspected and
+// must be treated as occupied — never mistaken for empty. Fail-closed.
+type ResidualEntries = { unreadable: boolean; entries: string[] };
+function residualEntries(dir: string): ResidualEntries {
   try {
-    return fs
-      .readdirSync(dir)
-      .filter((entry) => !DESTINATION_CLEANABLE.has(entry.toLowerCase()));
+    return {
+      unreadable: false,
+      entries: fs
+        .readdirSync(dir)
+        .filter((entry) => !DESTINATION_CLEANABLE.has(entry.toLowerCase())),
+    };
   } catch {
-    return ["<unreadable>"];
+    return { unreadable: true, entries: [] };
+  }
+}
+
+// Does `dir` carry any data the migration would actually copy? Mirrors the
+// copy filter in execute() exactly (round-8 P1-2): singleton artifacts,
+// regenerable caches and the breadcrumb are pruned, so a profile holding ONLY
+// those has nothing to migrate. Fail-closed: an unreadable dir reports
+// copyable data — a marker-only completion must never strand a legacy profile
+// that still holds IndexedDB / Local Storage / Cookies.
+function hasCopyableData(dir: string): boolean {
+  try {
+    return fs.readdirSync(dir).some((entry) => {
+      const lower = entry.toLowerCase();
+      return (
+        lower !== MIGRATION_BREADCRUMB &&
+        !SKIP_DIRS.has(lower) &&
+        !ELECTRON_LOCK_FILES.has(lower)
+      );
+    });
+  } catch {
+    return true;
   }
 }
 
@@ -127,6 +169,26 @@ export type MigrationPlan = {
   reason?: "destination-occupied" | "too-many-failures";
 };
 
+export type LockLostAction = "quit-now" | "dialog-then-quit";
+
+/**
+ * What should a process that LOST the single-instance lock do?
+ *
+ * The lock is taken on the legacy path whenever a migration is planned, so a
+ * lock failure means another instance already holds that path:
+ * - "migrate" plan -> a migration-relevant conflict (the other instance may be
+ *   migrating right now): say so, then quit.
+ * - anything else   -> the ordinary second-instance flow (the running instance
+ *   focuses itself): quit silently.
+ *
+ * The caller must also guarantee that a losing process never runs normal
+ * startup — the quit has to happen before any window is created, or a second
+ * process briefly opens on the same profile (round-7 review).
+ */
+export function decideLockLostAction(plan: MigrationPlan): LockLostAction {
+  return plan.action === "migrate" ? "dialog-then-quit" : "quit-now";
+}
+
 export type MigrationResult = "done" | "failed" | "skipped";
 
 export type MigrationRuntime = {
@@ -136,10 +198,6 @@ export type MigrationRuntime = {
     error(msg: string, err: unknown): void;
   };
 };
-
-function hasProfileSentinel(dir: string): boolean {
-  return PROFILE_SENTINELS.some((name) => fs.existsSync(path.join(dir, name)));
-}
 
 // The breadcrumb lives in the legacy dir; when that dir is unwritable
 // (read-only / full volume) it falls back to appData — otherwise a write
@@ -169,6 +227,16 @@ function readBreadcrumb(
   return readBreadcrumbFile(primary) ?? readBreadcrumbFile(fallback);
 }
 
+// Round-8 P2-1: the retry-exhausted dialog must point the user at the file
+// that actually exists — the breadcrumb may have fallen back to appData when
+// the legacy dir is unwritable (round-6 P2-1).
+export function actualBreadcrumbFile(oldDir: string): string {
+  const [primary, fallback] = breadcrumbPaths(oldDir);
+  if (fs.existsSync(primary)) return primary;
+  if (fs.existsSync(fallback)) return fallback;
+  return primary; // nothing recorded yet; the primary is where it would land
+}
+
 function writeBreadcrumb(oldDir: string, err: unknown): void {
   const prev = readBreadcrumb(oldDir) ?? { attempts: 0 };
   const payload = JSON.stringify({
@@ -193,6 +261,14 @@ function removeBreadcrumb(oldDir: string): void {
     } catch {
       // best-effort
     }
+  }
+  // Round-8 P2-7: a successful migration also clears the one-shot notice
+  // bookkeeping — the "already shown" records are stale once the migration is
+  // done (the dialogs they gate can never fire again).
+  try {
+    fs.rmSync(path.join(path.dirname(oldDir), MIGRATION_NOTICES), { force: true });
+  } catch {
+    // best-effort
   }
 }
 
@@ -259,11 +335,21 @@ export function planUserDataMigration(
     // carries residual data (a live profile grew after the publish — e.g. the
     // user deleted Preferences to reset UI state; re-migrating would destroy
     // every byte written since, round-6 P1-1 scenario A), or when the legacy
-    // profile has no sentinel either (regenerable caches only — re-copying
-    // would publish nothing and loop forever). Only a bare marker over an
-    // EMPTY destination with a data-bearing legacy is torn and re-migrated.
+    // profile has nothing copyable left (regenerable caches / singleton
+    // artifacts only — re-copying would publish nothing and loop forever;
+    // judged by the copy filter's own rule, round-8 P1-2). Only a bare marker
+    // over an EMPTY destination with a data-bearing legacy is torn and
+    // re-migrated. A destination that cannot be inspected is never assumed
+    // complete — stay on the legacy profile (round-8 P2-3 tri-state).
     if (fs.existsSync(path.join(newDir, MIGRATION_MARKER))) {
-      if (residualEntries(newDir).length > 0 || !hasProfileSentinel(oldDir)) {
+      const residual = residualEntries(newDir);
+      if (residual.unreadable) {
+        log.warn(
+          `[userData] ${newDir} holds a migration marker but cannot be inspected; keeping the legacy profile this session.`
+        );
+        return { action: "legacy", oldDir, newDir, stagingDir };
+      }
+      if (residual.entries.length > 0 || !hasCopyableData(oldDir)) {
         return { action: "none", oldDir, newDir, stagingDir };
       }
       log.warn(
@@ -274,12 +360,13 @@ export function planUserDataMigration(
     // known-cleanable is occupied by data we do not own. Stay on the
     // established legacy profile and let index.ts say so (reason consumed
     // there). A sentinel probe alone would miss a live profile in its first
-    // ~10 s (Local Storage present, Preferences not written yet).
+    // ~10 s (Local Storage present, Preferences not written yet). An
+    // unreadable destination is occupied, never deletable (round-8 P2-3).
     if (fs.existsSync(newDir)) {
       const residual = residualEntries(newDir);
-      if (residual.length > 0) {
+      if (residual.unreadable || residual.entries.length > 0) {
         log.warn(
-          `[userData] ${newDir} already holds data without a migration marker (entries: ${residual.join(", ")}); keeping both profiles and NOT migrating (legacy data stays in ${oldDir}).`
+          `[userData] ${newDir} already holds data without a migration marker (entries: ${residual.unreadable ? "<unreadable>" : residual.entries.join(", ")}); keeping both profiles and NOT migrating (legacy data stays in ${oldDir}).`
         );
         return { action: "legacy", oldDir, newDir, stagingDir, reason: "destination-occupied" };
       }
@@ -323,11 +410,11 @@ export function executeUserDataMigration(
     // never deleted.
     if (fs.existsSync(plan.newDir)) {
       const residual = residualEntries(plan.newDir);
-      if (residual.length > 0) {
+      if (residual.unreadable || residual.entries.length > 0) {
         // A skip is NOT a success — the caller must not relaunch onto the
         // non-ours destination; this session stays on the legacy path.
         runtime.log.warn(
-          `[userData] ${plan.newDir} holds unexpected entries (${residual.join(", ")}); not migrating (both profiles kept).`
+          `[userData] ${plan.newDir} holds unexpected entries (${residual.unreadable ? "<unreadable>" : residual.entries.join(", ")}); not migrating (both profiles kept).`
         );
         return "skipped";
       }

--- a/apps/web/src-election/main/userDataMigration.ts
+++ b/apps/web/src-election/main/userDataMigration.ts
@@ -9,32 +9,40 @@ import path from "path";
 // every existing user would silently start with a fresh empty profile (lost
 // session, localStorage, IndexedDB message stores, drafts).
 //
-// Design (round 4 — structural, per reviews):
+// Design (round 5 — per review):
 // - Mutual exclusion comes from Electron's OWN single-instance lock. index.ts
 //   points userData at the legacy dir BEFORE requestSingleInstanceLock(), so
 //   the lock is taken on the legacy path (the primary-instance lookup keys off
 //   the userData path): a running legacy instance or a concurrent launch fails
 //   the lock and quits. On success index.ts relaunches so the next process
-//   takes the OCTO lock. (P0-1/P1-1 from rounds 2-3.)
+//   takes the OCTO lock. The second-instance dialog is gated to the
+//   migration-related paths (round-5 P1-2). Note the lock protects the legacy
+//   dir, and the destination rmSync in execute() targets OCTO, which no live
+//   process can hold (the migration path never takes the OCTO lock before
+//   publishing) — documented invariant (round-5 P1-3).
 // - Staging copy + atomic rename: copy into <appData>/OCTO.migrating, then
 //   renameSync into place. DMWork is never mutated, so a failed attempt
 //   retries on the next launch and a release rollback keeps the legacy
 //   profile.
-// - Completion marker + profile sentinel (round-4 P1-2): the sentinel is
-//   <appData>/OCTO/.migrated-from-dmwork AND a real profile file
-//   (Preferences / Local State). A bare marker (power loss mid-publish, no
-//   fsync anywhere) is NOT trusted — plan() treats it as torn and re-migrates.
-//   The marker is written into the staging dir BEFORE the rename so profile+
-//   marker publish atomically.
-// - Failure containment ("never throws"): every I/O in plan()/execute() is
-//   inside try/catch; plan degrades to "legacy", execute to "failed", index.ts
-//   has a defensive try/catch backstop. Failures are visible: breadcrumbs in
-//   the legacy profile bound retries (round-4 P1-1), and index.ts surfaces
-//   dialogs for occupied-destination / too-many-failures / lock-held.
+// - Completion marker + profile sentinel (round-4 P1-2, refined round-5 P0-1):
+//   a migration is "complete" when the marker AND a profile sentinel coexist,
+//   OR when the legacy profile itself carries no sentinel (regenerable caches
+//   only — re-copying would publish nothing and loop forever). The invariant
+//   "execute() === 'done' implies the next plan() returns 'none'" is pinned by
+//   a round-trip test. A bare marker with a data-bearing legacy is treated as
+//   torn and re-migrated. The marker is written into the staging dir BEFORE
+//   the rename so profile+marker publish atomically.
+// - Failure containment and visibility: every I/O in plan()/execute() is
+//   inside try/catch ("never throws"); plan distinguishes ENOENT (none, fresh
+//   install) from other stat errors (legacy — never silently start a fresh
+//   OCTO next to an unreachable DMWork, round-5 P1-1); failures are bounded by
+//   a breadcrumb (attempts+lastError, cleared on success) and surfaced via
+//   dialogs from index.ts.
 // - Destination policy (round-4 P2-1): a destination counts as a REAL profile
-//   only when it has a profile sentinel. Anything else (lock files, Crashpad,
-//   caches) is cleanable and does not block migration — no allowlist polarity.
-// - Copy filter anchored to top-level entries, case-insensitive (nits).
+//   only when it has a profile sentinel; anything else (locks, Crashpad,
+//   caches) is cleanable and does not block migration.
+// - Copy filter anchored to top-level entries, case-insensitive; the
+//   breadcrumb is never copied (round-5 P2).
 // ---------------------------------------------------------------------------
 
 export const LEGACY_USER_DATA_DIR = "DMWork";
@@ -130,21 +138,35 @@ export function planUserDataMigration(appDataDir: string, brandName: string): Mi
   const newDir = path.join(appDataDir, brandName);
   const stagingDir = `${newDir}.migrating`;
   try {
-    // P2-6: the legacy path must be a directory; a regular file is not a
-    // profile (and would blow up the copy) — treat as "no migration".
+    // P1-2 (round-5): distinguish "no legacy profile" (ENOENT -> none, the
+    // normal fresh-install path) from "cannot inspect" (other errors ->
+    // legacy, never silently start a fresh OCTO profile next to an
+    // unreachable DMWork one).
     let oldIsDir = false;
     try {
       oldIsDir = fs.statSync(oldDir).isDirectory();
-    } catch {
-      oldIsDir = false;
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+        return { action: "none", oldDir, newDir, stagingDir };
+      }
+      console.error(
+        `[userData] cannot inspect ${oldDir} (${(err as NodeJS.ErrnoException).code ?? err}); using the legacy profile this session.`,
+        err
+      );
+      return { action: "legacy", oldDir, newDir, stagingDir };
     }
     if (!oldIsDir) {
+      // A regular file is not a profile (P2-6, round-4).
       return { action: "none", oldDir, newDir, stagingDir };
     }
-    // P1-2: marker alone is not trusted — it must be accompanied by a real
-    // profile sentinel. A bare marker (torn publish) re-migrates.
+    // P0-1 (round-5): the round-trip invariant is "execute() === 'done'
+    // implies the NEXT plan() returns 'none'". A marker without a profile
+    // sentinel is only "torn" when the legacy profile actually had data to
+    // carry; if the legacy profile has no sentinel either (regenerable caches
+    // only), re-migrating would copy nothing and loop forever — so that state
+    // counts as migrated.
     if (fs.existsSync(path.join(newDir, MIGRATION_MARKER))) {
-      if (hasProfileSentinel(newDir)) {
+      if (hasProfileSentinel(newDir) || !hasProfileSentinel(oldDir)) {
         return { action: "none", oldDir, newDir, stagingDir };
       }
       console.warn(
@@ -210,16 +232,21 @@ export function executeUserDataMigration(
     if (fs.existsSync(plan.stagingDir)) {
       fs.rmSync(plan.stagingDir, { recursive: true, force: true });
     }
-    fs.mkdirSync(plan.stagingDir);
+    fs.mkdirSync(plan.stagingDir, { mode: 0o700 });
     // F3 + P2-3: never copy singleton artifacts / locks; anchor the filter to
-    // top-level entries (nested dirs are left alone), case-insensitive.
+    // top-level entries (nested dirs are left alone), case-insensitive. The
+    // breadcrumb is migration bookkeeping, never copied (round-5 P2).
     fs.cpSync(plan.oldDir, plan.stagingDir, {
       recursive: true,
       filter: (src) => {
         const rel = path.relative(plan.oldDir, src);
         if (rel.includes(path.sep)) return true; // nested: never prune
         const lower = rel.toLowerCase();
-        return !SKIP_DIRS.has(lower) && !ELECTRON_LOCK_FILES.has(lower);
+        return (
+          lower !== MIGRATION_BREADCRUMB &&
+          !SKIP_DIRS.has(lower) &&
+          !ELECTRON_LOCK_FILES.has(lower)
+        );
       },
     });
     // F5: marker lands in staging BEFORE the rename, so profile+marker publish

--- a/apps/web/src-election/main/userDataMigration.ts
+++ b/apps/web/src-election/main/userDataMigration.ts
@@ -1,6 +1,7 @@
 import fs from "fs";
 import os from "os";
 import path from "path";
+import { execFileSync } from "child_process";
 
 // ---------------------------------------------------------------------------
 // One-time userData migration from the legacy DMWork profile to OCTO.
@@ -23,25 +24,27 @@ import path from "path";
 //   staging dir BEFORE the rename (F5), so profile+marker publish atomically
 //   and a post-rename marker failure can no longer strand a markerless
 //   destination.
-// - Cross-launch mutex (F2): the staging dir itself is the mutex.
-//   fs.mkdirSync is atomic — EEXIST means another launch is mid-migration,
-//   so this launch defers to the legacy profile. A stale staging dir (owner
-//   pid dead, or no owner file from a pre-upgrade crash) is claimed and
-//   retried. The migration therefore runs BEFORE requestSingleInstanceLock()
-//   and never has to delete a lock it holds; the fallback also happens before
-//   the lock, so the fallback session's lock is created in the legacy dir it
-//   writes (F4) — no double writer anywhere.
+// - Cross-launch mutex (F2): the staging dir is the mutex, claimed atomically
+//   by exclusive-creating the owner file ({ flag: "wx" }) — whoever writes
+//   .migration-owner.json first is the migrator. A launcher that loses the
+//   claim either defers (owner pid alive) or reclaims (owner dead / crash
+//   residue). mkdir is only a directory bootstrap, never the claim itself, so
+//   a process preempted between mkdir and owner-write cannot be misjudged as
+//   stale. The migration runs BEFORE requestSingleInstanceLock() and never
+//   has to delete a lock it holds; the fallback also happens before the lock,
+//   so the fallback session's lock is created in the legacy dir it writes
+//   (F4) — no double writer anywhere.
 // - Legacy instance guard (F1): a running DMWork-branded process holds
 //   <appData>/DMWork/SingletonLock. On POSIX Chromium writes that file as a
 //   symlink to a deliberately non-existent target "<hostname>-<pid>", so
-//   existsSync (which follows links) can never see it; Windows has no such
-//   file at all (ProcessSingleton uses OS primitives). We lstat the link,
+//   existsSync (which follows links) can never see it; we lstat the link,
 //   parse the target, confirm the hostname and that the pid is alive, and
 //   only then defer. A stale lock (dead pid / foreign hostname / unparseable)
 //   is treated as not held so a crash can never permanently trap users. On
-//   Windows the guard is a no-op by design: a live legacy process keeps its
-//   profile files open, so the copy/rename fails and the catch falls back to
-//   the legacy profile — same outcome, no data loss.
+//   Windows there is no SingletonLock file (ProcessSingleton uses named
+//   mutexes), so we probe running processes by the legacy image name
+//   (DMWork.exe) instead — deferring is required there, not best-effort,
+//   because Windows allows copying files that are open by another process.
 // - Fallback on failure: if the copy/rename fails, this session keeps using
 //   the legacy profile via setUserDataDir(oldDir) — the user keeps their data
 //   and the migration retries on the next launch (marker still absent).
@@ -99,9 +102,15 @@ export type MigrationRuntime = {
 
 // F1: detect a live legacy DMWork instance.
 // POSIX: SingletonLock is a symlink to "<hostname>-<pid>" whose target does
-// not exist, so lstat (no follow) is required. Windows: no SingletonLock
-// file — the guard intentionally returns false; see header comment.
+// not exist, so lstat (no follow) is required. Windows: no SingletonLock file
+// (ProcessSingleton uses OS primitives) — instead probe running processes by
+// the legacy image name; a live legacy process keeps its profile files open
+// and copying it would produce a torn snapshot, so deferring is required, not
+// just best-effort.
 export function isLegacyInstanceRunning(oldDir: string): boolean {
+  if (process.platform === "win32") {
+    return isLegacyProcessRunning();
+  }
   const lockPath = path.join(oldDir, "SingletonLock");
   let raw: string;
   try {
@@ -124,6 +133,27 @@ export function isLegacyInstanceRunning(oldDir: string): boolean {
   } catch (err) {
     // EPERM: the pid exists but is owned by another user -> still running.
     return (err as NodeJS.ErrnoException).code === "EPERM";
+  }
+}
+
+// Windows: no SingletonLock file exists; Chromium's ProcessSingleton there
+// uses named mutexes. Probe the legacy executable by image name instead.
+// The pre-rebrand (DMWork) executable name is "DMWork.exe" (the post-rebrand
+// productName "OCTO" landed in #1258); tasklist returns non-zero when the
+// filter matches nothing, which we treat as "not running".
+export function isLegacyProcessRunningOutput(output: string): boolean {
+  return /DMWork\.exe/i.test(output);
+}
+
+function isLegacyProcessRunning(): boolean {
+  try {
+    const out = execFileSync("tasklist", ["/FI", "IMAGENAME eq DMWork.exe", "/NH"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    return isLegacyProcessRunningOutput(out);
+  } catch {
+    return false;
   }
 }
 
@@ -171,17 +201,6 @@ function isStagingOwnedByLiveProcess(stagingDir: string): boolean {
   }
 }
 
-function writeOwnerFile(stagingDir: string): void {
-  fs.writeFileSync(
-    path.join(stagingDir, STAGING_OWNER_FILE),
-    JSON.stringify({
-      hostname: os.hostname(),
-      pid: process.pid,
-      startedAt: new Date().toISOString(),
-    })
-  );
-}
-
 export function executeUserDataMigration(
   plan: MigrationPlan,
   runtime: MigrationRuntime
@@ -203,24 +222,49 @@ export function executeUserDataMigration(
     return "deferred";
   }
   // action === "migrate"
-  // F2: acquire the staging dir as the cross-launch mutex BEFORE any copy.
+  // F2: the staging dir is the cross-launch mutex. mkdir is not the claim —
+  // the OWNER FILE is, via atomic exclusive create ({ flag: "wx" }). This
+  // closes the owner-file race: a process that mkdir'd but was preempted
+  // before writing its owner loses the claim to whoever writes the owner
+  // file first; a process that sees EEXIST on the owner file either defers
+  // (live owner) or reclaims (dead owner / crash residue).
+  let claimed = false;
   try {
-    fs.mkdirSync(plan.stagingDir);
-  } catch (err) {
-    if ((err as NodeJS.ErrnoException).code !== "EEXIST") throw err;
-    if (isStagingOwnedByLiveProcess(plan.stagingDir)) {
-      runtime.log.warn(
-        `[userData] another launch is mid-migration (${plan.stagingDir}); using the legacy profile for this session.`
-      );
-      runtime.setUserDataDir(plan.oldDir);
-      return "deferred";
+    try {
+      fs.mkdirSync(plan.stagingDir);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "EEXIST") throw err;
     }
-    // Stale staging from a crashed/interrupted attempt: claim it and retry.
-    fs.rmSync(plan.stagingDir, { recursive: true, force: true });
-    fs.mkdirSync(plan.stagingDir);
-  }
-  writeOwnerFile(plan.stagingDir);
-  try {
+    const ownerJson = JSON.stringify({
+      hostname: os.hostname(),
+      pid: process.pid,
+      startedAt: new Date().toISOString(),
+    });
+    try {
+      fs.writeFileSync(path.join(plan.stagingDir, STAGING_OWNER_FILE), ownerJson, { flag: "wx" });
+      claimed = true;
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "EEXIST") throw err;
+      if (isStagingOwnedByLiveProcess(plan.stagingDir)) {
+        runtime.log.warn(
+          `[userData] another launch is mid-migration (${plan.stagingDir}); using the legacy profile for this session.`
+        );
+        runtime.setUserDataDir(plan.oldDir);
+        return "deferred";
+      }
+      // Claimer is dead (crash / interrupted attempt): reclaim.
+      fs.rmSync(plan.stagingDir, { recursive: true, force: true });
+      fs.mkdirSync(plan.stagingDir);
+      fs.writeFileSync(path.join(plan.stagingDir, STAGING_OWNER_FILE), ownerJson, { flag: "wx" });
+      claimed = true;
+    }
+    // We hold the claim. Drop anything left in the dir by a crashed attempt
+    // (our owner file stays).
+    for (const entry of fs.readdirSync(plan.stagingDir)) {
+      if (entry !== STAGING_OWNER_FILE) {
+        fs.rmSync(path.join(plan.stagingDir, entry), { recursive: true, force: true });
+      }
+    }
     // F3: never copy Chromium singleton artifacts or locks into the new profile.
     fs.cpSync(plan.oldDir, plan.stagingDir, {
       recursive: true,
@@ -244,6 +288,9 @@ export function executeUserDataMigration(
     } catch {
       // best-effort; not all platforms support fsync on every fd type
     }
+    // The owner file is migration-internal metadata; never publish it into
+    // the final profile.
+    fs.rmSync(path.join(plan.stagingDir, STAGING_OWNER_FILE));
     // plan() already refused to migrate when newDir holds real data; if it
     // exists here it contains only lock files (F2/F10), which at this point
     // belong to no live process: we run before our own single-instance lock
@@ -256,10 +303,13 @@ export function executeUserDataMigration(
     runtime.log.info(`[userData] migrated legacy DMWork profile to ${plan.newDir}`);
     return "done";
   } catch (err) {
-    try {
-      fs.rmSync(plan.stagingDir, { recursive: true, force: true });
-    } catch {
-      // best-effort cleanup; the next launch retries anyway
+    // Only clean up a staging dir we actually claimed — never a live one.
+    if (claimed) {
+      try {
+        fs.rmSync(plan.stagingDir, { recursive: true, force: true });
+      } catch {
+        // best-effort cleanup; the next launch retries anyway
+      }
     }
     runtime.setUserDataDir(plan.oldDir);
     runtime.log.error(

--- a/apps/web/src-election/main/userDataMigration.ts
+++ b/apps/web/src-election/main/userDataMigration.ts
@@ -97,6 +97,33 @@ const SKIP_DIRS = new Set([
   "crashpad",
 ]);
 
+// Round-10 P0-1: ONE classification for "never migrates", shared by every
+// consumer so they can never disagree:
+//   - the copy filter (what gets published to the destination),
+//   - hasCopyableData (does the legacy still hold anything worth publishing),
+//   - DESTINATION_CLEANABLE (is a destination entry ours to delete).
+// Previously the first two used SKIP_DIRS+LOCKS+breadcrumb while the allowlist
+// ALSO listed dictionaries / network persistent state / OS metadata — a legacy
+// holding only e.g. .DS_Store planned "migrate", published it, and re-planned
+// "migrate" forever (relaunch boot loop, reproduced by round-10 review).
+const MIGRATION_NOISE = (() => {
+  const set = new Set<string>();
+  ELECTRON_LOCK_FILES.forEach((e) => set.add(e));
+  SKIP_DIRS.forEach((e) => set.add(e));
+  set.add(MIGRATION_BREADCRUMB);
+  // Regenerable, not user data (round-6 allowlist members): spelling
+  // dictionaries re-downloaded by Chromium; network-stack state.
+  set.add("dictionaries");
+  set.add("network persistent state");
+  // Round-8 P2-2 OS/Finder metadata. Leading dot matters:
+  // `.DS_Store`.toLowerCase() === ".ds_store".
+  set.add(".ds_store");
+  set.add("thumbs.db");
+  set.add("desktop.ini");
+  set.add(".localized");
+  return set;
+})();
+
 // Round-6 P1-1: the destination-decision ALLOWLIST. Deleting the destination
 // is permitted only when every top-level entry is one of these; anything else
 // is user data we do not own and must never be deleted.
@@ -107,24 +134,17 @@ const SKIP_DIRS = new Set([
 // (a crash-reporting process may still hold it).
 const DESTINATION_CLEANABLE = (() => {
   const set = new Set<string>();
-  ELECTRON_LOCK_FILES.forEach((e) => {
-    if (e !== "singletonlock" && e !== "singletoncookie" && e !== "singletonsocket") {
+  MIGRATION_NOISE.forEach((e) => {
+    if (
+      e !== "singletonlock" &&
+      e !== "singletoncookie" &&
+      e !== "singletonsocket" &&
+      e !== "crashpad"
+    ) {
       set.add(e);
     }
   });
-  SKIP_DIRS.forEach((e) => {
-    if (e !== "crashpad") set.add(e);
-  });
   set.add(MIGRATION_MARKER);
-  set.add("dictionaries");
-  set.add("network persistent state");
-  // Round-8 P2-2: OS/Finder metadata is regenerable noise, not user data —
-  // a single .DS_Store must not permanently block a migration. Note the
-  // leading dot: `.DS_Store`.toLowerCase() is ".ds_store".
-  set.add(".ds_store");
-  set.add("thumbs.db");
-  set.add("desktop.ini");
-  set.add(".localized");
   return set;
 })();
 
@@ -145,22 +165,15 @@ function residualEntries(dir: string): ResidualEntries {
   }
 }
 
-// Does `dir` carry any data the migration would actually copy? Mirrors the
-// copy filter in execute() exactly (round-8 P1-2): singleton artifacts,
-// regenerable caches and the breadcrumb are pruned, so a profile holding ONLY
-// those has nothing to migrate. Fail-closed: an unreadable dir reports
-// copyable data — a marker-only completion must never strand a legacy profile
-// that still holds IndexedDB / Local Storage / Cookies.
+// Does `dir` carry any data the migration would actually copy? Same rule as
+// the copy filter — MIGRATION_NOISE (round-10 P0-1: one classification for
+// "never migrates", so this predicate and the publish step can never
+// disagree). Fail-closed: an unreadable dir reports copyable data — a
+// marker-only completion must never strand a legacy profile that still holds
+// IndexedDB / Local Storage / Cookies.
 function hasCopyableData(dir: string): boolean {
   try {
-    return fs.readdirSync(dir).some((entry) => {
-      const lower = entry.toLowerCase();
-      return (
-        lower !== MIGRATION_BREADCRUMB &&
-        !SKIP_DIRS.has(lower) &&
-        !ELECTRON_LOCK_FILES.has(lower)
-      );
-    });
+    return fs.readdirSync(dir).some((entry) => !MIGRATION_NOISE.has(entry.toLowerCase()));
   } catch {
     return true;
   }
@@ -171,7 +184,7 @@ export type MigrationPlan = {
   oldDir: string;
   newDir: string;
   stagingDir: string;
-  reason?: "destination-occupied" | "too-many-failures";
+  reason?: "destination-occupied" | "too-many-failures" | "destination-unreadable";
 };
 
 export type LockLostAction = "quit-now" | "dialog-then-quit";
@@ -229,7 +242,14 @@ function readBreadcrumb(
   oldDir: string
 ): { attempts: number; lastError?: string; lastAttemptAt?: string } | null {
   const [primary, fallback] = breadcrumbPaths(oldDir);
-  return readBreadcrumbFile(primary) ?? readBreadcrumbFile(fallback);
+  const p = readBreadcrumbFile(primary);
+  const f = readBreadcrumbFile(fallback);
+  if (!p) return f;
+  if (!f) return p;
+  // Round-10 P1-1: a stale-but-readable primary (e.g. legacy dir became
+  // read-only after the breadcrumb was written there) must not shadow the
+  // newer fallback — take the max so the retry bound can never regress.
+  return p.attempts >= f.attempts ? p : f;
 }
 
 // Round-8 P2-1: the retry-exhausted dialog must point the user at the file
@@ -242,10 +262,35 @@ export function actualBreadcrumbFile(oldDir: string): string {
   return primary; // nothing recorded yet; the primary is where it would land
 }
 
-function writeBreadcrumb(oldDir: string, err: unknown): void {
+// Bump the attempt counter (and optionally refresh lastError). Round-10 P1-1:
+// execute() records the attempt BEFORE the copy starts — the failure modes
+// this bound exists for (ENOSPC and friends) can also make a post-failure
+// write fail, which would silently disable the retry bound.
+function bumpBreadcrumb(oldDir: string, err?: unknown): void {
   const prev = readBreadcrumb(oldDir) ?? { attempts: 0 };
   const payload = JSON.stringify({
     attempts: prev.attempts + 1,
+    lastError: err ? (err instanceof Error ? err.message : String(err)) : prev.lastError,
+    lastAttemptAt: new Date().toISOString(),
+  });
+  for (const file of breadcrumbPaths(oldDir)) {
+    try {
+      fs.writeFileSync(file, payload);
+      return;
+    } catch {
+      // try the next location; never throw from the failure path
+    }
+  }
+}
+
+// Round-10 P1-1: after a failed attempt, annotate the already-bumped record
+// with the failure detail WITHOUT incrementing again. No-op when even the
+// pre-copy bump could not be written (volume completely full).
+function annotateBreadcrumb(oldDir: string, err: unknown): void {
+  const prev = readBreadcrumb(oldDir);
+  if (!prev) return;
+  const payload = JSON.stringify({
+    ...prev,
     lastError: err instanceof Error ? err.message : String(err),
     lastAttemptAt: new Date().toISOString(),
   });
@@ -352,7 +397,15 @@ export function planUserDataMigration(
         log.warn(
           `[userData] ${newDir} holds a migration marker but cannot be inspected; keeping the legacy profile this session.`
         );
-        return { action: "legacy", oldDir, newDir, stagingDir };
+        // Round-10 P2-6: distinct reason so index.ts shows the right copy
+        // instead of the generic "plan failed" text.
+        return {
+          action: "legacy",
+          oldDir,
+          newDir,
+          stagingDir,
+          reason: "destination-unreadable",
+        };
       }
       if (residual.entries.length > 0 || !hasCopyableData(oldDir)) {
         return { action: "none", oldDir, newDir, stagingDir };
@@ -373,7 +426,15 @@ export function planUserDataMigration(
         log.warn(
           `[userData] ${newDir} already holds data without a migration marker (entries: ${residual.unreadable ? "<unreadable>" : residual.entries.join(", ")}); keeping both profiles and NOT migrating (legacy data stays in ${oldDir}).`
         );
-        return { action: "legacy", oldDir, newDir, stagingDir, reason: "destination-occupied" };
+        return {
+          action: "legacy",
+          oldDir,
+          newDir,
+          stagingDir,
+          // Round-10 P2-6: an uninspectable destination is not "occupied by
+          // known data" — distinct reason for the right dialog copy.
+          reason: residual.unreadable ? "destination-unreadable" : "destination-occupied",
+        };
       }
     }
     // P1-1: bound retries — after N consecutive failures the migration stops
@@ -406,6 +467,17 @@ export function planUserDataMigration(
   }
 }
 
+// Round-10 P2-3: special files (FIFOs/sockets) make cpSync abort the whole
+// migration with ERR_FS_CP_FIFO_PIPE; they are never profile data. Pure so it
+// is testable. `rel` is the path relative to the legacy root ("" never used).
+export function isCopyableSource(
+  rel: string,
+  stat: { isFIFO(): boolean; isSocket(): boolean }
+): boolean {
+  if (!rel.includes(path.sep) && MIGRATION_NOISE.has(rel.toLowerCase())) return false;
+  return !stat.isFIFO() && !stat.isSocket();
+}
+
 export function executeUserDataMigration(
   plan: MigrationPlan,
   runtime: MigrationRuntime
@@ -418,6 +490,11 @@ export function executeUserDataMigration(
   }
   // action === "migrate"
   try {
+    // Round-10 P1-1: record the attempt BEFORE any copy/rename I/O — the
+    // failure modes this bound exists for (ENOSPC etc.) can also make the
+    // post-failure write fail, silently disabling MAX_MIGRATION_ATTEMPTS.
+    // Success clears it via removeBreadcrumb below.
+    bumpBreadcrumb(plan.oldDir);
     // Round-6 P1-1: re-assert the destination is cleanable immediately before
     // deleting it — plan() may have run minutes ago. Polarity is an allowlist:
     // delete only if every top-level entry is known-cleanable; any unknown
@@ -444,19 +521,20 @@ export function executeUserDataMigration(
     fs.mkdirSync(plan.stagingDir, { mode: 0o700 });
     // F3 + P2-3: never copy singleton artifacts / locks; anchor the filter to
     // top-level entries (nested dirs are left alone), case-insensitive. The
-    // breadcrumb is migration bookkeeping, never copied (round-5 P2).
+    // breadcrumb is migration bookkeeping, never copied (round-5 P2). Noise
+    // classification is MIGRATION_NOISE (round-10 P0-1, shared with
+    // hasCopyableData / DESTINATION_CLEANABLE).
     fs.cpSync(plan.oldDir, plan.stagingDir, {
       recursive: true,
       preserveTimestamps: true,
       filter: (src) => {
-        const rel = path.relative(plan.oldDir, src);
-        if (rel.includes(path.sep)) return true; // nested: never prune
-        const lower = rel.toLowerCase();
-        return (
-          lower !== MIGRATION_BREADCRUMB &&
-          !SKIP_DIRS.has(lower) &&
-          !ELECTRON_LOCK_FILES.has(lower)
-        );
+        let st: fs.Stats;
+        try {
+          st = fs.lstatSync(src);
+        } catch {
+          return true; // vanished mid-copy; let cpSync report it
+        }
+        return isCopyableSource(path.relative(plan.oldDir, src), st);
       },
     });
     // F5: marker lands in staging BEFORE the rename, so profile+marker publish
@@ -473,11 +551,34 @@ export function executeUserDataMigration(
     } catch {
       // best-effort cleanup; the next launch retries anyway
     }
-    writeBreadcrumb(plan.oldDir, err);
+    // Round-10 P1-1: the attempt count was bumped up-front; only annotate the
+    // failure detail here (no double increment).
+    annotateBreadcrumb(plan.oldDir, err);
     runtime.log.error(
       "[userData] DMWork -> OCTO migration failed; keeping the legacy profile for this session (will retry on next launch):",
       err
     );
     return "failed";
+  }
+}
+
+// Round-10 P2-1: a leftover staging dir can hold credentials (Cookies /
+// IndexedDB were copied into it) until the publish. execute() cleans its own
+// staging, but none/legacy sessions never run execute — so the lock winner in
+// index.ts calls this on every startup. Single-instance-lock scoped: there is
+// never a concurrent writer.
+export function cleanupStaleStaging(
+  stagingDir: string,
+  log: MigrationRuntime["log"] = console
+): void {
+  try {
+    if (fs.existsSync(stagingDir)) {
+      fs.rmSync(stagingDir, { recursive: true, force: true });
+      log.warn(`[userData] removed stale staging dir ${stagingDir}`);
+    }
+  } catch (err) {
+    log.warn(
+      `[userData] could not remove stale staging dir ${stagingDir}: ${err instanceof Error ? err.message : String(err)}`
+    );
   }
 }

--- a/apps/web/src-election/main/userDataMigration.ts
+++ b/apps/web/src-election/main/userDataMigration.ts
@@ -1,0 +1,153 @@
+import fs from "fs";
+import path from "path";
+
+// ---------------------------------------------------------------------------
+// One-time userData migration from the legacy DMWork profile to OCTO.
+//
+// Why this exists: app.setName("OCTO") (main/index.ts) relocates Electron's
+// default userData from <appData>/DMWork to <appData>/OCTO. Without a migration
+// every existing user would silently start with a fresh empty profile (lost
+// session, localStorage, IndexedDB message stores, drafts).
+//
+// Design (each point maps to a review finding on PR #1258):
+// - Staging copy + atomic rename: copy into <appData>/OCTO.migrating, then
+//   renameSync into place. renameSync is atomic, so <appData>/OCTO only ever
+//   appears as a COMPLETE profile — a torn LevelDB can never be mistaken for a
+//   finished one. DMWork is never mutated, so a failed attempt simply retries
+//   on the next launch and a release rollback keeps the legacy profile.
+// - Completion marker: the sentinel is <appData>/OCTO/.migrated-from-dmwork,
+//   NOT the existence of <appData>/OCTO — startup itself (the single-instance
+//   lock, then Chromium) creates that directory, so destination-existence
+//   would latch a failed migration forever.
+// - Fallback on failure: if the copy/rename fails, this session keeps using
+//   the legacy profile via setUserDataDir(oldDir) — the user keeps their data
+//   and the migration retries on the next launch (marker still absent).
+// - Legacy instance guard: a running DMWork-branded process holds
+//   <appData>/DMWork/SingletonLock. When that lock exists we do NOT migrate
+//   (copying a live profile is a torn snapshot; on macOS/Linux rename(2) would
+//   even succeed against a live profile, giving two writers). Instead the
+//   caller points userData at the legacy dir before requestSingleInstanceLock()
+//   so the lock fails against the running instance and this launch quits.
+// - Runs after requestSingleInstanceLock(): only the process that holds the
+//   new single-instance lock performs the migration, closing the double-launch
+//   race.
+// ---------------------------------------------------------------------------
+
+export const LEGACY_USER_DATA_DIR = "DMWork";
+export const MIGRATION_MARKER = ".migrated-from-dmwork";
+
+// Electron's single-instance lock creates these files in userData. When the
+// migration runs after requestSingleInstanceLock(), <appData>/OCTO already
+// contains them; they are regenerable and must be removed before the staging
+// rename can land. Any OTHER entry in <appData>/OCTO is treated as real user
+// data we must not clobber.
+const ELECTRON_LOCK_FILES = new Set([
+  "SingletonLock",
+  "SingletonCookie",
+  "SingletonSocket",
+]);
+
+// Regenerable Chromium caches, intentionally not migrated.
+export const SKIP_DIRS = new Set([
+  "Cache",
+  "Code Cache",
+  "GPUCache",
+  "DawnCache",
+  "DawnGraphiteCache",
+  "DawnWebGPUCache",
+  "ShaderCache",
+]);
+
+export type MigrationPlan = {
+  action: "migrate" | "defer-legacy" | "none";
+  oldDir: string;
+  newDir: string;
+  stagingDir: string;
+};
+
+export function planUserDataMigration(appDataDir: string, brandName: string): MigrationPlan {
+  const oldDir = path.join(appDataDir, LEGACY_USER_DATA_DIR);
+  const newDir = path.join(appDataDir, brandName);
+  const stagingDir = `${newDir}.migrating`;
+  if (!fs.existsSync(oldDir) || fs.existsSync(path.join(newDir, MIGRATION_MARKER))) {
+    return { action: "none", oldDir, newDir, stagingDir };
+  }
+  if (fs.existsSync(path.join(oldDir, "SingletonLock"))) {
+    return { action: "defer-legacy", oldDir, newDir, stagingDir };
+  }
+  return { action: "migrate", oldDir, newDir, stagingDir };
+}
+
+export type MigrationResult = "done" | "deferred" | "failed";
+
+export type MigrationRuntime = {
+  setUserDataDir: (dir: string) => void;
+  log: {
+    info(msg: string): void;
+    warn(msg: string): void;
+    error(msg: string, err: unknown): void;
+  };
+};
+
+export function executeUserDataMigration(
+  plan: MigrationPlan,
+  runtime: MigrationRuntime
+): MigrationResult {
+  if (plan.action === "none") {
+    return "done";
+  }
+  if (plan.action === "defer-legacy") {
+    runtime.setUserDataDir(plan.oldDir);
+    runtime.log.warn(
+      `[userData] a legacy DMWork instance is still running (${path.join(
+        plan.oldDir,
+        "SingletonLock"
+      )} is held); using the legacy profile for this session. Quit the old app and relaunch to migrate.`
+    );
+    return "deferred";
+  }
+  // action === "migrate"
+  try {
+    // Stale staging dir from an interrupted previous attempt (crash mid-copy).
+    if (fs.existsSync(plan.stagingDir)) {
+      fs.rmSync(plan.stagingDir, { recursive: true, force: true });
+    }
+    // The single-instance lock (or an earlier failed run) may have created
+    // <appData>/OCTO containing only Electron's lock files. Remove those; if
+    // anything else is in there we treat it as user data we must not clobber
+    // and skip the migration (both profiles are kept, nothing is lost).
+    if (fs.existsSync(plan.newDir)) {
+      const entries = fs.readdirSync(plan.newDir);
+      const nonLock = entries.filter((name) => !ELECTRON_LOCK_FILES.has(name));
+      if (nonLock.length > 0) {
+        runtime.log.warn(
+          `[userData] ${plan.newDir} already contains data but no migration marker; not migrating (both profiles kept).`
+        );
+        return "done";
+      }
+      // The dir itself must also go: on Windows renameSync fails against an
+      // existing (even empty) destination directory.
+      fs.rmSync(plan.newDir, { recursive: true, force: true });
+    }
+    fs.cpSync(plan.oldDir, plan.stagingDir, {
+      recursive: true,
+      filter: (src) => !SKIP_DIRS.has(path.basename(src)),
+    });
+    fs.renameSync(plan.stagingDir, plan.newDir);
+    fs.writeFileSync(path.join(plan.newDir, MIGRATION_MARKER), new Date().toISOString());
+    runtime.log.info(`[userData] migrated legacy DMWork profile to ${plan.newDir}`);
+    return "done";
+  } catch (err) {
+    try {
+      fs.rmSync(plan.stagingDir, { recursive: true, force: true });
+    } catch {
+      // best-effort cleanup; the next launch retries anyway
+    }
+    runtime.setUserDataDir(plan.oldDir);
+    runtime.log.error(
+      "[userData] DMWork -> OCTO migration failed; keeping the legacy profile for this session (will retry on next launch):",
+      err
+    );
+    return "failed";
+  }
+}

--- a/apps/web/src-election/main/userDataMigration.ts
+++ b/apps/web/src-election/main/userDataMigration.ts
@@ -1,7 +1,5 @@
 import fs from "fs";
-import os from "os";
 import path from "path";
-import { execFileSync } from "child_process";
 
 // ---------------------------------------------------------------------------
 // One-time userData migration from the legacy DMWork profile to OCTO.
@@ -11,57 +9,50 @@ import { execFileSync } from "child_process";
 // every existing user would silently start with a fresh empty profile (lost
 // session, localStorage, IndexedDB message stores, drafts).
 //
-// Design (each point maps to a review finding on PR #1265):
+// Design (round 3 — structural, per review P0-1/P1-1/P1-2/P2-2/P2-5/P2-11):
+// - Mutual exclusion comes from Electron's OWN single-instance lock, keyed
+//   off the userData path on every platform. index.ts points userData at the
+//   legacy dir BEFORE requestSingleInstanceLock(), so the lock is taken on
+//   the legacy path:
+//     * a running legacy DMWork instance already holds that lock  -> this
+//       launch's requestSingleInstanceLock() fails and it quits (the legacy
+//       guard, cross-platform, no hand-written probe needed);
+//     * a concurrent launch during the migration hits the same held lock and
+//       quits — exactly one process can ever be the migrator, and no second
+//       window can appear mid-copy (the old deferral race that discarded a
+//       user's session is gone).
+//   On success index.ts relaunches so the next process takes the OCTO lock.
 // - Staging copy + atomic rename: copy into <appData>/OCTO.migrating, then
 //   renameSync into place. renameSync is atomic, so <appData>/OCTO only ever
-//   appears as a COMPLETE profile — a torn LevelDB can never be mistaken for a
-//   finished one. DMWork is never mutated, so a failed attempt simply retries
-//   on the next launch and a release rollback keeps the legacy profile.
+//   appears as a COMPLETE profile. DMWork is never mutated, so a failed
+//   attempt simply retries on the next launch and a release rollback keeps
+//   the legacy profile.
 // - Completion marker: the sentinel is <appData>/OCTO/.migrated-from-dmwork,
-//   NOT the existence of <appData>/OCTO — startup itself (the single-instance
-//   lock, then Chromium) creates that directory, so destination-existence
-//   would latch a failed migration forever. The marker is written into the
-//   staging dir BEFORE the rename (F5), so profile+marker publish atomically
-//   and a post-rename marker failure can no longer strand a markerless
-//   destination.
-// - Cross-launch mutex (F2): the staging dir is the mutex, claimed atomically
-//   by exclusive-creating the owner file ({ flag: "wx" }) — whoever writes
-//   .migration-owner.json first is the migrator. A launcher that loses the
-//   claim either defers (owner pid alive) or reclaims (owner dead / crash
-//   residue). mkdir is only a directory bootstrap, never the claim itself, so
-//   a process preempted between mkdir and owner-write cannot be misjudged as
-//   stale. The migration runs BEFORE requestSingleInstanceLock() and never
-//   has to delete a lock it holds; the fallback also happens before the lock,
-//   so the fallback session's lock is created in the legacy dir it writes
-//   (F4) — no double writer anywhere.
-// - Legacy instance guard (F1): a running DMWork-branded process holds
-//   <appData>/DMWork/SingletonLock. On POSIX Chromium writes that file as a
-//   symlink to a deliberately non-existent target "<hostname>-<pid>", so
-//   existsSync (which follows links) can never see it; we lstat the link,
-//   parse the target, confirm the hostname and that the pid is alive, and
-//   only then defer. A stale lock (dead pid / foreign hostname / unparseable)
-//   is treated as not held so a crash can never permanently trap users. On
-//   Windows there is no SingletonLock file (ProcessSingleton uses named
-//   mutexes), so we probe running processes by the legacy image name
-//   (DMWork.exe) instead — deferring is required there, not best-effort,
-//   because Windows allows copying files that are open by another process.
-// - Fallback on failure: if the copy/rename fails, this session keeps using
-//   the legacy profile via setUserDataDir(oldDir) — the user keeps their data
-//   and the migration retries on the next launch (marker still absent).
-// - Destination with real data (F6/F10): if <appData>/OCTO already exists
-//   with non-lock content and no marker, plan() returns "none" — permanently
-//   (not a per-launch re-decision), both profiles are kept, and the skip is
-//   surfaced through the log. Correctness never depends on enumerating every
-//   future file Chromium might create early.
+//   NOT the existence of <appData>/OCTO. The marker is written into the
+//   staging dir BEFORE the rename (round-1 F5), so profile+marker publish
+//   atomically and a post-rename marker failure can no longer strand a
+//   markerless destination.
+// - Failure containment ("never throws", round-2 P0-2): every I/O statement
+//   in both plan() and execute() is inside a try/catch. No input state may
+//   make them throw — plan() degrades to "legacy" (this session keeps the
+//   DMWork path, retried next launch), execute() degrades to "failed" with
+//   the legacy profile, and index.ts adds a defensive try/catch backstop.
+// - Destination with real data (round-1 F6/F10): if <appData>/OCTO already
+//   exists with non-lock content and no marker, plan() returns "none"
+//   permanently (idempotent, no per-launch re-decision), both profiles are
+//   kept, and the skip is logged loudly. execute() re-asserts the lock-only
+//   invariant immediately before deleting the destination (round-2 P2-6).
+// - Copy filter is anchored to top-level entries only (round-2 P2-3): nested
+//   dirs named like caches (e.g. Partitions/*/Cache) are NOT pruned — only a
+//   top-level entry in SKIP_DIRS / ELECTRON_LOCK_FILES is skipped.
 // ---------------------------------------------------------------------------
 
 export const LEGACY_USER_DATA_DIR = "DMWork";
 export const MIGRATION_MARKER = ".migrated-from-dmwork";
-export const STAGING_OWNER_FILE = ".migration-owner.json";
 
-// Files Electron/Chromium's ProcessSingleton creates in userData. They are
-// never migrated (F3) and are the only entries a pre-existing destination is
-// allowed to contain for the migration to proceed (F2/F10).
+// Files Electron/Chromium's ProcessSingleton creates in userData. Never
+// migrated (round-1 F3) and the only entries a pre-existing destination is
+// allowed to contain for the migration to proceed (round-1 F2/F10).
 const ELECTRON_LOCK_FILES = new Set([
   "SingletonLock",
   "SingletonCookie",
@@ -69,7 +60,7 @@ const ELECTRON_LOCK_FILES = new Set([
   "lockfile",
 ]);
 
-// Regenerable Chromium caches, intentionally not migrated.
+// Regenerable Chromium caches, intentionally not migrated (top-level only).
 export const SKIP_DIRS = new Set([
   "Cache",
   "Code Cache",
@@ -83,7 +74,7 @@ export const SKIP_DIRS = new Set([
 ]);
 
 export type MigrationPlan = {
-  action: "migrate" | "defer-legacy" | "none";
+  action: "migrate" | "legacy" | "none";
   oldDir: string;
   newDir: string;
   stagingDir: string;
@@ -92,7 +83,6 @@ export type MigrationPlan = {
 export type MigrationResult = "done" | "deferred" | "failed";
 
 export type MigrationRuntime = {
-  setUserDataDir: (dir: string) => void;
   log: {
     info(msg: string): void;
     warn(msg: string): void;
@@ -100,104 +90,39 @@ export type MigrationRuntime = {
   };
 };
 
-// F1: detect a live legacy DMWork instance.
-// POSIX: SingletonLock is a symlink to "<hostname>-<pid>" whose target does
-// not exist, so lstat (no follow) is required. Windows: no SingletonLock file
-// (ProcessSingleton uses OS primitives) — instead probe running processes by
-// the legacy image name; a live legacy process keeps its profile files open
-// and copying it would produce a torn snapshot, so deferring is required, not
-// just best-effort.
-export function isLegacyInstanceRunning(oldDir: string): boolean {
-  if (process.platform === "win32") {
-    return isLegacyProcessRunning();
-  }
-  const lockPath = path.join(oldDir, "SingletonLock");
-  let raw: string;
-  try {
-    const st = fs.lstatSync(lockPath);
-    raw = st.isSymbolicLink()
-      ? fs.readlinkSync(lockPath)
-      : fs.readFileSync(lockPath, "utf8").trim();
-  } catch {
-    return false; // ENOENT or unreadable -> not running; never trap on a stale lock
-  }
-  const match = /^(.+)-(\d+)$/.exec(raw);
-  if (!match) return false; // unparseable -> treat as stale, do not defer forever
-  const [, hostname, pidStr] = match;
-  if (hostname !== os.hostname()) return false; // lock from another machine -> stale
-  const pid = Number(pidStr);
-  if (!Number.isInteger(pid) || pid <= 0) return false;
-  try {
-    process.kill(pid, 0); // liveness probe, no signal
-    return true;
-  } catch (err) {
-    // EPERM: the pid exists but is owned by another user -> still running.
-    return (err as NodeJS.ErrnoException).code === "EPERM";
-  }
-}
-
-// Windows: no SingletonLock file exists; Chromium's ProcessSingleton there
-// uses named mutexes. Probe the legacy executable by image name instead.
-// The pre-rebrand (DMWork) executable name is "DMWork.exe" (the post-rebrand
-// productName "OCTO" landed in #1258); tasklist returns non-zero when the
-// filter matches nothing, which we treat as "not running".
-export function isLegacyProcessRunningOutput(output: string): boolean {
-  return /DMWork\.exe/i.test(output);
-}
-
-function isLegacyProcessRunning(): boolean {
-  try {
-    const out = execFileSync("tasklist", ["/FI", "IMAGENAME eq DMWork.exe", "/NH"], {
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "ignore"],
-    });
-    return isLegacyProcessRunningOutput(out);
-  } catch {
-    return false;
-  }
-}
-
 export function planUserDataMigration(appDataDir: string, brandName: string): MigrationPlan {
   const oldDir = path.join(appDataDir, LEGACY_USER_DATA_DIR);
   const newDir = path.join(appDataDir, brandName);
   const stagingDir = `${newDir}.migrating`;
-  if (!fs.existsSync(oldDir) || fs.existsSync(path.join(newDir, MIGRATION_MARKER))) {
-    return { action: "none", oldDir, newDir, stagingDir };
-  }
-  // F6/F10: a destination that already holds real data (no marker) wins.
-  // Deciding here — not in execute() — makes the decision idempotent across
-  // launches: plan() returns "none" forever, no per-launch re-decision loop.
-  if (fs.existsSync(newDir)) {
-    const nonLock = fs
-      .readdirSync(newDir)
-      .filter((name) => !ELECTRON_LOCK_FILES.has(name) && name !== MIGRATION_MARKER);
-    if (nonLock.length > 0) {
+  try {
+    if (!fs.existsSync(oldDir) || fs.existsSync(path.join(newDir, MIGRATION_MARKER))) {
       return { action: "none", oldDir, newDir, stagingDir };
     }
-  }
-  if (isLegacyInstanceRunning(oldDir)) {
-    return { action: "defer-legacy", oldDir, newDir, stagingDir };
-  }
-  return { action: "migrate", oldDir, newDir, stagingDir };
-}
-
-function isStagingOwnedByLiveProcess(stagingDir: string): boolean {
-  try {
-    const owner = JSON.parse(
-      fs.readFileSync(path.join(stagingDir, STAGING_OWNER_FILE), "utf8")
-    ) as { hostname?: unknown; pid?: unknown };
-    if (typeof owner.hostname !== "string" || typeof owner.pid !== "number") {
-      return false; // unparseable owner -> stale
+    // round-1 F6/F10: a destination that already holds real data (no marker)
+    // wins. Deciding here — not in execute() — makes the decision idempotent
+    // across launches: plan() returns "none" forever, no re-decision loop.
+    // The skip is surfaced loudly (round-2 P2-1).
+    if (fs.existsSync(newDir)) {
+      const nonLock = fs
+        .readdirSync(newDir)
+        .filter((name) => !ELECTRON_LOCK_FILES.has(name) && name !== MIGRATION_MARKER);
+      if (nonLock.length > 0) {
+        console.warn(
+          `[userData] ${newDir} already contains data but no migration marker; keeping both profiles and NOT migrating (legacy data stays in ${oldDir}).`
+        );
+        return { action: "none", oldDir, newDir, stagingDir };
+      }
     }
-    if (owner.hostname !== os.hostname()) return false; // from another machine
-    try {
-      process.kill(owner.pid, 0);
-      return true;
-    } catch (err) {
-      return (err as NodeJS.ErrnoException).code === "EPERM";
-    }
-  } catch {
-    return false; // no owner file (pre-upgrade crash residue) -> stale, claim it
+    return { action: "migrate", oldDir, newDir, stagingDir };
+  } catch (err) {
+    // round-2 P0-2: never throw out of plan(). Degrade to "legacy" — the
+    // caller points userData at DMWork for this session and retries next
+    // launch. Safer than guessing "none" (which would use an empty OCTO).
+    console.error(
+      `[userData] planUserDataMigration failed; using the legacy profile this session (will retry on next launch):`,
+      err
+    );
+    return { action: "legacy", oldDir, newDir, stagingDir };
   }
 }
 
@@ -205,113 +130,60 @@ export function executeUserDataMigration(
   plan: MigrationPlan,
   runtime: MigrationRuntime
 ): MigrationResult {
-  if (plan.action === "none") {
-    return "done";
-  }
-  if (plan.action === "defer-legacy") {
-    // F7: this branch is reachable because index.ts routes defer-legacy
-    // through executeUserDataMigration; the user-actionable message below is
-    // the only signal that a running legacy instance deferred the migration.
-    runtime.setUserDataDir(plan.oldDir);
-    runtime.log.warn(
-      `[userData] a legacy DMWork instance is still running (${path.join(
-        plan.oldDir,
-        "SingletonLock"
-      )} is held); using the legacy profile for this session. Quit the old app and relaunch to migrate.`
-    );
-    return "deferred";
+  if (plan.action !== "migrate") {
+    // "none": nothing to do. "legacy": the caller already pointed userData
+    // at the legacy dir before the single-instance lock; this session simply
+    // runs there and retries the migration next launch.
+    return plan.action === "legacy" ? "deferred" : "done";
   }
   // action === "migrate"
-  // F2: the staging dir is the cross-launch mutex. mkdir is not the claim —
-  // the OWNER FILE is, via atomic exclusive create ({ flag: "wx" }). This
-  // closes the owner-file race: a process that mkdir'd but was preempted
-  // before writing its owner loses the claim to whoever writes the owner
-  // file first; a process that sees EEXIST on the owner file either defers
-  // (live owner) or reclaims (dead owner / crash residue).
-  let claimed = false;
   try {
-    try {
-      fs.mkdirSync(plan.stagingDir);
-    } catch (err) {
-      if ((err as NodeJS.ErrnoException).code !== "EEXIST") throw err;
-    }
-    const ownerJson = JSON.stringify({
-      hostname: os.hostname(),
-      pid: process.pid,
-      startedAt: new Date().toISOString(),
-    });
-    try {
-      fs.writeFileSync(path.join(plan.stagingDir, STAGING_OWNER_FILE), ownerJson, { flag: "wx" });
-      claimed = true;
-    } catch (err) {
-      if ((err as NodeJS.ErrnoException).code !== "EEXIST") throw err;
-      if (isStagingOwnedByLiveProcess(plan.stagingDir)) {
+    // round-2 P2-6: re-assert the lock-only invariant immediately before
+    // deleting the destination — plan() may have run minutes ago (the copy
+    // below can be slow on multi-GB profiles).
+    if (fs.existsSync(plan.newDir)) {
+      const nonLock = fs
+        .readdirSync(plan.newDir)
+        .filter((name) => !ELECTRON_LOCK_FILES.has(name));
+      if (nonLock.length > 0) {
         runtime.log.warn(
-          `[userData] another launch is mid-migration (${plan.stagingDir}); using the legacy profile for this session.`
+          `[userData] ${plan.newDir} gained non-lock data since planning; not migrating (both profiles kept).`
         );
-        runtime.setUserDataDir(plan.oldDir);
-        return "deferred";
+        return "done";
       }
-      // Claimer is dead (crash / interrupted attempt): reclaim.
+      fs.rmSync(plan.newDir, { recursive: true, force: true });
+    }
+    // Crash residue from an interrupted previous attempt: with the
+    // single-instance lock as the mutex there is never a concurrent writer,
+    // so a leftover staging dir is always stale — clear it.
+    if (fs.existsSync(plan.stagingDir)) {
       fs.rmSync(plan.stagingDir, { recursive: true, force: true });
-      fs.mkdirSync(plan.stagingDir);
-      fs.writeFileSync(path.join(plan.stagingDir, STAGING_OWNER_FILE), ownerJson, { flag: "wx" });
-      claimed = true;
     }
-    // We hold the claim. Drop anything left in the dir by a crashed attempt
-    // (our owner file stays).
-    for (const entry of fs.readdirSync(plan.stagingDir)) {
-      if (entry !== STAGING_OWNER_FILE) {
-        fs.rmSync(path.join(plan.stagingDir, entry), { recursive: true, force: true });
-      }
-    }
-    // F3: never copy Chromium singleton artifacts or locks into the new profile.
+    fs.mkdirSync(plan.stagingDir);
+    // round-1 F3 + round-2 P2-3: never copy singleton artifacts / locks, and
+    // anchor the filter to top-level entries (nested dirs are left alone).
     fs.cpSync(plan.oldDir, plan.stagingDir, {
       recursive: true,
       filter: (src) => {
-        const name = path.basename(src);
-        return !SKIP_DIRS.has(name) && !ELECTRON_LOCK_FILES.has(name);
+        const rel = path.relative(plan.oldDir, src);
+        if (rel.includes(path.sep)) return true; // nested: never prune
+        return !SKIP_DIRS.has(rel) && !ELECTRON_LOCK_FILES.has(rel);
       },
     });
-    // F5: marker lands in staging BEFORE the rename, so profile+marker
-    // publish as one atomic step. A marker can no longer be missing after a
-    // successful rename (the old post-rename marker-failure window is gone).
+    // round-1 F5: marker lands in staging BEFORE the rename, so profile+marker
+    // publish as one atomic step. (No fsync: a marker is only ever written
+    // before the rename now, and claiming power-loss durability would require
+    // flushing the whole copied tree, which is out of scope — round-2 P2-4.)
     fs.writeFileSync(path.join(plan.stagingDir, MIGRATION_MARKER), new Date().toISOString());
-    // F8 (durability, best-effort): flush the marker before publishing.
-    try {
-      const fd = fs.openSync(path.join(plan.stagingDir, MIGRATION_MARKER), "a");
-      try {
-        fs.fsyncSync(fd);
-      } finally {
-        fs.closeSync(fd); // always close — a leaked handle blocks rename on Windows
-      }
-    } catch {
-      // best-effort; not all platforms support fsync on every fd type
-    }
-    // The owner file is migration-internal metadata; never publish it into
-    // the final profile.
-    fs.rmSync(path.join(plan.stagingDir, STAGING_OWNER_FILE));
-    // plan() already refused to migrate when newDir holds real data; if it
-    // exists here it contains only lock files (F2/F10), which at this point
-    // belong to no live process: we run before our own single-instance lock
-    // exists, and any concurrent launch that reached the lock already deferred
-    // (its lock lives in <oldDir>).
-    if (fs.existsSync(plan.newDir)) {
-      fs.rmSync(plan.newDir, { recursive: true, force: true });
-    }
     fs.renameSync(plan.stagingDir, plan.newDir);
     runtime.log.info(`[userData] migrated legacy DMWork profile to ${plan.newDir}`);
     return "done";
   } catch (err) {
-    // Only clean up a staging dir we actually claimed — never a live one.
-    if (claimed) {
-      try {
-        fs.rmSync(plan.stagingDir, { recursive: true, force: true });
-      } catch {
-        // best-effort cleanup; the next launch retries anyway
-      }
+    try {
+      fs.rmSync(plan.stagingDir, { recursive: true, force: true });
+    } catch {
+      // best-effort cleanup; the next launch retries anyway
     }
-    runtime.setUserDataDir(plan.oldDir);
     runtime.log.error(
       "[userData] DMWork -> OCTO migration failed; keeping the legacy profile for this session (will retry on next launch):",
       err

--- a/apps/web/src-election/main/userDataMigration.ts
+++ b/apps/web/src-election/main/userDataMigration.ts
@@ -1,4 +1,5 @@
 import fs from "fs";
+import os from "os";
 import path from "path";
 
 // ---------------------------------------------------------------------------
@@ -9,7 +10,7 @@ import path from "path";
 // every existing user would silently start with a fresh empty profile (lost
 // session, localStorage, IndexedDB message stores, drafts).
 //
-// Design (each point maps to a review finding on PR #1258):
+// Design (each point maps to a review finding on PR #1265):
 // - Staging copy + atomic rename: copy into <appData>/OCTO.migrating, then
 //   renameSync into place. renameSync is atomic, so <appData>/OCTO only ever
 //   appears as a COMPLETE profile — a torn LevelDB can never be mistaken for a
@@ -18,33 +19,51 @@ import path from "path";
 // - Completion marker: the sentinel is <appData>/OCTO/.migrated-from-dmwork,
 //   NOT the existence of <appData>/OCTO — startup itself (the single-instance
 //   lock, then Chromium) creates that directory, so destination-existence
-//   would latch a failed migration forever.
+//   would latch a failed migration forever. The marker is written into the
+//   staging dir BEFORE the rename (F5), so profile+marker publish atomically
+//   and a post-rename marker failure can no longer strand a markerless
+//   destination.
+// - Cross-launch mutex (F2): the staging dir itself is the mutex.
+//   fs.mkdirSync is atomic — EEXIST means another launch is mid-migration,
+//   so this launch defers to the legacy profile. A stale staging dir (owner
+//   pid dead, or no owner file from a pre-upgrade crash) is claimed and
+//   retried. The migration therefore runs BEFORE requestSingleInstanceLock()
+//   and never has to delete a lock it holds; the fallback also happens before
+//   the lock, so the fallback session's lock is created in the legacy dir it
+//   writes (F4) — no double writer anywhere.
+// - Legacy instance guard (F1): a running DMWork-branded process holds
+//   <appData>/DMWork/SingletonLock. On POSIX Chromium writes that file as a
+//   symlink to a deliberately non-existent target "<hostname>-<pid>", so
+//   existsSync (which follows links) can never see it; Windows has no such
+//   file at all (ProcessSingleton uses OS primitives). We lstat the link,
+//   parse the target, confirm the hostname and that the pid is alive, and
+//   only then defer. A stale lock (dead pid / foreign hostname / unparseable)
+//   is treated as not held so a crash can never permanently trap users. On
+//   Windows the guard is a no-op by design: a live legacy process keeps its
+//   profile files open, so the copy/rename fails and the catch falls back to
+//   the legacy profile — same outcome, no data loss.
 // - Fallback on failure: if the copy/rename fails, this session keeps using
 //   the legacy profile via setUserDataDir(oldDir) — the user keeps their data
 //   and the migration retries on the next launch (marker still absent).
-// - Legacy instance guard: a running DMWork-branded process holds
-//   <appData>/DMWork/SingletonLock. When that lock exists we do NOT migrate
-//   (copying a live profile is a torn snapshot; on macOS/Linux rename(2) would
-//   even succeed against a live profile, giving two writers). Instead the
-//   caller points userData at the legacy dir before requestSingleInstanceLock()
-//   so the lock fails against the running instance and this launch quits.
-// - Runs after requestSingleInstanceLock(): only the process that holds the
-//   new single-instance lock performs the migration, closing the double-launch
-//   race.
+// - Destination with real data (F6/F10): if <appData>/OCTO already exists
+//   with non-lock content and no marker, plan() returns "none" — permanently
+//   (not a per-launch re-decision), both profiles are kept, and the skip is
+//   surfaced through the log. Correctness never depends on enumerating every
+//   future file Chromium might create early.
 // ---------------------------------------------------------------------------
 
 export const LEGACY_USER_DATA_DIR = "DMWork";
 export const MIGRATION_MARKER = ".migrated-from-dmwork";
+export const STAGING_OWNER_FILE = ".migration-owner.json";
 
-// Electron's single-instance lock creates these files in userData. When the
-// migration runs after requestSingleInstanceLock(), <appData>/OCTO already
-// contains them; they are regenerable and must be removed before the staging
-// rename can land. Any OTHER entry in <appData>/OCTO is treated as real user
-// data we must not clobber.
+// Files Electron/Chromium's ProcessSingleton creates in userData. They are
+// never migrated (F3) and are the only entries a pre-existing destination is
+// allowed to contain for the migration to proceed (F2/F10).
 const ELECTRON_LOCK_FILES = new Set([
   "SingletonLock",
   "SingletonCookie",
   "SingletonSocket",
+  "lockfile",
 ]);
 
 // Regenerable Chromium caches, intentionally not migrated.
@@ -56,6 +75,8 @@ export const SKIP_DIRS = new Set([
   "DawnGraphiteCache",
   "DawnWebGPUCache",
   "ShaderCache",
+  "Service Worker",
+  "blob_storage",
 ]);
 
 export type MigrationPlan = {
@@ -64,19 +85,6 @@ export type MigrationPlan = {
   newDir: string;
   stagingDir: string;
 };
-
-export function planUserDataMigration(appDataDir: string, brandName: string): MigrationPlan {
-  const oldDir = path.join(appDataDir, LEGACY_USER_DATA_DIR);
-  const newDir = path.join(appDataDir, brandName);
-  const stagingDir = `${newDir}.migrating`;
-  if (!fs.existsSync(oldDir) || fs.existsSync(path.join(newDir, MIGRATION_MARKER))) {
-    return { action: "none", oldDir, newDir, stagingDir };
-  }
-  if (fs.existsSync(path.join(oldDir, "SingletonLock"))) {
-    return { action: "defer-legacy", oldDir, newDir, stagingDir };
-  }
-  return { action: "migrate", oldDir, newDir, stagingDir };
-}
 
 export type MigrationResult = "done" | "deferred" | "failed";
 
@@ -89,6 +97,91 @@ export type MigrationRuntime = {
   };
 };
 
+// F1: detect a live legacy DMWork instance.
+// POSIX: SingletonLock is a symlink to "<hostname>-<pid>" whose target does
+// not exist, so lstat (no follow) is required. Windows: no SingletonLock
+// file — the guard intentionally returns false; see header comment.
+export function isLegacyInstanceRunning(oldDir: string): boolean {
+  const lockPath = path.join(oldDir, "SingletonLock");
+  let raw: string;
+  try {
+    const st = fs.lstatSync(lockPath);
+    raw = st.isSymbolicLink()
+      ? fs.readlinkSync(lockPath)
+      : fs.readFileSync(lockPath, "utf8").trim();
+  } catch {
+    return false; // ENOENT or unreadable -> not running; never trap on a stale lock
+  }
+  const match = /^(.+)-(\d+)$/.exec(raw);
+  if (!match) return false; // unparseable -> treat as stale, do not defer forever
+  const [, hostname, pidStr] = match;
+  if (hostname !== os.hostname()) return false; // lock from another machine -> stale
+  const pid = Number(pidStr);
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0); // liveness probe, no signal
+    return true;
+  } catch (err) {
+    // EPERM: the pid exists but is owned by another user -> still running.
+    return (err as NodeJS.ErrnoException).code === "EPERM";
+  }
+}
+
+export function planUserDataMigration(appDataDir: string, brandName: string): MigrationPlan {
+  const oldDir = path.join(appDataDir, LEGACY_USER_DATA_DIR);
+  const newDir = path.join(appDataDir, brandName);
+  const stagingDir = `${newDir}.migrating`;
+  if (!fs.existsSync(oldDir) || fs.existsSync(path.join(newDir, MIGRATION_MARKER))) {
+    return { action: "none", oldDir, newDir, stagingDir };
+  }
+  // F6/F10: a destination that already holds real data (no marker) wins.
+  // Deciding here — not in execute() — makes the decision idempotent across
+  // launches: plan() returns "none" forever, no per-launch re-decision loop.
+  if (fs.existsSync(newDir)) {
+    const nonLock = fs
+      .readdirSync(newDir)
+      .filter((name) => !ELECTRON_LOCK_FILES.has(name) && name !== MIGRATION_MARKER);
+    if (nonLock.length > 0) {
+      return { action: "none", oldDir, newDir, stagingDir };
+    }
+  }
+  if (isLegacyInstanceRunning(oldDir)) {
+    return { action: "defer-legacy", oldDir, newDir, stagingDir };
+  }
+  return { action: "migrate", oldDir, newDir, stagingDir };
+}
+
+function isStagingOwnedByLiveProcess(stagingDir: string): boolean {
+  try {
+    const owner = JSON.parse(
+      fs.readFileSync(path.join(stagingDir, STAGING_OWNER_FILE), "utf8")
+    ) as { hostname?: unknown; pid?: unknown };
+    if (typeof owner.hostname !== "string" || typeof owner.pid !== "number") {
+      return false; // unparseable owner -> stale
+    }
+    if (owner.hostname !== os.hostname()) return false; // from another machine
+    try {
+      process.kill(owner.pid, 0);
+      return true;
+    } catch (err) {
+      return (err as NodeJS.ErrnoException).code === "EPERM";
+    }
+  } catch {
+    return false; // no owner file (pre-upgrade crash residue) -> stale, claim it
+  }
+}
+
+function writeOwnerFile(stagingDir: string): void {
+  fs.writeFileSync(
+    path.join(stagingDir, STAGING_OWNER_FILE),
+    JSON.stringify({
+      hostname: os.hostname(),
+      pid: process.pid,
+      startedAt: new Date().toISOString(),
+    })
+  );
+}
+
 export function executeUserDataMigration(
   plan: MigrationPlan,
   runtime: MigrationRuntime
@@ -97,6 +190,9 @@ export function executeUserDataMigration(
     return "done";
   }
   if (plan.action === "defer-legacy") {
+    // F7: this branch is reachable because index.ts routes defer-legacy
+    // through executeUserDataMigration; the user-actionable message below is
+    // the only signal that a running legacy instance deferred the migration.
     runtime.setUserDataDir(plan.oldDir);
     runtime.log.warn(
       `[userData] a legacy DMWork instance is still running (${path.join(
@@ -107,34 +203,56 @@ export function executeUserDataMigration(
     return "deferred";
   }
   // action === "migrate"
+  // F2: acquire the staging dir as the cross-launch mutex BEFORE any copy.
   try {
-    // Stale staging dir from an interrupted previous attempt (crash mid-copy).
-    if (fs.existsSync(plan.stagingDir)) {
-      fs.rmSync(plan.stagingDir, { recursive: true, force: true });
+    fs.mkdirSync(plan.stagingDir);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "EEXIST") throw err;
+    if (isStagingOwnedByLiveProcess(plan.stagingDir)) {
+      runtime.log.warn(
+        `[userData] another launch is mid-migration (${plan.stagingDir}); using the legacy profile for this session.`
+      );
+      runtime.setUserDataDir(plan.oldDir);
+      return "deferred";
     }
-    // The single-instance lock (or an earlier failed run) may have created
-    // <appData>/OCTO containing only Electron's lock files. Remove those; if
-    // anything else is in there we treat it as user data we must not clobber
-    // and skip the migration (both profiles are kept, nothing is lost).
-    if (fs.existsSync(plan.newDir)) {
-      const entries = fs.readdirSync(plan.newDir);
-      const nonLock = entries.filter((name) => !ELECTRON_LOCK_FILES.has(name));
-      if (nonLock.length > 0) {
-        runtime.log.warn(
-          `[userData] ${plan.newDir} already contains data but no migration marker; not migrating (both profiles kept).`
-        );
-        return "done";
-      }
-      // The dir itself must also go: on Windows renameSync fails against an
-      // existing (even empty) destination directory.
-      fs.rmSync(plan.newDir, { recursive: true, force: true });
-    }
+    // Stale staging from a crashed/interrupted attempt: claim it and retry.
+    fs.rmSync(plan.stagingDir, { recursive: true, force: true });
+    fs.mkdirSync(plan.stagingDir);
+  }
+  writeOwnerFile(plan.stagingDir);
+  try {
+    // F3: never copy Chromium singleton artifacts or locks into the new profile.
     fs.cpSync(plan.oldDir, plan.stagingDir, {
       recursive: true,
-      filter: (src) => !SKIP_DIRS.has(path.basename(src)),
+      filter: (src) => {
+        const name = path.basename(src);
+        return !SKIP_DIRS.has(name) && !ELECTRON_LOCK_FILES.has(name);
+      },
     });
+    // F5: marker lands in staging BEFORE the rename, so profile+marker
+    // publish as one atomic step. A marker can no longer be missing after a
+    // successful rename (the old post-rename marker-failure window is gone).
+    fs.writeFileSync(path.join(plan.stagingDir, MIGRATION_MARKER), new Date().toISOString());
+    // F8 (durability, best-effort): flush the marker before publishing.
+    try {
+      const fd = fs.openSync(path.join(plan.stagingDir, MIGRATION_MARKER), "a");
+      try {
+        fs.fsyncSync(fd);
+      } finally {
+        fs.closeSync(fd); // always close — a leaked handle blocks rename on Windows
+      }
+    } catch {
+      // best-effort; not all platforms support fsync on every fd type
+    }
+    // plan() already refused to migrate when newDir holds real data; if it
+    // exists here it contains only lock files (F2/F10), which at this point
+    // belong to no live process: we run before our own single-instance lock
+    // exists, and any concurrent launch that reached the lock already deferred
+    // (its lock lives in <oldDir>).
+    if (fs.existsSync(plan.newDir)) {
+      fs.rmSync(plan.newDir, { recursive: true, force: true });
+    }
     fs.renameSync(plan.stagingDir, plan.newDir);
-    fs.writeFileSync(path.join(plan.newDir, MIGRATION_MARKER), new Date().toISOString());
     runtime.log.info(`[userData] migrated legacy DMWork profile to ${plan.newDir}`);
     return "done";
   } catch (err) {

--- a/apps/web/tsconfig.e.json
+++ b/apps/web/tsconfig.e.json
@@ -1,5 +1,5 @@
 {
-  "exclude": ["node_modules", "src"],
+  "exclude": ["node_modules", "src", "src-election/**/__tests__/**"],
   "include": ["src-election/**/*"],
   "compilerOptions": {
     "outDir": "./out-election",

--- a/apps/web/tsconfig.e.tests.json
+++ b/apps/web/tsconfig.e.tests.json
@@ -1,18 +1,12 @@
 {
+  "extends": "./tsconfig.e.json",
   "compilerOptions": {
-    "module": "commonjs",
-    "moduleResolution": "node",
-    "target": "es2020",
-    "resolveJsonModule": true,
-    "esModuleInterop": true,
-    "allowSyntheticDefaultImports": true,
     "noEmit": true,
-    "baseUrl": "./",
-    "skipLibCheck": true,
     "types": ["node"]
   },
   "include": [
     "src-election/main/userDataMigration.ts",
     "src-election/**/__tests__/**/*.ts"
-  ]
+  ],
+  "exclude": ["node_modules", "src"]
 }

--- a/apps/web/tsconfig.e.tests.json
+++ b/apps/web/tsconfig.e.tests.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "target": "es2020",
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "noEmit": true,
+    "baseUrl": "./",
+    "skipLibCheck": true,
+    "types": ["node"]
+  },
+  "include": [
+    "src-election/main/userDataMigration.ts",
+    "src-election/**/__tests__/**/*.ts"
+  ]
+}


### PR DESCRIPTION
One-time migration of the legacy `<appData>/DMWork` user profile to `<appData>/OCTO` for the OCTO desktop (Electron) app.

`app.setName("OCTO")` (landing in #1258) relocates Electron's default `userData` from `<appData>/DMWork` to `<appData>/OCTO`. Without a migration, every existing desktop user would silently start with a fresh empty profile (lost session, localStorage, IndexedDB message stores, drafts).

> Merged on top of #1258 (now in main); the diff is exactly this migration: 2 source files (`index.ts`, `userDataMigration.ts`) + tests + 2 CI steps + `tsconfig.e.tests.json`.

## Design (round-11)

| Aspect | Implementation |
|---|---|
| Mutual exclusion | Electron's own single-instance lock. `index.ts` points `userData` at the legacy dir BEFORE `requestSingleInstanceLock()`, so the lock is taken on the legacy path: a running legacy instance or a concurrent launch fails the lock and quits (dialog gated to `action === "migrate"`, via the tested `decideLockLostAction`). On success the app relaunches so the next process locks `<appData>/OCTO` normally. The losing process never opens a window: the `ready` guard quits it, and `activate`/`open-url` are additionally gated on `gotTheLock`; `onDeepLink` guards a not-yet-created window. |
| Atomic publish | Staging copy into `<appData>/OCTO.migrating` (0700), then `renameSync` into place. `<appData>/OCTO` only ever appears complete; the legacy profile data is never mutated (only the failure-breadcrumb dotfile is written, with a fallback beside the staging dir). |
| Completion proof | Marker `<appData>/OCTO/.migrated-from-dmwork` + residual destination data. A bare marker over an EMPTY destination with a data-bearing legacy is torn and re-migrated; a marker with residual data (or a legacy holding nothing the copy would publish) is complete. Round-trip invariant: execute 'done' implies next plan 'none'. Marker is written into staging BEFORE the rename. |
| One classification (round-10 P0-1) | `MIGRATION_NOISE` is the single "never migrates" set shared by the copy filter, `hasCopyableData` and `DESTINATION_CLEANABLE` — the set-asymmetry that caused a relaunch boot loop for `.DS_Store`/`Dictionaries`-only legacies is structurally impossible now. |
| Destination safety | ALLOWLIST (fail-closed): the destination is deleted only when every top-level entry is known cleanable. ProcessSingleton artifacts and `Crashpad` are NOT cleanable — a live instance's fingerprint is treated as occupied. An uninspectable destination is `destination-unreadable` (distinct dialog), never assumed complete or deletable. |
| Occupied destination | plan() returns `action: "legacy"` + `reason: "destination-occupied"`; the session stays on DMWork and index.ts shows a one-shot bilingual dialog naming both directories. |
| Failure containment | Never-throws. stat ENOENT -> none (fresh install); other stat errors -> legacy. Breadcrumb bounds retries at 3: the attempt is recorded BEFORE the copy (so ENOSPC-class failures count), the failure path only annotates `lastError`, reads take `max(primary, fallback)`, and the recovery dialog names the file that actually exists. Stale staging (possible copied credentials) is cleaned by the lock winner on every startup. |
| Copy filter | Top-level only, case-insensitive, driven by `MIGRATION_NOISE`; FIFOs/sockets at any depth are skipped (`isCopyableSource`); nested dirs named like caches are preserved. `Service Worker/`/`blob_storage` pruning is safe — no `caches.open`/`serviceWorker.register` call sites anywhere in `apps/web` or `packages`. |

## Tests (62/62 pass)

- atomic migrate: source kept, marker written, no staging residue, second launch no-ops
- round-trip invariant: nothing-copyable legacy plans 'none' (table-driven over every noise member — `.DS_Store`/`Thumbs.db`/`desktop.ini`/`.localized`/`Dictionaries`/`Network Persistent State`/caches/`Singleton*`/`LockFile`/breadcrumb; mixed scenarios; real migrate asserts noise is not published)
- torn publish (bare marker, empty destination, data-bearing legacy) re-migrates — incl. legacy holding IndexedDB but no Preferences
- destination with residual data -> occupied -> legacy + reason, one-shot dialog
- destination holding `SingletonLock`/`Crashpad` -> occupied, never deleted
- marker/unreadable destination -> legacy + `destination-unreadable` reason
- allowlist fail-closed: destination holding `Local Storage` but no `Preferences` is NOT deleted — skipped
- retry bound: attempt recorded BEFORE copy (ENOSPC-mocked copy still counts); `max(primary, fallback)` read; breadcrumb write failure falls back to appData; success clears breadcrumb + notices
- stat ENOENT -> none; stat EACCES -> legacy; empty/nothing-copyable legacy -> none
- FIFO/socket filter (`isCopyableSource`), stale-staging cleanup, notice recorded after dialog display
- `decideLockLostAction` matrix; `actualBreadcrumbFile` primary/fallback selection

## Verification

- `tsc -p tsconfig.e.json` clean; `tsc -p tsconfig.e.tests.json` clean (extends tsconfig.e.json)
- `vitest run src-election`: 62/62 pass
- CI runs the electron main-process unit tests + test-suite typecheck (new steps)
- Human verification required before shipping (real machines): macOS cookie-encryption keyed to app name (session survival — inherited from #1258, not introduced here), Windows setPath/rmSync under open handles, multi-GB copy duration (round-10 P1-2: measurement + progress-window decision is a rollout item), three-platform two-instance concurrency (P1-1 regression), internal/beta-build OCTO-dir check (round-10 P2-4)

## Follow-ups (explicitly NOT in this PR, per round-11 review)

- Unify the classification further (single predicate + execute=done→plan=none invariant test suite) as a follow-up PR
- The three one-liners from round-11 review (marker in MIGRATION_NOISE, `actualBreadcrumbFile` max-consistent, bump after destination re-check) + FIFO-only-loop hardening ride along in that follow-up

## Notes

- Fresh installs (no DMWork dir) are a no-op.
- The migration is a one-time forward step; two profiles are never merged or clobbered.
