### PR TITLE
feat(drive): move share access/download to the authenticated route

### DIFF
--- a/packages/dmworkdrive/src/api/__tests__/driveApi.test.ts
+++ b/packages/dmworkdrive/src/api/__tests__/driveApi.test.ts
@@ -224,21 +224,27 @@ describe('share / invite / org', () => {
     });
   });
 
-  it('accessShareByToken hits the public route, omitting body when no password', async () => {
+  it('accessShareByToken hits the authed share-token route, omitting body when no password', async () => {
     inst.post.mockResolvedValue(ok({ file_id: 1 }));
     await driveApi.accessShareByToken('tok');
-    expect(inst.post).toHaveBeenCalledWith('/v1/drive/public/shares/tok/access', undefined);
+    expect(inst.post).toHaveBeenCalledWith('/v1/drive/shares/tok/access', undefined);
     await driveApi.accessShareByToken('tok', 'pw');
-    expect(inst.post).toHaveBeenCalledWith('/v1/drive/public/shares/tok/access', { password: 'pw' });
+    expect(inst.post).toHaveBeenCalledWith('/v1/drive/shares/tok/access', { password: 'pw' });
   });
 
-  it('downloadShareByToken POSTs the public download route, omitting body when no password', async () => {
+  it('downloadShareByToken POSTs the authed share-token download route, omitting body when no password', async () => {
     inst.post.mockResolvedValue(ok({ url: 'https://s/dl', filename: 'a.txt', content_type: 'text/plain' }));
     const res = await driveApi.downloadShareByToken('tok');
-    expect(inst.post).toHaveBeenCalledWith('/v1/drive/public/shares/tok/download', undefined);
+    expect(inst.post).toHaveBeenCalledWith('/v1/drive/shares/tok/download', undefined);
     expect(res.url).toBe('https://s/dl');
     await driveApi.downloadShareByToken('tok', 'pw');
-    expect(inst.post).toHaveBeenCalledWith('/v1/drive/public/shares/tok/download', { password: 'pw' });
+    expect(inst.post).toHaveBeenCalledWith('/v1/drive/shares/tok/download', { password: 'pw' });
+  });
+
+  it('revokeShare DELETEs /shares/:id — the owner-side sibling of the token routes', async () => {
+    inst.delete.mockResolvedValue(ok(undefined));
+    await driveApi.revokeShare('sh1');
+    expect(inst.delete).toHaveBeenCalledWith('/v1/drive/shares/sh1');
   });
 
   it('acceptInvite POSTs /invites/:token/accept', async () => {
@@ -326,15 +332,17 @@ describe('auth-header interceptor', () => {
     logout.mockRestore();
   });
 
-  it('does NOT log out on a share-route 401 carrying a business code (B1)', async () => {
+  it('does NOT log out on a share-token 401 carrying a business code (B1)', async () => {
     const logout = vi.spyOn(WKApp.shared, 'logout');
     const responseUse = inst.interceptors.response.use as ReturnType<typeof vi.fn>;
     const onError = responseUse.mock.calls[0][1];
     // Every share business code, on both share endpoints, is left for the page
     // to classify — the share rejected the caller, the octo session is fine.
+    // A query string must not break the path match.
     for (const url of [
-      '/v1/drive/public/shares/tok/access',
-      '/v1/drive/public/shares/tok/download',
+      '/v1/drive/shares/tok/access',
+      '/v1/drive/shares/tok/download',
+      '/v1/drive/shares/tok/access?x=1',
     ]) {
       for (const code of ['password_required', 'wrong_password', 'share_expired', 'not_found']) {
         await expect(
@@ -346,7 +354,36 @@ describe('auth-header interceptor', () => {
     logout.mockRestore();
   });
 
-  it('DOES log out on a share-route 401 that is a session failure, not a share code (B1)', async () => {
+  it('the share-token exemption is anchored — owner-side and near-miss paths still log out', async () => {
+    const logout = vi.spyOn(WKApp.shared, 'logout');
+    const responseUse = inst.interceptors.response.use as ReturnType<typeof vi.fn>;
+    const onError = responseUse.mock.calls[0][1];
+    // Only `${BASE}/shares/:token/access|download` is exempt. The owner-side
+    // siblings that share the prefix (list/create `/shares`, revoke
+    // `/shares/:id`), a near-miss prefix, a nested extra segment and a
+    // trailing slash are all genuine session 401s → global logout.
+    const notExempt = [
+      '/v1/drive/shares',
+      '/v1/drive/shares?page=1',
+      '/v1/drive/shares/sh1',
+      '/v1/drive/shares/tok/access/',
+      '/v1/drive/shares/tok/access/extra',
+      '/v1/drive/sharesX/tok/access',
+      '/v1/drive/public/shares/tok/access',
+      '/v1/driveX/shares/tok/access',
+      '/other/shares/tok/access',
+      '/v1/drive/shares//access',
+    ];
+    for (const url of notExempt) {
+      await expect(
+        onError({ response: { status: 401, data: { error: 'not_found' } }, config: { url } }),
+      ).rejects.toBeDefined();
+    }
+    expect(logout).toHaveBeenCalledTimes(notExempt.length);
+    logout.mockRestore();
+  });
+
+  it('DOES log out on a share-token 401 that is a session failure, not a share code (B1)', async () => {
     const logout = vi.spyOn(WKApp.shared, 'logout');
     const responseUse = inst.interceptors.response.use as ReturnType<typeof vi.fn>;
     const onError = responseUse.mock.calls[0][1];
@@ -356,13 +393,13 @@ describe('auth-header interceptor', () => {
     await expect(
       onError({
         response: { status: 401, data: { error: 'unauthorized' } },
-        config: { url: '/v1/drive/public/shares/tok/access' },
+        config: { url: '/v1/drive/shares/tok/access' },
       }),
     ).rejects.toBeDefined();
     await expect(
       onError({
         response: { status: 401 },
-        config: { url: '/v1/drive/public/shares/tok/download' },
+        config: { url: '/v1/drive/shares/tok/download' },
       }),
     ).rejects.toBeDefined();
     expect(logout).toHaveBeenCalledTimes(2);
@@ -376,7 +413,7 @@ describe('auth-header interceptor', () => {
     const logout = vi.spyOn(WKApp.shared, 'logout');
     inst.post.mockRejectedValue({
       response: { status: 401, data: { error: 'wrong_password', message: 'bad password' } },
-      config: { url: '/v1/drive/public/shares/tok/access' },
+      config: { url: '/v1/drive/shares/tok/access' },
     });
     await expect(driveApi.accessShareByToken('tok', 'nope')).rejects.toMatchObject({
       code: 'wrong_password',
@@ -384,7 +421,7 @@ describe('auth-header interceptor', () => {
     });
     inst.post.mockRejectedValue({
       response: { status: 401, data: { error: 'share_expired', message: 'expired' } },
-      config: { url: '/v1/drive/public/shares/tok/download' },
+      config: { url: '/v1/drive/shares/tok/download' },
     });
     await expect(driveApi.downloadShareByToken('tok')).rejects.toMatchObject({
       code: 'share_expired',

--- a/packages/dmworkdrive/src/api/driveApi.ts
+++ b/packages/dmworkdrive/src/api/driveApi.ts
@@ -108,19 +108,31 @@ const SHARE_BUSINESS_CODES = new Set([
 ]);
 
 /**
- * Whether `url` targets the public-share namespace, anchored to the exact drive
- * base path so it never matches a sibling like `/v1/drive/publicshares` or an
- * unrelated `/public/shares/` on another service.
+ * Whether `url` is a recipient-side share-token endpoint
+ * (`${BASE}/shares/:token/access|download`).
+ *
+ * Anchored to the exact drive base path AND to a single token segment followed by
+ * `access`/`download`, so it never matches an owner-side sibling under the same
+ * prefix — `POST|GET ${BASE}/shares`, `DELETE ${BASE}/shares/:id` — nor a
+ * near-miss like `${BASE}/sharesX/...` or an unrelated `/shares/` on another
+ * service. Query strings are ignored.
  */
-function isSharePublicPath(url: string): boolean {
+function isShareTokenPath(url: string): boolean {
   const path = url.split('?')[0];
-  return path.startsWith(`${BASE}/public/shares/`);
+  const prefix = `${BASE}/shares/`;
+  if (!path.startsWith(prefix)) return false;
+  const segments = path.slice(prefix.length).split('/');
+  return (
+    segments.length === 2 &&
+    segments[0] !== '' &&
+    (segments[1] === 'access' || segments[1] === 'download')
+  );
 }
 
 // Mirror APIClient: an expired octo session (401) logs the user out — EXCEPT a
-// 401 from `/v1/drive/public/shares/:token/*` whose envelope carries a share
-// business code, which means the share (not the session) rejected the caller.
-// ShareLandingPage classifies that response by its code. Every other 401 —
+// 401 from `/v1/drive/shares/:token/access|download` whose envelope carries a
+// share business code, which means the share (not the session) rejected the
+// caller. ShareLandingPage classifies that response by its code. Every other 401 —
 // including a share-route `unauthorized`/session-expired 401 — still logs out,
 // preserving the login-then-return-to-landing flow.
 driveAxios.interceptors.response.use(undefined, (err) => {
@@ -128,7 +140,7 @@ driveAxios.interceptors.response.use(undefined, (err) => {
     const url: string = err?.config?.url ?? '';
     const code = extractApiError(err).code;
     const isShareBusinessFailure =
-      isSharePublicPath(url) && !!code && SHARE_BUSINESS_CODES.has(code);
+      isShareTokenPath(url) && !!code && SHARE_BUSINESS_CODES.has(code);
     if (!isShareBusinessFailure) {
       WKApp.shared.logout();
     }
@@ -539,29 +551,32 @@ export async function revokeShare(shareId: string): Promise<void> {
 /**
  * Recipient-side share access. Requires a valid Octo session: any signed-in Octo
  * user may open a share (regardless of whether they belong to the file's Space);
- * external/anonymous visitors cannot. Sent through the authed `driveAxios`, so a
- * genuine session 401 still triggers logout — but a 401 carrying a share business
- * code (password_required / wrong_password / share_expired / not_found) does NOT,
- * so ShareLandingPage can classify it instead of tearing down the session. The
- * path keeps the `/public/shares/...` name for backend-route compatibility, but
- * the request carries the session token.
+ * external/anonymous visitors cannot. The endpoint lives on the authenticated
+ * drive mount (`/v1/drive/shares/:token/access`) — the anonymous
+ * `/v1/drive/public/*` routes were removed backend-side, so authentication is
+ * enforced by the mount while the share token/password still decides share
+ * authorization. Sent through the authed `driveAxios`, so a genuine session 401
+ * still triggers logout — but a 401 carrying a share business code
+ * (password_required / wrong_password / share_expired / not_found) does NOT, so
+ * ShareLandingPage can classify it instead of tearing down the session.
  */
 export async function accessShareByToken(token: string, password?: string): Promise<ShareAccess> {
-  return post<ShareAccess>(`/public/shares/${encodeURIComponent(token)}/access`, password ? { password } : undefined);
+  return post<ShareAccess>(`/shares/${encodeURIComponent(token)}/access`, password ? { password } : undefined);
 }
 
 /**
  * Recipient-side share download. Reuses the same token+password+expiry check as
  * accessShareByToken and returns the object-storage URL. Authed like access —
- * any signed-in Octo user may download; same 401 handling (session 401 logs out,
- * a share-business-code 401 is left for the caller to classify).
+ * any signed-in Octo user may download, a logged-out visitor cannot; same 401
+ * handling (session 401 logs out, a share-business-code 401 is left for the
+ * caller to classify).
  */
 export async function downloadShareByToken(
   token: string,
   password?: string,
 ): Promise<ShareDownload> {
   return post<ShareDownload>(
-    `/public/shares/${encodeURIComponent(token)}/download`,
+    `/shares/${encodeURIComponent(token)}/download`,
     password ? { password } : undefined,
   );
 }

--- a/packages/dmworkdrive/src/index.tsx
+++ b/packages/dmworkdrive/src/index.tsx
@@ -4,8 +4,8 @@
 export { default as DriveModule } from './module';
 
 // Landing pages + path helpers — the host Layout intercepts the share/invite
-// deep-link shapes pre-login (share renders anonymously; invite bounces through
-// login and back), mirroring how it handles the standalone `/d/:docId` link.
+// deep-link shapes pre-login (both bounce through login and back), mirroring how
+// it handles the standalone `/d/:docId` link.
 export { default as ShareLandingPage } from './pages/ShareLandingPage';
 export { default as InviteLandingPage } from './pages/InviteLandingPage';
 export {

--- a/packages/dmworkdrive/src/module.tsx
+++ b/packages/dmworkdrive/src/module.tsx
@@ -41,9 +41,9 @@ const vm = new DriveVM();
 
 // NOTE: the share (`/drive/s/:token`) and invite (`/drive/invite/:token`)
 // landing pages are intercepted by the host Layout (apps/web) as standalone
-// pages — share renders anonymously (public endpoints, no login), invite
-// bounces through login and back. This module no longer captures/rewrites those
-// deep-links; it owns only the authenticated two-pane `/drive` view. Keeping a
+// pages — both require a signed-in session and bounce through login and back.
+// This module no longer captures/rewrites those deep-links; it owns only the
+// authenticated two-pane `/drive` view. Keeping a
 // single source of truth for the landing routes (the host Layout) avoids the
 // double-routing that the old boot-time URL rewrite created.
 

--- a/packages/dmworkdrive/src/pages/ShareLandingPage.tsx
+++ b/packages/dmworkdrive/src/pages/ShareLandingPage.tsx
@@ -14,14 +14,16 @@ import './LandingPage.css';
  * Share-access landing page at `/drive/s/:id` (the share id doubles as the
  * access token). Requires a valid Octo session (the host Layout gates this route
  * behind login): any signed-in Octo user may open the share regardless of the
- * file's Space membership. Validates the token — prompting for a password when
- * the share is password-gated — then shows the file metadata returned by
- * `POST /v1/drive/public/shares/:token/access`.
+ * file's Space membership, but a logged-out visitor is bounced to login and
+ * returned here. Validates the token — prompting for a password when the share
+ * is password-gated — then shows the file metadata returned by
+ * `POST /v1/drive/shares/:token/access`.
  *
- * Download goes through `POST /v1/drive/public/shares/:token/download`: it
- * re-checks the same token+password+expiry and returns the object-storage URL,
- * so the recipient downloads the bytes directly without needing Space membership.
- * (The `/public/...` path name is a backend-route label; the request is authed.)
+ * Download goes through `POST /v1/drive/shares/:token/download`: it re-checks
+ * the same token+password+expiry and returns the object-storage URL, so the
+ * recipient downloads the bytes directly without needing Space membership.
+ * Both endpoints live on the authenticated drive mount — there is no anonymous
+ * access or download path.
  */
 
 type View =

--- a/packages/dmworkdrive/src/utils/links.ts
+++ b/packages/dmworkdrive/src/utils/links.ts
@@ -4,9 +4,9 @@
 // namespace, mirroring @octo/base buildDocLink (`/d/:docId`) and the docs
 // module's invite link (`/docs/invite/:token`): the octo host's RouteManager
 // re-pushes pathname-only and strips the query, so a `?token=` deep-link would
-// be wiped before the module mounts. The share id doubles as its public-access
-// token (drive backend keys `POST /v1/drive/public/shares/:id/access` on the
-// share id); invites carry their own opaque token.
+// be wiped before the module mounts. The share id doubles as its access token
+// (drive backend keys `POST /v1/drive/shares/:id/access` on the share id);
+// invites carry their own opaque token.
 //
 // The landing routes (`/drive/s/:id`, `/drive/invite/:token`) are registered
 // via the octo host Layout. Both REQUIRE a signed-in Octo session: a logged-out
@@ -59,13 +59,13 @@ export function inviteTokenFromPath(): string {
 }
 
 /**
- * Whether `pathname` is a drive public-share landing link (`/drive/s/:token`).
+ * Whether `pathname` is a drive share landing link (`/drive/s/:token`).
  * The host Layout intercepts this shape and renders ShareLandingPage (which
  * requires a signed-in session; a logged-out visitor is bounced to login and
  * returned here). Anchored to a single token segment, and the token must
  * survive safeDecode — a malformed %-escape or an encoded slash is rejected so
  * Layout never renders the page with an empty/ambiguous token that would POST to
- * `/public/shares//access`. Mirrors isSafeDriveLandingPath in the host allowlist.
+ * `/shares//access`. Mirrors isSafeDriveLandingPath in the host allowlist.
  */
 export function isDriveSharePath(pathname: string): boolean {
   return isLandingToken(pathname, /^\/drive\/s\/([^/?#]+)\/?$/);


### PR DESCRIPTION
## What

Point the Web share landing page at the **authenticated** drive share endpoints:

| | before | after |
|---|---|---|
| access | `POST /v1/drive/public/shares/:token/access` | `POST /v1/drive/shares/:token/access` |
| download | `POST /v1/drive/public/shares/:token/download` | `POST /v1/drive/shares/:token/download` |

The drive backend deleted the anonymous `/v1/drive/public` route group and remounted both handlers on the three authenticated mounts; the Web client uses the human mount. Authentication is now enforced by the mount, while the share token/password still decides share authorization. A recipient **does not** need to be a member of the file's Drive Space — any signed-in user with a valid share may access and download.

Business semantics are unchanged: `password_required` / `wrong_password` / `share_expired` / `not_found`, and attachment download.

## Why

Product requirement (owner, 2026-07-24, reconfirmed 2026-08-06): **a signed-in user may access and download a share; a logged-out visitor may not**, and should be guided to login and returned to the original share link.

The requests already carried the session token (the drive request interceptor attaches it unconditionally), and the host Layout already gated `/drive/s/:token` behind login with a return-target stash. This PR aligns the *path* with that reality and with the new backend contract — no new guard or route was needed on the host side.

## Notable change beyond the path swap

`isSharePublicPath` → `isShareTokenPath`, tightened from a prefix test to an exact `${BASE}/shares/:token/access|download` match.

The new recipient path shares its prefix with the **owner-side** share APIs, so keeping a loose `startsWith` would have wrongly exempted `GET|POST /shares` and `DELETE /shares/:id` from the global-logout-on-401 rule. The share-business-code exemption itself is behaviourally unchanged: a 401 carrying a share business code still reaches `ShareLandingPage.classify()`; every other 401 — including a session-expiry 401 on a share route — still logs out and keeps the return target.

Also removed two now-wrong comments claiming the share landing "renders anonymously (public endpoints, no login)".

## ⚠️ Deployment order constraint

**This PR depends on the octo-drive change (share access/download migrated to the authenticated mounts + anonymous `public` routes deleted) being deployed FIRST.** If Web ships before the backend is updated, the share landing page will 404. **Merging and deploying must be coordinated with the backend — this cannot be released on its own.**

## Files

- `packages/dmworkdrive/src/api/driveApi.ts` — endpoint paths, `isShareTokenPath`, docstrings
- `packages/dmworkdrive/src/api/__tests__/driveApi.test.ts` — new paths + path-anchoring boundary cases
- `packages/dmworkdrive/src/pages/ShareLandingPage.tsx` — docstring
- `packages/dmworkdrive/src/utils/links.ts` — comments
- `packages/dmworkdrive/src/index.tsx`, `packages/dmworkdrive/src/module.tsx` — stale "anonymous" comments

No production code changed outside `packages/dmworkdrive`.

## Tests

`cd packages/dmworkdrive && pnpm test` → **23 files / 231 tests passed**

New/updated coverage:
- `accessShareByToken` / `downloadShareByToken` assert the exact new paths (with and without password).
- `revokeShare` asserts `DELETE /v1/drive/shares/:id` — the owner-side sibling that must not be confused with a token path.
- Share-business-code 401 exemption, including a query-string variant.
- **Path anchoring**: 10 non-exempt URLs all still log out — `/shares`, `/shares?page=1`, `/shares/sh1`, `/shares/tok/access/`, `/shares/tok/access/extra`, `/sharesX/tok/access`, `/public/shares/tok/access`, `/driveX/shares/tok/access`, `/other/shares/tok/access`, `/shares//access`.
- Session-expiry 401 on a share route still logs out.

Pre-login guard regression (unchanged code, confirmed still green):
`cd apps/web && npx vitest run src/__tests__/layoutDriveLanding.test.ts src/Layout/__tests__/standaloneReturn.test.ts` → **2 files / 21 tests passed**

`cd apps/web && pnpm build` → succeeded.

`cd apps/web && pnpm test` → 36 failed / 1032 passed. **Identical before and after this change** (verified by re-running on a stashed tree): all failures are pre-existing on `main` and unrelated (voice input, avatar CSS px assertions, Playwright e2e specs run under vitest).

`pnpm lint` (repo standard, `turbo run lint`) → no tasks executed; no package in this repo defines a `lint` script.

## Residual old-endpoint references

`grep -rn "drive/public" --exclude-dir=node_modules` → 2 hits, both intentional:
- `driveApi.ts` docstring noting the anonymous routes were removed backend-side.
- `driveApi.test.ts` listing `/v1/drive/public/shares/tok/access` as a **negative** case that must no longer be exempted.

No live code path references the old endpoints.

## Spec / expectation deltas

None. Matches spec D-8 / §3.1 / §5.7 and the product requirement above.
