### PR TITLE
fix(messages): unify rich text image preview

### DIFF
--- a/packages/dmworkbase/src/Messages/Image/ImagePreview.tsx
+++ b/packages/dmworkbase/src/Messages/Image/ImagePreview.tsx
@@ -1,0 +1,191 @@
+import React from "react";
+import { Toast } from "@douyinfe/semi-ui";
+import { Copy, Download, RotateCw, X, ZoomIn, ZoomOut } from "lucide-react";
+import Lightbox, {
+  isImageSlide,
+  useLightboxState,
+} from "yet-another-react-lightbox";
+import type { Slide, ZoomRef } from "yet-another-react-lightbox";
+import Zoom from "yet-another-react-lightbox/plugins/zoom";
+import "yet-another-react-lightbox/styles.css";
+import { t } from "../../i18n";
+import { copyImageToClipboard } from "../../Utils/clipboard";
+import { downloadFile } from "../../Utils/download";
+import "./index.css";
+
+interface ImagePreviewToolbarProps {
+  zoom: ZoomRef;
+  filename?: string;
+  onReset: () => void;
+  onRotate: () => void;
+}
+
+export function ImagePreviewToolbar({
+  zoom,
+  filename,
+  onReset,
+  onRotate,
+}: ImagePreviewToolbarProps) {
+  const { currentSlide } = useLightboxState();
+  const [copying, setCopying] = React.useState(false);
+  const src =
+    currentSlide && isImageSlide(currentSlide) ? currentSlide.src : "";
+
+  const handleCopy = async () => {
+    if (!src) return;
+    setCopying(true);
+    try {
+      await copyImageToClipboard(src);
+      Toast.success(t("base.module.contextMenus.copyImageSuccess"));
+    } catch (error) {
+      Toast.warning(
+        error instanceof Error
+          ? error.message
+          : t("base.module.contextMenus.copyFailed")
+      );
+    } finally {
+      setCopying(false);
+    }
+  };
+
+  return (
+    <div className="wk-image-preview-toolbar">
+      <button
+        type="button"
+        aria-label={t("base.filePreview.pdf.zoomOut")}
+        title={t("base.filePreview.pdf.zoomOut")}
+        disabled={zoom.disabled || zoom.zoom <= zoom.minZoom}
+        onClick={zoom.zoomOut}
+      >
+        <ZoomOut size={19} />
+      </button>
+      <button
+        type="button"
+        className="wk-image-preview-toolbar-reset"
+        aria-label={t("base.filePreview.pdf.actualSize")}
+        title={t("base.filePreview.pdf.actualSize")}
+        onClick={() => {
+          zoom.changeZoom(1);
+          onReset();
+        }}
+      >
+        1:1
+      </button>
+      <button
+        type="button"
+        aria-label={t("base.filePreview.pdf.zoomIn")}
+        title={t("base.filePreview.pdf.zoomIn")}
+        disabled={zoom.disabled || zoom.zoom >= zoom.maxZoom}
+        onClick={zoom.zoomIn}
+      >
+        <ZoomIn size={19} />
+      </button>
+      <span className="wk-image-preview-toolbar-divider" />
+      <button
+        type="button"
+        aria-label={t("base.message.imagePreview.rotate")}
+        title={t("base.message.imagePreview.rotate")}
+        onClick={() => {
+          zoom.changeZoom(1);
+          onRotate();
+        }}
+      >
+        <RotateCw size={19} />
+      </button>
+      <span className="wk-image-preview-toolbar-divider" />
+      <button
+        type="button"
+        aria-label={t("base.module.contextMenus.copyImage")}
+        title={t("base.module.contextMenus.copyImage")}
+        disabled={!src || copying}
+        onClick={handleCopy}
+      >
+        <Copy size={19} />
+      </button>
+      <span className="wk-image-preview-toolbar-divider" />
+      <button
+        type="button"
+        aria-label={t("base.filePreview.download")}
+        title={t("base.filePreview.download")}
+        disabled={!src}
+        onClick={() => src && downloadFile(src, filename || "image.png")}
+      >
+        <Download size={19} />
+      </button>
+    </div>
+  );
+}
+
+interface ImagePreviewLightboxProps {
+  open: boolean;
+  close: () => void;
+  slides: readonly Slide[];
+  index?: number;
+  filename?: string;
+  isMulti?: boolean;
+}
+
+export function ImagePreviewLightbox({
+  open,
+  close,
+  slides,
+  index,
+  filename,
+  isMulti,
+}: ImagePreviewLightboxProps) {
+  const [rotation, setRotation] = React.useState(0);
+  const resetRotation = () => setRotation(0);
+
+  return (
+    <Lightbox
+      className="wk-image-preview"
+      open={open}
+      close={() => {
+        resetRotation();
+        close();
+      }}
+      slides={slides}
+      index={index}
+      plugins={[Zoom]}
+      labels={{
+        Close: t("base.common.close"),
+        "Zoom in": t("base.filePreview.pdf.zoomIn"),
+        "Zoom out": t("base.filePreview.pdf.zoomOut"),
+      }}
+      toolbar={{ buttons: ["zoom", "close"] }}
+      zoom={{
+        minZoom: 0.25,
+        maxZoomPixelRatio: 4,
+        zoomInMultiplier: 1.25,
+        scrollToZoom: true,
+      }}
+      carousel={{
+        finite: true,
+        imageProps: {
+          style: {
+            maxWidth: rotation % 180 ? "100cqh" : "100%",
+            maxHeight: rotation % 180 ? "100cqw" : "100%",
+          },
+        },
+      }}
+      controller={{ closeOnBackdropClick: true }}
+      on={{ entering: resetRotation, view: resetRotation }}
+      styles={{
+        root: { "--yarl__image_preview_rotation": `${rotation}deg` },
+      }}
+      render={{
+        buttonPrev: isMulti ? undefined : () => null,
+        buttonNext: isMulti ? undefined : () => null,
+        buttonZoom: (zoom) => (
+          <ImagePreviewToolbar
+            zoom={zoom}
+            filename={filename}
+            onReset={resetRotation}
+            onRotate={() => setRotation((value) => (value + 90) % 360)}
+          />
+        ),
+        iconClose: () => <X size={22} />,
+      }}
+    />
+  );
+}

--- a/packages/dmworkbase/src/Messages/Image/index.tsx
+++ b/packages/dmworkbase/src/Messages/Image/index.tsx
@@ -4,14 +4,7 @@ import WKApp from "../../App"
 import { MessageContentTypeConst } from "../../Service/Const"
 import MessageBase from "../Base"
 import { MessageCell } from "../MessageCell"
-import Lightbox, { isImageSlide, useLightboxState } from "yet-another-react-lightbox"
-import type { Slide, ZoomRef } from "yet-another-react-lightbox"
-import Zoom from "yet-another-react-lightbox/plugins/zoom"
-import "yet-another-react-lightbox/styles.css"
-import { Copy, Download, RotateCw, X, ZoomIn, ZoomOut } from "lucide-react"
 import { Toast } from "@douyinfe/semi-ui"
-import { downloadFile } from "../../Utils/download"
-import { copyImageToClipboard } from "../../Utils/clipboard"
 import MessageRow from "../../ui/message/MessageRow"
 import SingleImage from "../../ui/message/ImageContent/SingleImage"
 import MultiImage from "../../ui/message/ImageContent/MultiImage"
@@ -19,165 +12,11 @@ import type { ImageTransferState } from "../../ui/message/ImageContent/SingleIma
 import { getImageMessageUI } from "../../bridge/message/useImageMessageUI"
 import { isMessageSelectable } from "../../Service/messageSelection"
 import { t } from "../../i18n"
-import "./index.css"
+import { ImagePreviewLightbox } from "./ImagePreview"
+
+export { ImagePreviewLightbox, ImagePreviewToolbar } from "./ImagePreview"
 
 const SMALL_FILE_THRESHOLD = 1024 * 1024 // 1MB 以下不显示进度覆盖层
-
-interface ImagePreviewToolbarProps {
-    zoom: ZoomRef
-    filename?: string
-    onReset: () => void
-    onRotate: () => void
-}
-
-export function ImagePreviewToolbar({ zoom, filename, onReset, onRotate }: ImagePreviewToolbarProps) {
-    const { currentSlide } = useLightboxState()
-    const [copying, setCopying] = React.useState(false)
-    const src = currentSlide && isImageSlide(currentSlide) ? currentSlide.src : ""
-
-    const handleCopy = async () => {
-        if (!src) return
-        setCopying(true)
-        try {
-            await copyImageToClipboard(src)
-            Toast.success(t("base.module.contextMenus.copyImageSuccess"))
-        } catch (error) {
-            Toast.warning(error instanceof Error ? error.message : t("base.module.contextMenus.copyFailed"))
-        } finally {
-            setCopying(false)
-        }
-    }
-
-    return (
-        <div className="wk-image-preview-toolbar">
-            <button
-                type="button"
-                aria-label={t("base.filePreview.pdf.zoomOut")}
-                title={t("base.filePreview.pdf.zoomOut")}
-                disabled={zoom.disabled || zoom.zoom <= zoom.minZoom}
-                onClick={zoom.zoomOut}
-            >
-                <ZoomOut size={19} />
-            </button>
-            <button
-                type="button"
-                className="wk-image-preview-toolbar-reset"
-                aria-label={t("base.filePreview.pdf.actualSize")}
-                title={t("base.filePreview.pdf.actualSize")}
-                onClick={() => {
-                    zoom.changeZoom(1)
-                    onReset()
-                }}
-            >
-                1:1
-            </button>
-            <button
-                type="button"
-                aria-label={t("base.filePreview.pdf.zoomIn")}
-                title={t("base.filePreview.pdf.zoomIn")}
-                disabled={zoom.disabled || zoom.zoom >= zoom.maxZoom}
-                onClick={zoom.zoomIn}
-            >
-                <ZoomIn size={19} />
-            </button>
-            <span className="wk-image-preview-toolbar-divider" />
-            <button
-                type="button"
-                aria-label={t("base.message.imagePreview.rotate")}
-                title={t("base.message.imagePreview.rotate")}
-                onClick={() => {
-                    zoom.changeZoom(1)
-                    onRotate()
-                }}
-            >
-                <RotateCw size={19} />
-            </button>
-            <span className="wk-image-preview-toolbar-divider" />
-            <button
-                type="button"
-                aria-label={t("base.module.contextMenus.copyImage")}
-                title={t("base.module.contextMenus.copyImage")}
-                disabled={!src || copying}
-                onClick={handleCopy}
-            >
-                <Copy size={19} />
-            </button>
-            <span className="wk-image-preview-toolbar-divider" />
-            <button
-                type="button"
-                aria-label={t("base.filePreview.download")}
-                title={t("base.filePreview.download")}
-                disabled={!src}
-                onClick={() => src && downloadFile(src, filename || "image.png")}
-            >
-                <Download size={19} />
-            </button>
-        </div>
-    )
-}
-
-interface ImagePreviewLightboxProps {
-    open: boolean
-    close: () => void
-    slides: readonly Slide[]
-    index?: number
-    filename?: string
-    isMulti?: boolean
-}
-
-export function ImagePreviewLightbox({ open, close, slides, index, filename, isMulti }: ImagePreviewLightboxProps) {
-    const [rotation, setRotation] = React.useState(0)
-    const resetRotation = () => setRotation(0)
-
-    return (
-        <Lightbox
-            className="wk-image-preview"
-            open={open}
-            close={() => {
-                resetRotation()
-                close()
-            }}
-            slides={slides}
-            index={index}
-            plugins={[Zoom]}
-            labels={{
-                Close: t("base.common.close"),
-                "Zoom in": t("base.filePreview.pdf.zoomIn"),
-                "Zoom out": t("base.filePreview.pdf.zoomOut"),
-            }}
-            toolbar={{ buttons: ["zoom", "close"] }}
-            zoom={{ minZoom: 0.25, maxZoomPixelRatio: 4, zoomInMultiplier: 1.25, scrollToZoom: true }}
-            carousel={{
-                finite: true,
-                imageProps: {
-                    style: {
-                        maxWidth: rotation % 180 ? "100cqh" : "100%",
-                        maxHeight: rotation % 180 ? "100cqw" : "100%",
-                    },
-                },
-            }}
-            controller={{ closeOnBackdropClick: true }}
-            on={{ entering: resetRotation, view: resetRotation }}
-            styles={{
-                root: { "--yarl__image_preview_rotation": `${rotation}deg` },
-            }}
-            render={{
-                buttonPrev: isMulti ? undefined : () => null,
-                buttonNext: isMulti ? undefined : () => null,
-                buttonZoom: (zoom) => (
-                    <ImagePreviewToolbar
-                        zoom={zoom}
-                        filename={filename}
-                        onReset={resetRotation}
-                        onRotate={() => setRotation(value => (value + 90) % 360)}
-                    />
-                ),
-                iconClose: () => <X size={22} />,
-            }}
-        />
-    )
-}
-
 
 export class ImageContent extends MediaMessageContent {
     width!: number

--- a/packages/dmworkbase/src/Messages/Text/MarkdownContent.tsx
+++ b/packages/dmworkbase/src/Messages/Text/MarkdownContent.tsx
@@ -8,18 +8,15 @@ import rehypeKatex from "rehype-katex";
 import rehypeSanitize, { defaultSchema } from "rehype-sanitize";
 import Toast from "@douyinfe/semi-ui/lib/es/toast";
 import { Copy } from "lucide-react";
-import Lightbox from "yet-another-react-lightbox";
-import Download from "yet-another-react-lightbox/plugins/download";
-import "yet-another-react-lightbox/styles.css";
 import "highlight.js/styles/github-dark.css";
 import "katex/dist/katex.min.css";
 import "./markdown.css";
 import WKApp from "../../App";
 import { isSafeUrl } from "../../Utils/security";
 import { linkifySafeUrls } from "../../Utils/linkify";
-import { downloadFile } from "../../Utils/download";
 import { copyToClipboard } from "../../Utils/clipboard";
 import { t } from "../../i18n";
+import { ImagePreviewLightbox } from "../Image/ImagePreview";
 import { getMentionRenderState } from "./mentionRenderState";
 import {
   isForwardDocCard,
@@ -475,7 +472,7 @@ function renderParagraph(children: React.ReactNode, props: any): React.ReactElem
 /**
  * Markdown / RichText 正文内联图片：
  *  - url 安全校验（仅 http/https，挡 data:/javascript:/file: 等），不安全则降级为文本占位；
- *  - 点击打开 Lightbox 大图预览（与 ImageCell 行为一致，带下载）；
+ *  - 点击复用 ImageCell 的大图预览与底部工具栏；
  *  - src 经 datasource 处理，与其它图片渲染路径补全 base URL 保持一致。
  */
 const MarkdownImage: React.FC<{ src?: string; alt?: string }> = ({
@@ -504,24 +501,11 @@ const MarkdownImage: React.FC<{ src?: string; alt?: string }> = ({
         loading="lazy"
         onClick={() => setOpen(true)}
       />
-      <Lightbox
+      <ImagePreviewLightbox
         open={open}
         close={() => setOpen(false)}
         slides={[{ src: resolved, alt: alt || "" }]}
-        plugins={[Download]}
-        download={{
-          download: ({ slide }) => {
-            if (slide?.src) {
-              downloadFile(slide.src, alt || "image.png");
-            }
-          },
-        }}
-        carousel={{ finite: true }}
-        controller={{ closeOnBackdropClick: true }}
-        render={{
-          buttonPrev: () => null,
-          buttonNext: () => null,
-        }}
+        filename={alt || "image.png"}
       />
     </>
   );

--- a/packages/dmworkbase/src/Messages/Text/__tests__/MarkdownImagePreview.test.tsx
+++ b/packages/dmworkbase/src/Messages/Text/__tests__/MarkdownImagePreview.test.tsx
@@ -1,0 +1,80 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import ReactDOM from "react-dom";
+import { act } from "react-dom/test-utils";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  previewProps: undefined as any,
+}));
+
+vi.mock("../../../App", () => ({
+  default: {
+    dataSource: {
+      commonDataSource: {
+        getImageURL: (src: string) => `https://cdn.example.com/${src}`,
+      },
+    },
+  },
+}));
+
+vi.mock("../../Image/ImagePreview", () => ({
+  ImagePreviewLightbox: (props: any) => {
+    mocks.previewProps = props;
+    return props.open ? <div data-testid="image-preview" /> : null;
+  },
+}));
+
+vi.mock("../../../i18n", () => ({
+  t: (key: string) => key,
+}));
+
+import { MarkdownImage } from "../MarkdownContent";
+
+let container: HTMLDivElement | null = null;
+
+afterEach(() => {
+  if (!container) return;
+  ReactDOM.unmountComponentAtNode(container);
+  container.remove();
+  container = null;
+});
+
+describe("MarkdownImage preview", () => {
+  it("uses the shared image preview with the resolved source and filename", () => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+
+    act(() => {
+      ReactDOM.render(
+        <MarkdownImage src="images/report.png" alt="report.png" />,
+        container
+      );
+    });
+
+    expect(mocks.previewProps.open).toBe(false);
+
+    act(() => {
+      container
+        ?.querySelector("img")
+        ?.dispatchEvent(
+          new MouseEvent("click", { bubbles: true, cancelable: true })
+        );
+    });
+
+    expect(mocks.previewProps).toMatchObject({
+      open: true,
+      filename: "report.png",
+      slides: [
+        {
+          src: "https://cdn.example.com/images/report.png",
+          alt: "report.png",
+        },
+      ],
+    });
+    expect(
+      container.querySelector('[data-testid="image-preview"]')
+    ).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- reuse the standard chat image preview for images embedded in rich text messages
- provide the same translucent backdrop and bottom toolbar with zoom, reset, rotate, copy, and download actions
- extract the existing image preview into a shared component without changing standalone image behavior
- add regression coverage for resolved image URLs and filenames

## Scope

This PR only changes image preview behavior for inline/rich text message images. It does not change message sending, image loading, routes, or user-visible entry points.

## Verification

- `pnpm --dir packages/dmworkbase exec vitest run src/Messages/Text/__tests__ src/bridge/message/__tests__/useRichTextMessageUI.test.ts src/Messages/RichText/__tests__/RichTextContent.test.ts src/Messages/Image/__tests__/ImageContent.test.ts src/ui/message/MixedContent/__tests__/MixedContent.test.tsx` (10 files, 63 tests)
- `pnpm i18n:check`
- `VITE_API_URL=http://127.0.0.1 pnpm --dir apps/web build`
- `git diff --check`