### PR TITLE
fix: send interactive card actions as current user

### DIFF
--- a/packages/dmworkbase/src/Messages/InteractiveCard/InteractiveCardCell.tsx
+++ b/packages/dmworkbase/src/Messages/InteractiveCard/InteractiveCardCell.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { type Action, type AdaptiveCard } from "adaptivecards";
-import { Channel, MessageText } from "wukongimjssdk";
+import { Channel, Mention, MessageText } from "wukongimjssdk";
 import { Toast } from "@douyinfe/semi-ui";
 import WKApp from "../../App";
 import { getMessageRow } from "../../bridge/message/useMessageRow";
@@ -37,7 +37,10 @@ import {
   resolveActionMessageText,
   UnsupportedActionMessageEffectError,
 } from "./sdk/actionMessage";
-import { sendActionWithCurrentUserMessage } from "../../Service/ActionMessageSender";
+import {
+  ActionMessageSendError,
+  sendActionWithCurrentUserMessage,
+} from "../../Service/ActionMessageSender";
 import { enhanceRenderedOctoCard, renderOctoCard } from "./sdk/renderOctoCard";
 import { classifyCardSender, fetchSenderChannelInfo } from "./senderTrust";
 import "./index.css";
@@ -79,6 +82,21 @@ function renderPlainText(text: string, keyPrefix: string): React.ReactNode {
       {i !== lines.length - 1 ? <br /> : null}
     </span>
   ));
+}
+
+function createActionMessageContent(text: string, action: Action): MessageText {
+  const content = new MessageText(text);
+  const data = (action as unknown as { data?: Record<string, unknown> }).data;
+  const replyTargetUID =
+    typeof data?.reply_target_uid === "string"
+      ? data.reply_target_uid.trim()
+      : "";
+  if (replyTargetUID) {
+    const mention = new Mention();
+    mention.uids = [replyTargetUID];
+    content.mention = mention;
+  }
+  return content;
 }
 
 /**
@@ -374,7 +392,12 @@ export class InteractiveCardCell extends MessageCell {
     try {
       actionEffect = resolveActionMessageEffect(action, card);
       if (actionEffect)
-        actionMessage = resolveActionMessageText(actionEffect, action, card);
+        actionMessage = resolveActionMessageText(
+          actionEffect,
+          action,
+          card,
+          inputs
+        );
     } catch (err) {
       if (
         err instanceof UnsupportedActionMessageEffectError ||
@@ -421,11 +444,13 @@ export class InteractiveCardCell extends MessageCell {
     const submitPromise =
       actionEffect && actionMessage
         ? sendActionWithCurrentUserMessage({
-            operationKey: `${message.messageID}:${actionId}:${WKApp.loginInfo.uid}`,
+            operationKey: `${message.messageID}:${
+              this.renderedKey ?? "current-frame"
+            }:${actionId}:${WKApp.loginInfo.uid}`,
             content: actionMessage,
             sendMessage: () =>
               this.props.context.sendMessage(
-                new MessageText(actionMessage!),
+                createActionMessageContent(actionMessage!, action),
                 sendChannel
               ),
             submitAction: submit,
@@ -434,8 +459,12 @@ export class InteractiveCardCell extends MessageCell {
 
     submitPromise
       .then(() => {
+        if (this.mounted && gen === this.submitGen) {
+          this.submitError = null;
+          this.forceUpdate();
+        }
         // 受理成功（含 replay）：保持 loading 等 bot 重写的新帧到达（syncSdkCard 重置）；
-        // 若 bot 迟迟不重写，10s 超时兜底恢复可点。无需在此变更状态。
+        // 若 bot 迟迟不重写，10s 超时兜底恢复可点。
       })
       .catch((err) => {
         // 已卸载 / 被新提交或新帧取代 → 忽略过期响应，不覆盖当前 UI 态。
@@ -443,7 +472,8 @@ export class InteractiveCardCell extends MessageCell {
         this.clearSubmitTimer();
         this.submitting = false;
         this.submitError = t(
-          isRetryableCardActionError(err)
+          isRetryableCardActionError(err) ||
+            err instanceof ActionMessageSendError
             ? "base.message.interactiveCard.submitRetry"
             : "base.message.interactiveCard.submitFailed"
         );

--- a/packages/dmworkbase/src/Messages/InteractiveCard/InteractiveCardCell.tsx
+++ b/packages/dmworkbase/src/Messages/InteractiveCard/InteractiveCardCell.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { type Action, type AdaptiveCard } from "adaptivecards";
+import { Channel, MessageText } from "wukongimjssdk";
 import { Toast } from "@douyinfe/semi-ui";
 import WKApp from "../../App";
 import { getMessageRow } from "../../bridge/message/useMessageRow";
@@ -30,9 +31,14 @@ import {
 } from "./denyReasonDialog";
 import { collectCardInputs, validateCardInputs } from "./sdk/cardInputs";
 import {
-  enhanceRenderedOctoCard,
-  renderOctoCard,
-} from "./sdk/renderOctoCard";
+  type ActionMessageEffect,
+  InvalidActionMessageSourceError,
+  resolveActionMessageEffect,
+  resolveActionMessageText,
+  UnsupportedActionMessageEffectError,
+} from "./sdk/actionMessage";
+import { sendActionWithCurrentUserMessage } from "../../Service/ActionMessageSender";
+import { enhanceRenderedOctoCard, renderOctoCard } from "./sdk/renderOctoCard";
 import { classifyCardSender, fetchSenderChannelInfo } from "./senderTrust";
 import "./index.css";
 import "@mlt-org/octo-card-profile-octo-chat/theme.css";
@@ -261,9 +267,7 @@ export class InteractiveCardCell extends MessageCell {
       const url = (action as unknown as { url?: unknown }).url;
       if (classifyCardSender(message.fromUID) === "webhook") {
         const target =
-          typeof url === "string"
-            ? parseWebhookIssuePreviewTarget(url)
-            : null;
+          typeof url === "string" ? parseWebhookIssuePreviewTarget(url) : null;
         if (target) {
           context.openWebhookPreview?.(target);
           return;
@@ -311,7 +315,9 @@ export class InteractiveCardCell extends MessageCell {
     const data = (action as unknown as { data?: Record<string, unknown> }).data;
     if (
       isDocsDenyAction(data) &&
-      card.getAllInputs().some((input) => input.id === DOCS_DENY_REASON_INPUT_ID)
+      card
+        .getAllInputs()
+        .some((input) => input.id === DOCS_DENY_REASON_INPUT_ID)
     ) {
       // isDocsDenyAction is a type guard → data is narrowed to non-null here.
       const asString = (v: unknown) => (typeof v === "string" ? v : undefined);
@@ -325,12 +331,14 @@ export class InteractiveCardCell extends MessageCell {
         if (!this.mounted || this.submitting) return;
         const current = this.computeState().decision;
         if (current.kind !== "card" || !current.interactive) return;
-        this.performSubmit(card, actionId, { [DOCS_DENY_REASON_INPUT_ID]: reason });
+        this.performSubmit(action, card, actionId, {
+          [DOCS_DENY_REASON_INPUT_ID]: reason,
+        });
       });
       return;
     }
 
-    this.performSubmit(card, actionId, null);
+    this.performSubmit(action, card, actionId, null);
   }
 
   /**
@@ -338,6 +346,7 @@ export class InteractiveCardCell extends MessageCell {
    * 提交态/超时/代次判活与原逻辑一致。
    */
   private performSubmit(
+    action: Action,
     card: AdaptiveCard,
     actionId: string,
     extraInputs: Record<string, string> | null
@@ -360,6 +369,24 @@ export class InteractiveCardCell extends MessageCell {
     const channel = message.channel;
     if (!channel) return;
 
+    let actionEffect: ActionMessageEffect | null = null;
+    let actionMessage: string | undefined;
+    try {
+      actionEffect = resolveActionMessageEffect(action, card);
+      if (actionEffect)
+        actionMessage = resolveActionMessageText(actionEffect, action, card);
+    } catch (err) {
+      if (
+        err instanceof UnsupportedActionMessageEffectError ||
+        err instanceof InvalidActionMessageSourceError
+      ) {
+        this.submitError = t("base.message.interactiveCard.submitFailed");
+        this.forceUpdate();
+        return;
+      }
+      throw err;
+    }
+
     // person DM 与系统 bot（notification 等）的 recv 包 channelID 可能塌缩为接收人
     // 自身 uid，直接回传会让服务端 fakeChannel(self,self) miss → 400。回退到权威对端
     // message.fromUID，确保 channel_id 与服务端存储键一致（群/普通 DM 为 no-op）。
@@ -369,6 +396,12 @@ export class InteractiveCardCell extends MessageCell {
       fromUID: message.fromUID,
       selfUID: WKApp.loginInfo.uid,
     });
+    // The received person-DM packet can collapse channelID to selfUID. Use the
+    // same normalized peer channel for the real user message and card action.
+    const sendChannel =
+      channelId === channel.channelID
+        ? channel
+        : new Channel(channelId, channel.channelType);
 
     // 本次提交代次：使此前提交/超时/新帧作废，且异步回调据此判活。
     const gen = ++this.submitGen;
@@ -377,13 +410,29 @@ export class InteractiveCardCell extends MessageCell {
     this.forceUpdate();
     this.armSubmitTimer(gen);
 
-    submitCardAction({
-      messageId: message.messageID,
-      channelId,
-      channelType: channel.channelType,
-      actionId,
-      inputs,
-    })
+    const submit = () =>
+      submitCardAction({
+        messageId: message.messageID,
+        channelId,
+        channelType: channel.channelType,
+        actionId,
+        inputs,
+      });
+    const submitPromise =
+      actionEffect && actionMessage
+        ? sendActionWithCurrentUserMessage({
+            operationKey: `${message.messageID}:${actionId}:${WKApp.loginInfo.uid}`,
+            content: actionMessage,
+            sendMessage: () =>
+              this.props.context.sendMessage(
+                new MessageText(actionMessage!),
+                sendChannel
+              ),
+            submitAction: submit,
+          })
+        : submit();
+
+    submitPromise
       .then(() => {
         // 受理成功（含 replay）：保持 loading 等 bot 重写的新帧到达（syncSdkCard 重置）；
         // 若 bot 迟迟不重写，10s 超时兜底恢复可点。无需在此变更状态。

--- a/packages/dmworkbase/src/Messages/InteractiveCard/__tests__/actionMessage.test.ts
+++ b/packages/dmworkbase/src/Messages/InteractiveCard/__tests__/actionMessage.test.ts
@@ -88,6 +88,28 @@ describe("card runtime message source", () => {
     );
     target.remove();
   });
+
+  it("falls back to the normal submit path for an optional unsupported version", () => {
+    const { card, action, target } = makeCard();
+    action.data = {
+      effect: "send_current_user_message",
+      effect_version: 2,
+      effect_required: false,
+      message_source: { type: "choice_labels", input_id: "decision_choice" },
+    };
+    expect(resolveActionMessageEffect(action, card)).toBeNull();
+
+    action.data = {
+      effect: "send_current_user_message",
+      effect_version: 2,
+      effect_required: true,
+      message_source: { type: "choice_labels", input_id: "decision_choice" },
+    };
+    expect(() => resolveActionMessageEffect(action, card)).toThrow(
+      "send_current_user_message@2"
+    );
+    target.remove();
+  });
 });
 
 describe("sendActionWithCurrentUserMessage", () => {

--- a/packages/dmworkbase/src/Messages/InteractiveCard/__tests__/actionMessage.test.ts
+++ b/packages/dmworkbase/src/Messages/InteractiveCard/__tests__/actionMessage.test.ts
@@ -1,0 +1,118 @@
+// @vitest-environment jsdom
+
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import { AdaptiveCard } from "adaptivecards";
+import { sendActionWithCurrentUserMessage } from "../../../Service/ActionMessageSender";
+import {
+  resolveActionMessageEffect,
+  resolveActionMessageText,
+} from "../sdk/actionMessage";
+
+beforeAll(() => {
+  if (!window.matchMedia) {
+    (window as any).matchMedia = () => ({
+      matches: false,
+      addEventListener() {},
+      removeEventListener() {},
+    });
+  }
+  AdaptiveCard.onProcessMarkdown = (text, result) => {
+    result.outputHtml = text;
+    result.didProcess = true;
+  };
+});
+
+function makeCard() {
+  const card = new AdaptiveCard();
+  card.parse({
+    type: "AdaptiveCard",
+    version: "1.5",
+    body: [
+      {
+        type: "Input.ChoiceSet",
+        id: "decision_choice",
+        isMultiSelect: true,
+        value: "interaction,mobile",
+        choices: [
+          { title: "补全消息交互（推荐）", value: "interaction" },
+          { title: "完善移动端布局", value: "mobile" },
+        ],
+      },
+      { type: "Input.Text", id: "decision_note", value: "先做交互" },
+    ],
+    actions: [
+      {
+        type: "Action.Submit",
+        id: "decision_send",
+        title: "发送选择",
+        data: {
+          effect: "send_current_user_message",
+          effect_version: 1,
+          message_source: {
+            type: "compose",
+            parts: [
+              { type: "choice_labels", input_id: "decision_choice" },
+              { type: "input_text", input_id: "decision_note" },
+            ],
+          },
+        },
+      },
+    ],
+  });
+  const target = document.createElement("div");
+  document.body.appendChild(target);
+  const rendered = card.render();
+  if (rendered) target.appendChild(rendered);
+  return { card, action: card.getActionById("decision_send")!, target };
+}
+
+describe("card runtime message source", () => {
+  it("maps selected ChoiceSet values to their displayed labels", () => {
+    const { card, action, target } = makeCard();
+    const effect = resolveActionMessageEffect(action, card);
+    expect(effect).not.toBeNull();
+    expect(resolveActionMessageText(effect!, action, card)).toBe(
+      "补全消息交互（推荐）\n完善移动端布局\n先做交互"
+    );
+    target.remove();
+  });
+
+  it("does not silently fall back when an explicit source is malformed", () => {
+    const { card, action, target } = makeCard();
+    action.data = {
+      effect: "append_user_message",
+      message_source: { type: "unknown_source", input_id: "decision_choice" },
+    };
+    expect(() => resolveActionMessageEffect(action, card)).toThrow(
+      "message_source is malformed"
+    );
+    target.remove();
+  });
+});
+
+describe("sendActionWithCurrentUserMessage", () => {
+  it("does not resend the user message when the card action is retried", async () => {
+    const sendMessage = vi.fn().mockResolvedValue({
+      messageID: "user-message-1",
+      clientMsgNo: "client-message-1",
+    });
+    const submitAction = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("card action unavailable"))
+      .mockResolvedValueOnce({ accepted: true });
+    const options = {
+      operationKey: "card-1:decision_send:user-1",
+      content: "补全消息交互（推荐）",
+      sendMessage,
+      submitAction,
+    };
+
+    await expect(sendActionWithCurrentUserMessage(options)).rejects.toThrow(
+      "card action unavailable"
+    );
+    await sendActionWithCurrentUserMessage(options);
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(submitAction).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/dmworkbase/src/Messages/InteractiveCard/__tests__/actionMessage.test.ts
+++ b/packages/dmworkbase/src/Messages/InteractiveCard/__tests__/actionMessage.test.ts
@@ -34,7 +34,10 @@ function makeCard() {
         isMultiSelect: true,
         value: "interaction,mobile",
         choices: [
-          { title: "补全消息交互（推荐）", value: "interaction" },
+          {
+            title: "补全消息交互（推荐）\n这是卡片内的说明",
+            value: "interaction",
+          },
           { title: "完善移动端布局", value: "mobile" },
         ],
       },
@@ -79,7 +82,7 @@ describe("card runtime message source", () => {
 
   it("does not silently fall back when an explicit source is malformed", () => {
     const { card, action, target } = makeCard();
-    action.data = {
+    (action as any).data = {
       effect: "append_user_message",
       message_source: { type: "unknown_source", input_id: "decision_choice" },
     };
@@ -89,9 +92,24 @@ describe("card runtime message source", () => {
     target.remove();
   });
 
+  it("uses dialog values when composing the message", () => {
+    const { card, action, target } = makeCard();
+    (action as any).data = {
+      effect: "send_current_user_message",
+      message_source: { type: "input_text", input_id: "decision_note" },
+    };
+    const effect = resolveActionMessageEffect(action, card);
+    expect(
+      resolveActionMessageText(effect!, action, card, {
+        decision_note: "来自弹窗的原因",
+      })
+    ).toBe("来自弹窗的原因");
+    target.remove();
+  });
+
   it("falls back to the normal submit path for an optional unsupported version", () => {
     const { card, action, target } = makeCard();
-    action.data = {
+    (action as any).data = {
       effect: "send_current_user_message",
       effect_version: 2,
       effect_required: false,
@@ -99,7 +117,7 @@ describe("card runtime message source", () => {
     };
     expect(resolveActionMessageEffect(action, card)).toBeNull();
 
-    action.data = {
+    (action as any).data = {
       effect: "send_current_user_message",
       effect_version: 2,
       effect_required: true,
@@ -136,5 +154,30 @@ describe("sendActionWithCurrentUserMessage", () => {
 
     expect(sendMessage).toHaveBeenCalledTimes(1);
     expect(submitAction).toHaveBeenCalledTimes(2);
+  });
+
+  it("sends again for a new card frame while reusing the same-frame retry", async () => {
+    const sendMessage = vi.fn().mockResolvedValue({ messageID: "message-1" });
+    const submitAction = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("card action unavailable"))
+      .mockResolvedValue({ accepted: true });
+
+    const retry = {
+      operationKey: "card-1:frame-1:decision_send:user-1",
+      content: "补全消息交互（推荐）",
+      sendMessage,
+      submitAction,
+    };
+    await expect(sendActionWithCurrentUserMessage(retry)).rejects.toThrow();
+    await sendActionWithCurrentUserMessage(retry);
+
+    await sendActionWithCurrentUserMessage({
+      ...retry,
+      operationKey: "card-1:frame-2:decision_send:user-1",
+    });
+
+    expect(sendMessage).toHaveBeenCalledTimes(2);
+    expect(submitAction).toHaveBeenCalledTimes(3);
   });
 });

--- a/packages/dmworkbase/src/Messages/InteractiveCard/sdk/actionMessage.ts
+++ b/packages/dmworkbase/src/Messages/InteractiveCard/sdk/actionMessage.ts
@@ -112,6 +112,7 @@ export function resolveActionMessageEffect(
     );
   }
   if (version > capability.version) {
+    if (data.effect_required === false) return null;
     throw new UnsupportedActionMessageEffectError(`${data.effect}@${version}`);
   }
 

--- a/packages/dmworkbase/src/Messages/InteractiveCard/sdk/actionMessage.ts
+++ b/packages/dmworkbase/src/Messages/InteractiveCard/sdk/actionMessage.ts
@@ -1,0 +1,223 @@
+import type { Action, AdaptiveCard } from "adaptivecards";
+import { runtimeCapabilityForEffect } from "./runtimeCapabilities";
+
+export type ActionMessageSource =
+  | { type: "action.title" }
+  | { type: "choice_labels"; inputId: string; separator?: string }
+  | { type: "input_text"; inputId: string }
+  | { type: "compose"; parts: ActionMessageSource[]; separator?: string };
+
+export interface ActionMessageEffect {
+  effect: "append_user_message" | "send_current_user_message";
+  version: number;
+  required: boolean;
+  source: ActionMessageSource;
+}
+
+export class UnsupportedActionMessageEffectError extends Error {
+  constructor(effect: string) {
+    super(`Unsupported card action effect: ${effect}`);
+    this.name = "UnsupportedActionMessageEffectError";
+  }
+}
+
+export class InvalidActionMessageSourceError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "InvalidActionMessageSourceError";
+  }
+}
+
+type JsonObject = Record<string, unknown>;
+
+function isObject(value: unknown): value is JsonObject {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value : undefined;
+}
+
+function parseSource(value: unknown): ActionMessageSource | undefined {
+  if (!isObject(value) || typeof value.type !== "string") return undefined;
+  const inputId = stringValue(value.input_id ?? value.inputId);
+  if (value.type === "action.title") return { type: "action.title" };
+  if (value.type === "choice_labels" && inputId) {
+    return {
+      type: "choice_labels",
+      inputId,
+      ...(typeof value.separator === "string"
+        ? { separator: value.separator }
+        : {}),
+    };
+  }
+  if (value.type === "input_text" && inputId) {
+    return { type: "input_text", inputId };
+  }
+  if (value.type === "compose" && Array.isArray(value.parts)) {
+    const parts = value.parts.map(parseSource);
+    if (
+      parts.every((part): part is ActionMessageSource => part !== undefined)
+    ) {
+      return {
+        type: "compose",
+        parts,
+        ...(typeof value.separator === "string"
+          ? { separator: value.separator }
+          : {}),
+      };
+    }
+  }
+  return undefined;
+}
+
+function findLegacyChoiceInput(card: AdaptiveCard): string | undefined {
+  return card.getAllInputs().find((input) => {
+    const candidate = input as unknown as { choices?: unknown };
+    return Array.isArray(candidate.choices) && typeof input.id === "string";
+  })?.id;
+}
+
+/** Resolve the Web-executed effect. Cards without an effect keep the old path. */
+export function resolveActionMessageEffect(
+  action: Action,
+  card: AdaptiveCard
+): ActionMessageEffect | null {
+  const data = (action as unknown as { data?: unknown }).data;
+  if (!isObject(data) || data.effect === undefined) return null;
+  if (typeof data.effect !== "string") {
+    throw new InvalidActionMessageSourceError(
+      "Card action effect must be a string"
+    );
+  }
+
+  const capability = runtimeCapabilityForEffect(data.effect);
+  if (
+    !capability ||
+    capability.status !== "supported" ||
+    (data.effect !== "append_user_message" &&
+      data.effect !== "send_current_user_message")
+  ) {
+    if (data.effect_required !== false) {
+      throw new UnsupportedActionMessageEffectError(data.effect);
+    }
+    return null;
+  }
+
+  const version =
+    typeof data.effect_version === "number" ? data.effect_version : 1;
+  if (!Number.isInteger(version) || version < 1) {
+    throw new InvalidActionMessageSourceError(
+      "Card action effect_version must be a positive integer"
+    );
+  }
+  if (version > capability.version) {
+    throw new UnsupportedActionMessageEffectError(`${data.effect}@${version}`);
+  }
+
+  // append_user_message was shipped before message_source existed. Infer only its
+  // historical ChoiceSet behavior; new cards must declare the source explicitly.
+  const hasDeclaredSource =
+    Object.prototype.hasOwnProperty.call(data, "message_source") ||
+    Object.prototype.hasOwnProperty.call(data, "messageSource");
+  const declaredSource = data.message_source ?? data.messageSource;
+  const parsedSource = parseSource(declaredSource);
+  if (hasDeclaredSource && !parsedSource) {
+    throw new InvalidActionMessageSourceError(
+      "Card action message_source is malformed"
+    );
+  }
+  const source =
+    parsedSource ??
+    (data.effect === "append_user_message"
+      ? (() => {
+          const inputId = findLegacyChoiceInput(card);
+          return inputId
+            ? ({ type: "choice_labels", inputId } as ActionMessageSource)
+            : ({ type: "action.title" } as ActionMessageSource);
+        })()
+      : undefined);
+  if (!source) {
+    throw new InvalidActionMessageSourceError(
+      "Current-user message effect requires a supported message_source"
+    );
+  }
+
+  return {
+    effect: data.effect,
+    version,
+    required: data.effect_required !== false,
+    source,
+  };
+}
+
+interface CardInputLike {
+  id?: string;
+  value?: unknown;
+  choices?: Array<{ title?: string; value?: string }>;
+}
+
+function inputFor(card: AdaptiveCard, inputId: string): CardInputLike {
+  const input = card.getAllInputs().find((item) => item.id === inputId) as
+    | CardInputLike
+    | undefined;
+  if (!input)
+    throw new InvalidActionMessageSourceError(`Unknown card input: ${inputId}`);
+  return input;
+}
+
+function resolveSourceText(
+  source: ActionMessageSource,
+  card: AdaptiveCard,
+  action: Action
+): string {
+  if (source.type === "action.title") {
+    const title = (action as unknown as { title?: unknown }).title;
+    if (typeof title !== "string" || !title.trim()) {
+      throw new InvalidActionMessageSourceError("Action.title is empty");
+    }
+    return title.trim();
+  }
+  if (source.type === "input_text") {
+    const value = inputFor(card, source.inputId).value;
+    return value == null ? "" : String(value).trim();
+  }
+  if (source.type === "choice_labels") {
+    const input = inputFor(card, source.inputId);
+    if (!Array.isArray(input.choices)) {
+      throw new InvalidActionMessageSourceError(
+        `Input ${source.inputId} is not a ChoiceSet`
+      );
+    }
+    const rawValue = input.value == null ? "" : String(input.value);
+    const values = rawValue
+      .split(",")
+      .map((value) => value.trim())
+      .filter(Boolean);
+    const labels = values.map((value) => {
+      const choice = input.choices?.find((item) => item.value === value);
+      if (!choice?.title) {
+        throw new InvalidActionMessageSourceError(
+          `Choice value is not declared by ${source.inputId}: ${value}`
+        );
+      }
+      return choice.title.trim();
+    });
+    return labels.join(source.separator ?? "\n");
+  }
+  const parts = source.parts
+    .map((part) => resolveSourceText(part, card, action).trim())
+    .filter(Boolean);
+  return parts.join(source.separator ?? "\n");
+}
+
+export function resolveActionMessageText(
+  effect: ActionMessageEffect,
+  action: Action,
+  card: AdaptiveCard
+): string {
+  const text = resolveSourceText(effect.source, card, action).trim();
+  if (!text)
+    throw new InvalidActionMessageSourceError("Current-user message is empty");
+  return text;
+}

--- a/packages/dmworkbase/src/Messages/InteractiveCard/sdk/actionMessage.ts
+++ b/packages/dmworkbase/src/Messages/InteractiveCard/sdk/actionMessage.ts
@@ -29,16 +29,22 @@ export class InvalidActionMessageSourceError extends Error {
 }
 
 type JsonObject = Record<string, unknown>;
+const MAX_SOURCE_DEPTH = 8;
 
 function isObject(value: unknown): value is JsonObject {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function stringValue(value: unknown): string | undefined {
-  return typeof value === "string" && value.trim() ? value : undefined;
+  const text = typeof value === "string" ? value.trim() : "";
+  return text || undefined;
 }
 
-function parseSource(value: unknown): ActionMessageSource | undefined {
+function parseSource(
+  value: unknown,
+  depth = 0
+): ActionMessageSource | undefined {
+  if (depth > MAX_SOURCE_DEPTH) return undefined;
   if (!isObject(value) || typeof value.type !== "string") return undefined;
   const inputId = stringValue(value.input_id ?? value.inputId);
   if (value.type === "action.title") return { type: "action.title" };
@@ -55,7 +61,7 @@ function parseSource(value: unknown): ActionMessageSource | undefined {
     return { type: "input_text", inputId };
   }
   if (value.type === "compose" && Array.isArray(value.parts)) {
-    const parts = value.parts.map(parseSource);
+    const parts = value.parts.map((part) => parseSource(part, depth + 1));
     if (
       parts.every((part): part is ActionMessageSource => part !== undefined)
     ) {
@@ -104,6 +110,14 @@ export function resolveActionMessageEffect(
     return null;
   }
 
+  if (
+    data.effect_version !== undefined &&
+    typeof data.effect_version !== "number"
+  ) {
+    throw new InvalidActionMessageSourceError(
+      "Card action effect_version must be a positive integer"
+    );
+  }
   const version =
     typeof data.effect_version === "number" ? data.effect_version : 1;
   if (!Number.isInteger(version) || version < 1) {
@@ -170,7 +184,8 @@ function inputFor(card: AdaptiveCard, inputId: string): CardInputLike {
 function resolveSourceText(
   source: ActionMessageSource,
   card: AdaptiveCard,
-  action: Action
+  action: Action,
+  inputValues?: Record<string, string>
 ): string {
   if (source.type === "action.title") {
     const title = (action as unknown as { title?: unknown }).title;
@@ -180,7 +195,12 @@ function resolveSourceText(
     return title.trim();
   }
   if (source.type === "input_text") {
-    const value = inputFor(card, source.inputId).value;
+    const value = Object.prototype.hasOwnProperty.call(
+      inputValues ?? {},
+      source.inputId
+    )
+      ? inputValues?.[source.inputId]
+      : inputFor(card, source.inputId).value;
     return value == null ? "" : String(value).trim();
   }
   if (source.type === "choice_labels") {
@@ -190,7 +210,14 @@ function resolveSourceText(
         `Input ${source.inputId} is not a ChoiceSet`
       );
     }
-    const rawValue = input.value == null ? "" : String(input.value);
+    const rawValue = Object.prototype.hasOwnProperty.call(
+      inputValues ?? {},
+      source.inputId
+    )
+      ? inputValues?.[source.inputId] ?? ""
+      : input.value == null
+      ? ""
+      : String(input.value);
     const values = rawValue
       .split(",")
       .map((value) => value.trim())
@@ -202,12 +229,12 @@ function resolveSourceText(
           `Choice value is not declared by ${source.inputId}: ${value}`
         );
       }
-      return choice.title.trim();
+      return choice.title.trim().split(/\r?\n/, 1)[0].trim();
     });
     return labels.join(source.separator ?? "\n");
   }
   const parts = source.parts
-    .map((part) => resolveSourceText(part, card, action).trim())
+    .map((part) => resolveSourceText(part, card, action, inputValues).trim())
     .filter(Boolean);
   return parts.join(source.separator ?? "\n");
 }
@@ -215,9 +242,15 @@ function resolveSourceText(
 export function resolveActionMessageText(
   effect: ActionMessageEffect,
   action: Action,
-  card: AdaptiveCard
+  card: AdaptiveCard,
+  inputValues?: Record<string, string>
 ): string {
-  const text = resolveSourceText(effect.source, card, action).trim();
+  const text = resolveSourceText(
+    effect.source,
+    card,
+    action,
+    inputValues
+  ).trim();
   if (!text)
     throw new InvalidActionMessageSourceError("Current-user message is empty");
   return text;

--- a/packages/dmworkbase/src/Messages/InteractiveCard/sdk/runtimeCapabilities.ts
+++ b/packages/dmworkbase/src/Messages/InteractiveCard/sdk/runtimeCapabilities.ts
@@ -1,0 +1,48 @@
+export interface WebRuntimeCapability {
+  id: string;
+  version: number;
+  effects: readonly string[];
+  status: "supported" | "planned";
+}
+
+/** Web-owned local behavior registry. Keep this separate from Render Profile capabilities. */
+export const WEB_RUNTIME_CAPABILITIES: readonly WebRuntimeCapability[] = [
+  {
+    id: "message.send.current_user",
+    version: 1,
+    effects: ["send_current_user_message", "append_user_message"],
+    status: "supported",
+  },
+  {
+    id: "clipboard.write",
+    version: 1,
+    effects: ["write_clipboard"],
+    status: "planned",
+  },
+  {
+    id: "composer.insert",
+    version: 1,
+    effects: ["insert_composer_text"],
+    status: "planned",
+  },
+  {
+    id: "panel.open",
+    version: 1,
+    effects: ["open_panel"],
+    status: "planned",
+  },
+  {
+    id: "url.open",
+    version: 1,
+    effects: ["open_url"],
+    status: "planned",
+  },
+];
+
+export function runtimeCapabilityForEffect(
+  effect: string
+): WebRuntimeCapability | undefined {
+  return WEB_RUNTIME_CAPABILITIES.find((capability) =>
+    capability.effects.includes(effect)
+  );
+}

--- a/packages/dmworkbase/src/Service/ActionMessageSender.ts
+++ b/packages/dmworkbase/src/Service/ActionMessageSender.ts
@@ -1,0 +1,86 @@
+import type { Message } from "wukongimjssdk";
+
+const ENTRY_TTL_MS = 24 * 60 * 60 * 1000;
+
+interface SentEntry {
+  key: string;
+  content: string;
+  updatedAt: number;
+}
+
+type Stage =
+  | "user_message_sending"
+  | "user_message_sent"
+  | "card_action_submitting"
+  | "completed";
+
+export interface ActionMessageSenderOptions {
+  operationKey: string;
+  content: string;
+  sendMessage: () => Promise<Message>;
+  submitAction: () => Promise<unknown>;
+  onStage?: (stage: Stage) => void;
+}
+
+export interface ActionMessageSenderResult {
+  message?: Message;
+  reusedMessage: boolean;
+}
+
+const memoryEntries = new Map<string, SentEntry>();
+const inFlightSends = new Map<string, Promise<Message>>();
+
+function findEntry(key: string, content: string): SentEntry | undefined {
+  const now = Date.now();
+  for (const [entryKey, entry] of memoryEntries) {
+    if (now - entry.updatedAt >= ENTRY_TTL_MS) {
+      memoryEntries.delete(entryKey);
+    }
+  }
+  const entry = memoryEntries.get(key);
+  return entry?.content === content ? entry : undefined;
+}
+
+function writeEntry(entry: SentEntry): void {
+  memoryEntries.set(entry.key, entry);
+}
+
+/** Send a durable user message once, then run the card action. */
+export async function sendActionWithCurrentUserMessage(
+  options: ActionMessageSenderOptions
+): Promise<ActionMessageSenderResult> {
+  let entry = findEntry(options.operationKey, options.content);
+  let message: Message | undefined;
+  let reusedMessage = false;
+
+  if (entry) {
+    reusedMessage = true;
+  } else {
+    options.onStage?.("user_message_sending");
+    const sendKey = `${options.operationKey}\u0000${options.content}`;
+    let sendPromise = inFlightSends.get(sendKey);
+    if (!sendPromise) {
+      sendPromise = options.sendMessage();
+      inFlightSends.set(sendKey, sendPromise);
+    }
+    try {
+      message = await sendPromise;
+    } finally {
+      if (inFlightSends.get(sendKey) === sendPromise)
+        inFlightSends.delete(sendKey);
+    }
+    entry = {
+      key: options.operationKey,
+      content: options.content,
+      updatedAt: Date.now(),
+    };
+    writeEntry(entry);
+    options.onStage?.("user_message_sent");
+  }
+
+  options.onStage?.("card_action_submitting");
+  await options.submitAction();
+  writeEntry({ ...entry, updatedAt: Date.now() });
+  options.onStage?.("completed");
+  return { message, reusedMessage };
+}

--- a/packages/dmworkbase/src/Service/ActionMessageSender.ts
+++ b/packages/dmworkbase/src/Service/ActionMessageSender.ts
@@ -8,6 +8,16 @@ interface SentEntry {
   updatedAt: number;
 }
 
+export class ActionMessageSendError extends Error {
+  readonly cause: unknown;
+
+  constructor(cause: unknown) {
+    super("Failed to send card action user message");
+    this.name = "ActionMessageSendError";
+    this.cause = cause;
+  }
+}
+
 type Stage =
   | "user_message_sending"
   | "user_message_sent"
@@ -65,6 +75,8 @@ export async function sendActionWithCurrentUserMessage(
     }
     try {
       message = await sendPromise;
+    } catch (error) {
+      throw new ActionMessageSendError(error);
     } finally {
       if (inFlightSends.get(sendKey) === sendPromise)
         inFlightSends.delete(sendKey);


### PR DESCRIPTION
## What changed

- Send declared card action messages through the normal current-user message path before submitting the card action.
- Resolve ChoiceSet display labels and bounded message sources without adding a prefix.
- Reuse the page-level sent-message state on card-action retry and normalize person-DM channels.
- Upgrade @mlt-org/octo-card-profile-octo-chat to 1.2.0-rc.2.

## Why

Interactive card choices need to appear as durable user messages immediately while preserving the existing card-action and bot flow.

## Validation

- Web targeted interactive-card tests: 9 passed.

## Remaining integration check

- Confirm the Bot ordinary-message consumer does not process the placeholder user message a second time.
