### PR TITLE
feat: support dark theme styling

### DIFF
--- a/packages/dmworkbase/src/App.css
+++ b/packages/dmworkbase/src/App.css
@@ -62,8 +62,8 @@
     --wk-message-item: #0F0F0F;
     --wk-message-color: white;
 
-    --semi-color-primary: var(--wk-color-theme, #1C1C23);
-    --semi-color-primary-hover: #2A2A33;
+    --semi-color-primary: var(--wk-neutral-600);
+    --semi-color-primary-hover: var(--wk-neutral-500);
 
     /* Dark mode 适配变量 */
     --bg-primary: #1a1a1a;
@@ -124,6 +124,15 @@ html {
     --semi-color-primary-light-default: #F1F1F3;
     --semi-color-primary-light-hover: #E9E9EC;
     --semi-color-primary-light-active: #E1E1E5;
+  }
+
+  html body[theme-mode=dark] {
+    --semi-color-primary: var(--wk-neutral-600);
+    --semi-color-primary-hover: var(--wk-neutral-500);
+    --semi-color-primary-active: var(--wk-neutral-700);
+    --semi-color-primary-light-default: var(--wk-white-alpha-08);
+    --semi-color-primary-light-hover: var(--wk-white-alpha-12);
+    --semi-color-primary-light-active: var(--wk-white-alpha-12);
   }
 
   div {

--- a/packages/dmworkbase/src/App.css
+++ b/packages/dmworkbase/src/App.css
@@ -61,10 +61,6 @@
 
     --wk-message-item: #0F0F0F;
     --wk-message-color: white;
-
-    --semi-color-primary: var(--wk-neutral-600);
-    --semi-color-primary-hover: var(--wk-neutral-500);
-
     /* Dark mode 适配变量 */
     --bg-primary: #1a1a1a;
     --bg-secondary: #242424;
@@ -127,9 +123,9 @@ html {
   }
 
   html body[theme-mode=dark] {
-    --semi-color-primary: var(--wk-neutral-600);
-    --semi-color-primary-hover: var(--wk-neutral-500);
-    --semi-color-primary-active: var(--wk-neutral-700);
+    --semi-color-primary: var(--wk-brand-primary);
+    --semi-color-primary-hover: var(--wk-brand-primary-hover);
+    --semi-color-primary-active: var(--wk-purple-700);
     --semi-color-primary-light-default: var(--wk-white-alpha-08);
     --semi-color-primary-light-hover: var(--wk-white-alpha-12);
     --semi-color-primary-light-active: var(--wk-white-alpha-12);

--- a/packages/dmworkbase/src/App.tsx
+++ b/packages/dmworkbase/src/App.tsx
@@ -880,8 +880,11 @@ export default class WKApp extends ProviderListener {
     this.deviceName = this.getOSAndVersion();
     this.deviceModel = this.getBrandsFromUserAgent();
 
-    // 暗黑模式已关闭，强制亮色
-    WKApp.config.themeMode = ThemeMode.light;
+    const storedThemeMode = StorageService.shared.getItem("theme-mode");
+    WKApp.config.themeMode =
+      storedThemeMode === `${ThemeMode.dark}` || storedThemeMode === "dark"
+        ? ThemeMode.dark
+        : ThemeMode.light;
 
     registerImConnectAddressProvider(
       WKSDK.shared(),

--- a/packages/dmworkbase/src/Components/ChannelQRCode/index.css
+++ b/packages/dmworkbase/src/Components/ChannelQRCode/index.css
@@ -7,7 +7,7 @@
 
 .wk-channelqrcode-box {
     width: 100%;
-    background-color: var(--wk-color-item);
+    background-color: var(--wk-bg-surface);
     display: flex;
     align-items: center;
     justify-content: center;
@@ -37,14 +37,14 @@
 
 .wk-channelqrcode-expire {
     font-size: 12px;
-    color: #666;
+    color: var(--wk-text-tertiary);
     text-align: center;
     padding: 20px 0px;
 }
 
 .wk-channelqrcode-info-name {
     text-align: center;
-    color: var(--wk-text-item);;
+    color: var(--wk-text-primary);
 }
 
 .wk-channelqrcode-qrcode-box {
@@ -61,7 +61,7 @@
     top: 0px;
     width: 100%;
     height: 100%;
-    background-color: rgb(255, 255, 255,0.98);
+    background-color: color-mix(in srgb, var(--wk-bg-surface) 98%, transparent);
     border-bottom-left-radius: 10px;
     border-bottom-right-radius: 10px;
 
@@ -73,13 +73,13 @@
 }
 
 body[theme-mode=dark] .wk-channelqrcode-qrcode-mask {
-    background-color: rgb(0, 0, 0,0.98);
+    background-color: color-mix(in srgb, var(--wk-bg-surface) 98%, transparent);
 }
 
 .wk-channelqrcode-qrcode-mask p {
     font-size: 18px;
     margin-bottom: 0px;
-    color: #666;
+    color: var(--wk-text-secondary);
 }
 
 .wk-channelqrcode-qrcode-loading {

--- a/packages/dmworkbase/src/Components/ChannelQRCode/index.css
+++ b/packages/dmworkbase/src/Components/ChannelQRCode/index.css
@@ -72,10 +72,6 @@
 
 }
 
-body[theme-mode=dark] .wk-channelqrcode-qrcode-mask {
-    background-color: color-mix(in srgb, var(--wk-bg-surface) 98%, transparent);
-}
-
 .wk-channelqrcode-qrcode-mask p {
     font-size: 18px;
     margin-bottom: 0px;

--- a/packages/dmworkbase/src/Components/Conversation/FoldSessionCard/index.css
+++ b/packages/dmworkbase/src/Components/Conversation/FoldSessionCard/index.css
@@ -2,7 +2,7 @@
   position: relative;
   width: 100%;
   max-width: min(680px, calc(100vw - 120px));
-  background: var(--wk-bg-elevated);
+  background: var(--wk-bg-legacy-card);
   border: none;
   border-radius: 8px;
   padding: 12px;
@@ -183,13 +183,13 @@
 .wk-fold-session-divider-line {
   flex: 1;
   height: 1px;
-  background: var(--wk-border-subtle);
+  background: var(--wk-border-legacy-subtle);
 }
 
 .wk-fold-session-divider-text {
   font-size: 12px;
   font-weight: 500;
-  color: var(--wk-text-tertiary);
+  color: var(--wk-text-legacy-tertiary);
   white-space: nowrap;
 }
 
@@ -302,7 +302,7 @@
   font-size: 14px;
   font-weight: 400;
   line-height: 1.6;
-  color: var(--wk-text-primary);
+  color: var(--wk-text-legacy-primary);
 }
 
 /* 隐藏表情图标,折叠状态显示为普通消息 */

--- a/packages/dmworkbase/src/Components/Conversation/FoldSessionCard/index.css
+++ b/packages/dmworkbase/src/Components/Conversation/FoldSessionCard/index.css
@@ -2,7 +2,7 @@
   position: relative;
   width: 100%;
   max-width: min(680px, calc(100vw - 120px));
-  background: rgba(28, 28, 35, 0.04);
+  background: var(--wk-bg-elevated);
   border: none;
   border-radius: 8px;
   padding: 12px;
@@ -183,13 +183,13 @@
 .wk-fold-session-divider-line {
   flex: 1;
   height: 1px;
-  background: rgba(28, 28, 35, 0.1);
+  background: var(--wk-border-subtle);
 }
 
 .wk-fold-session-divider-text {
   font-size: 12px;
   font-weight: 500;
-  color: rgba(28, 28, 35, 0.4);
+  color: var(--wk-text-tertiary);
   white-space: nowrap;
 }
 
@@ -302,7 +302,7 @@
   font-size: 14px;
   font-weight: 400;
   line-height: 1.6;
-  color: rgba(28, 28, 35, 0.8);
+  color: var(--wk-text-primary);
 }
 
 /* 隐藏表情图标,折叠状态显示为普通消息 */

--- a/packages/dmworkbase/src/Components/Conversation/index.css
+++ b/packages/dmworkbase/src/Components/Conversation/index.css
@@ -134,7 +134,7 @@ body[theme-mode="dark"] .wk-conversation-content {
 .wk-fold-session-participant-name {
   font-size: 14px;
   font-weight: 600 !important;
-  color: #000000;
+  color: var(--wk-text-primary);
 }
 
 /* AI 名称样式 (和普通名字一样,不需要特殊样式) */
@@ -216,7 +216,7 @@ body[theme-mode="dark"] .wk-conversation-content {
 .wk-fold-session-time {
   font-size: 14px;
   font-weight: 400;
-  color: rgba(28, 28, 35, 0.4);
+  color: var(--wk-text-tertiary);
   white-space: nowrap;
 }
 
@@ -313,8 +313,8 @@ body[theme-mode="dark"] .wk-conversation-content {
 .wk-fold-msg-name {
   font-size: 12px;
   font-weight: 700;
-  color: rgba(28, 28, 35, 1);
-  background: rgba(255, 255, 255, 1);
+  color: var(--wk-text-primary);
+  background: var(--wk-bg-surface);
   border-radius: 3px;
   padding: 2px 8px;
   height: 20px;
@@ -326,13 +326,13 @@ body[theme-mode="dark"] .wk-conversation-content {
 .wk-fold-msg-time {
   font-size: 12px;
   font-weight: 400;
-  color: rgba(28, 28, 35, 0.4);
+  color: var(--wk-text-tertiary);
 }
 
 .wk-fold-msg-text {
   font-size: 14px;
   font-weight: 400;
-  color: rgba(28, 28, 35, 0.8);
+  color: var(--wk-text-primary);
   line-height: 1.6;
 }
 

--- a/packages/dmworkbase/src/Components/Conversation/index.css
+++ b/packages/dmworkbase/src/Components/Conversation/index.css
@@ -134,7 +134,7 @@ body[theme-mode="dark"] .wk-conversation-content {
 .wk-fold-session-participant-name {
   font-size: 14px;
   font-weight: 600 !important;
-  color: var(--wk-text-primary);
+  color: var(--wk-text-legacy-absolute);
 }
 
 /* AI 名称样式 (和普通名字一样,不需要特殊样式) */
@@ -216,7 +216,7 @@ body[theme-mode="dark"] .wk-conversation-content {
 .wk-fold-session-time {
   font-size: 14px;
   font-weight: 400;
-  color: var(--wk-text-tertiary);
+  color: var(--wk-text-legacy-tertiary);
   white-space: nowrap;
 }
 
@@ -313,7 +313,7 @@ body[theme-mode="dark"] .wk-conversation-content {
 .wk-fold-msg-name {
   font-size: 12px;
   font-weight: 700;
-  color: var(--wk-text-primary);
+  color: var(--wk-text-legacy-title);
   background: var(--wk-bg-surface);
   border-radius: 3px;
   padding: 2px 8px;
@@ -326,13 +326,13 @@ body[theme-mode="dark"] .wk-conversation-content {
 .wk-fold-msg-time {
   font-size: 12px;
   font-weight: 400;
-  color: var(--wk-text-tertiary);
+  color: var(--wk-text-legacy-tertiary);
 }
 
 .wk-fold-msg-text {
   font-size: 14px;
   font-weight: 400;
-  color: var(--wk-text-primary);
+  color: var(--wk-text-legacy-primary);
   line-height: 1.6;
 }
 

--- a/packages/dmworkbase/src/Components/NavRail/NavSettingsPanel.tsx
+++ b/packages/dmworkbase/src/Components/NavRail/NavSettingsPanel.tsx
@@ -151,7 +151,6 @@ export default class NavSettingsPanel extends Component<NavSettingsPanelProps, N
                             </button>
                         </div>
                     )}
-                    {/* 暗黑模式入口已关闭 */}
                     {showAccountCenter && (
                         <NavFlyoutMenuItem onSelect={() => {
                             onToggleSetting();

--- a/packages/dmworkbase/src/Messages/File/index.css
+++ b/packages/dmworkbase/src/Messages/File/index.css
@@ -5,22 +5,20 @@
   min-width: 200px;
   max-width: 280px;
   gap: 12px;
-  box-sizing: border-box;
-  background: var(--wk-bg-elevated);
-  border: 1px solid var(--wk-border-default);
+  background: var(--wk-file-card-bg);
   border-radius: 8px;
   cursor: pointer;
-  transition: background-color 0.15s, border-color 0.15s, box-shadow 0.15s;
+  transition: background-color 0.15s, box-shadow 0.15s;
 }
 
 /* 可点击的文件卡片 hover 效果 */
 .wk-message-file--clickable:hover {
-  background: var(--wk-bg-hover);
+  background: var(--wk-file-card-hover-bg);
   box-shadow: var(--wk-shadow-sm);
 }
 
 .wk-message-file--clickable:active {
-  background: var(--wk-bg-selected);
+  background: var(--wk-file-card-active-bg);
 }
 
 /* 激活态（正在预览） */
@@ -62,7 +60,7 @@
 .wk-message-file-name {
   font-size: 14px;
   font-weight: 500;
-  color: var(--wk-text-primary);
+  color: var(--wk-text-legacy-primary);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -74,14 +72,14 @@
   align-items: center;
   gap: 8px;
   font-size: 12px;
-  color: var(--wk-text-tertiary);
+  color: var(--wk-text-legacy-tertiary);
 }
 
 .wk-message-file-ext {
   padding: 0 4px;
   border-radius: 2px;
-  background-color: var(--wk-brand-tint-08);
-  color: var(--wk-brand-primary);
+  background-color: var(--wk-file-ext-bg);
+  color: var(--wk-color-theme);
   font-size: 10px;
   font-weight: 600;
   line-height: 1.6;
@@ -101,12 +99,12 @@
   align-items: center;
   justify-content: center;
   cursor: pointer;
-  color: var(--wk-brand-primary);
+  color: var(--wk-color-theme);
   transition: background-color 0.2s;
 }
 
 .wk-message-file-action:hover {
-  background-color: var(--wk-brand-tint-08);
+  background-color: var(--wk-file-ext-bg);
 }
 
 .wk-message-base-bubble-box.send .wk-message-file-name {
@@ -118,22 +116,22 @@
 }
 
 .wk-message-base-bubble-box.send .wk-message-file-ext {
-  background-color: var(--wk-brand-tint-08);
-  color: var(--wk-brand-primary);
+  background-color: var(--wk-file-send-tint-10);
+  color: var(--wk-color-theme);
 }
 
 .wk-message-base-bubble-box.send .wk-message-file-action {
-  color: var(--wk-brand-primary);
+  color: var(--wk-color-theme);
 }
 
 .wk-message-base-bubble-box.send .wk-message-file-action:hover {
-  background-color: var(--wk-brand-tint-08);
+  background-color: var(--wk-file-send-tint-08);
 }
 
 .wk-message-file-caption {
   padding: 4px 8px 8px;
   font-size: 14px;
-  color: var(--wk-text-primary);
+  color: var(--wk-text-item);
   word-break: break-word;
   line-height: 1.4;
 }
@@ -150,7 +148,7 @@
 
 .wk-message-file-progress-bar {
   height: 4px;
-  background-color: var(--wk-border-default);
+  background-color: var(--wk-black-alpha-12);
   border-radius: 2px;
   overflow: hidden;
   margin: 6px 0 2px;
@@ -165,15 +163,15 @@
 
 .wk-message-file-progress-text {
   font-size: 11px;
-  color: var(--wk-text-tertiary);
+  color: var(--wk-text-item-second, #999);
 }
 
 .wk-message-base-bubble-box.send .wk-message-file-progress-bar {
-  background-color: var(--wk-border-default);
+  background-color: var(--wk-file-send-tint-15);
 }
 
 .wk-message-base-bubble-box.send .wk-message-file-progress-fill {
-  background-color: var(--wk-brand-primary);
+  background-color: var(--wk-color-theme);
 }
 
 .wk-message-base-bubble-box.send .wk-message-file-progress-text {

--- a/packages/dmworkbase/src/Messages/File/index.css
+++ b/packages/dmworkbase/src/Messages/File/index.css
@@ -5,30 +5,32 @@
   min-width: 200px;
   max-width: 280px;
   gap: 12px;
-  background: rgba(28, 28, 35, 0.05);
+  box-sizing: border-box;
+  background: var(--wk-bg-elevated);
+  border: 1px solid var(--wk-border-default);
   border-radius: 8px;
   cursor: pointer;
-  transition: background-color 0.15s, box-shadow 0.15s;
+  transition: background-color 0.15s, border-color 0.15s, box-shadow 0.15s;
 }
 
 /* 可点击的文件卡片 hover 效果 */
 .wk-message-file--clickable:hover {
-  background: rgba(28, 28, 35, 0.08);
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+  background: var(--wk-bg-hover);
+  box-shadow: var(--wk-shadow-sm);
 }
 
 .wk-message-file--clickable:active {
-  background: rgba(28, 28, 35, 0.12);
+  background: var(--wk-bg-selected);
 }
 
 /* 激活态（正在预览） */
 .wk-message-file--active {
-  border: 1px solid var(--wk-color-theme);
+  border-color: var(--wk-brand-primary);
   background: var(--wk-brand-tint-06);
 }
 
 .wk-message-file--active:hover {
-  border-color: var(--wk-color-theme);
+  border-color: var(--wk-brand-primary);
   background: var(--wk-brand-tint-06);
 }
 
@@ -43,7 +45,7 @@
 }
 
 .wk-message-file-icon-label {
-  color: #fff;
+  color: var(--wk-text-on-brand);
   font-size: 11px;
   font-weight: 700;
   letter-spacing: 0.5px;
@@ -60,7 +62,7 @@
 .wk-message-file-name {
   font-size: 14px;
   font-weight: 500;
-  color: rgba(28, 28, 35, 0.8);
+  color: var(--wk-text-primary);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -72,14 +74,14 @@
   align-items: center;
   gap: 8px;
   font-size: 12px;
-  color: rgba(28, 28, 35, 0.4);
+  color: var(--wk-text-tertiary);
 }
 
 .wk-message-file-ext {
   padding: 0 4px;
   border-radius: 2px;
-  background-color: rgba(99, 102, 241, 0.1);
-  color: var(--wk-color-theme);
+  background-color: var(--wk-brand-tint-08);
+  color: var(--wk-brand-primary);
   font-size: 10px;
   font-weight: 600;
   line-height: 1.6;
@@ -99,12 +101,12 @@
   align-items: center;
   justify-content: center;
   cursor: pointer;
-  color: var(--wk-color-theme);
+  color: var(--wk-brand-primary);
   transition: background-color 0.2s;
 }
 
 .wk-message-file-action:hover {
-  background-color: rgba(99, 102, 241, 0.1);
+  background-color: var(--wk-brand-tint-08);
 }
 
 .wk-message-base-bubble-box.send .wk-message-file-name {
@@ -116,22 +118,22 @@
 }
 
 .wk-message-base-bubble-box.send .wk-message-file-ext {
-  background-color: rgba(0, 180, 148, 0.1);
-  color: var(--wk-color-theme);
+  background-color: var(--wk-brand-tint-08);
+  color: var(--wk-brand-primary);
 }
 
 .wk-message-base-bubble-box.send .wk-message-file-action {
-  color: var(--wk-color-theme);
+  color: var(--wk-brand-primary);
 }
 
 .wk-message-base-bubble-box.send .wk-message-file-action:hover {
-  background-color: rgba(0, 180, 148, 0.08);
+  background-color: var(--wk-brand-tint-08);
 }
 
 .wk-message-file-caption {
   padding: 4px 8px 8px;
   font-size: 14px;
-  color: var(--wk-text-item);
+  color: var(--wk-text-primary);
   word-break: break-word;
   line-height: 1.4;
 }
@@ -148,7 +150,7 @@
 
 .wk-message-file-progress-bar {
   height: 4px;
-  background-color: rgba(0, 0, 0, 0.1);
+  background-color: var(--wk-border-default);
   border-radius: 2px;
   overflow: hidden;
   margin: 6px 0 2px;
@@ -156,22 +158,22 @@
 
 .wk-message-file-progress-fill {
   height: 100%;
-  background-color: var(--wk-color-primary, #1c1c23);
+  background-color: var(--wk-brand-primary);
   border-radius: 2px;
   transition: width 0.2s ease;
 }
 
 .wk-message-file-progress-text {
   font-size: 11px;
-  color: var(--wk-text-item-second, #999);
+  color: var(--wk-text-tertiary);
 }
 
 .wk-message-base-bubble-box.send .wk-message-file-progress-bar {
-  background-color: rgba(0, 180, 148, 0.15);
+  background-color: var(--wk-border-default);
 }
 
 .wk-message-base-bubble-box.send .wk-message-file-progress-fill {
-  background-color: var(--wk-color-theme);
+  background-color: var(--wk-brand-primary);
 }
 
 .wk-message-base-bubble-box.send .wk-message-file-progress-text {
@@ -180,22 +182,22 @@
 
 /* 失败状态文案 */
 .wk-message-file-failed-text {
-  color: #ef4444;
+  color: var(--wk-color-error);
 }
 
 .wk-message-file-retry-hint {
   font-size: 11px;
-  color: #ef4444;
+  color: var(--wk-color-error);
   margin-top: 2px;
 }
 
 /* 发送方气泡里失败文案 */
 .wk-message-base-bubble-box.send .wk-message-file-failed-text {
-  color: #ef4444;
+  color: var(--wk-color-error);
 }
 
 .wk-message-base-bubble-box.send .wk-message-file-retry-hint {
-  color: #ef4444;
+  color: var(--wk-color-error);
 }
 
 /* Text file preview modal */

--- a/packages/dmworkbase/src/Messages/File/index.css
+++ b/packages/dmworkbase/src/Messages/File/index.css
@@ -6,9 +6,11 @@
   max-width: 280px;
   gap: 12px;
   background: var(--wk-file-card-bg);
+  border: 1px solid transparent;
   border-radius: 8px;
+  box-sizing: border-box;
   cursor: pointer;
-  transition: background-color 0.15s, box-shadow 0.15s;
+  transition: background-color 0.15s, border-color 0.15s, box-shadow 0.15s;
 }
 
 /* 可点击的文件卡片 hover 效果 */

--- a/packages/dmworkbase/src/Messages/HistorySplit/index.css
+++ b/packages/dmworkbase/src/Messages/HistorySplit/index.css
@@ -1,7 +1,6 @@
 
 
 .wk-message-split-box {
-    --wk-message-split-line-color: var(--wk-border-default);
     width: 85%;
     margin: 0 auto;
     padding: 20px;
@@ -9,12 +8,8 @@
     display: table;
 }
 
-body[theme-mode="dark"] .wk-message-split-box {
-    --wk-message-split-line-color: var(--wk-border-strong);
-}
-
 .wk-message-split-content {
-    color: var(--wk-text-tertiary);
+    color: var(--wk-history-split-text);
     padding: 5px 8px 0;
     white-space: nowrap;
     width: auto;
@@ -23,10 +18,9 @@ body[theme-mode="dark"] .wk-message-split-box {
 }
 
 .wk-message-split-line1 {
-    background-image: linear-gradient(360deg, transparent, var(--wk-message-split-line-color));
+    background-image: linear-gradient(360deg, transparent, var(--wk-history-split-line));
     background-position: 0 0,0 100%;
     background-repeat: no-repeat;
-    -moz-background-size: 100% 1px;
     background-size: 100% 1px;
     top: 13px;
     width: 50%;
@@ -35,10 +29,9 @@ body[theme-mode="dark"] .wk-message-split-box {
 }
 
 .wk-message-split-line2 {
-    background-image: linear-gradient(360deg, var(--wk-message-split-line-color), transparent);
+    background-image: linear-gradient(360deg, var(--wk-history-split-line), transparent);
     background-position: 0 0,0 100%;
     background-repeat: no-repeat;
-    -moz-background-size: 100% 1px;
     background-size: 100% 1px;
     top: 13px;
     width: 50%;

--- a/packages/dmworkbase/src/Messages/HistorySplit/index.css
+++ b/packages/dmworkbase/src/Messages/HistorySplit/index.css
@@ -1,6 +1,7 @@
 
 
 .wk-message-split-box {
+    --wk-message-split-line-color: var(--wk-border-default);
     width: 85%;
     margin: 0 auto;
     padding: 20px;
@@ -8,8 +9,12 @@
     display: table;
 }
 
+body[theme-mode="dark"] .wk-message-split-box {
+    --wk-message-split-line-color: var(--wk-border-strong);
+}
+
 .wk-message-split-content {
-    color: rgba(9,30,66,.74);
+    color: var(--wk-text-tertiary);
     padding: 5px 8px 0;
     white-space: nowrap;
     width: auto;
@@ -18,11 +23,7 @@
 }
 
 .wk-message-split-line1 {
-    background-image: -webkit-gradient(linear,0 0,0 100%,from(transparent),to(rgba(9,30,66,.12)));
-    background-image: -webkit-linear-gradient(360deg,transparent,rgba(9,30,66,.12));
-    background-image: -moz-linear-gradient(360deg,transparent,rgba(9,30,66,.12));
-    background-image: -o-linear-gradient(360deg,transparent,rgba(9,30,66,.12));
-    background-image: linear-gradient(360deg,transparent,rgba(9,30,66,.12));
+    background-image: linear-gradient(360deg, transparent, var(--wk-message-split-line-color));
     background-position: 0 0,0 100%;
     background-repeat: no-repeat;
     -moz-background-size: 100% 1px;
@@ -34,11 +35,7 @@
 }
 
 .wk-message-split-line2 {
-    background-image: -webkit-gradient(linear,0 0,0 100%,from(#c5d0d5),to(transparent));
-    background-image: -webkit-linear-gradient(360deg,rgba(9,30,66,.12),transparent);
-    background-image: -moz-linear-gradient(360deg,rgba(9,30,66,.12),transparent);
-    background-image: -o-linear-gradient(360deg,rgba(9,30,66,.12),transparent);
-    background-image: linear-gradient(360deg,rgba(9,30,66,.12),transparent);
+    background-image: linear-gradient(360deg, var(--wk-message-split-line-color), transparent);
     background-position: 0 0,0 100%;
     background-repeat: no-repeat;
     -moz-background-size: 100% 1px;

--- a/packages/dmworkbase/src/Messages/Mergeforward/index.css
+++ b/packages/dmworkbase/src/Messages/Mergeforward/index.css
@@ -44,7 +44,7 @@
 
 .wk-mergeforwards-content-item {
   font-size: var(--wk-text-size-base);
-  color: var(--wk-text-secondary);
+  color: var(--wk-icon-muted);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -63,7 +63,7 @@
   align-items: center;
   justify-content: space-between;
   font-size: var(--wk-text-size-sm);
-  color: var(--wk-text-tertiary);
+  color: var(--wk-brand-tint-35);
 }
 
 .wk-mergeforwards-content-tip p {

--- a/packages/dmworkbase/src/Messages/Mergeforward/index.css
+++ b/packages/dmworkbase/src/Messages/Mergeforward/index.css
@@ -44,7 +44,7 @@
 
 .wk-mergeforwards-content-item {
   font-size: var(--wk-text-size-base);
-  color: var(--wk-icon-muted);
+  color: var(--wk-text-secondary);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -63,7 +63,7 @@
   align-items: center;
   justify-content: space-between;
   font-size: var(--wk-text-size-sm);
-  color: var(--wk-brand-tint-35);
+  color: var(--wk-text-tertiary);
 }
 
 .wk-mergeforwards-content-tip p {

--- a/packages/dmworkbase/src/Messages/Mergeforward/index.tsx
+++ b/packages/dmworkbase/src/Messages/Mergeforward/index.tsx
@@ -461,7 +461,7 @@ export class MergeforwardCell extends MessageCell<any, MergeforwardCellState> {
               <p>{this.context.t("base.mergeForward.chatHistory")}</p>
               <p>
                 {" "}
-                <MessageTrail message={message} timeStyle={{ color: "#999" }} />
+                <MessageTrail message={message} timeStyle={{ color: "var(--wk-text-tertiary)" }} />
               </p>
             </div>
           </div>

--- a/packages/dmworkbase/src/Messages/Text/markdown.css
+++ b/packages/dmworkbase/src/Messages/Text/markdown.css
@@ -8,6 +8,7 @@
   line-height: 1.6;
   word-break: break-word;
   min-width: 0;
+  color: var(--wk-text-primary);
 }
 
 /* ── 段落 ── */
@@ -108,6 +109,10 @@
   border-radius: var(--wk-r-md);
   overflow: hidden;
   border: 1px solid var(--wk-border-subtle);
+}
+
+body[theme-mode="dark"] .wk-markdown-pre-wrapper {
+  border-color: var(--wk-border-strong);
 }
 
 .wk-markdown pre {

--- a/packages/dmworkbase/src/Messages/Text/markdown.css
+++ b/packages/dmworkbase/src/Messages/Text/markdown.css
@@ -8,7 +8,6 @@
   line-height: 1.6;
   word-break: break-word;
   min-width: 0;
-  color: var(--wk-text-primary);
 }
 
 /* ── 段落 ── */

--- a/packages/dmworkbase/src/Messages/ThreadCreated/index.css
+++ b/packages/dmworkbase/src/Messages/ThreadCreated/index.css
@@ -4,8 +4,8 @@
   flex-direction: column;
   gap: 4px;
   padding: 12px;
-  background: rgba(28, 28, 35, 0.04);
-  border-left: 4px solid rgba(28, 28, 35, 0.8);
+  background: var(--wk-bg-elevated);
+  border-left: 4px solid var(--wk-border-strong);
   border-radius: 0 4px 4px 0;
   cursor: pointer;
   transition: background 0.2s;
@@ -14,7 +14,7 @@
 }
 
 .wk-thread-created-card:hover {
-  background: rgba(28, 28, 35, 0.06);
+  background: var(--wk-bg-hover);
 }
 
 /* 消息正文预览 */
@@ -22,7 +22,7 @@
   font-size: 14px;
   font-weight: 400;
   line-height: 22px;
-  color: rgba(28, 28, 35, 1.0);
+  color: var(--wk-text-primary);
   overflow: hidden;
   text-overflow: ellipsis;
   display: -webkit-box;
@@ -40,7 +40,7 @@
 
 /* Thread 链接 */
 .wk-thread-created-link {
-  color: rgba(127, 59, 245, 1.0);
+  color: var(--wk-text-accent);
   font-weight: 400;
   white-space: nowrap;
   overflow: hidden;
@@ -57,7 +57,7 @@
 
 /* 参与者文字 */
 .wk-thread-created-participants {
-  color: rgba(28, 28, 35, 0.6);
+  color: var(--wk-text-secondary);
   font-size: 12px;
   white-space: nowrap;
   margin-left: auto;

--- a/packages/dmworkbase/src/Messages/ThreadCreated/index.css
+++ b/packages/dmworkbase/src/Messages/ThreadCreated/index.css
@@ -4,8 +4,8 @@
   flex-direction: column;
   gap: 4px;
   padding: 12px;
-  background: var(--wk-bg-elevated);
-  border-left: 4px solid var(--wk-border-strong);
+  background: var(--wk-bg-legacy-card);
+  border-left: 4px solid var(--wk-border-legacy-strong);
   border-radius: 0 4px 4px 0;
   cursor: pointer;
   transition: background 0.2s;
@@ -14,7 +14,7 @@
 }
 
 .wk-thread-created-card:hover {
-  background: var(--wk-bg-hover);
+  background: var(--wk-bg-legacy-card-hover);
 }
 
 /* 消息正文预览 */
@@ -22,7 +22,7 @@
   font-size: 14px;
   font-weight: 400;
   line-height: 22px;
-  color: var(--wk-text-primary);
+  color: var(--wk-text-legacy-title);
   overflow: hidden;
   text-overflow: ellipsis;
   display: -webkit-box;
@@ -57,7 +57,7 @@
 
 /* 参与者文字 */
 .wk-thread-created-participants {
-  color: var(--wk-text-secondary);
+  color: var(--wk-text-legacy-secondary);
   font-size: 12px;
   white-space: nowrap;
   margin-left: auto;

--- a/packages/dmworkbase/src/theme/semantic.css
+++ b/packages/dmworkbase/src/theme/semantic.css
@@ -110,6 +110,7 @@
   /* ── Legacy chat/message values（light 保持旧视觉，dark 在主题块重映射） ── */
   --wk-bg-legacy-card: rgba(28, 28, 35, 0.04);
   --wk-bg-legacy-card-hover: rgba(28, 28, 35, 0.06);
+  --wk-bg-legacy-surface: #ffffff;
   --wk-bg-legacy-hover-subtle: var(--wk-brand-tint-02);
   --wk-bg-legacy-press: var(--wk-brand-tint-12);
   --wk-border-legacy-default: rgba(46, 50, 56, 0.09);
@@ -147,6 +148,8 @@
   --wk-summary-progress-active: rgba(0, 0, 0, 0.8);
   --wk-summary-danger-hover: #e03a32;
   --wk-summary-dark-button-hover: #333333;
+  --wk-overlay-scrim: var(--wk-black-alpha-30);
+  --wk-chat-selector-shadow: 0 8px 24px var(--wk-black-alpha-12), 0 0 0 1px var(--wk-black-alpha-06);
 
   /* ── Icon & Text opacity（基于主色的不同透明度） ── */
   --wk-icon-muted: rgba(28, 28, 35, 0.4); /* 40% icon/三角 */
@@ -408,6 +411,7 @@ body[theme-mode="dark"] {
   --wk-brand-tint-02: var(--wk-white-alpha-04);
   --wk-bg-legacy-card: var(--wk-bg-elevated);
   --wk-bg-legacy-card-hover: var(--wk-bg-hover);
+  --wk-bg-legacy-surface: var(--wk-bg-elevated);
   --wk-bg-legacy-hover-subtle: var(--wk-white-alpha-04);
   --wk-bg-legacy-press: var(--wk-white-alpha-12);
   --wk-border-legacy-default: var(--wk-border-default);
@@ -440,6 +444,8 @@ body[theme-mode="dark"] {
   --wk-summary-progress-active: var(--wk-text-primary);
   --wk-summary-danger-hover: var(--wk-color-danger-hover);
   --wk-summary-dark-button-hover: var(--wk-brand-primary-hover);
+  --wk-overlay-scrim: var(--wk-black-alpha-50);
+  --wk-chat-selector-shadow: var(--wk-shadow-lg);
   --wk-icon-muted: var(--wk-white-alpha-40);
   --wk-icon-default: var(--wk-white-alpha-80);
   --wk-icon-hover: var(--wk-color-white);
@@ -563,7 +569,9 @@ body[theme-mode="dark"] {
   --wk-code-bg: var(--wk-neutral-900);
   --wk-code-border: var(--wk-white-alpha-07);
 
-  /* Semi Design token 覆盖 */
+}
+
+html body[theme-mode="dark"] {
   --semi-color-bg-0: var(--wk-bg-surface);
   --semi-color-bg-1: var(--wk-bg-elevated);
   --semi-color-text-0: var(--wk-text-primary);

--- a/packages/dmworkbase/src/theme/semantic.css
+++ b/packages/dmworkbase/src/theme/semantic.css
@@ -96,6 +96,7 @@
   --wk-shadow-dropdown: 0 12px 32px var(--wk-black-alpha-12); /* 弹窗阴影 */
 
   /* ── Brand tint（主色半透明，基于 #1C1C23） ── */
+  --wk-brand-tint-02: rgba(28, 28, 35, 0.02);
   --wk-brand-tint-03: rgba(28, 28, 35, 0.03);
   --wk-brand-tint-04: rgba(28, 28, 35, 0.04);
   --wk-brand-tint-06: rgba(28, 28, 35, 0.06);
@@ -105,6 +106,47 @@
   --wk-brand-tint-15: rgba(28, 28, 35, 0.15);
   --wk-brand-tint-35: rgba(28, 28, 35, 0.35);
   --wk-brand-accent: var(--wk-brand-black);
+
+  /* ── Legacy chat/message values（light 保持旧视觉，dark 在主题块重映射） ── */
+  --wk-bg-legacy-card: rgba(28, 28, 35, 0.04);
+  --wk-bg-legacy-card-hover: rgba(28, 28, 35, 0.06);
+  --wk-bg-legacy-hover-subtle: var(--wk-brand-tint-02);
+  --wk-bg-legacy-press: var(--wk-brand-tint-12);
+  --wk-border-legacy-default: rgba(46, 50, 56, 0.09);
+  --wk-border-legacy-subtle: var(--wk-brand-tint-10);
+  --wk-border-legacy-strong: rgba(28, 28, 35, 0.8);
+  --wk-border-legacy-medium: rgba(28, 28, 35, 0.4);
+  --wk-text-legacy-title: var(--wk-brand-black);
+  --wk-text-legacy-absolute: #000000;
+  --wk-text-legacy-primary: rgba(28, 28, 35, 0.8);
+  --wk-text-legacy-secondary: rgba(28, 28, 35, 0.6);
+  --wk-text-legacy-tertiary: rgba(28, 28, 35, 0.4);
+  --wk-text-legacy-quaternary: var(--wk-brand-tint-35);
+  --wk-file-card-bg: rgba(28, 28, 35, 0.05);
+  --wk-file-card-hover-bg: var(--wk-brand-tint-08);
+  --wk-file-card-active-bg: var(--wk-brand-tint-12);
+  --wk-file-ext-bg: rgba(99, 102, 241, 0.1);
+  --wk-file-send-tint-08: rgba(0, 180, 148, 0.08);
+  --wk-file-send-tint-10: rgba(0, 180, 148, 0.1);
+  --wk-file-send-tint-15: rgba(0, 180, 148, 0.15);
+  --wk-history-split-text: rgba(9, 30, 66, 0.74);
+  --wk-history-split-line: rgba(9, 30, 66, 0.12);
+  --wk-summary-card-bg: #ffffff;
+  --wk-summary-card-hover-bg: #fcfbff;
+  --wk-summary-card-active-bg: linear-gradient(
+    180deg,
+    rgba(252, 243, 255, 0.8) 0%,
+    rgba(255, 255, 255, 0.8) 90%,
+    rgba(255, 255, 255, 0.8) 100%
+  );
+  --wk-summary-card-active-border: #ffffff;
+  --wk-summary-content-text: #1c1f23;
+  --wk-summary-meta-text: rgba(28, 31, 35, 0.6);
+  --wk-summary-chip-bg: rgba(28, 31, 35, 0.06);
+  --wk-summary-progress-muted: rgba(0, 0, 0, 0.4);
+  --wk-summary-progress-active: rgba(0, 0, 0, 0.8);
+  --wk-summary-danger-hover: #e03a32;
+  --wk-summary-dark-button-hover: #333333;
 
   /* ── Icon & Text opacity（基于主色的不同透明度） ── */
   --wk-icon-muted: rgba(28, 28, 35, 0.4); /* 40% icon/三角 */
@@ -344,11 +386,11 @@
    ============================================================ */
 body[theme-mode="dark"] {
   /* Legacy aliases still used by the chat shell and conversation list. */
-  --wk-color-theme: var(--wk-neutral-0);
-  --wk-brand-primary: var(--wk-text-primary);
-  --wk-brand-primary-hover: var(--wk-color-white);
-  --wk-brand-from: var(--wk-text-primary);
-  --wk-brand-to: var(--wk-text-primary);
+  --wk-color-theme: var(--wk-brand-primary);
+  --wk-brand-primary: var(--wk-color-accent);
+  --wk-brand-primary-hover: var(--wk-color-accent-hover);
+  --wk-brand-from: var(--wk-brand-primary);
+  --wk-brand-to: var(--wk-brand-primary);
   --wk-brand-gradient: var(--wk-brand-primary);
   --wk-brand-gradient-hover: var(--wk-brand-primary-hover);
   --wk-brand-gradient-subtle: var(--wk-white-alpha-08);
@@ -362,7 +404,42 @@ body[theme-mode="dark"] {
   --wk-brand-tint-12: var(--wk-white-alpha-12);
   --wk-brand-tint-15: var(--wk-white-alpha-12);
   --wk-brand-tint-35: var(--wk-white-alpha-40);
-  --wk-brand-accent: var(--wk-text-primary);
+  --wk-brand-accent: var(--wk-color-accent);
+  --wk-brand-tint-02: var(--wk-white-alpha-04);
+  --wk-bg-legacy-card: var(--wk-bg-elevated);
+  --wk-bg-legacy-card-hover: var(--wk-bg-hover);
+  --wk-bg-legacy-hover-subtle: var(--wk-white-alpha-04);
+  --wk-bg-legacy-press: var(--wk-white-alpha-12);
+  --wk-border-legacy-default: var(--wk-border-default);
+  --wk-border-legacy-subtle: var(--wk-border-default);
+  --wk-border-legacy-strong: var(--wk-white-alpha-40);
+  --wk-border-legacy-medium: var(--wk-white-alpha-40);
+  --wk-text-legacy-title: var(--wk-text-primary);
+  --wk-text-legacy-absolute: var(--wk-text-primary);
+  --wk-text-legacy-primary: var(--wk-text-primary);
+  --wk-text-legacy-secondary: var(--wk-text-secondary);
+  --wk-text-legacy-tertiary: var(--wk-text-tertiary);
+  --wk-text-legacy-quaternary: var(--wk-white-alpha-40);
+  --wk-file-card-bg: var(--wk-bg-elevated);
+  --wk-file-card-hover-bg: var(--wk-bg-hover);
+  --wk-file-card-active-bg: var(--wk-bg-active);
+  --wk-file-ext-bg: var(--wk-brand-tint-08);
+  --wk-file-send-tint-08: var(--wk-teal-alpha-08);
+  --wk-file-send-tint-10: var(--wk-teal-alpha-10);
+  --wk-file-send-tint-15: rgba(11, 134, 125, 0.15);
+  --wk-history-split-text: var(--wk-text-secondary);
+  --wk-history-split-line: var(--wk-border-strong);
+  --wk-summary-card-bg: var(--wk-bg-elevated);
+  --wk-summary-card-hover-bg: var(--wk-bg-hover);
+  --wk-summary-card-active-bg: var(--wk-bg-selected);
+  --wk-summary-card-active-border: var(--wk-border-glow);
+  --wk-summary-content-text: var(--wk-text-primary);
+  --wk-summary-meta-text: var(--wk-text-secondary);
+  --wk-summary-chip-bg: var(--wk-bg-elevated);
+  --wk-summary-progress-muted: var(--wk-text-tertiary);
+  --wk-summary-progress-active: var(--wk-text-primary);
+  --wk-summary-danger-hover: var(--wk-color-danger-hover);
+  --wk-summary-dark-button-hover: var(--wk-brand-primary-hover);
   --wk-icon-muted: var(--wk-white-alpha-40);
   --wk-icon-default: var(--wk-white-alpha-80);
   --wk-icon-hover: var(--wk-color-white);
@@ -487,12 +564,6 @@ body[theme-mode="dark"] {
   --wk-code-border: var(--wk-white-alpha-07);
 
   /* Semi Design token 覆盖 */
-  --semi-color-primary: var(--wk-neutral-600);
-  --semi-color-primary-hover: var(--wk-neutral-500);
-  --semi-color-primary-active: var(--wk-neutral-700);
-  --semi-color-primary-light-default: var(--wk-white-alpha-08);
-  --semi-color-primary-light-hover: var(--wk-white-alpha-12);
-  --semi-color-primary-light-active: var(--wk-white-alpha-12);
   --semi-color-bg-0: var(--wk-bg-surface);
   --semi-color-bg-1: var(--wk-bg-elevated);
   --semi-color-text-0: var(--wk-text-primary);

--- a/packages/dmworkbase/src/theme/semantic.css
+++ b/packages/dmworkbase/src/theme/semantic.css
@@ -340,10 +340,37 @@
 /* ============================================================
    Dark Theme — body[theme-mode=dark]
 
-   ⚠️ 暗黑模式当前已关闭（App.tsx 强制 ThemeMode.light），设置面板无切换入口
-   保留以下 CSS 变量定义以备后续重启暗黑模式功能
+   由 WKApp.config.themeMode 控制 body[theme-mode=dark]。
    ============================================================ */
 body[theme-mode="dark"] {
+  /* Legacy aliases still used by the chat shell and conversation list. */
+  --wk-color-theme: var(--wk-neutral-0);
+  --wk-brand-primary: var(--wk-text-primary);
+  --wk-brand-primary-hover: var(--wk-color-white);
+  --wk-brand-from: var(--wk-text-primary);
+  --wk-brand-to: var(--wk-text-primary);
+  --wk-brand-gradient: var(--wk-brand-primary);
+  --wk-brand-gradient-hover: var(--wk-brand-primary-hover);
+  --wk-brand-gradient-subtle: var(--wk-white-alpha-08);
+  --wk-brand-primary-ring: var(--wk-white-alpha-12);
+  --wk-brand-glow: var(--wk-white-alpha-12);
+  --wk-brand-tint-03: var(--wk-white-alpha-04);
+  --wk-brand-tint-04: var(--wk-white-alpha-04);
+  --wk-brand-tint-06: var(--wk-white-alpha-06);
+  --wk-brand-tint-08: var(--wk-white-alpha-08);
+  --wk-brand-tint-10: var(--wk-white-alpha-08);
+  --wk-brand-tint-12: var(--wk-white-alpha-12);
+  --wk-brand-tint-15: var(--wk-white-alpha-12);
+  --wk-brand-tint-35: var(--wk-white-alpha-40);
+  --wk-brand-accent: var(--wk-text-primary);
+  --wk-icon-muted: var(--wk-white-alpha-40);
+  --wk-icon-default: var(--wk-white-alpha-80);
+  --wk-icon-hover: var(--wk-color-white);
+  --wk-text-strong: var(--wk-color-white);
+  --wk-bg-item-hover: var(--wk-white-alpha-08);
+  --wk-bg-tab: var(--wk-white-alpha-06);
+  --wk-shadow-dropdown: 0 12px 32px var(--wk-black-alpha-50);
+
   --wk-accent-tint-06: rgba(127, 59, 245, 0.1);
   --wk-accent-tint-08: rgba(127, 59, 245, 0.12);
   --wk-accent-tint-10: rgba(127, 59, 245, 0.16);
@@ -460,8 +487,12 @@ body[theme-mode="dark"] {
   --wk-code-border: var(--wk-white-alpha-07);
 
   /* Semi Design token 覆盖 */
-  --semi-color-primary: var(--wk-brand-primary);
-  --semi-color-primary-hover: var(--wk-brand-primary-hover);
+  --semi-color-primary: var(--wk-neutral-600);
+  --semi-color-primary-hover: var(--wk-neutral-500);
+  --semi-color-primary-active: var(--wk-neutral-700);
+  --semi-color-primary-light-default: var(--wk-white-alpha-08);
+  --semi-color-primary-light-hover: var(--wk-white-alpha-12);
+  --semi-color-primary-light-active: var(--wk-white-alpha-12);
   --semi-color-bg-0: var(--wk-bg-surface);
   --semi-color-bg-1: var(--wk-bg-elevated);
   --semi-color-text-0: var(--wk-text-primary);

--- a/packages/dmworkbase/src/ui/message/MergeforwardCard/index.css
+++ b/packages/dmworkbase/src/ui/message/MergeforwardCard/index.css
@@ -4,9 +4,9 @@
  */
 
 .wk-mf-card {
-  background: rgba(28, 28, 35, 0.03);
+  background: var(--wk-bg-elevated);
   border-radius: 8px;
-  border: 1px solid rgba(46, 50, 56, 0.09);
+  border: 1px solid var(--wk-border-default);
   padding: 12px;
   cursor: pointer;
   /* 宽度由最长内容决定，不设固定宽度 */
@@ -17,14 +17,14 @@
 }
 
 .wk-mf-card:hover {
-  background: rgba(28, 28, 35, 0.02);
+  background: var(--wk-bg-hover);
 }
 
 /* 标题行 */
 .wk-mf-card__title {
   font-size: 14px;
   font-weight: 500;
-  color: #1c1c23;
+  color: var(--wk-text-primary);
   margin-bottom: 8px;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -41,7 +41,7 @@
 
 .wk-mf-card__item {
   font-size: 12px;
-  color: rgba(28, 28, 35, 0.6);
+  color: var(--wk-text-secondary);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -50,12 +50,12 @@
 /* 分割线 */
 .wk-mf-card__divider {
   height: 1px;
-  background: rgba(46, 50, 56, 0.09);
+  background: var(--wk-border-default);
   margin-bottom: 10px;
 }
 
 /* 底部标签 */
 .wk-mf-card__footer {
   font-size: 12px;
-  color: rgba(28, 28, 35, 0.35);
+  color: var(--wk-text-tertiary);
 }

--- a/packages/dmworkbase/src/ui/message/MergeforwardCard/index.css
+++ b/packages/dmworkbase/src/ui/message/MergeforwardCard/index.css
@@ -4,9 +4,9 @@
  */
 
 .wk-mf-card {
-  background: var(--wk-bg-elevated);
+  background: var(--wk-brand-tint-03);
   border-radius: 8px;
-  border: 1px solid var(--wk-border-default);
+  border: 1px solid var(--wk-border-legacy-default);
   padding: 12px;
   cursor: pointer;
   /* 宽度由最长内容决定，不设固定宽度 */
@@ -17,14 +17,14 @@
 }
 
 .wk-mf-card:hover {
-  background: var(--wk-bg-hover);
+  background: var(--wk-bg-legacy-hover-subtle);
 }
 
 /* 标题行 */
 .wk-mf-card__title {
   font-size: 14px;
   font-weight: 500;
-  color: var(--wk-text-primary);
+  color: var(--wk-text-legacy-title);
   margin-bottom: 8px;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -41,7 +41,7 @@
 
 .wk-mf-card__item {
   font-size: 12px;
-  color: var(--wk-text-secondary);
+  color: var(--wk-text-legacy-secondary);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -50,12 +50,12 @@
 /* 分割线 */
 .wk-mf-card__divider {
   height: 1px;
-  background: var(--wk-border-default);
+  background: var(--wk-border-legacy-default);
   margin-bottom: 10px;
 }
 
 /* 底部标签 */
 .wk-mf-card__footer {
   font-size: 12px;
-  color: var(--wk-text-tertiary);
+  color: var(--wk-text-legacy-quaternary);
 }

--- a/packages/dmworkbase/src/ui/message/MessageRow/index.css
+++ b/packages/dmworkbase/src/ui/message/MessageRow/index.css
@@ -23,7 +23,7 @@
   right: 0;
   top: -2px;
   bottom: -2px;
-  background-color: var(--wk-bg-item-hover);
+  background-color: var(--wk-bg-legacy-card);
   opacity: 0;
   transition: opacity 0.2s;
   pointer-events: none;
@@ -148,12 +148,12 @@
 
 .wk-msg-row-timestamp {
   font-size: 12px;
-  color: var(--wk-text-tertiary);
+  color: var(--wk-text-legacy-tertiary);
 }
 
 .wk-msg-row-edited {
   font-size: 12px;
-  color: var(--wk-text-tertiary);
+  color: var(--wk-text-legacy-tertiary);
   opacity: 1;
 }
 
@@ -162,7 +162,7 @@
  */
 .wk-msg-row-timestamp-hover {
   font-size: 10px;
-  color: var(--wk-text-tertiary);
+  color: var(--wk-text-legacy-tertiary);
   opacity: 0;
   pointer-events: none;
   transition: opacity 0.2s;

--- a/packages/dmworkbase/src/ui/message/MessageRow/index.css
+++ b/packages/dmworkbase/src/ui/message/MessageRow/index.css
@@ -23,7 +23,7 @@
   right: 0;
   top: -2px;
   bottom: -2px;
-  background-color: rgba(28, 28, 35, 0.04);
+  background-color: var(--wk-bg-item-hover);
   opacity: 0;
   transition: opacity 0.2s;
   pointer-events: none;
@@ -148,12 +148,12 @@
 
 .wk-msg-row-timestamp {
   font-size: 12px;
-  color: rgba(28, 28, 35, 0.4);
+  color: var(--wk-text-tertiary);
 }
 
 .wk-msg-row-edited {
   font-size: 12px;
-  color: rgba(28, 28, 35, 0.4);
+  color: var(--wk-text-tertiary);
   opacity: 1;
 }
 
@@ -162,7 +162,7 @@
  */
 .wk-msg-row-timestamp-hover {
   font-size: 10px;
-  color: rgba(28, 28, 35, 0.4);
+  color: var(--wk-text-tertiary);
   opacity: 0;
   pointer-events: none;
   transition: opacity 0.2s;

--- a/packages/dmworkbase/src/ui/message/ReplyBlock/index.css
+++ b/packages/dmworkbase/src/ui/message/ReplyBlock/index.css
@@ -7,7 +7,7 @@
   display: flex;
   align-items: stretch;
   gap: 8px;
-  background: rgba(28, 28, 35, 0.04);
+  background: var(--wk-bg-elevated);
   border-radius: 6px;
   padding: 6px 8px;
   cursor: pointer;
@@ -19,7 +19,7 @@
 .wk-reply-block__bar {
   width: 2px;
   border-radius: 1px;
-  background: rgba(28, 28, 35, 0.4);
+  background: var(--wk-border-strong);
   flex-shrink: 0;
   align-self: stretch;
   min-height: 18px;
@@ -45,7 +45,7 @@
 .wk-reply-block__name {
   font-size: 12px;
   font-weight: 400;
-  color: rgba(28, 28, 35, 0.6);
+  color: var(--wk-text-secondary);
   line-height: 18px;
   white-space: nowrap;
   overflow: hidden;
@@ -57,7 +57,7 @@
 .wk-reply-block__space {
   font-size: 12px;
   font-weight: 400;
-  color: rgba(28, 28, 35, 0.45);
+  color: var(--wk-text-tertiary);
   line-height: 18px;
   white-space: nowrap;
   overflow: hidden;
@@ -69,7 +69,7 @@
 .wk-reply-block__digest {
   font-size: 12px;
   font-weight: 400;
-  color: rgba(28, 28, 35, 0.6);
+  color: var(--wk-text-secondary);
   line-height: 18px;
   white-space: nowrap;
   overflow: hidden;

--- a/packages/dmworkbase/src/ui/message/ReplyBlock/index.css
+++ b/packages/dmworkbase/src/ui/message/ReplyBlock/index.css
@@ -7,7 +7,7 @@
   display: flex;
   align-items: stretch;
   gap: 8px;
-  background: var(--wk-bg-elevated);
+  background: var(--wk-bg-legacy-card);
   border-radius: 6px;
   padding: 6px 8px;
   cursor: pointer;
@@ -19,7 +19,7 @@
 .wk-reply-block__bar {
   width: 2px;
   border-radius: 1px;
-  background: var(--wk-border-strong);
+  background: var(--wk-border-legacy-medium);
   flex-shrink: 0;
   align-self: stretch;
   min-height: 18px;
@@ -45,7 +45,7 @@
 .wk-reply-block__name {
   font-size: 12px;
   font-weight: 400;
-  color: var(--wk-text-secondary);
+  color: var(--wk-text-legacy-secondary);
   line-height: 18px;
   white-space: nowrap;
   overflow: hidden;
@@ -57,7 +57,7 @@
 .wk-reply-block__space {
   font-size: 12px;
   font-weight: 400;
-  color: var(--wk-text-tertiary);
+  color: var(--wk-text-legacy-tertiary);
   line-height: 18px;
   white-space: nowrap;
   overflow: hidden;
@@ -69,7 +69,7 @@
 .wk-reply-block__digest {
   font-size: 12px;
   font-weight: 400;
-  color: var(--wk-text-secondary);
+  color: var(--wk-text-legacy-secondary);
   line-height: 18px;
   white-space: nowrap;
   overflow: hidden;

--- a/packages/dmworkbase/src/ui/message/SystemTag/index.css
+++ b/packages/dmworkbase/src/ui/message/SystemTag/index.css
@@ -10,7 +10,7 @@
   background-color: var(--wk-bg-elevated);
   border-radius: var(--wk-r-full);
   font-size: var(--wk-text-size-sm);
-  color: var(--wk-text-tertiary);
+  color: var(--wk-text-legacy-tertiary);
   user-select: none;
 }
 
@@ -44,7 +44,7 @@
   margin: 0;
   border: none;
   background: transparent;
-  color: var(--wk-text-secondary);
+  color: var(--wk-text-legacy-secondary);
   font-size: 16px;
   line-height: 1;
   cursor: pointer;
@@ -52,5 +52,5 @@
 }
 
 .wk-msg-system-tag-close:hover {
-  color: var(--wk-text-primary);
+  color: var(--wk-text-legacy-title);
 }

--- a/packages/dmworkbase/src/ui/message/SystemTag/index.css
+++ b/packages/dmworkbase/src/ui/message/SystemTag/index.css
@@ -7,10 +7,10 @@
   align-items: center;
   gap: var(--wk-sp-1);
   padding: var(--wk-sp-1) var(--wk-sp-2);
-  background-color: rgba(242, 243, 244, 1);
+  background-color: var(--wk-bg-elevated);
   border-radius: var(--wk-r-full);
   font-size: var(--wk-text-size-sm);
-  color: rgba(28, 28, 35, 0.4);
+  color: var(--wk-text-tertiary);
   user-select: none;
 }
 
@@ -44,7 +44,7 @@
   margin: 0;
   border: none;
   background: transparent;
-  color: rgba(28, 28, 35, 0.6);
+  color: var(--wk-text-secondary);
   font-size: 16px;
   line-height: 1;
   cursor: pointer;
@@ -52,5 +52,5 @@
 }
 
 .wk-msg-system-tag-close:hover {
-  color: rgba(28, 28, 35, 1);
+  color: var(--wk-text-primary);
 }

--- a/packages/dmworkbase/src/ui/message/TextContent/index.css
+++ b/packages/dmworkbase/src/ui/message/TextContent/index.css
@@ -4,7 +4,7 @@
 
 .wk-msg-text-content {
   font-size: 14px;
-  color: rgba(28, 28, 35, 0.8);
+  color: var(--wk-text-primary);
   line-height: 22px;
   word-wrap: break-word;
   word-break: break-word;

--- a/packages/dmworkbase/src/ui/message/TextContent/index.css
+++ b/packages/dmworkbase/src/ui/message/TextContent/index.css
@@ -4,7 +4,7 @@
 
 .wk-msg-text-content {
   font-size: 14px;
-  color: var(--wk-text-primary);
+  color: var(--wk-text-legacy-primary);
   line-height: 22px;
   word-wrap: break-word;
   word-break: break-word;

--- a/packages/dmworkbase/src/ui/message/Timestamp/index.css
+++ b/packages/dmworkbase/src/ui/message/Timestamp/index.css
@@ -4,6 +4,6 @@
 
 .wk-msg-timestamp {
   font-size: var(--wk-text-size-sm);
-  color: rgba(28, 28, 35, 0.4);
+  color: var(--wk-text-tertiary);
   user-select: none;
 }

--- a/packages/dmworkbase/src/ui/message/Timestamp/index.css
+++ b/packages/dmworkbase/src/ui/message/Timestamp/index.css
@@ -4,6 +4,6 @@
 
 .wk-msg-timestamp {
   font-size: var(--wk-text-size-sm);
-  color: var(--wk-text-tertiary);
+  color: var(--wk-text-legacy-tertiary);
   user-select: none;
 }

--- a/packages/dmworksummary/src/components/ChatSummaryNewModal.css
+++ b/packages/dmworksummary/src/components/ChatSummaryNewModal.css
@@ -10,6 +10,8 @@
     flex-direction: column;
     padding: 16px 16px 12px;
     overflow: auto;
+    color: var(--wk-text-primary);
+    background: var(--wk-bg-surface);
 }
 
 .chat-summary-modal-embedded .chat-summary-modal-header {
@@ -76,8 +78,8 @@
     flex-shrink: 0;
     margin: auto -16px -12px;
     padding: 10px 16px 12px;
-    background: var(--semi-color-bg-0);
-    border-top: 1px solid var(--semi-color-border);
+    background: var(--wk-bg-surface);
+    border-top: 1px solid var(--wk-border-default);
     z-index: 1;
 }
 
@@ -96,7 +98,7 @@
 .chat-summary-modal-title {
     font-size: 18px;
     font-weight: 600;
-    color: var(--wk-text-primary, #1C1F23);
+    color: var(--wk-text-primary);
 }
 
 .chat-summary-modal-ai-badge {
@@ -104,19 +106,20 @@
     font-weight: 500;
     padding: 2px 6px;
     border-radius: 4px;
-    background-color: var(--wk-color-primary, #3370FF);
-    color: #fff;
+    background-color: var(--wk-color-accent);
+    color: var(--wk-text-on-brand);
 }
 
 .chat-summary-modal-desc {
     font-size: 13px;
-    color: var(--wk-text-tertiary, #8F959E);
+    color: var(--wk-text-tertiary);
     line-height: 20px;
     margin-bottom: 16px;
 }
 
 .chat-summary-modal-input-area {
-    border: 1px solid var(--wk-border-default, #E5E6EB);
+    border: 1px solid var(--wk-border-default);
+    background: var(--wk-bg-surface);
     border-radius: 8px;
     margin-bottom: 16px;
     min-height: 200px;
@@ -126,7 +129,7 @@
 }
 
 .chat-summary-modal-input-area:focus-within {
-    border-color: var(--wk-border-default, #E5E6EB);
+    border-color: var(--wk-border-strong);
 }
 
 .chat-summary-modal-input-wrap {
@@ -145,7 +148,7 @@
     border-radius: 0;
     outline: none;
     background-color: transparent;
-    color: var(--wk-text-primary, #1C1F23);
+    color: var(--wk-text-primary);
     box-sizing: border-box;
     flex: 1;
     min-height: 40px;
@@ -164,7 +167,7 @@
 
 .chat-summary-modal-templates-label {
     font-size: 13px;
-    color: var(--wk-text-secondary, #646A73);
+    color: var(--wk-text-secondary);
     margin-bottom: 12px;
     padding: 0 12px;
 }

--- a/packages/dmworksummary/src/index.css
+++ b/packages/dmworksummary/src/index.css
@@ -148,7 +148,7 @@
     justify-content: flex-end;
     gap: 12px;
     padding: 16px;
-    background: #fff;
+    background: var(--wk-bg-surface);
     max-width: 984px;
     margin: 0 auto;
     width: 100%;
@@ -170,13 +170,13 @@
 }
 
 .summary-detail-footer-btn--cancel {
-    background: #fff;
-    border: 1px solid rgba(28, 28, 35, 0.1);
+    background: var(--wk-bg-surface);
+    border: 1px solid var(--wk-brand-tint-10);
     color: var(--wk-text-secondary);
 }
 
 .summary-detail-footer-btn--cancel:hover {
-    background: var(--wk-bg-hover);
+    background: var(--wk-brand-tint-02);
 }
 
 .summary-detail-footer-btn--save {
@@ -386,7 +386,7 @@ body[theme-mode="dark"] .summary-list-status-trigger:hover {
     border-radius: 12px;
     padding: 12px;
     cursor: pointer;
-    background: #fff;
+    background: var(--wk-summary-card-bg);
     transition: background-color 0.15s;
     display: flex;
     flex-direction: column;
@@ -394,16 +394,16 @@ body[theme-mode="dark"] .summary-list-status-trigger:hover {
 }
 
 .summary-card:hover {
-    background: #FCFBFF;
+    background: var(--wk-summary-card-hover-bg);
 }
 
 .summary-card--active {
-    background: linear-gradient(180deg, rgba(252, 243, 255, 0.8) 0%, rgba(255, 255, 255, 0.8) 90%, rgba(255, 255, 255, 0.8) 100%);
-    border: 2px solid #FFFFFF;
+    background: var(--wk-summary-card-active-bg);
+    border: 2px solid var(--wk-summary-card-active-border);
 }
 
 .summary-card--active:hover {
-    background: linear-gradient(180deg, rgba(252, 243, 255, 0.8) 0%, rgba(255, 255, 255, 0.8) 90%, rgba(255, 255, 255, 0.8) 100%);
+    background: var(--wk-summary-card-active-bg);
 }
 
 .summary-card-attention-dot {
@@ -455,7 +455,7 @@ body[theme-mode="dark"] .summary-list-status-trigger:hover {
     font-size: 12px;
     font-weight: 400;
     line-height: 18px;
-    color: rgba(28, 28, 35, 0.4);
+    color: var(--wk-text-legacy-tertiary);
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
@@ -517,7 +517,7 @@ body[theme-mode="dark"] .summary-list-status-trigger:hover {
     font-size: 14px;
     font-weight: 500;
     line-height: 18px;
-    color: #1C1C23;
+    color: var(--wk-text-legacy-title);
     display: -webkit-box;
     -webkit-line-clamp: 2;
     -webkit-box-orient: vertical;
@@ -528,7 +528,7 @@ body[theme-mode="dark"] .summary-list-status-trigger:hover {
     font-size: 12px;
     font-weight: 400;
     line-height: 16px;
-    color: rgba(28, 28, 35, 0.8);
+    color: var(--wk-text-legacy-primary);
     display: -webkit-box;
     -webkit-line-clamp: 2;
     -webkit-box-orient: vertical;
@@ -547,7 +547,7 @@ body[theme-mode="dark"] .summary-list-status-trigger:hover {
     font-size: 12px;
     font-weight: 400;
     line-height: 18px;
-    color: rgba(28, 28, 35, 0.4);
+    color: var(--wk-text-legacy-tertiary);
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
@@ -563,15 +563,15 @@ body[theme-mode="dark"] .summary-list-status-trigger:hover {
     border: none;
     background: none;
     cursor: pointer;
-    color: rgba(28, 28, 35, 0.4);
+    color: var(--wk-text-legacy-tertiary);
     border-radius: 4px;
     padding: 0;
     flex-shrink: 0;
 }
 
 .summary-card-more:hover {
-    background: rgba(28, 28, 35, 0.06);
-    color: rgba(28, 28, 35, 0.8);
+    background: var(--wk-brand-tint-06);
+    color: var(--wk-text-legacy-primary);
 }
 
 /* Dropdown menu */
@@ -591,7 +591,7 @@ body[theme-mode="dark"] .summary-list-status-trigger:hover {
 
 .summary-card-menu .semi-dropdown-item-danger,
 .summary-card-menu .semi-dropdown-item[data-type="danger"] {
-    color: #F54A45;
+    color: var(--wk-color-error);
 }
 
 /* ========== Summary Confirm PopConfirm ========== */
@@ -614,7 +614,7 @@ body[theme-mode="dark"] .summary-list-status-trigger:hover {
 
 .summary-confirm-icon {
     flex-shrink: 0;
-    color: #F54A45;
+    color: var(--wk-color-error);
     line-height: 1;
 }
 
@@ -628,14 +628,14 @@ body[theme-mode="dark"] .summary-list-status-trigger:hover {
     font-size: 18px;
     font-weight: 600;
     line-height: 24px;
-    color: var(--wk-text-primary);
+    color: var(--wk-text-legacy-title);
 }
 
 .summary-confirm-desc {
     font-size: 14px;
     font-weight: 400;
     line-height: 20px;
-    color: var(--wk-text-primary);
+    color: var(--wk-text-legacy-title);
 }
 
 .summary-confirm-close {
@@ -643,13 +643,13 @@ body[theme-mode="dark"] .summary-list-status-trigger:hover {
     background: none;
     cursor: pointer;
     padding: 0;
-    color: rgba(28, 28, 35, 0.4);
+    color: var(--wk-text-legacy-tertiary);
     line-height: 1;
     flex-shrink: 0;
 }
 
 .summary-confirm-close:hover {
-    color: rgba(28, 28, 35, 0.8);
+    color: var(--wk-text-legacy-primary);
 }
 
 .summary-confirm-footer {
@@ -682,31 +682,31 @@ body[theme-mode="dark"] .summary-list-status-trigger:hover {
 }
 
 .summary-confirm-btn--cancel:hover {
-    background: rgba(28, 28, 35, 0.02);
+    background: var(--wk-bg-legacy-hover-subtle);
 }
 
 .summary-confirm-btn--danger {
-    background: #F54A45;
-    color: #fff;
+    background: var(--wk-color-error);
+    color: var(--wk-text-on-brand);
     font-size: 14px;
     font-weight: 600;
     line-height: 20px;
 }
 
 .summary-confirm-btn--danger:hover {
-    background: #E03A32;
+    background: var(--wk-summary-danger-hover);
 }
 
 .summary-confirm-btn--dark {
-    background: #1C1C23;
-    color: #fff;
+    background: var(--wk-brand-primary);
+    color: var(--wk-text-on-brand);
     font-size: 12px;
     font-weight: 600;
     line-height: 20px;
 }
 
 .summary-confirm-btn--dark:hover {
-    background: #333;
+    background: var(--wk-summary-dark-button-hover);
 }
 
 /* Regenerate modal */
@@ -855,13 +855,13 @@ body[theme-mode="dark"] .summary-list-status-trigger:hover {
 }
 
 .summary-card-respond-btn--accept {
-    background: #1C1C23;
-    color: #fff;
+    background: var(--wk-brand-primary);
+    color: var(--wk-text-on-brand);
 }
 
 .summary-card-respond-btn--reject {
-    background: rgba(28, 28, 35, 0.06);
-    color: rgba(28, 28, 35, 0.6);
+    background: var(--wk-brand-tint-06);
+    color: var(--wk-text-legacy-secondary);
 }
 
 /* Sidebar reuse */
@@ -1082,7 +1082,7 @@ body[theme-mode="dark"] .summary-list-status-trigger:hover {
     margin: 0;
     font-size: 17px;
     font-weight: 600;
-    color: #1C1C23;
+    color: var(--wk-text-legacy-title);
     line-height: 24px;
     overflow: visible !important;
     text-overflow: clip !important;
@@ -1155,7 +1155,7 @@ body[theme-mode="dark"] .summary-list-status-trigger:hover {
     font-size: 14px;
     font-weight: 400;
     line-height: 20px;
-    color: #000000;
+    color: var(--wk-text-legacy-absolute);
 }
 
 .summary-progress-copy {
@@ -1166,13 +1166,13 @@ body[theme-mode="dark"] .summary-list-status-trigger:hover {
     font-size: 14px;
     font-weight: 400;
     line-height: 20px;
-    color: #000000;
+    color: var(--wk-text-legacy-absolute);
 }
 
 .summary-progress-desc {
     margin-top: 4px;
     font-size: 14px;
-    color: rgba(28, 28, 35, 0.6);
+    color: var(--wk-icon-default);
 }
 
 .summary-detail-processing h3 {
@@ -1209,12 +1209,12 @@ body[theme-mode="dark"] .summary-list-status-trigger:hover {
     font-size: 14px;
     font-weight: 500;
     line-height: 20px;
-    color: #1C1C23;
+    color: var(--wk-text-legacy-title);
     margin: 0;
 }
 
 .summary-detail-failed-reason {
-    color: rgba(28, 28, 35, 0.6);
+    color: var(--wk-icon-default);
     margin: 0;
     padding: 0;
     background: transparent;
@@ -1255,7 +1255,7 @@ body[theme-mode="dark"] .summary-list-status-trigger:hover {
 /* Result */
 .summary-detail-result {
     margin-bottom: 0;
-    background: rgba(28, 28, 35, 0.03);
+    background: var(--wk-brand-tint-03);
     border: none;
     border-radius: 12px;
     padding: 24px;
@@ -1300,7 +1300,7 @@ body[theme-mode="dark"] .summary-list-status-trigger:hover {
     font-size: 14px;
     font-weight: 400;
     line-height: 20px;
-    color: rgba(28, 31, 35, 0.6);
+    color: var(--wk-summary-meta-text);
     text-align: left;
 }
 
@@ -1317,7 +1317,7 @@ body[theme-mode="dark"] .summary-list-status-trigger:hover {
     align-items: center;
     padding: 4px 12px;
     height: 24px;
-    background: rgba(28, 31, 35, 0.06);
+    background: var(--wk-summary-chip-bg);
     border-radius: 99px;
     font-size: 12px;
     font-weight: 400;
@@ -1329,7 +1329,7 @@ body[theme-mode="dark"] .summary-list-status-trigger:hover {
 /* Divider between meta and content */
 .summary-detail-meta-divider {
     height: 1px;
-    background: rgba(28, 28, 35, 0.15);
+    background: var(--wk-brand-tint-15);
     border: none;
     margin: 0;
 }
@@ -1376,7 +1376,7 @@ body[theme-mode="dark"] .summary-list-status-trigger:hover {
 .summary-detail-personal,
 .summary-detail-team,
 .summary-detail-members {
-    background: rgba(28, 28, 35, 0.03);
+    background: var(--wk-brand-tint-03);
     border: none;
     border-radius: 12px;
     padding: 24px;
@@ -1464,7 +1464,7 @@ body[theme-mode="dark"] .summary-list-status-trigger:hover {
 .summary-detail-content-box {
     line-height: 22px;
     font-size: 14px;
-    color: #1C1F23;
+    color: var(--wk-summary-content-text);
 }
 
 .summary-detail-content-box .summary-content-markdown table {
@@ -1512,7 +1512,7 @@ body[theme-mode="dark"] .summary-list-status-trigger:hover {
     resize: none !important;
     font-family: inherit;
     color: var(--semi-color-text-0);
-    background-color: #fff;
+    background-color: var(--wk-bg-surface);
     outline: none;
     box-sizing: border-box;
     overflow-y: auto !important;
@@ -1769,7 +1769,7 @@ body[theme-mode="dark"] .summary-list-status-trigger:hover {
 .summary-content-markdown {
     line-height: 22px;
     font-size: 14px;
-    color: #1C1F23;
+    color: var(--wk-summary-content-text);
     counter-reset: md-section;
 }
 
@@ -1778,7 +1778,7 @@ body[theme-mode="dark"] .summary-list-status-trigger:hover {
     margin: 20px 0 14px;
     font-weight: 500;
     line-height: 26px;
-    color: #1C1F23;
+    color: var(--wk-summary-content-text);
     border-bottom: none;
     padding-bottom: 0;
 }
@@ -1791,7 +1791,7 @@ body[theme-mode="dark"] .summary-list-status-trigger:hover {
     font-weight: 600;
     line-height: 26px;
     letter-spacing: -0.01em;
-    color: #1C1F23;
+    color: var(--wk-summary-content-text);
     counter-increment: md-section;
     display: flex;
     align-items: baseline;
@@ -1814,7 +1814,7 @@ body[theme-mode="dark"] .summary-list-status-trigger:hover {
     margin: 16px 0 8px;
     font-weight: 600;
     line-height: 24px;
-    color: #1C1F23;
+    color: var(--wk-summary-content-text);
 }
 
 .summary-content-markdown p {
@@ -1832,7 +1832,7 @@ body[theme-mode="dark"] .summary-list-status-trigger:hover {
     margin: 6px 0;
     line-height: 22px;
     font-size: 14px;
-    color: #1C1F23;
+    color: var(--wk-summary-content-text);
 }
 
 .summary-content-markdown blockquote {
@@ -1974,16 +1974,16 @@ body[theme-mode="dark"] .summary-list-status-trigger:hover {
 }
 
 .summary-progress-stage-done {
-    color: rgba(0, 0, 0, 0.4);
+    color: var(--wk-summary-progress-muted);
 }
 
 .summary-progress-stage-active {
-    color: rgba(0, 0, 0, 0.8);
+    color: var(--wk-summary-progress-active);
     font-weight: 400;
 }
 
 .summary-progress-stage-pending {
-    color: rgba(0, 0, 0, 0.4);
+    color: var(--wk-summary-progress-muted);
 }
 
 .summary-progress-stage-failed {
@@ -2678,7 +2678,7 @@ body[theme-mode="dark"] .summary-list-status-trigger:hover {
 }
 
 .chat-summary-template-card:hover {
-    background-color: var(--wk-bg-hover);
+    background-color: var(--wk-purple-alpha-04);
 }
 
 .chat-summary-template-card:active {
@@ -3788,7 +3788,7 @@ body.summary-version-detail-open .summary-schedule-page {
 }
 
 .chat-selector-item:hover {
-    background: var(--wk-bg-hover);
+    background: var(--wk-bg-legacy-hover-subtle);
 }
 
 .chat-selector-item--indent {
@@ -3848,7 +3848,7 @@ body.summary-version-detail-open .summary-schedule-page {
 }
 
 .chat-selector-selected-item:hover {
-    background: var(--wk-bg-hover);
+    background: var(--wk-bg-legacy-hover-subtle);
 }
 
 .chat-selector-selected-name {
@@ -3906,7 +3906,7 @@ body.summary-version-detail-open .summary-schedule-page {
 }
 
 .chat-selector-btn--cancel:hover {
-    background: var(--wk-bg-hover);
+    background: var(--wk-bg-legacy-hover-subtle);
 }
 
 .chat-selector-btn--confirm {
@@ -4145,13 +4145,13 @@ body.summary-version-detail-open .summary-schedule-page {
     padding: 0 5px;
     border-radius: var(--wk-r-full);
     background: var(--wk-color-accent);
-    color: #fff;
+    color: var(--wk-text-on-brand);
     font-size: 11px;
     font-weight: 600;
     line-height: 18px;
 }
 .summary-version-trigger.is-active .summary-version-trigger-count {
-    background: #fff;
+    background: var(--wk-bg-surface);
     color: var(--wk-color-accent);
 }
 

--- a/packages/dmworksummary/src/index.css
+++ b/packages/dmworksummary/src/index.css
@@ -268,13 +268,23 @@ body[theme-mode="dark"] .summary-list-create-icon-btn:hover {
     gap: 8px;
     height: 32px;
     padding: 0 12px;
-    border: 1px solid var(--wk-border-default);
+    border: 1px solid transparent;
     border-radius: 99px;
-    background: var(--wk-bg-elevated);
+    background: var(--wk-bg-legacy-card);
     transition: border-color var(--wk-dur-fast) var(--wk-ease), background-color var(--wk-dur-fast) var(--wk-ease);
 }
 
 .summary-list-search-wrap:focus-within {
+    border-color: transparent;
+    background: var(--wk-bg-legacy-card);
+}
+
+body[theme-mode="dark"] .summary-list-search-wrap {
+    border-color: var(--wk-border-default);
+    background: var(--wk-bg-elevated);
+}
+
+body[theme-mode="dark"] .summary-list-search-wrap:focus-within {
     border-color: var(--wk-border-strong);
     background: var(--wk-bg-surface);
 }
@@ -674,7 +684,7 @@ body[theme-mode="dark"] .summary-list-status-trigger:hover {
 
 .summary-confirm-btn--cancel {
     background: var(--wk-bg-surface);
-    border: 1px solid var(--wk-border-default);
+    border: 1px solid var(--wk-brand-tint-10);
     color: var(--wk-text-secondary);
     font-size: 12px;
     font-weight: 600;
@@ -753,12 +763,12 @@ body[theme-mode="dark"] .summary-list-status-trigger:hover {
 }
 
 .summary-regenerate-mode:hover {
-    background: var(--wk-bg-elevated);
+    background: var(--semi-color-fill-0);
 }
 
 .summary-regenerate-mode--selected {
-    border-color: var(--wk-border-glow);
-    background: var(--wk-bg-selected);
+    border-color: var(--semi-color-primary);
+    background: var(--semi-color-primary-light-default);
 }
 
 .summary-regenerate-mode__indicator {
@@ -1172,7 +1182,7 @@ body[theme-mode="dark"] .summary-list-status-trigger:hover {
 .summary-progress-desc {
     margin-top: 4px;
     font-size: 14px;
-    color: var(--wk-icon-default);
+    color: var(--wk-text-legacy-secondary);
 }
 
 .summary-detail-processing h3 {
@@ -1214,7 +1224,7 @@ body[theme-mode="dark"] .summary-list-status-trigger:hover {
 }
 
 .summary-detail-failed-reason {
-    color: var(--wk-icon-default);
+    color: var(--wk-text-legacy-secondary);
     margin: 0;
     padding: 0;
     background: transparent;
@@ -1698,7 +1708,7 @@ body[theme-mode="dark"] .summary-list-status-trigger:hover {
 .summary-detail-participant-report-toggle {
     margin-top: 12px;
     font-size: 13px;
-    color: var(--wk-color-accent);
+    color: var(--semi-color-primary);
     font-weight: 500;
 }
 
@@ -2303,11 +2313,16 @@ body[theme-mode="dark"] .summary-list-status-trigger:hover {
     margin-left: auto;
     display: flex;
     gap: 0;
-    background: var(--wk-bg-elevated);
-    border: 1px solid var(--wk-border-default);
+    background: var(--semi-color-fill-0);
+    border: 1px solid transparent;
     border-radius: var(--semi-border-radius-full);
     padding: 2px;
     flex-shrink: 0;
+}
+
+body[theme-mode="dark"] .summary-workbench-mode-switch {
+    background: var(--wk-bg-elevated);
+    border-color: var(--wk-border-default);
 }
 
 .summary-workbench-mode-btn {
@@ -2479,7 +2494,7 @@ body[theme-mode="dark"] .summary-list-status-trigger:hover {
 /* Divider */
 .summary-workbench-divider {
     height: 1px;
-    background: var(--wk-border-default);
+    background: var(--wk-brand-tint-15);
     flex-shrink: 0;
 }
 
@@ -2572,8 +2587,8 @@ body[theme-mode="dark"] .summary-list-status-trigger:hover {
     gap: 4px;
     padding: 2px 6px 2px 4px;
     height: 24px;
-    background: var(--wk-bg-elevated);
-    border: 1px solid var(--wk-border-default);
+    background: var(--wk-bg-legacy-surface);
+    border: 1px solid var(--wk-brand-tint-08);
     border-radius: 99px;
     flex-shrink: 0;
     white-space: nowrap;
@@ -2669,12 +2684,16 @@ body[theme-mode="dark"] .summary-list-status-trigger:hover {
     border: 1px solid transparent;
     border-radius: 12px;
     cursor: pointer;
-    background-color: var(--wk-bg-elevated);
-    border-color: var(--wk-border-default);
+    background-color: var(--wk-bg-legacy-card);
     transition: background-color 0.15s;
     overflow: hidden;
     position: relative;
     box-sizing: border-box;
+}
+
+body[theme-mode="dark"] .chat-summary-template-card {
+    background-color: var(--wk-bg-elevated);
+    border-color: var(--wk-border-default);
 }
 
 .chat-summary-template-card:hover {
@@ -2683,6 +2702,10 @@ body[theme-mode="dark"] .summary-list-status-trigger:hover {
 
 .chat-summary-template-card:active {
     background-color: var(--wk-bg-selected);
+    border-color: var(--wk-purple-alpha-20);
+}
+
+body[theme-mode="dark"] .chat-summary-template-card:active {
     border-color: var(--wk-border-glow);
 }
 
@@ -2847,8 +2870,8 @@ body[theme-mode="dark"] .summary-template-create-btn:hover {
 }
 
 .summary-template-custom-empty:hover {
-    border-color: var(--wk-border-glow);
-    background: var(--wk-bg-selected);
+    border-color: var(--semi-color-primary);
+    background: var(--semi-color-primary-light-default);
 }
 
 .summary-template-custom-empty-title {
@@ -2886,7 +2909,7 @@ body[theme-mode="dark"] .summary-template-create-btn:hover {
     flex-shrink: 0;
     padding: 0;
     border: 0;
-    color: var(--wk-color-accent);
+    color: var(--semi-color-primary);
     background: transparent;
     font-size: var(--wk-text-size-sm);
     line-height: var(--wk-line-height-sm);
@@ -2894,7 +2917,7 @@ body[theme-mode="dark"] .summary-template-create-btn:hover {
 }
 
 .summary-template-applied-action:hover {
-    color: var(--wk-color-accent-hover);
+    color: var(--semi-color-primary-hover);
 }
 
 /* ========== Mobile Responsive ========== */
@@ -3303,7 +3326,7 @@ body[theme-mode="dark"] .summary-template-create-btn:hover {
 .summary-template-more-button {
     border: 0;
     background: transparent;
-    color: var(--wk-color-accent);
+    color: var(--semi-color-primary);
     font-size: var(--wk-text-size-sm);
     line-height: var(--wk-line-height-sm);
     padding: var(--wk-sp-1) 0;
@@ -3312,7 +3335,7 @@ body[theme-mode="dark"] .summary-template-create-btn:hover {
 }
 
 .summary-template-more-button:hover {
-    color: var(--wk-color-accent-hover);
+    color: var(--semi-color-primary-hover);
 }
 
 .summary-more-template-grid {
@@ -3571,8 +3594,8 @@ body.summary-version-detail-open .summary-schedule-page {
     gap: 4px;
     padding: 4px 10px;
     border-radius: 4px;
-    background: var(--wk-bg-elevated);
-    color: var(--wk-color-accent);
+    background: var(--semi-color-fill-0);
+    color: var(--semi-color-primary);
     font-size: 13px;
     cursor: pointer;
     user-select: none;
@@ -3580,14 +3603,14 @@ body.summary-version-detail-open .summary-schedule-page {
     margin-right: 8px;
 }
 .summary-workbench-ref-btn:hover {
-    background: var(--wk-bg-hover);
+    background: var(--semi-color-fill-1);
 }
 .summary-workbench-ref-btn--disabled {
     opacity: 0.5;
     cursor: not-allowed;
 }
 .summary-workbench-ref-btn--disabled:hover {
-    background: var(--wk-bg-elevated);
+    background: var(--semi-color-fill-0);
 }
 /* 已引用卡片 */
 .summary-workbench-ref-card {
@@ -3596,14 +3619,19 @@ body.summary-version-detail-open .summary-schedule-page {
     gap: 6px;
     padding: 4px 10px;
     border-radius: 4px;
-    background: var(--wk-bg-selected);
-    border: 1px solid var(--wk-border-glow);
+    background: var(--semi-color-primary-light-default);
     font-size: 13px;
     margin-right: 8px;
     max-width: 320px;
 }
+
+body[theme-mode="dark"] .summary-workbench-ref-card {
+    background: var(--wk-bg-selected);
+    border: 1px solid var(--wk-border-glow);
+}
+
 .summary-workbench-ref-card-label {
-    color: var(--wk-color-accent);
+    color: var(--semi-color-primary);
     font-weight: 500;
     flex-shrink: 0;
 }
@@ -3633,7 +3661,7 @@ body.summary-version-detail-open .summary-schedule-page {
     left: 0;
     right: 0;
     bottom: 0;
-    background: var(--wk-black-alpha-50);
+    background: var(--wk-overlay-scrim);
     display: flex;
     align-items: center;
     justify-content: center;
@@ -3645,12 +3673,15 @@ body.summary-version-detail-open .summary-schedule-page {
     max-height: 560px;
     color: var(--wk-text-primary);
     background: var(--wk-bg-surface);
-    border: 1px solid var(--wk-border-default);
     border-radius: 12px;
-    box-shadow: var(--wk-shadow-lg);
+    box-shadow: var(--wk-chat-selector-shadow);
     display: flex;
     flex-direction: column;
     overflow: hidden;
+}
+
+body[theme-mode="dark"] .chat-selector-modal {
+    border: 1px solid var(--wk-border-default);
 }
 
 .chat-selector-header {
@@ -3658,7 +3689,7 @@ body.summary-version-detail-open .summary-schedule-page {
     align-items: center;
     justify-content: space-between;
     padding: 16px;
-    border-bottom: 1px solid var(--wk-border-default);
+    border-bottom: 1px solid var(--wk-brand-tint-15);
 }
 
 .chat-selector-title {
@@ -3693,7 +3724,7 @@ body.summary-version-detail-open .summary-schedule-page {
     flex-shrink: 0;
     display: flex;
     flex-direction: column;
-    border-right: 1px solid var(--wk-border-default);
+    border-right: 1px solid var(--wk-brand-tint-15);
 }
 
 .chat-selector-search {
@@ -3883,7 +3914,7 @@ body.summary-version-detail-open .summary-schedule-page {
     justify-content: flex-end;
     gap: 12px;
     padding: 16px;
-    border-top: 1px solid var(--wk-border-default);
+    border-top: 1px solid var(--wk-brand-tint-15);
 }
 
 .chat-selector-btn {
@@ -3899,7 +3930,7 @@ body.summary-version-detail-open .summary-schedule-page {
 
 .chat-selector-btn--cancel {
     background: var(--wk-bg-surface);
-    border: 1px solid var(--wk-border-default);
+    border: 1px solid var(--wk-brand-tint-10);
     color: var(--wk-text-secondary);
     font-size: 12px;
     font-weight: 600;

--- a/packages/dmworksummary/src/index.css
+++ b/packages/dmworksummary/src/index.css
@@ -10,6 +10,8 @@
     flex-direction: column;
     position: relative;
     padding: 20px 16px;
+    color: var(--wk-text-primary);
+    background: var(--wk-bg-surface);
 }
 
 .summary-create-page,
@@ -25,6 +27,8 @@
     position: relative;
     padding: 20px 16px;
     overflow-y: auto;
+    color: var(--wk-text-primary);
+    background: var(--wk-bg-surface);
 }
 
 .summary-list-page {
@@ -50,7 +54,7 @@
     text-align: center;
     padding: 12px 0;
     font-size: 12px;
-    color: rgba(28, 28, 35, 0.4);
+    color: var(--wk-text-tertiary);
 }
 
 /* 面板模式：去掉 max-width 居中，收紧 padding，占满父容器宽度 */
@@ -91,7 +95,8 @@
     padding: 0;
     overflow: hidden;
     isolation: isolate;
-    background: #fff;
+    color: var(--wk-text-primary);
+    background: var(--wk-bg-surface);
 }
 
 /* 禁用 WKViewQueue 路由切换动画（右滑入/出），总结相关页面直接显示 */
@@ -128,6 +133,7 @@
     flex: 1;
     overflow-y: auto;
     padding: 0;
+    background: var(--wk-bg-surface);
 }
 
 .summary-detail-sources-footer {
@@ -166,20 +172,20 @@
 .summary-detail-footer-btn--cancel {
     background: #fff;
     border: 1px solid rgba(28, 28, 35, 0.1);
-    color: rgba(28, 28, 35, 0.8);
+    color: var(--wk-text-secondary);
 }
 
 .summary-detail-footer-btn--cancel:hover {
-    background: rgba(28, 28, 35, 0.02);
+    background: var(--wk-bg-hover);
 }
 
 .summary-detail-footer-btn--save {
-    background: #1C1C23;
-    color: #fff;
+    background: var(--wk-brand-primary);
+    color: var(--wk-text-on-brand);
 }
 
 .summary-detail-footer-btn--save:hover {
-    background: #333;
+    background: var(--wk-brand-primary-hover);
 }
 
 /* 详情页内容区域 - 使用更宽敞的布局 */
@@ -218,6 +224,35 @@
     gap: 8px;
 }
 
+.summary-list-create-icon-btn {
+    width: 32px;
+    height: 32px;
+    min-width: 32px;
+    padding: 0;
+    border-radius: var(--wk-r-sm);
+    color: var(--wk-text-primary);
+    background: transparent;
+}
+
+.summary-list-create-icon-btn:hover {
+    color: var(--wk-text-primary);
+    background: var(--wk-bg-elevated);
+}
+
+body[theme-mode="dark"] .summary-list-create-icon-btn {
+    color: var(--wk-text-on-brand);
+    background: var(--wk-brand-primary);
+}
+
+body[theme-mode="dark"] .summary-list-create-icon-btn:hover {
+    color: var(--wk-text-on-brand);
+    background: var(--wk-brand-primary-hover);
+}
+
+.summary-list-create-icon-btn .semi-icon {
+    color: currentColor;
+}
+
 .summary-list-toolbar {
     display: flex;
     align-items: center;
@@ -233,12 +268,19 @@
     gap: 8px;
     height: 32px;
     padding: 0 12px;
+    border: 1px solid var(--wk-border-default);
     border-radius: 99px;
-    background: rgba(28, 28, 35, 0.04);
+    background: var(--wk-bg-elevated);
+    transition: border-color var(--wk-dur-fast) var(--wk-ease), background-color var(--wk-dur-fast) var(--wk-ease);
+}
+
+.summary-list-search-wrap:focus-within {
+    border-color: var(--wk-border-strong);
+    background: var(--wk-bg-surface);
 }
 
 .summary-list-search-icon {
-    color: rgba(28, 28, 35, 0.4);
+    color: var(--wk-text-tertiary);
     flex-shrink: 0;
 }
 
@@ -251,11 +293,11 @@
     font-family: inherit;
     font-size: 14px;
     line-height: 20px;
-    color: var(--semi-color-text-0);
+    color: var(--wk-text-primary);
 }
 
 .summary-list-search-input::placeholder {
-    color: rgba(28, 28, 35, 0.4);
+    color: var(--wk-text-tertiary);
 }
 
 .summary-list-status-trigger {
@@ -265,13 +307,22 @@
     cursor: pointer;
     font-size: 14px;
     line-height: 20px;
-    color: var(--semi-color-text-0);
+    color: var(--wk-text-secondary);
     white-space: nowrap;
     flex-shrink: 0;
+    transition: color var(--wk-dur-fast) var(--wk-ease);
 }
 
 .summary-list-status-trigger:hover {
-    color: var(--semi-color-primary);
+    color: var(--wk-text-primary);
+}
+
+body[theme-mode="dark"] .summary-list-status-trigger {
+    color: var(--wk-text-primary);
+}
+
+body[theme-mode="dark"] .summary-list-status-trigger:hover {
+    color: var(--wk-text-accent);
 }
 
 .summary-list-search {
@@ -577,14 +628,14 @@
     font-size: 18px;
     font-weight: 600;
     line-height: 24px;
-    color: #1C1C23;
+    color: var(--wk-text-primary);
 }
 
 .summary-confirm-desc {
     font-size: 14px;
     font-weight: 400;
     line-height: 20px;
-    color: #1C1C23;
+    color: var(--wk-text-primary);
 }
 
 .summary-confirm-close {
@@ -622,9 +673,9 @@
 }
 
 .summary-confirm-btn--cancel {
-    background: #fff;
-    border: 1px solid rgba(28, 28, 35, 0.1);
-    color: rgba(28, 28, 35, 0.8);
+    background: var(--wk-bg-surface);
+    border: 1px solid var(--wk-border-default);
+    color: var(--wk-text-secondary);
     font-size: 12px;
     font-weight: 600;
     line-height: 20px;
@@ -702,12 +753,12 @@
 }
 
 .summary-regenerate-mode:hover {
-    background: var(--semi-color-fill-0);
+    background: var(--wk-bg-elevated);
 }
 
 .summary-regenerate-mode--selected {
-    border-color: var(--semi-color-primary);
-    background: var(--semi-color-primary-light-default);
+    border-color: var(--wk-border-glow);
+    background: var(--wk-bg-selected);
 }
 
 .summary-regenerate-mode__indicator {
@@ -738,7 +789,7 @@
 
 .summary-regenerate-mode__desc {
     margin-top: var(--wk-sp-1);
-    color: var(--semi-color-text-2);
+    color: var(--wk-text-tertiary);
     font-size: var(--wk-text-size-sm);
     line-height: var(--wk-leading-normal);
 }
@@ -939,7 +990,7 @@
     display: block;
     font-weight: 500;
     margin-bottom: 8px;
-    color: var(--semi-color-text-0);
+    color: var(--wk-text-primary);
 }
 
 /* ========== Confirm Info ========== */
@@ -1192,7 +1243,7 @@
     border: 1px solid var(--semi-color-border);
     border-radius: 8px;
     margin: 28px 0;
-    color: var(--semi-color-text-1);
+    color: var(--wk-text-secondary);
 }
 
 .summary-detail-cancelled p,
@@ -1271,7 +1322,7 @@
     font-size: 12px;
     font-weight: 400;
     line-height: 16px;
-    color: rgba(28, 28, 35, 0.6);
+    color: var(--wk-text-secondary);
     white-space: nowrap;
 }
 
@@ -1647,7 +1698,7 @@
 .summary-detail-participant-report-toggle {
     margin-top: 12px;
     font-size: 13px;
-    color: var(--semi-color-primary);
+    color: var(--wk-color-accent);
     font-weight: 500;
 }
 
@@ -2213,7 +2264,8 @@
     height: 100%;
     padding: 80px 32px;
     overflow-y: auto;
-    background: #fff;
+    color: var(--wk-text-primary);
+    background: var(--wk-bg-surface);
 }
 
 /* 面板模式 */
@@ -2222,6 +2274,8 @@
     overflow: visible;
     height: auto;
     min-height: 100%;
+    color: var(--wk-text-primary);
+    background: var(--wk-bg-surface);
 }
 
 .summary-workbench--panel > .summary-workbench-header,
@@ -2249,7 +2303,8 @@
     margin-left: auto;
     display: flex;
     gap: 0;
-    background: var(--semi-color-fill-0);
+    background: var(--wk-bg-elevated);
+    border: 1px solid var(--wk-border-default);
     border-radius: var(--semi-border-radius-full);
     padding: 2px;
     flex-shrink: 0;
@@ -2265,18 +2320,18 @@
     line-height: 20px;
     padding: 4px 12px;
     border-radius: var(--semi-border-radius-full);
-    color: var(--semi-color-text-2);
+    color: var(--wk-text-tertiary);
     white-space: nowrap;
     transition: background 0.15s, color 0.15s;
 }
 
 .summary-workbench-mode-btn--active {
-    background: var(--semi-color-bg-1);
-    color: var(--semi-color-text-0);
+    background: var(--wk-bg-surface);
+    color: var(--wk-text-primary);
 }
 
 .summary-workbench-mode-btn:not(.summary-workbench-mode-btn--active):hover {
-    color: var(--semi-color-text-1);
+    color: var(--wk-text-secondary);
 }
 
 .summary-workbench-header-emoji {
@@ -2289,7 +2344,7 @@
     font-size: 24px;
     font-weight: 600;
     line-height: 36px;
-    color: var(--semi-color-text-0);
+    color: var(--wk-text-primary);
 }
 
 /* Content card */
@@ -2299,6 +2354,7 @@
     padding: 24px;
     gap: 24px;
     border-radius: 12px;
+    background: var(--wk-bg-surface);
 }
 
 /* Agent 模式：给 AgentChatPanel 一个确定的有界高度 */
@@ -2335,7 +2391,7 @@
     font-size: 14px;
     line-height: 20px;
     overflow-y: auto;
-    color: var(--semi-color-text-0);
+    color: var(--wk-text-primary);
     box-sizing: border-box;
 }
 
@@ -2345,7 +2401,7 @@
     justify-content: space-between;
     padding: 4px 0;
     font-size: 12px;
-    color: rgba(28, 28, 35, 0.4);
+    color: var(--wk-text-tertiary);
     flex-shrink: 0;
 }
 
@@ -2357,7 +2413,7 @@
 }
 
 .summary-workbench-textarea::placeholder {
-    color: rgba(28, 28, 34, 0.4);
+    color: var(--wk-text-tertiary);
 }
 
 /* Templates section */
@@ -2371,7 +2427,7 @@
     font-size: 14px;
     font-weight: 600;
     line-height: 22px;
-    color: var(--semi-color-text-0);
+    color: var(--wk-text-primary);
 }
 
 .summary-workbench-templates {
@@ -2423,7 +2479,7 @@
 /* Divider */
 .summary-workbench-divider {
     height: 1px;
-    background: rgba(28, 28, 35, 0.15);
+    background: var(--wk-border-default);
     flex-shrink: 0;
 }
 
@@ -2452,12 +2508,12 @@
     font-size: 14px;
     font-weight: 600;
     line-height: 20px;
-    color: var(--semi-color-text-0);
+    color: var(--wk-text-primary);
     white-space: nowrap;
 }
 
 .summary-workbench-required-asterisk {
-    color: #F5394C;
+    color: var(--wk-color-error);
     font-style: normal;
     font-size: 14px;
     margin-left: 2px;
@@ -2467,7 +2523,7 @@
     font-size: 14px;
     font-weight: 400;
     line-height: 20px;
-    color: rgba(28, 28, 35, 0.4);
+    color: var(--wk-text-tertiary);
 }
 
 .summary-workbench-add-chat {
@@ -2516,8 +2572,8 @@
     gap: 4px;
     padding: 2px 6px 2px 4px;
     height: 24px;
-    background: #fff;
-    border: 1px solid rgba(28, 28, 35, 0.08);
+    background: var(--wk-bg-elevated);
+    border: 1px solid var(--wk-border-default);
     border-radius: 99px;
     flex-shrink: 0;
     white-space: nowrap;
@@ -2531,7 +2587,7 @@
     font-size: 12px;
     font-weight: 400;
     line-height: 20px;
-    color: #1C1C23;
+    color: var(--wk-text-primary);
     max-width: 80px;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -2545,19 +2601,19 @@
     padding: 0;
     display: inline-flex;
     align-items: center;
-    color: rgba(28, 28, 35, 0.4);
+    color: var(--wk-text-tertiary);
     flex-shrink: 0;
 }
 
 .summary-workbench-chat-chip-close:hover {
-    color: rgba(28, 28, 35, 0.8);
+    color: var(--wk-text-secondary);
 }
 
 .summary-workbench-chat-chip-overflow {
     font-size: 12px;
     font-weight: 400;
     line-height: 20px;
-    color: #1C1C23;
+    color: var(--wk-text-primary);
     cursor: pointer;
     flex-shrink: 0;
     white-space: nowrap;
@@ -2585,12 +2641,12 @@
 }
 
 .summary-workbench-start-btn:disabled {
-    background-color: rgba(28, 28, 35, 0.06) !important;
-    color: rgba(28, 28, 35, 0.2) !important;
+    background-color: var(--wk-bg-elevated) !important;
+    color: var(--wk-text-disabled) !important;
 }
 
 .summary-workbench-start-btn:disabled svg {
-    color: rgba(28, 28, 35, 0.2);
+    color: var(--wk-text-disabled);
     margin-right: 4px;
 }
 
@@ -2613,7 +2669,8 @@
     border: 1px solid transparent;
     border-radius: 12px;
     cursor: pointer;
-    background-color: rgba(28, 28, 35, 0.04);
+    background-color: var(--wk-bg-elevated);
+    border-color: var(--wk-border-default);
     transition: background-color 0.15s;
     overflow: hidden;
     position: relative;
@@ -2621,12 +2678,12 @@
 }
 
 .chat-summary-template-card:hover {
-    background-color: rgba(127, 59, 245, 0.04);
+    background-color: var(--wk-bg-hover);
 }
 
 .chat-summary-template-card:active {
-    background-color: rgba(127, 59, 245, 0.06);
-    border: 1px solid rgba(127, 59, 245, 0.2);
+    background-color: var(--wk-bg-selected);
+    border-color: var(--wk-border-glow);
 }
 
 .chat-summary-template-card:active .chat-summary-template-card-title {
@@ -2634,7 +2691,7 @@
 }
 
 .chat-summary-template-card:active .chat-summary-template-card-desc {
-    color: rgba(127, 59, 245, 0.8);
+    color: var(--wk-text-accent);
 }
 
 .chat-summary-template-card-custom {
@@ -2644,7 +2701,7 @@
 .chat-summary-template-card-icon {
     display: inline-flex;
     align-items: center;
-    color: var(--semi-color-text-2);
+    color: var(--wk-text-tertiary);
     flex-shrink: 0;
 }
 
@@ -2663,7 +2720,7 @@
 }
 
 .chat-summary-template-card-title {
-    color: #1C1C23;
+    color: var(--wk-text-primary);
     font-size: 14px;
     font-weight: 500;
     line-height: 18px;
@@ -2673,7 +2730,7 @@
 }
 
 .chat-summary-template-card-desc {
-    color: rgba(28, 28, 35, 0.6);
+    color: var(--wk-text-secondary);
     font-size: 12px;
     font-weight: 400;
     line-height: 16px;
@@ -2688,7 +2745,7 @@
 
 .chat-summary-template-card-pattern {
     margin-top: var(--wk-sp-1);
-    color: var(--semi-color-text-2);
+    color: var(--wk-text-tertiary);
     font-size: var(--wk-text-size-sm);
     line-height: var(--wk-line-height-sm);
     overflow: hidden;
@@ -2711,10 +2768,37 @@
 }
 
 .summary-template-custom-title {
-    color: var(--semi-color-text-1);
+    color: var(--wk-text-secondary);
     font-size: var(--wk-text-size-sm);
     font-weight: 600;
     line-height: 24px;
+}
+
+.summary-template-create-btn {
+    color: var(--wk-color-accent);
+    background: transparent;
+    border-radius: var(--wk-r-sm);
+}
+
+.summary-template-create-btn:hover {
+    color: var(--wk-color-accent-hover);
+    background: var(--wk-bg-selected);
+}
+
+body[theme-mode="dark"] .summary-template-create-btn {
+    color: var(--wk-text-accent);
+    background: var(--wk-bg-selected);
+}
+
+body[theme-mode="dark"] .summary-template-create-btn:hover {
+    color: var(--wk-text-primary);
+    background: var(--wk-bg-hover);
+}
+
+.summary-template-create-btn:disabled,
+.summary-template-create-btn.semi-button-disabled {
+    color: var(--wk-text-disabled);
+    background: transparent;
 }
 
 .summary-template-custom-list {
@@ -2754,17 +2838,17 @@
 .summary-template-custom-empty {
     width: 100%;
     padding: var(--wk-sp-3);
-    border: 1px dashed var(--semi-color-border);
+    border: 1px dashed var(--wk-border-default);
     border-radius: var(--wk-r-sm);
-    background: var(--semi-color-fill-0);
-    color: var(--semi-color-text-1);
+    background: var(--wk-bg-elevated);
+    color: var(--wk-text-secondary);
     text-align: left;
     cursor: pointer;
 }
 
 .summary-template-custom-empty:hover {
-    border-color: var(--semi-color-primary);
-    background: var(--semi-color-primary-light-default);
+    border-color: var(--wk-border-glow);
+    background: var(--wk-bg-selected);
 }
 
 .summary-template-custom-empty-title {
@@ -2777,7 +2861,7 @@
 .summary-template-custom-empty-desc {
     display: block;
     margin-top: var(--wk-sp-1);
-    color: var(--semi-color-text-2);
+    color: var(--wk-text-tertiary);
     font-size: var(--wk-text-size-sm);
     line-height: var(--wk-line-height-sm);
 }
@@ -2787,7 +2871,7 @@
     align-items: center;
     gap: var(--wk-sp-2);
     padding: 0 var(--wk-sp-4) var(--wk-sp-2);
-    color: var(--semi-color-text-2);
+    color: var(--wk-text-tertiary);
     font-size: var(--wk-text-size-sm);
     line-height: var(--wk-line-height-sm);
 }
@@ -2802,7 +2886,7 @@
     flex-shrink: 0;
     padding: 0;
     border: 0;
-    color: var(--semi-color-primary);
+    color: var(--wk-color-accent);
     background: transparent;
     font-size: var(--wk-text-size-sm);
     line-height: var(--wk-line-height-sm);
@@ -2810,7 +2894,7 @@
 }
 
 .summary-template-applied-action:hover {
-    color: var(--semi-color-primary-hover);
+    color: var(--wk-color-accent-hover);
 }
 
 /* ========== Mobile Responsive ========== */
@@ -2950,12 +3034,15 @@
     display: flex;
     flex-direction: column;
     min-height: 0;
+    color: var(--wk-text-primary);
+    background: var(--wk-bg-surface);
 }
 
 .wk-summary-panel-detail-back {
     flex-shrink: 0;
     padding: 8px 12px;
-    border-bottom: 1px solid var(--semi-color-border);
+    background: var(--wk-bg-surface);
+    border-bottom: 1px solid var(--wk-border-default);
 }
 
 .wk-summary-panel-detail-back-btn {
@@ -2967,19 +3054,20 @@
     cursor: pointer;
     padding: 4px 6px;
     font-size: 14px;
-    color: var(--semi-color-text-1);
+    color: var(--wk-text-secondary);
     border-radius: 6px;
     transition: background-color 0.15s;
 }
 
 .wk-summary-panel-detail-back-btn:hover {
-    background-color: var(--semi-color-fill-0);
+    background-color: var(--wk-bg-elevated);
 }
 
 .wk-summary-panel-detail-body {
     flex: 1;
     min-height: 0;
     overflow: hidden;
+    background: var(--wk-bg-surface);
 }
 
 /* ──────────────────────────────────────────────────────────────────
@@ -3127,19 +3215,19 @@
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    color: rgba(28, 28, 35, 0.4);
+    color: var(--wk-text-tertiary);
     border-radius: 4px;
     line-height: 1;
 }
 
 .chat-summary-template-edit:hover {
     color: var(--wk-color-accent);
-    background: rgba(127, 59, 245, 0.06);
+    background: var(--wk-bg-selected);
 }
 
 .chat-summary-template-delete:hover {
-    color: #F54A45;
-    background: rgba(245, 74, 69, 0.06);
+    color: var(--wk-color-error);
+    background: var(--wk-color-error-bg);
 }
 
 .summary-template-edit-textarea {
@@ -3147,10 +3235,10 @@
     min-height: 160px;
     resize: vertical;
     padding: var(--wk-sp-3);
-    border: 1px solid var(--semi-color-border);
+    border: 1px solid var(--wk-border-default);
     border-radius: var(--wk-r-sm);
-    color: var(--semi-color-text-0);
-    background: var(--semi-color-bg-0);
+    color: var(--wk-text-primary);
+    background: var(--wk-bg-surface);
     font-size: var(--wk-text-size-md);
     line-height: var(--wk-line-height-md);
     box-sizing: border-box;
@@ -3163,7 +3251,7 @@
 .summary-template-edit-label {
     display: block;
     margin-bottom: var(--wk-sp-1);
-    color: var(--semi-color-text-1);
+    color: var(--wk-text-secondary);
     font-size: var(--wk-text-size-sm);
     line-height: var(--wk-line-height-sm);
 }
@@ -3171,10 +3259,10 @@
 .summary-template-edit-input {
     width: 100%;
     padding: var(--wk-sp-2) var(--wk-sp-3);
-    border: 1px solid var(--semi-color-border);
+    border: 1px solid var(--wk-border-default);
     border-radius: var(--wk-r-sm);
-    color: var(--semi-color-text-0);
-    background: var(--semi-color-bg-0);
+    color: var(--wk-text-primary);
+    background: var(--wk-bg-surface);
     font-size: var(--wk-text-size-md);
     line-height: var(--wk-line-height-md);
     box-sizing: border-box;
@@ -3189,7 +3277,7 @@
 
 .summary-template-edit-hint {
     margin-top: var(--wk-sp-2);
-    color: var(--semi-color-text-2);
+    color: var(--wk-text-tertiary);
     font-size: var(--wk-text-size-sm);
     line-height: var(--wk-line-height-sm);
 }
@@ -3215,7 +3303,7 @@
 .summary-template-more-button {
     border: 0;
     background: transparent;
-    color: var(--semi-color-primary);
+    color: var(--wk-color-accent);
     font-size: var(--wk-text-size-sm);
     line-height: var(--wk-line-height-sm);
     padding: var(--wk-sp-1) 0;
@@ -3224,7 +3312,7 @@
 }
 
 .summary-template-more-button:hover {
-    color: var(--semi-color-primary-hover);
+    color: var(--wk-color-accent-hover);
 }
 
 .summary-more-template-grid {
@@ -3461,19 +3549,19 @@ body.summary-version-detail-open .summary-schedule-page {
 
 .summary-detail-team-previous {
     border-style: dashed;
-    border-color: var(--semi-color-border);
-    background: var(--semi-color-fill-0);
+    border-color: var(--wk-border-default);
+    background: var(--wk-bg-elevated);
 }
 
 .summary-detail-previous-desc {
     margin: 6px 0 12px;
-    color: var(--semi-color-text-2);
+    color: var(--wk-text-tertiary);
     font-size: 13px;
     line-height: 1.5;
 }
 
 .summary-detail-team-generating-card {
-    background: linear-gradient(135deg, var(--semi-color-primary-light-default) 0%, var(--semi-color-bg-1) 100%);
+    background: linear-gradient(135deg, var(--wk-bg-selected) 0%, var(--wk-bg-elevated) 100%);
 }
 /* ─── Chat reference (CHAT-REFERENCE-BASED-DESIGN-v1) ────────────────── */
 /* 引用总结按钮 — chat header 里 */
@@ -3483,8 +3571,8 @@ body.summary-version-detail-open .summary-schedule-page {
     gap: 4px;
     padding: 4px 10px;
     border-radius: 4px;
-    background: var(--semi-color-fill-0);
-    color: var(--semi-color-primary);
+    background: var(--wk-bg-elevated);
+    color: var(--wk-color-accent);
     font-size: 13px;
     cursor: pointer;
     user-select: none;
@@ -3492,14 +3580,14 @@ body.summary-version-detail-open .summary-schedule-page {
     margin-right: 8px;
 }
 .summary-workbench-ref-btn:hover {
-    background: var(--semi-color-fill-1);
+    background: var(--wk-bg-hover);
 }
 .summary-workbench-ref-btn--disabled {
     opacity: 0.5;
     cursor: not-allowed;
 }
 .summary-workbench-ref-btn--disabled:hover {
-    background: var(--semi-color-fill-0);
+    background: var(--wk-bg-elevated);
 }
 /* 已引用卡片 */
 .summary-workbench-ref-card {
@@ -3508,33 +3596,34 @@ body.summary-version-detail-open .summary-schedule-page {
     gap: 6px;
     padding: 4px 10px;
     border-radius: 4px;
-    background: var(--semi-color-primary-light-default);
+    background: var(--wk-bg-selected);
+    border: 1px solid var(--wk-border-glow);
     font-size: 13px;
     margin-right: 8px;
     max-width: 320px;
 }
 .summary-workbench-ref-card-label {
-    color: var(--semi-color-primary);
+    color: var(--wk-color-accent);
     font-weight: 500;
     flex-shrink: 0;
 }
 .summary-workbench-ref-card-title {
-    color: var(--semi-color-text-0);
+    color: var(--wk-text-primary);
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
 }
 .summary-workbench-ref-card-remove {
     cursor: pointer;
-    color: var(--semi-color-text-2);
+    color: var(--wk-text-tertiary);
     padding: 0 2px;
     border-radius: 2px;
     transition: background 0.15s;
     flex-shrink: 0;
 }
 .summary-workbench-ref-card-remove:hover {
-    background: var(--semi-color-fill-1);
-    color: var(--semi-color-danger);
+    background: var(--wk-bg-hover);
+    color: var(--wk-color-error);
 }
 
 /* ========== Chat Selector Modal ========== */
@@ -3544,7 +3633,7 @@ body.summary-version-detail-open .summary-schedule-page {
     left: 0;
     right: 0;
     bottom: 0;
-    background: rgba(0, 0, 0, 0.3);
+    background: var(--wk-black-alpha-50);
     display: flex;
     align-items: center;
     justify-content: center;
@@ -3554,9 +3643,11 @@ body.summary-version-detail-open .summary-schedule-page {
 .chat-selector-modal {
     width: 600px;
     max-height: 560px;
-    background: #fff;
+    color: var(--wk-text-primary);
+    background: var(--wk-bg-surface);
+    border: 1px solid var(--wk-border-default);
     border-radius: 12px;
-    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12), 0 0 0 1px rgba(0, 0, 0, 0.06);
+    box-shadow: var(--wk-shadow-lg);
     display: flex;
     flex-direction: column;
     overflow: hidden;
@@ -3567,14 +3658,14 @@ body.summary-version-detail-open .summary-schedule-page {
     align-items: center;
     justify-content: space-between;
     padding: 16px;
-    border-bottom: 1px solid rgba(28, 28, 35, 0.15);
+    border-bottom: 1px solid var(--wk-border-default);
 }
 
 .chat-selector-title {
     font-size: 16px;
     font-weight: 600;
     line-height: 24px;
-    color: #1C1C23;
+    color: var(--wk-text-primary);
 }
 
 .chat-selector-close {
@@ -3582,13 +3673,13 @@ body.summary-version-detail-open .summary-schedule-page {
     background: none;
     cursor: pointer;
     padding: 0;
-    color: rgba(28, 28, 35, 0.4);
+    color: var(--wk-text-tertiary);
     display: flex;
     align-items: center;
 }
 
 .chat-selector-close:hover {
-    color: rgba(28, 28, 35, 0.8);
+    color: var(--wk-text-secondary);
 }
 
 .chat-selector-content {
@@ -3602,7 +3693,7 @@ body.summary-version-detail-open .summary-schedule-page {
     flex-shrink: 0;
     display: flex;
     flex-direction: column;
-    border-right: 1px solid rgba(28, 28, 35, 0.15);
+    border-right: 1px solid var(--wk-border-default);
 }
 
 .chat-selector-search {
@@ -3613,11 +3704,11 @@ body.summary-version-detail-open .summary-schedule-page {
     height: 36px;
     padding: 0 12px;
     border-radius: 9999px;
-    background: rgba(28, 28, 35, 0.04);
+    background: var(--wk-bg-elevated);
 }
 
 .chat-selector-search-icon {
-    color: rgba(28, 28, 35, 0.4);
+    color: var(--wk-text-tertiary);
     flex-shrink: 0;
     font-size: 16px;
 }
@@ -3630,11 +3721,11 @@ body.summary-version-detail-open .summary-schedule-page {
     font-family: inherit;
     font-size: 14px;
     line-height: 20px;
-    color: #1C1C23;
+    color: var(--wk-text-primary);
 }
 
 .chat-selector-search-input::placeholder {
-    color: rgba(28, 28, 35, 0.4);
+    color: var(--wk-text-tertiary);
 }
 
 .chat-selector-tabs {
@@ -3642,7 +3733,7 @@ body.summary-version-detail-open .summary-schedule-page {
     align-items: center;
     gap: 4px;
     padding: 4px 16px;
-    border-bottom: 1px solid rgba(28, 28, 35, 0.08);
+    border-bottom: 1px solid var(--wk-border-subtle);
 }
 
 .chat-selector-tab {
@@ -3653,7 +3744,7 @@ body.summary-version-detail-open .summary-schedule-page {
     font-family: inherit;
     font-size: 13px;
     line-height: 20px;
-    color: rgba(28, 28, 35, 0.6);
+    color: var(--wk-text-secondary);
     border-radius: 4px;
     white-space: nowrap;
 }
@@ -3670,7 +3761,7 @@ body.summary-version-detail-open .summary-schedule-page {
     padding: 4px 16px;
     cursor: pointer;
     font-size: 12px;
-    color: rgba(28, 28, 35, 0.6);
+    color: var(--wk-text-secondary);
     white-space: nowrap;
 }
 
@@ -3697,7 +3788,7 @@ body.summary-version-detail-open .summary-schedule-page {
 }
 
 .chat-selector-item:hover {
-    background: rgba(28, 28, 35, 0.02);
+    background: var(--wk-bg-hover);
 }
 
 .chat-selector-item--indent {
@@ -3721,7 +3812,7 @@ body.summary-version-detail-open .summary-schedule-page {
     font-size: 14px;
     font-weight: 400;
     line-height: 20px;
-    color: #1C1C23;
+    color: var(--wk-text-primary);
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
@@ -3740,7 +3831,7 @@ body.summary-version-detail-open .summary-schedule-page {
     font-size: 14px;
     font-weight: 500;
     line-height: 20px;
-    color: rgba(28, 28, 35, 0.4);
+    color: var(--wk-text-tertiary);
 }
 
 .chat-selector-right-list {
@@ -3757,7 +3848,7 @@ body.summary-version-detail-open .summary-schedule-page {
 }
 
 .chat-selector-selected-item:hover {
-    background: rgba(28, 28, 35, 0.02);
+    background: var(--wk-bg-hover);
 }
 
 .chat-selector-selected-name {
@@ -3766,7 +3857,7 @@ body.summary-version-detail-open .summary-schedule-page {
     font-size: 14px;
     font-weight: 400;
     line-height: 20px;
-    color: #1C1C23;
+    color: var(--wk-text-primary);
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
@@ -3777,13 +3868,13 @@ body.summary-version-detail-open .summary-schedule-page {
     background: none;
     cursor: pointer;
     padding: 0;
-    color: rgba(28, 28, 35, 0.4);
+    color: var(--wk-text-tertiary);
     display: flex;
     align-items: center;
 }
 
 .chat-selector-selected-remove:hover {
-    color: rgba(28, 28, 35, 0.8);
+    color: var(--wk-text-secondary);
 }
 
 .chat-selector-footer {
@@ -3792,7 +3883,7 @@ body.summary-version-detail-open .summary-schedule-page {
     justify-content: flex-end;
     gap: 12px;
     padding: 16px;
-    border-top: 1px solid rgba(28, 28, 35, 0.15);
+    border-top: 1px solid var(--wk-border-default);
 }
 
 .chat-selector-btn {
@@ -3807,26 +3898,26 @@ body.summary-version-detail-open .summary-schedule-page {
 }
 
 .chat-selector-btn--cancel {
-    background: #fff;
-    border: 1px solid rgba(28, 28, 35, 0.1);
-    color: rgba(28, 28, 35, 0.8);
+    background: var(--wk-bg-surface);
+    border: 1px solid var(--wk-border-default);
+    color: var(--wk-text-secondary);
     font-size: 12px;
     font-weight: 600;
 }
 
 .chat-selector-btn--cancel:hover {
-    background: rgba(28, 28, 35, 0.02);
+    background: var(--wk-bg-hover);
 }
 
 .chat-selector-btn--confirm {
-    background: #1C1C23;
-    color: #fff;
+    background: var(--wk-brand-primary);
+    color: var(--wk-text-on-brand);
     font-size: 14px;
     font-weight: 600;
 }
 
 .chat-selector-btn--confirm:hover {
-    background: #333;
+    background: var(--wk-brand-primary-hover);
 }
 
 /* ── 总结 Markdown 渲染增强(对齐版本管理原型)──────────────────────────

--- a/packages/dmworksummary/src/pages/SummaryCreatePage.tsx
+++ b/packages/dmworksummary/src/pages/SummaryCreatePage.tsx
@@ -1183,6 +1183,7 @@ export default class SummaryCreatePage extends Component<SummaryCreatePageProps,
                                         {translate("summary.templates.custom.myTemplatesTitleWithCount", { values: { count: customTemplates.length, limit: customTemplateLimit } })}
                                     </div>
                                     <Button
+                                        className="summary-template-create-btn"
                                         theme="borderless"
                                         size="small"
                                         icon={<Plus size={14} />}

--- a/packages/dmworksummary/src/pages/SummaryListPage.tsx
+++ b/packages/dmworksummary/src/pages/SummaryListPage.tsx
@@ -569,6 +569,7 @@ export default class SummaryListPage extends Component<SummaryListPageProps, Sum
                         {isPanel && (
                             <Tooltip content={translate("summary.chatSummary.createNew")} position="bottom">
                                 <Button
+                                    className="summary-list-create-icon-btn"
                                     icon={<IconPlus />}
                                     theme="borderless"
                                     onClick={this.handleCreate}
@@ -585,6 +586,7 @@ export default class SummaryListPage extends Component<SummaryListPageProps, Sum
                         ) : (
                             <Tooltip content={translate("summary.list.createTooltip")} position="bottom">
                                 <Button
+                                    className="summary-list-create-icon-btn"
                                     icon={<IconPlus />}
                                     theme="borderless"
                                     onClick={this.handleCreate}


### PR DESCRIPTION
## Summary
- Restore theme-mode persistence and dark theme tokens while keeping the dark-mode settings entry hidden.
- Adapt chat/message and smart summary surfaces to semantic theme variables.
- Preserve existing light theme styling.
- Dark mode is not publicly available yet, and no user-facing toggle is provided for now.
- Reopened from #1263 due to a stale review state on the previous PR; this branch uses the same reviewed head commit.

## Test
- pnpm --dir packages/dmworkbase exec vitest run src/Components/NavRail/__tests__/NavSettingsPanelFlyout.test.tsx
- pnpm lint:css (0 errors, existing warnings remain)