### PR TITLE
chore: upgrade octo chat card profile to rc2

### DIFF
--- a/docs/render-profile-local-validation.md
+++ b/docs/render-profile-local-validation.md
@@ -11,7 +11,7 @@
 
 ## File Map
 
-- `packages/dmworkbase/package.json`：固定安装 npm 发布的 Forge `1.2.0-rc.1` 制品。
+- `packages/dmworkbase/package.json`：固定安装 npm 发布的 Forge `1.2.0-rc.2` 制品。
 - `Messages/InteractiveCard/InteractiveCardContent.ts`：容忍解析/编码可选 `render_profile`。
 - `Messages/InteractiveCard/renderDecision.ts`：在原 Wire Profile 协商之外选择 legacy/Forge 渲染档位。
 - `Messages/InteractiveCard/sdk/renderOctoCard.ts`：按档位选择现有 HostConfig 或制品 HostConfig。

--- a/packages/dmworkbase/package.json
+++ b/packages/dmworkbase/package.json
@@ -6,7 +6,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@mlt-org/octo-card-profile-octo-chat": "1.2.0-rc.1",
+    "@mlt-org/octo-card-profile-octo-chat": "1.2.0-rc.2",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",

--- a/packages/dmworkbase/src/Messages/InteractiveCard/fixtures/decision-0.2.json
+++ b/packages/dmworkbase/src/Messages/InteractiveCard/fixtures/decision-0.2.json
@@ -5,7 +5,7 @@
   "body": [
     {
       "type": "Container",
-      "id": "octo-surface-accent-header",
+      "id": "octo-surface-header-accent-main",
       "style": "accent",
       "bleed": true,
       "spacing": "None",
@@ -111,7 +111,7 @@
     },
     {
       "type": "Container",
-      "id": "octo-surface-default-footer",
+      "id": "octo-surface-footer-default-actions",
       "style": "emphasis",
       "bleed": true,
       "separator": true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -400,8 +400,8 @@ importers:
         specifier: ^1.5.5
         version: 1.7.1
       '@mlt-org/octo-card-profile-octo-chat':
-        specifier: 1.2.0-rc.1
-        version: 1.2.0-rc.1
+        specifier: 1.2.0-rc.2
+        version: 1.2.0-rc.2
       '@react-pdf-viewer/bookmark':
         specifier: ^3.12.0
         version: 3.12.0(pdfjs-dist@3.11.174(encoding@0.1.13))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
@@ -2587,8 +2587,8 @@ packages:
   '@mermaid-js/parser@1.2.0':
     resolution: {integrity: sha512-oYPyv8A4As1yH5Bx+04iQEQxXuIQDe0GKCNSRgao6z8AM9jixXIfP0vsppRLvGf+nKIOb9/LdpWA4YuJiVvESA==}
 
-  '@mlt-org/octo-card-profile-octo-chat@1.2.0-rc.1':
-    resolution: {integrity: sha512-rzaO97RpRgGStMKEVBOsxt1F2/v7MTQOZwN64vkPIgi37090ng125XNNfB9D9TD+pOF46I4OBmPo/rjrNcQl6A==}
+  '@mlt-org/octo-card-profile-octo-chat@1.2.0-rc.2':
+    resolution: {integrity: sha512-MZfEJOGuKj27kToreQBgk1tVvGtnMr01QaTqG7sesJJoPNd/7b6IQRqwG9ruwLi8O5bW2SrfOvH8jj24iC4Bcw==}
 
   '@mswjs/interceptors@0.41.9':
     resolution: {integrity: sha512-VVPPgHyQ6ShqnrmDWuxjmUIsO9gWyOZFmuOfLd9LfBGQJwZfy0gvv9pbHSJuoFNIYC7ZDX9aoFwowjcdSC4E8w==}
@@ -13193,7 +13193,7 @@ snapshots:
     dependencies:
       '@chevrotain/types': 11.1.2
 
-  '@mlt-org/octo-card-profile-octo-chat@1.2.0-rc.1': {}
+  '@mlt-org/octo-card-profile-octo-chat@1.2.0-rc.2': {}
 
   '@mswjs/interceptors@0.41.9':
     dependencies:


### PR DESCRIPTION
## What changed

- Upgrade `@mlt-org/octo-card-profile-octo-chat` from `1.2.0-rc.1` to `1.2.0-rc.2`.
- Refresh `pnpm-lock.yaml` integrity and snapshot entries.
- Update the local render-profile validation document.
- Migrate the decision-card fixture surface ids to the rc.2 selector contract.

## Why

This dependency upgrade is split from PR #1272 so the interactive-card behavior changes can be reviewed independently.

## Validation

- Lockfile and package specifier are consistent.
- The fixture now uses `octo-surface-header-accent-main` and `octo-surface-footer-default-actions`, matching rc.2 and the Forge template.
- `renderProfile.test.ts` and `actionMessage.test.ts` passed.
