### PR TITLE
fix(docs): keep in-page anchors inside the HTML preview frame

### DIFF
--- a/packages/docs/src/html/HtmlDocView.test.tsx
+++ b/packages/docs/src/html/HtmlDocView.test.tsx
@@ -640,11 +640,17 @@ describe('sanitizeDocHtml', () => {
 })
 
 describe('injectBaseHref', () => {
-  it('inserts <base> at the START of an existing <head> with a trailing-slash href', () => {
-    const out = injectBaseHref('<html><head><title>t</title></head><body>x</body></html>', 'https://od.test')
-    expect(out).toContain('<head><base href="https://od.test/">')
+  it('inserts <base> at the START of an existing <head> using the href verbatim (no forced slash)', () => {
+    const out = injectBaseHref('<html><head><title>t</title></head><body>x</body></html>', 'https://od.test/d/s/v/3')
+    expect(out).toContain('<head><base href="https://od.test/d/s/v/3">')
     // Only one base, and it precedes the original head content.
     expect(out.indexOf('<base')).toBeLessThan(out.indexOf('<title>'))
+  })
+
+  it('does NOT force a trailing slash on a file-style base (would shift relative resolution)', () => {
+    const out = injectBaseHref('<html><head></head><body>x</body></html>', 'https://od.test/d/s/v/3')
+    expect(out).toContain('<base href="https://od.test/d/s/v/3">')
+    expect(out).not.toContain('v/3/">')
   })
 
   it('preserves an already-trailing slash and prepends <base> when there is no <head>', () => {
@@ -654,6 +660,52 @@ describe('injectBaseHref', () => {
 
   it('is a no-op when baseUrl is empty', () => {
     expect(injectBaseHref('<p>x</p>', '')).toBe('<p>x</p>')
+  })
+})
+
+describe('file-style <base> relative resolution (regression guard for srcset/source/CSS url())', () => {
+  // The <base> is the document's own render URL (…/d/{slug}/v/{ver}) — a FILE, not a directory.
+  // Relative refs therefore resolve against the doc's directory (…/d/{slug}/v/), and root-relative
+  // signed-asset refs (/d/{slug}/assets/{sha}) must stay untouched. These assert the browser URL
+  // algorithm the <base> relies on, with no new deps.
+  const base = buildOctoDocUrl('slug', '3') // e.g. /docs-html/d/slug/v/3
+  const abs = 'https://od.test/d/slug/v/3'
+
+  it('root-relative signed asset (/d/<slug>/assets/<sha>) is UNAFFECTED by the file-style base', () => {
+    // octo-doc emits root-relative signed refs; these resolve against origin, ignoring the base path.
+    expect(new URL('/d/slug/assets/abc123?sig=s', abs).href).toBe('https://od.test/d/slug/assets/abc123?sig=s')
+  })
+
+  it('document-level relative ./x and ../x resolve to the doc directory, not one level too deep', () => {
+    // ./img.png sits beside the doc (…/v/img.png); ../img.png climbs to …/d/slug/img.png.
+    expect(new URL('./img.png', abs).href).toBe('https://od.test/d/slug/v/img.png')
+    expect(new URL('../img.png', abs).href).toBe('https://od.test/d/slug/img.png')
+  })
+
+  it('srcset candidate URLs resolve against the file-style base the same way', () => {
+    // A parser splits srcset into candidates; each relative candidate resolves like a plain src.
+    for (const candidate of ['a.png', './a.png', '../a.png']) {
+      expect(() => new URL(candidate, abs)).not.toThrow()
+    }
+    expect(new URL('a.png', abs).href).toBe('https://od.test/d/slug/v/a.png')
+    expect(new URL('../a.png', abs).href).toBe('https://od.test/d/slug/a.png')
+  })
+
+  it('<source src> (video/audio) relative refs resolve to the doc directory', () => {
+    expect(new URL('clip.mp4', abs).href).toBe('https://od.test/d/slug/v/clip.mp4')
+    expect(new URL('media/clip.webm', abs).href).toBe('https://od.test/d/slug/v/media/clip.webm')
+  })
+
+  it('inline <style> url() relative refs resolve to the doc directory (base drives CSS too)', () => {
+    // A bare url(bg.png) in an inline stylesheet resolves against the document base URL.
+    const cssUrlRef = 'bg.png'
+    expect(new URL(cssUrlRef, abs).href).toBe('https://od.test/d/slug/v/bg.png')
+    expect(new URL('../shared/bg.png', abs).href).toBe('https://od.test/d/slug/shared/bg.png')
+  })
+
+  it('buildOctoDocUrl stays file-style (no trailing slash) so the base does not shift one level', () => {
+    expect(base).not.toMatch(/\/$/)
+    expect(base).toContain('/d/slug/v/3')
   })
 })
 
@@ -1079,11 +1131,14 @@ describe('HtmlDocView — header parity (presence / comments / members / more)',
     expect(screen.getByText('docs.standalone.openInNewPage')).toBeTruthy()
   })
 
-  it('injects a <base> into the iframe srcdoc so CSS/relative assets resolve to the doc origin', async () => {
+  it('injects a <base> pointing at the doc\'s own render URL (not the directory root) so relative/CSS assets resolve and bare #fragments stay in-page', async () => {
     serveDoc('<html><head></head><body><p>body</p></body></html>')
     const { container } = render(<HtmlDocView docId="d1" space="sp" />)
     const frame = await waitForFrame(container)
-    expect(frame.getAttribute('srcdoc')).toContain('<base href="https://od.test/">')
+    // Base is the document's own URL (…/d/d1/v/latest), NOT the directory root — this keeps a bare
+    // #fragment resolving to THIS document instead of navigating the frame to the docs home.
+    expect(frame.getAttribute('srcdoc')).toContain('<base href="https://od.test/d/d1/v/latest">')
+    expect(frame.getAttribute('srcdoc')).not.toContain('<base href="https://od.test/">')
   })
 })
 

--- a/packages/docs/src/html/HtmlPreviewFrame.test.tsx
+++ b/packages/docs/src/html/HtmlPreviewFrame.test.tsx
@@ -1,0 +1,595 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, waitFor, cleanup, fireEvent } from '@testing-library/react'
+import { HtmlPreviewFrame } from './HtmlPreviewFrame.tsx'
+import {
+  bindAnchorNavigation,
+  buildAbsoluteOctoDocUrl,
+  injectBaseHref,
+} from './htmlDocFrameHelpers.ts'
+import * as helpers from './htmlDocFrameHelpers.ts'
+const actualBind = bindAnchorNavigation
+import { setWKApp } from '../octoweb/index.ts'
+import { createMockWKApp } from '../octoweb/mock.ts'
+
+// HtmlPreviewFrame raw-fetches published HTML from the octo-doc backend; stub the global fetch.
+function stubFetch(body: string) {
+  const spy = vi.fn(() =>
+    Promise.resolve({ ok: true, status: 200, text: async () => body } as Response),
+  ) as unknown as typeof fetch
+  vi.stubGlobal('fetch', spy)
+  return spy as unknown as ReturnType<typeof vi.fn>
+}
+
+async function waitForFrame(container: HTMLElement): Promise<HTMLIFrameElement> {
+  return waitFor(() => {
+    const frame = container.querySelector('iframe') as HTMLIFrameElement | null
+    expect(frame).toBeTruthy()
+    return frame as HTMLIFrameElement
+  })
+}
+
+// jsdom does not render srcDoc into contentDocument; write the body ourselves then fire load,
+// mirroring the pattern used by HtmlDocView.test.tsx.
+function writeIframeBody(iframe: HTMLIFrameElement, body: string): Document {
+  const doc = iframe.contentDocument as Document
+  doc.open()
+  doc.write(`<!doctype html><html><head></head><body>${body}</body></html>`)
+  doc.close()
+  fireEvent.load(iframe)
+  return doc
+}
+
+// Same as writeIframeBody but lets a test seed <head> markup (e.g. a real <base target>) so the
+// effective-target resolution runs against a genuine DOM, not a mocked getter.
+function writeIframeDoc(iframe: HTMLIFrameElement, head: string, body: string): Document {
+  const doc = iframe.contentDocument as Document
+  doc.open()
+  doc.write(`<!doctype html><html><head>${head}</head><body>${body}</body></html>`)
+  doc.close()
+  fireEvent.load(iframe)
+  return doc
+}
+
+beforeEach(() => {
+  setWKApp(createMockWKApp())
+  ;(window as unknown as { __OCTO_DOC_BASE__?: string }).__OCTO_DOC_BASE__ = 'https://od.test'
+})
+afterEach(() => {
+  cleanup()
+  delete (window as unknown as { __OCTO_DOC_BASE__?: unknown }).__OCTO_DOC_BASE__
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+describe('HtmlPreviewFrame — in-page anchor interception', () => {
+  it('intercepts a bare #fragment click and scrolls instead of navigating the frame', async () => {
+    stubFetch('<a id="lnk" href="#intro">go</a><section id="intro">Intro</section>')
+    const { container } = render(<HtmlPreviewFrame slug="s" version="3" title="t" />)
+    const frame = await waitForFrame(container)
+    const doc = writeIframeBody(
+      frame,
+      '<a id="lnk" href="#intro">go</a><section id="intro">Intro</section>',
+    )
+
+    const target = doc.getElementById('intro') as HTMLElement
+    const scrollSpy = vi.fn()
+    target.scrollIntoView = scrollSpy
+
+    const evt = new (doc.defaultView as Window & typeof globalThis).MouseEvent('click', {
+      bubbles: true,
+      cancelable: true,
+      button: 0,
+    })
+    doc.getElementById('lnk')!.dispatchEvent(evt)
+
+    expect(evt.defaultPrevented).toBe(true)
+    expect(scrollSpy).toHaveBeenCalledWith({ block: 'start' })
+  })
+
+  it('intercepts a click on an element nested inside the anchor (closest())', async () => {
+    stubFetch('x')
+    const { container } = render(<HtmlPreviewFrame slug="s" version="3" title="t" />)
+    const frame = await waitForFrame(container)
+    const doc = writeIframeBody(
+      frame,
+      '<a href="#intro"><span id="inner">go</span></a><h2 id="intro">Intro</h2>',
+    )
+    const target = doc.getElementById('intro') as HTMLElement
+    const scrollSpy = vi.fn()
+    target.scrollIntoView = scrollSpy
+
+    const evt = new (doc.defaultView as Window & typeof globalThis).MouseEvent('click', {
+      bubbles: true,
+      cancelable: true,
+      button: 0,
+    })
+    doc.getElementById('inner')!.dispatchEvent(evt)
+
+    expect(evt.defaultPrevented).toBe(true)
+    expect(scrollSpy).toHaveBeenCalledWith({ block: 'start' })
+  })
+
+  it('preventDefaults even when the fragment target is missing (never navigates away)', async () => {
+    stubFetch('x')
+    const { container } = render(<HtmlPreviewFrame slug="s" version="3" title="t" />)
+    const frame = await waitForFrame(container)
+    const doc = writeIframeBody(frame, '<a id="lnk" href="#nope">go</a>')
+
+    const evt = new (doc.defaultView as Window & typeof globalThis).MouseEvent('click', {
+      bubbles: true,
+      cancelable: true,
+      button: 0,
+    })
+    doc.getElementById('lnk')!.dispatchEvent(evt)
+    expect(evt.defaultPrevented).toBe(true)
+  })
+
+  it('intercepts an <area href="#frag"> image-map click (closest a-only would miss it)', async () => {
+    stubFetch('x')
+    const { container } = render(<HtmlPreviewFrame slug="s" version="3" title="t" />)
+    const frame = await waitForFrame(container)
+    const doc = writeIframeBody(
+      frame,
+      '<map name="m"><area id="ar" shape="rect" coords="0,0,10,10" href="#intro"></map><section id="intro">Intro</section>',
+    )
+    const scrollSpy = vi.fn()
+    ;(doc.getElementById('intro') as HTMLElement).scrollIntoView = scrollSpy
+
+    const evt = new (doc.defaultView as Window & typeof globalThis).MouseEvent('click', {
+      bubbles: true,
+      cancelable: true,
+      button: 0,
+    })
+    doc.getElementById('ar')!.dispatchEvent(evt)
+    expect(evt.defaultPrevented).toBe(true)
+    expect(scrollSpy).toHaveBeenCalledWith({ block: 'start' })
+  })
+
+  it('scrolls to an element with id="top" instead of jumping to the page top (#top swallow bug)', async () => {
+    stubFetch('x')
+    const { container } = render(<HtmlPreviewFrame slug="s" version="3" title="t" />)
+    const frame = await waitForFrame(container)
+    const doc = writeIframeBody(frame, '<a id="lnk" href="#top">go</a><section id="top">Top section</section>')
+    const scrollSpy = vi.fn()
+    ;(doc.getElementById('top') as HTMLElement).scrollIntoView = scrollSpy
+    const scrollToSpy = vi.fn()
+    ;(doc.defaultView as unknown as { scrollTo: unknown }).scrollTo = scrollToSpy
+
+    const evt = new (doc.defaultView as Window & typeof globalThis).MouseEvent('click', {
+      bubbles: true,
+      cancelable: true,
+      button: 0,
+    })
+    doc.getElementById('lnk')!.dispatchEvent(evt)
+    expect(evt.defaultPrevented).toBe(true)
+    expect(scrollSpy).toHaveBeenCalledWith({ block: 'start' })
+    expect(scrollToSpy).not.toHaveBeenCalled()
+  })
+
+  it('falls back to page top for #top only when no id="top" element exists', async () => {
+    stubFetch('x')
+    const { container } = render(<HtmlPreviewFrame slug="s" version="3" title="t" />)
+    const frame = await waitForFrame(container)
+    const doc = writeIframeBody(frame, '<a id="lnk" href="#top">go</a><section id="intro">no top here</section>')
+    const scrollToSpy = vi.fn()
+    ;(doc.defaultView as unknown as { scrollTo: unknown }).scrollTo = scrollToSpy
+
+    const evt = new (doc.defaultView as Window & typeof globalThis).MouseEvent('click', {
+      bubbles: true,
+      cancelable: true,
+      button: 0,
+    })
+    doc.getElementById('lnk')!.dispatchEvent(evt)
+    expect(evt.defaultPrevented).toBe(true)
+    expect(scrollToSpy).toHaveBeenCalledWith(0, 0)
+  })
+
+  it('resolves a same-document href-with-fragment (base points at the doc URL) as in-page', async () => {
+    stubFetch('x')
+    const { container } = render(<HtmlPreviewFrame slug="s" version="3" title="t" />)
+    const frame = await waitForFrame(container)
+    const docUrl = buildAbsoluteOctoDocUrl('s', '3')
+    const doc = writeIframeBody(
+      frame,
+      `<a id="lnk" href="${docUrl}#intro">go</a><section id="intro">Intro</section>`,
+    )
+    const target = doc.getElementById('intro') as HTMLElement
+    const scrollSpy = vi.fn()
+    target.scrollIntoView = scrollSpy
+
+    const evt = new (doc.defaultView as Window & typeof globalThis).MouseEvent('click', {
+      bubbles: true,
+      cancelable: true,
+      button: 0,
+    })
+    doc.getElementById('lnk')!.dispatchEvent(evt)
+    expect(evt.defaultPrevented).toBe(true)
+    expect(scrollSpy).toHaveBeenCalledWith({ block: 'start' })
+  })
+})
+
+describe('HtmlPreviewFrame — pass-through (must NOT intercept)', () => {
+  function setup() {
+    // Non-empty fetch body so the frame actually renders (empty raw => 'empty' state, no iframe).
+    stubFetch('<a id="lnk">go</a>')
+  }
+
+  async function clickAndGetEvent(
+    body: string,
+    init: MouseEventInit,
+    linkId = 'lnk',
+  ): Promise<{ evt: MouseEvent }> {
+    const { container } = render(<HtmlPreviewFrame slug="s" version="3" title="t" />)
+    const frame = await waitForFrame(container)
+    const doc = writeIframeBody(frame, body)
+    const evt = new (doc.defaultView as Window & typeof globalThis).MouseEvent('click', {
+      bubbles: true,
+      cancelable: true,
+      ...init,
+    })
+    doc.getElementById(linkId)!.dispatchEvent(evt)
+    return { evt }
+  }
+
+  it('does not intercept target="_blank"', async () => {
+    setup()
+    const { evt } = await clickAndGetEvent(
+      '<a id="lnk" target="_blank" href="#intro">go</a><i id="intro"></i>',
+      { button: 0 },
+    )
+    expect(evt.defaultPrevented).toBe(false)
+  })
+
+  it('does not intercept a named target', async () => {
+    setup()
+    const { evt } = await clickAndGetEvent(
+      '<a id="lnk" target="win" href="#intro">go</a><i id="intro"></i>',
+      { button: 0 },
+    )
+    expect(evt.defaultPrevented).toBe(false)
+  })
+
+  it('does not intercept modified clicks (ctrl/meta/shift/alt)', async () => {
+    for (const mod of [{ ctrlKey: true }, { metaKey: true }, { shiftKey: true }, { altKey: true }]) {
+      setup()
+      const { evt } = await clickAndGetEvent('<a id="lnk" href="#intro">go</a><i id="intro"></i>', {
+        button: 0,
+        ...mod,
+      })
+      expect(evt.defaultPrevented).toBe(false)
+      cleanup()
+    }
+  })
+
+  it('does not intercept middle-click (button !== 0)', async () => {
+    setup()
+    const { evt } = await clickAndGetEvent('<a id="lnk" href="#intro">go</a><i id="intro"></i>', {
+      button: 1,
+    })
+    expect(evt.defaultPrevented).toBe(false)
+  })
+
+  it('does not intercept a cross-document link (different path)', async () => {
+    setup()
+    const { evt } = await clickAndGetEvent(
+      '<a id="lnk" href="https://od.test/d/other/v/1#intro">go</a>',
+      { button: 0 },
+    )
+    expect(evt.defaultPrevented).toBe(false)
+  })
+
+  it('does not intercept a plain external link with no fragment', async () => {
+    setup()
+    const { evt } = await clickAndGetEvent('<a id="lnk" href="https://example.com/">go</a>', {
+      button: 0,
+    })
+    expect(evt.defaultPrevented).toBe(false)
+  })
+
+  it('does not intercept a fragment link under a real <base target="_blank">', async () => {
+    setup()
+    const { container } = render(<HtmlPreviewFrame slug="s" version="3" title="t" />)
+    const frame = await waitForFrame(container)
+    const doc = writeIframeDoc(
+      frame,
+      '<base target="_blank">',
+      '<a id="lnk" href="#intro">go</a><i id="intro"></i>',
+    )
+    const link = doc.getElementById('lnk') as HTMLAnchorElement
+    // Real <base target> — the element carries NO target attribute of its own, proving we resolve
+    // the base rather than reading a (fictional) inherited anchor.target.
+    expect(link.getAttribute('target')).toBeNull()
+    const evt = new (doc.defaultView as Window & typeof globalThis).MouseEvent('click', {
+      bubbles: true,
+      cancelable: true,
+      button: 0,
+    })
+    link.dispatchEvent(evt)
+    expect(evt.defaultPrevented).toBe(false)
+  })
+
+  it('still intercepts and scrolls under a real <base target="_self">', async () => {
+    setup()
+    const { container } = render(<HtmlPreviewFrame slug="s" version="3" title="t" />)
+    const frame = await waitForFrame(container)
+    const doc = writeIframeDoc(
+      frame,
+      '<base target="_self">',
+      '<a id="lnk" href="#intro">go</a><i id="intro"></i>',
+    )
+    const target = doc.getElementById('intro') as HTMLElement
+    const scrollSpy = vi.fn()
+    target.scrollIntoView = scrollSpy
+    const evt = new (doc.defaultView as Window & typeof globalThis).MouseEvent('click', {
+      bubbles: true,
+      cancelable: true,
+      button: 0,
+    })
+    doc.getElementById('lnk')!.dispatchEvent(evt)
+    expect(evt.defaultPrevented).toBe(true)
+    expect(scrollSpy).toHaveBeenCalledWith({ block: 'start' })
+  })
+
+  it('treats the reserved keyword case-insensitively: <base target="_SELF"> still scrolls in-page', async () => {
+    setup()
+    const { container } = render(<HtmlPreviewFrame slug="s" version="3" title="t" />)
+    const frame = await waitForFrame(container)
+    const doc = writeIframeDoc(
+      frame,
+      '<base target="_SELF">',
+      '<a id="lnk" href="#intro">go</a><i id="intro"></i>',
+    )
+    const target = doc.getElementById('intro') as HTMLElement
+    const scrollSpy = vi.fn()
+    target.scrollIntoView = scrollSpy
+    const evt = new (doc.defaultView as Window & typeof globalThis).MouseEvent('click', {
+      bubbles: true,
+      cancelable: true,
+      button: 0,
+    })
+    doc.getElementById('lnk')!.dispatchEvent(evt)
+    expect(evt.defaultPrevented).toBe(true)
+    expect(scrollSpy).toHaveBeenCalledWith({ block: 'start' })
+  })
+
+  it('treats a whitespace-padded " _self " as a NAMED target and lets it through', async () => {
+    setup()
+    const { container } = render(<HtmlPreviewFrame slug="s" version="3" title="t" />)
+    const frame = await waitForFrame(container)
+    const doc = writeIframeDoc(
+      frame,
+      '<base target=" _self ">',
+      '<a id="lnk" href="#intro">go</a><i id="intro"></i>',
+    )
+    const evt = new (doc.defaultView as Window & typeof globalThis).MouseEvent('click', {
+      bubbles: true,
+      cancelable: true,
+      button: 0,
+    })
+    doc.getElementById('lnk')!.dispatchEvent(evt)
+    expect(evt.defaultPrevented).toBe(false)
+  })
+
+  it('lets the element\u2019s own target="_self" override a <base target="_blank">', async () => {
+    setup()
+    const { container } = render(<HtmlPreviewFrame slug="s" version="3" title="t" />)
+    const frame = await waitForFrame(container)
+    const doc = writeIframeDoc(
+      frame,
+      '<base target="_blank">',
+      '<a id="lnk" target="_self" href="#intro">go</a><i id="intro"></i>',
+    )
+    const target = doc.getElementById('intro') as HTMLElement
+    const scrollSpy = vi.fn()
+    target.scrollIntoView = scrollSpy
+    const evt = new (doc.defaultView as Window & typeof globalThis).MouseEvent('click', {
+      bubbles: true,
+      cancelable: true,
+      button: 0,
+    })
+    doc.getElementById('lnk')!.dispatchEvent(evt)
+    expect(evt.defaultPrevented).toBe(true)
+    expect(scrollSpy).toHaveBeenCalledWith({ block: 'start' })
+  })
+
+  it('lets an <area> under a real <base target="_blank"> through', async () => {
+    setup()
+    const { container } = render(<HtmlPreviewFrame slug="s" version="3" title="t" />)
+    const frame = await waitForFrame(container)
+    const doc = writeIframeDoc(
+      frame,
+      '<base target="_blank">',
+      '<map name="m"><area id="ar" href="#intro" shape="rect" coords="0,0,1,1"></map><i id="intro"></i>',
+    )
+    const evt = new (doc.defaultView as Window & typeof globalThis).MouseEvent('click', {
+      bubbles: true,
+      cancelable: true,
+      button: 0,
+    })
+    doc.getElementById('ar')!.dispatchEvent(evt)
+    expect(evt.defaultPrevented).toBe(false)
+  })
+
+  it('resolves the target-bearing <base> even when a target-less <base> precedes it', async () => {
+    setup()
+    const { container } = render(<HtmlPreviewFrame slug="s" version="3" title="t" />)
+    const frame = await waitForFrame(container)
+    // Mirrors production: our injected href-only <base> comes first; the author's <base target>
+    // follows. We must find the one carrying target, not the first base.
+    const doc = writeIframeDoc(
+      frame,
+      '<base href="https://od.test/d/s/v/3"><base target="_blank">',
+      '<a id="lnk" href="#intro">go</a><i id="intro"></i>',
+    )
+    const evt = new (doc.defaultView as Window & typeof globalThis).MouseEvent('click', {
+      bubbles: true,
+      cancelable: true,
+      button: 0,
+    })
+    doc.getElementById('lnk')!.dispatchEvent(evt)
+    expect(evt.defaultPrevented).toBe(false)
+  })
+
+  it('does not intercept a link carrying a download attribute (browser handles the download)', async () => {
+    setup()
+    const { evt } = await clickAndGetEvent(
+      '<a id="lnk" download href="#intro">go</a><i id="intro"></i>',
+      { button: 0 },
+    )
+    expect(evt.defaultPrevented).toBe(false)
+  })
+
+  it('respects an already-defaultPrevented event', async () => {
+    stubFetch('<a id="lnk">go</a>')
+    const { container } = render(<HtmlPreviewFrame slug="s" version="3" title="t" />)
+    const frame = await waitForFrame(container)
+    const doc = writeIframeBody(frame, '<a id="lnk" href="#intro">go</a><i id="intro"></i>')
+    const target = doc.getElementById('intro') as HTMLElement
+    const scrollSpy = vi.fn()
+    target.scrollIntoView = scrollSpy
+    // A listener registered first calls preventDefault; ours must then bail out.
+    doc.getElementById('lnk')!.addEventListener('click', (e) => e.preventDefault())
+    const evt = new (doc.defaultView as Window & typeof globalThis).MouseEvent('click', {
+      bubbles: true,
+      cancelable: true,
+      button: 0,
+    })
+    doc.getElementById('lnk')!.dispatchEvent(evt)
+    expect(scrollSpy).not.toHaveBeenCalled()
+  })
+})
+
+describe('HtmlPreviewFrame — listener lifecycle', () => {
+  // Wrap bindAnchorNavigation so each returned unbind records into unbindCalls when invoked.
+  let unbindCalls: number[]
+  beforeEach(() => {
+    unbindCalls = []
+    vi.spyOn(helpers, 'bindAnchorNavigation').mockImplementation((doc, url) => {
+      const real = actualBind(doc, url)
+      return () => {
+        unbindCalls.push(1)
+        real()
+      }
+    })
+  })
+
+  it('unbinds the old-document listener when slug changes (no intercept on the stale doc)', async () => {
+    stubFetch('<a id="lnk" href="#intro">go</a><i id="intro"></i>')
+    const { container, rerender } = render(<HtmlPreviewFrame slug="s" version="3" title="t" />)
+    const frame = await waitForFrame(container)
+    const staleDoc = writeIframeBody(frame, '<a id="lnk" href="#intro">go</a><i id="intro"></i>')
+
+    // Re-render with a new slug — the effect cleanup must drop the listener bound to staleDoc.
+    rerender(<HtmlPreviewFrame slug="s2" version="3" title="t" />)
+    await waitFor(() => expect(unbindCalls.length).toBeGreaterThan(0))
+
+    const link = staleDoc.getElementById('lnk')
+    if (link) {
+      const evt = new (staleDoc.defaultView as Window & typeof globalThis).MouseEvent('click', {
+        bubbles: true,
+        cancelable: true,
+        button: 0,
+      })
+      link.dispatchEvent(evt)
+      expect(evt.defaultPrevented).toBe(false)
+    }
+    // Either the stale iframe DOM was torn down (link null) or the listener was removed; both prove
+    // the old-document listener does not survive a slug change.
+    expect(unbindCalls.length).toBeGreaterThan(0)
+  })
+
+  it('unbinds on unmount', async () => {
+    stubFetch('<a id="lnk" href="#intro">go</a><i id="intro"></i>')
+    const { container, unmount } = render(<HtmlPreviewFrame slug="s" version="3" title="t" />)
+    const frame = await waitForFrame(container)
+    const doc = writeIframeBody(frame, '<a id="lnk" href="#intro">go</a><i id="intro"></i>')
+    const before = unbindCalls.length
+    unmount()
+    expect(unbindCalls.length).toBeGreaterThan(before)
+
+    const link = doc.getElementById('lnk')
+    if (link) {
+      const evt = new (doc.defaultView as Window & typeof globalThis).MouseEvent('click', {
+        bubbles: true,
+        cancelable: true,
+        button: 0,
+      })
+      link.dispatchEvent(evt)
+      expect(evt.defaultPrevented).toBe(false)
+    }
+  })
+})
+
+describe('bindAnchorNavigation — unit (name= fallback + escaping)', () => {
+  it('falls back to [name=...] when no id matches, escaping the value', () => {
+    const doc = document.implementation.createHTMLDocument('t')
+    doc.body.innerHTML = '<a id="lnk" href="#a.b">go</a><a name="a.b">anchor</a>'
+    const named = doc.querySelectorAll('a')[1] as HTMLElement
+    const scrollSpy = vi.fn()
+    named.scrollIntoView = scrollSpy
+    const unbind = bindAnchorNavigation(doc, 'https://od.test/d/s/v/3')
+
+    const evt = new MouseEvent('click', { bubbles: true, cancelable: true, button: 0 })
+    doc.getElementById('lnk')!.dispatchEvent(evt)
+    expect(evt.defaultPrevented).toBe(true)
+    expect(scrollSpy).toHaveBeenCalledWith({ block: 'start' })
+    unbind()
+  })
+
+  it('decodes a percent-encoded fragment before lookup', () => {
+    const doc = document.implementation.createHTMLDocument('t')
+    doc.body.innerHTML = '<a id="lnk" href="#a%20b">go</a><h2 id="a b">x</h2>'
+    const target = doc.getElementById('a b') as HTMLElement
+    const scrollSpy = vi.fn()
+    target.scrollIntoView = scrollSpy
+    const unbind = bindAnchorNavigation(doc, 'https://od.test/d/s/v/3')
+    const evt = new MouseEvent('click', { bubbles: true, cancelable: true, button: 0 })
+    doc.getElementById('lnk')!.dispatchEvent(evt)
+    expect(scrollSpy).toHaveBeenCalledWith({ block: 'start' })
+    unbind()
+  })
+
+  it('resolves a name= anchor with CSS-metacharacter/newline chars without throwing (getElementsByName, no selector build)', () => {
+    // A raw selector built from this name would abort querySelector after preventDefault, leaving
+    // the click stranded (no scroll, no navigation). getElementsByName sidesteps the selector.
+    const doc = document.implementation.createHTMLDocument('t')
+    const rawName = 'a\nb"]:c'
+    doc.body.innerHTML = '<a id="lnk">go</a>'
+    const named = doc.createElement('a')
+    named.setAttribute('name', rawName)
+    doc.body.appendChild(named)
+    doc.getElementById('lnk')!.setAttribute('href', `#${encodeURIComponent(rawName)}`)
+    const scrollSpy = vi.fn()
+    named.scrollIntoView = scrollSpy
+    const unbind = bindAnchorNavigation(doc, 'https://od.test/d/s/v/3')
+    const evt = new MouseEvent('click', { bubbles: true, cancelable: true, button: 0 })
+    expect(() => doc.getElementById('lnk')!.dispatchEvent(evt)).not.toThrow()
+    expect(evt.defaultPrevented).toBe(true)
+    expect(scrollSpy).toHaveBeenCalledWith({ block: 'start' })
+    unbind()
+  })
+
+  it('unbind() removes the listener', () => {
+    const doc = document.implementation.createHTMLDocument('t')
+    doc.body.innerHTML = '<a id="lnk" href="#intro">go</a><i id="intro"></i>'
+    const target = doc.getElementById('intro') as HTMLElement
+    const scrollSpy = vi.fn()
+    target.scrollIntoView = scrollSpy
+    const unbind = bindAnchorNavigation(doc, 'https://od.test/d/s/v/3')
+    unbind()
+    const evt = new MouseEvent('click', { bubbles: true, cancelable: true, button: 0 })
+    doc.getElementById('lnk')!.dispatchEvent(evt)
+    expect(scrollSpy).not.toHaveBeenCalled()
+  })
+})
+
+describe('injectBaseHref — document-self base (no forced trailing slash)', () => {
+  it('inserts the doc render URL verbatim, not the directory root', () => {
+    const docUrl = buildAbsoluteOctoDocUrl('s', '3')
+    const out = injectBaseHref('<html><head></head><body>x</body></html>', docUrl)
+    expect(out).toContain(`<base href="${docUrl}">`)
+    expect(docUrl).toContain('/d/s/v/3')
+    // Must NOT be turned into a directory (…/v/3/) — that would shift relative resolution.
+    expect(out).not.toContain('/v/3/">')
+  })
+})

--- a/packages/docs/src/html/HtmlPreviewFrame.tsx
+++ b/packages/docs/src/html/HtmlPreviewFrame.tsx
@@ -3,9 +3,10 @@
 import { useEffect, useRef, useState } from 'react'
 import {
   absolutizeDocAssetUrls,
+  bindAnchorNavigation,
+  buildAbsoluteOctoDocUrl,
   buildOctoDocUrl,
   injectBaseHref,
-  resolveAbsoluteOctoDocBase,
   resolveOctoDocBase,
 } from './htmlDocFrameHelpers.ts'
 import { getWKApp, t } from '../octoweb/index.ts'
@@ -48,6 +49,8 @@ export function HtmlPreviewFrame({
   const [state, setState] = useState<PreviewLoadState>({ status: 'loading' })
   const iframeRef = useRef<HTMLIFrameElement>(null)
   const seq = useRef(0)
+  // Unbind for the parent-side in-page anchor handler; cleared on reload / unmount / slug|version.
+  const unbindAnchors = useRef<(() => void) | null>(null)
 
   useEffect(() => {
     const mySeq = ++seq.current
@@ -75,8 +78,12 @@ export function HtmlPreviewFrame({
           ? {
               status: 'ready',
               // Absolutize known asset attrs, then inject <base> as the catch-all (CSS url()/root
-              // resources) — identical to the original HtmlDocView pipeline.
-              html: injectBaseHref(absolutizeDocAssetUrls(raw, url), resolveAbsoluteOctoDocBase()),
+              // resources). Base points at the document's OWN render URL so bare #fragments resolve
+              // to this document (not the directory root) rather than navigating the frame away.
+              html: injectBaseHref(
+                absolutizeDocAssetUrls(raw, url),
+                buildAbsoluteOctoDocUrl(slug, version),
+              ),
               raw,
             }
           : { status: 'empty' }
@@ -104,6 +111,14 @@ export function HtmlPreviewFrame({
     return () => frameRef?.(null)
   }, [frameRef])
 
+  // Any slug/version change (or unmount) must drop the anchor listener bound to the OLD document.
+  useEffect(() => {
+    return () => {
+      unbindAnchors.current?.()
+      unbindAnchors.current = null
+    }
+  }, [slug, version])
+
   if (state.status === 'loading') {
     return (
       <div className="octo-html-doc-state" role="status">
@@ -130,7 +145,20 @@ export function HtmlPreviewFrame({
       sandbox="allow-same-origin"
       title={title}
       srcDoc={state.html}
-      onLoad={() => onFrameLoad?.(iframeRef.current?.contentDocument ?? null, iframeRef.current as HTMLIFrameElement)}
+      onLoad={() => {
+        // Rebind cleanly: unbind the previous document's listener before wiring the fresh one.
+        unbindAnchors.current?.()
+        unbindAnchors.current = null
+        const doc = iframeRef.current?.contentDocument ?? null
+        if (doc) {
+          try {
+            unbindAnchors.current = bindAnchorNavigation(doc, buildOctoDocUrl(slug, version))
+          } catch (err) {
+            console.warn('[HtmlPreviewFrame] unable to bind in-page anchor navigation', err)
+          }
+        }
+        onFrameLoad?.(doc, iframeRef.current as HTMLIFrameElement)
+      }}
     />
   )
 }

--- a/packages/docs/src/html/htmlDocFrameHelpers.ts
+++ b/packages/docs/src/html/htmlDocFrameHelpers.ts
@@ -20,6 +20,13 @@ export function buildOctoDocUrl(slug: string, version: string): string {
   return `${resolveOctoDocBase()}/d/${encodeURIComponent(slug)}/v/${encodeURIComponent(version)}`
 }
 
+// Absolute render URL of the document itself (not the directory root). Used as the <base> so a
+// bare fragment resolves against THIS document — the file-style path also gives correct relative
+// (./x, ../x) asset resolution.
+export function buildAbsoluteOctoDocUrl(slug: string, version: string): string {
+  return resolveAbsoluteUrl(buildOctoDocUrl(slug, version))
+}
+
 function resolveAbsoluteUrl(value: string): string {
   const pageOrigin =
     typeof window !== 'undefined' && window.location?.origin ? window.location.origin : 'http://localhost'
@@ -69,12 +76,130 @@ export function absolutizeDocAssetUrls(html: string, docUrl = resolveAbsoluteOct
   return `${doctype}${doc.documentElement.outerHTML}`
 }
 
+// baseUrl is inserted verbatim: forcing a trailing slash would turn a file-style doc URL
+// (…/v/3) into a directory (…/v/3/), shifting relative resolution down one level and breaking
+// fragment-vs-document identity. Callers pass the exact desired base.
 export function injectBaseHref(html: string, baseUrl: string): string {
   if (!baseUrl) return html
-  const href = baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`
-  const baseTag = `<base href="${href.replace(/"/g, '&quot;')}">`
+  const baseTag = `<base href="${baseUrl.replace(/"/g, '&quot;')}">`
   const headOpen = /<head[^>]*>/i.exec(html)
   if (!headOpen) return `${baseTag}${html}`
   const at = headOpen.index + headOpen[0].length
   return `${html.slice(0, at)}${baseTag}${html.slice(at)}`
+}
+
+function findFragmentTarget(doc: Document, rawFragment: string): Element | null {
+  try {
+    let id = rawFragment
+    try {
+      id = decodeURIComponent(rawFragment)
+    } catch {
+      /* keep raw when it is not valid percent-encoding */
+    }
+    if (!id) return null
+    const byId = doc.getElementById(id)
+    if (byId) return byId
+    // Name lookup via getElementsByName avoids building a selector string: an id with newline/NULL
+    // or other CSS metacharacters would otherwise abort querySelector and (post-preventDefault)
+    // strand the click — neither scrolling nor navigating.
+    return doc.getElementsByName(id)[0] ?? null
+  } catch {
+    return null
+  }
+}
+
+// Effective link target = the element's own target attribute, or (when absent/empty) the target of
+// the first <base> that actually carries a target attribute. Per HTML this base may differ from the
+// one deciding href, so we scan for a target-bearing base rather than the first base — our injected
+// href-only <base> must not shadow the author's <base target>.
+// Values are read verbatim: a target is a browsing-context NAME, so trimming would turn a named
+// " _self " into the reserved keyword and silently change navigation semantics.
+function resolveEffectiveTarget(anchor: Element, doc: Document): string {
+  const own = anchor.getAttribute('target')
+  if (own) return own
+  const bases = doc.getElementsByTagName('base')
+  for (let i = 0; i < bases.length; i++) {
+    const t = bases[i].getAttribute('target')
+    if (t) return t
+  }
+  return ''
+}
+
+/**
+ * Parent-side in-page anchor handling for the sandboxed (no-scripts) preview iframe.
+ *
+ * With a <base>, a bare `#frag` on `about:srcdoc` resolves to an absolute URL that differs from the
+ * document's own URL, so the browser treats the click as cross-document navigation and replaces the
+ * whole frame. We intercept clicks whose resolved target (minus fragment) is THIS document (or that
+ * are plain `#` fragments) and scroll instead — never navigating the frame away.
+ *
+ * @returns an unbind function; callers MUST invoke it on reload / unmount / slug|version change.
+ */
+export function bindAnchorNavigation(doc: Document, docUrl: string): () => void {
+  const view = doc.defaultView
+  const docHref = (() => {
+    try {
+      return resolveAbsoluteUrl(docUrl)
+    } catch {
+      return docUrl
+    }
+  })()
+  const docNoFragment = docHref.split('#')[0]
+
+  const onClick = (event: MouseEvent) => {
+    // Honour explicit new-tab / modified clicks and anything already handled upstream.
+    if (event.defaultPrevented) return
+    if (event.button !== 0) return
+    if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return
+    const target = event.target as Element | null
+    // Also match <area href> (image-map anchors) which closest('a') misses.
+    const anchor = target?.closest?.('a[href], area[href]') as
+      | HTMLAnchorElement
+      | HTMLAreaElement
+      | null
+    if (!anchor) return
+    // Let the browser handle downloads and any effective target (incl. one from <base target>).
+    if (anchor.hasAttribute('download')) return
+    // target reflects only the element's own attribute; the browser layers <base target> on top of
+    // that, so resolve the effective value ourselves before deciding to intercept.
+    // Reserved target keywords are ASCII case-insensitive, so `_SELF` must count as self-targeting.
+    const effectiveTarget = resolveEffectiveTarget(anchor, doc)
+    if (effectiveTarget && effectiveTarget.toLowerCase() !== '_self') return
+    const rawHref = anchor.getAttribute('href')
+    if (rawHref == null) return
+
+    let fragment: string | null = null
+    if (rawHref.startsWith('#')) {
+      fragment = rawHref.slice(1)
+    } else {
+      // Resolve against the document's own URL; only treat as in-page when it targets THIS doc.
+      let resolved: URL
+      try {
+        resolved = new URL(rawHref, docHref)
+      } catch {
+        return
+      }
+      if (!resolved.hash) return
+      if (`${resolved.origin}${resolved.pathname}${resolved.search}` !== docNoFragment) return
+      fragment = resolved.hash.slice(1)
+    }
+    if (fragment == null) return
+
+    // From here it is an in-page anchor: never let the frame navigate, even on a miss.
+    event.preventDefault()
+    // Fragment semantics: locate the target first (so id="top" wins); only scroll to the page top
+    // when the fragment is empty, or it is `top` with no matching element.
+    const el = fragment ? findFragmentTarget(doc, fragment) : null
+    if (el) {
+      el.scrollIntoView({ block: 'start' })
+      return
+    }
+    if (fragment === '' || fragment === 'top') {
+      view?.scrollTo?.(0, 0)
+      doc.documentElement?.scrollTo?.(0, 0)
+    }
+  }
+
+  doc.addEventListener('click', onClick)
+  return () => doc.removeEventListener('click', onClick)
 }


### PR DESCRIPTION
## Summary

HTML 文档在 Web 预览 iframe 里点自己的目录/导航栏（`href="#intro"` 这类页内锚点）时，整个 iframe 会被导航到 octo-doc 首页，页内跳转完全不可用。

根因是我们注入的 `<base>`：按 HTML 规范，纯 fragment 也要按 base URL 解析，而 `srcDoc` 文档自身地址是 `about:srcdoc`，与 base 指向的任何 http 地址都不相等 —— 浏览器于是判定为跨文档导航并整页替换，而不是页内滚动。base 当前指向目录根 `/docs-html/`，所以落点正好是 octo-doc 首页。

`<base>` 不能简单删除：它是资源解析的兜底网（`absolutizeDocAssetUrls` 只重写 `img[src]`/`link[href]` 且仅当路径含 `/assets/`，CSS 内 `url()`、`<style>`、`srcset`、`<source>`、media 元素全靠 base）。因此本 PR 保留 base，改两处：

1. **base 指向文档自身的渲染 URL**（`/docs-html/d/<slug>/v/<n>`）而不是目录根，并去掉 `injectBaseHref` 无条件补尾斜杠的行为（补斜杠会把文件式 URL 当目录，令相对解析基准错一层）。
2. **parent 侧拦截页内锚点点击**：新增 `bindAnchorNavigation`，在 iframe 的 live `contentDocument` 上监听 click，命中页内锚点则 `preventDefault` + `scrollIntoView`。

该模式下 iframe 是 `sandbox="allow-same-origin"`、**不给 `allow-scripts`**，注入脚本不会执行，所以拦截必须在 parent 侧做 —— 这也意味着本 PR **完全没有触碰 sandbox / 安全边界**。

## Linked Spec

无独立 spec；bug 由 HTML 文档预览的页内导航失效反馈引出。仓库当前无 `.octospec/`，遵循 octo-spec 全局规则（无密钥、不 fail-open、输入校验与边界、Conventional Commits）。

## How verified

- `packages/docs` 全量：**16 files / 264 tests 全绿**（基线 246，净增 18 条）
- `npx tsc --noEmit -p tsconfig.typecheck.json`：仅 `../dmworkbase/**` 既有基线报错（axios 类型缺失等），无新增
- `npx turbo run build --filter=@octo/web`：production build 成功
- `git diff --check` 通过
- **反向验证**（一次只动一个变量，确认测试有效且改动必要）：
  - 还原 base 改动 → base 形态相关测试失败
  - 移除锚点绑定 → 拦截行为测试全部失败
  - 还原 `.toLowerCase()` → `<base target="_SELF">` 测试失败（1 failed / 28 passed）
  - 加回 `.trim()` → `<base target=" _self ">` 测试失败（1 failed / 28 passed）
- **真实环境验证**：以 upstream/main + 本 commit 打镜像部署（校验过 bundle 内确实含新代码，非旧产物），与未修复实例并行对比

经过 4 轮独立 adversarial review，累计修掉 1 个 P1 + 5 个 P2，最终 APPROVE。

## COMPREHENSION

**(a) 对承载路径做了什么（before/after）**

承载路径 = `HtmlPreviewFrame` 的「fetch 文档 HTML → 变换 → 挂 srcDoc → iframe 渲染」。

- before：`injectBaseHref(absolutizeDocAssetUrls(raw, url), resolveAbsoluteOctoDocBase())`，base = `<origin>/docs-html/`（目录根，强制补尾斜杠）；iframe 无任何 click 处理。页内锚点 → 跨文档导航 → 整帧替换为 octo-doc 首页。
- after：base = `<origin>/docs-html/d/<slug>/v/<n>`（文档自身，原样不补斜杠）；`onLoad` 时在 iframe document 上绑定 `bindAnchorNavigation`，页内锚点 → `preventDefault` + `scrollIntoView`。
- 资源解析：根相对引用（`/d/<slug>/assets/<sha>`，即 octo-doc 签名资源的真实形状）**不受影响**；文档层级相对引用（`./x`、`../x`）现在解析到文档所在目录，语义更正确。
- 未改动：`<base>` 仍注入、`absolutizeDocAssetUrls` 重写范围一行未动、iframe 仍用 `srcDoc`、`sandbox="allow-same-origin"` 未变、无新增依赖。

**(b) 什么可能坏（依赖方 + 失败模式）**

- `HtmlPreviewFrame` 的消费方：`HtmlDocView`（文档预览）与 `HtmlDiffModal`（版本对比双栏预览）。两者都经 `HtmlPreviewFrame` 走同一路径，测试已覆盖，无回归。
- 最大回归面 = base 从「目录」变「文件」导致的相对 URL 解析基准变化。已按资源形态逐类审计：根相对不受影响；纯相对改为相对文档目录（更正确）；`srcset`/`<source>`/media/内联 CSS `url()` 已补测试作为护栏。
- 锚点拦截的失败模式 = **误拦**（把本该跨文档的链接吞掉变死链）或**漏拦**（仍然跳走）。为此：同文档判定用 `new URL` 规范化后比较 `origin+pathname+search`；显式放行 `target`（含 `<base target>` 继承，保留关键字大小写不敏感）、`download`、修饰键、非左键、已 `defaultPrevented`；`<area>` 与 `<a>` 同等处理。
- fail-silent 风险：fragment 目标定位改用 `getElementsByName` 而非拼接选择器（含控制字符的 id 曾会让 `querySelector` 抛异常，而此时已 `preventDefault` → 既不滚动也不导航，静默死掉），并加 try/catch 兜底。
- 生命周期：`onLoad` 重绑前先解绑；slug/version 变更与卸载均解绑，无监听泄漏。

**(c) 怎么知道它有效**

除上述测试/typecheck/build 外，关键证据是**反向验证**：每处改动逐个还原，确认只有对应测试失败 —— 同时证明测试有效与改动必要。审计过程还发现并修掉一条**假绿测试**（用 `Object.defineProperty` 覆写 `target` getter 测虚构行为，已改为真实构造 `<base target>` 元素）。另有真实环境部署对比验证（修复实例 vs 未修复实例）。

## 部署前提 / 必配环境变量

本 PR **不引入任何新环境变量**，纯前端逻辑修复，无需额外配置。

为便于部署校验，Web 容器现有相关变量（保持原值即可）：

| 变量 | 说明 | 不配的后果 |
| --- | --- | --- |
| `DOC_APP_URL` | octo-doc 上游地址，nginx `location /docs-html/` 的 `proxy_pass` 目标 | 为空时该路由直接 503，HTML 文档无法渲染（与本 PR 无关，属既有前提） |
| `DOCS_BACKEND_URL` | octo-docs-backend 地址，承载 `/api/v1/docs*` 元数据面 | 文档列表/成员/分享等 REST 不可用 |
| `API_URL` | octo-server 地址 | 主站 API 不可用 |
| `OCTO_HTML_SOURCE_DIFF_ENABLED` | HTML 源码 diff 开关，默认 `false` | 与本 PR 无关，保持原值 |

注：`VITE_OCTO_DOC_BASE` / `window.__OCTO_DOC_BASE__` 未配置时前端默认 `/docs-html`，与 nginx 路由一致，无需改动。
