### PR TITLE
fix(messages): resolve emoji image path via BASE_URL for correct file:// and subpath rendering

### DIFF
--- a/packages/dmworkbase/src/Messages/Text/index.tsx
+++ b/packages/dmworkbase/src/Messages/Text/index.tsx
@@ -104,7 +104,7 @@ export class TextCell extends MessageCell {
             // 自定义表情（[xxx]）单发时放大显示。优先用服务端清单驱动的 isCustomEmoji；
             // 旧 mock/实现未提供时回退到历史的本地 custom_ 图路径判断。
             const emojiUrl = WKApp.emojiService.getImage(token)
-            return WKApp.emojiService.isCustomEmoji?.(token) ?? !!(emojiUrl && emojiUrl.includes("/emoji/custom_"))
+            return WKApp.emojiService.isCustomEmoji?.(token) ?? !!(emojiUrl && emojiUrl.includes("emoji/custom_"))
         }
         return false
     }
@@ -156,7 +156,7 @@ export class TextCell extends MessageCell {
             const token = emojiParts[0].text
             const emojiUrl = WKApp.emojiService.getImage(token)
             // 自定义表情按清单判定(对服务端 CDN/绝对 url 同样生效),回退到旧的本地路径子串。
-            const isCustom = WKApp.emojiService.isCustomEmoji?.(token) ?? !!(emojiUrl && emojiUrl.includes("/emoji/custom_"))
+            const isCustom = WKApp.emojiService.isCustomEmoji?.(token) ?? !!(emojiUrl && emojiUrl.includes("emoji/custom_"))
             if (isCustom && emojiUrl) {
                 return (
                     <span className="wk-message-text-richemoji wk-message-text-richemoji--large">

--- a/packages/dmworkbase/src/Service/EmojiService.ts
+++ b/packages/dmworkbase/src/Service/EmojiService.ts
@@ -377,7 +377,11 @@ export class DefaultEmojiService implements EmojiService {
     }
 
     private localImage(base: string): string {
-        return `./emoji/${base}.png`
+        // 用 BASE_URL 拼接而非写死相对路径 "./"：web 构建 base="/"（绝对路径，
+        // 页面 URL 带任意路径段都正确解析），electron 构建 base="./"（file:// 下
+        // 相对 index.html 不变）。写死 "./" 在页面 URL 带路径段（如 /chat/、/xxx/）
+        // 时会被解析到 /xxx/emoji/...，SPA fallback 返回 HTML → <img> 破图不显示。
+        return `${import.meta.env.BASE_URL}emoji/${base}.png`
     }
 
     // 自定义表情最终图片地址：优先 manifest 下发的 url（绝对 url 原样用，相对 url 拼到 API

--- a/packages/dmworkbase/src/Service/__tests__/EmojiService.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/EmojiService.test.ts
@@ -31,9 +31,9 @@ beforeEach(() => {
 describe("EmojiService 内置兜底（未拉取 manifest）", () => {
   it("getImage 对内置自定义表情返回本地 PNG，对 Unicode 返回本地 PNG", () => {
     const svc = freshService()
-    expect(svc.getImage("[使命必达]")).toBe("./emoji/custom_mission.png")
-    expect(svc.getImage("[尚方宝剑]")).toBe("./emoji/custom_shangfang.png")
-    expect(svc.getImage("😀")).toBe("./emoji/0_0.png")
+    expect(svc.getImage("[使命必达]")).toBe("/emoji/custom_mission.png")
+    expect(svc.getImage("[尚方宝剑]")).toBe("/emoji/custom_shangfang.png")
+    expect(svc.getImage("😀")).toBe("/emoji/0_0.png")
     expect(svc.getImage("不存在")).toBe("")
   })
 
@@ -52,7 +52,7 @@ describe("EmojiService 内置兜底（未拉取 manifest）", () => {
     expect(firstFour).toEqual(["[使命必达]", "[崇尚行动]", "[有品位]", "[尚方宝剑]"])
     // name 为人类可读标签，image 为本地图
     expect(all[0].name).toBe("使命必达")
-    expect(all[0].image).toBe("./emoji/custom_mission.png")
+    expect(all[0].image).toBe("/emoji/custom_mission.png")
   })
 
   it("emojiRegExp 匹配自定义 token 与 Unicode，且缓存同一实例", () => {
@@ -84,7 +84,7 @@ describe("EmojiService load() 拉取服务端 manifest", () => {
     // 调用路径为相对 base 路径（apiClient 会拼 apiURL）
     expect(apiGet).toHaveBeenCalledWith("common/emojis")
 
-    expect(svc.getImage("[使命必达]")).toBe("./emoji/custom_mission.png") // 空 url → 本地兜底
+    expect(svc.getImage("[使命必达]")).toBe("/emoji/custom_mission.png") // 空 url → 本地兜底
     expect(svc.getImage("[新表情]")).toBe("/api/v1/emoji/custom_new.png") // 相对 url 拼 base
     expect(svc.getImage("[绝对图]")).toBe("https://cdn.example.com/a.png") // 绝对 url 原样
     expect(svc.isCustomEmoji?.("[新表情]")).toBe(true)
@@ -123,14 +123,14 @@ describe("EmojiService load() 拉取服务端 manifest", () => {
     await svc.load?.()
     expect(svc.isCustomEmoji?.("[使命必达]")).toBe(false)
     // Unicode 仍在
-    expect(svc.getImage("😀")).toBe("./emoji/0_0.png")
+    expect(svc.getImage("😀")).toBe("/emoji/0_0.png")
   })
 
   it("失败：保持内置兜底，不抛错", async () => {
     apiGet.mockRejectedValueOnce(new Error("network down"))
     const svc = freshService()
     await expect(svc.load?.()).resolves.toBeUndefined()
-    expect(svc.getImage("[使命必达]")).toBe("./emoji/custom_mission.png")
+    expect(svc.getImage("[使命必达]")).toBe("/emoji/custom_mission.png")
     expect(svc.getAllEmoji().length).toBe(4 + 152)
   })
 

--- a/packages/dmworkbase/src/bridge/message/useTextMessageUI.ts
+++ b/packages/dmworkbase/src/bridge/message/useTextMessageUI.ts
@@ -88,7 +88,7 @@ export function getTextMessageUI(
     // 自定义表情(含服务端 url)按清单判定;不再用本地 /emoji/custom_ 路径子串
     // (对 CDN/绝对 url 失效)。旧实现未提供该方法时回退到原判断。
     (WKApp.emojiService.isCustomEmoji?.(emojis[0].key) ??
-      emojis[0].url.includes("/emoji/custom_"));
+      emojis[0].url.includes("emoji/custom_"));
 
   // 获取纯文本内容（优先使用编辑后的内容）
   const effectiveContent = getEffectiveContent(message) as any;
@@ -143,7 +143,7 @@ export function useTextMessageUI(message: MessageWrap) {
       emojis.length === 1 &&
       // 自定义表情(含服务端 url)按清单判定;不再用本地 /emoji/custom_ 路径子串。
       (WKApp.emojiService.isCustomEmoji?.(emojis[0].key) ??
-        emojis[0].url.includes("/emoji/custom_"));
+        emojis[0].url.includes("emoji/custom_"));
 
     // 获取纯文本内容（优先使用编辑后的内容）
     const effectiveContent = getEffectiveContent(message) as any;

--- a/packages/dmworkbase/src/ui/message/MessageReactionPicker/data.ts
+++ b/packages/dmworkbase/src/ui/message/MessageReactionPicker/data.ts
@@ -49,25 +49,25 @@ export const DEFAULT_TOKENS: PickerEmoji[] = [
   {
     key: BUILTIN_CUSTOM_EMOJI_KEYS.mission,
     char: BUILTIN_CUSTOM_EMOJI_KEYS.mission,
-    image: "/emoji/custom_mission.png",
+    image: `${import.meta.env.BASE_URL}emoji/custom_mission.png`,
     nameKey: "base.reaction.emoji.mission",
   },
   {
     key: BUILTIN_CUSTOM_EMOJI_KEYS.action,
     char: BUILTIN_CUSTOM_EMOJI_KEYS.action,
-    image: "/emoji/custom_action.png",
+    image: `${import.meta.env.BASE_URL}emoji/custom_action.png`,
     nameKey: "base.reaction.emoji.action",
   },
   {
     key: BUILTIN_CUSTOM_EMOJI_KEYS.taste,
     char: BUILTIN_CUSTOM_EMOJI_KEYS.taste,
-    image: "/emoji/custom_taste.png",
+    image: `${import.meta.env.BASE_URL}emoji/custom_taste.png`,
     nameKey: "base.reaction.emoji.taste",
   },
   {
     key: BUILTIN_CUSTOM_EMOJI_KEYS.shangfang,
     char: BUILTIN_CUSTOM_EMOJI_KEYS.shangfang,
-    image: "/emoji/custom_shangfang.png",
+    image: `${import.meta.env.BASE_URL}emoji/custom_shangfang.png`,
     nameKey: "base.reaction.emoji.shangfang",
   },
 ];


### PR DESCRIPTION
## Summary

Fixes emoji images not displaying in the desktop (Electron `file://`) build and under routed web URLs. Split out of the desktop-support PR (#1258) to keep that one scoped to branding + packaging.

## Problem

Emoji `<img>` tags used a hardcoded relative path `./emoji/...` (`EmojiService.localImage`) or absolute `/emoji/...` (reaction picker). Under a URL that carries path segments (`/chat/`, `/xxx/`), the relative form resolves to `/xxx/emoji/...`, and the SPA fallback returns `index.html` (HTML) instead of the PNG — so the emoji renders as a broken image. In the Electron `file://` build the same relative-path fragility applies.

## Fix

Build the emoji path from `import.meta.env.BASE_URL`:
- **web build** (`base: '/'`) → absolute `/emoji/...` that resolves at any URL depth
- **electron build** (`base: './'`) → relative `./emoji/...`, correct for `file://`

Changes:
- `EmojiService.localImage`: `` './emoji/' `` → `` `${import.meta.env.BASE_URL}emoji/` ``
- `MessageReactionPicker/data.ts`: 4 built-in custom emojis use `BASE_URL` too
- `isCustomEmoji` fallback checks `'emoji/custom_'` (matches both absolute and relative forms)
- Tests assert `/emoji/` (vitest `BASE_URL='/'`)

## Verification

- `EmojiService.test.ts` 10/10 pass
- `tsc -p tsconfig.e.json` clean
- Verified in a real Windows Electron build: emoji render correctly (no broken images) in message list, file:// loaded
