### PR TITLE
test(summary): migrate e2e locators to testids

### DIFF
--- a/apps/web/e2e-kit/msw-handlers/s19-summary-list-cancel-task.ts
+++ b/apps/web/e2e-kit/msw-handlers/s19-summary-list-cancel-task.ts
@@ -2,9 +2,12 @@
 /* eslint-disable @typescript-eslint/no-explicit-any -- msw resolver types */
 import type { Page } from "@playwright/test";
 
+/** S19 task ID (in-progress, cancellable). */
+export const S19_TASK_ID = 19019;
+
 /** S19: Summary 列表生成中任务取消. */
 export async function registerS19SummaryListCancelTask(page: Page): Promise<void> {
-  await page.evaluate(() => {
+  await page.evaluate(([TASK_ID]) => {
     type MSW = {
       worker: { use: (...h: unknown[]) => void };
       http: {
@@ -17,7 +20,7 @@ export async function registerS19SummaryListCancelTask(page: Page): Promise<void
     if (!msw) throw new Error("[S19] MSW worker 未就绪 (等 __MSW_READY__).");
     const { worker, http, HttpResponse } = msw;
     const env = (data: unknown) => HttpResponse.json({ code: 0, message: "ok", data });
-    const taskId = 19019;
+    const taskId = TASK_ID;
     const now = "2026-08-06T19:10:00Z";
     const makeItem = (status: number) => ({
       task_id: taskId,
@@ -54,7 +57,7 @@ export async function registerS19SummaryListCancelTask(page: Page): Promise<void
         const state = (window as unknown as { __s19State__: { cancelled: boolean } }).__s19State__;
         return env({ items: [makeItem(state.cancelled ? 5 : 2)], total: 1, attention_count: 0, unread_count: 0, pending_invitation_count: 0 });
       }),
-      http.post("*/summary/api/v1/summaries/19019/cancel", () => {
+      http.post(`*/summary/api/v1/summaries/${TASK_ID}/cancel`, () => {
         const state = (window as unknown as { __s19State__: { cancelled: boolean } }).__s19State__;
         state.cancelled = true;
         return env({});
@@ -64,5 +67,5 @@ export async function registerS19SummaryListCancelTask(page: Page): Promise<void
         return env({ tasks: [{ id: taskId, status: state.cancelled ? 5 : 2 }] });
       })
     );
-  });
+  }, [S19_TASK_ID]);
 }

--- a/apps/web/e2e-kit/msw-handlers/s20-summary-list-retry-failed.ts
+++ b/apps/web/e2e-kit/msw-handlers/s20-summary-list-retry-failed.ts
@@ -2,9 +2,12 @@
 /* eslint-disable @typescript-eslint/no-explicit-any -- msw resolver types */
 import type { Page } from "@playwright/test";
 
+/** S20 task ID (failed, retryable). */
+export const S20_TASK_ID = 20020;
+
 /** S20: Summary 列表失败任务重试. */
 export async function registerS20SummaryListRetryFailed(page: Page): Promise<void> {
-  await page.evaluate(() => {
+  await page.evaluate(([TASK_ID]) => {
     type MSW = {
       worker: { use: (...h: unknown[]) => void };
       http: {
@@ -17,7 +20,7 @@ export async function registerS20SummaryListRetryFailed(page: Page): Promise<voi
     if (!msw) throw new Error("[S20] MSW worker 未就绪 (等 __MSW_READY__).");
     const { worker, http, HttpResponse } = msw;
     const env = (data: unknown) => HttpResponse.json({ code: 0, message: "ok", data });
-    const taskId = 20020;
+    const taskId = TASK_ID;
     const now = "2026-08-06T20:10:00Z";
     const makeItem = (status: number) => ({
       task_id: taskId,
@@ -54,7 +57,7 @@ export async function registerS20SummaryListRetryFailed(page: Page): Promise<voi
         const state = (window as unknown as { __s20State__: { retried: boolean } }).__s20State__;
         return env({ items: [makeItem(state.retried ? 2 : 4)], total: 1, attention_count: state.retried ? 0 : 1, unread_count: 0, pending_invitation_count: 0 });
       }),
-      http.post("*/summary/api/v1/summaries/20020/regenerate", () => {
+      http.post(`*/summary/api/v1/summaries/${TASK_ID}/regenerate`, () => {
         const state = (window as unknown as { __s20State__: { retried: boolean } }).__s20State__;
         state.retried = true;
         return env({ task_id: taskId });
@@ -64,5 +67,5 @@ export async function registerS20SummaryListRetryFailed(page: Page): Promise<voi
         return env({ tasks: [{ id: taskId, status: state.retried ? 2 : 4 }] });
       })
     );
-  });
+  }, [S20_TASK_ID]);
 }

--- a/apps/web/e2e-kit/msw-handlers/s24-summary-multi-collab-submit.ts
+++ b/apps/web/e2e-kit/msw-handlers/s24-summary-multi-collab-submit.ts
@@ -2,9 +2,16 @@
 /* eslint-disable @typescript-eslint/no-explicit-any -- msw resolver types */
 import type { Page } from "@playwright/test";
 
+/** S24 task ID. */
+export const S24_TASK_ID = 24024;
+/** S24 logged-in user ID (the submitter). */
+export const S24_MY_USER_ID = "e2e-user-1";
+/** S24 other participant user ID. */
+export const S24_OTHER_USER_ID = "s24-member-a";
+
 /** S24: 多人 BY_PERSON 个人报告提交. */
 export async function registerS24SummaryMultiCollabSubmit(page: Page): Promise<void> {
-  await page.evaluate(() => {
+  await page.evaluate(([TASK_ID, MY_USER_ID, OTHER_USER_ID]) => {
     type MSW = {
       worker: { use: (...h: unknown[]) => void };
       http: {
@@ -17,12 +24,12 @@ export async function registerS24SummaryMultiCollabSubmit(page: Page): Promise<v
     if (!msw) throw new Error("[S24] MSW worker 未就绪 (等 __MSW_READY__).");
     const { worker, http, HttpResponse } = msw;
     const env = (data: unknown) => HttpResponse.json({ code: 0, message: "ok", data });
-    const taskId = 24024;
+    const taskId = TASK_ID;
     const now = "2026-08-06T23:10:00Z";
     const source = { source_type: 1, source_id: "s24-multi-group", source_name: "S24 多人项目群" };
     const participants = [
-      { user_id: "e2e-user-1", user_name: "E2E Tester", status: 1, confirmed_at: now },
-      { user_id: "s24-member-a", user_name: "S24 Alice", status: 1, confirmed_at: now },
+      { user_id: MY_USER_ID, user_name: "E2E Tester", status: 1, confirmed_at: now },
+      { user_id: OTHER_USER_ID, user_name: "S24 Alice", status: 1, confirmed_at: now },
     ];
     const listItem = {
       task_id: taskId,
@@ -102,7 +109,7 @@ export async function registerS24SummaryMultiCollabSubmit(page: Page): Promise<v
     const makeMembers = (submitted: boolean) => ({
       members: [
         {
-          user_id: "e2e-user-1",
+          user_id: MY_USER_ID,
           user_name: "E2E Tester",
           status: submitted ? "submitted" : "completed",
           submitted_at: submitted ? "2026-08-06T23:18:00Z" : null,
@@ -110,7 +117,7 @@ export async function registerS24SummaryMultiCollabSubmit(page: Page): Promise<v
           citations: [],
         },
         {
-          user_id: "s24-member-a",
+          user_id: OTHER_USER_ID,
           user_name: "S24 Alice",
           status: "submitted",
           submitted_at: "2026-08-06T23:11:00Z",
@@ -124,25 +131,25 @@ export async function registerS24SummaryMultiCollabSubmit(page: Page): Promise<v
 
     worker.use(
       http.get("*/summary/api/v1/summaries", () => env({ items: [listItem], total: 1, attention_count: 1, unread_count: 1, pending_invitation_count: 0 })),
-      http.get("*/summary/api/v1/summaries/24024", () => {
+      http.get(`*/summary/api/v1/summaries/${TASK_ID}`, () => {
         const state = (window as unknown as { __s24State__: { submitted: boolean } }).__s24State__;
         return env(makeDetail(state.submitted));
       }),
-      http.get("*/summary/api/v1/summaries/24024/personal", () => {
+      http.get(`*/summary/api/v1/summaries/${TASK_ID}/personal`, () => {
         const state = (window as unknown as { __s24State__: { submitted: boolean } }).__s24State__;
         return env(makePersonal(state.submitted));
       }),
-      http.get("*/summary/api/v1/summaries/24024/members", () => {
+      http.get(`*/summary/api/v1/summaries/${TASK_ID}/members`, () => {
         const state = (window as unknown as { __s24State__: { submitted: boolean } }).__s24State__;
         return env(makeMembers(state.submitted));
       }),
-      http.post("*/summary/api/v1/summaries/24024/submit", () => {
+      http.post(`*/summary/api/v1/summaries/${TASK_ID}/submit`, () => {
         const state = (window as unknown as { __s24State__: { submitted: boolean } }).__s24State__;
         state.submitted = true;
         return env({});
       }),
-      http.post("*/summary/api/v1/summaries/24024/read", () => env({ is_unread: false, has_pending_invitation: false, needs_attention: false })),
-      http.get("*/summary/api/v1/summaries/24024/versions", () => env({ versions: [], keep_limit: 3 }))
+      http.post(`*/summary/api/v1/summaries/${TASK_ID}/read`, () => env({ is_unread: false, has_pending_invitation: false, needs_attention: false })),
+      http.get(`*/summary/api/v1/summaries/${TASK_ID}/versions`, () => env({ versions: [], keep_limit: 3 }))
     );
-  });
+  }, [S24_TASK_ID, S24_MY_USER_ID, S24_OTHER_USER_ID]);
 }

--- a/apps/web/e2e-kit/msw-handlers/s25-summary-invite-respond.ts
+++ b/apps/web/e2e-kit/msw-handlers/s25-summary-invite-respond.ts
@@ -2,6 +2,11 @@
 /* eslint-disable @typescript-eslint/no-explicit-any -- msw resolver types */
 import type { Page } from "@playwright/test";
 
+/** S25 accept-invite task ID. */
+export const S25_ACCEPT_TASK_ID = 250251;
+/** S25 reject-invite task ID. */
+export const S25_REJECT_TASK_ID = 250252;
+
 /** S25: Summary 列表待确认邀请同意 / 拒绝. */
 export async function registerS25SummaryInviteRespond(page: Page): Promise<void> {
   await page.evaluate(() => {

--- a/apps/web/e2e-kit/msw-handlers/s25-summary-invite-respond.ts
+++ b/apps/web/e2e-kit/msw-handlers/s25-summary-invite-respond.ts
@@ -9,7 +9,7 @@ export const S25_REJECT_TASK_ID = 250252;
 
 /** S25: Summary 列表待确认邀请同意 / 拒绝. */
 export async function registerS25SummaryInviteRespond(page: Page): Promise<void> {
-  await page.evaluate(() => {
+  await page.evaluate(({ ACCEPT_TASK_ID, REJECT_TASK_ID }) => {
     type MSW = {
       worker: { use: (...h: unknown[]) => void };
       http: {
@@ -67,26 +67,26 @@ export async function registerS25SummaryInviteRespond(page: Page): Promise<void>
     worker.use(
       http.get("*/summary/api/v1/summaries", () => {
         const state = (window as unknown as { __s25State__: { accepted: boolean; rejected: boolean } }).__s25State__;
-        const acceptedItem = makeItem(250251, "S25 同意邀请总结", state.accepted ? "accepted" : undefined);
-        const rejectedItem = makeItem(250252, "S25 拒绝邀请总结", state.rejected ? "rejected" : undefined);
+        const acceptedItem = makeItem(ACCEPT_TASK_ID, "S25 同意邀请总结", state.accepted ? "accepted" : undefined);
+        const rejectedItem = makeItem(REJECT_TASK_ID, "S25 拒绝邀请总结", state.rejected ? "rejected" : undefined);
         return env({ items: [acceptedItem, rejectedItem], total: 2, attention_count: state.accepted && state.rejected ? 0 : 2, unread_count: 0, pending_invitation_count: state.accepted && state.rejected ? 0 : 2 });
       }),
       http.post("*/summary/api/v1/summaries/:taskId/respond", async ({ params, request }: any) => {
         const state = (window as unknown as { __s25State__: { accepted: boolean; rejected: boolean } }).__s25State__;
         const body = await request.json();
-        if (String(params.taskId) === "250251" && body.action === "accept") state.accepted = true;
-        if (String(params.taskId) === "250252" && body.action === "reject") state.rejected = true;
+        if (String(params.taskId) === String(ACCEPT_TASK_ID) && body.action === "accept") state.accepted = true;
+        if (String(params.taskId) === String(REJECT_TASK_ID) && body.action === "reject") state.rejected = true;
         return env({});
       }),
       http.post("*/summary/api/v1/summaries/batch-status", () => {
         const state = (window as unknown as { __s25State__: { accepted: boolean; rejected: boolean } }).__s25State__;
         return env({
           tasks: [
-            { id: 250251, status: state.accepted ? 2 : 1 },
-            { id: 250252, status: state.rejected ? 5 : 1 },
+            { id: ACCEPT_TASK_ID, status: state.accepted ? 2 : 1 },
+            { id: REJECT_TASK_ID, status: state.rejected ? 5 : 1 },
           ],
         });
       })
     );
-  });
+  }, { ACCEPT_TASK_ID: S25_ACCEPT_TASK_ID, REJECT_TASK_ID: S25_REJECT_TASK_ID });
 }

--- a/apps/web/e2e-kit/tests/summary/_testids.ts
+++ b/apps/web/e2e-kit/tests/summary/_testids.ts
@@ -8,6 +8,7 @@ export const T = {
     listContent: "summary-list-content",
     listSearch: "summary-list-search",
     listStatusFilter: "summary-list-status-filter",
+    listCreate: "summary-list-create",
     createEntry: "summary-create-entry",
 
     // Card (per-task)

--- a/apps/web/e2e-kit/tests/summary/_testids.ts
+++ b/apps/web/e2e-kit/tests/summary/_testids.ts
@@ -1,38 +1,39 @@
-export const summaryTestIds = {
-    // ── List page ──
+/**
+ * Stable data-testid constants for Summary e2e tests.
+ * Mirrors packages/dmworksummary/src/utils/testIds.ts — keep in sync.
+ */
+export const T = {
+    // List page
     list: "summary-list",
     listContent: "summary-list-content",
     listSearch: "summary-list-search",
     listStatusFilter: "summary-list-status-filter",
-    listCreate: "summary-create",
     createEntry: "summary-create-entry",
 
-    // ── Card (per-task) ──
+    // Card (per-task)
     card: (taskId: number) => `summary-card-${taskId}`,
     cardMenu: (taskId: number) => `summary-card-menu-${taskId}`,
     cardAcceptBtn: (taskId: number) => `summary-card-accept-${taskId}`,
     cardRejectBtn: (taskId: number) => `summary-card-reject-${taskId}`,
 
-    // ── Create page ──
+    // Create page
     create: "summary-create",
     createTopic: "summary-create-topic",
     createSelectChat: "summary-create-select-chat",
     createSelectMembers: "summary-create-select-members",
     createSubmit: "summary-create-submit",
-    // Agent mode buttons on create page
     createAgentTab: "summary-create-agent-tab",
     createNormalTab: "summary-create-normal-tab",
     createPanelStartBtn: "summary-create-panel-start-btn",
 
-    // ── Chat selector modal ──
+    // Chat/member selector modal
     chatSelectorModal: "summary-chat-selector-modal",
     chatSelectorAllGroupsTab: "summary-chat-selector-all-groups-tab",
     chatSelectorConfirmBtn: "summary-chat-selector-confirm-btn",
     chatSelectorSearchInput: "summary-chat-selector-search-input",
     memberSelectorConfirmBtn: "summary-member-selector-confirm-btn",
 
-    // ── Detail page ──
-    detail: (taskId: number) => `summary-detail-${taskId}`,
+    // Detail page
     detailPage: "summary-detail-page",
     detailTitle: "summary-detail-title",
     detailRegenerateBtn: "summary-detail-regenerate-btn",
@@ -46,27 +47,27 @@ export const summaryTestIds = {
     detailSubmitMyBtn: "summary-detail-submit-my-btn",
     detailMyDraftEditBtn: "summary-detail-my-draft-edit-btn",
 
-    // ── Editor footer (inline edit save/cancel) ──
+    // Inline editor footer
     editorSaveBtn: "summary-editor-save-btn",
     editorCancelBtn: "summary-editor-cancel-btn",
     editorTextarea: "summary-editor-textarea",
 
-    // ── Regenerate modal ──
+    // Regenerate modal
     regenerateInput: "summary-regenerate-input",
     regenerateSubmitBtn: "summary-regenerate-submit-btn",
     regenerateCancelBtn: "summary-regenerate-cancel-btn",
     regenerateModal: "summary-regenerate-modal",
 
-    // ── Delete confirmation ──
+    // Delete confirmation
     deleteConfirmOkBtn: "summary-delete-confirm-ok-btn",
     deleteConfirmDialog: "summary-delete-confirm-dialog",
 
-    // ── Version panel ──
+    // Version panel
     versionPanel: "summary-version-panel",
-    versionCard: (versionNum: number | string) => `summary-version-card-${versionNum}`,
+    versionCard: (v: number | string) => `summary-version-card-${v}`,
     versionRestoreBtn: "summary-version-restore-btn",
 
-    // ── Agent chat panel (in create page / continue-refine) ──
+    // Agent chat panel
     agentPanel: "summary-agent-panel",
     agentInput: "summary-agent-input",
     agentSendBtn: "summary-agent-send-btn",
@@ -75,7 +76,6 @@ export const summaryTestIds = {
     agentSaveDialog: "summary-agent-save-dialog",
     agentSaveTitleInput: "summary-agent-save-title-input",
     agentSaveConfirmBtn: "summary-agent-save-confirm-btn",
-    // Reference picker entry + card (agent mode)
     agentRefEntry: "summary-agent-ref-entry",
     agentRefSearchInput: "summary-agent-ref-search-input",
     agentRefCard: "summary-agent-ref-card",
@@ -85,7 +85,7 @@ export const summaryTestIds = {
     agentRefSideBody: "summary-agent-ref-side-body",
     agentRefSideCloseBtn: "summary-agent-ref-side-close-btn",
 
-    // ── Chat summary panel (in-chat panel) ──
+    // In-chat summary panel
     chatPanel: "summary-chat-panel",
     chatPanelHeaderBtn: "summary-chat-panel-header-btn",
     chatPanelDetailInPanel: "summary-chat-panel-detail",

--- a/apps/web/e2e-kit/tests/summary/_testids.ts
+++ b/apps/web/e2e-kit/tests/summary/_testids.ts
@@ -35,6 +35,7 @@ export const T = {
     memberSelectorConfirmBtn: "summary-member-selector-confirm-btn",
 
     // Detail page
+    detail: (taskId: number) => `summary-detail-${taskId}`,
     detailPage: "summary-detail-page",
     detailTitle: "summary-detail-title",
     detailRegenerateBtn: "summary-detail-regenerate-btn",
@@ -44,6 +45,7 @@ export const T = {
     detailContinueRefineBtn: "summary-detail-continue-refine-btn",
     detailEditBtn: "summary-detail-edit-btn",
     detailMembersSection: "summary-detail-members",
+    detailMemberRow: (userId: string) => `summary-detail-member-row-${userId}`,
     detailMyPendingRow: "summary-detail-my-pending-row",
     detailSubmitMyBtn: "summary-detail-submit-my-btn",
     detailMyDraftEditBtn: "summary-detail-my-draft-edit-btn",

--- a/apps/web/e2e-kit/tests/summary/agent/S10-summary-agent-reference-side-panel.spec.ts
+++ b/apps/web/e2e-kit/tests/summary/agent/S10-summary-agent-reference-side-panel.spec.ts
@@ -47,6 +47,9 @@ test.describe("@S10 @p1 @summary @agent @summary-agent @summary-reference S10 �
     await expect(
       authedPage.getByTestId(T.agentRefSidePanel).getByTestId(T.agentRefSideTitle)
     ).toBeVisible({ timeout: 15_000 });
+    await expect(
+      authedPage.getByTestId(T.agentRefSidePanel).getByTestId(T.agentRefSideTitle)
+    ).toContainText("S10 已有客户总结");
     await expect(authedPage.getByText(/以下内容为该总结的最新版本/)).toBeVisible();
     await expect(authedPage.getByText("历史风险需要继续跟进")).toBeVisible();
 

--- a/apps/web/e2e-kit/tests/summary/agent/S10-summary-agent-reference-side-panel.spec.ts
+++ b/apps/web/e2e-kit/tests/summary/agent/S10-summary-agent-reference-side-panel.spec.ts
@@ -7,6 +7,7 @@
 import { test, expect } from "../../../fixtures-authed";
 import { registerS10SummaryAgentReferenceSidePanel } from "../../../msw-handlers/s10-summary-agent-reference-side-panel";
 import { startRequestMonitor, sanityCheck } from "../../../_lib/sanity";
+import { T } from "../_testids";
 
 const sanityConfig = {
   // CI leak target plus legacy mock host marker; workflow proxy-error grep remains the fail-closed guard.
@@ -22,37 +23,37 @@ test.describe("@S10 @p1 @summary @agent @summary-agent @summary-reference S10 �
 
     await authedPage.getByRole("button", { name: "智能总结" }).click();
     await expect(authedPage.getByText("暂无总结记录")).toBeVisible({ timeout: 15_000 });
-    await authedPage.getByRole("button", { name: "创建第一份总结" }).click();
+    await authedPage.getByTestId(T.createEntry).click();
 
     await expect(authedPage.getByText("邀请同事一起总结信息")).toBeVisible({ timeout: 15_000 });
-    await authedPage.getByRole("button", { name: "Agent 总结" }).click();
+    await authedPage.getByTestId(T.createAgentTab).click();
     await expect(
       authedPage.getByText("你好，我是总结助手，想总结什么尽管告诉我。")
     ).toBeVisible({ timeout: 15_000 });
 
-    const referenceEntry = authedPage.getByTitle("点击选择一份已有总结作为参考");
+    const referenceEntry = authedPage.getByTestId(T.agentRefEntry);
     await expect(referenceEntry).toBeVisible();
     await referenceEntry.click();
 
     await expect(authedPage.getByText("选择要引用的总结")).toBeVisible({ timeout: 15_000 });
-    await expect(authedPage.getByPlaceholder("搜索总结标题")).toBeVisible();
+    await expect(authedPage.getByTestId(T.agentRefSearchInput)).toBeVisible();
     await authedPage.getByText("S10 已有客户总结", { exact: true }).click();
 
     await expect(authedPage.getByText("已引用")).toBeVisible();
-    const referenceCard = authedPage.locator(".summary-workbench-ref-card");
+    const referenceCard = authedPage.getByTestId(T.agentRefCard);
     await expect(referenceCard.getByText("S10 已有客户总结", { exact: true })).toBeVisible();
 
     await referenceCard.click();
     await expect(
-      authedPage.locator(".summary-workbench-ref-side-title", { hasText: "S10 已有客户总结" })
+      authedPage.getByTestId(T.agentRefSidePanel).getByTestId(T.agentRefSideTitle)
     ).toBeVisible({ timeout: 15_000 });
     await expect(authedPage.getByText(/以下内容为该总结的最新版本/)).toBeVisible();
     await expect(authedPage.getByText("历史风险需要继续跟进")).toBeVisible();
 
-    await authedPage.locator(".summary-workbench-ref-card-remove").click();
+    await authedPage.getByTestId(T.agentRefRemoveBtn).click();
     await expect(authedPage.getByText("已引用")).toHaveCount(0);
-    await expect(authedPage.getByTitle("点击选择一份已有总结作为参考")).toBeVisible();
-    await expect(authedPage.locator(".summary-workbench-ref-side")).toHaveCount(0);
+    await expect(authedPage.getByTestId(T.agentRefEntry)).toBeVisible();
+    await expect(authedPage.getByTestId(T.agentRefSidePanel)).toHaveCount(0);
     await expect(authedPage.getByText("加载失败")).toHaveCount(0);
 
     await sanityCheck(authedPage, ctx);

--- a/apps/web/e2e-kit/tests/summary/agent/S11-summary-agent-continue-refine.spec.ts
+++ b/apps/web/e2e-kit/tests/summary/agent/S11-summary-agent-continue-refine.spec.ts
@@ -29,6 +29,7 @@ test.describe("@S11 @p0 @summary @agent @summary-agent @summary-detail @summary-
     });
     await expect(authedPage.getByTestId(T.detailTitle)).toContainText("S11 Agent 原总结");
     await expect(authedPage.getByTestId(T.detailContinueRefineBtn)).toBeVisible();
+    await expect(authedPage.getByTestId(T.detailContinueRefineBtn)).toContainText("继续优化");
     await authedPage.getByTestId(T.detailContinueRefineBtn).click();
 
     await expect(

--- a/apps/web/e2e-kit/tests/summary/agent/S11-summary-agent-continue-refine.spec.ts
+++ b/apps/web/e2e-kit/tests/summary/agent/S11-summary-agent-continue-refine.spec.ts
@@ -43,6 +43,9 @@ test.describe("@S11 @p0 @summary @agent @summary-agent @summary-detail @summary-
       authedPage.getByTestId(T.agentRefSidePanel).getByTestId(T.agentRefSideTitle)
     ).toBeVisible({ timeout: 15_000 });
     await expect(
+      authedPage.getByTestId(T.agentRefSidePanel).getByTestId(T.agentRefSideTitle)
+    ).toContainText("S11 Agent 原总结");
+    await expect(
       authedPage.getByTestId(T.agentRefSideBody).getByText("S11 原总结风险清单")
     ).toBeVisible();
     await expect(authedPage.getByText("加载失败")).toHaveCount(0);

--- a/apps/web/e2e-kit/tests/summary/agent/S11-summary-agent-continue-refine.spec.ts
+++ b/apps/web/e2e-kit/tests/summary/agent/S11-summary-agent-continue-refine.spec.ts
@@ -27,6 +27,7 @@ test.describe("@S11 @p0 @summary @agent @summary-agent @summary-detail @summary-
     await expect(authedPage.getByTestId(T.detailTitle)).toBeVisible({
       timeout: 15_000,
     });
+    await expect(authedPage.getByTestId(T.detailTitle)).toContainText("S11 Agent 原总结");
     await expect(authedPage.getByTestId(T.detailContinueRefineBtn)).toBeVisible();
     await authedPage.getByTestId(T.detailContinueRefineBtn).click();
 

--- a/apps/web/e2e-kit/tests/summary/agent/S11-summary-agent-continue-refine.spec.ts
+++ b/apps/web/e2e-kit/tests/summary/agent/S11-summary-agent-continue-refine.spec.ts
@@ -7,6 +7,7 @@
 import { test, expect } from "../../../fixtures-authed";
 import { registerS11SummaryAgentContinueRefine } from "../../../msw-handlers/s11-summary-agent-continue-refine";
 import { startRequestMonitor, sanityCheck } from "../../../_lib/sanity";
+import { T } from "../_testids";
 
 const sanityConfig = {
   realHosts: ["127.0.0.1:9", "mock.e2e.local"],
@@ -23,26 +24,26 @@ test.describe("@S11 @p0 @summary @agent @summary-agent @summary-detail @summary-
     await expect(authedPage.getByText("S11 Agent 原总结")).toBeVisible({ timeout: 15_000 });
     await authedPage.getByText("S11 Agent 原总结").click();
 
-    await expect(authedPage.locator(".summary-detail-title", { hasText: "S11 Agent 原总结" })).toBeVisible({
+    await expect(authedPage.getByTestId(T.detailTitle)).toBeVisible({
       timeout: 15_000,
     });
-    await expect(authedPage.getByRole("button", { name: "继续优化" })).toBeVisible();
-    await authedPage.getByRole("button", { name: "继续优化" }).click();
+    await expect(authedPage.getByTestId(T.detailContinueRefineBtn)).toBeVisible();
+    await authedPage.getByTestId(T.detailContinueRefineBtn).click();
 
     await expect(
       authedPage.getByText("你好，我是总结助手，想总结什么尽管告诉我。")
     ).toBeVisible({ timeout: 15_000 });
-    await expect(authedPage.getByRole("button", { name: "Agent 总结" })).toHaveClass(/active/);
-    const referenceCard = authedPage.locator(".summary-workbench-ref-card");
+    await expect(authedPage.getByTestId(T.createAgentTab)).toHaveClass(/active/);
+    const referenceCard = authedPage.getByTestId(T.agentRefCard);
     await expect(referenceCard.getByText("已引用")).toBeVisible();
     await expect(referenceCard.getByText("S11 Agent 原总结", { exact: true })).toBeVisible();
 
     await referenceCard.click();
     await expect(
-      authedPage.locator(".summary-workbench-ref-side-title", { hasText: "S11 Agent 原总结" })
+      authedPage.getByTestId(T.agentRefSidePanel).getByTestId(T.agentRefSideTitle)
     ).toBeVisible({ timeout: 15_000 });
     await expect(
-      authedPage.locator(".summary-workbench-ref-side-body").getByText("S11 原总结风险清单")
+      authedPage.getByTestId(T.agentRefSideBody).getByText("S11 原总结风险清单")
     ).toBeVisible();
     await expect(authedPage.getByText("加载失败")).toHaveCount(0);
 

--- a/apps/web/e2e-kit/tests/summary/agent/S12-summary-agent-save-failure.spec.ts
+++ b/apps/web/e2e-kit/tests/summary/agent/S12-summary-agent-save-failure.spec.ts
@@ -7,6 +7,7 @@
 import { test, expect } from "../../../fixtures-authed";
 import { registerS12SummaryAgentSaveFailure } from "../../../msw-handlers/s12-summary-agent-save-failure";
 import { startRequestMonitor, sanityCheck } from "../../../_lib/sanity";
+import { T } from "../_testids";
 
 const sanityConfig = {
   realHosts: ["127.0.0.1:9", "mock.e2e.local"],
@@ -21,30 +22,27 @@ test.describe("@S12 @p1 @summary @agent @summary-agent @summary-create @error-st
 
     await authedPage.getByRole("button", { name: "智能总结" }).click();
     await expect(authedPage.getByText("暂无总结记录")).toBeVisible({ timeout: 15_000 });
-    await authedPage.getByRole("button", { name: "创建第一份总结" }).click();
+    await authedPage.getByTestId(T.createEntry).click();
 
     await expect(authedPage.getByText("邀请同事一起总结信息")).toBeVisible({ timeout: 15_000 });
-    await authedPage.getByRole("button", { name: "Agent 总结" }).click();
-    await authedPage
-      .getByPlaceholder("输入你的问题，回车发送（Shift+Enter 换行）")
-      .fill("S12 生成保存失败测试内容");
-    await authedPage.getByRole("button", { name: "发送" }).click();
+    await authedPage.getByTestId(T.createAgentTab).click();
+    await authedPage.getByTestId(T.agentInput).fill("S12 生成保存失败测试内容");
+    await authedPage.getByTestId(T.agentSendBtn).click();
 
     await expect(authedPage.getByText("S12 生成保存失败测试内容")).toBeVisible();
     await expect(authedPage.getByText("S12 Agent 已生成可保存内容")).toBeVisible({ timeout: 15_000 });
 
-    await authedPage.getByRole("button", { name: "保存为总结" }).click();
-    const saveDialog = authedPage.getByRole("dialog", { name: "保存为总结" });
-    await expect(saveDialog).toBeVisible();
-    await saveDialog.getByPlaceholder("为这份总结起个标题").fill("S12 保存失败总结");
-    await saveDialog.getByText("确定", { exact: true }).click();
+    await authedPage.getByTestId(T.agentSaveBtn).click();
+    await expect(authedPage.getByTestId(T.agentSaveDialog)).toBeVisible();
+    await authedPage.getByTestId(T.agentSaveTitleInput).fill("S12 保存失败总结");
+    await authedPage.getByTestId(T.agentSaveConfirmBtn).click();
 
     await expect(
       authedPage.getByText("当前对话还没有可保存的总结，请先与 AI 对话产出内容")
     ).toBeVisible({ timeout: 15_000 });
     await expect(authedPage.getByText("S12 生成保存失败测试内容")).toBeVisible();
     await expect(authedPage.getByText("S12 Agent 已生成可保存内容")).toBeVisible();
-    await expect(authedPage.locator(".summary-detail-title", { hasText: "S12 保存失败总结" })).toHaveCount(0);
+    await expect(authedPage.getByTestId(T.detailTitle)).toHaveCount(0);
     await expect(authedPage.getByText("AI 总结已保存")).toHaveCount(0);
 
     await sanityCheck(authedPage, ctx);

--- a/apps/web/e2e-kit/tests/summary/agent/S12-summary-agent-save-failure.spec.ts
+++ b/apps/web/e2e-kit/tests/summary/agent/S12-summary-agent-save-failure.spec.ts
@@ -33,7 +33,13 @@ test.describe("@S12 @p1 @summary @agent @summary-agent @summary-create @error-st
     await expect(authedPage.getByText("S12 Agent 已生成可保存内容")).toBeVisible({ timeout: 15_000 });
 
     await authedPage.getByTestId(T.agentSaveBtn).click();
-    await expect(authedPage.getByTestId(T.agentSaveDialog)).toBeVisible();
+    const saveDialog = authedPage.getByTestId(T.agentSaveDialog);
+    await expect(saveDialog).toBeVisible();
+    await expect(saveDialog.getByRole("heading", { name: "保存为总结" })).toBeVisible();
+    await expect(authedPage.getByTestId(T.agentSaveTitleInput)).toHaveAttribute(
+      "placeholder",
+      "为这份总结起个标题"
+    );
     await authedPage.getByTestId(T.agentSaveTitleInput).fill("S12 保存失败总结");
     await authedPage.getByTestId(T.agentSaveConfirmBtn).click();
 

--- a/apps/web/e2e-kit/tests/summary/agent/S13-summary-agent-new-session.spec.ts
+++ b/apps/web/e2e-kit/tests/summary/agent/S13-summary-agent-new-session.spec.ts
@@ -7,6 +7,7 @@
 import { test, expect } from "../../../fixtures-authed";
 import { registerS13SummaryAgentNewSession } from "../../../msw-handlers/s13-summary-agent-new-session";
 import { startRequestMonitor, sanityCheck } from "../../../_lib/sanity";
+import { T } from "../_testids";
 
 const sanityConfig = {
   realHosts: ["127.0.0.1:9", "mock.e2e.local"],
@@ -21,33 +22,31 @@ test.describe("@S13 @p1 @summary @agent @summary-agent @summary-reference S13 �
 
     await authedPage.getByRole("button", { name: "智能总结" }).click();
     await expect(authedPage.getByText("暂无总结记录")).toBeVisible({ timeout: 15_000 });
-    await authedPage.getByRole("button", { name: "创建第一份总结" }).click();
+    await authedPage.getByTestId(T.createEntry).click();
 
     await expect(authedPage.getByText("邀请同事一起总结信息")).toBeVisible({ timeout: 15_000 });
-    await authedPage.getByRole("button", { name: "Agent 总结" }).click();
+    await authedPage.getByTestId(T.createAgentTab).click();
     await expect(
       authedPage.getByText("你好，我是总结助手，想总结什么尽管告诉我。")
     ).toBeVisible({ timeout: 15_000 });
 
-    await authedPage.getByTitle("点击选择一份已有总结作为参考").click();
+    await authedPage.getByTestId(T.agentRefEntry).click();
     await expect(authedPage.getByText("选择要引用的总结")).toBeVisible({ timeout: 15_000 });
     await authedPage.getByText("S13 可引用总结", { exact: true }).click();
 
-    const referenceCard = authedPage.locator(".summary-workbench-ref-card");
+    const referenceCard = authedPage.getByTestId(T.agentRefCard);
     await expect(referenceCard.getByText("已引用")).toBeVisible();
     await expect(referenceCard.getByText("S13 可引用总结", { exact: true })).toBeVisible();
 
-    await authedPage
-      .getByPlaceholder("输入你的问题，回车发送（Shift+Enter 换行）")
-      .fill("S13 第一轮问题");
-    await authedPage.getByRole("button", { name: "发送" }).click();
+    await authedPage.getByTestId(T.agentInput).fill("S13 第一轮问题");
+    await authedPage.getByTestId(T.agentSendBtn).click();
 
     await expect(authedPage.getByText("S13 第一轮问题")).toBeVisible();
     await expect(authedPage.getByText("S13 Agent 已生成第一轮回复")).toBeVisible({ timeout: 15_000 });
 
-    await authedPage.getByRole("button", { name: "新会话" }).click();
+    await authedPage.getByTestId(T.agentNewSessionBtn).click();
     await expect(authedPage.getByText("已引用")).toHaveCount(0);
-    await expect(authedPage.getByTitle("点击选择一份已有总结作为参考")).toBeVisible();
+    await expect(authedPage.getByTestId(T.agentRefEntry)).toBeVisible();
     await expect(authedPage.getByText("S13 第一轮问题")).toHaveCount(0);
     await expect(authedPage.getByText("S13 Agent 已生成第一轮回复")).toHaveCount(0);
     await expect(

--- a/apps/web/e2e-kit/tests/summary/agent/S9-summary-agent-chat-save.spec.ts
+++ b/apps/web/e2e-kit/tests/summary/agent/S9-summary-agent-chat-save.spec.ts
@@ -52,6 +52,7 @@ test.describe("@S9 @p0 @summary @agent @summary-agent @summary-create @summary-d
     await expect(
       authedPage.getByTestId(T.detailTitle)
     ).toBeVisible({ timeout: 15_000 });
+    await expect(authedPage.getByTestId(T.detailTitle)).toContainText("S9 Agent 风险总结");
     await expect(authedPage.getByText("AI 摘要")).toBeVisible();
     await expect(authedPage.getByText("S9 Agent 总结已保存")).toBeVisible();
     await expect(authedPage.getByText("风险项需要提前暴露")).toBeVisible();

--- a/apps/web/e2e-kit/tests/summary/agent/S9-summary-agent-chat-save.spec.ts
+++ b/apps/web/e2e-kit/tests/summary/agent/S9-summary-agent-chat-save.spec.ts
@@ -7,6 +7,7 @@
 import { test, expect } from "../../../fixtures-authed";
 import { registerS9SummaryAgentChatSave } from "../../../msw-handlers/s9-summary-agent-chat-save";
 import { startRequestMonitor, sanityCheck } from "../../../_lib/sanity";
+import { T } from "../_testids";
 
 const sanityConfig = {
   // CI leak target plus legacy mock host marker; workflow proxy-error grep remains the fail-closed guard.
@@ -22,37 +23,34 @@ test.describe("@S9 @p0 @summary @agent @summary-agent @summary-create @summary-d
 
     await authedPage.getByRole("button", { name: "智能总结" }).click();
     await expect(authedPage.getByText("暂无总结记录")).toBeVisible({ timeout: 15_000 });
-    await authedPage.getByRole("button", { name: "创建第一份总结" }).click();
+    await authedPage.getByTestId(T.createEntry).click();
 
     await expect(authedPage.getByText("邀请同事一起总结信息")).toBeVisible({ timeout: 15_000 });
-    await authedPage.getByRole("button", { name: "Agent 总结" }).click();
+    await authedPage.getByTestId(T.createAgentTab).click();
 
     await expect(
       authedPage.getByText("你好，我是总结助手，想总结什么尽管告诉我。")
     ).toBeVisible({ timeout: 15_000 });
-    await expect(authedPage.getByRole("button", { name: "新会话" })).toBeVisible();
-    await expect(authedPage.getByRole("button", { name: "保存为总结" })).toHaveCount(0);
+    await expect(authedPage.getByTestId(T.agentNewSessionBtn)).toBeVisible();
+    await expect(authedPage.getByTestId(T.agentSaveBtn)).toHaveCount(0);
 
-    await authedPage
-      .getByPlaceholder("输入你的问题，回车发送（Shift+Enter 换行）")
-      .fill("S9 总结项目风险和下周计划");
-    await authedPage.getByRole("button", { name: "发送" }).click();
+    await authedPage.getByTestId(T.agentInput).fill("S9 总结项目风险和下周计划");
+    await authedPage.getByTestId(T.agentSendBtn).click();
 
     await expect(authedPage.getByText("S9 总结项目风险和下周计划")).toBeVisible();
     await expect(authedPage.getByText("S9 Agent 已整理项目风险和下周计划")).toBeVisible({
       timeout: 15_000,
     });
-    await expect(authedPage.getByRole("button", { name: "保存为总结" })).toBeVisible();
+    await expect(authedPage.getByTestId(T.agentSaveBtn)).toBeVisible();
 
-    await authedPage.getByRole("button", { name: "保存为总结" }).click();
-    const saveDialog = authedPage.getByRole("dialog", { name: "保存为总结" });
-    await expect(saveDialog).toBeVisible();
-    await saveDialog.getByPlaceholder("为这份总结起个标题").fill("S9 Agent 风险总结");
-    await saveDialog.getByText("确定", { exact: true }).click();
+    await authedPage.getByTestId(T.agentSaveBtn).click();
+    await expect(authedPage.getByTestId(T.agentSaveDialog)).toBeVisible();
+    await authedPage.getByTestId(T.agentSaveTitleInput).fill("S9 Agent 风险总结");
+    await authedPage.getByTestId(T.agentSaveConfirmBtn).click();
 
     await expect(authedPage.getByText("AI 总结已保存")).toBeVisible({ timeout: 15_000 });
     await expect(
-      authedPage.locator(".summary-detail-title", { hasText: "S9 Agent 风险总结" })
+      authedPage.getByTestId(T.detailTitle)
     ).toBeVisible({ timeout: 15_000 });
     await expect(authedPage.getByText("AI 摘要")).toBeVisible();
     await expect(authedPage.getByText("S9 Agent 总结已保存")).toBeVisible();

--- a/apps/web/e2e-kit/tests/summary/agent/S9-summary-agent-chat-save.spec.ts
+++ b/apps/web/e2e-kit/tests/summary/agent/S9-summary-agent-chat-save.spec.ts
@@ -44,7 +44,13 @@ test.describe("@S9 @p0 @summary @agent @summary-agent @summary-create @summary-d
     await expect(authedPage.getByTestId(T.agentSaveBtn)).toBeVisible();
 
     await authedPage.getByTestId(T.agentSaveBtn).click();
-    await expect(authedPage.getByTestId(T.agentSaveDialog)).toBeVisible();
+    const saveDialog = authedPage.getByTestId(T.agentSaveDialog);
+    await expect(saveDialog).toBeVisible();
+    await expect(saveDialog.getByRole("heading", { name: "保存为总结" })).toBeVisible();
+    await expect(authedPage.getByTestId(T.agentSaveTitleInput)).toHaveAttribute(
+      "placeholder",
+      "为这份总结起个标题"
+    );
     await authedPage.getByTestId(T.agentSaveTitleInput).fill("S9 Agent 风险总结");
     await authedPage.getByTestId(T.agentSaveConfirmBtn).click();
 

--- a/apps/web/e2e-kit/tests/summary/agent/S9-summary-agent-chat-save.spec.ts
+++ b/apps/web/e2e-kit/tests/summary/agent/S9-summary-agent-chat-save.spec.ts
@@ -32,6 +32,7 @@ test.describe("@S9 @p0 @summary @agent @summary-agent @summary-create @summary-d
       authedPage.getByText("你好，我是总结助手，想总结什么尽管告诉我。")
     ).toBeVisible({ timeout: 15_000 });
     await expect(authedPage.getByTestId(T.agentNewSessionBtn)).toBeVisible();
+    await expect(authedPage.getByTestId(T.agentNewSessionBtn)).toContainText("新会话");
     await expect(authedPage.getByTestId(T.agentSaveBtn)).toHaveCount(0);
 
     await authedPage.getByTestId(T.agentInput).fill("S9 总结项目风险和下周计划");

--- a/apps/web/e2e-kit/tests/summary/chat/S22-summary-chat-panel-history-detail.spec.ts
+++ b/apps/web/e2e-kit/tests/summary/chat/S22-summary-chat-panel-history-detail.spec.ts
@@ -8,6 +8,7 @@ import { test, expect } from "../../../fixtures-authed";
 import { installMockImRuntime } from "../../../_kit/mock-im-runtime";
 import { registerS22SummaryChatPanelHistoryDetail } from "../../../msw-handlers/s22-summary-chat-panel-history-detail";
 import { startRequestMonitor, sanityCheck } from "../../../_lib/sanity";
+import { T } from "../_testids";
 
 const sanityConfig = {
   realHosts: ["127.0.0.1:9", "mock.e2e.local"],
@@ -48,15 +49,15 @@ test.describe("@S22 @p1 @summary @chat @summary-panel @summary-detail S22 — �
       authedPage.locator(".wk-chat-conversation-header-channel-info-name", { hasText: "S22 项目群" })
     ).toBeVisible({ timeout: 15_000 });
 
-    await authedPage.locator('.wk-chat-conversation-header-right [title="智能总结"]').click();
-    const panel = authedPage.locator(".wk-summary-panel");
+    await authedPage.getByTestId(T.chatPanelHeaderBtn).click();
+    const panel = authedPage.getByTestId(T.chatPanel);
     await expect(panel.getByRole("heading", { name: "聊天内的智能总结" })).toBeVisible({ timeout: 15_000 });
     await expect(panel.getByText("S22 聊天内总结", { exact: true })).toBeVisible();
     await expect(panel.getByText("已完成", { exact: true })).toBeVisible();
 
     await panel.getByText("S22 聊天内总结", { exact: true }).click();
-    await expect(panel.getByText("返回")).toBeVisible({ timeout: 15_000 });
-    await expect(panel.locator(".summary-detail-page")).toBeVisible();
+    await expect(panel.getByTestId(T.chatPanelBackBtn)).toBeVisible({ timeout: 15_000 });
+    await expect(panel.getByTestId(T.detailPage)).toBeVisible();
     await expect(panel.getByText("AI 摘要")).toBeVisible();
     await expect(panel.getByText("S22 聊天内详情正文")).toBeVisible();
     await expect(panel.getByText("加载失败")).toHaveCount(0);

--- a/apps/web/e2e-kit/tests/summary/chat/S22-summary-chat-panel-history-detail.spec.ts
+++ b/apps/web/e2e-kit/tests/summary/chat/S22-summary-chat-panel-history-detail.spec.ts
@@ -57,6 +57,7 @@ test.describe("@S22 @p1 @summary @chat @summary-panel @summary-detail S22 — �
 
     await panel.getByText("S22 聊天内总结", { exact: true }).click();
     await expect(panel.getByTestId(T.chatPanelBackBtn)).toBeVisible({ timeout: 15_000 });
+    await expect(panel.getByTestId(T.chatPanelBackBtn)).toContainText("返回");
     await expect(panel.getByTestId(T.detailPage)).toBeVisible();
     await expect(panel.getByText("AI 摘要")).toBeVisible();
     await expect(panel.getByText("S22 聊天内详情正文")).toBeVisible();

--- a/apps/web/e2e-kit/tests/summary/chat/S23-summary-chat-panel-create-refresh.spec.ts
+++ b/apps/web/e2e-kit/tests/summary/chat/S23-summary-chat-panel-create-refresh.spec.ts
@@ -8,6 +8,7 @@ import { test, expect } from "../../../fixtures-authed";
 import { installMockImRuntime } from "../../../_kit/mock-im-runtime";
 import { registerS23SummaryChatPanelCreateRefresh } from "../../../msw-handlers/s23-summary-chat-panel-create-refresh";
 import { startRequestMonitor, sanityCheck } from "../../../_lib/sanity";
+import { T } from "../_testids";
 
 const sanityConfig = {
   realHosts: ["127.0.0.1:9", "mock.e2e.local"],
@@ -48,14 +49,12 @@ test.describe("@S23 @p2 @summary @chat @summary-panel @summary-create S23 — �
       authedPage.locator(".wk-chat-conversation-header-channel-info-name", { hasText: "S23 项目群" })
     ).toBeVisible({ timeout: 15_000 });
 
-    await authedPage.locator('.wk-chat-conversation-header-right [title="智能总结"]').click();
-    const panel = authedPage.locator(".wk-summary-panel");
+    await authedPage.getByTestId(T.chatPanelHeaderBtn).click();
+    const panel = authedPage.getByTestId(T.chatPanel);
     await expect(panel.getByText("邀请同事一起总结信息")).toBeVisible({ timeout: 15_000 });
 
-    await panel
-      .getByPlaceholder("请输入你想总结的主题，例如：总结本周项目进展、整理客户反馈要点")
-      .fill("S23 聊天内新建总结");
-    await panel.locator(".summary-workbench-start-btn").click();
+    await panel.getByTestId(T.createTopic).fill("S23 聊天内新建总结");
+    await panel.getByTestId(T.createSubmit).click();
 
     await expect(authedPage.getByText("总结任务已创建")).toBeVisible({ timeout: 15_000 });
     await expect(panel.getByRole("heading", { name: "聊天内的智能总结" })).toBeVisible({ timeout: 15_000 });

--- a/apps/web/e2e-kit/tests/summary/create/S5-summary-create-basic.spec.ts
+++ b/apps/web/e2e-kit/tests/summary/create/S5-summary-create-basic.spec.ts
@@ -22,13 +22,13 @@ test.describe("@S5 @p1 @summary @create @summary-create S5 — Summary 创建主
 
     await authedPage.getByRole("button", { name: "智能总结" }).click();
     await expect(authedPage.getByText("暂无总结记录")).toBeVisible({ timeout: 15_000 });
-    await authedPage.getByRole("button", { name: "创建第一份总结" }).click();
+    await authedPage.getByTestId("summary-create").click();
 
     await expect(authedPage.getByText("邀请同事一起总结信息")).toBeVisible({ timeout: 15_000 });
-    const startButton = authedPage.getByRole("button", { name: "开始总结" }).nth(1);
+    const startButton = authedPage.getByTestId("summary-create-submit");
     await expect(startButton).toBeDisabled();
 
-    await authedPage.getByRole("button", { name: "选择聊天" }).click();
+    await authedPage.getByTestId("summary-create-select-chat").click();
     await expect(authedPage.getByText("选择聊天").last()).toBeVisible({ timeout: 15_000 });
     await authedPage.getByRole("button", { name: "全部群聊" }).click();
     await authedPage.getByText("S5 项目群", { exact: true }).click();
@@ -37,7 +37,7 @@ test.describe("@S5 @p1 @summary @create @summary-create S5 — Summary 创建主
 
     await expect(authedPage.getByText("S5 项目群", { exact: true })).toBeVisible();
     await authedPage
-      .getByPlaceholder("请输入你想总结的主题，例如：总结本周项目进展、整理客户反馈要点")
+      .getByTestId("summary-create-topic")
       .fill("S5 项目复盘总结");
     await expect(startButton).toBeEnabled();
     await startButton.click();

--- a/apps/web/e2e-kit/tests/summary/create/S5-summary-create-basic.spec.ts
+++ b/apps/web/e2e-kit/tests/summary/create/S5-summary-create-basic.spec.ts
@@ -22,7 +22,7 @@ test.describe("@S5 @p1 @summary @create @summary-create S5 — Summary 创建主
 
     await authedPage.getByRole("button", { name: "智能总结" }).click();
     await expect(authedPage.getByText("暂无总结记录")).toBeVisible({ timeout: 15_000 });
-    await authedPage.getByTestId("summary-create").click();
+    await authedPage.getByTestId("summary-create-entry").click();
 
     await expect(authedPage.getByText("邀请同事一起总结信息")).toBeVisible({ timeout: 15_000 });
     const startButton = authedPage.getByTestId("summary-create-submit");

--- a/apps/web/e2e-kit/tests/summary/create/S5-summary-create-basic.spec.ts
+++ b/apps/web/e2e-kit/tests/summary/create/S5-summary-create-basic.spec.ts
@@ -7,6 +7,7 @@
 import { test, expect } from "../../../fixtures-authed";
 import { registerS5SummaryCreateBasic } from "../../../msw-handlers/s5-summary-create-basic";
 import { startRequestMonitor, sanityCheck } from "../../../_lib/sanity";
+import { T } from "../_testids";
 
 const sanityConfig = {
   // CI leak target plus legacy mock host marker; workflow proxy-error grep remains the fail-closed guard.
@@ -22,22 +23,22 @@ test.describe("@S5 @p1 @summary @create @summary-create S5 — Summary 创建主
 
     await authedPage.getByRole("button", { name: "智能总结" }).click();
     await expect(authedPage.getByText("暂无总结记录")).toBeVisible({ timeout: 15_000 });
-    await authedPage.getByTestId("summary-create-entry").click();
+    await authedPage.getByTestId(T.createEntry).click();
 
     await expect(authedPage.getByText("邀请同事一起总结信息")).toBeVisible({ timeout: 15_000 });
-    const startButton = authedPage.getByTestId("summary-create-submit");
+    const startButton = authedPage.getByTestId(T.createSubmit);
     await expect(startButton).toBeDisabled();
 
-    await authedPage.getByTestId("summary-create-select-chat").click();
+    await authedPage.getByTestId(T.createSelectChat).click();
     await expect(authedPage.getByText("选择聊天").last()).toBeVisible({ timeout: 15_000 });
-    await authedPage.getByRole("button", { name: "全部群聊" }).click();
+    await authedPage.getByTestId(T.chatSelectorAllGroupsTab).click();
     await authedPage.getByText("S5 项目群", { exact: true }).click();
     await expect(authedPage.getByText("已选 1 / 30")).toBeVisible();
-    await authedPage.getByRole("button", { name: "确定" }).click();
+    await authedPage.getByTestId(T.chatSelectorConfirmBtn).click();
 
     await expect(authedPage.getByText("S5 项目群", { exact: true })).toBeVisible();
     await authedPage
-      .getByTestId("summary-create-topic")
+      .getByTestId(T.createTopic)
       .fill("S5 项目复盘总结");
     await expect(startButton).toBeEnabled();
     await startButton.click();

--- a/apps/web/e2e-kit/tests/summary/create/S8-summary-create-participants.spec.ts
+++ b/apps/web/e2e-kit/tests/summary/create/S8-summary-create-participants.spec.ts
@@ -8,6 +8,7 @@ import { test, expect } from "../../../fixtures-authed";
 import { installMockImRuntime } from "../../../_kit/mock-im-runtime";
 import { registerS8SummaryCreateParticipants } from "../../../msw-handlers/s8-summary-create-participants";
 import { startRequestMonitor, sanityCheck } from "../../../_lib/sanity";
+import { T } from "../_testids";
 
 const sanityConfig = {
   // CI leak target plus legacy mock host marker; workflow proxy-error grep remains the fail-closed guard.
@@ -39,28 +40,28 @@ test.describe("@S8 @p1 @summary @create @summary-create @member-select S8 — Su
 
     await authedPage.getByRole("button", { name: "智能总结" }).click();
     await expect(authedPage.getByText("暂无总结记录")).toBeVisible({ timeout: 15_000 });
-    await authedPage.getByTestId("summary-create-entry").click();
+    await authedPage.getByTestId(T.createEntry).click();
 
     await expect(authedPage.getByText("邀请同事一起总结信息")).toBeVisible({ timeout: 15_000 });
-    const startButton = authedPage.getByTestId("summary-create-submit");
+    const startButton = authedPage.getByTestId(T.createSubmit);
     await expect(startButton).toBeDisabled();
 
-    await authedPage.getByTestId("summary-create-select-chat").click();
-    await authedPage.getByRole("button", { name: "全部群聊" }).click();
+    await authedPage.getByTestId(T.createSelectChat).click();
+    await authedPage.getByTestId(T.chatSelectorAllGroupsTab).click();
     await authedPage.getByText("S8 项目群", { exact: true }).click();
     await expect(authedPage.getByText("已选 1 / 30")).toBeVisible();
-    await authedPage.getByRole("button", { name: "确定" }).click();
+    await authedPage.getByTestId(T.chatSelectorConfirmBtn).click();
     await expect(authedPage.getByText("S8 项目群", { exact: true })).toBeVisible();
 
-    await authedPage.getByTestId("summary-create-select-members").click();
+    await authedPage.getByTestId(T.createSelectMembers).click();
     await expect(authedPage.getByText("选择参与者").last()).toBeVisible({ timeout: 15_000 });
     await authedPage.getByText("S8 Alice", { exact: true }).click();
     await expect(authedPage.getByText("已选 1 / 30")).toBeVisible();
-    await authedPage.getByRole("button", { name: "确定" }).click();
+    await authedPage.getByTestId(T.memberSelectorConfirmBtn).click();
     await expect(authedPage.getByText("S8 Alice", { exact: true })).toBeVisible();
 
     await authedPage
-      .getByTestId("summary-create-topic")
+      .getByTestId(T.createTopic)
       .fill("S8 多人协作总结");
     await expect(startButton).toBeEnabled();
     await startButton.click();

--- a/apps/web/e2e-kit/tests/summary/create/S8-summary-create-participants.spec.ts
+++ b/apps/web/e2e-kit/tests/summary/create/S8-summary-create-participants.spec.ts
@@ -39,20 +39,20 @@ test.describe("@S8 @p1 @summary @create @summary-create @member-select S8 — Su
 
     await authedPage.getByRole("button", { name: "智能总结" }).click();
     await expect(authedPage.getByText("暂无总结记录")).toBeVisible({ timeout: 15_000 });
-    await authedPage.getByRole("button", { name: "创建第一份总结" }).click();
+    await authedPage.getByTestId("summary-create").click();
 
     await expect(authedPage.getByText("邀请同事一起总结信息")).toBeVisible({ timeout: 15_000 });
-    const startButton = authedPage.getByRole("button", { name: "开始总结" }).nth(1);
+    const startButton = authedPage.getByTestId("summary-create-submit");
     await expect(startButton).toBeDisabled();
 
-    await authedPage.getByRole("button", { name: "选择聊天" }).click();
+    await authedPage.getByTestId("summary-create-select-chat").click();
     await authedPage.getByRole("button", { name: "全部群聊" }).click();
     await authedPage.getByText("S8 项目群", { exact: true }).click();
     await expect(authedPage.getByText("已选 1 / 30")).toBeVisible();
     await authedPage.getByRole("button", { name: "确定" }).click();
     await expect(authedPage.getByText("S8 项目群", { exact: true })).toBeVisible();
 
-    await authedPage.getByRole("button", { name: "选择参与者" }).click();
+    await authedPage.getByTestId("summary-create-select-members").click();
     await expect(authedPage.getByText("选择参与者").last()).toBeVisible({ timeout: 15_000 });
     await authedPage.getByText("S8 Alice", { exact: true }).click();
     await expect(authedPage.getByText("已选 1 / 30")).toBeVisible();
@@ -60,7 +60,7 @@ test.describe("@S8 @p1 @summary @create @summary-create @member-select S8 — Su
     await expect(authedPage.getByText("S8 Alice", { exact: true })).toBeVisible();
 
     await authedPage
-      .getByPlaceholder("请输入你想总结的主题，例如：总结本周项目进展、整理客户反馈要点")
+      .getByTestId("summary-create-topic")
       .fill("S8 多人协作总结");
     await expect(startButton).toBeEnabled();
     await startButton.click();

--- a/apps/web/e2e-kit/tests/summary/create/S8-summary-create-participants.spec.ts
+++ b/apps/web/e2e-kit/tests/summary/create/S8-summary-create-participants.spec.ts
@@ -39,7 +39,7 @@ test.describe("@S8 @p1 @summary @create @summary-create @member-select S8 — Su
 
     await authedPage.getByRole("button", { name: "智能总结" }).click();
     await expect(authedPage.getByText("暂无总结记录")).toBeVisible({ timeout: 15_000 });
-    await authedPage.getByTestId("summary-create").click();
+    await authedPage.getByTestId("summary-create-entry").click();
 
     await expect(authedPage.getByText("邀请同事一起总结信息")).toBeVisible({ timeout: 15_000 });
     const startButton = authedPage.getByTestId("summary-create-submit");

--- a/apps/web/e2e-kit/tests/summary/detail/S14-summary-detail-version-restore.spec.ts
+++ b/apps/web/e2e-kit/tests/summary/detail/S14-summary-detail-version-restore.spec.ts
@@ -7,6 +7,7 @@
 import { test, expect } from "../../../fixtures-authed";
 import { registerS14SummaryDetailVersionRestore } from "../../../msw-handlers/s14-summary-detail-version-restore";
 import { startRequestMonitor, sanityCheck } from "../../../_lib/sanity";
+import { T } from "../_testids";
 
 const sanityConfig = {
   realHosts: ["127.0.0.1:9", "mock.e2e.local"],
@@ -23,28 +24,28 @@ test.describe("@S14 @p1 @summary @detail @summary-detail @summary-version S14 �
     await expect(authedPage.getByText("S14 版本总结")).toBeVisible({ timeout: 15_000 });
     await authedPage.getByText("S14 版本总结").click();
 
-    await expect(authedPage.locator(".summary-detail-title", { hasText: "S14 版本总结" })).toBeVisible({
+    await expect(authedPage.getByTestId(T.detailTitle)).toBeVisible({
       timeout: 15_000,
     });
     await expect(authedPage.getByText("S14 当前版本内容")).toBeVisible();
-    await expect(authedPage.getByRole("button", { name: /版本记录\s*2/ })).toBeVisible({
+    await expect(authedPage.getByTestId(T.detailVersionTrigger)).toBeVisible({
       timeout: 15_000,
     });
 
-    await authedPage.getByRole("button", { name: /版本记录\s*2/ }).click();
-    const versionPanel = authedPage.locator(".version-panel");
+    await authedPage.getByTestId(T.detailVersionTrigger).click();
+    const versionPanel = authedPage.getByTestId(T.versionPanel);
     await expect(versionPanel.getByRole("heading", { name: "版本记录" })).toBeVisible();
     await expect(versionPanel.getByText("保留最近 3 个版本")).toBeVisible();
     await expect(versionPanel.getByText("V2")).toBeVisible();
-    await expect(versionPanel.locator(".version-card", { hasText: "V2" }).getByText("当前版本").first()).toBeVisible();
+    await expect(versionPanel.getByTestId(T.versionCard(2)).getByText("当前版本").first()).toBeVisible();
     await expect(versionPanel.getByText("V1")).toBeVisible();
 
-    await versionPanel.locator(".version-card", { hasText: "V1" }).click();
+    await versionPanel.getByTestId(T.versionCard(1)).click();
     await expect(authedPage.getByText("正在查看 V1 历史版本")).toBeVisible({ timeout: 15_000 });
     await expect(authedPage.getByText("S14 历史版本内容")).toBeVisible();
-    await expect(versionPanel.getByRole("button", { name: "恢复此版本" })).toBeVisible();
+    await expect(versionPanel.getByTestId(T.versionRestoreBtn)).toBeVisible();
 
-    await versionPanel.getByRole("button", { name: "恢复此版本" }).click();
+    await versionPanel.getByTestId(T.versionRestoreBtn).click();
     await expect(authedPage.getByText("已恢复到所选版本")).toBeVisible({ timeout: 15_000 });
     await expect(authedPage.getByText("S14 历史版本已恢复")).toBeVisible({ timeout: 15_000 });
     await expect(authedPage.getByText("S14 当前版本内容")).toHaveCount(0);

--- a/apps/web/e2e-kit/tests/summary/detail/S14-summary-detail-version-restore.spec.ts
+++ b/apps/web/e2e-kit/tests/summary/detail/S14-summary-detail-version-restore.spec.ts
@@ -47,6 +47,7 @@ test.describe("@S14 @p1 @summary @detail @summary-detail @summary-version S14 �
     await expect(authedPage.getByText("正在查看 V1 历史版本")).toBeVisible({ timeout: 15_000 });
     await expect(authedPage.getByText("S14 历史版本内容")).toBeVisible();
     await expect(versionPanel.getByTestId(T.versionRestoreBtn)).toBeVisible();
+    await expect(versionPanel.getByTestId(T.versionRestoreBtn)).toContainText("恢复此版本");
 
     await versionPanel.getByTestId(T.versionRestoreBtn).click();
     await expect(authedPage.getByText("已恢复到所选版本")).toBeVisible({ timeout: 15_000 });

--- a/apps/web/e2e-kit/tests/summary/detail/S14-summary-detail-version-restore.spec.ts
+++ b/apps/web/e2e-kit/tests/summary/detail/S14-summary-detail-version-restore.spec.ts
@@ -36,9 +36,9 @@ test.describe("@S14 @p1 @summary @detail @summary-detail @summary-version S14 �
     const versionPanel = authedPage.getByTestId(T.versionPanel);
     await expect(versionPanel.getByRole("heading", { name: "版本记录" })).toBeVisible();
     await expect(versionPanel.getByText("保留最近 3 个版本")).toBeVisible();
-    await expect(versionPanel.getByText("V2")).toBeVisible();
-    await expect(versionPanel.getByTestId(T.versionCard(2)).getByText("当前版本").first()).toBeVisible();
-    await expect(versionPanel.getByText("V1")).toBeVisible();
+    await expect(versionPanel.getByTestId(T.versionCard(2))).toContainText("V2");
+    await expect(versionPanel.getByTestId(T.versionCard(2))).toContainText("当前版本");
+    await expect(versionPanel.getByTestId(T.versionCard(1))).toContainText("V1");
 
     await versionPanel.getByTestId(T.versionCard(1)).click();
     await expect(authedPage.getByText("正在查看 V1 历史版本")).toBeVisible({ timeout: 15_000 });

--- a/apps/web/e2e-kit/tests/summary/detail/S14-summary-detail-version-restore.spec.ts
+++ b/apps/web/e2e-kit/tests/summary/detail/S14-summary-detail-version-restore.spec.ts
@@ -27,10 +27,13 @@ test.describe("@S14 @p1 @summary @detail @summary-detail @summary-version S14 �
     await expect(authedPage.getByTestId(T.detailTitle)).toBeVisible({
       timeout: 15_000,
     });
+    await expect(authedPage.getByTestId(T.detailTitle)).toContainText("S14 版本总结");
     await expect(authedPage.getByText("S14 当前版本内容")).toBeVisible();
     await expect(authedPage.getByTestId(T.detailVersionTrigger)).toBeVisible({
       timeout: 15_000,
     });
+    await expect(authedPage.getByTestId(T.detailVersionTrigger)).toContainText("版本记录");
+    await expect(authedPage.getByTestId(T.detailVersionTrigger)).toContainText("2");
 
     await authedPage.getByTestId(T.detailVersionTrigger).click();
     const versionPanel = authedPage.getByTestId(T.versionPanel);

--- a/apps/web/e2e-kit/tests/summary/detail/S15-summary-detail-edit-save.spec.ts
+++ b/apps/web/e2e-kit/tests/summary/detail/S15-summary-detail-edit-save.spec.ts
@@ -31,6 +31,7 @@ test.describe("@S15 @p1 @summary @detail @summary-detail @summary-edit S15 — S
     await authedPage.getByTestId(T.detailEditBtn).click();
     const editor = authedPage.getByTestId(T.editorTextarea);
     await expect(editor).toBeVisible();
+    await expect(editor).toHaveAttribute("placeholder", "编辑总结内容...");
     await editor.fill("## S15 可编辑总结\n\n- S15 草稿取消内容\n");
     await authedPage.getByTestId(T.editorCancelBtn).click();
 

--- a/apps/web/e2e-kit/tests/summary/detail/S15-summary-detail-edit-save.spec.ts
+++ b/apps/web/e2e-kit/tests/summary/detail/S15-summary-detail-edit-save.spec.ts
@@ -7,6 +7,7 @@
 import { test, expect } from "../../../fixtures-authed";
 import { registerS15SummaryDetailEditSave } from "../../../msw-handlers/s15-summary-detail-edit-save";
 import { startRequestMonitor, sanityCheck } from "../../../_lib/sanity";
+import { T } from "../_testids";
 
 const sanityConfig = {
   realHosts: ["127.0.0.1:9", "mock.e2e.local"],
@@ -23,22 +24,22 @@ test.describe("@S15 @p1 @summary @detail @summary-detail @summary-edit S15 — S
     await expect(authedPage.getByText("S15 可编辑总结")).toBeVisible({ timeout: 15_000 });
     await authedPage.getByText("S15 可编辑总结").click();
 
-    await expect(authedPage.locator(".summary-detail-title", { hasText: "S15 可编辑总结" })).toBeVisible({ timeout: 15_000 });
+    await expect(authedPage.getByTestId(T.detailTitle)).toBeVisible({ timeout: 15_000 });
     await expect(authedPage.getByText("S15 原始正文内容")).toBeVisible();
 
-    await authedPage.locator(".summary-detail-inline-edit", { hasText: "编辑" }).click();
-    const editor = authedPage.locator(".summary-editor-textarea");
+    await authedPage.getByTestId(T.detailEditBtn).click();
+    const editor = authedPage.getByTestId(T.editorTextarea);
     await expect(editor).toBeVisible();
     await editor.fill("## S15 可编辑总结\n\n- S15 草稿取消内容\n");
-    await authedPage.locator(".summary-detail-footer-btn--cancel").click();
+    await authedPage.getByTestId(T.editorCancelBtn).click();
 
     await expect(authedPage.getByText("S15 原始正文内容")).toBeVisible();
     await expect(authedPage.getByText("S15 草稿取消内容")).toHaveCount(0);
 
-    await authedPage.locator(".summary-detail-inline-edit", { hasText: "编辑" }).click();
+    await authedPage.getByTestId(T.detailEditBtn).click();
     await expect(editor).toBeVisible();
     await editor.fill("## S15 可编辑总结\n\n- S15 已保存正文内容\n");
-    await authedPage.locator(".summary-detail-footer-btn--save").click();
+    await authedPage.getByTestId(T.editorSaveBtn).click();
 
     await expect(authedPage.getByText("保存成功", { exact: true })).toBeVisible({ timeout: 15_000 });
     await expect(authedPage.getByText("S15 已保存正文内容")).toBeVisible({ timeout: 15_000 });

--- a/apps/web/e2e-kit/tests/summary/detail/S15-summary-detail-edit-save.spec.ts
+++ b/apps/web/e2e-kit/tests/summary/detail/S15-summary-detail-edit-save.spec.ts
@@ -25,6 +25,7 @@ test.describe("@S15 @p1 @summary @detail @summary-detail @summary-edit S15 — S
     await authedPage.getByText("S15 可编辑总结").click();
 
     await expect(authedPage.getByTestId(T.detailTitle)).toBeVisible({ timeout: 15_000 });
+    await expect(authedPage.getByTestId(T.detailTitle)).toContainText("S15 可编辑总结");
     await expect(authedPage.getByText("S15 原始正文内容")).toBeVisible();
 
     await authedPage.getByTestId(T.detailEditBtn).click();

--- a/apps/web/e2e-kit/tests/summary/detail/S16-summary-detail-refine.spec.ts
+++ b/apps/web/e2e-kit/tests/summary/detail/S16-summary-detail-refine.spec.ts
@@ -7,6 +7,7 @@
 import { test, expect } from "../../../fixtures-authed";
 import { registerS16SummaryDetailRefine } from "../../../msw-handlers/s16-summary-detail-refine";
 import { startRequestMonitor, sanityCheck } from "../../../_lib/sanity";
+import { T } from "../_testids";
 
 const sanityConfig = {
   realHosts: ["127.0.0.1:9", "mock.e2e.local"],
@@ -23,14 +24,14 @@ test.describe("@S16 @p2 @summary @detail @summary-detail @summary-refine S16 —
     await expect(authedPage.getByText("S16 可调整总结")).toBeVisible({ timeout: 15_000 });
     await authedPage.getByText("S16 可调整总结").click();
 
-    await expect(authedPage.locator(".summary-detail-title", { hasText: "S16 可调整总结" })).toBeVisible({ timeout: 15_000 });
+    await expect(authedPage.getByTestId(T.detailTitle)).toBeVisible({ timeout: 15_000 });
     await expect(authedPage.getByText("S16 原始正文内容", { exact: true })).toBeVisible();
 
-    await authedPage.getByRole("button", { name: /重新生成/ }).click();
-    await expect(authedPage.getByText("修改提示词并重新生成")).toBeVisible({ timeout: 15_000 });
+    await authedPage.getByTestId(T.detailRegenerateBtn).click();
+    await expect(authedPage.getByTestId(T.regenerateModal)).toBeVisible({ timeout: 15_000 });
     await expect(authedPage.getByText("按意见调整当前结果")).toBeVisible();
-    await authedPage.locator("#summary-regenerate-input").fill("S16 请补充风险说明");
-    await authedPage.getByRole("button", { name: "按意见调整" }).click();
+    await authedPage.getByTestId(T.regenerateInput).fill("S16 请补充风险说明");
+    await authedPage.getByTestId(T.regenerateSubmitBtn).click();
 
     await expect(authedPage.getByText("修改成功，已更新到版本 2")).toBeVisible({ timeout: 15_000 });
     await expect(authedPage.getByText("S16 已按意见调整正文", { exact: true })).toBeVisible({ timeout: 15_000 });

--- a/apps/web/e2e-kit/tests/summary/detail/S16-summary-detail-refine.spec.ts
+++ b/apps/web/e2e-kit/tests/summary/detail/S16-summary-detail-refine.spec.ts
@@ -29,6 +29,7 @@ test.describe("@S16 @p2 @summary @detail @summary-detail @summary-refine S16 —
 
     await authedPage.getByTestId(T.detailRegenerateBtn).click();
     await expect(authedPage.getByTestId(T.regenerateModal)).toBeVisible({ timeout: 15_000 });
+    await expect(authedPage.getByText("修改提示词并重新生成")).toBeVisible();
     await expect(authedPage.getByText("按意见调整当前结果")).toBeVisible();
     await authedPage.getByTestId(T.regenerateInput).fill("S16 请补充风险说明");
     await authedPage.getByTestId(T.regenerateSubmitBtn).click();

--- a/apps/web/e2e-kit/tests/summary/detail/S16-summary-detail-refine.spec.ts
+++ b/apps/web/e2e-kit/tests/summary/detail/S16-summary-detail-refine.spec.ts
@@ -25,6 +25,7 @@ test.describe("@S16 @p2 @summary @detail @summary-detail @summary-refine S16 —
     await authedPage.getByText("S16 可调整总结").click();
 
     await expect(authedPage.getByTestId(T.detailTitle)).toBeVisible({ timeout: 15_000 });
+    await expect(authedPage.getByTestId(T.detailTitle)).toContainText("S16 可调整总结");
     await expect(authedPage.getByText("S16 原始正文内容", { exact: true })).toBeVisible();
 
     await authedPage.getByTestId(T.detailRegenerateBtn).click();

--- a/apps/web/e2e-kit/tests/summary/detail/S17-summary-detail-delete.spec.ts
+++ b/apps/web/e2e-kit/tests/summary/detail/S17-summary-detail-delete.spec.ts
@@ -7,6 +7,7 @@
 import { test, expect } from "../../../fixtures-authed";
 import { registerS17SummaryDetailDelete } from "../../../msw-handlers/s17-summary-detail-delete";
 import { startRequestMonitor, sanityCheck } from "../../../_lib/sanity";
+import { T } from "../_testids";
 
 const sanityConfig = {
   realHosts: ["127.0.0.1:9", "mock.e2e.local"],
@@ -23,18 +24,17 @@ test.describe("@S17 @p1 @summary @detail @summary-detail @summary-delete S17 —
     await expect(authedPage.getByText("S17 待删除总结")).toBeVisible({ timeout: 15_000 });
     await authedPage.getByText("S17 待删除总结").click();
 
-    await expect(authedPage.locator(".summary-detail-title", { hasText: "S17 待删除总结" })).toBeVisible({ timeout: 15_000 });
+    await expect(authedPage.getByTestId(T.detailTitle)).toBeVisible({ timeout: 15_000 });
     await expect(authedPage.getByText("S17 删除前正文内容")).toBeVisible();
 
-    await authedPage.getByRole("button", { name: "删除" }).click();
-    const confirmDialog = authedPage.getByRole("dialog", { name: "确认删除" });
-    await expect(confirmDialog).toBeVisible();
-    await confirmDialog.getByText("确定", { exact: true }).click();
+    await authedPage.getByTestId(T.detailDeleteBtn).click();
+    await expect(authedPage.getByRole("dialog", { name: "确认删除" })).toBeVisible();
+    await authedPage.getByTestId(T.deleteConfirmOkBtn).click();
 
     await expect(authedPage.getByText("删除成功")).toBeVisible({ timeout: 15_000 });
     await expect(authedPage.getByText("暂无总结记录")).toBeVisible({ timeout: 15_000 });
     await expect(authedPage.getByText("S17 待删除总结")).toHaveCount(0);
-    await expect(authedPage.locator(".summary-detail-title", { hasText: "S17 待删除总结" })).toHaveCount(0);
+    await expect(authedPage.getByTestId(T.detailTitle)).toHaveCount(0);
 
     await sanityCheck(authedPage, ctx);
   });

--- a/apps/web/e2e-kit/tests/summary/detail/S17-summary-detail-delete.spec.ts
+++ b/apps/web/e2e-kit/tests/summary/detail/S17-summary-detail-delete.spec.ts
@@ -25,6 +25,7 @@ test.describe("@S17 @p1 @summary @detail @summary-detail @summary-delete S17 —
     await authedPage.getByText("S17 待删除总结").click();
 
     await expect(authedPage.getByTestId(T.detailTitle)).toBeVisible({ timeout: 15_000 });
+    await expect(authedPage.getByTestId(T.detailTitle)).toContainText("S17 待删除总结");
     await expect(authedPage.getByText("S17 删除前正文内容")).toBeVisible();
 
     await authedPage.getByTestId(T.detailDeleteBtn).click();

--- a/apps/web/e2e-kit/tests/summary/detail/S24-summary-multi-collab-submit.spec.ts
+++ b/apps/web/e2e-kit/tests/summary/detail/S24-summary-multi-collab-submit.spec.ts
@@ -30,8 +30,10 @@ test.describe("@S24 @p2 @summary @detail @summary-detail @multi-collab S24 — �
     await expect(authedPage.getByText("我（待提交）")).toBeVisible();
     await expect(authedPage.getByText("S24 我的个人报告内容")).toBeVisible();
 
+    await expect(authedPage.getByTestId(T.detailMyPendingRow).getByTestId(T.detailSubmitMyBtn)).toContainText("提交我的总结");
     await authedPage.getByTestId(T.detailMyPendingRow).getByTestId(T.detailSubmitMyBtn).click();
 
+    await expect(authedPage.getByText("已提交", { exact: true })).toBeVisible({ timeout: 15_000 });
     await expect(authedPage.getByTestId(T.detailMemberRow(S24_MY_USER_ID)).getByText("已提交", { exact: true })).toBeVisible({ timeout: 15_000 });
     await expect(authedPage.getByText("S24 团队汇总已刷新", { exact: true })).toBeVisible({ timeout: 15_000 });
     await expect(authedPage.getByText("我（待提交）")).toHaveCount(0);

--- a/apps/web/e2e-kit/tests/summary/detail/S24-summary-multi-collab-submit.spec.ts
+++ b/apps/web/e2e-kit/tests/summary/detail/S24-summary-multi-collab-submit.spec.ts
@@ -5,7 +5,7 @@
  * S24: 多人 BY_PERSON 个人报告提交.
  */
 import { test, expect } from "../../../fixtures-authed";
-import { registerS24SummaryMultiCollabSubmit } from "../../../msw-handlers/s24-summary-multi-collab-submit";
+import { registerS24SummaryMultiCollabSubmit, S24_MY_USER_ID, S24_TASK_ID } from "../../../msw-handlers/s24-summary-multi-collab-submit";
 import { startRequestMonitor, sanityCheck } from "../../../_lib/sanity";
 import { T } from "../_testids";
 
@@ -25,13 +25,14 @@ test.describe("@S24 @p2 @summary @detail @summary-detail @multi-collab S24 — �
     await authedPage.getByText("S24 多人协作总结").click();
 
     await expect(authedPage.getByTestId(T.detailTitle)).toBeVisible({ timeout: 15_000 });
+    await expect(authedPage.getByTestId(T.detailTitle)).toContainText("S24 多人协作总结");
     await expect(authedPage.getByText("你的个人总结已生成，提交后才会汇入团队总结。")).toBeVisible({ timeout: 15_000 });
     await expect(authedPage.getByText("我（待提交）")).toBeVisible();
     await expect(authedPage.getByText("S24 我的个人报告内容")).toBeVisible();
 
     await authedPage.getByTestId(T.detailMyPendingRow).getByTestId(T.detailSubmitMyBtn).click();
 
-    await expect(authedPage.getByTestId(T.detailMembersSection).filter({ hasText: "E2E Tester" }).getByText("已提交", { exact: true })).toBeVisible({ timeout: 15_000 });
+    await expect(authedPage.getByTestId(T.detailMemberRow(S24_MY_USER_ID)).getByText("已提交", { exact: true })).toBeVisible({ timeout: 15_000 });
     await expect(authedPage.getByText("S24 团队汇总已刷新", { exact: true })).toBeVisible({ timeout: 15_000 });
     await expect(authedPage.getByText("我（待提交）")).toHaveCount(0);
     await expect(authedPage.getByText("加载失败")).toHaveCount(0);

--- a/apps/web/e2e-kit/tests/summary/detail/S24-summary-multi-collab-submit.spec.ts
+++ b/apps/web/e2e-kit/tests/summary/detail/S24-summary-multi-collab-submit.spec.ts
@@ -7,6 +7,7 @@
 import { test, expect } from "../../../fixtures-authed";
 import { registerS24SummaryMultiCollabSubmit } from "../../../msw-handlers/s24-summary-multi-collab-submit";
 import { startRequestMonitor, sanityCheck } from "../../../_lib/sanity";
+import { T } from "../_testids";
 
 const sanityConfig = {
   realHosts: ["127.0.0.1:9", "mock.e2e.local"],
@@ -23,14 +24,14 @@ test.describe("@S24 @p2 @summary @detail @summary-detail @multi-collab S24 — �
     await expect(authedPage.getByText("S24 多人协作总结")).toBeVisible({ timeout: 15_000 });
     await authedPage.getByText("S24 多人协作总结").click();
 
-    await expect(authedPage.locator(".summary-detail-title", { hasText: "S24 多人协作总结" })).toBeVisible({ timeout: 15_000 });
+    await expect(authedPage.getByTestId(T.detailTitle)).toBeVisible({ timeout: 15_000 });
     await expect(authedPage.getByText("你的个人总结已生成，提交后才会汇入团队总结。")).toBeVisible({ timeout: 15_000 });
     await expect(authedPage.getByText("我（待提交）")).toBeVisible();
     await expect(authedPage.getByText("S24 我的个人报告内容")).toBeVisible();
 
-    await authedPage.locator(".summary-detail-my-pending-row").getByRole("button", { name: "提交我的总结" }).click();
+    await authedPage.getByTestId(T.detailMyPendingRow).getByTestId(T.detailSubmitMyBtn).click();
 
-    await expect(authedPage.locator(".summary-detail-members").getByText("已提交", { exact: true })).toBeVisible({ timeout: 15_000 });
+    await expect(authedPage.getByTestId(T.detailMembersSection).getByText("已提交", { exact: true }).first()).toBeVisible({ timeout: 15_000 });
     await expect(authedPage.getByText("S24 团队汇总已刷新", { exact: true })).toBeVisible({ timeout: 15_000 });
     await expect(authedPage.getByText("我（待提交）")).toHaveCount(0);
     await expect(authedPage.getByText("加载失败")).toHaveCount(0);

--- a/apps/web/e2e-kit/tests/summary/detail/S24-summary-multi-collab-submit.spec.ts
+++ b/apps/web/e2e-kit/tests/summary/detail/S24-summary-multi-collab-submit.spec.ts
@@ -5,7 +5,7 @@
  * S24: 多人 BY_PERSON 个人报告提交.
  */
 import { test, expect } from "../../../fixtures-authed";
-import { registerS24SummaryMultiCollabSubmit, S24_MY_USER_ID, S24_TASK_ID } from "../../../msw-handlers/s24-summary-multi-collab-submit";
+import { registerS24SummaryMultiCollabSubmit, S24_MY_USER_ID } from "../../../msw-handlers/s24-summary-multi-collab-submit";
 import { startRequestMonitor, sanityCheck } from "../../../_lib/sanity";
 import { T } from "../_testids";
 

--- a/apps/web/e2e-kit/tests/summary/detail/S24-summary-multi-collab-submit.spec.ts
+++ b/apps/web/e2e-kit/tests/summary/detail/S24-summary-multi-collab-submit.spec.ts
@@ -31,7 +31,7 @@ test.describe("@S24 @p2 @summary @detail @summary-detail @multi-collab S24 — �
 
     await authedPage.getByTestId(T.detailMyPendingRow).getByTestId(T.detailSubmitMyBtn).click();
 
-    await expect(authedPage.getByTestId(T.detailMembersSection).getByText("已提交", { exact: true }).first()).toBeVisible({ timeout: 15_000 });
+    await expect(authedPage.getByTestId(T.detailMembersSection).filter({ hasText: "E2E Tester" }).getByText("已提交", { exact: true })).toBeVisible({ timeout: 15_000 });
     await expect(authedPage.getByText("S24 团队汇总已刷新", { exact: true })).toBeVisible({ timeout: 15_000 });
     await expect(authedPage.getByText("我（待提交）")).toHaveCount(0);
     await expect(authedPage.getByText("加载失败")).toHaveCount(0);

--- a/apps/web/e2e-kit/tests/summary/detail/S6-summary-detail-failed.spec.ts
+++ b/apps/web/e2e-kit/tests/summary/detail/S6-summary-detail-failed.spec.ts
@@ -7,6 +7,7 @@
 import { test, expect } from "../../../fixtures-authed";
 import { registerS6SummaryDetailFailed } from "../../../msw-handlers/s6-summary-detail-failed";
 import { startRequestMonitor, sanityCheck } from "../../../_lib/sanity";
+import { T } from "../_testids";
 
 const sanityConfig = {
   // CI leak target plus legacy mock host marker; workflow proxy-error grep remains the fail-closed guard.
@@ -28,9 +29,7 @@ test.describe("@S6 @p1 @summary @detail @summary-detail S6 — Summary 失败详
 
     await authedPage.getByText("S6 失败总结").click();
 
-    await expect(
-      authedPage.getByRole("heading", { name: "S6 失败总结", level: 2 })
-    ).toBeVisible({ timeout: 15_000 });
+    await expect(authedPage.getByTestId(T.detailTitle)).toBeVisible({ timeout: 15_000 });
     await expect(authedPage.getByRole("heading", { name: "总结生成失败", level: 3 })).toBeVisible();
     await expect(authedPage.getByText("S6 模拟生成失败：模型服务暂不可用")).toBeVisible();
     await expect(authedPage.getByText("📝 总结内容")).toHaveCount(0);

--- a/apps/web/e2e-kit/tests/summary/detail/S6-summary-detail-failed.spec.ts
+++ b/apps/web/e2e-kit/tests/summary/detail/S6-summary-detail-failed.spec.ts
@@ -30,6 +30,7 @@ test.describe("@S6 @p1 @summary @detail @summary-detail S6 — Summary 失败详
     await authedPage.getByText("S6 失败总结").click();
 
     await expect(authedPage.getByTestId(T.detailTitle)).toBeVisible({ timeout: 15_000 });
+    await expect(authedPage.getByTestId(T.detailTitle)).toContainText("S6 失败总结");
     await expect(authedPage.getByRole("heading", { name: "总结生成失败", level: 3 })).toBeVisible();
     await expect(authedPage.getByText("S6 模拟生成失败：模型服务暂不可用")).toBeVisible();
     await expect(authedPage.getByText("📝 总结内容")).toHaveCount(0);

--- a/apps/web/e2e-kit/tests/summary/list/S1-summary-list-detail.spec.ts
+++ b/apps/web/e2e-kit/tests/summary/list/S1-summary-list-detail.spec.ts
@@ -7,6 +7,7 @@
 import { test, expect } from "../../../fixtures-authed";
 import { registerS1SummaryListDetail } from "../../../msw-handlers/s1-summary-list-detail";
 import { startRequestMonitor, sanityCheck } from "../../../_lib/sanity";
+import { T } from "../_testids";
 
 const sanityConfig = {
   // CI leak target plus legacy mock host marker; workflow proxy-error grep remains the fail-closed guard.
@@ -25,7 +26,7 @@ test.describe("@S1 @p0 @summary @list @summary-list @summary-detail S1 — Summa
     await expect(
       authedPage.getByRole("heading", { name: "智能总结" })
     ).toBeVisible({ timeout: 15_000 });
-    await expect(authedPage.getByTestId("summary-list-search")).toBeVisible();
+    await expect(authedPage.getByTestId(T.listSearch)).toBeVisible();
     await expect(authedPage.getByText("暂无总结记录")).toHaveCount(0);
 
     await expect(authedPage.getByText("S1 项目进展总结")).toBeVisible({

--- a/apps/web/e2e-kit/tests/summary/list/S1-summary-list-detail.spec.ts
+++ b/apps/web/e2e-kit/tests/summary/list/S1-summary-list-detail.spec.ts
@@ -25,7 +25,7 @@ test.describe("@S1 @p0 @summary @list @summary-list @summary-detail S1 — Summa
     await expect(
       authedPage.getByRole("heading", { name: "智能总结" })
     ).toBeVisible({ timeout: 15_000 });
-    await expect(authedPage.getByPlaceholder("搜索总结...")).toBeVisible();
+    await expect(authedPage.getByTestId("summary-list-search")).toBeVisible();
     await expect(authedPage.getByText("暂无总结记录")).toHaveCount(0);
 
     await expect(authedPage.getByText("S1 项目进展总结")).toBeVisible({

--- a/apps/web/e2e-kit/tests/summary/list/S18-summary-list-poll-completed.spec.ts
+++ b/apps/web/e2e-kit/tests/summary/list/S18-summary-list-poll-completed.spec.ts
@@ -7,6 +7,7 @@
 import { test, expect } from "../../../fixtures-authed";
 import { registerS18SummaryListPollCompleted } from "../../../msw-handlers/s18-summary-list-poll-completed";
 import { startRequestMonitor, sanityCheck } from "../../../_lib/sanity";
+import { T } from "../_testids";
 
 const sanityConfig = {
   realHosts: ["127.0.0.1:9", "mock.e2e.local"],
@@ -26,7 +27,7 @@ test.describe("@S18 @p1 @summary @list @summary-list @summary-poll S18 — Summa
     await expect(authedPage.getByText("已完成", { exact: true })).toBeVisible({ timeout: 8_000 });
     await authedPage.getByText("S18 轮询总结").click();
 
-    await expect(authedPage.locator(".summary-detail-title", { hasText: "S18 轮询总结" })).toBeVisible({ timeout: 15_000 });
+    await expect(authedPage.getByTestId(T.detailTitle)).toBeVisible({ timeout: 15_000 });
     await expect(authedPage.getByText("AI 摘要")).toBeVisible();
     await expect(authedPage.getByText("S18 轮询后已完成", { exact: true })).toBeVisible();
     await expect(authedPage.getByText("加载失败")).toHaveCount(0);

--- a/apps/web/e2e-kit/tests/summary/list/S18-summary-list-poll-completed.spec.ts
+++ b/apps/web/e2e-kit/tests/summary/list/S18-summary-list-poll-completed.spec.ts
@@ -28,6 +28,7 @@ test.describe("@S18 @p1 @summary @list @summary-list @summary-poll S18 — Summa
     await authedPage.getByText("S18 轮询总结").click();
 
     await expect(authedPage.getByTestId(T.detailTitle)).toBeVisible({ timeout: 15_000 });
+    await expect(authedPage.getByTestId(T.detailTitle)).toContainText("S18 轮询总结");
     await expect(authedPage.getByText("AI 摘要")).toBeVisible();
     await expect(authedPage.getByText("S18 轮询后已完成", { exact: true })).toBeVisible();
     await expect(authedPage.getByText("加载失败")).toHaveCount(0);

--- a/apps/web/e2e-kit/tests/summary/list/S19-summary-list-cancel-task.spec.ts
+++ b/apps/web/e2e-kit/tests/summary/list/S19-summary-list-cancel-task.spec.ts
@@ -23,8 +23,8 @@ test.describe("@S19 @p1 @summary @list @summary-list @summary-cancel S19 — Sum
     await expect(authedPage.getByText("S19 可取消总结")).toBeVisible({ timeout: 15_000 });
     await expect(authedPage.getByText("AI正在分析聊天记录...")).toBeVisible();
 
-    const card = authedPage.locator(".summary-card", { hasText: "S19 可取消总结" });
-    await card.getByRole("button", { name: "more" }).click();
+    const card = authedPage.getByTestId("summary-card-19019");
+    await card.getByTestId("summary-card-menu-19019").click();
     await authedPage.getByRole("menuitem", { name: "取消任务" }).click();
 
     await expect(authedPage.getByText("已取消总结任务")).toBeVisible({ timeout: 15_000 });

--- a/apps/web/e2e-kit/tests/summary/list/S19-summary-list-cancel-task.spec.ts
+++ b/apps/web/e2e-kit/tests/summary/list/S19-summary-list-cancel-task.spec.ts
@@ -5,7 +5,7 @@
  * S19: Summary 列表生成中任务取消.
  */
 import { test, expect } from "../../../fixtures-authed";
-import { registerS19SummaryListCancelTask } from "../../../msw-handlers/s19-summary-list-cancel-task";
+import { registerS19SummaryListCancelTask, S19_TASK_ID } from "../../../msw-handlers/s19-summary-list-cancel-task";
 import { startRequestMonitor, sanityCheck } from "../../../_lib/sanity";
 import { T } from "../_testids";
 
@@ -24,8 +24,8 @@ test.describe("@S19 @p1 @summary @list @summary-list @summary-cancel S19 — Sum
     await expect(authedPage.getByText("S19 可取消总结")).toBeVisible({ timeout: 15_000 });
     await expect(authedPage.getByText("AI正在分析聊天记录...")).toBeVisible();
 
-    const card = authedPage.getByTestId(T.card(19019));
-    await card.getByTestId(T.cardMenu(19019)).click();
+    const card = authedPage.getByTestId(T.card(S19_TASK_ID));
+    await card.getByTestId(T.cardMenu(S19_TASK_ID)).click();
     await authedPage.getByRole("menuitem", { name: "取消任务" }).click();
 
     await expect(authedPage.getByText("已取消总结任务")).toBeVisible({ timeout: 15_000 });

--- a/apps/web/e2e-kit/tests/summary/list/S19-summary-list-cancel-task.spec.ts
+++ b/apps/web/e2e-kit/tests/summary/list/S19-summary-list-cancel-task.spec.ts
@@ -7,6 +7,7 @@
 import { test, expect } from "../../../fixtures-authed";
 import { registerS19SummaryListCancelTask } from "../../../msw-handlers/s19-summary-list-cancel-task";
 import { startRequestMonitor, sanityCheck } from "../../../_lib/sanity";
+import { T } from "../_testids";
 
 const sanityConfig = {
   realHosts: ["127.0.0.1:9", "mock.e2e.local"],
@@ -23,8 +24,8 @@ test.describe("@S19 @p1 @summary @list @summary-list @summary-cancel S19 — Sum
     await expect(authedPage.getByText("S19 可取消总结")).toBeVisible({ timeout: 15_000 });
     await expect(authedPage.getByText("AI正在分析聊天记录...")).toBeVisible();
 
-    const card = authedPage.getByTestId("summary-card-19019");
-    await card.getByTestId("summary-card-menu-19019").click();
+    const card = authedPage.getByTestId(T.card(19019));
+    await card.getByTestId(T.cardMenu(19019)).click();
     await authedPage.getByRole("menuitem", { name: "取消任务" }).click();
 
     await expect(authedPage.getByText("已取消总结任务")).toBeVisible({ timeout: 15_000 });

--- a/apps/web/e2e-kit/tests/summary/list/S2-summary-empty-create-entry.spec.ts
+++ b/apps/web/e2e-kit/tests/summary/list/S2-summary-empty-create-entry.spec.ts
@@ -33,6 +33,7 @@ test.describe("@S2 @p1 @summary @list @summary-list @summary-create S2 — Summa
     await expect(authedPage.getByText("已完成", { exact: true })).toHaveCount(0);
     await expect(authedPage.getByText("失败", { exact: true })).toHaveCount(0);
 
+    await expect(authedPage.getByTestId(T.createEntry)).toContainText("创建第一份总结");
     await authedPage.getByTestId(T.createEntry).click();
 
     await expect(authedPage.getByText("邀请同事一起总结信息")).toBeVisible({

--- a/apps/web/e2e-kit/tests/summary/list/S2-summary-empty-create-entry.spec.ts
+++ b/apps/web/e2e-kit/tests/summary/list/S2-summary-empty-create-entry.spec.ts
@@ -7,6 +7,7 @@
 import { test, expect } from "../../../fixtures-authed";
 import { registerS2SummaryEmptyCreateEntry } from "../../../msw-handlers/s2-summary-empty-create-entry";
 import { startRequestMonitor, sanityCheck } from "../../../_lib/sanity";
+import { T } from "../_testids";
 
 const sanityConfig = {
   // CI leak target plus legacy mock host marker; workflow proxy-error grep remains the fail-closed guard.
@@ -32,14 +33,12 @@ test.describe("@S2 @p1 @summary @list @summary-list @summary-create S2 — Summa
     await expect(authedPage.getByText("已完成", { exact: true })).toHaveCount(0);
     await expect(authedPage.getByText("失败", { exact: true })).toHaveCount(0);
 
-    await authedPage.getByRole("button", { name: "创建第一份总结" }).click();
+    await authedPage.getByTestId(T.createEntry).click();
 
     await expect(authedPage.getByText("邀请同事一起总结信息")).toBeVisible({
       timeout: 15_000,
     });
-    await expect(
-      authedPage.getByPlaceholder("请输入你想总结的主题，例如：总结本周项目进展、整理客户反馈要点")
-    ).toBeVisible();
+    await expect(authedPage.getByTestId(T.createTopic)).toBeVisible();
 
     await sanityCheck(authedPage, ctx);
   });

--- a/apps/web/e2e-kit/tests/summary/list/S2-summary-empty-create-entry.spec.ts
+++ b/apps/web/e2e-kit/tests/summary/list/S2-summary-empty-create-entry.spec.ts
@@ -39,6 +39,10 @@ test.describe("@S2 @p1 @summary @list @summary-list @summary-create S2 — Summa
       timeout: 15_000,
     });
     await expect(authedPage.getByTestId(T.createTopic)).toBeVisible();
+    await expect(authedPage.getByTestId(T.createTopic)).toHaveAttribute(
+      "placeholder",
+      "请输入你想总结的主题，例如：总结本周项目进展、整理客户反馈要点"
+    );
 
     await sanityCheck(authedPage, ctx);
   });

--- a/apps/web/e2e-kit/tests/summary/list/S20-summary-list-retry-failed.spec.ts
+++ b/apps/web/e2e-kit/tests/summary/list/S20-summary-list-retry-failed.spec.ts
@@ -7,6 +7,7 @@
 import { test, expect } from "../../../fixtures-authed";
 import { registerS20SummaryListRetryFailed } from "../../../msw-handlers/s20-summary-list-retry-failed";
 import { startRequestMonitor, sanityCheck } from "../../../_lib/sanity";
+import { T } from "../_testids";
 
 const sanityConfig = {
   realHosts: ["127.0.0.1:9", "mock.e2e.local"],
@@ -23,8 +24,8 @@ test.describe("@S20 @p1 @summary @list @summary-list @summary-retry S20 — Summ
     await expect(authedPage.getByText("S20 失败可重试总结")).toBeVisible({ timeout: 15_000 });
     await expect(authedPage.getByText("失败", { exact: true })).toBeVisible();
 
-    const card = authedPage.getByTestId("summary-card-20020");
-    await card.getByTestId("summary-card-menu-20020").click();
+    const card = authedPage.getByTestId(T.card(20020));
+    await card.getByTestId(T.cardMenu(20020)).click();
     await authedPage.getByRole("menuitem", { name: "重试" }).click();
 
     await expect(authedPage.getByText("已重新提交总结任务")).toBeVisible({ timeout: 15_000 });

--- a/apps/web/e2e-kit/tests/summary/list/S20-summary-list-retry-failed.spec.ts
+++ b/apps/web/e2e-kit/tests/summary/list/S20-summary-list-retry-failed.spec.ts
@@ -23,8 +23,8 @@ test.describe("@S20 @p1 @summary @list @summary-list @summary-retry S20 — Summ
     await expect(authedPage.getByText("S20 失败可重试总结")).toBeVisible({ timeout: 15_000 });
     await expect(authedPage.getByText("失败", { exact: true })).toBeVisible();
 
-    const card = authedPage.locator(".summary-card", { hasText: "S20 失败可重试总结" });
-    await card.getByRole("button", { name: "more" }).click();
+    const card = authedPage.getByTestId("summary-card-20020");
+    await card.getByTestId("summary-card-menu-20020").click();
     await authedPage.getByRole("menuitem", { name: "重试" }).click();
 
     await expect(authedPage.getByText("已重新提交总结任务")).toBeVisible({ timeout: 15_000 });

--- a/apps/web/e2e-kit/tests/summary/list/S20-summary-list-retry-failed.spec.ts
+++ b/apps/web/e2e-kit/tests/summary/list/S20-summary-list-retry-failed.spec.ts
@@ -5,7 +5,7 @@
  * S20: Summary 列表失败任务重试.
  */
 import { test, expect } from "../../../fixtures-authed";
-import { registerS20SummaryListRetryFailed } from "../../../msw-handlers/s20-summary-list-retry-failed";
+import { registerS20SummaryListRetryFailed, S20_TASK_ID } from "../../../msw-handlers/s20-summary-list-retry-failed";
 import { startRequestMonitor, sanityCheck } from "../../../_lib/sanity";
 import { T } from "../_testids";
 
@@ -24,8 +24,8 @@ test.describe("@S20 @p1 @summary @list @summary-list @summary-retry S20 — Summ
     await expect(authedPage.getByText("S20 失败可重试总结")).toBeVisible({ timeout: 15_000 });
     await expect(authedPage.getByText("失败", { exact: true })).toBeVisible();
 
-    const card = authedPage.getByTestId(T.card(20020));
-    await card.getByTestId(T.cardMenu(20020)).click();
+    const card = authedPage.getByTestId(T.card(S20_TASK_ID));
+    await card.getByTestId(T.cardMenu(S20_TASK_ID)).click();
     await authedPage.getByRole("menuitem", { name: "重试" }).click();
 
     await expect(authedPage.getByText("已重新提交总结任务")).toBeVisible({ timeout: 15_000 });

--- a/apps/web/e2e-kit/tests/summary/list/S21-summary-list-load-more.spec.ts
+++ b/apps/web/e2e-kit/tests/summary/list/S21-summary-list-load-more.spec.ts
@@ -7,6 +7,7 @@
 import { test, expect } from "../../../fixtures-authed";
 import { registerS21SummaryListLoadMore } from "../../../msw-handlers/s21-summary-list-load-more";
 import { startRequestMonitor, sanityCheck } from "../../../_lib/sanity";
+import { T } from "../_testids";
 
 const sanityConfig = {
   realHosts: ["127.0.0.1:9", "mock.e2e.local"],
@@ -23,7 +24,7 @@ test.describe("@S21 @p2 @summary @list @summary-list @pagination S21 — Summary
     await expect(authedPage.getByText("S21 第 01 条总结")).toBeVisible({ timeout: 15_000 });
     await expect(authedPage.getByText("暂无总结记录")).toHaveCount(0);
 
-    const list = authedPage.locator(".summary-list-content");
+    const list = authedPage.getByTestId(T.listContent);
     await list.evaluate((el) => {
       el.scrollTop = el.scrollHeight;
       el.dispatchEvent(new Event("scroll", { bubbles: true }));

--- a/apps/web/e2e-kit/tests/summary/list/S25-summary-invite-respond.spec.ts
+++ b/apps/web/e2e-kit/tests/summary/list/S25-summary-invite-respond.spec.ts
@@ -29,7 +29,9 @@ test.describe("@S25 @p2 @summary @list @summary-list @summary-invite S25 — Sum
     await expect(acceptCard).toContainText("S25 同意邀请总结");
     await expect(rejectCard).toContainText("S25 拒绝邀请总结");
     await expect(acceptCard.getByTestId(T.cardAcceptBtn(S25_ACCEPT_TASK_ID))).toBeVisible();
+    await expect(acceptCard.getByTestId(T.cardAcceptBtn(S25_ACCEPT_TASK_ID))).toContainText("同意");
     await expect(rejectCard.getByTestId(T.cardRejectBtn(S25_REJECT_TASK_ID))).toBeVisible();
+    await expect(rejectCard.getByTestId(T.cardRejectBtn(S25_REJECT_TASK_ID))).toContainText("拒绝");
 
     await acceptCard.getByTestId(T.cardAcceptBtn(S25_ACCEPT_TASK_ID)).click();
     await expect(authedPage.getByText("已同意")).toBeVisible({ timeout: 15_000 });

--- a/apps/web/e2e-kit/tests/summary/list/S25-summary-invite-respond.spec.ts
+++ b/apps/web/e2e-kit/tests/summary/list/S25-summary-invite-respond.spec.ts
@@ -7,6 +7,7 @@
 import { test, expect } from "../../../fixtures-authed";
 import { registerS25SummaryInviteRespond } from "../../../msw-handlers/s25-summary-invite-respond";
 import { startRequestMonitor, sanityCheck } from "../../../_lib/sanity";
+import { T } from "../_testids";
 
 const sanityConfig = {
   realHosts: ["127.0.0.1:9", "mock.e2e.local"],
@@ -20,23 +21,23 @@ test.describe("@S25 @p2 @summary @list @summary-list @summary-invite S25 — Sum
     const ctx = startRequestMonitor(authedPage, sanityConfig);
 
     await authedPage.getByRole("button", { name: "智能总结" }).click();
-    const acceptCard = authedPage.locator(".summary-card", { hasText: "S25 同意邀请总结" });
-    const rejectCard = authedPage.locator(".summary-card", { hasText: "S25 拒绝邀请总结" });
+    const acceptCard = authedPage.getByTestId(T.card(250251));
+    const rejectCard = authedPage.getByTestId(T.card(250252));
 
     await expect(acceptCard).toBeVisible({ timeout: 15_000 });
     await expect(rejectCard).toBeVisible();
-    await expect(acceptCard.getByRole("button", { name: "同意" })).toBeVisible();
-    await expect(rejectCard.getByRole("button", { name: "拒绝" })).toBeVisible();
+    await expect(acceptCard.getByTestId(T.cardAcceptBtn(250251))).toBeVisible();
+    await expect(rejectCard.getByTestId(T.cardRejectBtn(250252))).toBeVisible();
 
-    await acceptCard.getByRole("button", { name: "同意" }).click();
+    await acceptCard.getByTestId(T.cardAcceptBtn(250251)).click();
     await expect(authedPage.getByText("已同意")).toBeVisible({ timeout: 15_000 });
-    await expect(acceptCard.getByRole("button", { name: "同意" })).toHaveCount(0);
-    await expect(acceptCard.getByRole("button", { name: "拒绝" })).toHaveCount(0);
+    await expect(acceptCard.getByTestId(T.cardAcceptBtn(250251))).toHaveCount(0);
+    await expect(acceptCard.getByTestId(T.cardRejectBtn(250251))).toHaveCount(0);
 
-    await rejectCard.getByRole("button", { name: "拒绝" }).click();
+    await rejectCard.getByTestId(T.cardRejectBtn(250252)).click();
     await expect(authedPage.getByText("已拒绝")).toBeVisible({ timeout: 15_000 });
-    await expect(rejectCard.getByRole("button", { name: "同意" })).toHaveCount(0);
-    await expect(rejectCard.getByRole("button", { name: "拒绝" })).toHaveCount(0);
+    await expect(rejectCard.getByTestId(T.cardAcceptBtn(250252))).toHaveCount(0);
+    await expect(rejectCard.getByTestId(T.cardRejectBtn(250252))).toHaveCount(0);
     await expect(authedPage.getByText("加载失败")).toHaveCount(0);
 
     await sanityCheck(authedPage, ctx);

--- a/apps/web/e2e-kit/tests/summary/list/S25-summary-invite-respond.spec.ts
+++ b/apps/web/e2e-kit/tests/summary/list/S25-summary-invite-respond.spec.ts
@@ -26,6 +26,8 @@ test.describe("@S25 @p2 @summary @list @summary-list @summary-invite S25 — Sum
 
     await expect(acceptCard).toBeVisible({ timeout: 15_000 });
     await expect(rejectCard).toBeVisible();
+    await expect(acceptCard).toContainText("S25 同意邀请总结");
+    await expect(rejectCard).toContainText("S25 拒绝邀请总结");
     await expect(acceptCard.getByTestId(T.cardAcceptBtn(250251))).toBeVisible();
     await expect(rejectCard.getByTestId(T.cardRejectBtn(250252))).toBeVisible();
 

--- a/apps/web/e2e-kit/tests/summary/list/S25-summary-invite-respond.spec.ts
+++ b/apps/web/e2e-kit/tests/summary/list/S25-summary-invite-respond.spec.ts
@@ -5,7 +5,7 @@
  * S25: Summary 列表待确认邀请同意 / 拒绝.
  */
 import { test, expect } from "../../../fixtures-authed";
-import { registerS25SummaryInviteRespond } from "../../../msw-handlers/s25-summary-invite-respond";
+import { registerS25SummaryInviteRespond, S25_ACCEPT_TASK_ID, S25_REJECT_TASK_ID } from "../../../msw-handlers/s25-summary-invite-respond";
 import { startRequestMonitor, sanityCheck } from "../../../_lib/sanity";
 import { T } from "../_testids";
 
@@ -21,25 +21,25 @@ test.describe("@S25 @p2 @summary @list @summary-list @summary-invite S25 — Sum
     const ctx = startRequestMonitor(authedPage, sanityConfig);
 
     await authedPage.getByRole("button", { name: "智能总结" }).click();
-    const acceptCard = authedPage.getByTestId(T.card(250251));
-    const rejectCard = authedPage.getByTestId(T.card(250252));
+    const acceptCard = authedPage.getByTestId(T.card(S25_ACCEPT_TASK_ID));
+    const rejectCard = authedPage.getByTestId(T.card(S25_REJECT_TASK_ID));
 
     await expect(acceptCard).toBeVisible({ timeout: 15_000 });
     await expect(rejectCard).toBeVisible();
     await expect(acceptCard).toContainText("S25 同意邀请总结");
     await expect(rejectCard).toContainText("S25 拒绝邀请总结");
-    await expect(acceptCard.getByTestId(T.cardAcceptBtn(250251))).toBeVisible();
-    await expect(rejectCard.getByTestId(T.cardRejectBtn(250252))).toBeVisible();
+    await expect(acceptCard.getByTestId(T.cardAcceptBtn(S25_ACCEPT_TASK_ID))).toBeVisible();
+    await expect(rejectCard.getByTestId(T.cardRejectBtn(S25_REJECT_TASK_ID))).toBeVisible();
 
-    await acceptCard.getByTestId(T.cardAcceptBtn(250251)).click();
+    await acceptCard.getByTestId(T.cardAcceptBtn(S25_ACCEPT_TASK_ID)).click();
     await expect(authedPage.getByText("已同意")).toBeVisible({ timeout: 15_000 });
-    await expect(acceptCard.getByTestId(T.cardAcceptBtn(250251))).toHaveCount(0);
-    await expect(acceptCard.getByTestId(T.cardRejectBtn(250251))).toHaveCount(0);
+    await expect(acceptCard.getByTestId(T.cardAcceptBtn(S25_ACCEPT_TASK_ID))).toHaveCount(0);
+    await expect(acceptCard.getByTestId(T.cardRejectBtn(S25_ACCEPT_TASK_ID))).toHaveCount(0);
 
-    await rejectCard.getByTestId(T.cardRejectBtn(250252)).click();
+    await rejectCard.getByTestId(T.cardRejectBtn(S25_REJECT_TASK_ID)).click();
     await expect(authedPage.getByText("已拒绝")).toBeVisible({ timeout: 15_000 });
-    await expect(rejectCard.getByTestId(T.cardAcceptBtn(250252))).toHaveCount(0);
-    await expect(rejectCard.getByTestId(T.cardRejectBtn(250252))).toHaveCount(0);
+    await expect(rejectCard.getByTestId(T.cardAcceptBtn(S25_REJECT_TASK_ID))).toHaveCount(0);
+    await expect(rejectCard.getByTestId(T.cardRejectBtn(S25_REJECT_TASK_ID))).toHaveCount(0);
     await expect(authedPage.getByText("加载失败")).toHaveCount(0);
 
     await sanityCheck(authedPage, ctx);

--- a/apps/web/e2e-kit/tests/summary/list/S3-summary-list-search.spec.ts
+++ b/apps/web/e2e-kit/tests/summary/list/S3-summary-list-search.spec.ts
@@ -25,7 +25,7 @@ test.describe("@S3 @p1 @summary @list @summary-list @summary-search S3 — Summa
     await expect(authedPage.getByText("S3 周报总结")).toBeVisible({ timeout: 15_000 });
     await expect(authedPage.getByText("S3 客户反馈总结")).toBeVisible();
 
-    await authedPage.getByPlaceholder("搜索总结...").fill("客户");
+    await authedPage.getByTestId("summary-list-search").fill("客户");
 
     await expect(authedPage.getByText("S3 客户反馈总结")).toBeVisible({ timeout: 15_000 });
     await expect(authedPage.getByText("S3 周报总结")).toHaveCount(0);

--- a/apps/web/e2e-kit/tests/summary/list/S3-summary-list-search.spec.ts
+++ b/apps/web/e2e-kit/tests/summary/list/S3-summary-list-search.spec.ts
@@ -7,6 +7,7 @@
 import { test, expect } from "../../../fixtures-authed";
 import { registerS3SummaryListSearch } from "../../../msw-handlers/s3-summary-list-search";
 import { startRequestMonitor, sanityCheck } from "../../../_lib/sanity";
+import { T } from "../_testids";
 
 const sanityConfig = {
   // CI leak target plus legacy mock host marker; workflow proxy-error grep remains the fail-closed guard.
@@ -25,7 +26,7 @@ test.describe("@S3 @p1 @summary @list @summary-list @summary-search S3 — Summa
     await expect(authedPage.getByText("S3 周报总结")).toBeVisible({ timeout: 15_000 });
     await expect(authedPage.getByText("S3 客户反馈总结")).toBeVisible();
 
-    await authedPage.getByTestId("summary-list-search").fill("客户");
+    await authedPage.getByTestId(T.listSearch).fill("客户");
 
     await expect(authedPage.getByText("S3 客户反馈总结")).toBeVisible({ timeout: 15_000 });
     await expect(authedPage.getByText("S3 周报总结")).toHaveCount(0);

--- a/apps/web/e2e-kit/tests/summary/list/S4-summary-list-status-filter.spec.ts
+++ b/apps/web/e2e-kit/tests/summary/list/S4-summary-list-status-filter.spec.ts
@@ -7,6 +7,7 @@
 import { test, expect } from "../../../fixtures-authed";
 import { registerS4SummaryListStatusFilter } from "../../../msw-handlers/s4-summary-list-status-filter";
 import { startRequestMonitor, sanityCheck } from "../../../_lib/sanity";
+import { T } from "../_testids";
 
 const sanityConfig = {
   // CI leak target plus legacy mock host marker; workflow proxy-error grep remains the fail-closed guard.
@@ -25,7 +26,7 @@ test.describe("@S4 @p1 @summary @list @summary-list @summary-filter S4 — Summa
     await expect(authedPage.getByText("S4 已完成总结")).toBeVisible({ timeout: 15_000 });
     await expect(authedPage.getByText("S4 失败总结")).toBeVisible();
 
-    await authedPage.getByTestId("summary-list-status-filter").click();
+    await authedPage.getByTestId(T.listStatusFilter).click();
     await authedPage.getByRole("menuitem", { name: "失败" }).click();
 
     await expect(authedPage.getByText("S4 失败总结")).toBeVisible({ timeout: 15_000 });

--- a/apps/web/e2e-kit/tests/summary/list/S4-summary-list-status-filter.spec.ts
+++ b/apps/web/e2e-kit/tests/summary/list/S4-summary-list-status-filter.spec.ts
@@ -25,7 +25,7 @@ test.describe("@S4 @p1 @summary @list @summary-list @summary-filter S4 — Summa
     await expect(authedPage.getByText("S4 已完成总结")).toBeVisible({ timeout: 15_000 });
     await expect(authedPage.getByText("S4 失败总结")).toBeVisible();
 
-    await authedPage.getByText("全部状态", { exact: true }).click();
+    await authedPage.getByTestId("summary-list-status-filter").click();
     await authedPage.getByRole("menuitem", { name: "失败" }).click();
 
     await expect(authedPage.getByText("S4 失败总结")).toBeVisible({ timeout: 15_000 });

--- a/packages/dmworksummary/src/__tests__/testIdsParity.test.ts
+++ b/packages/dmworksummary/src/__tests__/testIdsParity.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest';
+import { summaryTestIds } from '../utils/testIds';
+
+/**
+ * Guard: e2e _testids.ts must mirror production testIds.ts.
+ *
+ * Loads both files as text, extracts string literals and function templates
+ * via regex (avoiding any React/Playwright import at Vitest time), and checks
+ * that every production key/value is present with an identical string or
+ * template body.
+ *
+ * Dynamic function params differ between files (e.g. versionNum vs v); we only
+ * compare the produced template string, not parameter names.
+ */
+
+// Use vitest's vi to avoid requiring @types/node; fs/path/url are available in
+// Node at runtime (vitest runs in Node). Fall back to require for environments
+// without node: protocol support.
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const _fs = require('fs');
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const _path = require('path');
+
+// When run via vitest from packages/dmworksummary, cwd is that package root.
+// When run via turbo from repo root, cwd may be repo root. Resolve robustly.
+const _cwd = process.cwd();
+const _pkgRoot = _cwd.endsWith('dmworksummary') ? _cwd : _path.join(_cwd, 'packages/dmworksummary');
+const _repoRoot = _path.resolve(_pkgRoot, '../..');
+const prodPath = _path.join(_pkgRoot, 'src/utils/testIds.ts');
+const e2ePath = _path.join(_repoRoot, 'apps/web/e2e-kit/tests/summary/_testids.ts');
+const prodSrc = _fs.readFileSync(prodPath, 'utf-8');
+const e2eSrc = _fs.readFileSync(e2ePath, 'utf-8');
+
+/** Extract `key: "string-literal"` pairs from object source text. */
+function extractStringEntries(src: string): Record<string, string> {
+  const entries: Record<string, string> = {};
+  const re = /(\w+)\s*:\s*"([^"]*)"/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(src)) !== null) {
+    entries[m[1]] = m[2];
+  }
+  return entries;
+}
+
+/**
+ * Extract `key: (params) => \`template-${expr}\`` pairs, returning the
+ * template body text with ${...} placeholders replaced by a single `%s`
+ * placeholder so we can compare template *shape* without caring about arg names.
+ *
+ * Only handles single-line arrow functions returning a template literal —
+ * which is the form used throughout both testids files.
+ */
+function extractFunctionEntries(src: string): Record<string, string> {
+  const entries: Record<string, string> = {};
+  // Match  key: (params) => `template body with ${...} expressions`
+  const re = /(\w+)\s*:\s*\([^)]*\)\s*=>\s*`([^`]*)`/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(src)) !== null) {
+    // Normalise ${…} to %s so param-name differences (versionNum vs v) don't fail.
+    entries[m[1]] = m[2].replace(/\$\{[^}]+\}/g, '%s');
+  }
+  return entries;
+}
+
+const prodStrings = extractStringEntries(prodSrc);
+const prodFns = extractFunctionEntries(prodSrc);
+const e2eStrings = extractStringEntries(e2eSrc);
+const e2eFns = extractFunctionEntries(e2eSrc);
+
+describe('testIds parity guard (prod <-> e2e)', () => {
+  it('all production string testids exist in e2e _testids.ts', () => {
+    for (const [key, val] of Object.entries(prodStrings)) {
+      expect(e2eStrings[key], `missing/incorrect string key "${key}"`).toBe(val);
+    }
+  });
+
+  it('all production function testids produce matching templates in e2e', () => {
+    for (const [key, template] of Object.entries(prodFns)) {
+      expect(e2eFns[key], `missing/incorrect function key "${key}"`).toBe(template);
+    }
+  });
+
+  it('e2e _testids has no extra string keys not in production', () => {
+    for (const key of Object.keys(e2eStrings)) {
+      expect(prodStrings[key], `e2e-only string key "${key}"`).toBeDefined();
+    }
+  });
+
+  it('e2e _testids has no extra function keys not in production', () => {
+    for (const key of Object.keys(e2eFns)) {
+      expect(prodFns[key], `e2e-only function key "${key}"`).toBeDefined();
+    }
+  });
+
+  it('detail() is present in production (sanity check)', () => {
+    expect(typeof summaryTestIds.detail).toBe('function');
+    expect(summaryTestIds.detail(123)).toBe('summary-detail-123');
+  });
+
+  it('detailMemberRow() is present and produces expected testid', () => {
+    expect(typeof summaryTestIds.detailMemberRow).toBe('function');
+    expect(summaryTestIds.detailMemberRow('user-1')).toBe('summary-detail-member-row-user-1');
+  });
+});

--- a/packages/dmworksummary/src/__tests__/testIdsParity.test.ts
+++ b/packages/dmworksummary/src/__tests__/testIdsParity.test.ts
@@ -154,6 +154,7 @@ describe('testIds parity guard (prod <-> e2e)', () => {
   const dynamicSamples: Array<{ key: string; args: unknown[]; expected: string }> = [
     { key: 'detail',        args: [123],            expected: 'summary-detail-123' },
     { key: 'card',          args: [250251],         expected: 'summary-card-250251' },
+    { key: 'cardMenu',       args: [19019],          expected: 'summary-card-menu-19019' },
     { key: 'cardAcceptBtn', args: [250251],         expected: 'summary-card-accept-250251' },
     { key: 'cardRejectBtn', args: [250252],         expected: 'summary-card-reject-250252' },
     { key: 'detailMemberRow', args: ['e2e-user-1'], expected: 'summary-detail-member-row-e2e-user-1' },

--- a/packages/dmworksummary/src/__tests__/testIdsParity.test.ts
+++ b/packages/dmworksummary/src/__tests__/testIdsParity.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect } from 'vitest';
+// Dynamic import of e2e T is not possible (TS outside project), but we load its
+// source as text and eval dynamic-call results for actual sample invocations.
 import { summaryTestIds } from '../utils/testIds';
 
 /**
@@ -10,7 +12,9 @@ import { summaryTestIds } from '../utils/testIds';
  * template body.
  *
  * Dynamic function params differ between files (e.g. versionNum vs v); we only
- * compare the produced template string, not parameter names.
+ * compare the produced template string, not parameter names. We additionally
+ * evaluate a representative sample of dynamic calls against both prod and e2e
+ * sources to catch template-body drift that regex normalization alone could miss.
  */
 
 // Use vitest's vi to avoid requiring @types/node; fs/path/url are available in
@@ -67,6 +71,47 @@ const prodFns = extractFunctionEntries(prodSrc);
 const e2eStrings = extractStringEntries(e2eSrc);
 const e2eFns = extractFunctionEntries(e2eSrc);
 
+// Extract the object literal body from a source file (strip `export const X =`
+// prefix and `as const;` suffix) so we can eval dynamic-call samples without
+// involving the full TS toolchain.
+function extractObjectBody(src: string, constName: string): string {
+  const marker = `export const ${constName}`;
+  const startIdx = src.indexOf(marker);
+  if (startIdx < 0) throw new Error(`parity: cannot find const "${constName}" in source`);
+  const eqIdx = src.indexOf('=', startIdx);
+  // Find first '{' after =
+  const braceStart = src.indexOf('{', eqIdx);
+  // Walk braces to find matching close.
+  let depth = 0;
+  let i = braceStart;
+  for (; i < src.length; i++) {
+    const ch = src[i];
+    if (ch === '{') depth++;
+    else if (ch === '}') {
+      depth--;
+      if (depth === 0) break;
+    }
+  }
+  return src.slice(braceStart, i + 1);
+}
+
+// Build in-memory T objects from the source object bodies (JS-only, no TS
+// types/as const/export). Used only to assert actual-call output parity for
+// representative dynamic testids.
+function evalTestIdsObject(src: string): Record<string, unknown> {
+  // Strip TypeScript type annotations on arrow-function parameters to make the
+  // object literal eval-able as plain JS. e.g. `(taskId: number) =>` → `(taskId) =>`
+  // and `(v: number | string) =>` → `(v) =>`.
+  const cleaned = src
+    .replace(/\((\w+)\s*:\s*[^)]*\)/g, '($1)')
+    .replace(/as const/g, '');
+  // eslint-disable-next-line no-new-func
+  return new Function(`return ${cleaned};`)() as Record<string, unknown>;
+}
+
+const _prodEval = evalTestIdsObject(extractObjectBody(prodSrc, 'summaryTestIds'));
+const _e2eEval  = evalTestIdsObject(extractObjectBody(e2eSrc, 'T'));
+
 describe('testIds parity guard (prod <-> e2e)', () => {
   it('all production string testids exist in e2e _testids.ts', () => {
     for (const [key, val] of Object.entries(prodStrings)) {
@@ -101,4 +146,32 @@ describe('testIds parity guard (prod <-> e2e)', () => {
     expect(typeof summaryTestIds.detailMemberRow).toBe('function');
     expect(summaryTestIds.detailMemberRow('user-1')).toBe('summary-detail-member-row-user-1');
   });
+
+  // Dynamic-call parity: for representative dynamic testids, evaluate the
+  // object literal extracted from each source and assert concrete sample
+  // invocations produce identical strings. This catches cases where the
+  // template-shape regex (${...}→%s) would mask a drift in literal prefix/suffix.
+  const dynamicSamples: Array<{ key: string; args: unknown[]; expected: string }> = [
+    { key: 'detail',        args: [123],            expected: 'summary-detail-123' },
+    { key: 'card',          args: [250251],         expected: 'summary-card-250251' },
+    { key: 'cardAcceptBtn', args: [250251],         expected: 'summary-card-accept-250251' },
+    { key: 'cardRejectBtn', args: [250252],         expected: 'summary-card-reject-250252' },
+    { key: 'detailMemberRow', args: ['e2e-user-1'], expected: 'summary-detail-member-row-e2e-user-1' },
+    { key: 'versionCard',   args: [2],              expected: 'summary-version-card-2' },
+  ];
+
+  for (const { key, args, expected } of dynamicSamples) {
+    it(`dynamic testid ${key}(${args.map(a => JSON.stringify(a)).join(', ')}) matches between prod and e2e`, () => {
+      const prodFn = _prodEval[key];
+      const e2eFn  = _e2eEval[key];
+      expect(typeof prodFn, `prod missing dynamic key "${key}"`).toBe('function');
+      expect(typeof e2eFn,  `e2e  missing dynamic key "${key}"`).toBe('function');
+      // eslint-disable-next-line @typescript-eslint/ban-types
+      const prodVal = (prodFn as Function)(...args);
+      // eslint-disable-next-line @typescript-eslint/ban-types
+      const e2eVal  = (e2eFn  as Function)(...args);
+      expect(prodVal, `prod ${key} sample`).toBe(expected);
+      expect(e2eVal,  `e2e ${key} sample diverges from prod`).toBe(prodVal);
+    });
+  }
 });

--- a/packages/dmworksummary/src/components/AgentChatPanel.tsx
+++ b/packages/dmworksummary/src/components/AgentChatPanel.tsx
@@ -4,6 +4,7 @@ import { I18nContext } from '@octo/base';
 import type { ChatMessage, ChatCandidate, AgentProgressEvent, AgentDoneEvent, AgentErrorEvent } from '../types/summary';
 import { agentChatStream, agentChat } from '../api/summaryApi';
 import { genSessionId } from '../utils/summaryHelpers';
+import { summaryTestIds } from '../utils/testIds';
 import './AgentChatPanel.css';
 
 interface AgentChatPanelProps {
@@ -356,12 +357,13 @@ export default class AgentChatPanel extends Component<AgentChatPanelProps, Agent
         const isBusy = sending || isStreaming;
 
         return (
-            <div className="agent-chat-panel">
+            <div data-testid={summaryTestIds.agentPanel} className="agent-chat-panel">
                 {(onNewSession || referenceHeader) && (
                     <div className="agent-chat-panel-header">
                         {referenceHeader}
                         {onNewSession && (
                             <Button
+                                data-testid={summaryTestIds.agentNewSessionBtn}
                                 theme="borderless"
                                 size="small"
                                 disabled={isBusy}
@@ -401,6 +403,7 @@ export default class AgentChatPanel extends Component<AgentChatPanelProps, Agent
                 </div>
                 <div className="agent-chat-panel-input">
                     <textarea
+                        data-testid={summaryTestIds.agentInput}
                         className="agent-chat-textarea"
                         value={input}
                         placeholder={t('summary.create.agentChatPlaceholder')}
@@ -410,6 +413,7 @@ export default class AgentChatPanel extends Component<AgentChatPanelProps, Agent
                         onKeyDown={this.handleKeyDown}
                     />
                     <Button
+                        data-testid={summaryTestIds.agentSendBtn}
                         theme="solid"
                         size="default"
                         loading={isBusy}
@@ -420,6 +424,7 @@ export default class AgentChatPanel extends Component<AgentChatPanelProps, Agent
                     </Button>
                     {canSave && (
                         <Button
+                            data-testid={summaryTestIds.agentSaveBtn}
                             size="default"
                             disabled={!this.hasAssistantOutput() || savingSummary}
                             loading={savingSummary}
@@ -439,8 +444,13 @@ export default class AgentChatPanel extends Component<AgentChatPanelProps, Agent
                     okText={t('summary.common.confirm')}
                     cancelText={t('summary.common.cancel')}
                     confirmLoading={savingSummary}
+                    okButtonProps={{ 'data-testid': summaryTestIds.agentSaveConfirmBtn } as any}
+                    modalRender={(node) => (
+                        <div data-testid={summaryTestIds.agentSaveDialog}>{node}</div>
+                    )}
                 >
                     <Input
+                        data-testid={summaryTestIds.agentSaveTitleInput}
                         placeholder={t('summary.create.titlePlaceholder')}
                         value={summaryTitle}
                         onChange={v => this.setState({ summaryTitle: v })}

--- a/packages/dmworksummary/src/components/ChatSelectorModal.tsx
+++ b/packages/dmworksummary/src/components/ChatSelectorModal.tsx
@@ -11,6 +11,7 @@ import * as api from "../api/summaryApi";
 import WKApp from "@octo/base/src/App";
 import SidebarService, { SidebarTargetType } from "@octo/base/src/Service/SidebarService";
 import { MAX_CHAT_SELECT } from "../constants/limits";
+import { summaryTestIds } from "../utils/testIds";
 
 interface MemberCandidate {
     uid: string;
@@ -493,7 +494,7 @@ export default class ChatSelectorModal extends Component<Props, State> {
         if (!visible) return null;
 
         return (
-            <div className="chat-selector-overlay" onClick={onCancel}>
+            <div data-testid={summaryTestIds.chatSelectorModal} className="chat-selector-overlay" onClick={onCancel}>
                 <div className="chat-selector-modal" onClick={(e) => e.stopPropagation()}>
                     {/* Header */}
                     <div className="chat-selector-header">
@@ -510,6 +511,7 @@ export default class ChatSelectorModal extends Component<Props, State> {
                             <div className="chat-selector-search">
                                 <IconSearch className="chat-selector-search-icon" />
                                 <input
+                                    data-testid={summaryTestIds.chatSelectorSearchInput}
                                     className="chat-selector-search-input"
                                     placeholder={t("summary.chatSelector.searchPlaceholder")}
                                     value={keyword}
@@ -521,6 +523,7 @@ export default class ChatSelectorModal extends Component<Props, State> {
                                     {currentTabs.map((tab) => (
                                         <button
                                             key={tab.key}
+                                            data-testid={tab.key === "group" ? summaryTestIds.chatSelectorAllGroupsTab : undefined}
                                             className={`chat-selector-tab${activeTab === tab.key ? " chat-selector-tab--active" : ""}`}
                                             onClick={() => this.handleTabChange(tab.key)}
                                         >
@@ -611,7 +614,12 @@ export default class ChatSelectorModal extends Component<Props, State> {
                         <button type="button" className="chat-selector-btn chat-selector-btn--cancel" onClick={onCancel}>
                             {t("summary.common.cancel")}
                         </button>
-                        <button type="button" className="chat-selector-btn chat-selector-btn--confirm" onClick={this.handleConfirm}>
+                        <button
+                            type="button"
+                            data-testid={mode === "members" ? summaryTestIds.memberSelectorConfirmBtn : summaryTestIds.chatSelectorConfirmBtn}
+                            className="chat-selector-btn chat-selector-btn--confirm"
+                            onClick={this.handleConfirm}
+                        >
                             {t("summary.common.confirm")}
                         </button>
                     </div>

--- a/packages/dmworksummary/src/components/ChatSummaryPanel.tsx
+++ b/packages/dmworksummary/src/components/ChatSummaryPanel.tsx
@@ -10,6 +10,7 @@ import { X, ChevronLeft } from 'lucide-react';
 import SummaryListPage from '../pages/SummaryListPage';
 import SummaryCreatePage from '../pages/SummaryCreatePage';
 import SummaryDetailPage from '../pages/SummaryDetailPage';
+import { summaryTestIds } from '../utils/testIds';
 
 interface ChatSummaryPanelProps {
     visible: boolean;
@@ -152,7 +153,7 @@ export default class ChatSummaryPanel extends Component<
         const isCreate = view === 'create';
 
         return (
-            <div ref={this.rootRef} style={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
+            <div ref={this.rootRef} data-testid={summaryTestIds.chatPanel} style={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
                 {/* 左边缘分隔条：拖动调宽，双击重置默认宽度（复用 thread 面板样式） */}
                 <div
                     className={`wk-thread-panel-splitter${isDragging ? ' wk-thread-panel-splitter-active' : ''}`}
@@ -181,10 +182,11 @@ export default class ChatSummaryPanel extends Component<
 
                 {/* 创建视图：返回按钮 + 内嵌创建表单（复用 SummaryCreatePage embedded） */}
                 {isCreate && (
-                    <div className="wk-summary-panel-detail">
+                    <div data-testid={summaryTestIds.chatPanelDetailInPanel} className="wk-summary-panel-detail">
                         <div className="wk-summary-panel-detail-back">
                             <button
                                 type="button"
+                                data-testid={summaryTestIds.chatPanelBackBtn}
                                 className="wk-summary-panel-detail-back-btn"
                                 onClick={this.handleBackToList}
                             >
@@ -205,10 +207,11 @@ export default class ChatSummaryPanel extends Component<
 
                 {/* 详情视图：复用整页 SummaryDetailPage，外层加面板级返回栏 */}
                 {isDetail && (
-                    <div className="wk-summary-panel-detail">
+                    <div data-testid={summaryTestIds.chatPanelDetailInPanel} className="wk-summary-panel-detail">
                         <div className="wk-summary-panel-detail-back">
                             <button
                                 type="button"
+                                data-testid={summaryTestIds.chatPanelBackBtn}
                                 className="wk-summary-panel-detail-back-btn"
                                 onClick={this.handleBack}
                             >

--- a/packages/dmworksummary/src/components/ChatSummaryStarButton.tsx
+++ b/packages/dmworksummary/src/components/ChatSummaryStarButton.tsx
@@ -5,6 +5,8 @@ import { WKApp, I18nContext } from '@octo/base';
 import { Sparkle } from 'lucide-react';
 import * as summaryApi from '../api/summaryApi';
 
+import { summaryTestIds } from '../utils/testIds';
+
 interface ChatSummaryStarButtonProps {
     channel: { channelID: string; channelType: number };
 }
@@ -126,6 +128,7 @@ export default class ChatSummaryStarButton extends Component<
         const { t } = this.context;
         return (
             <div
+                data-testid={summaryTestIds.chatPanelHeaderBtn}
                 onClick={(e) => {
                     e.stopPropagation();
                     void this.handleClick();

--- a/packages/dmworksummary/src/components/OverflowTooltip.tsx
+++ b/packages/dmworksummary/src/components/OverflowTooltip.tsx
@@ -7,9 +7,10 @@ interface OverflowTooltipProps {
     style?: React.CSSProperties;
     as?: React.ElementType;
     title?: string;
+    "data-testid"?: string;
 }
 
-const OverflowTooltip: React.FC<OverflowTooltipProps> = ({ children, className, style, as: Component = "div", title }) => {
+const OverflowTooltip: React.FC<OverflowTooltipProps> = ({ children, className, style, as: Component = "div", title, "data-testid": dataTestId }) => {
     const containerRef = useRef<HTMLElement>(null);
     const [visible, setVisible] = useState(false);
 
@@ -42,6 +43,7 @@ const OverflowTooltip: React.FC<OverflowTooltipProps> = ({ children, className, 
                 ref={containerRef}
                 className={className}
                 style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", ...style }}
+                data-testid={dataTestId}
                 onMouseEnter={handleMouseEnter}
                 onMouseLeave={handleMouseLeave}
             >

--- a/packages/dmworksummary/src/components/SummaryCard.tsx
+++ b/packages/dmworksummary/src/components/SummaryCard.tsx
@@ -7,6 +7,7 @@ import type { SummaryListItem } from "../types/summary";
 import { ParticipantStatus, TaskStatus, TriggerType } from "../types/summary";
 import { getStatusLabel } from "../utils/summaryHelpers";
 import { deriveSummaryDisplayContent } from "../utils/templateResolver";
+import { summaryTestIds } from "../utils/testIds";
 
 interface SummaryCardProps {
     task: SummaryListItem;
@@ -122,6 +123,7 @@ const SummaryCard: React.FC<SummaryCardProps> = ({ task, active, onClick, onDele
 
     return (
         <div
+            data-testid={summaryTestIds.card(task.task_id)}
             className={`summary-card${active ? " summary-card--active" : ""}`}
             onClick={() => onClick(task.task_id)}
         >
@@ -235,6 +237,7 @@ const SummaryCard: React.FC<SummaryCardProps> = ({ task, active, onClick, onDele
                         }
                     >
                         <button
+                            data-testid={summaryTestIds.cardMenu(task.task_id)}
                             type="button"
                             className="summary-card-more"
                             onClick={(e) => e.stopPropagation()}

--- a/packages/dmworksummary/src/components/SummaryCard.tsx
+++ b/packages/dmworksummary/src/components/SummaryCard.tsx
@@ -256,12 +256,14 @@ const SummaryCard: React.FC<SummaryCardProps> = ({ task, active, onClick, onDele
                     onClick={(e) => e.stopPropagation()}
                 >
                     <button
+                        data-testid={summaryTestIds.cardAcceptBtn(task.task_id)}
                         className="summary-card-respond-btn summary-card-respond-btn--accept"
                         onClick={() => onRespond(task.task_id, "accept")}
                     >
                         {t("summary.action.accept")}
                     </button>
                     <button
+                        data-testid={summaryTestIds.cardRejectBtn(task.task_id)}
                         className="summary-card-respond-btn summary-card-respond-btn--reject"
                         onClick={() => onRespond(task.task_id, "reject")}
                     >

--- a/packages/dmworksummary/src/components/SummaryEditor.tsx
+++ b/packages/dmworksummary/src/components/SummaryEditor.tsx
@@ -4,6 +4,7 @@ import { I18nContext, t } from "@octo/base";
 import VoiceInputButton from "@octo/base/src/Components/VoiceInputButton";
 import type { ReplaceMode, SelectionRange } from "@octo/base/src/Components/VoiceInputButton";
 import * as api from "../api/summaryApi";
+import { summaryTestIds } from "../utils/testIds";
 
 interface SummaryEditorProps {
     taskId: number;
@@ -118,6 +119,7 @@ export default class SummaryEditor extends Component<SummaryEditorProps, Summary
                 <div style={{ position: "relative" }}>
                     <textarea
                         ref={this.textareaRef}
+                        data-testid={summaryTestIds.editorTextarea}
                         className="summary-editor-textarea"
                         value={content}
                         onChange={this.handleChange}

--- a/packages/dmworksummary/src/components/SummaryReferencePicker.tsx
+++ b/packages/dmworksummary/src/components/SummaryReferencePicker.tsx
@@ -4,6 +4,7 @@ import { IconClose, IconLink } from '@douyinfe/semi-icons';
 import { listSummaries } from '../api/summaryApi';
 import type { SummaryListItem } from '../types/summary';
 import { I18nContext, type I18nCtx } from '@octo/base';
+import { summaryTestIds } from '../utils/testIds';
 import './SummaryReferencePicker.css';
 
 /**
@@ -117,6 +118,7 @@ export default class SummaryReferencePicker extends Component<
                 className="summary-reference-picker-modal"
             >
                 <Input
+                    data-testid={summaryTestIds.agentRefSearchInput}
                     prefix={<IconLink />}
                     value={keyword}
                     onChange={this.handleKeywordChange}

--- a/packages/dmworksummary/src/components/SummaryReferenceSidePanel.tsx
+++ b/packages/dmworksummary/src/components/SummaryReferenceSidePanel.tsx
@@ -4,6 +4,7 @@ import { I18nContext } from '@octo/base';
 import SummaryContent from './SummaryContent';
 import { getSummaryDetail, getPersonalResult } from '../api/summaryApi';
 import type { SummaryDetail, PersonalResult } from '../types/summary';
+import { summaryTestIds } from '../utils/testIds';
 import './SummaryReferenceSidePanel.css';
 
 /**
@@ -114,12 +115,13 @@ class SummaryReferenceSidePanel extends Component<
             : personalResult?.content || '';
 
         return (
-            <div className="summary-workbench-ref-side">
+            <div data-testid={summaryTestIds.agentRefSidePanel} className="summary-workbench-ref-side">
                 <div className="summary-workbench-ref-side-header">
-                    <span className="summary-workbench-ref-side-title" title={title}>
+                    <span data-testid={summaryTestIds.agentRefSideTitle} className="summary-workbench-ref-side-title" title={title}>
                         {title}
                     </span>
                     <span
+                        data-testid={summaryTestIds.agentRefSideCloseBtn}
                         className="summary-workbench-ref-side-close"
                         onClick={onClose}
                         title={t('summary.chatReference.remove')}
@@ -130,7 +132,7 @@ class SummaryReferenceSidePanel extends Component<
                 <div className="summary-workbench-ref-side-hint">
                     {t('summary.chatReference.previewLatestHint')}
                 </div>
-                <div className="summary-workbench-ref-side-body">
+                <div data-testid={summaryTestIds.agentRefSideBody} className="summary-workbench-ref-side-body">
                     {loading && (
                         <div className="summary-workbench-ref-side-loading">
                             <Spin />

--- a/packages/dmworksummary/src/components/SummaryVersionPanel.tsx
+++ b/packages/dmworksummary/src/components/SummaryVersionPanel.tsx
@@ -5,6 +5,7 @@ import { ChevronRight } from "lucide-react";
 import { useI18n } from "@octo/base";
 import type { SummaryVersionItem } from "../types/summary";
 import { formatDate } from "../utils/summaryHelpers";
+import { summaryTestIds } from "../utils/testIds";
 
 interface SummaryVersionPanelProps {
     open: boolean;
@@ -93,7 +94,7 @@ const SummaryVersionPanel: React.FC<SummaryVersionPanelProps> = ({
                 aria-label={t("summary.detail.versionPanelClose")}
                 onClick={onClose}
             />
-            <aside className="version-panel" aria-label={t("summary.detail.versionRecords")}>
+            <aside data-testid={summaryTestIds.versionPanel} className="version-panel" aria-label={t("summary.detail.versionRecords")}>
                 <header className="version-panel__header">
                     <span className="version-panel__icon" aria-hidden>
                         <IconHistory />
@@ -123,6 +124,7 @@ const SummaryVersionPanel: React.FC<SummaryVersionPanelProps> = ({
                             <button
                                 key={version.result_id}
                                 type="button"
+                                data-testid={summaryTestIds.versionCard(version.version)}
                                 className={`version-card${isCurrent ? " is-current" : ""}${isSelected ? " is-selected" : ""}`}
                                 aria-pressed={isSelected}
                                 onClick={() => onSelect(version)}
@@ -162,6 +164,7 @@ const SummaryVersionPanel: React.FC<SummaryVersionPanelProps> = ({
                 {showRestore && (
                     <footer className="version-panel__footer">
                         <Button
+                            data-testid={summaryTestIds.versionRestoreBtn}
                             className="version-panel__restore"
                             theme="solid"
                             type="primary"

--- a/packages/dmworksummary/src/pages/SummaryCreatePage.tsx
+++ b/packages/dmworksummary/src/pages/SummaryCreatePage.tsx
@@ -849,6 +849,7 @@ export default class SummaryCreatePage extends Component<SummaryCreatePageProps,
         if (referencedTask) {
             return (
                 <div
+                    data-testid={summaryTestIds.agentRefCard}
                     className="summary-workbench-ref-card"
                     onClick={() => this.setState((prev) => ({ sidePanelOpen: !prev.sidePanelOpen }))}
                     style={{ cursor: 'pointer' }}
@@ -861,6 +862,7 @@ export default class SummaryCreatePage extends Component<SummaryCreatePageProps,
                         {referencedTask.title || `task_id=${referencedTask.task_id}`}
                     </span>
                     <span
+                        data-testid={summaryTestIds.agentRefRemoveBtn}
                         className="summary-workbench-ref-card-remove"
                         onClick={(e) => {
                             // 阻止事件冒泡触发卡片 onClick (toggle SidePanel)
@@ -879,6 +881,7 @@ export default class SummaryCreatePage extends Component<SummaryCreatePageProps,
         }
         return (
             <span
+                data-testid={summaryTestIds.agentRefEntry}
                 className="summary-workbench-ref-btn"
                 onClick={() => this.setState({ showReferencePicker: true })}
                 title={translate('summary.chatReference.buttonTip')}
@@ -1031,6 +1034,7 @@ export default class SummaryCreatePage extends Component<SummaryCreatePageProps,
                     <div className="summary-workbench-mode-switch">
                         <button
                             type="button"
+                            data-testid={summaryTestIds.createNormalTab}
                             className={`summary-workbench-mode-btn${mode === 'normal' ? ' summary-workbench-mode-btn--active' : ''}`}
                             onClick={() => this.handleSelectMode('normal')}
                         >
@@ -1038,6 +1042,7 @@ export default class SummaryCreatePage extends Component<SummaryCreatePageProps,
                         </button>
                         <button
                             type="button"
+                            data-testid={summaryTestIds.createAgentTab}
                             className={`summary-workbench-mode-btn${mode === 'agent' ? ' summary-workbench-mode-btn--active' : ''}`}
                             onClick={() => this.handleSelectMode('agent')}
                         >

--- a/packages/dmworksummary/src/pages/SummaryCreatePage.tsx
+++ b/packages/dmworksummary/src/pages/SummaryCreatePage.tsx
@@ -44,6 +44,7 @@ import { SummaryMode, SourceType } from "../types/summary";
 import { Channel, WKSDK } from "wukongimjssdk";
 import { describeSchedule, scheduleToParams, genSessionId, readAgentChatSession, writeAgentChatSession, clearAgentChatSession, readAgentChatReferenced, writeAgentChatReferenced, clearAgentChatReferenced } from "../utils/summaryHelpers";
 import { resolveTemplate, computeTemplateSelection, getTemplateEditableFields, deriveSummaryTitle, limitTemplateSummaryContent, type ResolvableTemplate } from "../utils/templateResolver";
+import { summaryTestIds } from "../utils/testIds";
 
 const { Text } = Typography;
 
@@ -1022,7 +1023,7 @@ export default class SummaryCreatePage extends Component<SummaryCreatePageProps,
         const templateEditorVisible = creatingCustomTemplate || !!editingTemplate;
 
         return (
-            <div className={`summary-workbench${this.props.embedded ? " summary-workbench--panel" : ""}`}>
+            <div data-testid={summaryTestIds.create} className={`summary-workbench${this.props.embedded ? " summary-workbench--panel" : ""}`}>
                 {/* Header */}
                 <div className="summary-workbench-header">
                     <span className="summary-workbench-header-emoji">🚀</span>
@@ -1116,6 +1117,7 @@ export default class SummaryCreatePage extends Component<SummaryCreatePageProps,
                         <>
                     <div className="summary-workbench-input-wrap">
                         <textarea
+                            data-testid={summaryTestIds.createTopic}
                             ref={this.textareaRef}
                             className="summary-workbench-textarea"
                             value={topic}
@@ -1293,6 +1295,7 @@ export default class SummaryCreatePage extends Component<SummaryCreatePageProps,
                                 </div>
                             ) : (
                                 <button
+                                    data-testid={summaryTestIds.createSelectChat}
                                     type="button"
                                     className="summary-workbench-add-chat"
                                     onClick={() => this.setState({ showChatSelector: true })}
@@ -1339,6 +1342,7 @@ export default class SummaryCreatePage extends Component<SummaryCreatePageProps,
                                     </div>
                                 )}
                                 <button
+                                    data-testid={summaryTestIds.createSelectMembers}
                                     type="button"
                                     className="summary-workbench-add-chat"
                                     onClick={this.handleOpenMemberSelector}
@@ -1349,6 +1353,7 @@ export default class SummaryCreatePage extends Component<SummaryCreatePageProps,
                             </div>
                         </div>
                         <Button
+                            data-testid={summaryTestIds.createSubmit}
                             theme="solid"
                             className="summary-workbench-start-btn"
                             loading={submitting}

--- a/packages/dmworksummary/src/pages/SummaryDetailPage.tsx
+++ b/packages/dmworksummary/src/pages/SummaryDetailPage.tsx
@@ -56,6 +56,7 @@ import {
     formatScheduleSummary,
     shouldReactivateOnSave,
 } from "../utils/summaryHelpers";
+import { summaryTestIds } from "../utils/testIds";
 import CitationText from "../components/CitationText";
 import SelectedSourcesPanel from "../components/SelectedSourcesPanel";
 import ScheduleConfigModal from "../components/ScheduleConfigModal";
@@ -2832,6 +2833,7 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
                 </div>
                 {canEdit && (
                     <Button
+                        data-testid={summaryTestIds.detailEditBtn}
                         className="summary-detail-inline-edit"
                         size="small"
                         theme="borderless"
@@ -3196,7 +3198,7 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
         const { t } = this.context;
         if (membersLoading) {
             return (
-                <div className="summary-detail-members">
+                <div data-testid={summaryTestIds.detailMembersSection} className="summary-detail-members">
                     {this.renderMemberStatusHeader()}
                     <Spin size="small" />
                 </div>
@@ -3215,7 +3217,7 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
         };
 
         return (
-            <div className="summary-detail-members">
+            <div data-testid={summaryTestIds.detailMembersSection} className="summary-detail-members">
                 {this.renderMemberStatusHeader()}
                 <div className="summary-detail-members-list">
                     {members.map((m) => {
@@ -3448,6 +3450,7 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
             return (
                 <div
                     key="__my_pending_submit_editing__"
+                    data-testid={summaryTestIds.detailMyPendingRow}
                     className="summary-detail-participant-report-item summary-detail-my-pending-row"
                 >
                     <div className="summary-detail-participant-report-header">
@@ -3468,12 +3471,14 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
         return (
             <div
                 key="__my_pending_submit__"
+                data-testid={summaryTestIds.detailMyPendingRow}
                 className="summary-detail-participant-report-item summary-detail-my-pending-row"
             >
                 <div className="summary-detail-participant-report-header">
                     <span>{t("summary.detail.mySubmitRowName")}</span>
                     {/* OCT-21：提交前编辑入口。文案复用 summary.common.edit；按钮放在「提交给全部」左侧。 */}
                     <Button
+                        data-testid={summaryTestIds.detailMyDraftEditBtn}
                         size="small"
                         theme="borderless"
                         icon={<IconEdit />}
@@ -3483,6 +3488,7 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
                         {t("summary.common.edit")}
                     </Button>
                     <Button
+                        data-testid={summaryTestIds.detailSubmitMyBtn}
                         size="small"
                         theme="solid"
                         style={{ marginLeft: 8 }}
@@ -3907,7 +3913,7 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
             <>
             <div className="summary-detail-title-row">
                 <div className="summary-detail-header-title-wrap">
-                    <OverflowTooltip as="h2" className="summary-detail-title" title={displayTitle}>
+                    <OverflowTooltip as="h2" data-testid={summaryTestIds.detailTitle} className="summary-detail-title" title={displayTitle}>
                         {displayTitle}
                     </OverflowTooltip>
                     {this.renderScheduleSummary()}
@@ -3915,6 +3921,7 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
                 <div className="summary-detail-header-actions">
                     {detail && detail.status === TaskStatus.COMPLETED && detail.trigger_type === TriggerType.AGENT && (
                         <Button
+                            data-testid={summaryTestIds.detailContinueRefineBtn}
                             theme="solid"
                             type="primary"
                             onClick={this.handleContinueRefine}
@@ -3928,6 +3935,7 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
                         const versionPanelActive = this.state.versionPanelOpen;
                         return (
                             <Button
+                                data-testid={summaryTestIds.detailVersionTrigger}
                                 className={`summary-version-trigger${versionPanelActive ? " is-active" : ""}`}
                                 theme="borderless"
                                 type="tertiary"
@@ -3976,6 +3984,7 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
                     )}
                     {showRegenerate && !showRetry && (
                         <Button
+                            data-testid={summaryTestIds.detailRegenerateBtn}
                             className="summary-detail-header-btn"
                             theme="borderless"
                             type="tertiary"
@@ -3987,6 +3996,7 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
                     )}
                     {showRetry && (
                         <Button
+                            data-testid={summaryTestIds.detailRetryBtn}
                             className="summary-detail-header-btn"
                             theme="borderless"
                             type="tertiary"
@@ -3998,6 +4008,7 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
                     )}
                     {showDelete && (
                         <Button
+                            data-testid={summaryTestIds.detailDeleteBtn}
                             className="summary-detail-header-btn summary-detail-header-btn--danger"
                             theme="borderless"
                             type="danger"
@@ -4007,6 +4018,7 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
                                 title: t("summary.summaryCard.deleteTitle"),
                                 content: t("summary.summaryCard.deleteContent", { values: { title: detail?.title || detail?.task_no || "" } }),
                                 onOk: this.handleDeleteTask,
+                                okButtonProps: { 'data-testid': summaryTestIds.deleteConfirmOkBtn } as any,
                             })}
                         />
                     )}
@@ -4066,7 +4078,7 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
         const hasToc = this.shouldShowToc();
 
         return (
-            <div className="summary-detail-page">
+            <div data-testid={summaryTestIds.detailPage} className="summary-detail-page">
                 <div
                     ref={this.layoutRef}
                     className={`summary-detail-layout${this.isVersionPanelActuallyOpen() ? " has-version-panel" : ""}${hasToc ? " has-toc" : ""}${this.state.layoutWidth != null && this.state.layoutWidth > 0 && this.state.layoutWidth < SummaryDetailPage.TOC_MIN_LAYOUT_WIDTH ? " version-panel-overlay" : ""}`}
@@ -4241,6 +4253,7 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
                     <div className="summary-detail-footer">
                         <button
                             type="button"
+                            data-testid={summaryTestIds.editorCancelBtn}
                             className="summary-detail-footer-btn summary-detail-footer-btn--cancel"
                             onClick={() => {
                                 if (this.state.editingTeamSummary) {
@@ -4258,6 +4271,7 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
                         </button>
                         <button
                             type="button"
+                            data-testid={summaryTestIds.editorSaveBtn}
                             className="summary-detail-footer-btn summary-detail-footer-btn--save"
                             onClick={() => {
                                 if (this.editorSaveFn) {
@@ -4297,6 +4311,9 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
                     centered
                     maskClosable
                     onCancel={this.handleRegenerateCancel}
+                    modalRender={(node) => (
+                        <div data-testid={summaryTestIds.regenerateModal}>{node}</div>
+                    )}
                 >
                     <div className="summary-confirm-body">
                         <div className="summary-confirm-main">
@@ -4348,6 +4365,7 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
                         <div className="summary-regenerate-textarea-wrap">
                             <textarea
                                 id="summary-regenerate-input"
+                                data-testid={summaryTestIds.regenerateInput}
                                 ref={this.regenerateTopicRef}
                                 className="summary-regenerate-textarea"
                                 rows={3}
@@ -4381,11 +4399,12 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
                         </div>
                     </div>
                     <div className="summary-confirm-footer">
-                        <button type="button" className="summary-confirm-btn summary-confirm-btn--cancel" onClick={this.handleRegenerateCancel}>
+                        <button data-testid={summaryTestIds.regenerateCancelBtn} type="button" className="summary-confirm-btn summary-confirm-btn--cancel" onClick={this.handleRegenerateCancel}>
                             {t("summary.common.cancel")}
                         </button>
                         <button
                             type="button"
+                            data-testid={summaryTestIds.regenerateSubmitBtn}
                             className="summary-confirm-btn summary-confirm-btn--dark"
                             disabled={this.state.regenerateSubmitting || (this.state.regenerateMode === "refine" && !this.hasRegenerateRefineBaseResult()) || !(this.state.regenerateMode === "refine"
                                 ? this.state.refineFeedback.trim()

--- a/packages/dmworksummary/src/pages/SummaryDetailPage.tsx
+++ b/packages/dmworksummary/src/pages/SummaryDetailPage.tsx
@@ -3229,7 +3229,7 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
                             !isMe &&
                             m.user_id !== detail?.creator_id;
                         return (
-                            <div key={m.user_id} className="summary-detail-member-item">
+                            <div key={m.user_id} data-testid={summaryTestIds.detailMemberRow(m.user_id)} className="summary-detail-member-item">
                                 <span className="summary-detail-member-name">{m.user_name}</span>
                                 <Tag color={st.type} prefixIcon={st.icon} size="small">
                                     {st.label}

--- a/packages/dmworksummary/src/pages/SummaryListPage.tsx
+++ b/packages/dmworksummary/src/pages/SummaryListPage.tsx
@@ -587,7 +587,7 @@ export default class SummaryListPage extends Component<SummaryListPageProps, Sum
                         ) : (
                             <Tooltip content={translate("summary.list.createTooltip")} position="bottom">
                                 <Button
-                                    data-testid={summaryTestIds.create}
+                                    data-testid={summaryTestIds.listCreate}
                                     className="summary-list-create-icon-btn"
                                     icon={<IconPlus />}
                                     theme="borderless"

--- a/packages/dmworksummary/src/pages/SummaryListPage.tsx
+++ b/packages/dmworksummary/src/pages/SummaryListPage.tsx
@@ -678,7 +678,7 @@ export default class SummaryListPage extends Component<SummaryListPageProps, Sum
                 )}
 
                 {!loading && items.length > 0 && (
-                    <div className="summary-list-content" onScroll={this.handleScroll}>
+                    <div data-testid={summaryTestIds.listContent} className="summary-list-content" onScroll={this.handleScroll}>
                         {items.map((item) => (
                             <SummaryCard
                                 key={item.task_id}

--- a/packages/dmworksummary/src/pages/SummaryListPage.tsx
+++ b/packages/dmworksummary/src/pages/SummaryListPage.tsx
@@ -18,6 +18,7 @@ import type {
 } from "../types/summary";
 import { TaskStatus } from "../types/summary";
 import { getStatusLabel, isTerminalStatus } from "../utils/summaryHelpers";
+import { summaryTestIds } from "../utils/testIds";
 import SummaryCard from "../components/SummaryCard";
 import SummaryCreatePage from "./SummaryCreatePage";
 import SummaryDetailPage from "./SummaryDetailPage";
@@ -560,7 +561,7 @@ export default class SummaryListPage extends Component<SummaryListPageProps, Sum
         const isPanel = Boolean(channelId);
 
         return (
-            <div className={`summary-list-page${isPanel ? " summary-list-page--panel" : ""}`}>
+            <div data-testid={summaryTestIds.list} className={`summary-list-page${isPanel ? " summary-list-page--panel" : ""}`}>
                 <div className="summary-list-header">
                     <h2 className="summary-list-title">
                         {isPanel ? translate("summary.chatSummary.panelTitle") : translate("summary.list.title")}
@@ -585,6 +586,7 @@ export default class SummaryListPage extends Component<SummaryListPageProps, Sum
                         ) : (
                             <Tooltip content={translate("summary.list.createTooltip")} position="bottom">
                                 <Button
+                                    data-testid={summaryTestIds.create}
                                     icon={<IconPlus />}
                                     theme="borderless"
                                     onClick={this.handleCreate}
@@ -598,6 +600,7 @@ export default class SummaryListPage extends Component<SummaryListPageProps, Sum
                     <div className="summary-list-search-wrap">
                         <IconSearch className="summary-list-search-icon" />
                         <input
+                            data-testid={summaryTestIds.listSearch}
                             className="summary-list-search-input"
                             placeholder={translate("summary.list.searchPlaceholder")}
                             value={keyword}
@@ -621,7 +624,7 @@ export default class SummaryListPage extends Component<SummaryListPageProps, Sum
                             </Dropdown.Menu>
                         }
                     >
-                        <div className="summary-list-status-trigger">
+                        <div data-testid={summaryTestIds.listStatusFilter} className="summary-list-status-trigger">
                             <span>{statusOptions.find((o) => o.value === (statusFilter ?? ""))?.label ?? statusOptions[0]?.label}</span>
                             <ChevronDown size={14} />
                         </div>

--- a/packages/dmworksummary/src/pages/SummaryListPage.tsx
+++ b/packages/dmworksummary/src/pages/SummaryListPage.tsx
@@ -658,7 +658,7 @@ export default class SummaryListPage extends Component<SummaryListPageProps, Sum
                             <>
                                 <div className="summary-list-empty-title">{translate("summary.list.emptyTitle")}</div>
                                 <div className="summary-list-empty-desc">{translate("summary.chatSummary.emptyDescription")}</div>
-                                <Button data-testid={summaryTestIds.create} theme="solid" onClick={this.handleCreate} style={{ marginTop: 16 }}>
+                                <Button data-testid={summaryTestIds.createEntry} theme="solid" onClick={this.handleCreate} style={{ marginTop: 16 }}>
                                     {translate("summary.chatSummary.createNew")}
                                 </Button>
                             </>
@@ -669,7 +669,7 @@ export default class SummaryListPage extends Component<SummaryListPageProps, Sum
                                 <div className="summary-list-empty-desc">
                                     {translate("summary.list.emptyDesc")}
                                 </div>
-                                <Button data-testid={summaryTestIds.create} theme="solid" onClick={this.handleCreate} style={{ marginTop: 16 }}>
+                                <Button data-testid={summaryTestIds.createEntry} theme="solid" onClick={this.handleCreate} style={{ marginTop: 16 }}>
                                     {translate("summary.list.createFirst")}
                                 </Button>
                             </>

--- a/packages/dmworksummary/src/pages/SummaryListPage.tsx
+++ b/packages/dmworksummary/src/pages/SummaryListPage.tsx
@@ -658,7 +658,7 @@ export default class SummaryListPage extends Component<SummaryListPageProps, Sum
                             <>
                                 <div className="summary-list-empty-title">{translate("summary.list.emptyTitle")}</div>
                                 <div className="summary-list-empty-desc">{translate("summary.chatSummary.emptyDescription")}</div>
-                                <Button theme="solid" onClick={this.handleCreate} style={{ marginTop: 16 }}>
+                                <Button data-testid={summaryTestIds.create} theme="solid" onClick={this.handleCreate} style={{ marginTop: 16 }}>
                                     {translate("summary.chatSummary.createNew")}
                                 </Button>
                             </>
@@ -669,7 +669,7 @@ export default class SummaryListPage extends Component<SummaryListPageProps, Sum
                                 <div className="summary-list-empty-desc">
                                     {translate("summary.list.emptyDesc")}
                                 </div>
-                                <Button theme="solid" onClick={this.handleCreate} style={{ marginTop: 16 }}>
+                                <Button data-testid={summaryTestIds.create} theme="solid" onClick={this.handleCreate} style={{ marginTop: 16 }}>
                                     {translate("summary.list.createFirst")}
                                 </Button>
                             </>

--- a/packages/dmworksummary/src/utils/testIds.ts
+++ b/packages/dmworksummary/src/utils/testIds.ts
@@ -1,0 +1,13 @@
+export const summaryTestIds = {
+    list: "summary-list",
+    listSearch: "summary-list-search",
+    listStatusFilter: "summary-list-status-filter",
+    create: "summary-create",
+    createTopic: "summary-create-topic",
+    createSelectChat: "summary-create-select-chat",
+    createSelectMembers: "summary-create-select-members",
+    createSubmit: "summary-create-submit",
+    card: (taskId: number) => `summary-card-${taskId}`,
+    cardMenu: (taskId: number) => `summary-card-menu-${taskId}`,
+    detail: (taskId: number) => `summary-detail-${taskId}`,
+} as const;

--- a/packages/dmworksummary/src/utils/testIds.ts
+++ b/packages/dmworksummary/src/utils/testIds.ts
@@ -4,7 +4,7 @@ export const summaryTestIds = {
     listContent: "summary-list-content",
     listSearch: "summary-list-search",
     listStatusFilter: "summary-list-status-filter",
-    listCreate: "summary-create",
+    listCreate: "summary-list-create",
     createEntry: "summary-create-entry",
 
     // ── Card (per-task) ──

--- a/packages/dmworksummary/src/utils/testIds.ts
+++ b/packages/dmworksummary/src/utils/testIds.ts
@@ -42,6 +42,7 @@ export const summaryTestIds = {
     detailContinueRefineBtn: "summary-detail-continue-refine-btn",
     detailEditBtn: "summary-detail-edit-btn",
     detailMembersSection: "summary-detail-members",
+    detailMemberRow: (userId: string) => `summary-detail-member-row-${userId}`,
     detailMyPendingRow: "summary-detail-my-pending-row",
     detailSubmitMyBtn: "summary-detail-submit-my-btn",
     detailMyDraftEditBtn: "summary-detail-my-draft-edit-btn",

--- a/packages/dmworksummary/src/utils/testIds.ts
+++ b/packages/dmworksummary/src/utils/testIds.ts
@@ -3,6 +3,7 @@ export const summaryTestIds = {
     listSearch: "summary-list-search",
     listStatusFilter: "summary-list-status-filter",
     create: "summary-create",
+    createEntry: "summary-create-entry",
     createTopic: "summary-create-topic",
     createSelectChat: "summary-create-select-chat",
     createSelectMembers: "summary-create-select-members",


### PR DESCRIPTION
## Summary

Migrate the Summary module's E2E interaction locators to stable `data-testid` selectors.

## What changed

- Added shared Summary test ID constants for list, create, agent, chat-panel, detail, version, modal, and collaboration flows.
- Added production `data-testid` attributes to the corresponding interactive controls and stable containers.
- Added an E2E-side test ID helper to avoid selector string drift.
- Replaced fragile CSS, placeholder, and accessible-name interaction locators across the 24 affected Summary cases.
- Kept content assertions based on visible text, and retained role/name locators for shell-owned navigation and portal menu items where appropriate.
- Fixed Semi UI modal hidden-DOM duplicate issues by placing selectors on visible modal content.

## Verification

- `git diff --check`
- `pnpm install --frozen-lockfile`
- Selected representative cases: 3 passed.
- All 24 modified Summary E2E cases: **24 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
