### PR TITLE
fix(forward-modal): show Bot creator member name

### DIFF
--- a/packages/dmworkbase/src/Components/ConversationSelect/index.tsx
+++ b/packages/dmworkbase/src/Components/ConversationSelect/index.tsx
@@ -69,7 +69,7 @@ export default function ConversationSelect({
   // 授权区 Bot 展开器（feature: user+Bot grants）：把选中人员创建的 Bot 按人归组，
   // 默认全选、逐个可取消；仅当授权开关开启且确有 Bot 时渲染。失败/无 Bot 时为空快照。
   const resolveName = React.useCallback(
-    (uid: string) => allItems.find((it) => it.channelID === uid)?.displayName || uid,
+    (uid: string) => allItems.find((it) => it.channelID === uid)?.displayName || "",
     [allItems],
   )
   // The hook owns the confirm-time getter: readLatestSelectedBotUids() reads the freshest selected

--- a/packages/dmworkbase/src/Components/ForwardModal/hooks/__tests__/useForwardBotSnapshot.test.tsx
+++ b/packages/dmworkbase/src/Components/ForwardModal/hooks/__tests__/useForwardBotSnapshot.test.tsx
@@ -5,7 +5,7 @@ import ReactDOM from "react-dom"
 import { act } from "react-dom/test-utils"
 
 const hoisted = vi.hoisted(() => ({
-  subscribers: new Map<string, Array<{ uid?: string }>>(),
+  subscribers: new Map<string, Array<{ uid?: string; remark?: string; name?: string }>>(),
   syncCurrentImChannelSubscribers: vi.fn(async () => undefined),
   listBots: vi.fn(async (_spaceId: string) => [] as Array<{ uid?: string; name?: string; creator_uid?: string }>),
 }))
@@ -203,6 +203,23 @@ describe("useForwardBotSnapshot", () => {
     // Re-selecting flips it back on.
     act(() => { latest?.toggleBot("b_2") })
     expect(selectedBotUids(latest)).toEqual(["b_1", "b_2"])
+  })
+
+  it("uses the group member display name when the Bot creator is absent from forward candidates", async () => {
+    hoisted.subscribers.set("g_1", [
+      { uid: "u_hidden", remark: "群内备注", name: "成员昵称" },
+    ])
+    hoisted.listBots.mockResolvedValue([
+      { uid: "b_1", name: "Hidden Bot", creator_uid: "u_hidden" },
+    ])
+    await render({
+      selectedIDs: ["g_1"],
+      selectedChannels: [new Channel("g_1", 2)],
+      spaceId: "s_1",
+      enabled: true,
+    })
+
+    expect(latest?.groups[0]).toMatchObject({ uid: "u_hidden", name: "群内备注" })
   })
 
   it("expands group members and de-duplicates people across group + person targets", async () => {

--- a/packages/dmworkbase/src/Components/ForwardModal/hooks/__tests__/useForwardBotSnapshot.test.tsx
+++ b/packages/dmworkbase/src/Components/ForwardModal/hooks/__tests__/useForwardBotSnapshot.test.tsx
@@ -5,7 +5,12 @@ import ReactDOM from "react-dom"
 import { act } from "react-dom/test-utils"
 
 const hoisted = vi.hoisted(() => ({
-  subscribers: new Map<string, Array<{ uid?: string; remark?: string; name?: string }>>(),
+  subscribers: new Map<string, Array<{
+    uid?: string
+    remark?: string
+    name?: string
+    orgData?: { real_name?: string; realname_verified?: boolean }
+  }>>(),
   syncCurrentImChannelSubscribers: vi.fn(async () => undefined),
   listBots: vi.fn(async (_spaceId: string) => [] as Array<{ uid?: string; name?: string; creator_uid?: string }>),
 }))
@@ -41,6 +46,7 @@ function Probe({
   selectedChannels,
   spaceId,
   enabled,
+  resolveName = (uid) => `name:${uid}`,
   onValue,
   onGetter,
 }: {
@@ -48,6 +54,7 @@ function Probe({
   selectedChannels: Channel[]
   spaceId?: string
   enabled: boolean
+  resolveName?: (uid: string) => string
   onValue: (value: ForwardBotSnapshot | undefined) => void
   onGetter?: (read: () => string[]) => void
 }) {
@@ -56,7 +63,7 @@ function Probe({
     selectedChannels,
     spaceId,
     enabled,
-    (uid) => `name:${uid}`,
+    resolveName,
   )
   onValue(snapshot)
   onGetter?.(readLatestSelectedBotUids)
@@ -95,6 +102,7 @@ describe("useForwardBotSnapshot", () => {
     selectedChannels: Channel[]
     spaceId?: string
     enabled: boolean
+    resolveName?: (uid: string) => string
   }) {
     act(() => {
       ReactDOM.render(
@@ -108,6 +116,7 @@ describe("useForwardBotSnapshot", () => {
     selectedChannels: Channel[]
     spaceId?: string
     enabled: boolean
+    resolveName?: (uid: string) => string
   }) {
     await act(async () => {
       ReactDOM.render(
@@ -217,9 +226,47 @@ describe("useForwardBotSnapshot", () => {
       selectedChannels: [new Channel("g_1", 2)],
       spaceId: "s_1",
       enabled: true,
+      resolveName: () => "",
     })
 
     expect(latest?.groups[0]).toMatchObject({ uid: "u_hidden", name: "群内备注" })
+  })
+
+  it("prefers the candidate display name when both candidate and group member names exist", async () => {
+    hoisted.subscribers.set("g_1", [{ uid: "u_ada", name: "群内昵称" }])
+    hoisted.listBots.mockResolvedValue([
+      { uid: "b_1", name: "Ada Bot", creator_uid: "u_ada" },
+    ])
+    await render({
+      selectedIDs: ["g_1"],
+      selectedChannels: [new Channel("g_1", 2)],
+      spaceId: "s_1",
+      enabled: true,
+      resolveName: () => "候选显示名",
+    })
+
+    expect(latest?.groups[0]).toMatchObject({ uid: "u_ada", name: "候选显示名" })
+  })
+
+  it("uses the canonical verified real name from the group subscriber fallback", async () => {
+    hoisted.subscribers.set("g_1", [{
+      uid: "u_verified",
+      remark: "群内备注",
+      name: "成员昵称",
+      orgData: { real_name: "认证实名", realname_verified: true },
+    }])
+    hoisted.listBots.mockResolvedValue([
+      { uid: "b_1", name: "Verified Bot", creator_uid: "u_verified" },
+    ])
+    await render({
+      selectedIDs: ["g_1"],
+      selectedChannels: [new Channel("g_1", 2)],
+      spaceId: "s_1",
+      enabled: true,
+      resolveName: () => "",
+    })
+
+    expect(latest?.groups[0]).toMatchObject({ uid: "u_verified", name: "认证实名" })
   })
 
   it("expands group members and de-duplicates people across group + person targets", async () => {

--- a/packages/dmworkbase/src/Components/ForwardModal/hooks/useForwardBotSnapshot.ts
+++ b/packages/dmworkbase/src/Components/ForwardModal/hooks/useForwardBotSnapshot.ts
@@ -6,6 +6,7 @@ import {
   syncCurrentImChannelSubscribers,
 } from "../../../im-runtime/currentChannelRuntime"
 import SpaceBotService from "../../../Service/SpaceBotService"
+import { subscriberDisplayName } from "../../../Utils/displayName"
 import type { ForwardBotCreatorGroup, ForwardBotSnapshot } from "../grant"
 
 /** Injectable name lookup so the panel can show a display name instead of a raw uid. */
@@ -124,8 +125,12 @@ export function useForwardBotSnapshot(
         for (const s of subs) {
           if (typeof s?.uid !== "string" || !s.uid) continue
           people.add(s.uid)
-          const name = s.remark || s.name
-          if (typeof name === "string" && name.trim()) peopleNames.set(s.uid, name)
+          const name = subscriberDisplayName({
+            name: s.name,
+            remark: s.remark,
+            orgData: s.orgData,
+          }).trim()
+          if (name && !peopleNames.has(s.uid)) peopleNames.set(s.uid, name)
         }
       }
 
@@ -205,7 +210,7 @@ export function useForwardBotSnapshot(
       })
       groups.push({
         uid: creatorUid,
-        name: resolved.peopleNames.get(creatorUid) || resolveName?.(creatorUid) || creatorUid,
+        name: resolveName?.(creatorUid) || resolved.peopleNames.get(creatorUid) || creatorUid,
         bots,
       })
     }

--- a/packages/dmworkbase/src/Components/ForwardModal/hooks/useForwardBotSnapshot.ts
+++ b/packages/dmworkbase/src/Components/ForwardModal/hooks/useForwardBotSnapshot.ts
@@ -13,6 +13,7 @@ export type ForwardNameResolver = (uid: string) => string
 
 interface ResolvedModel {
   peopleUids: string[]
+  peopleNames: Map<string, string>
   botsByCreator: Map<string, Array<{ uid: string; name: string }>>
 }
 
@@ -106,6 +107,7 @@ export function useForwardBotSnapshot(
     void (async () => {
       // 1) expand targets → distinct people uids (person peer + group members).
       const people = new Set<string>()
+      const peopleNames = new Map<string, string>()
       for (const ch of selectedChannels) {
         if (ch.channelType === ChannelTypePerson) {
           if (ch.channelID) people.add(ch.channelID)
@@ -119,7 +121,12 @@ export function useForwardBotSnapshot(
         }
         if (generation.current !== gen) return
         const subs = getCurrentImChannelSubscribers<Channel, ImSubscriberLike>(ch)
-        for (const s of subs) if (typeof s?.uid === "string" && s.uid) people.add(s.uid)
+        for (const s of subs) {
+          if (typeof s?.uid !== "string" || !s.uid) continue
+          people.add(s.uid)
+          const name = s.remark || s.name
+          if (typeof name === "string" && name.trim()) peopleNames.set(s.uid, name)
+        }
       }
 
       // 2) fetch Space Bots and group by creator — only creators present in the people snapshot.
@@ -142,7 +149,7 @@ export function useForwardBotSnapshot(
         byCreator.set(bot.creator_uid, list)
       }
 
-      commit({ peopleUids: [...people], botsByCreator: byCreator })
+      commit({ peopleUids: [...people], peopleNames, botsByCreator: byCreator })
     })()
 
     return () => {
@@ -198,7 +205,7 @@ export function useForwardBotSnapshot(
       })
       groups.push({
         uid: creatorUid,
-        name: resolveName?.(creatorUid) || creatorUid,
+        name: resolved.peopleNames.get(creatorUid) || resolveName?.(creatorUid) || creatorUid,
         bots,
       })
     }


### PR DESCRIPTION
## Summary

- preserve group-member display names while expanding forward authorization targets
- prefer the group member's `remark` / `name` before falling back to candidate lookup or UID
- add a regression test for Bot creators absent from recent/friend forward candidates

## Root cause

The Bot authorization snapshot kept only each group member UID. Creator labels were later resolved exclusively from the incomplete forward candidate list, so members absent from recent chats/friends fell back to their raw UID.

## Verification

- `pnpm exec vitest run src/Components/ForwardModal/hooks/__tests__/useForwardBotSnapshot.test.tsx` — 19 passed
- `git diff --check` — passed
- Full `pnpm test` baseline is not green on current upstream main: 2448 tests passed and 46 unrelated UI tests failed with React 17/19 element incompatibility errors. The changed ForwardModal suite passed within that run.
- Package-wide `tsc --noEmit` also has existing repository-wide dependency/type errors unrelated to this change.
