### PR TITLE
fix(docs): keep in-page anchors in-page by spelling them against about:srcdoc

### DIFF
--- a/packages/docs/src/html/HtmlDocView.test.tsx
+++ b/packages/docs/src/html/HtmlDocView.test.tsx
@@ -159,6 +159,94 @@ describe('absolutizeDocAssetUrls', () => {
   })
 })
 
+describe('absolutizeDocAssetUrls — in-page fragment hrefs (srcdoc same-document identity)', () => {
+  // srcDoc renders at about:srcdoc while the injected <base> is an http URL, so a bare `#frag`
+  // resolves cross-document and the browser replaces the whole frame. Re-spelling it as
+  // about:srcdoc#frag restores same-document identity. Verified in Chromium 141 + Firefox 153.
+  const DOC = 'https://od.test/d/slug/v/3'
+
+  it('rewrites a bare #fragment href to about:srcdoc#fragment', () => {
+    const out = absolutizeDocAssetUrls('<html><body><a href="#intro">go</a></body></html>', DOC)
+    expect(out).toContain('href="about:srcdoc#intro"')
+    expect(out).not.toContain('href="#intro"')
+  })
+
+  it('rewrites an empty #fragment (scroll-to-top link)', () => {
+    const out = absolutizeDocAssetUrls('<html><body><a href="#">top</a></body></html>', DOC)
+    expect(out).toContain('href="about:srcdoc#"')
+  })
+
+  it('rewrites <area href> image-map fragments too', () => {
+    const out = absolutizeDocAssetUrls(
+      '<html><body><map name="m"><area shape="rect" coords="0,0,9,9" href="#intro"></map></body></html>',
+      DOC
+    )
+    expect(out).toContain('href="about:srcdoc#intro"')
+  })
+
+  it('preserves percent-encoding in the fragment verbatim', () => {
+    const out = absolutizeDocAssetUrls('<html><body><a href="#%E4%B8%AD%E6%96%87">cn</a></body></html>', DOC)
+    expect(out).toContain('href="about:srcdoc#%E4%B8%AD%E6%96%87"')
+  })
+
+  it('rewrites a fully-qualified self-link with a fragment (same document)', () => {
+    const out = absolutizeDocAssetUrls(`<html><body><a href="${DOC}#intro">go</a></body></html>`, DOC)
+    expect(out).toContain('href="about:srcdoc#intro"')
+  })
+
+  it('leaves a fully-qualified link to a DIFFERENT doc alone', () => {
+    const out = absolutizeDocAssetUrls(
+      '<html><body><a href="https://od.test/d/other/v/1#intro">go</a></body></html>',
+      DOC
+    )
+    expect(out).toContain('href="https://od.test/d/other/v/1#intro"')
+    expect(out).not.toContain('about:srcdoc')
+  })
+
+  it('leaves an external link with no fragment alone', () => {
+    const out = absolutizeDocAssetUrls('<html><body><a href="https://example.com/">x</a></body></html>', DOC)
+    expect(out).toContain('href="https://example.com/"')
+    expect(out).not.toContain('about:srcdoc')
+  })
+
+  it('leaves relative hrefs alone (they resolve against the injected <base>, not the doc URL)', () => {
+    const out = absolutizeDocAssetUrls('<html><body><a href="chapter.html#intro">x</a></body></html>', DOC)
+    expect(out).toContain('href="chapter.html#intro"')
+    expect(out).not.toContain('about:srcdoc')
+  })
+
+  it('skips a fragment link that carries its own target (author wants a new context)', () => {
+    const out = absolutizeDocAssetUrls(
+      '<html><body><a target="_blank" href="#intro">x</a></body></html>',
+      DOC
+    )
+    expect(out).toContain('href="#intro"')
+    expect(out).not.toContain('about:srcdoc')
+  })
+
+  it('skips ALL fragment links when the document declares <base target> (inherited target)', () => {
+    // Browser-verified: under <base target="_blank"> the rewritten href does not scroll in place,
+    // so rewriting would swallow the author's intent instead of fixing navigation.
+    const out = absolutizeDocAssetUrls(
+      '<html><head><base target="_blank"></head><body><a href="#intro">x</a></body></html>',
+      DOC
+    )
+    expect(out).toContain('href="#intro"')
+    expect(out).not.toContain('about:srcdoc#')
+  })
+
+  it('does not disturb asset rewriting or control neutralization in the same pass', () => {
+    const out = absolutizeDocAssetUrls(
+      '<html><head><link rel="stylesheet" href="assets/doc.css"></head><body><a href="#intro">go</a><img src="assets/a.png"><div contenteditable="true">e</div></body></html>',
+      DOC
+    )
+    expect(out).toContain('href="about:srcdoc#intro"')
+    expect(out).toContain('href="https://od.test/d/slug/v/assets/doc.css"')
+    expect(out).toContain('src="https://od.test/d/slug/v/assets/a.png"')
+    expect(out).toContain('contenteditable="false"')
+  })
+})
+
 describe('resolveHtmlDocAnchorText', () => {
   it('returns text anchors directly and null for doc-level anchors', () => {
     const doc = new DOMParser().parseFromString('<p>unused</p>', 'text/html')

--- a/packages/docs/src/html/htmlDocFrameHelpers.ts
+++ b/packages/docs/src/html/htmlDocFrameHelpers.ts
@@ -56,6 +56,51 @@ function neutralizeEditableControls(doc: Document) {
   doc.querySelectorAll('input, textarea, select, button').forEach((el) => el.setAttribute('disabled', ''))
 }
 
+// srcDoc documents live at about:srcdoc. Address of the rendered doc — an in-page fragment must be
+// spelled against THIS, not the <base>.
+export const SRCDOC_URL = 'about:srcdoc'
+
+// A bare `#frag` is resolved against the <base> we inject, producing an http URL that differs from
+// about:srcdoc — the browser then treats the click as cross-document and replaces the whole frame.
+// Re-spelling it as `about:srcdoc#frag` restores same-document identity, so the browser scrolls
+// natively. The <base> stays untouched, so every asset (CSS url(), srcset, <source>, svg) keeps
+// resolving exactly as before.
+function rewriteInPageFragmentHrefs(doc: Document, absoluteDocUrl: string) {
+  // An effective target (own attr, or inherited from any <base target>) means the author wants a
+  // different browsing context; leave those to the browser.
+  const baseTarget = Array.from(doc.getElementsByTagName('base')).some((b) => !!b.getAttribute('target'))
+  const docNoFragment = (() => {
+    try {
+      const u = new URL(absoluteDocUrl)
+      return `${u.origin}${u.pathname}${u.search}`
+    } catch {
+      return null
+    }
+  })()
+  doc.querySelectorAll('a[href], area[href]').forEach((el) => {
+    const href = el.getAttribute('href')
+    if (href == null) return
+    if (baseTarget || el.getAttribute('target')) return
+    if (href.startsWith('#')) {
+      el.setAttribute('href', `${SRCDOC_URL}${href}`)
+      return
+    }
+    // A fully-qualified self-link (…/d/{slug}/v/{ver}#frag) is the same document too. Relative
+    // hrefs are NOT touched: the browser resolves them against the injected <base>, which is not
+    // this docUrl, so we cannot decide same-document identity for them here.
+    if (!docNoFragment || !/^[a-zA-Z][a-zA-Z\d+.-]*:/.test(href)) return
+    let resolved: URL
+    try {
+      resolved = new URL(href)
+    } catch {
+      return
+    }
+    if (!resolved.hash) return
+    if (`${resolved.origin}${resolved.pathname}${resolved.search}` !== docNoFragment) return
+    el.setAttribute('href', `${SRCDOC_URL}${resolved.hash}`)
+  })
+}
+
 export function absolutizeDocAssetUrls(html: string, docUrl = resolveAbsoluteOctoDocBase()): string {
   if (typeof DOMParser === 'undefined') return html
   const absoluteDocUrl = resolveAbsoluteUrl(docUrl)
@@ -64,6 +109,7 @@ export function absolutizeDocAssetUrls(html: string, docUrl = resolveAbsoluteOct
   const doc = new DOMParser().parseFromString(html, 'text/html')
   doc.querySelectorAll('img[src]').forEach((el) => absolutizeAssetAttr(el, 'src', absoluteDocUrl, basePrefix))
   doc.querySelectorAll('link[href]').forEach((el) => absolutizeAssetAttr(el, 'href', absoluteDocUrl, basePrefix))
+  rewriteInPageFragmentHrefs(doc, absoluteDocUrl)
   neutralizeEditableControls(doc)
   const doctype = doc.doctype ? `<!doctype ${doc.doctype.name}>` : ''
   return `${doctype}${doc.documentElement.outerHTML}`


### PR DESCRIPTION
## Summary

HTML 文档在 Web 预览 iframe 里点自己的目录/导航栏（`href="#intro"` 这类页内锚点）时，整个 iframe 被导航走而不是页内滚动。

根因是**承载方式**，不是文档写法：预览用 `srcDoc` 渲染，文档自身地址是 `about:srcdoc`；而资源解析又依赖注入的 `<base href="http://…">`。按 HTML 规范纯 fragment 也要按 base URL 解析，解析结果与 `about:srcdoc` 不相等 —— 浏览器于是判定为跨文档导航并整页替换。文档里的 `href="#intro"` 完全是标准且正确的写法。

本 PR 在**已有的**那次变换遍历里，把同文档锚点的 href 改写成 `about:srcdoc#frag`：同文档身份恢复，浏览器走原生 fragment 滚动。

- **`<base>` 一行未动**，因此 CSS `url()`、`<style>`、`srcset`、`<source>`、media、svg 引用的解析行为与改动前完全一致。
- **不需要任何 parent 侧点击拦截**，滚动交回浏览器原生行为。
- **sandbox 未动**：仍是 `sandbox="allow-same-origin"`、仍不给 `allow-scripts`。这既是安全边界不变，也是本方案成立的前提 —— iframe 内脚本不执行，就不可能有运行时动态生成的新锚点，一次静态改写即全覆盖。

放行规则（不改写）：
1. 带有效 target 的链接 —— 自身 `target` 属性，或从任意 `<base target>` 继承。作者想开新上下文，不能吞掉。
2. 相对 href（如 `chapter.html#intro`）—— 它们按 `<base>` 解析，而 base 不是本文档 URL，此处无法判定同文档身份，一律不碰。
3. 跨文档的完整 URL、以及无 fragment 的外链。

## Linked Spec

无独立 spec；bug 由 HTML 文档预览的页内导航失效反馈引出（同一现象另见 #1277，该 PR 采用 parent 侧运行时拦截，本 PR 改为在承载层消除病因）。仓库当前无 `.octospec/`，遵循 octo-spec 全局规则（无密钥、不 fail-open、输入校验与边界、Conventional Commits）。

## How verified

**真实浏览器 A/B 实测（结论的核心证据）** —— 用生产同款 `sandbox="allow-same-origin"`（不给 `allow-scripts`）的 iframe：

- 基线复现：`href="#intro"` 点击后 `location.href` 变为 `http://…/d/slug/v/3#intro`，服务器日志出现该文档路径的 `GET` 请求，`#intro` 元素消失（文档已被替换），scrollY 仍为 0 —— 确认真的发生了跨文档导航。
- 修复后：`href="about:srcdoc#intro"` 点击后 `location.href` = `about:srcdoc#intro`，**零网络请求**，scrollY 从 1200 跳到 2692，`#intro` 仍在 —— 原生同文档滚动。
- 覆盖边界：空 fragment `#`（回顶）、`#top` 无同名元素、`<area>` 图像映射、percent-encoded 中文锚点、完整自链接 —— 全部页内滚动。
- `<base target="_blank">` 下改写后的 href **不会**页内滚动（scrollY 不变）—— 这就是放行规则 1 的实测依据，不是想象出来的边界。
- Chromium 141 与 Firefox 153 结论一致。

**真实管线产物验证**：直接调用本分支的 `absolutizeDocAssetUrls` + `injectBaseHref` 生成 srcdoc，喂进真实浏览器：4 类导航锚点（bare `#frag` / `#` / 自链接 / `<area>`）全部页内滚动且从未离开 `about:srcdoc`；外链保持原样。同时与 main 产物逐行 diff，确认**只有 4 个 `a`/`area` 的 href 发生变化**，其余字节完全一致。

**测试 / 构建**：
- `packages/docs` 全量：**15 files / 239 tests 全绿**（基线 228，净增 11）
- `tsc --noEmit -p tsconfig.typecheck.json`：改动前后输出**完全一致**（仅 `../dmworkbase/**` 与 board contract test 的既有基线报错），无新增
- `turbo run build --filter=@octo/web`：production build 成功（`✓ built in 6.23s`）
- `git diff --check` 通过

**反向验证**（一次只动一个变量，同时证明测试有效与改动必要）：
- 移除 `rewriteInPageFragmentHrefs` 调用 → 6 条新测试失败，其余 80 条通过
- 移除 target 放行判断 → 恰好 2 条 target 相关测试失败
- 移除同文档身份比较 → 恰好 1 条「跨文档链接不改写」测试失败

## COMPREHENSION

**(a) 对承载路径做了什么（before/after）**

承载路径 = `HtmlPreviewFrame` 的「fetch 文档 HTML → 变换 → 挂 srcDoc → iframe 渲染」，`HtmlDocView`（文档预览）与 `HtmlDiffModal`（版本对比双栏）共用。

- before：`injectBaseHref(absolutizeDocAssetUrls(raw, url), resolveAbsoluteOctoDocBase())`。`a[href]` 原样保留，页内锚点 → 跨文档导航 → 整帧被替换。
- after：`absolutizeDocAssetUrls` 在同一次 DOM 遍历里多做一步 `rewriteInPageFragmentHrefs`，把同文档锚点写成 `about:srcdoc#frag`；点击 → 浏览器原生同文档滚动。
- 未改动：`<base>` 注入逻辑与其尾斜杠行为、`img[src]`/`link[href]` 重写规则、`/assets/` 判定、`neutralizeEditableControls`、`srcDoc` 承载方式、`sandbox="allow-same-origin"`、无新增依赖、无新增环境变量。

**(b) 什么可能坏（依赖方 + 失败模式）**

- 依赖方：`HtmlPreviewFrame` → `HtmlDocView` / `HtmlDiffModal`。两者走同一条变换路径，测试均覆盖。
- 最大风险 = **误改写**，即把本该跨文档的链接写成 `about:srcdoc#…` 变成死链。因此只改写两类：以 `#` 开头的、以及解析后 `origin+pathname+search` 与本文档完全相等的完整 URL；相对 href 与外链一律不碰。
- 第二风险 = **吞掉作者意图**：`<base target>` 或链接自身 `target` 表示要开新上下文，改写后浏览器不再新开也不滚动（已实测），故这两种情况完整放行。
- 图片/样式回归面：`<base>` 与资源重写规则一行未动，与 main 产物的字节级 diff 证明只有 4 个 href 变化，图片链路无回归面。
- 覆盖完整性：iframe 不给 `allow-scripts`，文档内脚本不执行，不存在运行时新增锚点，静态一次改写即全覆盖。
- 与 #1277 的关系：机制不同、互不冲突。若 #1277 先合入，其 parent 侧 `bindAnchorNavigation` 会先于原生行为 `preventDefault` 并自行 `scrollIntoView`，行为仍正确（只是多一层冗余）；建议后续单独清理，本 PR 不动它以保持单一职责。

**(c) 怎么知道它有效**

不靠推断，靠三层证据：① 真实 Chromium + Firefox 的 A/B 实测（含 bug 基线复现与 5 类边界）；② 直接把本分支管线的真实产物喂进浏览器验证，并与 main 产物字节级 diff 确认改动面；③ 239 tests / typecheck 基线一致 / production build 成功，外加逐项还原的反向验证。

## 部署前提 / 必配环境变量

本 PR **不引入任何新环境变量**，纯前端逻辑修复，无需额外配置。现有 Web 容器变量（如 `DOC_APP_URL` octo-doc 上游地址、`VITE_OCTO_DOC_BASE` / `window.__OCTO_DOC_BASE__` 预览前缀）**保持原值即可**，本改动不读取也不改变它们的语义。
