### PR TITLE
fix(electron): detect desktop runtime for API URL

### DIFF
--- a/apps/web/src/index.tsx
+++ b/apps/web/src/index.tsx
@@ -23,7 +23,15 @@ import { resolveApiURL } from './apiURL';
 // VITE_API_URL 只填 origin（协议+域名+端口），不要带路径
 // 例如: https://api.example.com (而非 https://api.example.com/v1/)
 
-if((window as any).__TAURI_IPC__ || (window as any)?.__POWERED_ELECTRON__) {
+// 正式 Electron 包通过 VITE_ELECTRON_BUILD 在编译期标记桌面运行时。
+// preload 标记仍然保留，用于开发环境和 IPC 能力；但不能只依赖 preload 判断 API
+// 环境，否则 preload 加载异常时会误走 Web 分支，把 `/api/v1/` 解析成 `file:///api/v1/`。
+const isDesktopRuntime =
+  Boolean((window as any).__TAURI_IPC__ || (window as any).__POWERED_ELECTRON__) ||
+  import.meta.env.VITE_ELECTRON_BUILD === "true" ||
+  window.location.protocol === "file:"
+
+if(isDesktopRuntime) {
   // 开发环境的 Tauri/Electron 页面运行在 localhost:3000，走 Vite 同源代理，
   // 避免直接请求远程 API 时被浏览器 CORS 拦截。正式桌面包没有 Vite 代理，
   // 仍然使用 VITE_API_URL 直连后端。

--- a/apps/web/src/vite-env.d.ts
+++ b/apps/web/src/vite-env.d.ts
@@ -4,6 +4,7 @@ interface ImportMetaEnv {
   // Optional at type level: Web env doesn't require it (uses /api/v1/ relative path)
   // Required at runtime for Tauri/Electron builds (enforced in index.tsx)
   readonly VITE_API_URL?: string
+  readonly VITE_ELECTRON_BUILD?: string
   readonly VITE_VERSION: string
   // Enables the enterprise SSO entry (OIDC) on the login page.
   // Open-source builds leave this unset to keep the entry hidden.


### PR DESCRIPTION
## Summary
- detect packaged Electron builds via VITE_ELECTRON_BUILD
- recognize file:// desktop runtime as a fallback
- preserve preload-based detection for development and IPC support
- declare VITE_ELECTRON_BUILD in ImportMetaEnv

## Validation
- pnpm --filter @octo/web build:electron