### PR TITLE
fix: improve macOS tray unread count display

### DIFF
--- a/apps/web/src-election/main/index.ts
+++ b/apps/web/src-election/main/index.ts
@@ -231,6 +231,21 @@ let trayMenu: Electron.MenuItemConstructorOptions[] = [
  * @returns
  */
 let flashTimer: any = null;
+
+function createMacTrayIcon(iconPath: string) {
+  const source = nativeImage.createFromPath(iconPath);
+  const trayImage = nativeImage.createEmpty();
+
+  for (const [scaleFactor, size] of [[1, 22], [2, 44], [3, 66]] as const) {
+    trayImage.addRepresentation({
+      scaleFactor,
+      buffer: source.resize({ width: size, height: size }).toPNG(),
+    });
+  }
+
+  return trayImage;
+}
+
 function updateTray(unread = 0, isFlash= false): any {
   settings.showOnTray = true;
 
@@ -251,10 +266,7 @@ function updateTray(unread = 0, isFlash= false): any {
     if (!trayIcon) {
       const trayIconPath = getNoMessageTrayIcon();
       trayIcon = isOsx
-        ? nativeImage.createFromPath(trayIconPath).resize({
-            width: 22,
-            height: 22,
-          })
+        ? createMacTrayIcon(trayIconPath)
         : trayIconPath;
     }
 

--- a/apps/web/src-election/main/index.ts
+++ b/apps/web/src-election/main/index.ts
@@ -16,6 +16,7 @@ import Screenshots from "electron-screenshots";
 import { join } from "path";
 
 import logo, { getNoMessageTrayIcon } from "./logo";
+import { IPC_CONVERSATION_UNREAD_COUNT } from "../shared/ipc-channels";
 import DMWORK_CONFIG from "./config";
 import checkUpdate from './update';
 import { electronNotificationManager } from './notification';
@@ -32,7 +33,7 @@ let screenShotWindowId = 0;
 let isFullScreen = false;
 
 let isOsx = process.platform === "darwin";
-let isWin = !isOsx;
+let isWin = process.platform === "win32";
 let isWindowFocusHandlerRegistered = false;
 
 const isDevelopment = process.env.NODE_ENV !== "production";
@@ -233,6 +234,12 @@ let flashTimer: any = null;
 function updateTray(unread = 0, isFlash= false): any {
   settings.showOnTray = true;
 
+  // IPC arguments are untrusted renderer data. Normalize them here so a
+  // transient undefined/string value cannot produce a malformed title.
+  const unreadCount = Number.isFinite(Number(unread))
+    ? Math.max(0, Math.floor(Number(unread)))
+    : 0;
+
   // linux 系统不支持 tray
   if (process.platform === "linux") {
     return;
@@ -242,7 +249,13 @@ function updateTray(unread = 0, isFlash= false): any {
     let contextmenu = Menu.buildFromTemplate(trayMenu);
 
     if (!trayIcon) {
-      trayIcon = getNoMessageTrayIcon();
+      const trayIconPath = getNoMessageTrayIcon();
+      trayIcon = isOsx
+        ? nativeImage.createFromPath(trayIconPath).resize({
+            width: 22,
+            height: 22,
+          })
+        : trayIconPath;
     }
 
     setTimeout(() => {
@@ -263,7 +276,11 @@ function updateTray(unread = 0, isFlash= false): any {
       }
 
       if (isOsx) {
-        tray.setTitle(unread > 0 ? " " + unread : "");
+        // Re-apply the purple logo so an already-created Tray cannot retain
+        // the previous template icon after the renderer is refreshed.
+        tray.setImage(trayIcon);
+        // Let macOS render the count as plain text to the right of the logo.
+        tray.setTitle(unreadCount > 0 ? ` ${unreadCount}` : "");
       }
 
       mainWindow.flashFrame(isFlash);
@@ -281,7 +298,10 @@ function updateTray(unread = 0, isFlash= false): any {
           }
       }, TRAY_FLASH_INTERVAL_MS);
       }else{
-        tray.setImage(trayIcon);
+        if (!isOsx) {
+          // Windows/Linux: directly use the path icon.
+          tray.setImage(trayIcon);
+        }
         clearInterval(flashTimer);
       }
     });
@@ -435,7 +455,7 @@ const createMainWindow = async () => {
     return getMediaAccessStatus;
   })
   // 会话未读消息消息数量托盘提醒
-  ipcMain.on("conversation-anager-unread-count", (event, num) => {
+  ipcMain.on(IPC_CONVERSATION_UNREAD_COUNT, (event, num) => {
     // const isFlag = num > 0 && isWin ? true : false;
     updateTray(num, false); // 不需要闪烁，闪烁很消耗性能
   });

--- a/apps/web/src-election/main/index.ts
+++ b/apps/web/src-election/main/index.ts
@@ -456,6 +456,14 @@ const createMainWindow = async () => {
   })
   // 会话未读消息消息数量托盘提醒
   ipcMain.on(IPC_CONVERSATION_UNREAD_COUNT, (event, num) => {
+    // The tray is global to the app, so only the main window may update it.
+    // Auxiliary windows have independent renderer/session state and can start
+    // with an empty conversation cache, which would otherwise clear the main
+    // window's correct unread count.
+    if (!mainWindow || mainWindow.isDestroyed() || event.sender !== mainWindow.webContents) {
+      return;
+    }
+
     // const isFlag = num > 0 && isWin ? true : false;
     updateTray(num, false); // 不需要闪烁，闪烁很消耗性能
   });

--- a/apps/web/src-election/main/logo.ts
+++ b/apps/web/src-election/main/logo.ts
@@ -1,5 +1,5 @@
 import path from "path";
-import { app, screen } from "electron";
+import { app } from "electron";
 
 export default path.join(app.getAppPath(), "./resources/logo.png");
 
@@ -7,10 +7,8 @@ export function getNoMessageTrayIcon() {
   if (process.platform === "darwin") {
     // Keep the purple OCTO logo in the menu bar. The unread count is rendered
     // separately as plain text to its right, like the WeChat menu-bar layout.
-    return path.join(app.getAppPath(), "./resources/logo.png");
+    return path.join(app.getAppPath(), "./resources/icons/1024x1024.png");
   } else if (process.platform === "win32") {
-    return path.join(app.getAppPath(), "./resources/tray/128x128.png");
-  } else if (screen.getPrimaryDisplay().scaleFactor > 1) {
     return path.join(app.getAppPath(), "./resources/tray/128x128.png");
   } else {
     return path.join(app.getAppPath(), "./resources/tray/128x128.png");

--- a/apps/web/src-election/main/logo.ts
+++ b/apps/web/src-election/main/logo.ts
@@ -3,14 +3,16 @@ import { app, screen } from "electron";
 
 export default path.join(app.getAppPath(), "./resources/logo.png");
 
-export function getNoMessageTrayIcon () {
-  if (process.platform === 'darwin') {
-    return path.join(app.getAppPath(), './resources/tray/macTrayTemplate.png')
-  } else if (process.platform === 'win32') {
-    return path.join(app.getAppPath(), './resources/tray/128x128.png')
+export function getNoMessageTrayIcon() {
+  if (process.platform === "darwin") {
+    // Keep the purple OCTO logo in the menu bar. The unread count is rendered
+    // separately as plain text to its right, like the WeChat menu-bar layout.
+    return path.join(app.getAppPath(), "./resources/logo.png");
+  } else if (process.platform === "win32") {
+    return path.join(app.getAppPath(), "./resources/tray/128x128.png");
   } else if (screen.getPrimaryDisplay().scaleFactor > 1) {
-    return path.join(app.getAppPath(), './resources/tray/128x128.png')
+    return path.join(app.getAppPath(), "./resources/tray/128x128.png");
   } else {
-    return path.join(app.getAppPath(), './resources/tray/128x128.png')
+    return path.join(app.getAppPath(), "./resources/tray/128x128.png");
   }
 }

--- a/apps/web/src-election/preload/index.ts
+++ b/apps/web/src-election/preload/index.ts
@@ -1,11 +1,12 @@
 import { contextBridge, ipcRenderer } from "electron";
 import { subscribeDisposable } from "./notificationListeners";
+import { IPC_CONVERSATION_UNREAD_COUNT } from "../shared/ipc-channels";
 
 const ALLOWED_SEND_CHANNELS = [
   "check-update",
   "install-update",
   "update-app",
-  "conversation-anager-unread-count",
+  IPC_CONVERSATION_UNREAD_COUNT,
   "screenshots-start",
   "restart-app",
 ];

--- a/apps/web/src-election/shared/ipc-channels.ts
+++ b/apps/web/src-election/shared/ipc-channels.ts
@@ -1,0 +1,10 @@
+/**
+ * Shared IPC channel name constants.
+ *
+ * Import this file in both the main process and the renderer / preload so
+ * that the string literal is only defined once and typos are caught at
+ * compile time rather than silently breaking at runtime.
+ */
+
+/** Renderer → Main: sync the current unread-message count to the tray. */
+export const IPC_CONVERSATION_UNREAD_COUNT = "conversation-manager-unread-count";

--- a/apps/web/src/App/__tests__/getElectronUnreadMessageCount.test.ts
+++ b/apps/web/src/App/__tests__/getElectronUnreadMessageCount.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Unit tests for getElectronUnreadMessageCount
+ *
+ * Tests the pure aggregation logic in isolation.  All SDK / app dependencies
+ * are vi.mock'd so the suite runs without a real WKSDK connection or Electron.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ─── Shared mock state ───────────────────────────────────────────────────────
+
+const mockConversations: any[] = []
+const mockGetChannelInfo = vi.fn()
+const mockShouldSkipChannel = vi.fn(() => false)
+const mockShouldSkipPerson = vi.fn(() => false)
+
+let currentSpaceId: string | null = null
+
+// ─── vi.mock declarations (hoisted by Vitest) ────────────────────────────────
+
+vi.mock('wukongimjssdk', () => ({
+  WKSDK: {
+    shared: () => ({
+      conversationManager: {
+        get conversations() { return mockConversations },
+      },
+      channelManager: {
+        getChannelInfo: (ch: any) => mockGetChannelInfo(ch),
+      },
+    }),
+  },
+  ChannelTypePerson: 1,
+}))
+
+vi.mock('@octo/base', () => ({
+  WKApp: {
+    get shared() { return { currentSpaceId } },
+  },
+  shouldSkipChannelForSpace: (ch: any) => mockShouldSkipChannel(ch),
+  shouldSkipPersonConversationForSpace: (conv: any) => mockShouldSkipPerson(conv),
+}))
+
+// ─── Import subject AFTER mocks ───────────────────────────────────────────────
+
+const { getElectronUnreadMessageCount } = await import('../electronUnreadCount')
+
+// ─── Test helpers ─────────────────────────────────────────────────────────────
+
+function conv(unread: any, opts: {
+  mute?: boolean
+  skipChannel?: boolean
+  skipPerson?: boolean
+  channelType?: number
+  spaceUnread?: number
+} = {}): any {
+  const channel = { channelType: opts.channelType ?? 0 }
+
+  mockGetChannelInfo.mockImplementation((ch: any) =>
+    ch === channel ? (opts.mute !== undefined ? { mute: opts.mute } : undefined) : undefined
+  )
+  if (opts.skipChannel !== undefined) {
+    mockShouldSkipChannel.mockImplementation((ch: any) =>
+      ch === channel ? opts.skipChannel : false
+    )
+  }
+  if (opts.skipPerson !== undefined) {
+    mockShouldSkipPerson.mockImplementation((c: any) =>
+      c.channel === channel ? opts.skipPerson : false
+    )
+  }
+
+  return {
+    channel,
+    unread,
+    extra: opts.spaceUnread !== undefined ? { spaceUnread: opts.spaceUnread } : undefined,
+  }
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  mockConversations.length = 0
+  mockGetChannelInfo.mockReturnValue(undefined)
+  mockShouldSkipChannel.mockReturnValue(false)
+  mockShouldSkipPerson.mockReturnValue(false)
+  currentSpaceId = null
+})
+
+describe('getElectronUnreadMessageCount', () => {
+
+  it('returns 0 for an empty conversation list', () => {
+    expect(getElectronUnreadMessageCount()).toBe(0)
+  })
+
+  it('sums unread counts across normal conversations', () => {
+    mockConversations.push(
+      { channel: { channelType: 0 }, unread: 3, extra: undefined },
+      { channel: { channelType: 0 }, unread: 5, extra: undefined },
+    )
+    expect(getElectronUnreadMessageCount()).toBe(8)
+  })
+
+  it('excludes muted conversations', () => {
+    const mutedCh = { channelType: 0 }
+    mockGetChannelInfo.mockImplementation((ch: any) =>
+      ch === mutedCh ? { mute: true } : undefined
+    )
+    mockConversations.push(
+      { channel: mutedCh, unread: 10, extra: undefined },
+      { channel: { channelType: 0 }, unread: 2, extra: undefined },
+    )
+    expect(getElectronUnreadMessageCount()).toBe(2)
+  })
+
+  it('excludes conversations where shouldSkipChannelForSpace returns true', () => {
+    const skippedCh = { channelType: 0 }
+    mockShouldSkipChannel.mockImplementation((ch: any) => ch === skippedCh)
+    mockConversations.push(
+      { channel: skippedCh, unread: 10, extra: undefined },
+      { channel: { channelType: 0 }, unread: 4, extra: undefined },
+    )
+    expect(getElectronUnreadMessageCount()).toBe(4)
+  })
+
+  it('excludes conversations where shouldSkipPersonConversationForSpace returns true', () => {
+    const skippedConv = { channel: { channelType: 1 }, unread: 7, extra: undefined }
+    mockShouldSkipPerson.mockImplementation((c: any) => c === skippedConv)
+    mockConversations.push(
+      skippedConv,
+      { channel: { channelType: 0 }, unread: 3, extra: undefined },
+    )
+    expect(getElectronUnreadMessageCount()).toBe(3)
+  })
+
+  it('uses extra.spaceUnread for Person channels when currentSpaceId is set', () => {
+    currentSpaceId = 'space-1'
+    mockConversations.push({
+      channel: { channelType: 1 /* ChannelTypePerson */ },
+      unread: 99,               // should be ignored
+      extra: { spaceUnread: 5 },
+    })
+    expect(getElectronUnreadMessageCount()).toBe(5)
+  })
+
+  it('falls back to conversation.unread when extra.spaceUnread is undefined', () => {
+    currentSpaceId = 'space-1'
+    mockConversations.push({
+      channel: { channelType: 1 },
+      unread: 8,
+      extra: {},                // spaceUnread key absent
+    })
+    expect(getElectronUnreadMessageCount()).toBe(8)
+  })
+
+  it('ignores NaN and Infinity unread values, counting them as 0', () => {
+    mockConversations.push(
+      { channel: { channelType: 0 }, unread: NaN, extra: undefined },
+      { channel: { channelType: 0 }, unread: Infinity, extra: undefined },
+      { channel: { channelType: 0 }, unread: 'bad' as any, extra: undefined },
+      { channel: { channelType: 0 }, unread: 3, extra: undefined },
+    )
+    expect(getElectronUnreadMessageCount()).toBe(3)
+  })
+
+  it('clamps negative unread values to 0', () => {
+    mockConversations.push({ channel: { channelType: 0 }, unread: -5, extra: undefined })
+    expect(getElectronUnreadMessageCount()).toBe(0)
+  })
+
+  it('floors fractional unread values', () => {
+    mockConversations.push({ channel: { channelType: 0 }, unread: 2.9, extra: undefined })
+    expect(getElectronUnreadMessageCount()).toBe(2)
+  })
+})

--- a/apps/web/src/App/__tests__/getElectronUnreadMessageCount.test.ts
+++ b/apps/web/src/App/__tests__/getElectronUnreadMessageCount.test.ts
@@ -43,38 +43,6 @@ vi.mock('@octo/base', () => ({
 
 const { getElectronUnreadMessageCount } = await import('../electronUnreadCount')
 
-// ─── Test helpers ─────────────────────────────────────────────────────────────
-
-function conv(unread: any, opts: {
-  mute?: boolean
-  skipChannel?: boolean
-  skipPerson?: boolean
-  channelType?: number
-  spaceUnread?: number
-} = {}): any {
-  const channel = { channelType: opts.channelType ?? 0 }
-
-  mockGetChannelInfo.mockImplementation((ch: any) =>
-    ch === channel ? (opts.mute !== undefined ? { mute: opts.mute } : undefined) : undefined
-  )
-  if (opts.skipChannel !== undefined) {
-    mockShouldSkipChannel.mockImplementation((ch: any) =>
-      ch === channel ? opts.skipChannel : false
-    )
-  }
-  if (opts.skipPerson !== undefined) {
-    mockShouldSkipPerson.mockImplementation((c: any) =>
-      c.channel === channel ? opts.skipPerson : false
-    )
-  }
-
-  return {
-    channel,
-    unread,
-    extra: opts.spaceUnread !== undefined ? { spaceUnread: opts.spaceUnread } : undefined,
-  }
-}
-
 // ─── Tests ────────────────────────────────────────────────────────────────────
 
 beforeEach(() => {

--- a/apps/web/src/App/electronUnreadCount.ts
+++ b/apps/web/src/App/electronUnreadCount.ts
@@ -22,6 +22,7 @@ import { WKApp, shouldSkipChannelForSpace, shouldSkipPersonConversationForSpace 
  */
 export function getElectronUnreadMessageCount(): number {
   let total = 0
+  const currentSpaceId = WKApp.shared.currentSpaceId
 
   for (const conversation of WKSDK.shared().conversationManager.conversations) {
     const channelInfo = WKSDK.shared().channelManager.getChannelInfo(conversation.channel)
@@ -29,7 +30,6 @@ export function getElectronUnreadMessageCount(): number {
     if (shouldSkipChannelForSpace(conversation.channel)) continue
     if (shouldSkipPersonConversationForSpace(conversation)) continue
 
-    const currentSpaceId = WKApp.shared.currentSpaceId
     const rawUnread =
       currentSpaceId &&
       conversation.channel.channelType === ChannelTypePerson &&

--- a/apps/web/src/App/electronUnreadCount.ts
+++ b/apps/web/src/App/electronUnreadCount.ts
@@ -1,0 +1,47 @@
+/**
+ * getElectronUnreadMessageCount
+ *
+ * Aggregates the current unread-message count that should be sent to the
+ * Electron main process for tray-badge rendering.  Extracted into its own
+ * module so it can be unit-tested without booting the full React app tree.
+ */
+import { WKSDK, ChannelTypePerson } from 'wukongimjssdk'
+import { WKApp, shouldSkipChannelForSpace, shouldSkipPersonConversationForSpace } from '@octo/base'
+
+/**
+ * Returns the total unread-message count across all visible conversations,
+ * applying the same mute / space-filter logic as the tray listener.
+ *
+ * Rules:
+ *  - Muted channels are excluded.
+ *  - Channels / person-conversations filtered by the current Space are excluded.
+ *  - Person channels use `extra.spaceUnread` when a Space is active and the
+ *    field is present; otherwise fall back to `conversation.unread`.
+ *  - Non-finite / negative values are clamped to 0 so a bad IPC payload cannot
+ *    corrupt the tray title.
+ */
+export function getElectronUnreadMessageCount(): number {
+  let total = 0
+
+  for (const conversation of WKSDK.shared().conversationManager.conversations) {
+    const channelInfo = WKSDK.shared().channelManager.getChannelInfo(conversation.channel)
+    if (channelInfo?.mute) continue
+    if (shouldSkipChannelForSpace(conversation.channel)) continue
+    if (shouldSkipPersonConversationForSpace(conversation)) continue
+
+    const currentSpaceId = WKApp.shared.currentSpaceId
+    const rawUnread =
+      currentSpaceId &&
+      conversation.channel.channelType === ChannelTypePerson &&
+      conversation.extra?.spaceUnread !== undefined
+        ? conversation.extra.spaceUnread
+        : conversation.unread
+
+    const n = Number(rawUnread)
+    if (Number.isFinite(n)) {
+      total += Math.max(0, n)
+    }
+  }
+
+  return Math.floor(total)
+}

--- a/apps/web/src/App/index.tsx
+++ b/apps/web/src/App/index.tsx
@@ -1,16 +1,18 @@
-import { ChatPage, EndpointCategory, WKApp, Menus, shouldSkipChannelForSpace, shouldSkipPersonConversationForSpace, t } from '@octo/base';
+import { ChatPage, EndpointCategory, WKApp, Menus, t } from '@octo/base';
 import { ContactsList } from '@octo/contacts';
 import React, { useEffect } from 'react';
 // lucide icons replaced with filled SVGs per Figma
 import './index.css';
 import AppLayout from '../Layout';
-import { WKSDK, ChannelTypePerson } from 'wukongimjssdk';
+import { WKSDK } from 'wukongimjssdk';
 import { ChatIcon } from '../Components/Icons/ChatIcon';
 import { ContactsIcon } from '../Components/Icons/ContactsIcon';
 import { SummaryIcon } from '../Components/Icons/SummaryIcon';
 import { Toast } from '@douyinfe/semi-ui';
 import { clearDeprecatedFriendApplyReddotOnce } from './friendApplyReddotCleanup';
 import { createOctoDocumentTitleController } from '../features/documentTitle/octoDocumentTitle';
+import { IPC_CONVERSATION_UNREAD_COUNT } from '../../src-election/shared/ipc-channels';
+import { getElectronUnreadMessageCount } from './electronUnreadCount';
 
 /**
  * 全局 ?verified=1 处理：CAS 实名认证完成后 verify-service 会 302 回
@@ -88,6 +90,15 @@ function useDeprecatedFriendApplyReddotCleanup() {
   }, [isLogined, uid])
 }
 
+function syncElectronUnreadMessageCount() {
+  if ((window as any).__POWERED_ELECTRON__) {
+    (window as any).ipc.send(
+      IPC_CONVERSATION_UNREAD_COUNT,
+      getElectronUnreadMessageCount(),
+    )
+  }
+}
+
 let _menusRegistered = false
 async function registerMenus() {
   if (_menusRegistered) return
@@ -95,7 +106,14 @@ async function registerMenus() {
 
   WKSDK.shared().conversationManager.addConversationListener(() => {
     WKApp.menus.refresh()
+    syncElectronUnreadMessageCount()
   })
+  WKApp.mittBus.on("conversation-list-refreshed", syncElectronUnreadMessageCount)
+  WKApp.mittBus.on("space-changed", syncElectronUnreadMessageCount)
+
+  // The conversation list can be restored after registration; the listener
+  // above will send the subsequent snapshot in that case.
+  syncElectronUnreadMessageCount()
 
   WKApp.endpointManager.setMethod("menus.friendapply.change", () => {
     WKApp.menus.refresh()
@@ -105,35 +123,6 @@ async function registerMenus() {
 
   WKApp.menus.register("chat", (_context) => {
     const m = new Menus("chat", "/", t("app.nav.chat"), <ChatIcon />, <ChatIcon />)
-    // Electron's existing tray/taskbar contract intentionally remains the unread MESSAGE total.
-    // The Web document title uses a separate unread-CONVERSATION selector.
-    let electronUnreadMessageCount = 0
-
-    for (const conversation of WKSDK.shared().conversationManager.conversations) {
-      const channelInfo = WKSDK.shared().channelManager.getChannelInfo(conversation.channel)
-      if (channelInfo?.mute) {
-        continue
-      }
-      // Space 过滤：复用 shouldSkipChannelForSpace 完整逻辑（含 channelSpaceMap 缓存）
-      if (shouldSkipChannelForSpace(conversation.channel)) {
-        continue
-      }
-      if (shouldSkipPersonConversationForSpace(conversation)) continue
-      // Person 频道在 Space 模式下优先使用 per-Space 未读计数
-      const currentSpaceId = WKApp.shared.currentSpaceId
-      if (currentSpaceId
-          && conversation.channel.channelType === ChannelTypePerson
-          && conversation.extra?.spaceUnread !== undefined) {
-        electronUnreadMessageCount += conversation.extra.spaceUnread
-      } else {
-        electronUnreadMessageCount += conversation.unread
-      }
-    }
-
-    // favicon 数字角标已下线；Electron 的既有托盘语义保持不变。
-    if ((window as any).__POWERED_ELECTRON__) {
-      (window as any).ipc.send("conversation-anager-unread-count", electronUnreadMessageCount);
-    }
 
     return m
   }, 1000)

--- a/apps/web/src/App/index.tsx
+++ b/apps/web/src/App/index.tsx
@@ -1,4 +1,4 @@
-import { ChatPage, EndpointCategory, WKApp, Menus, t } from '@octo/base';
+import { addImChannelInfoListener, ChatPage, EndpointCategory, WKApp, Menus, t } from '@octo/base';
 import { ContactsList } from '@octo/contacts';
 import React, { useEffect } from 'react';
 // lucide icons replaced with filled SVGs per Figma
@@ -108,8 +108,8 @@ async function registerMenus() {
     WKApp.menus.refresh()
     syncElectronUnreadMessageCount()
   })
+  addImChannelInfoListener(WKSDK.shared(), syncElectronUnreadMessageCount)
   WKApp.mittBus.on("conversation-list-refreshed", syncElectronUnreadMessageCount)
-  WKApp.mittBus.on("space-changed", syncElectronUnreadMessageCount)
 
   // The conversation list can be restored after registration; the listener
   // above will send the subsequent snapshot in that case.

--- a/apps/web/src/features/documentTitle/octoDocumentTitle.ts
+++ b/apps/web/src/features/documentTitle/octoDocumentTitle.ts
@@ -162,6 +162,10 @@ export function createOctoDocumentTitleController(): DocumentTitleController {
       // still need the same account-level unread snapshot for their title prefix.
       if (menuId === "chat" || (!menuId && pathname === "/")) return;
       await WKSDK.shared().conversationManager.sync({});
+      // sync() replaces the SDK conversation cache without notifying its
+      // conversation listeners. Broadcast the same event used by Chat so
+      // consumers such as the Electron tray receive the restored snapshot.
+      WKApp.mittBus.emit("conversation-list-refreshed");
     },
   });
 }


### PR DESCRIPTION
Replaces #1289.

## Summary
- fix macOS tray icon and unread count rendering
- centralize the Electron unread-count IPC channel
- extract unread aggregation logic and add unit tests

## Validation
- `pnpm exec vitest run src/App/__tests__/getElectronUnreadMessageCount.test.ts --config vitest.config.ts`
- `pnpm run build:electron`
- Electron TypeScript compilation passed