### PR TITLE
chore(docs): 去掉「新建文档」下拉里的「新建幻灯片」入口

### DIFF
--- a/packages/docs/src/config.ts
+++ b/packages/docs/src/config.ts
@@ -192,6 +192,23 @@ export const LINE_SPACING_ENABLED = envOr(import.meta.env?.VITE_DOCS_LINE_SPACIN
 export const PPT_CREATE_ENABLED = envOr(import.meta.env?.VITE_DOCS_PPT_CREATE, 'true') === 'true'
 
 /**
+ * Exposure gate for the caret-menu "New slides" ENTRY itself.
+ *
+ * The html_ppt create flow is still incomplete end to end (the R3 source/bootstrap layer is gated
+ * OFF by default — see PPT_SOURCE_ENABLED), so a user who creates a deck from the dropdown lands on
+ * a surface that cannot load its own content yet. Until that round ships, the entry is not offered:
+ * this flag DEFAULTS OFF and the "New slides" item is not rendered at all in the "+ 新建文档"
+ * dropdown (invisible and unreachable, so no deck can be minted from the docs list).
+ *
+ * This gate is deliberately SEPARATE from PPT_CREATE_ENABLED (which picks WHICH dialog the entry
+ * opens — the live template picker or the R1 coming-soon notice): removing the entry must not delete
+ * the create wiring, so a deployment that wants it back only needs `VITE_DOCS_PPT_ENTRY=true`. It
+ * touches nothing else — html_ppt routing, the read-only PptDocView, the type filter and existing
+ * decks are unaffected; only the create entry point in the dropdown disappears.
+ */
+export const PPT_ENTRY_ENABLED = envOr(import.meta.env?.VITE_DOCS_PPT_ENTRY, 'false') === 'true'
+
+/**
  * Exposure gate for the html_ppt viewer / editor / present surfaces that consume LIVE backend
  * source (R3-F1, XIN-1495 / XIN-1583).
  *

--- a/packages/docs/src/pages/DocsHome.pptEntryOff.test.tsx
+++ b/packages/docs/src/pages/DocsHome.pptEntryOff.test.tsx
@@ -3,22 +3,14 @@ import { render, screen, waitFor, cleanup, fireEvent } from '@testing-library/re
 import { setWKApp } from '../octoweb/index.ts'
 import { createMockWKApp } from '../octoweb/mock.ts'
 
-// ── R2-F1 P2-4: the PPT_CREATE_ENABLED rollback branch has coverage ──────────
-// The flag is read once at module scope in config.ts. With it OFF, DocsHome must fall back to the R1
-// "coming soon" notice (an acceptance item) and must NOT mount the live four-template picker — that
-// is the emergency rollback path, and it was previously untested. This file mocks config.ts with the
-// flag OFF (keeping every other config export real via importActual) so the whole file exercises the
-// OFF build without disturbing the flag-ON assertions in DocsHome.test.tsx.
-vi.mock('../config.ts', async () => {
-  const actual = await vi.importActual<typeof import('../config.ts')>('../config.ts')
-  // PPT_ENTRY_ENABLED is pinned ON so the caret-menu entry exists to click; this file is about the
-  // PPT_CREATE_ENABLED rollback branch, which is a different gate (see config.ts).
-  return { ...actual, PPT_CREATE_ENABLED: false, PPT_ENTRY_ENABLED: true }
-})
+// ── "New slides" entry hidden by default (PPT_ENTRY_ENABLED default OFF) ─────
+// The html_ppt create entry is no longer offered in the "+ 新建文档" dropdown: it is not rendered at
+// all, so it cannot be clicked and no deck can be minted from the docs list. This file exercises the
+// SHIPPED default (no config mock override) — DocsHome.test.tsx pins the entry ON to keep covering
+// the create wiring that stays in the codebase behind the flag.
+import { DocsHome } from './DocsHome.tsx'
 
-// Heavy child boundaries replaced with markers (same rationale as DocsHome.test.tsx): the editor /
-// board / sheet / html / ppt shells pull Tiptap/Yjs/Univer/WebSocket runtimes we do not need for a
-// list-only render.
+// Heavy child boundaries replaced with markers (same rationale as DocsHome.test.tsx).
 vi.mock('../editor/EditorShell.tsx', () => ({
   EditorShell: (props: { docId: string }) => <div data-testid="editor-shell">{props.docId}</div>,
 }))
@@ -38,19 +30,16 @@ vi.mock('../html-create/DocsBotConversation.tsx', () => ({
   DocsBotConversation: () => <div data-testid="bot-chat" />,
 }))
 
-// Imported AFTER the config mock is registered so DocsHome closes over the OFF flag.
-import { DocsHome } from './DocsHome.tsx'
-
 const realLocation = window.location
 
-describe('DocsHome — PPT_CREATE_ENABLED OFF (R1 coming-soon rollback, P2-4)', () => {
+describe('DocsHome — "New slides" entry hidden (PPT_ENTRY_ENABLED default OFF)', () => {
   beforeEach(() => {
     window.sessionStorage.clear()
     window.localStorage.clear()
     Object.defineProperty(window, 'location', {
       configurable: true,
       writable: true,
-      value: { search: '', assign: vi.fn() },
+      value: { origin: 'https://app.example.com', search: '', assign: vi.fn() },
     })
     vi.spyOn(window.history, 'replaceState').mockImplementation(() => {})
     vi.spyOn(window.history, 'pushState').mockImplementation(() => {})
@@ -67,7 +56,7 @@ describe('DocsHome — PPT_CREATE_ENABLED OFF (R1 coming-soon rollback, P2-4)', 
     window.sessionStorage.clear()
   })
 
-  it('opens the R1 "coming soon" notice — never the live template picker — when the flag is OFF', async () => {
+  it('does not render the "New slides" item in the new-document dropdown', async () => {
     const wk = createMockWKApp()
     wk.apiClient.responder = (method: string, url: string) => {
       if (method === 'get' && url.startsWith('/docs')) return { data: { total: 0, items: [] }, status: 200 }
@@ -77,16 +66,18 @@ describe('DocsHome — PPT_CREATE_ENABLED OFF (R1 coming-soon rollback, P2-4)', 
 
     render(<DocsHome />)
 
-    // Open the split "New" dropdown and choose "New slides".
     fireEvent.click(screen.getByLabelText('docs.list.newMenu'))
-    fireEvent.click(screen.getByText('docs.list.newPpt'))
 
-    // Flag OFF → the coming-soon notice shows and the create endpoint is never hit.
-    await waitFor(() => expect(screen.getByText('docs.ppt.createComingSoon')).toBeTruthy())
-    // The live picker (radiogroup of four template cards) must NOT render.
+    // The peer entries stay exactly as they are — only the slides entry is gone.
+    await waitFor(() => expect(screen.getByText('docs.list.newBoard')).toBeTruthy())
+    expect(screen.getByText('docs.sheet.new')).toBeTruthy()
+    expect(screen.getByText('docs.list.newHtml')).toBeTruthy()
+    expect(screen.queryByText('docs.list.newPpt')).toBeNull()
+    expect(screen.queryByRole('button', { name: 'docs.list.newPpt' })).toBeNull()
+
+    // Nothing PPT-related can be opened or created from the list.
     expect(screen.queryByRole('radiogroup')).toBeNull()
-    expect(screen.queryAllByRole('radio')).toHaveLength(0)
-    // Nothing is created server-side either.
+    expect(screen.queryByText('docs.ppt.createComingSoon')).toBeNull()
     expect(wk.apiClient.calls.some((c) => c.method === 'post' && c.url === '/ppt/docs')).toBe(false)
   })
 })

--- a/packages/docs/src/pages/DocsHome.test.tsx
+++ b/packages/docs/src/pages/DocsHome.test.tsx
@@ -26,6 +26,16 @@ import zhLocale from "../i18n/zh-CN.json";
 import enLocale from "../i18n/en-US.json";
 import { titleContextStore } from "@octo/base";
 
+// The caret-menu "New slides" entry is hidden by default now (PPT_ENTRY_ENABLED, default OFF), but
+// the html_ppt create wiring it drives is still shipped and must stay covered. This file pins the
+// ENTRY on — keeping every other config export real via importActual — so the picker / focus-restore
+// / open-redirect assertions below keep exercising the real menu path. The default-OFF behaviour
+// (entry absent from the dropdown) is covered in DocsHome.pptEntryOff.test.tsx.
+vi.mock('../config.ts', async () => {
+  const actual = await vi.importActual<typeof import('../config.ts')>('../config.ts')
+  return { ...actual, PPT_ENTRY_ENABLED: true }
+})
+
 // Replace the heavy editor shell (Tiptap + Yjs + Hocuspocus) with a marker so the DocsHome
 // render tests exercise target-resolution / navigation without mounting the real editor.
 // The marker surfaces the docId it was addressed with and the onBack affordance.

--- a/packages/docs/src/pages/DocsHome.tsx
+++ b/packages/docs/src/pages/DocsHome.tsx
@@ -24,6 +24,7 @@ import {
   DEFAULT_DOC_ID,
   DOC_TARGET_STORAGE_KEY,
   PPT_CREATE_ENABLED,
+  PPT_ENTRY_ENABLED,
 } from '../config.ts'
 import { createDoc, deleteDoc, getDoc, recordDocView, type DocListItem } from './docsApi.ts'
 import { useMemberNames } from '../members/useMemberNames.ts'
@@ -1068,21 +1069,25 @@ function DocsList({
             {/* New slides (html_ppt). Independent peer AFTER "HTML" — opens the four-template
                 picker (POST /api/v1/ppt/docs) behind the R2 flag, or the R1 coming-soon notice when
                 off. Like the HTML entry it only closes the menu + calls onCreatePpt; it NEVER
-                calls createDoc, so no empty deck is precreated. */}
-            <button
-              type="button"
-              className="octo-docs-new-menu-item"
-              disabled={creating}
-              onClick={() => {
-                setNewMenuAt(null)
-                // Hand the picker the PERSISTENT caret (not this menu item, which unmounts as the menu
-                // closes on the line above) as its focus-restore target — R2-F1.
-                onCreatePpt(caretRef.current)
-              }}
-            >
-              <span className="octo-docs-new-menu-icon" aria-hidden="true"><PptRowIcon /></span>
-              {t('docs.list.newPpt')}
-            </button>
+                calls createDoc, so no empty deck is precreated.
+                Hidden by default (PPT_ENTRY_ENABLED, default OFF) while the html_ppt round is still
+                incomplete: the create wiring stays intact, only the entry is not offered here. */}
+            {PPT_ENTRY_ENABLED && (
+              <button
+                type="button"
+                className="octo-docs-new-menu-item"
+                disabled={creating}
+                onClick={() => {
+                  setNewMenuAt(null)
+                  // Hand the picker the PERSISTENT caret (not this menu item, which unmounts as the menu
+                  // closes on the line above) as its focus-restore target — R2-F1.
+                  onCreatePpt(caretRef.current)
+                }}
+              >
+                <span className="octo-docs-new-menu-icon" aria-hidden="true"><PptRowIcon /></span>
+                {t('docs.list.newPpt')}
+              </button>
+            )}
             {/* Import entries merged into the "New" dropdown (was a standalone "Import" button).
                 Flag ON; formal owner sign-off still PENDING, gated by needs-human-review (was hidden
                 in #583). Toggle via IMPORT_ENABLED. Handlers unchanged — this only moves the entry. */}


### PR DESCRIPTION
## 结论

去掉「+ 新建文档」下拉菜单里的「新建幻灯片」入口。默认构建下该菜单项**完全不渲染**（不可见、不可点），因此无法再从文档列表创建 html_ppt deck。创建链路代码原样保留在仓库里，由一个新开关控制，需要时可一键恢复。

## 为什么

「新建幻灯片」(html_ppt) 端到端还不完整：R3 source/bootstrap 层默认关闭（`PPT_SOURCE_ENABLED` 默认 false），用户从下拉里创建出来的 deck 会落在一个还加载不了自身内容的页面上。所以先不对外暴露这个创建入口。

## 改动

1. `packages/docs/src/config.ts`：新增 `PPT_ENTRY_ENABLED`（`VITE_DOCS_PPT_ENTRY`，**默认 false**），只控制下拉菜单里「新建幻灯片」这一条是否渲染。
2. `packages/docs/src/pages/DocsHome.tsx`：菜单项包在 `{PPT_ENTRY_ENABLED && (...)}` 里；其余入口（新建画板 / 新建表格 / 新建 HTML / 各类导入）位置与行为完全不变。
3. 与 `PPT_CREATE_ENABLED` **相互独立**：后者决定入口打开哪个弹窗（真模板选择器 / R1 敬请期待），前者决定入口是否存在。`CreatePptModal`、`createPptTask`、`POST /ppt/docs` 全部保留未删。

不涉及：html_ppt 路由、只读 `PptDocView`、类型筛选、已存在的 deck —— 都不受影响，仅移除创建入口。

## 部署前提 / 必配环境变量

本 PR **无必配环境变量**（默认即为"入口隐藏"这一目标行为，不配任何变量就生效）。

可选回滚开关：

| 变量 | 默认值 | 不配的后果 |
| --- | --- | --- |
| `VITE_DOCS_PPT_ENTRY` | `false` | 不配 = 入口隐藏（本 PR 的目标行为）。设为 `true` 可恢复「新建幻灯片」菜单项，无需回滚代码。 |

注意：这是 Vite **构建期**变量，改它需要重新 build 前端镜像，运行期改容器 env 无效。

## 验证

- 新增 `DocsHome.pptEntryOff.test.tsx`（默认构建，不 mock 开关）：打开下拉后 `docs.list.newPpt` 不存在，画板/表格/HTML 三项仍在，且没有 `POST /ppt/docs`。✅
- `DocsHome.test.tsx`（105 tests）与 `DocsHome.pptFlagOff.test.tsx` 把 `PPT_ENTRY_ENABLED` 固定为 true，继续覆盖仍保留在代码里的创建链路 / 焦点回归 / open-redirect 防护。✅
- `packages/docs` 全量 vitest：211 passed / 3 failed，失败的 3 个文件（`excalidrawToolbarPatch.contract`、`octoNativeShapes.contract`、`TableReorderInterrupt`）在**未改动的 main 基线上同样失败**，与本 PR 无关。
