### PR TITLE
fix(card): render inline SVG data URLs on card image surfaces

### DIFF
--- a/packages/dmworkbase/src/Messages/InteractiveCard/__tests__/inlineImageRender.test.tsx
+++ b/packages/dmworkbase/src/Messages/InteractiveCard/__tests__/inlineImageRender.test.tsx
@@ -1,0 +1,72 @@
+// @vitest-environment jsdom
+//
+// 端到端回归：模板内联的 data:image/svg+xml 折叠图标必须真正渲成 <img>。
+// 曾经的故障是消毒层 https-only 把 Image.url 整键剥掉 —— 整卡不降级、文字照渲，
+// 只有 chevron 静默消失、ToggleVisibility 点不到。故这里从 fixture 原文一路走到
+// DOM 断言（validate → sanitize → SDK render），而不是只测消毒层返回值。
+
+import { beforeAll, describe, expect, it } from "vitest";
+import reasoningCard from "../fixtures/ai-reasoning-process-0.4.json";
+import { renderOctoCard } from "../sdk/renderOctoCard";
+import { validateCardForOcto } from "../validateCardForOcto";
+
+beforeAll(() => {
+  if (!window.matchMedia) {
+    (window as any).matchMedia = () => ({
+      matches: false,
+      addEventListener() {},
+      removeEventListener() {},
+    });
+  }
+});
+
+function mountTarget(): HTMLDivElement {
+  const div = document.createElement("div");
+  document.body.appendChild(div);
+  return div;
+}
+
+function renderReasoningCard(): HTMLDivElement {
+  const target = mountTarget();
+  renderOctoCard({
+    card: reasoningCard as unknown as Record<string, unknown>,
+    target,
+    onAction: () => {},
+  });
+  return target;
+}
+
+describe("ai.reasoning-process 卡片：内联 SVG 折叠图标", () => {
+  it("整卡通过 octo 预校验（不降级为 plain）", () => {
+    expect(
+      validateCardForOcto(reasoningCard as unknown as Record<string, unknown>)
+        .ok
+    ).toBe(true);
+  });
+
+  it("四个 chevron 图标渲成 data:image/svg+xml 的 <img>", () => {
+    const imgs = Array.from(
+      renderReasoningCard().querySelectorAll<HTMLImageElement>("img")
+    );
+    // reasoning 折叠 2 个（collapsed/expanded）+ phase 0 工具折叠 2 个。
+    expect(imgs).toHaveLength(4);
+    for (const img of imgs) {
+      expect(img.getAttribute("src")).toMatch(/^data:image\/svg\+xml,%3Csvg/);
+    }
+  });
+
+  it("图标的 altText 与 ToggleVisibility 可点性保留", () => {
+    const target = renderReasoningCard();
+    const alts = Array.from(
+      target.querySelectorAll<HTMLImageElement>("img")
+    ).map((img) => img.getAttribute("alt"));
+    expect(alts).toEqual(
+      expect.arrayContaining(["展开", "收起", "展开工具", "收起工具"])
+    );
+    // selectAction 使图片成为可激活元素（SDK 给可点元素加 role/tabindex）。
+    const clickable = target.querySelectorAll(
+      'img[role="button"], [role="button"] img, img[tabindex]'
+    );
+    expect(clickable.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/dmworkbase/src/Messages/InteractiveCard/__tests__/inlineImageUrl.test.ts
+++ b/packages/dmworkbase/src/Messages/InteractiveCard/__tests__/inlineImageUrl.test.ts
@@ -139,7 +139,177 @@ describe("isSafeInlineImageDataUrl — SVG 源内容（decode 后）", () => {
       isSafeInlineImageDataUrl("data:image/svg+xml,<svg>%3Cscr\tipt%3E</svg>")
     ).toBe(false);
   });
+});
 
+// 以下三组回归自 PR #1300 的评审：每条都是评审提出、我实测确认能通过旧实现的向量。
+describe("isSafeInlineImageDataUrl — 文档根必须是 SVG", () => {
+  it.each([
+    ["<html><body><svg/></body></html>", "wrapper 文档里藏 svg"],
+    ["<html><svg/></html>", "html 根"],
+    ["x<svg/>", "根前有文本"],
+    ["<foo><svg/></foo>", "任意元素根"],
+  ])("%s（%s）被拒", (svg) => {
+    expect(isSafeInlineImageDataUrl(svgDataUrl(svg))).toBe(false);
+  });
+
+  it.each([
+    ['<?xml version="1.0" encoding="UTF-8"?><svg xmlns="x"/>', "XML 声明前导"],
+    ["<!-- icon: chevron --><svg xmlns=x/>", "注释前导"],
+    ["   <svg xmlns=x/>", "空白前导"],
+    ["<?xml version=1.0?><!-- c --> <svg xmlns=x/>", "声明+注释+空白混合"],
+  ])("%s（%s）放行", (svg) => {
+    expect(isSafeInlineImageDataUrl(svgDataUrl(svg))).toBe(true);
+  });
+
+  it("未闭合的前导注释不能吞掉根判定", () => {
+    expect(isSafeInlineImageDataUrl(svgDataUrl("<!-- <svg/>"))).toBe(false);
+  });
+});
+
+describe("isSafeInlineImageDataUrl — 非 ASCII 命名空间前缀", () => {
+  // JS 的 \w 只含 ASCII，而 XML NameStartChar 允许 ñ 这类字符，
+  // `<ñ:script>` 与 `<script>` 等价。ASCII 前缀早已被拦，非 ASCII 变体曾漏网。
+  it.each([
+    ["<svg xmlns=x xmlns:ñ=x><ñ:script>alert`1`</ñ:script></svg>", "ñ:script"],
+    ["<svg xmlns=x><日:foreignObject/></svg>", "中日文前缀 foreignObject"],
+    ["<svg xmlns=x><ñ:use/></svg>", "ñ:use"],
+  ])("%s（%s）被拒", (svg) => {
+    expect(isSafeInlineImageDataUrl(svgDataUrl(svg))).toBe(false);
+  });
+});
+
+describe("isSafeInlineImageDataUrl — 属性合成与外部引用", () => {
+  it.each([
+    // SMIL：attributeName 指向事件/链接属性，从不写出字面 `on…=`
+    [
+      "<svg xmlns=x><set attributeName=onload to=alert`1`/></svg>",
+      "set → onload",
+    ],
+    [
+      '<svg xmlns=x><animate attributeName="onbegin" to="x"/></svg>',
+      "animate → onbegin",
+    ],
+    [
+      '<svg xmlns=x><animateTransform attributeName="href" to="x"/></svg>',
+      "animateTransform → href",
+    ],
+    // CSS 外部引用
+    ["<svg xmlns=x><style>@import //evil/x.css;</style></svg>", "@import"],
+    [
+      "<svg xmlns=x><style>rect{fill:url%23x}</style></svg>".replace(
+        "url%23x",
+        "url(https://evil/a.png)"
+      ),
+      "css url(https:)",
+    ],
+    // 外部内容元素
+    ["<svg xmlns=x><object data=//evil/></svg>", "object"],
+    ["<svg xmlns=x><embed src=//evil/></svg>", "embed"],
+    ["<svg xmlns=x><link rel=stylesheet href=//evil/></svg>", "link"],
+  ])("%s（%s）被拒", (svg) => {
+    expect(isSafeInlineImageDataUrl(svgDataUrl(svg))).toBe(false);
+  });
+
+  it("正常动画与同文档引用不被误拒", () => {
+    // attributeName 指向无害属性、url(#local) 引用同文档渐变 —— 都是图标常见写法。
+    const animated =
+      '<svg xmlns=x><animate attributeName="opacity" from="0" to="1"/></svg>';
+    expect(isSafeInlineImageDataUrl(svgDataUrl(animated))).toBe(true);
+    const localRef =
+      "<svg xmlns=x><style>rect{fill:url%28%23g%29}</style></svg>";
+    expect(
+      isSafeInlineImageDataUrl(
+        `data:image/svg+xml,${encodeURIComponent(localRef).replace(
+          /%2523/g,
+          "%23"
+        )}`
+      )
+    ).toBe(true);
+  });
+});
+
+describe("isSafeInlineImageDataUrl — 字节视图 vs 解析器视图", () => {
+  it("UTF-16LE + ASCII 诱饵的 base64 payload 被拒", () => {
+    // 注释里放码位使其 LE 字节拼出 "<svg/>"，骗过按字节扫描的根判定，
+    // 真正的 <script> 被 NUL 间隔从而匹配不到任何 deny 模式。
+    const decoy = "猼杶㸯"; // LE bytes: 3C 73 76 67 2F 3E
+    const doc = `<!--${decoy}--><svg xmlns="x"><script>alert\`1\`</script></svg>`;
+    const bytes: number[] = [];
+    for (const ch of doc) {
+      const c = ch.codePointAt(0) as number;
+      bytes.push(c & 0xff, (c >> 8) & 0xff);
+    }
+    const b64 = btoa(String.fromCharCode(...bytes));
+    // 前提复现：latin1 字节视图确实含诱饵、且不含 script
+    const latin1 = atob(b64);
+    expect(latin1.includes("<svg/>")).toBe(true);
+    expect(latin1.includes("script")).toBe(false);
+    // NUL 检查掐掉整类视图分歧
+    expect(isSafeInlineImageDataUrl(`data:image/svg+xml;base64,${b64}`)).toBe(
+      false
+    );
+  });
+
+  it("percent-encoded 的 NUL 同样被拒", () => {
+    expect(
+      isSafeInlineImageDataUrl("data:image/svg+xml,%3Csvg%20xmlns=x%00%2F%3E")
+    ).toBe(false);
+  });
+});
+
+describe("isSafeInlineImageDataUrl — 生产者编码契约（P2-2，行为钉死）", () => {
+  // encodeURIComponent 默认保留 !'()*，所以带括号的图标只做 encodeURIComponent 会被拒。
+  // 这是有意的（layer 1 要守住 backgroundImage 的 CSS 上下文），此处把契约钉成测试：
+  // 生产者必须完整编码或改用 base64。
+  const ICON =
+    '<svg xmlns="http://www.w3.org/2000/svg"><g transform="translate(2 2)"><path d="M0 0"/></g></svg>';
+
+  it("仅 encodeURIComponent（残留裸括号）→ 拒", () => {
+    expect(
+      isSafeInlineImageDataUrl(`data:image/svg+xml,${encodeURIComponent(ICON)}`)
+    ).toBe(false);
+  });
+
+  it("完整 percent-encode（含 !'()*）→ 放行", () => {
+    const full = encodeURIComponent(ICON).replace(
+      /[!'()*]/g,
+      (c) => `%${c.charCodeAt(0).toString(16).toUpperCase()}`
+    );
+    expect(isSafeInlineImageDataUrl(`data:image/svg+xml,${full}`)).toBe(true);
+  });
+
+  it("base64 → 放行", () => {
+    expect(
+      isSafeInlineImageDataUrl(`data:image/svg+xml;base64,${btoa(ICON)}`)
+    ).toBe(true);
+  });
+});
+
+describe("isSafeInlineImageDataUrl — base64 参数位置", () => {
+  it("base64 非末位被拒（浏览器会 percent-decode，我们会 atob，两侧字节不一致）", () => {
+    expect(
+      isSafeInlineImageDataUrl(
+        "data:image/svg+xml;base64;charset=utf-8,PHN2Zy8+"
+      )
+    ).toBe(false);
+  });
+
+  it("base64 重复出现被拒", () => {
+    expect(
+      isSafeInlineImageDataUrl("data:image/svg+xml;base64;base64,PHN2Zy8+")
+    ).toBe(false);
+  });
+
+  it("charset 在前、base64 末位 → 放行", () => {
+    expect(
+      isSafeInlineImageDataUrl(
+        `data:image/svg+xml;charset=utf-8;base64,${btoa('<svg xmlns="x"/>')}`
+      )
+    ).toBe(true);
+  });
+});
+
+describe("isSafeInlineImageDataUrl — 编码与参数（decode 前后）", () => {
   it("base64 形的恶意 SVG 同样被拒（解码后再检查）", () => {
     const evil = btoa("<svg onload=alert(1)/>");
     expect(isSafeInlineImageDataUrl(`data:image/svg+xml;base64,${evil}`)).toBe(

--- a/packages/dmworkbase/src/Messages/InteractiveCard/__tests__/inlineImageUrl.test.ts
+++ b/packages/dmworkbase/src/Messages/InteractiveCard/__tests__/inlineImageUrl.test.ts
@@ -1,0 +1,182 @@
+// 内联图片 data URL 白名单：仅 image/svg+xml，且 URL 字面量与 SVG 源双层校验。
+
+import { describe, expect, it } from "vitest";
+import {
+  MAX_INLINE_IMAGE_DATA_URL_LENGTH,
+  isSafeInlineImageDataUrl,
+} from "../sdk/inlineImageUrl";
+
+/** 把 SVG 源编码成 percent-encoded data URL（与服务端模板产物同形）。 */
+function svgDataUrl(svg: string): string {
+  return `data:image/svg+xml,${encodeURIComponent(svg)}`;
+}
+
+/** 生产模板实际下发的 chevron-down（附件卡片原文，逐字节复制）。 */
+const CHEVRON_DOWN =
+  "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%221em%22%20height%3D%221em%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22%23a1a6ab%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%222%22%20d%3D%22m6%209l6%206l6-6%22%2F%3E%3C%2Fsvg%3E";
+
+describe("isSafeInlineImageDataUrl — 放行", () => {
+  it("生产模板的 chevron data URL 通过", () => {
+    expect(isSafeInlineImageDataUrl(CHEVRON_DOWN)).toBe(true);
+  });
+
+  it("带 charset 参数 / base64 编码均通过", () => {
+    const svg =
+      '<svg xmlns="http://www.w3.org/2000/svg"><path d="M0 0"/></svg>';
+    expect(
+      isSafeInlineImageDataUrl(
+        `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg)}`
+      )
+    ).toBe(true);
+    expect(
+      isSafeInlineImageDataUrl(
+        `data:image/svg+xml;base64,${btoa(svg)}` // base64 不含 URL 危险字符
+      )
+    ).toBe(true);
+  });
+
+  it("MIME 大小写不敏感", () => {
+    expect(
+      isSafeInlineImageDataUrl(
+        `DATA:IMAGE/SVG+XML,${encodeURIComponent("<svg/>")}`
+      )
+    ).toBe(true);
+  });
+});
+
+describe("isSafeInlineImageDataUrl — MIME 白名单（服务端仅开 svg+xml）", () => {
+  it.each([
+    ["data:image/png;base64,iVBORw0KGgo=", "位图 png"],
+    ["data:image/gif;base64,R0lGODlhAQABAAAAACw=", "位图 gif"],
+    ["data:image/webp;base64,UklGRgA=", "位图 webp"],
+    ["data:text/html,%3Ch1%3Ex%3C%2Fh1%3E", "text/html"],
+    ["data:application/javascript,alert(1)", "js"],
+    ["data:,%3Csvg%2F%3E", "空 MIME"],
+    ["data:image/svg+xmlx,%3Csvg%2F%3E", "MIME 后缀污染"],
+    ["data:image/svg%2bxml,%3Csvg%2F%3E", "MIME 本身被编码"],
+  ])("%s（%s）被拒", (url) => {
+    expect(isSafeInlineImageDataUrl(url)).toBe(false);
+  });
+
+  it("非 data: scheme 一律走别处判断，此函数拒绝", () => {
+    expect(isSafeInlineImageDataUrl("https://cdn/a.svg")).toBe(false);
+    expect(isSafeInlineImageDataUrl("javascript:alert(1)")).toBe(false);
+    expect(isSafeInlineImageDataUrl("")).toBe(false);
+  });
+});
+
+describe("isSafeInlineImageDataUrl — URL 字面量危险字符", () => {
+  // backgroundImage 会被 SDK 拼进 CSS url('…')；引号/括号/反斜杠/空白可逃逸出该上下文。
+  it.each([
+    [`data:image/svg+xml,<svg xmlns='x'/>`, "单引号"],
+    [`data:image/svg+xml,<svg xmlns="x"/>`, "双引号"],
+    ["data:image/svg+xml,<svg/>)", "右括号"],
+    ["data:image/svg+xml,<svg (/>", "左括号"],
+    ["data:image/svg+xml,<svg\\/>", "反斜杠"],
+    ["data:image/svg+xml,<svg />", "空格"],
+    ["data:image/svg+xml,<svg\n/>", "换行"],
+    ["data:image/svg+xml,<svg\t/>", "制表符"],
+  ])("%s（%s）被拒", (url) => {
+    expect(isSafeInlineImageDataUrl(url)).toBe(false);
+  });
+});
+
+describe("isSafeInlineImageDataUrl — SVG 源内容（decode 后）", () => {
+  it.each([
+    [
+      '<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>',
+      "script 标签",
+    ],
+    [
+      "<svg><foreignObject><body>x</body></foreignObject></svg>",
+      "foreignObject",
+    ],
+    ['<svg><iframe src="//evil"/></svg>', "iframe"],
+    ['<svg><use href="//evil/x.svg#a"/></svg>', "use 外部引用"],
+    ['<svg><image href="//evil/track.png"/></svg>', "image 外部位图"],
+    ['<svg onload="alert(1)"/>', "事件属性"],
+    [
+      '<svg><a href="javascript:alert(1)"><rect/></a></svg>',
+      "javascript: 链接",
+    ],
+    ['<svg><a href="https://evil"/></svg>', "外部 href"],
+    ['<!DOCTYPE svg [<!ENTITY a "b">]><svg/>', "DTD / 实体（XXE）"],
+    ["<html><body>x</body></html>", "不是 SVG"],
+    ["", "空 payload"],
+    // 命名空间前缀：SVG 走 XML 解析，`<svg:script>` 等价于 `<script>`。
+    ["<svg><svg:script>alert(1)</svg:script></svg>", "带前缀的 script"],
+    [
+      '<svg xmlns:x="http://www.w3.org/2000/svg"><x:script>alert(1)</x:script></svg>',
+      "自定义前缀的 script",
+    ],
+    [
+      "<svg><a:foreignObject><body/></a:foreignObject></svg>",
+      "带前缀的 foreignObject",
+    ],
+    ['<svg><n:use href="//evil/x.svg#a"/></svg>', "带前缀的 use"],
+    ['<svg><n:image href="//evil/t.png"/></svg>', "带前缀的 image"],
+    // XML 字符实体：属性值里可编码绕过关键词匹配（`&#106;avascript:`）。
+    [
+      '<svg><a href="&#106;avascript:alert(1)">x</a></svg>',
+      "实体编码的 javascript:",
+    ],
+    ['<svg><a href="&#104;ttps://evil">x</a></svg>', "实体编码的外部 href"],
+    ['<svg><a ev:onload="alert(1)"/></svg>', "带前缀的事件属性"],
+    ['<svg><a xlink:href="#local"/></svg>', "任何 href 属性（图标不需要）"],
+  ])("%s（%s）被拒", (svg) => {
+    expect(isSafeInlineImageDataUrl(svgDataUrl(svg))).toBe(false);
+  });
+
+  it("非 ASCII 字符被拒（保证长度上限按字节生效）", () => {
+    // 未编码的多字节字符会让 url.length < UTF-8 字节数，绕过体积上限。
+    expect(isSafeInlineImageDataUrl("data:image/svg+xml,<svg>中</svg>")).toBe(
+      false
+    );
+  });
+
+  it("URL 内的裸 \\t / \\n 被拒（浏览器会剥除，可用于拆散关键词）", () => {
+    expect(
+      isSafeInlineImageDataUrl("data:image/svg+xml,<svg>%3Cscr\tipt%3E</svg>")
+    ).toBe(false);
+  });
+
+  it("base64 形的恶意 SVG 同样被拒（解码后再检查）", () => {
+    const evil = btoa("<svg onload=alert(1)/>");
+    expect(isSafeInlineImageDataUrl(`data:image/svg+xml;base64,${evil}`)).toBe(
+      false
+    );
+  });
+
+  it("损坏的编码（非法 percent / 非法 base64）被拒", () => {
+    expect(isSafeInlineImageDataUrl("data:image/svg+xml,%ZZ")).toBe(false);
+    expect(isSafeInlineImageDataUrl("data:image/svg+xml;base64,!!!")).toBe(
+      false
+    );
+  });
+
+  it("未知 data URL 参数被拒", () => {
+    expect(
+      isSafeInlineImageDataUrl(
+        `data:image/svg+xml;charset=utf-16,${encodeURIComponent("<svg/>")}`
+      )
+    ).toBe(false);
+  });
+});
+
+describe("isSafeInlineImageDataUrl — 体积上限", () => {
+  it("超长 data URL 被拒（防 payload 膨胀）", () => {
+    const filler = "0".repeat(MAX_INLINE_IMAGE_DATA_URL_LENGTH);
+    const url = svgDataUrl(`<svg><path d="${filler}"/></svg>`);
+    expect(url.length).toBeGreaterThan(MAX_INLINE_IMAGE_DATA_URL_LENGTH);
+    expect(isSafeInlineImageDataUrl(url)).toBe(false);
+  });
+
+  it("恰好达到上限的 data URL 仍通过", () => {
+    const head = svgDataUrl("<svg><path d=/></svg>");
+    // path 数据里补到刚好等于上限（encodeURIComponent 不转义数字，1 字符 = 1 字节）。
+    const pad = "0".repeat(MAX_INLINE_IMAGE_DATA_URL_LENGTH - head.length);
+    const url = head.replace("d%3D", `d%3D${pad}`);
+    expect(url.length).toBe(MAX_INLINE_IMAGE_DATA_URL_LENGTH);
+    expect(isSafeInlineImageDataUrl(url)).toBe(true);
+  });
+});

--- a/packages/dmworkbase/src/Messages/InteractiveCard/__tests__/sanitizeCardTree.test.ts
+++ b/packages/dmworkbase/src/Messages/InteractiveCard/__tests__/sanitizeCardTree.test.ts
@@ -1,6 +1,6 @@
 // sanitizeCardTree：图片面 URL 白名单消毒（喂 SDK 前）。不可变、不动 Action.OpenUrl.url。
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { sanitizeCardTree } from "../sdk/sanitizeCardTree";
 
 /** 模板内联图标（受限 data URL 白名单，详见 inlineImageUrl.test.ts）。 */
@@ -124,6 +124,65 @@ describe("sanitizeCardTree — 图片面白名单（https + 内联 SVG）", () =
     const snapshot = JSON.stringify(input);
     sanitizeCardTree(input);
     expect(JSON.stringify(input)).toBe(snapshot); // 原对象未被修改
+  });
+
+  it("被剥除的图片 URL 在 DEV 下有 console.warn（避免又一次静默丢图标）", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      sanitizeCardTree({
+        type: "AdaptiveCard",
+        body: [{ type: "Image", url: "http://evil/track.png" }],
+      });
+      expect(warn).toHaveBeenCalledTimes(1);
+      expect(String(warn.mock.calls[0][0])).toContain("Image.url");
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("合规 URL 不产生噪音", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      sanitizeCardTree({
+        type: "AdaptiveCard",
+        body: [
+          { type: "Image", url: "https://cdn/a.png" },
+          { type: "Image", url: SAFE_SVG_DATA_URL },
+        ],
+      });
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+    }
+  });
+});
+
+describe("sanitizeCardTree — __proto__ 不得复活被剥除的键", () => {
+  it("输入里 __proto__ 携带的 url 不出现在输出上", () => {
+    // out[key] = … 会命中原型 setter，把 url 从原型链上「复活」：消毒后的节点
+    // 会暴露输入里并不存在的键。内层对象没有 type:"Image"，url 门根本不会作用于它。
+    const input = JSON.parse(
+      '{"type":"AdaptiveCard","body":[{"type":"Image","altText":"x","__proto__":{"url":"javascript:alert(1)"}}]}'
+    );
+    expect(input.body[0].url).toBeUndefined(); // 前提：输入上读不到 url
+
+    const out = sanitizeCardTree(input) as any;
+    expect(out.body[0].url).toBeUndefined(); // 输出同样读不到
+    expect(out.body[0].altText).toBe("x"); // 其余字段不受影响
+    // 全局原型未被污染
+    expect(({} as any).url).toBeUndefined();
+  });
+
+  it("输出对象仍保有正常原型（SDK internalParse 依赖 hasOwnProperty）", () => {
+    // 这也是不能用 Object.create(null) 修上一条的原因：无原型对象上
+    // source.hasOwnProperty(...) 不存在，SDK 解析会直接抛。
+    const out = sanitizeCardTree({
+      type: "AdaptiveCard",
+      body: [{ type: "Image", url: "https://cdn/a.png" }],
+    }) as any;
+    expect(typeof out.hasOwnProperty).toBe("function");
+    expect(typeof out.body[0].hasOwnProperty).toBe("function");
+    expect(out.body[0].hasOwnProperty("url")).toBe(true);
   });
 });
 

--- a/packages/dmworkbase/src/Messages/InteractiveCard/__tests__/sanitizeCardTree.test.ts
+++ b/packages/dmworkbase/src/Messages/InteractiveCard/__tests__/sanitizeCardTree.test.ts
@@ -1,9 +1,14 @@
-// sanitizeCardTree：图片类 URL https-only 消毒（喂 SDK 前）。不可变、不动 Action.OpenUrl.url。
+// sanitizeCardTree：图片面 URL 白名单消毒（喂 SDK 前）。不可变、不动 Action.OpenUrl.url。
 
 import { describe, expect, it } from "vitest";
 import { sanitizeCardTree } from "../sdk/sanitizeCardTree";
 
-describe("sanitizeCardTree — 图片面 https-only", () => {
+/** 模板内联图标（受限 data URL 白名单，详见 inlineImageUrl.test.ts）。 */
+const SAFE_SVG_DATA_URL = `data:image/svg+xml,${encodeURIComponent(
+  '<svg xmlns="http://www.w3.org/2000/svg"><path d="m6 9l6 6l6-6"/></svg>'
+)}`;
+
+describe("sanitizeCardTree — 图片面白名单（https + 内联 SVG）", () => {
   it("Image.url 非 https → 剥除；https → 保留", () => {
     const httpImg = sanitizeCardTree({
       type: "AdaptiveCard",
@@ -19,19 +24,30 @@ describe("sanitizeCardTree — 图片面 https-only", () => {
     expect(httpsImg.body[0].url).toBe("https://cdn/a.png");
   });
 
-  it("data:/javascript: Image.url → 剥除（无 scheme 逃逸）", () => {
+  it("受限 SVG data URL 保留；不合白名单的 data:/javascript: → 剥除", () => {
     const out = sanitizeCardTree({
       type: "AdaptiveCard",
       body: [
-        { type: "Image", url: "data:image/svg+xml,<svg/>" },
+        { type: "Image", url: SAFE_SVG_DATA_URL },
+        { type: "Image", url: "data:text/html,%3Ch1%3Ex%3C%2Fh1%3E" },
+        { type: "Image", url: "data:image/png;base64,iVBORw0KGgo=" },
+        {
+          type: "Image",
+          url: `data:image/svg+xml,${encodeURIComponent(
+            '<svg onload="alert(1)"/>'
+          )}`,
+        },
         { type: "Image", url: "javascript:alert(1)" },
       ],
     }) as any;
-    expect(out.body[0].url).toBeUndefined();
-    expect(out.body[1].url).toBeUndefined();
+    expect(out.body[0].url).toBe(SAFE_SVG_DATA_URL); // 内联图标照渲
+    expect(out.body[1].url).toBeUndefined(); // text/html
+    expect(out.body[2].url).toBeUndefined(); // 位图 data URL（服务端未开）
+    expect(out.body[3].url).toBeUndefined(); // 带事件属性的 SVG
+    expect(out.body[4].url).toBeUndefined(); // javascript:
   });
 
-  it("backgroundImage 字符串与 {url} 两形 → 非 https 剥除、https 保留", () => {
+  it("backgroundImage 字符串与 {url} 两形 → 不合白名单剥除、合规保留", () => {
     const out = sanitizeCardTree({
       type: "AdaptiveCard",
       backgroundImage: "http://evil/bg.png",
@@ -42,14 +58,23 @@ describe("sanitizeCardTree — 图片面 https-only", () => {
           backgroundImage: { url: "http://evil/bg2.png", fillMode: "cover" },
           columns: [],
         },
+        {
+          type: "Container",
+          items: [],
+          backgroundImage: { url: SAFE_SVG_DATA_URL, fillMode: "repeat" },
+        },
       ],
     }) as any;
     expect(out.backgroundImage).toBeUndefined(); // 根 http 背景剥除
     expect(out.body[0].backgroundImage).toBe("https://cdn/bg.png"); // https 字符串保留
     expect(out.body[1].backgroundImage).toBeUndefined(); // {url} http 剥除
+    expect(out.body[2].backgroundImage).toEqual({
+      url: SAFE_SVG_DATA_URL,
+      fillMode: "repeat",
+    }); // {url} 内联 SVG 保留
   });
 
-  it("Action.*.iconUrl 非 https → 剥除；但 Action.OpenUrl.url（导航面）不动", () => {
+  it("Action.*.iconUrl 非白名单 → 剥除；但 Action.OpenUrl.url（导航面）不动", () => {
     const out = sanitizeCardTree({
       type: "AdaptiveCard",
       body: [{ type: "TextBlock", text: "x" }],
@@ -65,11 +90,17 @@ describe("sanitizeCardTree — 图片面 https-only", () => {
           id: "ok",
           iconUrl: "https://cdn/icon.png", // https 图标保留
         },
+        {
+          type: "Action.Submit",
+          id: "inline",
+          iconUrl: SAFE_SVG_DATA_URL, // 内联 SVG 图标保留
+        },
       ],
     }) as any;
     expect(out.actions[0].url).toBe("http://example.com/page"); // 导航 url 不动
     expect(out.actions[0].iconUrl).toBeUndefined(); // icon http 剥除
     expect(out.actions[1].iconUrl).toBe("https://cdn/icon.png");
+    expect(out.actions[2].iconUrl).toBe(SAFE_SVG_DATA_URL);
   });
 
   it("嵌套（Container>Image）也被消毒", () => {
@@ -136,7 +167,7 @@ describe("sanitizeCardTree — 剥除 fallback / requires（SDK 渲染面收敛�
     expect(out.body[0].items[0].fallback).toBeUndefined();
   });
 
-  it("fallback:\"drop\" 字符串形也被剥除", () => {
+  it('fallback:"drop" 字符串形也被剥除', () => {
     const out = sanitizeCardTree({
       type: "AdaptiveCard",
       body: [{ type: "Image", url: "https://cdn/a.png", fallback: "drop" }],

--- a/packages/dmworkbase/src/Messages/InteractiveCard/fixtures/ai-reasoning-process-0.4.json
+++ b/packages/dmworkbase/src/Messages/InteractiveCard/fixtures/ai-reasoning-process-0.4.json
@@ -1,0 +1,278 @@
+{
+  "body": [
+    {
+      "items": [
+        {
+          "columns": [
+            {
+              "items": [
+                {
+                  "columns": [
+                    {
+                      "items": [
+                        {
+                          "size": "Small",
+                          "spacing": "None",
+                          "text": "Reasoning",
+                          "type": "TextBlock",
+                          "weight": "Bolder",
+                          "wrap": true
+                        }
+                      ],
+                      "type": "Column",
+                      "width": "auto"
+                    },
+                    {
+                      "items": [
+                        {
+                          "altText": "展开",
+                          "id": "reasoning_toggle_collapsed",
+                          "isVisible": false,
+                          "selectAction": {
+                            "id": "reasoning_toggle",
+                            "targetElements": [
+                              "trace_panel",
+                              "collapsed_panel",
+                              "reasoning_toggle_collapsed",
+                              "reasoning_toggle_expanded"
+                            ],
+                            "type": "Action.ToggleVisibility"
+                          },
+                          "size": "Small",
+                          "spacing": "None",
+                          "type": "Image",
+                          "url": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%221em%22%20height%3D%221em%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22%23a1a6ab%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%222%22%20d%3D%22m6%209l6%206l6-6%22%2F%3E%3C%2Fsvg%3E",
+                          "width": "14px"
+                        },
+                        {
+                          "altText": "收起",
+                          "id": "reasoning_toggle_expanded",
+                          "isVisible": true,
+                          "selectAction": {
+                            "id": "reasoning_toggle_expanded_action",
+                            "targetElements": [
+                              "trace_panel",
+                              "collapsed_panel",
+                              "reasoning_toggle_collapsed",
+                              "reasoning_toggle_expanded"
+                            ],
+                            "type": "Action.ToggleVisibility"
+                          },
+                          "size": "Small",
+                          "spacing": "None",
+                          "type": "Image",
+                          "url": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%221em%22%20height%3D%221em%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22%23a1a6ab%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%222%22%20d%3D%22m18%2015l-6-6l-6%206%22%2F%3E%3C%2Fsvg%3E",
+                          "width": "14px"
+                        }
+                      ],
+                      "type": "Column",
+                      "verticalContentAlignment": "Center",
+                      "width": "auto"
+                    }
+                  ],
+                  "spacing": "None",
+                  "type": "ColumnSet"
+                },
+                {
+                  "color": "Accent",
+                  "size": "Small",
+                  "spacing": "None",
+                  "text": "Thinking",
+                  "type": "TextBlock",
+                  "wrap": true
+                }
+              ],
+              "type": "Column",
+              "width": "stretch"
+            }
+          ],
+          "id": "reasoning_header",
+          "spacing": "None",
+          "type": "ColumnSet"
+        },
+        {
+          "id": "trace_panel",
+          "isVisible": true,
+          "items": [
+            {
+              "id": "reasoning_phase_0",
+              "items": [
+                {
+                  "columns": [
+                    {
+                      "items": [
+                        {
+                          "size": "Small",
+                          "spacing": "None",
+                          "text": "Check the environment before answering.",
+                          "type": "TextBlock",
+                          "wrap": true
+                        }
+                      ],
+                      "type": "Column",
+                      "verticalContentAlignment": "Center",
+                      "width": "stretch"
+                    },
+                    {
+                      "items": [
+                        {
+                          "altText": "展开工具",
+                          "id": "reasoning_tools_toggle_collapsed_0",
+                          "isVisible": true,
+                          "selectAction": {
+                            "id": "reasoning_tools_toggle_action_0",
+                            "targetElements": [
+                              "reasoning_tools_panel_0",
+                              "reasoning_tools_toggle_collapsed_0",
+                              "reasoning_tools_toggle_expanded_0"
+                            ],
+                            "type": "Action.ToggleVisibility"
+                          },
+                          "size": "Small",
+                          "spacing": "None",
+                          "type": "Image",
+                          "url": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%221em%22%20height%3D%221em%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22%23a1a6ab%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%222%22%20d%3D%22m6%209l6%206l6-6%22%2F%3E%3C%2Fsvg%3E",
+                          "width": "14px"
+                        },
+                        {
+                          "altText": "收起工具",
+                          "id": "reasoning_tools_toggle_expanded_0",
+                          "isVisible": false,
+                          "selectAction": {
+                            "id": "reasoning_tools_toggle_expanded_action_0",
+                            "targetElements": [
+                              "reasoning_tools_panel_0",
+                              "reasoning_tools_toggle_collapsed_0",
+                              "reasoning_tools_toggle_expanded_0"
+                            ],
+                            "type": "Action.ToggleVisibility"
+                          },
+                          "size": "Small",
+                          "spacing": "None",
+                          "type": "Image",
+                          "url": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%221em%22%20height%3D%221em%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22%23a1a6ab%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%222%22%20d%3D%22m18%2015l-6-6l-6%206%22%2F%3E%3C%2Fsvg%3E",
+                          "width": "14px"
+                        }
+                      ],
+                      "type": "Column",
+                      "verticalContentAlignment": "Center",
+                      "width": "auto"
+                    }
+                  ],
+                  "spacing": "None",
+                  "type": "ColumnSet"
+                },
+                {
+                  "id": "reasoning_tools_panel_0",
+                  "isVisible": false,
+                  "items": [
+                    {
+                      "columns": [
+                        {
+                          "items": [],
+                          "type": "Column",
+                          "width": "8px"
+                        },
+                        {
+                          "items": [
+                            {
+                              "color": "Accent",
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "●",
+                              "type": "TextBlock"
+                            }
+                          ],
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "exec",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "auto"
+                        },
+                        {
+                          "items": [
+                            {
+                              "isSubtle": true,
+                              "size": "Small",
+                              "spacing": "None",
+                              "text": "sleep",
+                              "type": "TextBlock",
+                              "wrap": true
+                            }
+                          ],
+                          "spacing": "Small",
+                          "type": "Column",
+                          "verticalContentAlignment": "Center",
+                          "width": "stretch"
+                        }
+                      ],
+                      "spacing": "None",
+                      "type": "ColumnSet"
+                    }
+                  ],
+                  "spacing": "Small",
+                  "type": "Container"
+                }
+              ],
+              "spacing": "None",
+              "type": "Container"
+            },
+            {
+              "color": "Accent",
+              "size": "Small",
+              "spacing": "Medium",
+              "text": "◌  Working through…",
+              "type": "TextBlock",
+              "wrap": true
+            }
+          ],
+          "spacing": "Medium",
+          "type": "Container"
+        },
+        {
+          "id": "collapsed_panel",
+          "isVisible": false,
+          "items": [
+            {
+              "isSubtle": true,
+              "size": "Small",
+              "spacing": "None",
+              "text": "Reasoning in progress · open to follow along",
+              "type": "TextBlock",
+              "wrap": true
+            }
+          ],
+          "spacing": "Small",
+          "type": "Container"
+        }
+      ],
+      "spacing": "None",
+      "style": "emphasis",
+      "type": "Container"
+    }
+  ],
+  "metadata": {
+    "octo": {
+      "protocol": "octo-card@1.0",
+      "template": {
+        "id": "ai.reasoning-process",
+        "version": "0.4.0"
+      }
+    }
+  },
+  "type": "AdaptiveCard",
+  "version": "1.5"
+}

--- a/packages/dmworkbase/src/Messages/InteractiveCard/sdk/inlineImageUrl.ts
+++ b/packages/dmworkbase/src/Messages/InteractiveCard/sdk/inlineImageUrl.ts
@@ -8,22 +8,31 @@
  *
  * 安全模型（三层，任一不过即拒）：
  *
- * 1. **URL 字面量**：长度上限 + 禁危险字符。`Image.url` 由 SDK 赋给 `img.src`（DOM API，
+ * 1. **URL 字面量**：长度上限 + 字符白名单。`Image.url` 由 SDK 赋给 `img.src`（DOM API，
  *    无注入面），但容器 `backgroundImage` 会被拼进 CSS `background-image: url('…')`——
- *    引号/括号/反斜杠/空白可逃逸该上下文并注入额外 CSS 声明。合法的 percent-encoded /
- *    base64 data URL 天然不含这些字符，故统一按最严口径设防，一份规则覆盖
- *    `Image.url` / `Action.iconUrl` / `backgroundImage` 三个面。
+ *    引号/括号/反斜杠/空白可逃逸该上下文并注入额外 CSS 声明。一份规则覆盖
+ *    `Image.url` / `Action.iconUrl` / `backgroundImage` 三个面，按最严口径设防。
+ *
+ *    **生产者契约**：SVG 必须**完整** percent-encode 或改用 base64。注意
+ *    `encodeURIComponent` 默认保留 `!'()*`，所以带 `transform="translate(2 2)"`、
+ *    `fill="url(#g)"`、`clip-path` 的图标只做 `encodeURIComponent` 会被拒——须额外
+ *    编码这几个字符，或直接 `;base64`。被拒时 DEV 下有 `console.warn`（见
+ *    sanitizeCardTree），不再像修复前那样静默丢图标。
  *
  * 2. **MIME 与参数**：只放 `image/svg+xml`（对齐服务端），参数段仅允许
- *    `base64` / `charset=utf-8` / `charset=us-ascii`。位图 data URL、`text/html`、
- *    空 MIME、MIME 后缀污染（`image/svg+xmlx`）一律拒。
+ *    `charset=utf-8` / `charset=us-ascii` 与末位唯一的 `base64`。位图 data URL、
+ *    `text/html`、空 MIME、MIME 后缀污染（`image/svg+xmlx`）一律拒。
  *
- * 3. **SVG 源**：decode 后必须确实是 SVG，且不含脚本 / 事件属性 / 外部引用
- *    （`use`、`image`、任何 `href`）/ `foreignObject` / DTD 实体 / XML 字符实体。
- *    元素名一律容许命名空间前缀（`<svg:script>` 在 XML 解析下等价于 `<script>`）。
- *    浏览器在 `<img>` 与 CSS 背景中加载 SVG 时本就处于 secure static mode
- *    （不执行脚本、不取外部资源），这一层是纵深防御：既防 SDK 后续改用
- *    innerHTML 类路径，也防同一 helper 被复用到无沙箱的上下文。
+ * 3. **SVG 源**：decode 后必须以 SVG 为**文档根**（不只是文中某处出现 `<svg>`），
+ *    且不含脚本 / 事件属性 / SMIL 属性合成 / 外部引用 / DTD 实体 / 字节视图与
+ *    解析器视图不一致的编码（UTF-16 等含 NUL 的文档）。
+ *
+ *    **这一层是 best-effort 的字节级启发式，不是完备的 SVG 净化器。** 正则看到的是
+ *    字节，XML 解析器看到的是文档，两者之间永远存在分歧空间（命名空间前缀、字符集、
+ *    实体、属性合成……本层已知被绕过过数次）。真正阻断脚本执行与外部请求的是浏览器：
+ *    `<img>` 与 CSS 背景中的 SVG 一律以 secure static mode 渲染。所以**不要把本层当作
+ *    可依赖的隔离手段**——若哪天有客户端把卡片 SVG 内联进 DOM，必须先换成解析式净化
+ *    （DOMParser + 命名空间/属性遍历）再上线，而不是继续往这里加正则。
  *
  * 纯函数、无副作用；判定失败不抛异常（调用方据布尔值剥键）。
  */
@@ -34,9 +43,8 @@ export const MAX_INLINE_IMAGE_DATA_URL_LENGTH = 4096;
 /** 唯一放行的 MIME（服务端白名单同口径）。 */
 const DATA_SVG_PREFIX = "data:image/svg+xml";
 
-/** data URL 参数段白名单（小写比较）。 */
+/** data URL 非编码参数段白名单（小写比较）；`base64` 另按位置规则处理。 */
 const ALLOWED_DATA_PARAMS: ReadonlySet<string> = new Set([
-  "base64",
   "charset=utf-8",
   "charset=us-ascii",
 ]);
@@ -53,26 +61,41 @@ const UNSAFE_URL_CHARS = /['"()\\]/;
 /** 严格 base64 字面量（禁空、禁 URL-safe 变体、padding 最多 2）。 */
 const STRICT_BASE64 = /^[A-Za-z0-9+/]+={0,2}$/;
 
-/** SVG 根元素存在性（`<svg>` / `<svg ` / `<svg/>`，允许命名空间前缀）。 */
-const SVG_ROOT = /<\s*(?:[\w.-]+:)?svg[\s/>]/i;
+/**
+ * 文档根必须是 SVG。前缀组这里**故意**只收 ASCII（`[\w.-]+`）：根判定是 allow 方向，
+ * 放宽等于放行更多，非 ASCII 前缀的根一律 fail-closed。
+ */
+const SVG_ROOT = /^<(?:[\w.-]+:)?svg[\s/>]/i;
 
 /**
- * SVG 源禁用模式（decode 之后匹配，覆盖 percent / base64 编码绕过）。
+ * 禁用模式（decode 之后匹配，覆盖 percent / base64 编码绕过）。
  *
- * 元素名一律容许命名空间前缀：SVG 经 `<img>` 加载走 XML 解析，`<svg:script>` /
- * `<x:script xmlns:x="…/svg">` 与 `<script>` 等价，只匹配无前缀形会被绕过。
+ * 元素名前缀组用 `[^\s<>/=]+` 而非 `[\w.-]+`：JS 的 `\w` 只含 ASCII，而 XML 的
+ * NameStartChar 含非 ASCII，`<ñ:script>` 是合法且等价于 `<script>` 的写法。deny 方向
+ * 放宽只会多拦，安全。
  */
 const SVG_DENY_PATTERNS: readonly RegExp[] = [
-  /<\s*(?:[\w.-]+:)?script/i, // 脚本
-  /<\s*(?:[\w.-]+:)?foreignobject/i, // 嵌 HTML
-  /<\s*(?:[\w.-]+:)?iframe/i,
-  /<\s*(?:[\w.-]+:)?use\b/i, // 外部/片段引用
-  /<\s*(?:[\w.-]+:)?image\b/i, // 外部位图引用
+  /<\s*(?:[^\s<>/=]+:)?script/i, // 脚本
+  /<\s*(?:[^\s<>/=]+:)?foreignobject/i, // 嵌 HTML
+  /<\s*(?:[^\s<>/=]+:)?iframe/i,
+  /<\s*(?:[^\s<>/=]+:)?object/i,
+  /<\s*(?:[^\s<>/=]+:)?embed/i,
+  /<\s*(?:[^\s<>/=]+:)?link/i,
+  /<\s*(?:[^\s<>/=]+:)?use\b/i, // 外部/片段引用
+  /<\s*(?:[^\s<>/=]+:)?image\b/i, // 外部位图引用
   /<!\s*doctype/i, // DTD → XXE / 实体膨胀
   /<!\s*entity/i,
-  /\s(?:[\w.-]+:)?on[a-z-]+\s*=/i, // 事件处理属性（onload/onerror/…）
+  /\s(?:[^\s<>/=]+:)?on[a-z-]+\s*=/i, // 事件处理属性（onload/onerror/…）
+  // SMIL 属性合成：`<set attributeName="onload" to="…">` / `<animate attributeName="href">`
+  // 从不写出字面 `on…=`，绕过上面那条。只拦危险目标属性，`attributeName="opacity"`
+  // 之类的正常动画图标照放。
+  /attributename\s*=\s*["']?\s*(?:on|href|xlink:href)/i,
   /javascript\s*:/i,
   /\bhref\s*=/i, // 图标不需要任何链接/外部引用（含 xlink:href）
+  /@import/i, // `<style>@import "//evil"` 外部样式表
+  // CSS 里的外部资源引用。`url(#local)`（渐变/clip-path 同文档引用）必须放过，
+  // 所以只拦带 scheme 的形式。
+  /url\s*\(\s*["']?\s*(?:https?|data|blob|file|filesystem):/i,
   /&#/, // XML 字符实体：属性值内可编码绕过上面的关键词匹配
 ];
 
@@ -80,11 +103,19 @@ const SVG_DENY_PATTERNS: readonly RegExp[] = [
 function parseDataParams(params: string): { isBase64: boolean } | null {
   if (params === "") return { isBase64: false };
   if (!params.startsWith(";")) return null; // MIME 后缀污染，如 image/svg+xmlx
+  const segments = params.slice(1).split(";");
   let isBase64 = false;
-  for (const segment of params.slice(1).split(";")) {
-    const normalized = segment.toLowerCase();
+  for (let i = 0; i < segments.length; i++) {
+    const normalized = segments[i].toLowerCase();
+    if (normalized === "base64") {
+      // RFC 2397：`base64` 只有作为逗号前最后一段时才是编码标记，浏览器也如此实现。
+      // 出现在中间时浏览器会 percent-decode 而我们会 atob——两侧看到的字节不同。
+      // 要求唯一且末位，让「我们扫的就是浏览器要解析的」成为结构性保证而非巧合。
+      if (i !== segments.length - 1) return null;
+      isBase64 = true;
+      continue;
+    }
     if (!ALLOWED_DATA_PARAMS.has(normalized)) return null;
-    if (normalized === "base64") isBase64 = true;
   }
   return { isBase64 };
 }
@@ -103,9 +134,36 @@ function decodeDataPayload(payload: string, isBase64: boolean): string | null {
   }
 }
 
+/**
+ * 剥掉根元素之前允许出现的前导内容（空白、`<?xml …?>` 声明、`<!-- -->` 注释）。
+ * 用循环而非嵌套量词正则：后者对未闭合注释会退化成多项式回溯。
+ */
+function stripSvgPrologue(source: string): string {
+  let rest = source.trimStart();
+  for (;;) {
+    if (rest.startsWith("<?")) {
+      const end = rest.indexOf("?>");
+      if (end < 0) return rest; // 未闭合 → 留给根判定拒掉
+      rest = rest.slice(end + 2).trimStart();
+      continue;
+    }
+    if (rest.startsWith("<!--")) {
+      const end = rest.indexOf("-->");
+      if (end < 0) return rest;
+      rest = rest.slice(end + 3).trimStart();
+      continue;
+    }
+    return rest;
+  }
+}
+
 /** decode 后的 SVG 源是否安全。 */
 function isSafeSvgSource(source: string): boolean {
-  if (!SVG_ROOT.test(source)) return false;
+  // NUL 字节 ⇒ 这是 UTF-16/UTF-32 之类的宽字符文档：正则扫到的字节串与 XML 解析器
+  // 看到的文档结构不同（可在注释里放 ASCII 诱饵骗过根判定，真正的 script 则被 NUL
+  // 间隔而匹配不到）。合法的 UTF-8 SVG 不含 NUL，直接拒掉整类视图分歧。
+  if (source.includes("\x00")) return false;
+  if (!SVG_ROOT.test(stripSvgPrologue(source))) return false;
   return !SVG_DENY_PATTERNS.some((pattern) => pattern.test(source));
 }
 

--- a/packages/dmworkbase/src/Messages/InteractiveCard/sdk/inlineImageUrl.ts
+++ b/packages/dmworkbase/src/Messages/InteractiveCard/sdk/inlineImageUrl.ts
@@ -1,0 +1,141 @@
+/**
+ * 内联图片 `data:` URL 白名单（octo 卡片图片面）。
+ *
+ * 背景：卡片模板把折叠/展开等图标以 `data:image/svg+xml,…` 内联进 `Image.url`，
+ * 避免为几百字节的图标额外发起 CDN 请求、也避免图标域名成为新的外部依赖。
+ * 图片面原本一律 https-only（见 sanitizeCardTree），data URL 会被整键剥除、
+ * 图标静默消失，故此处按 **服务端白名单（仅 image/svg+xml）** 开一个受限口子。
+ *
+ * 安全模型（三层，任一不过即拒）：
+ *
+ * 1. **URL 字面量**：长度上限 + 禁危险字符。`Image.url` 由 SDK 赋给 `img.src`（DOM API，
+ *    无注入面），但容器 `backgroundImage` 会被拼进 CSS `background-image: url('…')`——
+ *    引号/括号/反斜杠/空白可逃逸该上下文并注入额外 CSS 声明。合法的 percent-encoded /
+ *    base64 data URL 天然不含这些字符，故统一按最严口径设防，一份规则覆盖
+ *    `Image.url` / `Action.iconUrl` / `backgroundImage` 三个面。
+ *
+ * 2. **MIME 与参数**：只放 `image/svg+xml`（对齐服务端），参数段仅允许
+ *    `base64` / `charset=utf-8` / `charset=us-ascii`。位图 data URL、`text/html`、
+ *    空 MIME、MIME 后缀污染（`image/svg+xmlx`）一律拒。
+ *
+ * 3. **SVG 源**：decode 后必须确实是 SVG，且不含脚本 / 事件属性 / 外部引用
+ *    （`use`、`image`、任何 `href`）/ `foreignObject` / DTD 实体 / XML 字符实体。
+ *    元素名一律容许命名空间前缀（`<svg:script>` 在 XML 解析下等价于 `<script>`）。
+ *    浏览器在 `<img>` 与 CSS 背景中加载 SVG 时本就处于 secure static mode
+ *    （不执行脚本、不取外部资源），这一层是纵深防御：既防 SDK 后续改用
+ *    innerHTML 类路径，也防同一 helper 被复用到无沙箱的上下文。
+ *
+ * 纯函数、无副作用；判定失败不抛异常（调用方据布尔值剥键）。
+ */
+
+/** data URL 字面量长度上限（字节；下面的字符白名单保证 1 字符 = 1 字节）。 */
+export const MAX_INLINE_IMAGE_DATA_URL_LENGTH = 4096;
+
+/** 唯一放行的 MIME（服务端白名单同口径）。 */
+const DATA_SVG_PREFIX = "data:image/svg+xml";
+
+/** data URL 参数段白名单（小写比较）。 */
+const ALLOWED_DATA_PARAMS: ReadonlySet<string> = new Set([
+  "base64",
+  "charset=utf-8",
+  "charset=us-ascii",
+]);
+
+/**
+ * data URL 只允许 ASCII 可打印**非空格**字符：排除空白与控制字符（浏览器会从 URL 里
+ * 剥除 \t\n\r，可用于拆散关键词），也排除非 ASCII（否则字符数 < UTF-8 字节数，长度上限失真）。
+ */
+const ALLOWED_URL_CHARS = /^[\x21-\x7e]+$/;
+
+/** 能逃逸 CSS `url('…')` / HTML 属性上下文的字符（ASCII 可打印集合内的危险子集）。 */
+const UNSAFE_URL_CHARS = /['"()\\]/;
+
+/** 严格 base64 字面量（禁空、禁 URL-safe 变体、padding 最多 2）。 */
+const STRICT_BASE64 = /^[A-Za-z0-9+/]+={0,2}$/;
+
+/** SVG 根元素存在性（`<svg>` / `<svg ` / `<svg/>`，允许命名空间前缀）。 */
+const SVG_ROOT = /<\s*(?:[\w.-]+:)?svg[\s/>]/i;
+
+/**
+ * SVG 源禁用模式（decode 之后匹配，覆盖 percent / base64 编码绕过）。
+ *
+ * 元素名一律容许命名空间前缀：SVG 经 `<img>` 加载走 XML 解析，`<svg:script>` /
+ * `<x:script xmlns:x="…/svg">` 与 `<script>` 等价，只匹配无前缀形会被绕过。
+ */
+const SVG_DENY_PATTERNS: readonly RegExp[] = [
+  /<\s*(?:[\w.-]+:)?script/i, // 脚本
+  /<\s*(?:[\w.-]+:)?foreignobject/i, // 嵌 HTML
+  /<\s*(?:[\w.-]+:)?iframe/i,
+  /<\s*(?:[\w.-]+:)?use\b/i, // 外部/片段引用
+  /<\s*(?:[\w.-]+:)?image\b/i, // 外部位图引用
+  /<!\s*doctype/i, // DTD → XXE / 实体膨胀
+  /<!\s*entity/i,
+  /\s(?:[\w.-]+:)?on[a-z-]+\s*=/i, // 事件处理属性（onload/onerror/…）
+  /javascript\s*:/i,
+  /\bhref\s*=/i, // 图标不需要任何链接/外部引用（含 xlink:href）
+  /&#/, // XML 字符实体：属性值内可编码绕过上面的关键词匹配
+];
+
+/** 解析 data URL 参数段；非法参数 → null，否则返回是否 base64。 */
+function parseDataParams(params: string): { isBase64: boolean } | null {
+  if (params === "") return { isBase64: false };
+  if (!params.startsWith(";")) return null; // MIME 后缀污染，如 image/svg+xmlx
+  let isBase64 = false;
+  for (const segment of params.slice(1).split(";")) {
+    const normalized = segment.toLowerCase();
+    if (!ALLOWED_DATA_PARAMS.has(normalized)) return null;
+    if (normalized === "base64") isBase64 = true;
+  }
+  return { isBase64 };
+}
+
+/** 解码 data URL payload；编码损坏 → null。 */
+function decodeDataPayload(payload: string, isBase64: boolean): string | null {
+  try {
+    if (isBase64) {
+      if (!STRICT_BASE64.test(payload)) return null;
+      // atob 产出 latin1 字节串——足够匹配下面全 ASCII 的禁用模式。
+      return atob(payload);
+    }
+    return decodeURIComponent(payload);
+  } catch {
+    return null;
+  }
+}
+
+/** decode 后的 SVG 源是否安全。 */
+function isSafeSvgSource(source: string): boolean {
+  if (!SVG_ROOT.test(source)) return false;
+  return !SVG_DENY_PATTERNS.some((pattern) => pattern.test(source));
+}
+
+/**
+ * 该字符串是否为可安全内联渲染的图片 data URL（当前仅 `image/svg+xml`）。
+ * 非 data: scheme 一律返回 false（https 判定见 `isHttpsUrl`）。
+ */
+export function isSafeInlineImageDataUrl(url: string): boolean {
+  if (url.length === 0 || url.length > MAX_INLINE_IMAGE_DATA_URL_LENGTH) {
+    return false;
+  }
+  if (!ALLOWED_URL_CHARS.test(url) || UNSAFE_URL_CHARS.test(url)) return false;
+  if (url.slice(0, DATA_SVG_PREFIX.length).toLowerCase() !== DATA_SVG_PREFIX) {
+    return false;
+  }
+
+  const rest = url.slice(DATA_SVG_PREFIX.length);
+  const separator = rest.indexOf(",");
+  if (separator < 0) return false; // 无 payload 分隔符
+
+  const params = parseDataParams(rest.slice(0, separator));
+  if (!params) return false;
+
+  const payload = rest.slice(separator + 1);
+  if (payload === "") return false;
+
+  const svg = decodeDataPayload(payload, params.isBase64);
+  if (svg === null) return false;
+
+  return isSafeSvgSource(svg);
+}
+
+export default isSafeInlineImageDataUrl;

--- a/packages/dmworkbase/src/Messages/InteractiveCard/sdk/renderOctoCard.ts
+++ b/packages/dmworkbase/src/Messages/InteractiveCard/sdk/renderOctoCard.ts
@@ -80,7 +80,7 @@ export function renderOctoCard(options: RenderOctoCardOptions): void {
   const ac = new AdaptiveCard();
   ac.hostConfig = createCardHostConfig(target, renderProfile);
   ac.onExecuteAction = (action) => onAction(action, ac);
-  // 图片类 URL 消毒（https-only），在 parse 前——SDK 自身不做 scheme 检查。
+  // 图片类 URL 消毒（https 或受限内联 SVG data URL），在 parse 前——SDK 自身不做 scheme 检查。
   ac.parse(sanitizeCardTree(card), createOctoSerializationContext());
   const rendered = ac.render();
   target.textContent = "";

--- a/packages/dmworkbase/src/Messages/InteractiveCard/sdk/sanitizeCardTree.ts
+++ b/packages/dmworkbase/src/Messages/InteractiveCard/sdk/sanitizeCardTree.ts
@@ -20,7 +20,13 @@ import { isSafeInlineImageDataUrl } from "./inlineImageUrl";
  * **不动 `Action.OpenUrl.url`**：那是导航面，契约允许 http/https，且已由 validateCardForOcto
  * + 点击期 openUrl 双重 isSafeUrl 守卫。
  *
+ * **图片面清单是穷举的，不是通配的**：本函数按键名识别 `url`(Image) / `iconUrl` / `backgroundImage`
+ * 三个键。SDK 还有别的取图键（如 `Media.poster` → `posterImageElement.src`），今天不可达
+ * ——`Media` 不在 validateElement 的白名单里，整卡会先降级——但谁若放宽元素白名单，
+ * **必须在同一个 commit 里把对应的取图键补进下面的分支**，否则新元素的图片面就是裸的。
+ *
  * 纯函数、不可变克隆：绝不改动传入的（可能被缓存/共享的）解码卡树。
+ * 唯一的例外是 DEV 下的 `console.warn`（见 warnRejectedImageUrl），生产构建会被剔除。
  */
 
 /** 图片面放行判定：https 或受限内联 SVG data URL。 */
@@ -28,23 +34,46 @@ function isRenderableImageUrl(url: string): boolean {
   return isHttpsUrl(url) || isSafeInlineImageDataUrl(url);
 }
 
+/**
+ * DEV 下报告被剥除的图片 URL。
+ *
+ * 剥键本身是静默的，而这正是本模块修复的那个 bug 难查的原因：整卡不降级、文字照渲、
+ * 只有图标凭空消失。图片面的白名单比服务端严（见 inlineImageUrl 的生产者契约），
+ * 所以模板一旦产出不合规的编码，需要一眼能看出是被这里拒的。
+ *
+ * 生产构建里 `import.meta.env.DEV` 为常量 false，整个调用被 tree-shake 掉。
+ */
+function warnRejectedImageUrl(surface: string, value: unknown): void {
+  if (!import.meta.env.DEV) return;
+  const shown = typeof value === "string" ? value.slice(0, 160) : value;
+  console.warn(
+    `[octo-card] ${surface} rejected by the image URL allowlist ` +
+      `(needs https or a fully-encoded data:image/svg+xml):`,
+    shown
+  );
+}
+
 /** 仅保留可渲染的图片 URL，否则返回 undefined（调用方据此剥除该键）。 */
-function keepImageUrl(value: unknown): string | undefined {
-  return typeof value === "string" && isRenderableImageUrl(value)
-    ? value
-    : undefined;
+function keepImageUrl(value: unknown, surface: string): string | undefined {
+  if (typeof value === "string" && isRenderableImageUrl(value)) return value;
+  warnRejectedImageUrl(surface, value);
+  return undefined;
 }
 
 /** backgroundImage 可为字符串或 `{url, ...}` 对象；不可渲染一律剥除。 */
 function sanitizeBackgroundImage(value: unknown): unknown | undefined {
   if (typeof value === "string") {
-    return isRenderableImageUrl(value) ? value : undefined;
+    if (isRenderableImageUrl(value)) return value;
+    warnRejectedImageUrl("backgroundImage", value);
+    return undefined;
   }
   if (value !== null && typeof value === "object" && !Array.isArray(value)) {
     const obj = value as Record<string, unknown>;
     if (typeof obj.url === "string" && isRenderableImageUrl(obj.url)) {
       return { ...obj };
     }
+    warnRejectedImageUrl("backgroundImage.url", obj.url);
+    return undefined;
   }
   return undefined; // 非法/不可渲染 → 不渲背景图
 }
@@ -64,15 +93,23 @@ function sanitizeNode(node: unknown): unknown {
     if (key === "fallback" || key === "requires") {
       continue;
     }
+    // `__proto__`：`out[key] = …` 会命中原型 setter，把被剥掉的键从原型链上「复活」
+    // ——消毒后的节点会暴露输入里并不存在的 url。SDK 当前用 hasOwnProperty 取属性所以
+    // 读不到，但不能依赖第三方实现细节。改用 Object.create(null) 反而更糟：SDK 的
+    // internalParse 调 `source.hasOwnProperty(...)`，无原型对象上该方法不存在会抛。
+    // 与 fallback/requires 一样直接跳过，零风险。
+    if (key === "__proto__") {
+      continue;
+    }
     // Image.url：图片面白名单（不误伤 Action.OpenUrl.url 等其它 url）。
     if (key === "url" && obj.type === "Image") {
-      const safe = keepImageUrl(value);
+      const safe = keepImageUrl(value, "Image.url");
       if (safe !== undefined) out[key] = safe;
       continue;
     }
     // 动作 iconUrl：图片面白名单。
     if (key === "iconUrl" && isActionType(obj.type)) {
-      const safe = keepImageUrl(value);
+      const safe = keepImageUrl(value, `${obj.type}.iconUrl`);
       if (safe !== undefined) out[key] = safe;
       continue;
     }

--- a/packages/dmworkbase/src/Messages/InteractiveCard/sdk/sanitizeCardTree.ts
+++ b/packages/dmworkbase/src/Messages/InteractiveCard/sdk/sanitizeCardTree.ts
@@ -1,12 +1,15 @@
 import { isHttpsUrl } from "../../../Utils/security";
+import { isSafeInlineImageDataUrl } from "./inlineImageUrl";
 
 /**
  * 喂官方 SDK 前的卡树消毒（落地计划「坑 B」+ fallback/requires 收敛）。
  *
- * (1) 图片面 **https-only（混合内容防护）**——`Image.url`、容器 `backgroundImage`
+ * (1) 图片面 **https 或内联 SVG data URL**——`Image.url`、容器 `backgroundImage`
  * （字符串或 `{url}` 对象形）、动作 `iconUrl`。官方 SDK 对这些字段一律原样写进 `img.src` /
  * CSS `background-image`，自身不做 scheme 检查；自研渲染器曾用 `isHttpsUrl` 守卫（占位），
- * 迁移后须在此补回。非 https 值一律**剥除**（对齐契约的 per-element 处理，不整卡降级）。
+ * 迁移后须在此补回。放行两类：https（避免 http 混合内容被浏览器拦成破图）与
+ * `data:image/svg+xml`（模板内联图标，白名单+源码校验见 `inlineImageUrl.ts`，与服务端同口径）。
+ * 其余值一律**剥除**（对齐契约的 per-element 处理，不整卡降级）。
  *
  * (2) 剥除 **`fallback` 与 `requires`**——SDK 会在 `requires` 能力门不满足时渲染元素的
  * `fallback` 子树；octo 的 HostConfig 未声明任何 host capability，故任意 `requires` 都不满足，
@@ -20,23 +23,30 @@ import { isHttpsUrl } from "../../../Utils/security";
  * 纯函数、不可变克隆：绝不改动传入的（可能被缓存/共享的）解码卡树。
  */
 
-/** 仅保留 https 图片 URL，否则返回 undefined（调用方据此剥除该键）。 */
-function keepHttpsUrl(value: unknown): string | undefined {
-  return typeof value === "string" && isHttpsUrl(value) ? value : undefined;
+/** 图片面放行判定：https 或受限内联 SVG data URL。 */
+function isRenderableImageUrl(url: string): boolean {
+  return isHttpsUrl(url) || isSafeInlineImageDataUrl(url);
 }
 
-/** backgroundImage 可为字符串或 `{url, ...}` 对象；非 https 一律剥除。 */
+/** 仅保留可渲染的图片 URL，否则返回 undefined（调用方据此剥除该键）。 */
+function keepImageUrl(value: unknown): string | undefined {
+  return typeof value === "string" && isRenderableImageUrl(value)
+    ? value
+    : undefined;
+}
+
+/** backgroundImage 可为字符串或 `{url, ...}` 对象；不可渲染一律剥除。 */
 function sanitizeBackgroundImage(value: unknown): unknown | undefined {
   if (typeof value === "string") {
-    return isHttpsUrl(value) ? value : undefined;
+    return isRenderableImageUrl(value) ? value : undefined;
   }
   if (value !== null && typeof value === "object" && !Array.isArray(value)) {
     const obj = value as Record<string, unknown>;
-    if (typeof obj.url === "string" && isHttpsUrl(obj.url)) {
+    if (typeof obj.url === "string" && isRenderableImageUrl(obj.url)) {
       return { ...obj };
     }
   }
-  return undefined; // 非法/非 https → 不渲背景图
+  return undefined; // 非法/不可渲染 → 不渲背景图
 }
 
 function isActionType(type: unknown): boolean {
@@ -54,19 +64,19 @@ function sanitizeNode(node: unknown): unknown {
     if (key === "fallback" || key === "requires") {
       continue;
     }
-    // Image.url：图片面 https-only（不误伤 Action.OpenUrl.url 等其它 url）。
+    // Image.url：图片面白名单（不误伤 Action.OpenUrl.url 等其它 url）。
     if (key === "url" && obj.type === "Image") {
-      const safe = keepHttpsUrl(value);
+      const safe = keepImageUrl(value);
       if (safe !== undefined) out[key] = safe;
       continue;
     }
-    // 动作 iconUrl：图片面 https-only。
+    // 动作 iconUrl：图片面白名单。
     if (key === "iconUrl" && isActionType(obj.type)) {
-      const safe = keepHttpsUrl(value);
+      const safe = keepImageUrl(value);
       if (safe !== undefined) out[key] = safe;
       continue;
     }
-    // 容器 backgroundImage：字符串或 {url}，https-only。
+    // 容器 backgroundImage：字符串或 {url}，同白名单。
     if (key === "backgroundImage") {
       const safe = sanitizeBackgroundImage(value);
       if (safe !== undefined) out[key] = safe;

--- a/packages/dmworkbase/src/Messages/InteractiveCard/validateCardForOcto.ts
+++ b/packages/dmworkbase/src/Messages/InteractiveCard/validateCardForOcto.ts
@@ -15,8 +15,9 @@ import { RenderBudget } from "./guards";
  *
  * 注意分工（与整卡降级区分）：
  *   - Action.OpenUrl / selectAction 的 url 非法（javascript: 等）→ **整卡降级**（本函数 ok:false）；
- *   - Image.url / backgroundImage / iconUrl 非 https（混合内容）→ **不在此降级**，属 per-element
- *     处理（喂 SDK 前对 card 树做 URL 消毒，见 S4），本函数视其结构合法。
+ *   - Image.url / backgroundImage / iconUrl 不在图片面白名单（非 https 且非受限内联 SVG
+ *     data URL）→ **不在此降级**，属 per-element 处理（喂 SDK 前对 card 树做 URL 消毒，见 S4），
+ *     本函数视其结构合法。
  */
 
 export interface ValidateOptions {


### PR DESCRIPTION
## Summary

Card templates inline their collapse/expand chevrons as `data:image/svg+xml,…` in `Image.url`. The pre-SDK sanitizer gated every image surface on https-only, so it stripped the `url` key outright — the card still passed octo validation and rendered its text, but the chevrons silently disappeared and `Action.ToggleVisibility` had nothing to click.

This is not a HostConfig matter: the AdaptiveCards HostConfig schema has no URL scheme knob (neither `sdk/octoHostConfig.ts` nor the `octo-chat/v1` profile's `host-config.json` carries one), and the SDK performs no scheme check of its own — it assigns `Image.url` straight to `img.src`.

## What changed

- **New `sdk/inlineImageUrl.ts`** — a restricted data URL allowlist matching the server's (`image/svg+xml` only).
- **`sdk/sanitizeCardTree.ts`** — `Image.url`, `Action.iconUrl` and container `backgroundImage` (both string and `{url}` forms) now accept https **or** a vetted inline SVG data URL. Immutability and the `fallback`/`requires` stripping are unchanged.
- **`sdk/renderOctoCard.ts`, `validateCardForOcto.ts`** — comment sync only; no behaviour change.

All three image surfaces were opened together. If the server only whitelisted `Image.url`, the other two simply never receive a data URL — whereas opening only one leaves a trap for when the server widens.

## Security model

Three layers, all must pass:

1. **URL literal** — 4096 byte cap; ASCII printable non-space only; no `' " ( ) \`. `Image.url` reaches the DOM through `img.src` (no injection surface), but `backgroundImage` is interpolated into CSS `url('…')`, where quotes and parens escape the context — so one rule covers all three surfaces at the strictest reading. Rejecting non-ASCII also keeps the byte cap honest (UTF-16 length would under-count by up to 3x); rejecting raw `\t\n\r` closes the trick of splitting a keyword with characters the browser strips from URLs.
2. **MIME and params** — `image/svg+xml` only (case-insensitive); params limited to `base64` / `charset=utf-8` / `charset=us-ascii`. Bitmap data URLs, `text/html`, empty MIME and suffix pollution (`image/svg+xmlx`) are rejected.
3. **SVG source, after decoding** (so percent- and base64-encoded evasion is covered) — must be an SVG, and must not contain `script` / `foreignObject` / `iframe` / `use` / `image` / event attributes / `javascript:` / any `href` / DTD entities / XML numeric character references. Element names allow a namespace prefix, since SVG loaded through `<img>` is XML-parsed and `<svg:script>` is equivalent to `<script>`. Decode failures fail closed.

Browsers already load SVG in `<img>` and CSS backgrounds under secure static mode (no script execution, no external fetches), so layer 3 is defence in depth — it protects against future render-path changes and against this helper being reused in an unsandboxed context.

Note this tightens one thing: any icon relying on `<use href="#id">` or an embedded link is now rejected (it would render as a missing image). The four production chevrons contain no `href`.

## Test plan

- `sdk/inlineImageUrl.ts` — 47 unit cases: the real production chevron passes; bitmap/`text/html`/empty/polluted MIME, dangerous URL characters, non-ASCII, oversize, corrupt encodings, and the full SVG deny list all reject. Includes namespace-prefix (`<svg:script>`, `<x:script>`, `<n:use>`) and entity-encoded (`&#106;avascript:`) bypasses, both of which were found during review and are now covered.
- `__tests__/sanitizeCardTree.test.ts` — 9 cases across the three image surfaces, both `backgroundImage` shapes, and the untouched `Action.OpenUrl.url` navigation surface.
- `__tests__/inlineImageRender.test.tsx` — end-to-end against the real `ai.reasoning-process` card fixture: validation passes, four `<img src="data:image/svg+xml,…">` render, alt text (展开/收起/展开工具/收起工具) and click affordance intact.
- **Mutation-checked**: reverting the sanitizer to https-only turns the end-to-end assertions red while whole-card validation stays green — reproducing the original symptom exactly. Short-circuiting the SVG source check reds 8 unit cases; dropping namespace-prefix tolerance reds 1.
- **Full `@octo/base` suite: 289 files / 2596 tests passing.** `prettier --check` clean.

Known, pre-existing and unrelated: `tsc --noEmit -p packages/dmworkbase` is blocked by Semi dependency typings, and `renderOctoCard.ts:2` reports TS2307 for `@mlt-org/octo-card-profile-octo-chat/host-config.json` (the package uses `exports` mapping; the tsconfig's moduleResolution does not follow it). Both reproduce on an unmodified tree. `packages/dmworkbase` has no `lint` script, so `turbo run lint` does not cover it.

## Deploy notes

- **CSP**: confirmed during review that the production `img-src` allows `data:` — inline SVG is not blocked by page policy.
- **Still worth aligning**: the server's per-image byte ceiling versus the 4096 used here, and the whole-card byte ceiling. Client node budget is `MAX_NODES = 200`, so the theoretical worst case is ~800 KB of inline data per card. A server limit stricter than 4096 would mean cards the client would accept never arrive; looser would mean icons silently dropped client-side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
