### PR TITLE
feat(meeting): Octo Meeting MVP P0 frontend module (draft)

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -35,3 +35,12 @@ VITE_ENTERPRISE_FS_ALLOW=
 # Falls back to VITE_API_URL when unset. For local development with octo-drive
 # running on :8080:
 # VITE_DRIVE_API_URL=http://127.0.0.1:8080
+
+# Meeting (octo-meeting-service) — standalone RTC/meeting service (XIN-1773).
+# MEETING_FEATURE_ENABLED: fail-safe/default-off top-level gate. The Meeting menu
+# and routes register ONLY when this is exactly "true". Leave unset/false until
+# the service and its gateway route (/meeting/api/v1) are deployed.
+# VITE_MEETING_FEATURE_ENABLED=false
+# Meeting service URL for local dev; the Vite proxy forwards /meeting/api/v1/*.
+# Falls back to VITE_API_URL when unset.
+# VITE_MEETING_API_URL=http://127.0.0.1:8093

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -60,6 +60,7 @@
   "dependencies": {
     "@dmwork/appbot": "workspace:*",
     "@dmwork/mcp": "workspace:*",
+    "@dmwork/meeting": "workspace:*",
     "@dmwork/skillmarket": "workspace:*",
     "@dmwork/summary": "workspace:*",
     "@douyinfe/semi-icons": "^2.93.0",

--- a/apps/web/src/index.tsx
+++ b/apps/web/src/index.tsx
@@ -62,6 +62,9 @@ WKApp.apiClient.config.spaceIdCallback = () => {
 }
 WKApp.config.appVersion = import.meta.env.VITE_VERSION || pkgVersion
 WKApp.config.appName = "Octo"
+// MEETING_FEATURE_ENABLED — fail-safe/default-off. The Meeting module registers
+// its menu and routes only when this is explicitly "true".
+WKApp.config.meetingFeatureEnabled = import.meta.env.VITE_MEETING_FEATURE_ENABLED === "true"
 
 WKApp.loginInfo.load() // 加载登录信息
 i18n.registerNamespace("app", {

--- a/apps/web/src/index.tsx
+++ b/apps/web/src/index.tsx
@@ -9,6 +9,7 @@ import  { LoginModule, BindModule } from '@octo/login';
 import  { DataSourceModule } from '@octo/datasource';
 import {ContactsModule} from '@octo/contacts';
 import { SummaryModule } from '@dmwork/summary';
+import { MeetingModule } from '@dmwork/meeting';
 import { McpMarketModule } from '@dmwork/mcp';
 import { SkillMarketModule } from '@dmwork/skillmarket';
 import { AppBotModule } from '@dmwork/appbot';
@@ -81,6 +82,7 @@ WKApp.shared.registerModule(new LoginModule()); // 登录模块
 WKApp.shared.registerModule(new BindModule()); // OIDC 自助绑定页 (/oidc/bind)
 WKApp.shared.registerModule(new ContactsModule()); // 联系模块
 WKApp.shared.registerModule(new SummaryModule()); // 智能总结模块
+WKApp.shared.registerModule(new MeetingModule()); // 会议模块
 WKApp.shared.registerModule(new McpMarketModule()); // MCP 市场模块
 WKApp.shared.registerModule(new SkillMarketModule()); // Skill 市场模块
 WKApp.shared.registerModule(new AppBotModule()); // App Bot 模块

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -168,8 +168,11 @@ export default defineConfig(({ mode }) => {
             env.VITE_MEETING_API_URL || apiOrigin || "http://localhost:8080",
           changeOrigin: true,
           secure: false,
+          // The client calls /meeting/api/v1/v1/... (BASE + canonical /v1 path).
+          // A standalone service serves /v1/...; strip the FULL /meeting/api/v1
+          // prefix so the local target receives /v1/... (not /api/v1/v1/...).
           rewrite: env.VITE_MEETING_API_URL
-            ? (path: string) => path.replace(/^\/meeting/, "")
+            ? (path: string) => path.replace(/^\/meeting\/api\/v1/, "")
             : undefined,
         },
         // Marketplace (MCP catalog) API — must be before the general /api/ rule.

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -158,6 +158,20 @@ export default defineConfig(({ mode }) => {
             ? (path: string) => path.replace(/^\/summary/, "")
             : undefined,
         },
+        // Meeting API — standalone octo-meeting-service, mounted at
+        // /meeting/api/v1 by the gateway (prod) and proxied here (dev). Without
+        // this rule a dev /meeting/api/v1/* request falls through to the SPA
+        // index.html (200), which the client now rejects as fail-closed. See
+        // octo-meeting-service (XIN-1773) for the gateway mount convention.
+        "/meeting/api/v1": {
+          target:
+            env.VITE_MEETING_API_URL || apiOrigin || "http://localhost:8080",
+          changeOrigin: true,
+          secure: false,
+          rewrite: env.VITE_MEETING_API_URL
+            ? (path: string) => path.replace(/^\/meeting/, "")
+            : undefined,
+        },
         // Marketplace (MCP catalog) API — must be before the general /api/ rule.
         // octo-marketplace serves its own /api/v1/*; the /market prefix is
         // stripped here (dev) and by nginx (prod). See octo-marketplace

--- a/packages/dmworkbase/src/App.tsx
+++ b/packages/dmworkbase/src/App.tsx
@@ -170,6 +170,7 @@ export class WKConfig {
   pageSizeOfMessage: number = 30; // 每次请求消息数量
   fileHelperUID: string = "fileHelper"; // 文件助手UID
   systemUID: string = "u_10000"; // 系统uid
+  meetingFeatureEnabled: boolean = false; // MEETING_FEATURE_ENABLED: fail-safe/default-off gate for the Meeting module
 
   private _themeMode: ThemeMode = ThemeMode.light; // 主题模式
 

--- a/packages/dmworkmeeting/package.json
+++ b/packages/dmworkmeeting/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@dmwork/meeting",
+  "version": "1.0.0",
+  "main": "src/index.tsx",
+  "scripts": {
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@douyinfe/semi-icons": "^2.93.0",
+    "@douyinfe/semi-ui": "^2.93.0",
+    "@octo/base": "workspace:*",
+    "axios": "^0.25.0",
+    "classnames": "^2.3.1"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^13.4.0",
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2"
+  }
+}

--- a/packages/dmworkmeeting/package.json
+++ b/packages/dmworkmeeting/package.json
@@ -10,15 +10,14 @@
     "@douyinfe/semi-icons": "^2.93.0",
     "@douyinfe/semi-ui": "^2.93.0",
     "@octo/base": "workspace:*",
-    "axios": "^0.25.0",
     "classnames": "^2.3.1"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.9.1",
-    "@testing-library/react": "^13.4.0",
+    "@testing-library/react": "^14.3.1",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
   }
 }

--- a/packages/dmworkmeeting/package.json
+++ b/packages/dmworkmeeting/package.json
@@ -7,10 +7,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@douyinfe/semi-icons": "^2.93.0",
-    "@douyinfe/semi-ui": "^2.93.0",
-    "@octo/base": "workspace:*",
-    "classnames": "^2.3.1"
+    "@octo/base": "workspace:*"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.9.1",

--- a/packages/dmworkmeeting/src/__mocks__/dmworkBase.ts
+++ b/packages/dmworkmeeting/src/__mocks__/dmworkBase.ts
@@ -1,0 +1,110 @@
+import React from 'react';
+import zhRaw from '../i18n/zh-CN.json';
+
+// Focused mock of the @octo/base seam the meeting module depends on. Only the
+// symbols meeting imports are provided; tests mutate WKApp fields to exercise
+// header injection, origin derivation and fail-closed branches.
+
+type MessageNode = string | { [key: string]: MessageNode };
+
+function flatten(messages: Record<string, MessageNode>, prefix = ''): Record<string, string> {
+  return Object.entries(messages).reduce<Record<string, string>>((acc, [key, value]) => {
+    const nextKey = prefix ? `${prefix}.${key}` : key;
+    if (typeof value === 'string') {
+      acc[nextKey] = value;
+    } else {
+      Object.assign(acc, flatten(value, nextKey));
+    }
+    return acc;
+  }, {});
+}
+
+// Loaded from the i18n JSON so the mock's `t` resolves real strings.
+let zhMessages: Record<string, string> = {};
+try {
+  zhMessages = Object.entries(flatten(zhRaw as Record<string, MessageNode>)).reduce<Record<string, string>>((acc, [k, v]) => {
+    acc[`meeting.${k}`] = v;
+    return acc;
+  }, {});
+} catch {
+  zhMessages = {};
+}
+
+function interpolate(template: string, values?: Record<string, unknown>) {
+  if (!values) return template;
+  return template.replace(/\{\{\s*([\w.-]+)\s*\}\}/g, (_, key) => String(values[key] ?? ''));
+}
+
+export const t = (
+  key: string,
+  options?: { values?: Record<string, unknown>; defaultValue?: string },
+) => interpolate(zhMessages[key] ?? options?.defaultValue ?? key, options?.values);
+
+export const i18n = {
+  t,
+  getLocale: () => 'zh-CN',
+  setLocale: () => {},
+  registerNamespace: () => {},
+};
+
+export function buildAcceptLanguage(): string {
+  return 'zh-CN,zh;q=0.9,en;q=0.8';
+}
+
+export interface IModule {
+  id(): string;
+  init(): void;
+}
+
+export class Menus {
+  id: string;
+  title: string;
+  icon: unknown;
+  selectedIcon: unknown;
+  routePath: string;
+  onPress?: () => void;
+  badge?: number;
+  constructor(
+    id: string,
+    routePath: string,
+    title: string,
+    icon: unknown,
+    selectedIcon: unknown,
+    onPress?: () => void,
+  ) {
+    this.id = id;
+    this.routePath = routePath;
+    this.title = title;
+    this.icon = icon;
+    this.selectedIcon = selectedIcon;
+    this.onPress = onPress;
+  }
+}
+
+// Spy-friendly logout counter used by client tests.
+export const __logoutCalls = { count: 0 };
+
+export const WKApp = {
+  loginInfo: { token: 'test-token-abc', uid: 'u-self' } as { token?: string; uid?: string },
+  shared: {
+    currentSpaceId: 'space-123' as string | undefined,
+    logout: () => {
+      __logoutCalls.count += 1;
+    },
+    registerModule: (_m: IModule) => {},
+  },
+  apiClient: { config: { apiURL: '/api/v1/' } as { apiURL?: string } },
+  menus: { register: (_id: string, _f: () => Menus | undefined, _sort?: number) => {}, refresh: () => {} },
+  route: { register: (_p: string, _h: (param: unknown) => React.ReactNode) => {} },
+  routeLeft: { push: () => {}, replaceToRoot: () => {}, popToRoot: () => {} },
+  routeRight: { push: () => {}, replaceToRoot: () => {}, popToRoot: () => {} },
+  mittBus: { on: () => {}, off: () => {}, emit: () => {} },
+  switchToMenuById: (_id: string) => {},
+};
+
+export function __resetWKApp() {
+  WKApp.loginInfo = { token: 'test-token-abc', uid: 'u-self' };
+  WKApp.shared.currentSpaceId = 'space-123';
+  WKApp.apiClient = { config: { apiURL: '/api/v1/' } };
+  __logoutCalls.count = 0;
+}

--- a/packages/dmworkmeeting/src/__mocks__/dmworkBase.ts
+++ b/packages/dmworkmeeting/src/__mocks__/dmworkBase.ts
@@ -83,21 +83,41 @@ export class Menus {
 
 // Spy-friendly logout counter used by client tests.
 export const __logoutCalls = { count: 0 };
+// Registration spies for module gating tests.
+export const __registered = { routes: [] as string[], menus: [] as string[] };
+export const __routeRightPushes: unknown[] = [];
 
 export const WKApp = {
   loginInfo: { token: 'test-token-abc', uid: 'u-self' } as { token?: string; uid?: string },
+  config: { meetingFeatureEnabled: true } as { meetingFeatureEnabled?: boolean },
   shared: {
     currentSpaceId: 'space-123' as string | undefined,
+    deviceId: 'device-hash-test',
     logout: () => {
       __logoutCalls.count += 1;
     },
     registerModule: (_m: IModule) => {},
   },
   apiClient: { config: { apiURL: '/api/v1/' } as { apiURL?: string } },
-  menus: { register: (_id: string, _f: () => Menus | undefined, _sort?: number) => {}, refresh: () => {} },
-  route: { register: (_p: string, _h: (param: unknown) => React.ReactNode) => {} },
+  menus: {
+    register: (id: string, _f: () => Menus | undefined, _sort?: number) => {
+      __registered.menus.push(id);
+    },
+    refresh: () => {},
+  },
+  route: {
+    register: (p: string, _h: (param: unknown) => React.ReactNode) => {
+      __registered.routes.push(p);
+    },
+  },
   routeLeft: { push: () => {}, replaceToRoot: () => {}, popToRoot: () => {} },
-  routeRight: { push: () => {}, replaceToRoot: () => {}, popToRoot: () => {} },
+  routeRight: {
+    push: (el: unknown) => {
+      __routeRightPushes.push(el);
+    },
+    replaceToRoot: () => {},
+    popToRoot: () => {},
+  },
   mittBus: { on: () => {}, off: () => {}, emit: () => {} },
   switchToMenuById: (_id: string) => {},
 };
@@ -106,5 +126,9 @@ export function __resetWKApp() {
   WKApp.loginInfo = { token: 'test-token-abc', uid: 'u-self' };
   WKApp.shared.currentSpaceId = 'space-123';
   WKApp.apiClient = { config: { apiURL: '/api/v1/' } };
+  WKApp.config = { meetingFeatureEnabled: true };
   __logoutCalls.count = 0;
+  __registered.routes = [];
+  __registered.menus = [];
+  __routeRightPushes.length = 0;
 }

--- a/packages/dmworkmeeting/src/__tests__/setup.ts
+++ b/packages/dmworkmeeting/src/__tests__/setup.ts
@@ -1,0 +1,30 @@
+import '@testing-library/jest-dom';
+
+// jsdom does not implement media APIs used by PreJoin/Room; provide inert stubs
+// so component tests can mount without touching real devices.
+if (!(navigator as unknown as { mediaDevices?: unknown }).mediaDevices) {
+  Object.defineProperty(navigator, 'mediaDevices', {
+    configurable: true,
+    value: {
+      getUserMedia: async () => ({ getTracks: () => [] }),
+      getDisplayMedia: async () => ({ getTracks: () => [] }),
+      enumerateDevices: async () => [],
+    },
+  });
+}
+
+if (typeof (globalThis as unknown as { matchMedia?: unknown }).matchMedia !== 'function') {
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    value: (query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    }),
+  });
+}

--- a/packages/dmworkmeeting/src/components/Blocked.tsx
+++ b/packages/dmworkmeeting/src/components/Blocked.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { t } from '@octo/base';
-import { directiveForCode, MeetingErrorCode } from '../service/errors';
+import { directiveForCode, MeetingErrorCode, isMeetingErrorCode } from '../service/errors';
 
 export interface BlockedProps {
   code: MeetingErrorCode;
@@ -17,7 +17,8 @@ export interface BlockedProps {
  * bounded retry when the directive is retriable. Never renders as "ended".
  */
 export default function Blocked({ code, values, onRetry, onBackHome }: BlockedProps) {
-  const directive = directiveForCode(code);
+  // Fail-safe against a snapshot that may add codes not yet in the table.
+  const directive = directiveForCode(isMeetingErrorCode(code) ? code : MeetingErrorCode.INTERNAL);
   return (
     <div className="meeting-blocked" role="alert" aria-live="assertive" data-code={code}>
       <p>{t(directive.i18nKey, values ? { values } : undefined)}</p>

--- a/packages/dmworkmeeting/src/components/Blocked.tsx
+++ b/packages/dmworkmeeting/src/components/Blocked.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { t } from '@octo/base';
+import { directiveForCode, MeetingErrorCode } from '../service/errors';
+
+export interface BlockedProps {
+  code: MeetingErrorCode;
+  /** Optional detail interpolated into the message (e.g. earliest join time). */
+  values?: Record<string, string | number>;
+  onRetry?: () => void;
+  onBackHome?: () => void;
+}
+
+/**
+ * Recoverable non-terminal error view (§6.4). Renders the directive's exact
+ * message for locked / full / too-early / rate-limited / version-conflict /
+ * credential-invalid / not-same-space / forbidden / network, and offers a
+ * bounded retry when the directive is retriable. Never renders as "ended".
+ */
+export default function Blocked({ code, values, onRetry, onBackHome }: BlockedProps) {
+  const directive = directiveForCode(code);
+  return (
+    <div className="meeting-blocked" role="alert" aria-live="assertive" data-code={code}>
+      <p>{t(directive.i18nKey, values ? { values } : undefined)}</p>
+      {directive.retriable && onRetry && (
+        <button type="button" onClick={onRetry}>
+          {t('meeting.service.retry')}
+        </button>
+      )}
+      {onBackHome && (
+        <button type="button" onClick={onBackHome}>
+          {t('meeting.terminal.backHome')}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/packages/dmworkmeeting/src/components/ControlBar.tsx
+++ b/packages/dmworkmeeting/src/components/ControlBar.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { t } from '@octo/base';
+
+export interface ControlBarProps {
+  micOn: boolean;
+  cameraOn: boolean;
+  sharing: boolean;
+  /** Server-authoritative capabilities; a false capability greys the control. */
+  canShare: boolean;
+  canMuteAll: boolean;
+  /** During reconnect all controls are greyed (§5). */
+  reconnecting: boolean;
+  serviceAvailable: boolean;
+  onToggleMic: () => void;
+  onToggleCamera: () => void;
+  onToggleShare: () => void;
+  onMuteAll?: () => void;
+  onLeave: () => void;
+}
+
+/** Button enabled = server capability ∧ not reconnecting ∧ service available (§5). */
+export default function ControlBar(props: ControlBarProps) {
+  const gate = !props.reconnecting && props.serviceAvailable;
+  return (
+    <div className="meeting-control-bar" role="toolbar" aria-label={t('meeting.room.participants')}>
+      <button type="button" aria-pressed={props.micOn} disabled={!gate} onClick={props.onToggleMic}>
+        {t('meeting.prejoin.microphone')}
+      </button>
+      <button type="button" aria-pressed={props.cameraOn} disabled={!gate} onClick={props.onToggleCamera}>
+        {t('meeting.prejoin.camera')}
+      </button>
+      <button
+        type="button"
+        aria-pressed={props.sharing}
+        disabled={!gate || !props.canShare}
+        aria-disabled={!gate || !props.canShare}
+        onClick={props.onToggleShare}
+      >
+        {props.sharing ? t('meeting.room.stopShare') : t('meeting.room.share')}
+      </button>
+      {props.canMuteAll && (
+        <button type="button" disabled={!gate} onClick={props.onMuteAll}>
+          {t('meeting.room.muteAll')}
+        </button>
+      )}
+      <button type="button" className="meeting-leave" onClick={props.onLeave}>
+        {t('meeting.room.leave')}
+      </button>
+    </div>
+  );
+}

--- a/packages/dmworkmeeting/src/components/DevicePreview.tsx
+++ b/packages/dmworkmeeting/src/components/DevicePreview.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { t } from '@octo/base';
+
+export interface DevicePreviewProps {
+  micOn: boolean;
+  cameraOn: boolean;
+  /** getUserMedia was denied — join is still allowed with limited media (EX-2). */
+  permissionDenied?: boolean;
+  onToggleMic: () => void;
+  onToggleCamera: () => void;
+}
+
+/** PreJoin device preview (§5, §10). Local-only media state; nothing persisted,
+ * never reported as business truth, and no LiveKit connection here. */
+export default function DevicePreview(props: DevicePreviewProps) {
+  return (
+    <div className="meeting-device-preview">
+      <div className="meeting-preview-video" aria-label={t('meeting.prejoin.camera')} />
+      <label>
+        <input type="checkbox" checked={props.micOn} onChange={props.onToggleMic} />
+        {t('meeting.prejoin.microphone')}
+      </label>
+      <label>
+        <input type="checkbox" checked={props.cameraOn} onChange={props.onToggleCamera} />
+        {t('meeting.prejoin.camera')}
+      </label>
+      {props.permissionDenied && (
+        <div role="alert" aria-live="assertive">
+          {t('meeting.prejoin.camera')} / {t('meeting.prejoin.microphone')}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/dmworkmeeting/src/components/ParticipantList.tsx
+++ b/packages/dmworkmeeting/src/components/ParticipantList.tsx
@@ -31,7 +31,7 @@ export default function ParticipantList({ participants, capabilities, onMute, on
         return (
           <li key={p.uid} className="meeting-participant">
             <span className="meeting-participant-name">{p.displayName ?? p.uid}</span>
-            <span className="meeting-participant-role">{p.role}</span>
+            <span className="meeting-participant-role">{t(`meeting.room.role.${p.role}`)}</span>
             {onMute && (
               <button type="button" disabled={!actionable} aria-disabled={!actionable} onClick={() => onMute(p.uid)}>
                 {t('meeting.room.muteAll')}
@@ -44,7 +44,7 @@ export default function ParticipantList({ participants, capabilities, onMute, on
             )}
             {onSetRole && capabilities.viewerRole === 'host' && p.role === 'member' && (
               <button type="button" onClick={() => onSetRole(p.uid, 'cohost')}>
-                → cohost
+                {t('meeting.room.promoteCohost')}
               </button>
             )}
           </li>

--- a/packages/dmworkmeeting/src/components/ParticipantList.tsx
+++ b/packages/dmworkmeeting/src/components/ParticipantList.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { t } from '@octo/base';
+import type { MeetingRole, Participant } from '../service/contracts';
+
+export interface RoleControlsCapabilities {
+  /** Viewer's own role — H can act on anyone; C only on M (§5, FD-23). */
+  viewerRole: MeetingRole;
+}
+
+export interface ParticipantListProps {
+  participants: Participant[];
+  capabilities: RoleControlsCapabilities;
+  onMute?: (uid: string) => void;
+  onRemove?: (uid: string) => void;
+  onSetRole?: (uid: string, role: MeetingRole) => void;
+}
+
+/** A control target is greyed unless the viewer's role authorizes it. C may only
+ * act on M; the final authority is server-side — this only pre-greys the UI. */
+export function canActOn(viewerRole: MeetingRole, targetRole: MeetingRole): boolean {
+  if (viewerRole === 'host') return true;
+  if (viewerRole === 'cohost') return targetRole === 'member';
+  return false;
+}
+
+export default function ParticipantList({ participants, capabilities, onMute, onRemove, onSetRole }: ParticipantListProps) {
+  return (
+    <ul className="meeting-participants" aria-label={t('meeting.room.participants')}>
+      {participants.map((p) => {
+        const actionable = canActOn(capabilities.viewerRole, p.role);
+        return (
+          <li key={p.uid} className="meeting-participant">
+            <span className="meeting-participant-name">{p.displayName ?? p.uid}</span>
+            <span className="meeting-participant-role">{p.role}</span>
+            {onMute && (
+              <button type="button" disabled={!actionable} aria-disabled={!actionable} onClick={() => onMute(p.uid)}>
+                {t('meeting.room.muteAll')}
+              </button>
+            )}
+            {onRemove && (
+              <button type="button" disabled={!actionable} aria-disabled={!actionable} onClick={() => onRemove(p.uid)}>
+                ✕
+              </button>
+            )}
+            {onSetRole && capabilities.viewerRole === 'host' && p.role === 'member' && (
+              <button type="button" onClick={() => onSetRole(p.uid, 'cohost')}>
+                → cohost
+              </button>
+            )}
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/packages/dmworkmeeting/src/components/PasswordChallenge.test.tsx
+++ b/packages/dmworkmeeting/src/components/PasswordChallenge.test.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import PasswordChallenge from './PasswordChallenge';
+
+describe('PasswordChallenge (§8, §11 a11y)', () => {
+  it('renders a labelled 6-digit input focused on mount, with an assertive status region', () => {
+    render(<PasswordChallenge inCooldown={false} cooldownRemainingSeconds={0} onSubmit={() => {}} />);
+    const input = screen.getByLabelText(/6/i) as HTMLInputElement;
+    expect(input).toBeInTheDocument();
+    expect(document.activeElement).toBe(input);
+    const status = document.getElementById('meeting-password-status');
+    expect(status).toHaveAttribute('aria-live', 'assertive');
+    expect(status).toHaveAttribute('role', 'alert');
+  });
+
+  it('a short (format-invalid) password does NOT call onSubmit (not counted)', () => {
+    const onSubmit = vi.fn();
+    render(<PasswordChallenge inCooldown={false} cooldownRemainingSeconds={0} onSubmit={onSubmit} />);
+    const input = screen.getByLabelText(/6/i) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '123' } });
+    // Submit is disabled below 6 chars; force submit via the form to hit the guard.
+    fireEvent.submit(input.closest('form') as HTMLFormElement);
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(input).toHaveAttribute('aria-invalid', 'true');
+  });
+
+  it('a valid 6-digit password calls onSubmit', () => {
+    const onSubmit = vi.fn();
+    render(<PasswordChallenge inCooldown={false} cooldownRemainingSeconds={0} onSubmit={onSubmit} />);
+    const input = screen.getByLabelText(/6/i) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '123456' } });
+    fireEvent.submit(input.closest('form') as HTMLFormElement);
+    expect(onSubmit).toHaveBeenCalledWith('123456');
+  });
+
+  it('non-digits are stripped from the input', () => {
+    render(<PasswordChallenge inCooldown={false} cooldownRemainingSeconds={0} onSubmit={() => {}} />);
+    const input = screen.getByLabelText(/6/i) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '12ab34' } });
+    expect(input.value).toBe('1234');
+  });
+
+  it('during cooldown the submit is disabled and the countdown is announced', () => {
+    render(<PasswordChallenge inCooldown cooldownRemainingSeconds={42} onSubmit={() => {}} />);
+    const status = document.getElementById('meeting-password-status');
+    expect(status?.textContent).toContain('42');
+    const button = screen.getByRole('button');
+    expect(button).toBeDisabled();
+  });
+
+  it('announces remaining attempts after a wrong password', () => {
+    render(
+      <PasswordChallenge inCooldown={false} cooldownRemainingSeconds={0} lastInvalid attemptsRemaining={3} onSubmit={() => {}} />,
+    );
+    expect(document.getElementById('meeting-password-status')?.textContent).toContain('3');
+  });
+});

--- a/packages/dmworkmeeting/src/components/PasswordChallenge.tsx
+++ b/packages/dmworkmeeting/src/components/PasswordChallenge.tsx
@@ -1,0 +1,82 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { t } from '@octo/base';
+import { isValidPasswordFormat } from '../logic/password';
+
+export interface PasswordChallengeProps {
+  /** Server-authoritative remaining attempts (shown after a wrong password). */
+  attemptsRemaining?: number;
+  inCooldown: boolean;
+  cooldownRemainingSeconds: number;
+  /** Last submission was rejected by the server as incorrect. */
+  lastInvalid?: boolean;
+  submitting?: boolean;
+  onSubmit: (password: string) => void;
+}
+
+/**
+ * 6-digit password challenge (§8, §11). Format errors are caught locally and do
+ * NOT consume a server attempt. All status changes are announced via aria-live;
+ * focus stays on the input; submission is disabled during cooldown/submitting.
+ */
+export default function PasswordChallenge(props: PasswordChallengeProps) {
+  const { attemptsRemaining, inCooldown, cooldownRemainingSeconds, lastInvalid, submitting, onSubmit } = props;
+  const [value, setValue] = useState('');
+  const [formatError, setFormatError] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  const disabled = inCooldown || submitting;
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (disabled) return;
+    if (!isValidPasswordFormat(value)) {
+      setFormatError(true); // FD: format invalid is not counted as an attempt
+      inputRef.current?.focus();
+      return;
+    }
+    setFormatError(false);
+    onSubmit(value);
+  };
+
+  // Priority of the announced status line.
+  let status = '';
+  if (formatError) status = t('meeting.error.passwordFormatInvalid');
+  else if (inCooldown) status = t('meeting.challenge.cooldown', { values: { seconds: cooldownRemainingSeconds } });
+  else if (lastInvalid && typeof attemptsRemaining === 'number')
+    status = t('meeting.challenge.attemptsRemaining', { values: { count: attemptsRemaining } });
+
+  return (
+    <form className="meeting-challenge" onSubmit={handleSubmit} aria-label={t('meeting.challenge.title')}>
+      <h2>{t('meeting.challenge.title')}</h2>
+      <label htmlFor="meeting-password-input">{t('meeting.challenge.inputLabel')}</label>
+      <input
+        id="meeting-password-input"
+        ref={inputRef}
+        inputMode="numeric"
+        autoComplete="off"
+        maxLength={6}
+        pattern="\d{6}"
+        placeholder={t('meeting.challenge.placeholder')}
+        value={value}
+        aria-invalid={formatError || Boolean(lastInvalid)}
+        aria-describedby="meeting-password-status"
+        disabled={disabled}
+        onChange={(e) => {
+          setFormatError(false);
+          setValue(e.target.value.replace(/[^\d]/g, '').slice(0, 6));
+        }}
+      />
+      <button type="submit" disabled={disabled || value.length !== 6} aria-disabled={disabled || value.length !== 6}>
+        {t('meeting.challenge.submit')}
+      </button>
+      {/* Assertive so screen readers announce attempts/cooldown/format errors immediately. */}
+      <div id="meeting-password-status" role="alert" aria-live="assertive">
+        {status}
+      </div>
+    </form>
+  );
+}

--- a/packages/dmworkmeeting/src/components/ServiceUnavailable.test.tsx
+++ b/packages/dmworkmeeting/src/components/ServiceUnavailable.test.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import ServiceUnavailable from './ServiceUnavailable';
+import ParticipantList, { canActOn } from './ParticipantList';
+
+describe('ServiceUnavailable (§6.2 fail-closed)', () => {
+  it('gateway-missing shows "feature not enabled" and no retry button', () => {
+    render(<ServiceUnavailable reason="gateway-missing" onRetry={() => {}} />);
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(screen.queryByRole('button')).toBeNull();
+  });
+
+  it('service-unavailable offers a retry with the retry_after countdown', () => {
+    const onRetry = vi.fn();
+    render(<ServiceUnavailable reason="service-unavailable" retryAfter={9} onRetry={onRetry} />);
+    const button = screen.getByRole('button');
+    expect(button.textContent).toContain('9');
+    fireEvent.click(button);
+    expect(onRetry).toHaveBeenCalled();
+  });
+});
+
+describe('ParticipantList role gating (FD-23)', () => {
+  it('canActOn: host acts on anyone; cohost only on member; member on none', () => {
+    expect(canActOn('host', 'host')).toBe(true);
+    expect(canActOn('host', 'member')).toBe(true);
+    expect(canActOn('cohost', 'member')).toBe(true);
+    expect(canActOn('cohost', 'host')).toBe(false);
+    expect(canActOn('cohost', 'cohost')).toBe(false);
+    expect(canActOn('member', 'member')).toBe(false);
+  });
+
+  it('cohost cannot mute another cohost (control greyed / disabled)', () => {
+    render(
+      <ParticipantList
+        capabilities={{ viewerRole: 'cohost' }}
+        participants={[{ uid: 'c2', role: 'cohost' }, { uid: 'm1', role: 'member' }]}
+        onMute={() => {}}
+      />,
+    );
+    const buttons = screen.getAllByRole('button');
+    // First participant (cohost) → disabled; second (member) → enabled.
+    expect(buttons[0]).toBeDisabled();
+    expect(buttons[1]).not.toBeDisabled();
+  });
+});

--- a/packages/dmworkmeeting/src/components/ServiceUnavailable.tsx
+++ b/packages/dmworkmeeting/src/components/ServiceUnavailable.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { t } from '@octo/base';
+
+export type ServiceUnavailableReason = 'service-unavailable' | 'gateway-missing';
+
+export interface ServiceUnavailableProps {
+  reason: ServiceUnavailableReason;
+  /** Seconds until an automatic retry is allowed (service-unavailable only). */
+  retryAfter?: number;
+  onRetry?: () => void;
+}
+
+/**
+ * Fail-closed service state (§6.2, §14). A missing gateway route ("feature not
+ * enabled") is distinct from a temporarily-unavailable service; neither is ever
+ * shown as "meeting does not exist".
+ */
+export default function ServiceUnavailable({ reason, retryAfter, onRetry }: ServiceUnavailableProps) {
+  const message = reason === 'gateway-missing' ? t('meeting.service.notEnabled') : t('meeting.service.unavailable');
+  return (
+    <div className="meeting-service-unavailable" role="alert" aria-live="polite">
+      <p>{message}</p>
+      {reason === 'service-unavailable' && onRetry && (
+        <button type="button" onClick={onRetry}>
+          {retryAfter ? `${t('meeting.service.retry')} (${retryAfter}s)` : t('meeting.service.retry')}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/packages/dmworkmeeting/src/components/Terminal.tsx
+++ b/packages/dmworkmeeting/src/components/Terminal.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { t } from '@octo/base';
+import { MeetingErrorCode } from '../service/errors';
+
+export type TerminalReason =
+  | 'ended'
+  | 'cancelled'
+  | 'removed'
+  | 'superseded'
+  | 'left'
+  | 'noShow'
+  | 'emptyTimeout';
+
+const CODE_TO_REASON: Partial<Record<MeetingErrorCode, TerminalReason>> = {
+  [MeetingErrorCode.ENDED]: 'ended',
+  [MeetingErrorCode.CANCELLED]: 'cancelled',
+  [MeetingErrorCode.REMOVED]: 'removed',
+};
+
+export function reasonForCode(code: MeetingErrorCode): TerminalReason {
+  return CODE_TO_REASON[code] ?? 'ended';
+}
+
+export interface TerminalProps {
+  reason: TerminalReason;
+  onBackHome?: () => void;
+}
+
+/** Terminal overlay (§4, §7). Never black-screens; offers a way back. */
+export default function Terminal({ reason, onBackHome }: TerminalProps) {
+  return (
+    <div className="meeting-terminal" role="status" aria-live="polite">
+      <p>{t(`meeting.terminal.${reason}`)}</p>
+      {onBackHome && (
+        <button type="button" onClick={onBackHome}>
+          {t('meeting.terminal.backHome')}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/packages/dmworkmeeting/src/components/Terminal.tsx
+++ b/packages/dmworkmeeting/src/components/Terminal.tsx
@@ -9,7 +9,8 @@ export type TerminalReason =
   | 'superseded'
   | 'left'
   | 'noShow'
-  | 'emptyTimeout';
+  | 'emptyTimeout'
+  | 'authRequired';
 
 const CODE_TO_REASON: Partial<Record<MeetingErrorCode, TerminalReason>> = {
   [MeetingErrorCode.ENDED]: 'ended',

--- a/packages/dmworkmeeting/src/components/VideoGrid.tsx
+++ b/packages/dmworkmeeting/src/components/VideoGrid.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import type { Participant } from '../service/contracts';
+
+export interface VideoGridProps {
+  participants: Participant[];
+  /** Conservative tile cap; beyond this, tiles virtualize (§13, OD-02 pending). */
+  maxTiles?: number;
+  activeSpeakerUid?: string;
+}
+
+/** Renders participant tiles. Beyond maxTiles the overflow count is surfaced
+ * rather than rendering unbounded tiles (§13). Media tracks are attached by the
+ * livekitRoom layer, not here. */
+export default function VideoGrid({ participants, maxTiles = 16, activeSpeakerUid }: VideoGridProps) {
+  const visible = participants.slice(0, maxTiles);
+  const overflow = participants.length - visible.length;
+  return (
+    <div className="meeting-video-grid" role="group">
+      {visible.map((p) => (
+        <div
+          key={p.uid}
+          className="meeting-tile"
+          data-active-speaker={p.uid === activeSpeakerUid ? 'true' : undefined}
+        >
+          <span>{p.displayName ?? p.uid}</span>
+        </div>
+      ))}
+      {overflow > 0 && <div className="meeting-tile-overflow">+{overflow}</div>}
+    </div>
+  );
+}

--- a/packages/dmworkmeeting/src/i18n/en-US.json
+++ b/packages/dmworkmeeting/src/i18n/en-US.json
@@ -35,7 +35,9 @@
     "share": "Share screen",
     "stopShare": "Stop sharing",
     "reconnecting": "Reconnecting…",
-    "participants": "Participants"
+    "participants": "Participants",
+    "role": { "host": "Host", "cohost": "Co-host", "member": "Member" },
+    "promoteCohost": "Make co-host"
   },
   "terminal": {
     "ended": "This meeting has ended",

--- a/packages/dmworkmeeting/src/i18n/en-US.json
+++ b/packages/dmworkmeeting/src/i18n/en-US.json
@@ -1,0 +1,82 @@
+{
+  "menu": { "title": "Meeting" },
+  "home": {
+    "title": "Meetings",
+    "quick": "Start now",
+    "schedule": "Schedule",
+    "join": "Join",
+    "upcoming": "Upcoming",
+    "history": "History",
+    "empty": "No meetings yet"
+  },
+  "join": {
+    "numberLabel": "Meeting number or link",
+    "numberPlaceholder": "Enter meeting number",
+    "submit": "Continue"
+  },
+  "challenge": {
+    "title": "Enter meeting password",
+    "inputLabel": "6-digit password",
+    "placeholder": "6 digits",
+    "submit": "Verify",
+    "attemptsRemaining": "{{count}} attempts remaining",
+    "cooldown": "Too many attempts. Try again in {{seconds}}s."
+  },
+  "prejoin": {
+    "title": "Ready to join",
+    "camera": "Camera",
+    "microphone": "Microphone",
+    "join": "Join now",
+    "retry": "Media temporarily unavailable, retrying in {{seconds}}s"
+  },
+  "room": {
+    "leave": "Leave",
+    "muteAll": "Mute all",
+    "share": "Share screen",
+    "stopShare": "Stop sharing",
+    "reconnecting": "Reconnecting…",
+    "participants": "Participants"
+  },
+  "terminal": {
+    "ended": "This meeting has ended",
+    "cancelled": "This meeting was cancelled",
+    "removed": "You were removed from the meeting",
+    "superseded": "You joined from another device",
+    "left": "You left the meeting",
+    "noShow": "The meeting ended because no one joined",
+    "emptyTimeout": "The meeting ended after being empty",
+    "backHome": "Back to meetings"
+  },
+  "service": {
+    "unavailable": "Meeting service is temporarily unavailable",
+    "notEnabled": "Meeting is not enabled",
+    "retry": "Retry"
+  },
+  "history": { "passwordEnabled": "Password protection: enabled", "passwordDisabled": "Password protection: disabled" },
+  "error": {
+    "authRequired": "Please sign in again",
+    "credentialInvalid": "Invalid meeting number or link",
+    "ended": "This meeting has ended",
+    "cancelled": "This meeting was cancelled",
+    "tooEarly": "You can join from {{earliestJoinAt}}",
+    "locked": "This meeting is locked",
+    "full": "This meeting is full",
+    "removed": "You were removed from the meeting",
+    "notSameSpace": "Switch to the correct space to access this meeting",
+    "passwordRequired": "This meeting requires a password",
+    "passwordFormatInvalid": "Please enter a 6-digit password",
+    "passwordInvalid": "Incorrect password",
+    "passwordCooldown": "Too many attempts. Please wait before retrying.",
+    "passwordPassExpired": "Verification expired, please re-enter the password",
+    "passwordImmutable": "Password cannot be changed after the meeting starts",
+    "forbidden": "You do not have permission for this action",
+    "versionConflict": "This meeting changed, refreshing…",
+    "idempotencyConflict": "Duplicate request detected",
+    "shareConflict": "Someone is already sharing",
+    "livekitUnavailable": "Media is temporarily unavailable",
+    "notificationDeferred": "Notifications will be delivered shortly",
+    "timeInvalid": "Please choose a valid time",
+    "rateLimited": "Too many requests, please wait",
+    "internal": "Something went wrong, please retry"
+  }
+}

--- a/packages/dmworkmeeting/src/i18n/en-US.json
+++ b/packages/dmworkmeeting/src/i18n/en-US.json
@@ -14,6 +14,22 @@
     "numberPlaceholder": "Enter meeting number",
     "submit": "Continue"
   },
+  "form": {
+    "titleLabel": "Title",
+    "startLabel": "Start time",
+    "enablePassword": "Require a password to join",
+    "save": "Save",
+    "createNow": "Start now",
+    "editTitle": "Edit meeting",
+    "cancelMeeting": "Cancel meeting"
+  },
+  "detail": {
+    "number": "Meeting number",
+    "copyNumber": "Copy number",
+    "copyLink": "Copy join link",
+    "copied": "Copied",
+    "edit": "Edit"
+  },
   "challenge": {
     "title": "Enter meeting password",
     "inputLabel": "6-digit password",
@@ -36,6 +52,7 @@
     "stopShare": "Stop sharing",
     "reconnecting": "Reconnecting…",
     "participants": "Participants",
+    "mediaUnavailable": "Media is not connected",
     "role": { "host": "Host", "cohost": "Co-host", "member": "Member" },
     "promoteCohost": "Make co-host"
   },
@@ -47,6 +64,7 @@
     "left": "You left the meeting",
     "noShow": "The meeting ended because no one joined",
     "emptyTimeout": "The meeting ended after being empty",
+    "authRequired": "Please sign in again",
     "backHome": "Back to meetings"
   },
   "service": {

--- a/packages/dmworkmeeting/src/i18n/zh-CN.json
+++ b/packages/dmworkmeeting/src/i18n/zh-CN.json
@@ -1,0 +1,82 @@
+{
+  "menu": { "title": "会议" },
+  "home": {
+    "title": "会议",
+    "quick": "快速会议",
+    "schedule": "预约会议",
+    "join": "加入会议",
+    "upcoming": "即将开始",
+    "history": "历史会议",
+    "empty": "暂无会议"
+  },
+  "join": {
+    "numberLabel": "会议号或链接",
+    "numberPlaceholder": "请输入会议号",
+    "submit": "继续"
+  },
+  "challenge": {
+    "title": "输入会议密码",
+    "inputLabel": "6 位数字密码",
+    "placeholder": "6 位数字",
+    "submit": "验证",
+    "attemptsRemaining": "还可尝试 {{count}} 次",
+    "cooldown": "尝试次数过多，请在 {{seconds}} 秒后重试。"
+  },
+  "prejoin": {
+    "title": "准备加入",
+    "camera": "摄像头",
+    "microphone": "麦克风",
+    "join": "立即加入",
+    "retry": "媒体暂不可用，{{seconds}} 秒后重试"
+  },
+  "room": {
+    "leave": "离开",
+    "muteAll": "全体静音",
+    "share": "共享屏幕",
+    "stopShare": "停止共享",
+    "reconnecting": "重新连接中…",
+    "participants": "成员"
+  },
+  "terminal": {
+    "ended": "会议已结束",
+    "cancelled": "会议已取消",
+    "removed": "你已被移出会议",
+    "superseded": "你已在其他设备加入",
+    "left": "你已离开会议",
+    "noShow": "无人加入，会议已结束",
+    "emptyTimeout": "会议因空房已结束",
+    "backHome": "返回会议列表"
+  },
+  "service": {
+    "unavailable": "会议服务暂不可用",
+    "notEnabled": "会议功能未启用",
+    "retry": "重试"
+  },
+  "history": { "passwordEnabled": "密码保护：已启用", "passwordDisabled": "密码保护：未启用" },
+  "error": {
+    "authRequired": "请重新登录",
+    "credentialInvalid": "会议号或链接无效",
+    "ended": "会议已结束",
+    "cancelled": "会议已取消",
+    "tooEarly": "可从 {{earliestJoinAt}} 开始入会",
+    "locked": "会议已锁定",
+    "full": "会议人数已满",
+    "removed": "你已被移出会议",
+    "notSameSpace": "请切换到正确的空间以访问该会议",
+    "passwordRequired": "该会议需要入会密码",
+    "passwordFormatInvalid": "请输入 6 位数字密码",
+    "passwordInvalid": "密码错误",
+    "passwordCooldown": "尝试次数过多，请稍后再试。",
+    "passwordPassExpired": "验证已过期，请重新输入密码",
+    "passwordImmutable": "会议开始后密码不可修改",
+    "forbidden": "你没有执行该操作的权限",
+    "versionConflict": "会议信息已变更，正在刷新…",
+    "idempotencyConflict": "检测到重复请求",
+    "shareConflict": "已有成员正在共享",
+    "livekitUnavailable": "媒体暂不可用",
+    "notificationDeferred": "通知将稍后送达",
+    "timeInvalid": "请选择有效的时间",
+    "rateLimited": "请求过于频繁，请稍候",
+    "internal": "出现错误，请重试"
+  }
+}

--- a/packages/dmworkmeeting/src/i18n/zh-CN.json
+++ b/packages/dmworkmeeting/src/i18n/zh-CN.json
@@ -35,7 +35,9 @@
     "share": "共享屏幕",
     "stopShare": "停止共享",
     "reconnecting": "重新连接中…",
-    "participants": "成员"
+    "participants": "成员",
+    "role": { "host": "主持人", "cohost": "联席主持", "member": "成员" },
+    "promoteCohost": "设为联席主持"
   },
   "terminal": {
     "ended": "会议已结束",

--- a/packages/dmworkmeeting/src/i18n/zh-CN.json
+++ b/packages/dmworkmeeting/src/i18n/zh-CN.json
@@ -14,6 +14,22 @@
     "numberPlaceholder": "请输入会议号",
     "submit": "继续"
   },
+  "form": {
+    "titleLabel": "标题",
+    "startLabel": "开始时间",
+    "enablePassword": "入会需要密码",
+    "save": "保存",
+    "createNow": "立即开始",
+    "editTitle": "编辑会议",
+    "cancelMeeting": "取消会议"
+  },
+  "detail": {
+    "number": "会议号",
+    "copyNumber": "复制会议号",
+    "copyLink": "复制入会链接",
+    "copied": "已复制",
+    "edit": "编辑"
+  },
   "challenge": {
     "title": "输入会议密码",
     "inputLabel": "6 位数字密码",
@@ -36,6 +52,7 @@
     "stopShare": "停止共享",
     "reconnecting": "重新连接中…",
     "participants": "成员",
+    "mediaUnavailable": "媒体未连接",
     "role": { "host": "主持人", "cohost": "联席主持", "member": "成员" },
     "promoteCohost": "设为联席主持"
   },
@@ -47,6 +64,7 @@
     "left": "你已离开会议",
     "noShow": "无人加入，会议已结束",
     "emptyTimeout": "会议因空房已结束",
+    "authRequired": "请重新登录",
     "backHome": "返回会议列表"
   },
   "service": {

--- a/packages/dmworkmeeting/src/index.tsx
+++ b/packages/dmworkmeeting/src/index.tsx
@@ -1,0 +1,5 @@
+export { MeetingModule } from './module';
+export { MeetingApiClient } from './service/MeetingApiClient';
+export { MeetingErrorCode, MEETING_ERROR_TABLE, directiveForCode } from './service/errors';
+export { evaluateAdmission } from './logic/admission';
+export type { Meeting, Participant } from './service/contracts';

--- a/packages/dmworkmeeting/src/logic/admission.test.ts
+++ b/packages/dmworkmeeting/src/logic/admission.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from 'vitest';
+import {
+  evaluateAdmission,
+  computePasswordRequired,
+  pickHostTransferTarget,
+  type AdmissionFacts,
+} from './admission';
+import { MeetingErrorCode } from '../service/errors';
+
+const base = (over: Partial<AdmissionFacts> = {}): AdmissionFacts => ({
+  callerAuthorizedToKnowExistence: true,
+  exists: true,
+  ended: false,
+  cancelled: false,
+  locked: false,
+  full: false,
+  removedForCaller: false,
+  tooEarly: false,
+  sameSpace: true,
+  passwordEnabled: false,
+  hasValidPassToken: false,
+  creatorExempt: false,
+  reconnectGraceExempt: false,
+  ...over,
+});
+
+describe('admission oracle — step-1 ordering (FD-27)', () => {
+  it('eligible with no password → allowedToPrejoin true (N1)', () => {
+    const v = evaluateAdmission(base());
+    expect(v.eligible).toBe(true);
+    expect(v.passwordRequired).toBe(false);
+    expect(v.allowedToPrejoin).toBe(true);
+  });
+
+  it('eligible + password enabled → challenge, not prejoin (N1)', () => {
+    const v = evaluateAdmission(base({ passwordEnabled: true }));
+    expect(v.eligible).toBe(true);
+    expect(v.passwordRequired).toBe(true);
+    expect(v.allowedToPrejoin).toBe(false);
+  });
+
+  it.each([
+    ['ended', { ended: true }, MeetingErrorCode.ENDED],
+    ['cancelled', { cancelled: true }, MeetingErrorCode.CANCELLED],
+    ['locked', { locked: true }, MeetingErrorCode.LOCKED],
+    ['full', { full: true }, MeetingErrorCode.FULL],
+    ['removed', { removedForCaller: true }, MeetingErrorCode.REMOVED],
+    ['too early', { tooEarly: true }, MeetingErrorCode.TOO_EARLY],
+    ['cross-space (authorized)', { sameSpace: false }, MeetingErrorCode.NOT_SAME_SPACE],
+  ] as const)('%s → %s', (_label, over, code) => {
+    const v = evaluateAdmission(base(over));
+    expect(v.eligible).toBe(false);
+    expect(v.code).toBe(code);
+    // Never leak password state on an ineligible verdict.
+    expect(v.passwordRequired).toBeUndefined();
+    expect(v.allowedToPrejoin).toBeUndefined();
+  });
+
+  it('multi-failure takes the FIRST code: locked + full + removed → LOCKED', () => {
+    expect(evaluateAdmission(base({ locked: true, full: true, removedForCaller: true })).code).toBe(
+      MeetingErrorCode.LOCKED,
+    );
+  });
+
+  it('multi-failure: removed + cross-Space → REMOVED (removed precedes space)', () => {
+    expect(evaluateAdmission(base({ removedForCaller: true, sameSpace: false })).code).toBe(
+      MeetingErrorCode.REMOVED,
+    );
+  });
+});
+
+describe('admission oracle — S-1 enumeration envelope', () => {
+  it('unauthorized caller always gets CREDENTIAL_INVALID, regardless of real state', () => {
+    // A live, locked, cross-space meeting that really exists — unauthorized
+    // caller must not learn any of that.
+    const v = evaluateAdmission(
+      base({ callerAuthorizedToKnowExistence: false, locked: true, sameSpace: false, passwordEnabled: true }),
+    );
+    expect(v.code).toBe(MeetingErrorCode.CREDENTIAL_INVALID);
+    expect(v.code).not.toBe(MeetingErrorCode.NOT_SAME_SPACE);
+    expect(v.code).not.toBe(MeetingErrorCode.LOCKED);
+  });
+
+  it('non-existent meeting is indistinguishable from unauthorized guess', () => {
+    const missing = evaluateAdmission(base({ exists: false }));
+    const unauthorized = evaluateAdmission(base({ callerAuthorizedToKnowExistence: false }));
+    expect(missing.code).toBe(MeetingErrorCode.CREDENTIAL_INVALID);
+    expect(unauthorized.code).toBe(MeetingErrorCode.CREDENTIAL_INVALID);
+  });
+
+  it('authorized cross-Space caller (creator/invitee/participant) gets NOT_SAME_SPACE, not 404', () => {
+    const v = evaluateAdmission(base({ callerAuthorizedToKnowExistence: true, sameSpace: false }));
+    expect(v.code).toBe(MeetingErrorCode.NOT_SAME_SPACE);
+  });
+});
+
+describe('password_required truth table (N1)', () => {
+  it('creator exemption suppresses password', () => {
+    expect(computePasswordRequired(base({ passwordEnabled: true, creatorExempt: true }))).toBe(false);
+  });
+  it('valid pass token suppresses password', () => {
+    expect(computePasswordRequired(base({ passwordEnabled: true, hasValidPassToken: true }))).toBe(false);
+  });
+  it('same-endpoint 15s grace suppresses password', () => {
+    expect(computePasswordRequired(base({ passwordEnabled: true, reconnectGraceExempt: true }))).toBe(false);
+  });
+  it('enabled with no exemption requires password', () => {
+    expect(computePasswordRequired(base({ passwordEnabled: true }))).toBe(true);
+  });
+});
+
+describe('host-transfer target ordering (N2, FD-06)', () => {
+  it('earliest joinAt wins, uid breaks ties, superseded/left excluded', () => {
+    const target = pickHostTransferTarget([
+      { uid: 'zeta', joinAt: '2026-01-01T00:00:01Z', superseded: false, left: false },
+      { uid: 'alpha', joinAt: '2026-01-01T00:00:01Z', superseded: false, left: false }, // tie → uid asc
+      { uid: 'early', joinAt: '2026-01-01T00:00:00Z', superseded: true, left: false }, // excluded
+      { uid: 'gone', joinAt: '2026-01-01T00:00:00Z', superseded: false, left: true }, // excluded
+    ]);
+    expect(target).toBe('alpha');
+  });
+  it('no active candidate → undefined', () => {
+    expect(pickHostTransferTarget([{ uid: 'x', joinAt: 't', superseded: true, left: false }])).toBeUndefined();
+  });
+});

--- a/packages/dmworkmeeting/src/logic/admission.ts
+++ b/packages/dmworkmeeting/src/logic/admission.ts
@@ -1,0 +1,101 @@
+// Deterministic admission oracle (frontend appendix §7, FD-27 / S-1 / N1 / FD-32).
+//
+// evaluate and finalize run the SAME oracle. The frontend NEVER infers meeting
+// status or the admission verdict locally at runtime — this pure function exists
+// to (a) drive deterministic unit tests that mirror the server contract, and
+// (b) render the correct terminal/challenge/prejoin state from the server's
+// verdict. The server remains the source of truth; this encodes the identical
+// ordering so red→green assertions are exact.
+
+import { MeetingErrorCode } from '../service/errors';
+
+/** All facts the oracle needs. Booleans reflect server-authoritative state. */
+export interface AdmissionFacts {
+  /** S-1: caller is same-Space active member OR creator OR invitee OR participant. */
+  callerAuthorizedToKnowExistence: boolean;
+  exists: boolean;
+  ended: boolean;
+  cancelled: boolean;
+  locked: boolean;
+  full: boolean;
+  removedForCaller: boolean;
+  tooEarly: boolean;
+  /** Caller's current Space equals the meeting's Space. */
+  sameSpace: boolean;
+  // password inputs (only consulted once eligible)
+  passwordEnabled: boolean;
+  hasValidPassToken: boolean;
+  creatorExempt: boolean; // creator joining own meeting (FD-26)
+  reconnectGraceExempt: boolean; // same-endpoint 15s grace (FD-29)
+}
+
+export interface AdmissionVerdict {
+  eligible: boolean;
+  /** Present only when NOT eligible — the first failing step-1 code. */
+  code?: MeetingErrorCode;
+  /** Only meaningful when eligible. */
+  passwordRequired?: boolean;
+  allowedToPrejoin?: boolean;
+}
+
+/**
+ * N1 truth table: password_required is true iff the meeting enables a password
+ * AND the caller has no TTL-valid pass token AND is not covered by the creator
+ * or same-endpoint-15s-grace exemptions.
+ */
+export function computePasswordRequired(facts: AdmissionFacts): boolean {
+  return (
+    facts.passwordEnabled && !facts.hasValidPassToken && !facts.creatorExempt && !facts.reconnectGraceExempt
+  );
+}
+
+/**
+ * The step-1 ordering (FD-27), applied AFTER the S-1 authorization envelope:
+ *   authorized-to-know → exists → not-ended → not-cancelled → not-locked →
+ *   not-full → not-removed → not-too-early → same-Space.
+ *
+ * On multiple failures the FIRST failing code wins ("locked + full + removed" →
+ * LOCKED; "removed + cross-Space" → REMOVED). An unauthorized caller collapses
+ * to CREDENTIAL_INVALID (404) for ANY real state and never sees NOT_SAME_SPACE,
+ * a step-1 code, or password state — indistinguishable from "does not exist".
+ */
+export function evaluateAdmission(facts: AdmissionFacts): AdmissionVerdict {
+  // S-1 envelope — decided before any state is revealed.
+  if (!facts.callerAuthorizedToKnowExistence) {
+    return { eligible: false, code: MeetingErrorCode.CREDENTIAL_INVALID };
+  }
+  if (!facts.exists) return { eligible: false, code: MeetingErrorCode.CREDENTIAL_INVALID };
+  if (facts.ended) return { eligible: false, code: MeetingErrorCode.ENDED };
+  if (facts.cancelled) return { eligible: false, code: MeetingErrorCode.CANCELLED };
+  if (facts.locked) return { eligible: false, code: MeetingErrorCode.LOCKED };
+  if (facts.full) return { eligible: false, code: MeetingErrorCode.FULL };
+  if (facts.removedForCaller) return { eligible: false, code: MeetingErrorCode.REMOVED };
+  if (facts.tooEarly) return { eligible: false, code: MeetingErrorCode.TOO_EARLY };
+  if (!facts.sameSpace) return { eligible: false, code: MeetingErrorCode.NOT_SAME_SPACE };
+
+  const passwordRequired = computePasswordRequired(facts);
+  return { eligible: true, passwordRequired, allowedToPrejoin: !passwordRequired };
+}
+
+/**
+ * Host-transfer target ordering (N2, FD-06). Server-authoritative; the frontend
+ * only renders the server's chosen host. This comparator encodes the identical
+ * rule (earliest active segment.joinAt asc, uid asc to break ties) purely for
+ * deterministic E2E/unit assertions of visibility order.
+ */
+export interface TransferCandidate {
+  uid: string;
+  joinAt: string; // UTC ISO-8601
+  superseded: boolean;
+  left: boolean;
+}
+
+export function pickHostTransferTarget(candidates: TransferCandidate[]): string | undefined {
+  const active = candidates.filter((c) => !c.superseded && !c.left);
+  if (active.length === 0) return undefined;
+  active.sort((a, b) => {
+    if (a.joinAt !== b.joinAt) return a.joinAt < b.joinAt ? -1 : 1;
+    return a.uid < b.uid ? -1 : a.uid > b.uid ? 1 : 0;
+  });
+  return active[0].uid;
+}

--- a/packages/dmworkmeeting/src/logic/password.test.ts
+++ b/packages/dmworkmeeting/src/logic/password.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isValidPasswordFormat,
+  reduceWrongPassword,
+  cooldownRemainingSeconds,
+  isCooldownExpired,
+  clearedCooldownState,
+  initialCooldownState,
+  MAX_PASSWORD_ATTEMPTS,
+  PASSWORD_COOLDOWN_SECONDS,
+} from './password';
+
+describe('password format (FD-24, PW-5)', () => {
+  it.each(['000000', '123456', '999999'])('accepts 6 digits: %s', (v) => {
+    expect(isValidPasswordFormat(v)).toBe(true);
+  });
+  it.each(['12345', '1234567', 'abcdef', '12 456', '', '12a456'])('rejects non-6-digit: %s', (v) => {
+    expect(isValidPasswordFormat(v)).toBe(false);
+  });
+});
+
+describe('cooldown reducer (FD-28, PW-1..4)', () => {
+  it('attempts 1..4 stay retriable (no cooldown)', () => {
+    for (const remaining of [4, 3, 2, 1]) {
+      const s = reduceWrongPassword({ attemptsRemaining: remaining });
+      expect(s.inCooldown).toBe(false);
+      expect(s.attemptsRemaining).toBe(remaining);
+    }
+  });
+
+  it('the 5th failure (0 remaining) enters cooldown with retry_at', () => {
+    const retryAtMs = 1_000 + PASSWORD_COOLDOWN_SECONDS * 1000;
+    const s = reduceWrongPassword({ attemptsRemaining: 0, retryAtMs, cooldown: true });
+    expect(s.inCooldown).toBe(true);
+    expect(s.retryAtMs).toBe(retryAtMs);
+  });
+
+  it('server cooldown flag forces cooldown even if remaining reported > 0', () => {
+    const s = reduceWrongPassword({ attemptsRemaining: 2, cooldown: true, retryAtMs: 9999 });
+    expect(s.inCooldown).toBe(true);
+  });
+
+  it('MAX attempts constant is 5', () => {
+    expect(MAX_PASSWORD_ATTEMPTS).toBe(5);
+    expect(initialCooldownState().attemptsRemaining).toBe(4);
+  });
+});
+
+describe('cooldown clock (deterministic, 5 min)', () => {
+  const nowMs = 1_000_000;
+  const state = { attemptsRemaining: 0, inCooldown: true, retryAtMs: nowMs + 300_000 };
+
+  it('reports remaining seconds', () => {
+    expect(cooldownRemainingSeconds(state, nowMs)).toBe(300);
+    expect(cooldownRemainingSeconds(state, nowMs + 299_000)).toBe(1);
+  });
+
+  it('expires exactly at retry_at and clears atomically', () => {
+    expect(isCooldownExpired(state, nowMs + 299_999)).toBe(false);
+    expect(isCooldownExpired(state, nowMs + 300_000)).toBe(true);
+    const cleared = clearedCooldownState();
+    expect(cleared.inCooldown).toBe(false);
+    expect(cleared.attemptsRemaining).toBe(4);
+  });
+});

--- a/packages/dmworkmeeting/src/logic/password.test.ts
+++ b/packages/dmworkmeeting/src/logic/password.test.ts
@@ -44,6 +44,21 @@ describe('cooldown reducer (FD-28, PW-1..4)', () => {
     expect(MAX_PASSWORD_ATTEMPTS).toBe(5);
     expect(initialCooldownState().attemptsRemaining).toBe(4);
   });
+
+  it('never wedges: 0 remaining WITHOUT retry_at does NOT enter cooldown', () => {
+    const s = reduceWrongPassword({ attemptsRemaining: 0 });
+    expect(s.inCooldown).toBe(false);
+  });
+
+  it('absent attempts_remaining is treated as unknown (stay on challenge, no cooldown)', () => {
+    const s = reduceWrongPassword({});
+    expect(s.inCooldown).toBe(false);
+  });
+
+  it('cooldown flag WITHOUT retry_at does not wedge (cannot count down)', () => {
+    const s = reduceWrongPassword({ cooldown: true });
+    expect(s.inCooldown).toBe(false);
+  });
 });
 
 describe('cooldown clock (deterministic, 5 min)', () => {

--- a/packages/dmworkmeeting/src/logic/password.ts
+++ b/packages/dmworkmeeting/src/logic/password.ts
@@ -27,15 +27,22 @@ export const initialCooldownState = (): CooldownState => ({
 
 /**
  * Reduce a wrong-password result. `attemptsRemaining` and `retryAtMs` come from
- * the server; when the server reports 0 remaining (the 5th failure) we enter
- * cooldown. A pure reducer so PW-1..4 (retriable) and PW-4→cooldown are exact.
+ * the server. Fail-safe against a provisional contract: we only enter cooldown
+ * when we can actually time it out (a `retryAtMs` is present) — a cooldown with
+ * no retry time would leave the input disabled forever behind a frozen "0s"
+ * countdown. A missing `attemptsRemaining` is treated as "unknown, stay on the
+ * challenge" rather than 0. A pure reducer so PW-1..4 and the absent-field
+ * shapes are exact.
  */
 export function reduceWrongPassword(
-  server: { attemptsRemaining: number; retryAtMs?: number; cooldown?: boolean },
+  server: { attemptsRemaining?: number; retryAtMs?: number; cooldown?: boolean },
 ): CooldownState {
-  const inCooldown = server.cooldown === true || server.attemptsRemaining <= 0;
+  const remaining = typeof server.attemptsRemaining === 'number' ? Math.max(0, server.attemptsRemaining) : undefined;
+  const wantsCooldown = server.cooldown === true || (remaining !== undefined && remaining <= 0);
+  // Never wedge: cooldown requires a retry time we can count down to.
+  const inCooldown = wantsCooldown && server.retryAtMs !== undefined;
   return {
-    attemptsRemaining: Math.max(0, server.attemptsRemaining),
+    attemptsRemaining: remaining ?? MAX_PASSWORD_ATTEMPTS - 1,
     inCooldown,
     retryAtMs: inCooldown ? server.retryAtMs : undefined,
   };

--- a/packages/dmworkmeeting/src/logic/password.ts
+++ b/packages/dmworkmeeting/src/logic/password.ts
@@ -1,0 +1,59 @@
+// Password format + attempt/cooldown state (§8, FD-24, FD-28). All time is
+// injected so tests are deterministic; the server remains authoritative for
+// attempts_remaining / retry_at (the frontend mirrors, never invents).
+
+export const PASSWORD_PATTERN = /^\d{6}$/;
+export const MAX_PASSWORD_ATTEMPTS = 5; // 1-4 retriable; the 5th enters cooldown
+export const PASSWORD_COOLDOWN_SECONDS = 300; // 5 minutes
+
+/** Frontend pre-check mirroring the prototype `submitPassword` guard. A format
+ * failure is surfaced locally and does NOT consume a server attempt. */
+export function isValidPasswordFormat(input: string): boolean {
+  return PASSWORD_PATTERN.test(input);
+}
+
+export interface CooldownState {
+  /** Server-authoritative remaining attempts before cooldown. */
+  attemptsRemaining: number;
+  inCooldown: boolean;
+  /** Epoch ms when cooldown ends (mirrors server retry_at). */
+  retryAtMs?: number;
+}
+
+export const initialCooldownState = (): CooldownState => ({
+  attemptsRemaining: MAX_PASSWORD_ATTEMPTS - 1, // attempts left AFTER the current one is available
+  inCooldown: false,
+});
+
+/**
+ * Reduce a wrong-password result. `attemptsRemaining` and `retryAtMs` come from
+ * the server; when the server reports 0 remaining (the 5th failure) we enter
+ * cooldown. A pure reducer so PW-1..4 (retriable) and PW-4→cooldown are exact.
+ */
+export function reduceWrongPassword(
+  server: { attemptsRemaining: number; retryAtMs?: number; cooldown?: boolean },
+): CooldownState {
+  const inCooldown = server.cooldown === true || server.attemptsRemaining <= 0;
+  return {
+    attemptsRemaining: Math.max(0, server.attemptsRemaining),
+    inCooldown,
+    retryAtMs: inCooldown ? server.retryAtMs : undefined,
+  };
+}
+
+/** Cooldown clears atomically on expiry (or on a successful verify). Deterministic
+ * via injected `nowMs`. Returns remaining seconds (ceil) and whether it cleared. */
+export function cooldownRemainingSeconds(state: CooldownState, nowMs: number): number {
+  if (!state.inCooldown || state.retryAtMs === undefined) return 0;
+  return Math.max(0, Math.ceil((state.retryAtMs - nowMs) / 1000));
+}
+
+export function isCooldownExpired(state: CooldownState, nowMs: number): boolean {
+  if (!state.inCooldown || state.retryAtMs === undefined) return false;
+  return nowMs >= state.retryAtMs;
+}
+
+/** On expiry/success the counter resets atomically (FD-28). */
+export function clearedCooldownState(): CooldownState {
+  return initialCooldownState();
+}

--- a/packages/dmworkmeeting/src/logic/stateMachine.test.ts
+++ b/packages/dmworkmeeting/src/logic/stateMachine.test.ts
@@ -56,6 +56,10 @@ describe('UI state machine (§7)', () => {
     expect(nextMeetingState('finalizing', { type: 'FINALIZE_PASS_EXPIRED' })).toBe('challenge');
   });
 
+  it('finalize step-1 recheck that now requires a password → back to challenge', () => {
+    expect(nextMeetingState('finalizing', { type: 'FINALIZE_PASSWORD_REQUIRED' })).toBe('challenge');
+  });
+
   it('finalize step-1 recheck (FD-32): terminal code → terminal, recoverable code → blocked', () => {
     expect(nextMeetingState('finalizing', { type: 'FINALIZE_STEP1', code: MeetingErrorCode.REMOVED })).toBe('terminal');
     expect(nextMeetingState('finalizing', { type: 'FINALIZE_STEP1', code: MeetingErrorCode.LOCKED })).toBe('blocked');

--- a/packages/dmworkmeeting/src/logic/stateMachine.test.ts
+++ b/packages/dmworkmeeting/src/logic/stateMachine.test.ts
@@ -12,10 +12,20 @@ describe('UI state machine (§7)', () => {
     expect(nextMeetingState('evaluating', { type: 'EVALUATE_ELIGIBLE', passwordRequired: false })).toBe('prejoin');
   });
 
-  it('ineligible → terminal', () => {
+  it('ineligible terminal code → terminal; recoverable code → blocked', () => {
     expect(nextMeetingState('evaluating', { type: 'EVALUATE_INELIGIBLE', code: MeetingErrorCode.ENDED })).toBe(
       'terminal',
     );
+    expect(nextMeetingState('evaluating', { type: 'EVALUATE_INELIGIBLE', code: MeetingErrorCode.LOCKED })).toBe(
+      'blocked',
+    );
+    expect(nextMeetingState('evaluating', { type: 'EVALUATE_INELIGIBLE', code: MeetingErrorCode.CREDENTIAL_INVALID })).toBe(
+      'blocked',
+    );
+  });
+
+  it('blocked is recoverable: RETRY → evaluating', () => {
+    expect(nextMeetingState('blocked', { type: 'RETRY' })).toBe('evaluating');
   });
 
   it('challenge: submit → verifying → pass → prejoin', () => {
@@ -46,8 +56,9 @@ describe('UI state machine (§7)', () => {
     expect(nextMeetingState('finalizing', { type: 'FINALIZE_PASS_EXPIRED' })).toBe('challenge');
   });
 
-  it('finalize step-1 recheck (FD-32) → terminal', () => {
-    expect(nextMeetingState('finalizing', { type: 'FINALIZE_STEP1', code: MeetingErrorCode.LOCKED })).toBe('terminal');
+  it('finalize step-1 recheck (FD-32): terminal code → terminal, recoverable code → blocked', () => {
+    expect(nextMeetingState('finalizing', { type: 'FINALIZE_STEP1', code: MeetingErrorCode.REMOVED })).toBe('terminal');
+    expect(nextMeetingState('finalizing', { type: 'FINALIZE_STEP1', code: MeetingErrorCode.LOCKED })).toBe('blocked');
   });
 
   it('room reconnect: SDK disconnect → reconnecting → ok → room', () => {

--- a/packages/dmworkmeeting/src/logic/stateMachine.test.ts
+++ b/packages/dmworkmeeting/src/logic/stateMachine.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import { nextMeetingState, isTerminalCode, type MeetingUiState } from './stateMachine';
+import { MeetingErrorCode } from '../service/errors';
+
+describe('UI state machine (§7)', () => {
+  it('idle → evaluating → challenge when password required', () => {
+    expect(nextMeetingState('idle', { type: 'START_EVALUATE' })).toBe('evaluating');
+    expect(nextMeetingState('evaluating', { type: 'EVALUATE_ELIGIBLE', passwordRequired: true })).toBe('challenge');
+  });
+
+  it('eligible without password → prejoin directly', () => {
+    expect(nextMeetingState('evaluating', { type: 'EVALUATE_ELIGIBLE', passwordRequired: false })).toBe('prejoin');
+  });
+
+  it('ineligible → terminal', () => {
+    expect(nextMeetingState('evaluating', { type: 'EVALUATE_INELIGIBLE', code: MeetingErrorCode.ENDED })).toBe(
+      'terminal',
+    );
+  });
+
+  it('challenge: submit → verifying → pass → prejoin', () => {
+    expect(nextMeetingState('challenge', { type: 'SUBMIT_PASSWORD' })).toBe('verifying');
+    expect(nextMeetingState('verifying', { type: 'PASSWORD_PASS' })).toBe('prejoin');
+  });
+
+  it('wrong password without cooldown stays on challenge; format-invalid stays on challenge', () => {
+    expect(nextMeetingState('verifying', { type: 'PASSWORD_INVALID', enteringCooldown: false })).toBe('challenge');
+    expect(nextMeetingState('challenge', { type: 'PASSWORD_FORMAT_INVALID' })).toBe('challenge');
+  });
+
+  it('5th wrong password → cooldown → expiry → challenge', () => {
+    expect(nextMeetingState('verifying', { type: 'PASSWORD_INVALID', enteringCooldown: true })).toBe('cooldown');
+    expect(nextMeetingState('cooldown', { type: 'COOLDOWN_EXPIRED' })).toBe('challenge');
+  });
+
+  it('prejoin → finalizing → room on success', () => {
+    expect(nextMeetingState('prejoin', { type: 'START_FINALIZE' })).toBe('finalizing');
+    expect(nextMeetingState('finalizing', { type: 'FINALIZE_SUCCESS' })).toBe('room');
+  });
+
+  it('LIVEKIT_UNAVAILABLE keeps PreJoin (retry, not back to challenge)', () => {
+    expect(nextMeetingState('finalizing', { type: 'FINALIZE_LIVEKIT_UNAVAILABLE' })).toBe('prejoin');
+  });
+
+  it('pass-token expiry at finalize → back to challenge (restart)', () => {
+    expect(nextMeetingState('finalizing', { type: 'FINALIZE_PASS_EXPIRED' })).toBe('challenge');
+  });
+
+  it('finalize step-1 recheck (FD-32) → terminal', () => {
+    expect(nextMeetingState('finalizing', { type: 'FINALIZE_STEP1', code: MeetingErrorCode.LOCKED })).toBe('terminal');
+  });
+
+  it('room reconnect: SDK disconnect → reconnecting → ok → room', () => {
+    expect(nextMeetingState('room', { type: 'SDK_DISCONNECT' })).toBe('reconnecting');
+    expect(nextMeetingState('reconnecting', { type: 'RECONNECT_OK' })).toBe('room');
+  });
+
+  it('room reconnect expiry → re-evaluate', () => {
+    expect(nextMeetingState('reconnecting', { type: 'RECONNECT_EXPIRED' })).toBe('evaluating');
+  });
+
+  it.each(['LEFT', 'ENDED', 'REMOVED', 'SUPERSEDED'] as const)('%s → terminal', (type) => {
+    expect(nextMeetingState('room', { type } as never)).toBe('terminal');
+  });
+
+  it('auth-required and service-unavailable are reachable from any state', () => {
+    const states: MeetingUiState[] = ['idle', 'challenge', 'prejoin', 'room'];
+    for (const s of states) {
+      expect(nextMeetingState(s, { type: 'AUTH_REQUIRED' })).toBe('terminal');
+      expect(nextMeetingState(s, { type: 'SERVICE_UNAVAILABLE' })).toBe('serviceUnavailable');
+    }
+  });
+});
+
+describe('terminal code classification (FD-32)', () => {
+  it.each([MeetingErrorCode.ENDED, MeetingErrorCode.CANCELLED, MeetingErrorCode.REMOVED])(
+    '%s is terminal',
+    (code) => expect(isTerminalCode(code)).toBe(true),
+  );
+  it.each([MeetingErrorCode.LOCKED, MeetingErrorCode.FULL, MeetingErrorCode.TOO_EARLY])(
+    '%s is recoverable (not terminal)',
+    (code) => expect(isTerminalCode(code)).toBe(false),
+  );
+});

--- a/packages/dmworkmeeting/src/logic/stateMachine.ts
+++ b/packages/dmworkmeeting/src/logic/stateMachine.ts
@@ -32,6 +32,7 @@ export type MeetingUiEvent =
   | { type: 'FINALIZE_SUCCESS' }
   | { type: 'FINALIZE_LIVEKIT_UNAVAILABLE' } // stay in prejoin, retry
   | { type: 'FINALIZE_PASS_EXPIRED' } // restart challenge
+  | { type: 'FINALIZE_PASSWORD_REQUIRED' } // step-1 recheck now requires a password → challenge
   | { type: 'FINALIZE_STEP1'; code: MeetingErrorCode } // predicate changed → terminal or specific state
   | { type: 'BLOCKED'; code: MeetingErrorCode } // recoverable non-terminal error
   | { type: 'RETRY' } // leave blocked → re-evaluate
@@ -87,6 +88,8 @@ export function nextMeetingState(state: MeetingUiState, event: MeetingUiEvent): 
       return 'prejoin'; // keep PreJoin + pass_token; retry finalize
     case 'FINALIZE_PASS_EXPIRED':
       return 'challenge'; // restart challenge
+    case 'FINALIZE_PASSWORD_REQUIRED':
+      return 'challenge'; // step-1 recheck now requires a password
     case 'FINALIZE_STEP1':
       return isTerminalCode(event.code) ? 'terminal' : 'blocked';
     case 'BLOCKED':

--- a/packages/dmworkmeeting/src/logic/stateMachine.ts
+++ b/packages/dmworkmeeting/src/logic/stateMachine.ts
@@ -15,6 +15,7 @@ export type MeetingUiState =
   | 'finalizing'
   | 'room'
   | 'reconnecting'
+  | 'blocked' // recoverable: locked / full / too-early / rate-limited / conflict / network
   | 'terminal' // ended / left / removed / superseded / cancelled / no-show / empty-timeout
   | 'serviceUnavailable';
 
@@ -32,6 +33,8 @@ export type MeetingUiEvent =
   | { type: 'FINALIZE_LIVEKIT_UNAVAILABLE' } // stay in prejoin, retry
   | { type: 'FINALIZE_PASS_EXPIRED' } // restart challenge
   | { type: 'FINALIZE_STEP1'; code: MeetingErrorCode } // predicate changed → terminal or specific state
+  | { type: 'BLOCKED'; code: MeetingErrorCode } // recoverable non-terminal error
+  | { type: 'RETRY' } // leave blocked → re-evaluate
   | { type: 'SDK_DISCONNECT' } // same-endpoint reconnect attempt
   | { type: 'RECONNECT_OK' }
   | { type: 'RECONNECT_EXPIRED' } // >15s / new endpoint → re-evaluate
@@ -62,8 +65,10 @@ export function nextMeetingState(state: MeetingUiState, event: MeetingUiEvent): 
     case 'EVALUATE_ELIGIBLE':
       return event.passwordRequired ? 'challenge' : 'prejoin';
     case 'EVALUATE_INELIGIBLE':
-      // Any ineligible step-1 code renders the corresponding terminal/blocked view.
-      return 'terminal';
+      // Terminal codes (ended/cancelled/removed) end the flow; every other
+      // ineligible code is recoverable and renders the blocked view — it must
+      // never hang or be shown as "ended".
+      return isTerminalCode(event.code) ? 'terminal' : 'blocked';
     case 'SUBMIT_PASSWORD':
       return state === 'challenge' ? 'verifying' : state;
     case 'PASSWORD_PASS':
@@ -83,7 +88,11 @@ export function nextMeetingState(state: MeetingUiState, event: MeetingUiEvent): 
     case 'FINALIZE_PASS_EXPIRED':
       return 'challenge'; // restart challenge
     case 'FINALIZE_STEP1':
-      return 'terminal';
+      return isTerminalCode(event.code) ? 'terminal' : 'blocked';
+    case 'BLOCKED':
+      return 'blocked';
+    case 'RETRY':
+      return 'evaluating';
     case 'SDK_DISCONNECT':
       return state === 'room' ? 'reconnecting' : state;
     case 'RECONNECT_OK':

--- a/packages/dmworkmeeting/src/logic/stateMachine.ts
+++ b/packages/dmworkmeeting/src/logic/stateMachine.ts
@@ -1,0 +1,101 @@
+// UI admission state machine (frontend appendix §7). Pure transition function so
+// every edge is unit-testable. The media layer (LiveKit) never drives business
+// admission — evaluate/finalize verdicts do.
+
+import { MeetingErrorCode } from '../service/errors';
+import { directiveForCode } from '../service/errors';
+
+export type MeetingUiState =
+  | 'idle'
+  | 'evaluating'
+  | 'challenge'
+  | 'verifying'
+  | 'cooldown'
+  | 'prejoin'
+  | 'finalizing'
+  | 'room'
+  | 'reconnecting'
+  | 'terminal' // ended / left / removed / superseded / cancelled / no-show / empty-timeout
+  | 'serviceUnavailable';
+
+export type MeetingUiEvent =
+  | { type: 'START_EVALUATE' }
+  | { type: 'EVALUATE_ELIGIBLE'; passwordRequired: boolean }
+  | { type: 'EVALUATE_INELIGIBLE'; code: MeetingErrorCode }
+  | { type: 'SUBMIT_PASSWORD' }
+  | { type: 'PASSWORD_PASS' }
+  | { type: 'PASSWORD_INVALID'; enteringCooldown: boolean }
+  | { type: 'PASSWORD_FORMAT_INVALID' } // never counts, stays on challenge
+  | { type: 'COOLDOWN_EXPIRED' }
+  | { type: 'START_FINALIZE' }
+  | { type: 'FINALIZE_SUCCESS' }
+  | { type: 'FINALIZE_LIVEKIT_UNAVAILABLE' } // stay in prejoin, retry
+  | { type: 'FINALIZE_PASS_EXPIRED' } // restart challenge
+  | { type: 'FINALIZE_STEP1'; code: MeetingErrorCode } // predicate changed → terminal or specific state
+  | { type: 'SDK_DISCONNECT' } // same-endpoint reconnect attempt
+  | { type: 'RECONNECT_OK' }
+  | { type: 'RECONNECT_EXPIRED' } // >15s / new endpoint → re-evaluate
+  | { type: 'LEFT' }
+  | { type: 'ENDED' }
+  | { type: 'REMOVED' }
+  | { type: 'SUPERSEDED' }
+  | { type: 'AUTH_REQUIRED' } // fail-closed → handled outside (logout); state parks terminal
+  | { type: 'SERVICE_UNAVAILABLE' }
+  | { type: 'RESET' };
+
+/** Codes that, when returned by a step-1 recheck at finalize (FD-32), map to a
+ * terminal state rather than a recoverable one. */
+export function isTerminalCode(code: MeetingErrorCode): boolean {
+  return directiveForCode(code).terminal;
+}
+
+export function nextMeetingState(state: MeetingUiState, event: MeetingUiEvent): MeetingUiState {
+  switch (event.type) {
+    case 'RESET':
+      return 'idle';
+    case 'AUTH_REQUIRED':
+      return 'terminal';
+    case 'SERVICE_UNAVAILABLE':
+      return 'serviceUnavailable';
+    case 'START_EVALUATE':
+      return 'evaluating';
+    case 'EVALUATE_ELIGIBLE':
+      return event.passwordRequired ? 'challenge' : 'prejoin';
+    case 'EVALUATE_INELIGIBLE':
+      // Any ineligible step-1 code renders the corresponding terminal/blocked view.
+      return 'terminal';
+    case 'SUBMIT_PASSWORD':
+      return state === 'challenge' ? 'verifying' : state;
+    case 'PASSWORD_PASS':
+      return 'prejoin';
+    case 'PASSWORD_INVALID':
+      return event.enteringCooldown ? 'cooldown' : 'challenge';
+    case 'PASSWORD_FORMAT_INVALID':
+      return 'challenge';
+    case 'COOLDOWN_EXPIRED':
+      return 'challenge';
+    case 'START_FINALIZE':
+      return state === 'prejoin' ? 'finalizing' : state;
+    case 'FINALIZE_SUCCESS':
+      return 'room';
+    case 'FINALIZE_LIVEKIT_UNAVAILABLE':
+      return 'prejoin'; // keep PreJoin + pass_token; retry finalize
+    case 'FINALIZE_PASS_EXPIRED':
+      return 'challenge'; // restart challenge
+    case 'FINALIZE_STEP1':
+      return 'terminal';
+    case 'SDK_DISCONNECT':
+      return state === 'room' ? 'reconnecting' : state;
+    case 'RECONNECT_OK':
+      return 'room';
+    case 'RECONNECT_EXPIRED':
+      return 'evaluating'; // re-evaluate with source=rejoin
+    case 'LEFT':
+    case 'ENDED':
+    case 'REMOVED':
+    case 'SUPERSEDED':
+      return 'terminal';
+    default:
+      return state;
+  }
+}

--- a/packages/dmworkmeeting/src/logic/timing.test.ts
+++ b/packages/dmworkmeeting/src/logic/timing.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest';
+import {
+  earliestJoinAtMs,
+  isTooEarly,
+  isWithinReconnectGrace,
+  isEmptyTimeoutElapsed,
+  isWithinReminderWindow,
+  EARLY_JOIN_WINDOW_SECONDS,
+  RECONNECT_GRACE_SECONDS,
+  EMPTY_TIMEOUT_SECONDS,
+} from './timing';
+
+describe('early-join window (B-2, FD-07): 599s allowed / 601s too early', () => {
+  const start = 10_000_000; // scheduled_start_at (ms)
+  it('earliest_join_at = start - 600s', () => {
+    expect(earliestJoinAtMs(start)).toBe(start - EARLY_JOIN_WINDOW_SECONDS * 1000);
+  });
+  it('601s before start → too early', () => {
+    expect(isTooEarly(start, start - 601_000)).toBe(true);
+  });
+  it('599s before start → allowed', () => {
+    expect(isTooEarly(start, start - 599_000)).toBe(false);
+  });
+  it('exactly at the 600s boundary → allowed', () => {
+    expect(isTooEarly(start, start - 600_000)).toBe(false);
+  });
+});
+
+describe('reconnect grace (B-3, FD-13/FD-29): 14.9s exempt / 15.1s re-evaluate', () => {
+  const leaveAtMs = 5_000_000;
+  const dev = 'device-hash-A';
+  it('14.9s after server leave_at, same endpoint → within grace', () => {
+    expect(
+      isWithinReconnectGrace({
+        leaveAtMs,
+        serverNowMs: leaveAtMs + 14_900,
+        originalDeviceIdHash: dev,
+        currentDeviceIdHash: dev,
+      }),
+    ).toBe(true);
+  });
+  it('15.1s after server leave_at → outside grace (re-evaluate)', () => {
+    expect(
+      isWithinReconnectGrace({
+        leaveAtMs,
+        serverNowMs: leaveAtMs + 15_100,
+        originalDeviceIdHash: dev,
+        currentDeviceIdHash: dev,
+      }),
+    ).toBe(false);
+  });
+  it('different device_id_hash within 14.9s → NOT exempt (endpoint change)', () => {
+    expect(
+      isWithinReconnectGrace({
+        leaveAtMs,
+        serverNowMs: leaveAtMs + 14_900,
+        originalDeviceIdHash: dev,
+        currentDeviceIdHash: 'device-hash-B',
+      }),
+    ).toBe(false);
+  });
+  it('unknown leave_at → NOT exempt (client clock is not authoritative)', () => {
+    expect(
+      isWithinReconnectGrace({
+        leaveAtMs: undefined,
+        serverNowMs: 9_999_999,
+        originalDeviceIdHash: dev,
+        currentDeviceIdHash: dev,
+      }),
+    ).toBe(false);
+  });
+  it('grace constant is 15s', () => expect(RECONNECT_GRACE_SECONDS).toBe(15));
+});
+
+describe('empty-room timeout (B-4, FD-22): server empty_since anchor, 300s', () => {
+  const emptySince = 20_000_000;
+  it('elapsed exactly at 300s', () => {
+    expect(isEmptyTimeoutElapsed(emptySince, emptySince + 300_000)).toBe(true);
+  });
+  it('not elapsed at 299s', () => {
+    expect(isEmptyTimeoutElapsed(emptySince, emptySince + 299_000)).toBe(false);
+  });
+  it('no empty_since anchor → never elapsed (frontend cannot derive it)', () => {
+    expect(isEmptyTimeoutElapsed(undefined, 99_999_999)).toBe(false);
+  });
+  it('timeout constant is 300s', () => expect(EMPTY_TIMEOUT_SECONDS).toBe(300));
+});
+
+describe('reminder window (E2E-2, 15 min)', () => {
+  const start = 30_000_000;
+  it('inside 15 min before start', () => {
+    expect(isWithinReminderWindow(start, start - 900_000 + 1)).toBe(true);
+  });
+  it('outside 15 min before start', () => {
+    expect(isWithinReminderWindow(start, start - 900_001)).toBe(false);
+  });
+  it('after start → not in window', () => {
+    expect(isWithinReminderWindow(start, start + 1)).toBe(false);
+  });
+});

--- a/packages/dmworkmeeting/src/logic/timing.ts
+++ b/packages/dmworkmeeting/src/logic/timing.ts
@@ -1,0 +1,61 @@
+// Server-authoritative time boundaries, encoded as pure functions with injected
+// clocks so E2E/unit assertions are exact. The frontend never derives these
+// verdicts at runtime from a client clock — it renders the server's decision;
+// these mirror the contract for deterministic tests (§9, §12, B-2/B-3/B-4).
+
+// ── B-2: early-join window (MEETING_EARLY_JOIN_WINDOW_SECONDS = 600). ──
+export const EARLY_JOIN_WINDOW_SECONDS = 600;
+
+/** earliest_join_at = scheduled_start_at - 600s. */
+export function earliestJoinAtMs(scheduledStartAtMs: number): number {
+  return scheduledStartAtMs - EARLY_JOIN_WINDOW_SECONDS * 1000;
+}
+
+/** True when the server would return TOO_EARLY. Asserted at 601s (too early) and
+ * 599s (allowed) before scheduled start. */
+export function isTooEarly(scheduledStartAtMs: number, serverNowMs: number): boolean {
+  return serverNowMs < earliestJoinAtMs(scheduledStartAtMs);
+}
+
+// ── B-3: reconnect grace (MEETING_RECONNECT_GRACE_SECONDS = 15). ──
+export const RECONNECT_GRACE_SECONDS = 15;
+
+/**
+ * Same-endpoint reconnect within grace reuses the original segment and is exempt
+ * from the password. The clock origin is the server-authoritative
+ * `segment.leave_at`; the client clock and LiveKit `participant_left` webhook
+ * arrival are NOT authoritative. Requires the same device_id_hash. Asserted at
+ * 14.9s (exempt) and 15.1s (re-evaluate).
+ */
+export function isWithinReconnectGrace(args: {
+  leaveAtMs: number | undefined;
+  serverNowMs: number;
+  originalDeviceIdHash: string | undefined;
+  currentDeviceIdHash: string;
+}): boolean {
+  const { leaveAtMs, serverNowMs, originalDeviceIdHash, currentDeviceIdHash } = args;
+  if (leaveAtMs === undefined) return false; // unknown leave_at → re-evaluate
+  if (!originalDeviceIdHash || originalDeviceIdHash !== currentDeviceIdHash) return false; // new endpoint → re-evaluate
+  return serverNowMs - leaveAtMs <= RECONNECT_GRACE_SECONDS * 1000;
+}
+
+// ── B-4: empty-room / no-show timeout (MEETING_EMPTY_TIMEOUT_SECONDS = 300). ──
+export const EMPTY_TIMEOUT_SECONDS = 300;
+
+/**
+ * Empty-room timeout is anchored to the server's `empty_since` (written under a
+ * lock; LiveKit webhooks are reconciliation only). The frontend/E2E must NOT
+ * derive "online = 0" from client-side participant counts. Returns whether the
+ * timeout has elapsed given the server anchor.
+ */
+export function isEmptyTimeoutElapsed(emptySinceMs: number | undefined, serverNowMs: number): boolean {
+  if (emptySinceMs === undefined) return false;
+  return serverNowMs - emptySinceMs >= EMPTY_TIMEOUT_SECONDS * 1000;
+}
+
+// ── Reminder window (E2E-2, 15 min). ──
+export const REMINDER_WINDOW_SECONDS = 900;
+export function isWithinReminderWindow(scheduledStartAtMs: number, serverNowMs: number): boolean {
+  const delta = scheduledStartAtMs - serverNowMs;
+  return delta <= REMINDER_WINDOW_SECONDS * 1000 && delta > 0;
+}

--- a/packages/dmworkmeeting/src/module.test.tsx
+++ b/packages/dmworkmeeting/src/module.test.tsx
@@ -1,0 +1,37 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { MeetingModule, isMeetingFeatureEnabled } from './module';
+import { WKApp, __registered, __resetWKApp } from './__mocks__/dmworkBase';
+
+beforeEach(() => __resetWKApp());
+
+describe('feature flag gating (#5, §14)', () => {
+  it('is fail-safe: default OFF when config is absent', () => {
+    (WKApp as unknown as { config?: unknown }).config = undefined;
+    expect(isMeetingFeatureEnabled()).toBe(false);
+  });
+
+  it('is OFF unless explicitly true', () => {
+    WKApp.config = {} as { meetingFeatureEnabled?: boolean };
+    expect(isMeetingFeatureEnabled()).toBe(false);
+    WKApp.config = { meetingFeatureEnabled: false };
+    expect(isMeetingFeatureEnabled()).toBe(false);
+    WKApp.config = { meetingFeatureEnabled: true };
+    expect(isMeetingFeatureEnabled()).toBe(true);
+  });
+
+  it('when OFF, init registers NEITHER routes NOR menu', () => {
+    WKApp.config = { meetingFeatureEnabled: false };
+    new MeetingModule().init();
+    expect(__registered.routes).toHaveLength(0);
+    expect(__registered.menus).toHaveLength(0);
+  });
+
+  it('when ON, init registers the meeting routes and menu', () => {
+    WKApp.config = { meetingFeatureEnabled: true };
+    new MeetingModule().init();
+    expect(__registered.routes).toEqual(
+      expect.arrayContaining(['/meeting', '/meeting/quick', '/meeting/schedule', '/meeting/join']),
+    );
+    expect(__registered.menus).toContain('meeting');
+  });
+});

--- a/packages/dmworkmeeting/src/module.test.tsx
+++ b/packages/dmworkmeeting/src/module.test.tsx
@@ -26,12 +26,11 @@ describe('feature flag gating (#5, §14)', () => {
     expect(__registered.menus).toHaveLength(0);
   });
 
-  it('when ON, init registers the meeting routes and menu', () => {
+  it('when ON, init registers the single /meeting route and menu', () => {
     WKApp.config = { meetingFeatureEnabled: true };
     new MeetingModule().init();
-    expect(__registered.routes).toEqual(
-      expect.arrayContaining(['/meeting', '/meeting/quick', '/meeting/schedule', '/meeting/join']),
-    );
+    // Only the menu route is registered; MeetingRoot owns sub-view routing.
+    expect(__registered.routes).toEqual(['/meeting']);
     expect(__registered.menus).toContain('meeting');
   });
 });

--- a/packages/dmworkmeeting/src/module.tsx
+++ b/packages/dmworkmeeting/src/module.tsx
@@ -1,24 +1,17 @@
 import React from 'react';
 import type { IModule } from '@octo/base';
 import { i18n, WKApp, Menus, t as translate } from '@octo/base';
-import MeetingHome from './pages/MeetingHome';
-import QuickSetup from './pages/QuickSetup';
-import SchedulePage from './pages/SchedulePage';
-import JoinEntry from './pages/JoinEntry';
-import JoinFlow from './pages/JoinFlow';
+import MeetingRoot from './pages/MeetingRoot';
 import enUS from './i18n/en-US.json';
 import zhCN from './i18n/zh-CN.json';
-import { deviceIdHash, parseJoinQuery } from './state/nav';
 
 /**
  * Top-level feature flag (§14): MEETING_FEATURE_ENABLED. Fail-safe / default
  * OFF — the module registers nothing (neither menu nor routes) unless the flag
- * is explicitly true. A misconfigured or absent config therefore hides Meeting
- * entirely rather than exposing a half-wired surface.
+ * is explicitly true, so a misconfigured or absent config hides Meeting entirely.
  */
 export function isMeetingFeatureEnabled(): boolean {
-  const cfg = (WKApp as unknown as { config?: { meetingFeatureEnabled?: boolean } }).config;
-  return cfg?.meetingFeatureEnabled === true;
+  return WKApp.config?.meetingFeatureEnabled === true;
 }
 
 function MeetingMenuIcon({ active }: { active?: boolean }) {
@@ -43,19 +36,10 @@ export class MeetingModule implements IModule {
     // Fail-safe: when the flag is off, register neither routes nor menu.
     if (!isMeetingFeatureEnabled()) return;
 
-    WKApp.route.register('/meeting', () => <MeetingHome />);
-    WKApp.route.register('/meeting/quick', () => <QuickSetup />);
-    WKApp.route.register('/meeting/schedule', () => <SchedulePage />);
-    WKApp.route.register('/meeting/join', (param: { meetingNumber?: string; linkToken?: string }) => {
-      // Prefer an explicit route param; otherwise parse the URL query so a cold
-      // load / back-forward on a deep link still resolves the credential.
-      const fromQuery = parseJoinQuery(typeof window !== 'undefined' ? window.location.search : '');
-      const meetingNumber = param?.meetingNumber ?? fromQuery?.meetingNumber;
-      const linkToken = param?.linkToken ?? fromQuery?.linkToken;
-      const source = linkToken ? 'link' : 'number';
-      if (!meetingNumber && !linkToken) return <JoinEntry />;
-      return <JoinFlow source={source} meetingNumber={meetingNumber} linkToken={linkToken} deviceIdHash={deviceIdHash()} autoStart />;
-    });
+    // Single menu route. The shell renders only the menu's routePath component,
+    // so MeetingRoot owns all `/meeting/*` sub-view routing (deep links +
+    // back/forward) internally — see pages/MeetingRoot.tsx.
+    WKApp.route.register('/meeting', () => <MeetingRoot />);
 
     WKApp.menus.register(
       'meeting',

--- a/packages/dmworkmeeting/src/module.tsx
+++ b/packages/dmworkmeeting/src/module.tsx
@@ -3,17 +3,22 @@ import type { IModule } from '@octo/base';
 import { i18n, WKApp, Menus, t as translate } from '@octo/base';
 import MeetingHome from './pages/MeetingHome';
 import QuickSetup from './pages/QuickSetup';
+import SchedulePage from './pages/SchedulePage';
+import JoinEntry from './pages/JoinEntry';
 import JoinFlow from './pages/JoinFlow';
 import enUS from './i18n/en-US.json';
 import zhCN from './i18n/zh-CN.json';
-import type { AdmissionSource } from './service/contracts';
+import { deviceIdHash, parseJoinQuery } from './state/nav';
 
-// Top-level feature flag (§14): MEETING_FEATURE_ENABLED. When off, the menu is
-// hidden. Read from the injected runtime config; default enabled so the module
-// registers routes but the menu factory can hide the entry.
-function isMeetingFeatureEnabled(): boolean {
+/**
+ * Top-level feature flag (§14): MEETING_FEATURE_ENABLED. Fail-safe / default
+ * OFF — the module registers nothing (neither menu nor routes) unless the flag
+ * is explicitly true. A misconfigured or absent config therefore hides Meeting
+ * entirely rather than exposing a half-wired surface.
+ */
+export function isMeetingFeatureEnabled(): boolean {
   const cfg = (WKApp as unknown as { config?: { meetingFeatureEnabled?: boolean } }).config;
-  return cfg?.meetingFeatureEnabled !== false;
+  return cfg?.meetingFeatureEnabled === true;
 }
 
 function MeetingMenuIcon({ active }: { active?: boolean }) {
@@ -26,27 +31,30 @@ function MeetingMenuIcon({ active }: { active?: boolean }) {
   );
 }
 
-/** Best-effort per-device hash used for reconnect grace / superseded detection
- * (§9, B-3). Never a security identity; the server owns the authoritative
- * segment/leave_at. */
-function deviceIdHash(): string {
-  const w = WKApp as unknown as { shared?: { deviceId?: string } };
-  return w.shared?.deviceId ?? 'web';
-}
-
 export class MeetingModule implements IModule {
   id(): string {
     return 'MeetingModule';
   }
 
   init(): void {
+    // i18n namespace is safe to register unconditionally.
     i18n.registerNamespace('meeting', { 'zh-CN': zhCN, 'en-US': enUS });
+
+    // Fail-safe: when the flag is off, register neither routes nor menu.
+    if (!isMeetingFeatureEnabled()) return;
 
     WKApp.route.register('/meeting', () => <MeetingHome />);
     WKApp.route.register('/meeting/quick', () => <QuickSetup />);
+    WKApp.route.register('/meeting/schedule', () => <SchedulePage />);
     WKApp.route.register('/meeting/join', (param: { meetingNumber?: string; linkToken?: string }) => {
-      const source: AdmissionSource = param?.linkToken ? 'link' : 'number';
-      return <JoinFlow source={source} meetingNumber={param?.meetingNumber} linkToken={param?.linkToken} deviceIdHash={deviceIdHash()} />;
+      // Prefer an explicit route param; otherwise parse the URL query so a cold
+      // load / back-forward on a deep link still resolves the credential.
+      const fromQuery = parseJoinQuery(typeof window !== 'undefined' ? window.location.search : '');
+      const meetingNumber = param?.meetingNumber ?? fromQuery?.meetingNumber;
+      const linkToken = param?.linkToken ?? fromQuery?.linkToken;
+      const source = linkToken ? 'link' : 'number';
+      if (!meetingNumber && !linkToken) return <JoinEntry />;
+      return <JoinFlow source={source} meetingNumber={meetingNumber} linkToken={linkToken} deviceIdHash={deviceIdHash()} autoStart />;
     });
 
     WKApp.menus.register(

--- a/packages/dmworkmeeting/src/module.tsx
+++ b/packages/dmworkmeeting/src/module.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import type { IModule } from '@octo/base';
+import { i18n, WKApp, Menus, t as translate } from '@octo/base';
+import MeetingHome from './pages/MeetingHome';
+import QuickSetup from './pages/QuickSetup';
+import JoinFlow from './pages/JoinFlow';
+import enUS from './i18n/en-US.json';
+import zhCN from './i18n/zh-CN.json';
+import type { AdmissionSource } from './service/contracts';
+
+// Top-level feature flag (§14): MEETING_FEATURE_ENABLED. When off, the menu is
+// hidden. Read from the injected runtime config; default enabled so the module
+// registers routes but the menu factory can hide the entry.
+function isMeetingFeatureEnabled(): boolean {
+  const cfg = (WKApp as unknown as { config?: { meetingFeatureEnabled?: boolean } }).config;
+  return cfg?.meetingFeatureEnabled !== false;
+}
+
+function MeetingMenuIcon({ active }: { active?: boolean }) {
+  const color = active ? 'var(--wk-brand-primary, #7C5CFC)' : 'currentColor';
+  return (
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M15 10l4.553-2.276A1 1 0 0121 8.618v6.764a1 1 0 01-1.447.894L15 14v-4z" />
+      <rect x="3" y="6" width="12" height="12" rx="2" />
+    </svg>
+  );
+}
+
+/** Best-effort per-device hash used for reconnect grace / superseded detection
+ * (§9, B-3). Never a security identity; the server owns the authoritative
+ * segment/leave_at. */
+function deviceIdHash(): string {
+  const w = WKApp as unknown as { shared?: { deviceId?: string } };
+  return w.shared?.deviceId ?? 'web';
+}
+
+export class MeetingModule implements IModule {
+  id(): string {
+    return 'MeetingModule';
+  }
+
+  init(): void {
+    i18n.registerNamespace('meeting', { 'zh-CN': zhCN, 'en-US': enUS });
+
+    WKApp.route.register('/meeting', () => <MeetingHome />);
+    WKApp.route.register('/meeting/quick', () => <QuickSetup />);
+    WKApp.route.register('/meeting/join', (param: { meetingNumber?: string; linkToken?: string }) => {
+      const source: AdmissionSource = param?.linkToken ? 'link' : 'number';
+      return <JoinFlow source={source} meetingNumber={param?.meetingNumber} linkToken={param?.linkToken} deviceIdHash={deviceIdHash()} />;
+    });
+
+    WKApp.menus.register(
+      'meeting',
+      () => {
+        if (!isMeetingFeatureEnabled()) return undefined;
+        return new Menus('meeting', '/meeting', translate('meeting.menu.title'), <MeetingMenuIcon />, <MeetingMenuIcon active />);
+      },
+      4003,
+    );
+  }
+}

--- a/packages/dmworkmeeting/src/pages/HistoryDetail.tsx
+++ b/packages/dmworkmeeting/src/pages/HistoryDetail.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { t } from '@octo/base';
+import type { Meeting } from '../service/contracts';
+
+/** History detail (§8, FD-31). Only exposes whether a password was enabled —
+ * never the password itself. */
+export default function HistoryDetail({ meeting }: { meeting: Meeting }) {
+  return (
+    <div className="meeting-history-detail">
+      <h2>{meeting.title}</h2>
+      <p data-status={meeting.status}>{meeting.status}</p>
+      <p>{meeting.passwordEnabled ? t('meeting.history.passwordEnabled') : t('meeting.history.passwordDisabled')}</p>
+    </div>
+  );
+}

--- a/packages/dmworkmeeting/src/pages/JoinEntry.tsx
+++ b/packages/dmworkmeeting/src/pages/JoinEntry.tsx
@@ -1,32 +1,43 @@
 import React, { useState } from 'react';
 import { t } from '@octo/base';
-import { openJoinFlow, deviceIdHash } from '../state/nav';
+import { openJoinFlow, parseJoinQuery } from '../state/nav';
 
 /**
  * Join-by-number / join-by-link entry (§4, FD-02). A link may be pasted whole;
- * we extract link_token from its query. Passwords are never entered here — the
- * challenge only appears after evaluate returns password_required.
+ * we parse it with the same `parseJoinQuery` used for cold-load deep links, so a
+ * pasted `…/meeting/join?meeting_number=123` resolves to the number rather than
+ * being sent verbatim. A bare input must be a numeric meeting number. Passwords
+ * are never entered here — the challenge only appears after evaluate returns
+ * password_required.
  */
 export default function JoinEntry() {
   const [value, setValue] = useState('');
+  const [error, setError] = useState<string>();
 
   const submit = (e: React.FormEvent) => {
     e.preventDefault();
     const raw = value.trim();
     if (!raw) return;
-    // If a full URL/link was pasted, prefer its link_token.
-    let linkToken: string | undefined;
+    setError(undefined);
+
+    // If a full URL/link was pasted, resolve its credential via the shared parser.
     try {
       const u = new URL(raw);
-      linkToken = u.searchParams.get('link_token') ?? undefined;
+      const creds = parseJoinQuery(u.search);
+      if (creds) {
+        openJoinFlow(creds);
+        return;
+      }
     } catch {
-      linkToken = undefined;
+      // Not a URL — fall through to bare-number handling.
     }
-    if (linkToken) {
-      openJoinFlow({ source: 'link', linkToken }, deviceIdHash());
-    } else {
-      openJoinFlow({ source: 'number', meetingNumber: raw }, deviceIdHash());
+
+    // A bare input must be a numeric meeting number.
+    if (!/^\d+$/.test(raw)) {
+      setError(t('meeting.error.credentialInvalid'));
+      return;
     }
+    openJoinFlow({ source: 'number', meetingNumber: raw });
   };
 
   return (
@@ -36,11 +47,20 @@ export default function JoinEntry() {
         id="meeting-join-input"
         value={value}
         placeholder={t('meeting.join.numberPlaceholder')}
-        onChange={(e) => setValue(e.target.value)}
+        aria-invalid={Boolean(error)}
+        onChange={(e) => {
+          setError(undefined);
+          setValue(e.target.value);
+        }}
       />
       <button type="submit" disabled={!value.trim()}>
         {t('meeting.join.submit')}
       </button>
+      {error && (
+        <div role="alert" aria-live="assertive">
+          {error}
+        </div>
+      )}
     </form>
   );
 }

--- a/packages/dmworkmeeting/src/pages/JoinEntry.tsx
+++ b/packages/dmworkmeeting/src/pages/JoinEntry.tsx
@@ -1,0 +1,46 @@
+import React, { useState } from 'react';
+import { t } from '@octo/base';
+import { openJoinFlow, deviceIdHash } from '../state/nav';
+
+/**
+ * Join-by-number / join-by-link entry (§4, FD-02). A link may be pasted whole;
+ * we extract link_token from its query. Passwords are never entered here — the
+ * challenge only appears after evaluate returns password_required.
+ */
+export default function JoinEntry() {
+  const [value, setValue] = useState('');
+
+  const submit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const raw = value.trim();
+    if (!raw) return;
+    // If a full URL/link was pasted, prefer its link_token.
+    let linkToken: string | undefined;
+    try {
+      const u = new URL(raw);
+      linkToken = u.searchParams.get('link_token') ?? undefined;
+    } catch {
+      linkToken = undefined;
+    }
+    if (linkToken) {
+      openJoinFlow({ source: 'link', linkToken }, deviceIdHash());
+    } else {
+      openJoinFlow({ source: 'number', meetingNumber: raw }, deviceIdHash());
+    }
+  };
+
+  return (
+    <form className="meeting-join-entry" onSubmit={submit} aria-label={t('meeting.home.join')}>
+      <label htmlFor="meeting-join-input">{t('meeting.join.numberLabel')}</label>
+      <input
+        id="meeting-join-input"
+        value={value}
+        placeholder={t('meeting.join.numberPlaceholder')}
+        onChange={(e) => setValue(e.target.value)}
+      />
+      <button type="submit" disabled={!value.trim()}>
+        {t('meeting.join.submit')}
+      </button>
+    </form>
+  );
+}

--- a/packages/dmworkmeeting/src/pages/JoinFlow.test.tsx
+++ b/packages/dmworkmeeting/src/pages/JoinFlow.test.tsx
@@ -75,6 +75,22 @@ describe('JoinFlow orchestration (§7)', () => {
     expect(screen.queryByText(T.challenge)).toBeNull();
   });
 
+  it('PASSWORD_COOLDOWN without a parsable retry_at stays on the challenge (no permanent wedge)', async () => {
+    asMock(MeetingApiClient.evaluate).mockResolvedValue({
+      eligible: true,
+      meetingId: 'm1',
+      passwordRequired: true,
+      passwordChallengeId: 'c1',
+    });
+    asMock(MeetingApiClient.verifyPassword).mockRejectedValue(httpErr(429, 'MEETING_PASSWORD_COOLDOWN'));
+    render(<JoinFlow source="number" meetingNumber="123" autoStart />);
+    const input = (await screen.findByLabelText(/6/i)) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '000000' } });
+    fireEvent.submit(input.closest('form') as HTMLFormElement);
+    // Input must NOT be permanently disabled — the challenge stays usable.
+    await waitFor(() => expect((screen.getByLabelText(/6/i) as HTMLInputElement).disabled).toBe(false));
+  });
+
   it('ENDED at evaluate → terminal', async () => {
     asMock(MeetingApiClient.evaluate).mockRejectedValue(httpErr(410, 'MEETING_ENDED'));
     render(<JoinFlow source="number" meetingNumber="123" autoStart />);

--- a/packages/dmworkmeeting/src/pages/JoinFlow.test.tsx
+++ b/packages/dmworkmeeting/src/pages/JoinFlow.test.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+// Mock the HTTP client so the orchestrator is exercised without network.
+vi.mock('../service/MeetingApiClient', () => ({
+  MeetingApiClient: {
+    evaluate: vi.fn(),
+    verifyPassword: vi.fn(),
+    finalize: vi.fn(),
+  },
+  newIdempotencyKey: () => 'test-key',
+  MeetingHttpError: class {},
+}));
+
+import JoinFlow from './JoinFlow';
+import { MeetingApiClient } from '../service/MeetingApiClient';
+
+// The @octo/base mock's t() resolves real zh-CN strings.
+const T = {
+  join: '立即加入',
+  challenge: '输入会议密码',
+  locked: '会议已锁定',
+  ended: '会议已结束',
+};
+
+const httpErr = (status: number, code?: string, extra: Record<string, unknown> = {}) => ({
+  response: { status, data: { code, ...extra } },
+});
+const asMock = (fn: unknown) => fn as ReturnType<typeof vi.fn>;
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('JoinFlow orchestration (§7)', () => {
+  it('eligible without password → PreJoin → finalize success (reuses explicit idempotency key)', async () => {
+    asMock(MeetingApiClient.evaluate).mockResolvedValue({ eligible: true, meetingId: 'm1', passwordRequired: false });
+    asMock(MeetingApiClient.finalize).mockResolvedValue({ livekitUrl: 'wss://x', livekitToken: 'tok', segmentId: 's', role: 'member' });
+    render(<JoinFlow source="number" meetingNumber="123" deviceIdHash="d" autoStart />);
+
+    fireEvent.click(await screen.findByText(T.join));
+    await waitFor(() => expect(MeetingApiClient.finalize).toHaveBeenCalled());
+    expect(asMock(MeetingApiClient.finalize).mock.calls[0][1]).toMatchObject({ idempotencyKey: 'test-key' });
+  });
+
+  it('eligible with password → challenge shown (never before evaluate says so)', async () => {
+    asMock(MeetingApiClient.evaluate).mockResolvedValue({
+      eligible: true,
+      meetingId: 'm1',
+      passwordRequired: true,
+      passwordChallengeId: 'c1',
+    });
+    render(<JoinFlow source="number" meetingNumber="123" deviceIdHash="d" autoStart />);
+    expect(await screen.findByText(T.challenge)).toBeInTheDocument();
+  });
+
+  it('LOCKED at evaluate → blocked (recoverable), not a hang and not "ended"', async () => {
+    asMock(MeetingApiClient.evaluate).mockRejectedValue(httpErr(423, 'MEETING_LOCKED'));
+    render(<JoinFlow source="number" meetingNumber="123" deviceIdHash="d" autoStart />);
+    expect(await screen.findByText(T.locked)).toBeInTheDocument();
+    expect(screen.queryByText(T.ended)).toBeNull();
+    // rendered as the blocked view, keyed by code
+    expect(document.querySelector('[data-code="MEETING_LOCKED"]')).not.toBeNull();
+  });
+
+  it('LIVEKIT_UNAVAILABLE at finalize keeps PreJoin, does not go to challenge', async () => {
+    asMock(MeetingApiClient.evaluate).mockResolvedValue({ eligible: true, meetingId: 'm1', passwordRequired: false });
+    asMock(MeetingApiClient.finalize).mockRejectedValue(httpErr(503, 'MEETING_LIVEKIT_UNAVAILABLE', { retry_after: 5 }));
+    render(<JoinFlow source="number" meetingNumber="123" deviceIdHash="d" autoStart />);
+    fireEvent.click(await screen.findByText(T.join));
+    await waitFor(() => expect(MeetingApiClient.finalize).toHaveBeenCalled());
+    expect(await screen.findByText(T.join)).toBeInTheDocument(); // still PreJoin
+    expect(screen.queryByText(T.challenge)).toBeNull();
+  });
+
+  it('ENDED at evaluate → terminal', async () => {
+    asMock(MeetingApiClient.evaluate).mockRejectedValue(httpErr(410, 'MEETING_ENDED'));
+    render(<JoinFlow source="number" meetingNumber="123" deviceIdHash="d" autoStart />);
+    expect(await screen.findByText(T.ended)).toBeInTheDocument();
+  });
+});

--- a/packages/dmworkmeeting/src/pages/JoinFlow.test.tsx
+++ b/packages/dmworkmeeting/src/pages/JoinFlow.test.tsx
@@ -36,7 +36,7 @@ describe('JoinFlow orchestration (§7)', () => {
   it('eligible without password → PreJoin → finalize success (reuses explicit idempotency key)', async () => {
     asMock(MeetingApiClient.evaluate).mockResolvedValue({ eligible: true, meetingId: 'm1', passwordRequired: false });
     asMock(MeetingApiClient.finalize).mockResolvedValue({ livekitUrl: 'wss://x', livekitToken: 'tok', segmentId: 's', role: 'member' });
-    render(<JoinFlow source="number" meetingNumber="123" deviceIdHash="d" autoStart />);
+    render(<JoinFlow source="number" meetingNumber="123" autoStart />);
 
     fireEvent.click(await screen.findByText(T.join));
     await waitFor(() => expect(MeetingApiClient.finalize).toHaveBeenCalled());
@@ -52,13 +52,13 @@ describe('JoinFlow orchestration (§7)', () => {
       passwordRequired: true,
       passwordChallengeId: 'c1',
     });
-    render(<JoinFlow source="number" meetingNumber="123" deviceIdHash="d" autoStart />);
+    render(<JoinFlow source="number" meetingNumber="123" autoStart />);
     expect(await screen.findByText(T.challenge)).toBeInTheDocument();
   });
 
   it('LOCKED at evaluate → blocked (recoverable), not a hang and not "ended"', async () => {
     asMock(MeetingApiClient.evaluate).mockRejectedValue(httpErr(423, 'MEETING_LOCKED'));
-    render(<JoinFlow source="number" meetingNumber="123" deviceIdHash="d" autoStart />);
+    render(<JoinFlow source="number" meetingNumber="123" autoStart />);
     expect(await screen.findByText(T.locked)).toBeInTheDocument();
     expect(screen.queryByText(T.ended)).toBeNull();
     // rendered as the blocked view, keyed by code
@@ -68,7 +68,7 @@ describe('JoinFlow orchestration (§7)', () => {
   it('LIVEKIT_UNAVAILABLE at finalize keeps PreJoin, does not go to challenge', async () => {
     asMock(MeetingApiClient.evaluate).mockResolvedValue({ eligible: true, meetingId: 'm1', passwordRequired: false });
     asMock(MeetingApiClient.finalize).mockRejectedValue(httpErr(503, 'MEETING_LIVEKIT_UNAVAILABLE', { retry_after: 5 }));
-    render(<JoinFlow source="number" meetingNumber="123" deviceIdHash="d" autoStart />);
+    render(<JoinFlow source="number" meetingNumber="123" autoStart />);
     fireEvent.click(await screen.findByText(T.join));
     await waitFor(() => expect(MeetingApiClient.finalize).toHaveBeenCalled());
     expect(await screen.findByText(T.join)).toBeInTheDocument(); // still PreJoin
@@ -77,7 +77,7 @@ describe('JoinFlow orchestration (§7)', () => {
 
   it('ENDED at evaluate → terminal', async () => {
     asMock(MeetingApiClient.evaluate).mockRejectedValue(httpErr(410, 'MEETING_ENDED'));
-    render(<JoinFlow source="number" meetingNumber="123" deviceIdHash="d" autoStart />);
+    render(<JoinFlow source="number" meetingNumber="123" autoStart />);
     expect(await screen.findByText(T.ended)).toBeInTheDocument();
   });
 });

--- a/packages/dmworkmeeting/src/pages/JoinFlow.test.tsx
+++ b/packages/dmworkmeeting/src/pages/JoinFlow.test.tsx
@@ -91,6 +91,28 @@ describe('JoinFlow orchestration (§7)', () => {
     await waitFor(() => expect((screen.getByLabelText(/6/i) as HTMLInputElement).disabled).toBe(false));
   });
 
+  it('finalize returning MEETING_PASSWORD_REQUIRED (SHOW_PASSWORD_CHALLENGE) returns to the challenge, not Blocked', async () => {
+    asMock(MeetingApiClient.evaluate).mockResolvedValue({ eligible: true, meetingId: 'm1', passwordRequired: false });
+    asMock(MeetingApiClient.finalize).mockRejectedValue(
+      httpErr(428, 'MEETING_PASSWORD_REQUIRED', { password_challenge_id: 'c2' }),
+    );
+    render(<JoinFlow source="number" meetingNumber="123" autoStart />);
+    fireEvent.click(await screen.findByText(T.join));
+    // Back on the challenge form (not a Blocked view).
+    expect(await screen.findByText(T.challenge)).toBeInTheDocument();
+    expect(document.querySelector('[data-code="MEETING_PASSWORD_REQUIRED"]')).toBeNull();
+  });
+
+  it('finalize MEETING_PASSWORD_REQUIRED WITHOUT a challenge id fails closed (blocked), not challenge', async () => {
+    asMock(MeetingApiClient.evaluate).mockResolvedValue({ eligible: true, meetingId: 'm1', passwordRequired: false });
+    asMock(MeetingApiClient.finalize).mockRejectedValue(httpErr(428, 'MEETING_PASSWORD_REQUIRED'));
+    render(<JoinFlow source="number" meetingNumber="123" autoStart />);
+    fireEvent.click(await screen.findByText(T.join));
+    // Fail-closed: no challenge id → blocked (INTERNAL), never a bare challenge.
+    await waitFor(() => expect(document.querySelector('[data-code="MEETING_INTERNAL"]')).not.toBeNull());
+    expect(screen.queryByText(T.challenge)).toBeNull();
+  });
+
   it('ENDED at evaluate → terminal', async () => {
     asMock(MeetingApiClient.evaluate).mockRejectedValue(httpErr(410, 'MEETING_ENDED'));
     render(<JoinFlow source="number" meetingNumber="123" autoStart />);

--- a/packages/dmworkmeeting/src/pages/JoinFlow.test.tsx
+++ b/packages/dmworkmeeting/src/pages/JoinFlow.test.tsx
@@ -22,6 +22,7 @@ const T = {
   challenge: '输入会议密码',
   locked: '会议已锁定',
   ended: '会议已结束',
+  leave: '离开',
 };
 
 const httpErr = (status: number, code?: string, extra: Record<string, unknown> = {}) => ({
@@ -40,6 +41,8 @@ describe('JoinFlow orchestration (§7)', () => {
     fireEvent.click(await screen.findByText(T.join));
     await waitFor(() => expect(MeetingApiClient.finalize).toHaveBeenCalled());
     expect(asMock(MeetingApiClient.finalize).mock.calls[0][1]).toMatchObject({ idempotencyKey: 'test-key' });
+    // finalize success renders the room (leave control present), not a placeholder.
+    expect(await screen.findByText(T.leave)).toBeInTheDocument();
   });
 
   it('eligible with password → challenge shown (never before evaluate says so)', async () => {

--- a/packages/dmworkmeeting/src/pages/JoinFlow.tsx
+++ b/packages/dmworkmeeting/src/pages/JoinFlow.tsx
@@ -1,6 +1,6 @@
-import React, { useCallback, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { t } from '@octo/base';
-import { MeetingApiClient } from '../service/MeetingApiClient';
+import { MeetingApiClient, newIdempotencyKey } from '../service/MeetingApiClient';
 import type { AdmissionSource } from '../service/contracts';
 import { nextMeetingState, type MeetingUiState } from '../logic/stateMachine';
 import {
@@ -14,8 +14,10 @@ import { directiveForCode, MeetingErrorCode } from '../service/errors';
 import PasswordChallenge from '../components/PasswordChallenge';
 import DevicePreview from '../components/DevicePreview';
 import Terminal, { reasonForCode } from '../components/Terminal';
+import Blocked from '../components/Blocked';
 import ServiceUnavailable from '../components/ServiceUnavailable';
 import { useCooldownClock } from '../state/useCooldownClock';
+import { backToHome } from '../state/nav';
 
 export interface JoinFlowProps {
   /** Deep-link inputs; only ONE credential is ever supplied (§4). */
@@ -24,19 +26,24 @@ export interface JoinFlowProps {
   meetingNumber?: string;
   linkToken?: string;
   deviceIdHash: string;
+  /** Begin evaluate immediately on mount (used when navigated with a credential). */
+  autoStart?: boolean;
 }
 
 /**
  * Admission orchestrator (§7). Drives idle→evaluate→challenge→prejoin→finalize
  * →room, honouring: password never shown until evaluate says so; pass_token
  * consumed only on successful finalize; LIVEKIT_UNAVAILABLE keeps PreJoin and
- * retries; step-1 recheck at finalize (FD-32) → terminal; fail-closed states.
+ * retries with the SAME idempotency key; step-1 recheck at finalize (FD-32) →
+ * terminal or blocked; every other canonical error → blocked/serviceUnavailable
+ * (never a hang, never a false "ended").
  */
 export default function JoinFlow(props: JoinFlowProps) {
   const [state, setState] = useState<MeetingUiState>('idle');
   const [meetingId, setMeetingId] = useState<string | undefined>(props.meetingId);
   const [challengeId, setChallengeId] = useState<string>();
-  const [terminalCode, setTerminalCode] = useState<MeetingErrorCode>();
+  const [errorCode, setErrorCode] = useState<MeetingErrorCode>();
+  const [errorValues, setErrorValues] = useState<Record<string, string | number>>();
   const [serviceKind, setServiceKind] = useState<'service-unavailable' | 'gateway-missing'>();
   const [retryAfter, setRetryAfter] = useState<number>();
   const [cooldown, setCooldown] = useState<CooldownState>(initialCooldownState());
@@ -44,42 +51,59 @@ export default function JoinFlow(props: JoinFlowProps) {
   const [submitting, setSubmitting] = useState(false);
   // Memory-only pass token — never persisted (§8).
   const passTokenRef = useRef<string | undefined>(undefined);
+  // ONE explicit Idempotency-Key reused across finalize retries; rotated on
+  // success so a later finalize is a fresh operation (#6, N3, FD-11).
+  const finalizeKeyRef = useRef<string>(newIdempotencyKey());
 
   const dispatch = useCallback((event: Parameters<typeof nextMeetingState>[1]) => {
     setState((prev: MeetingUiState) => nextMeetingState(prev, event));
   }, []);
 
+  // Route every failure to a defined UI state — no branch may leave the flow
+  // hanging on a spinner (#4).
   const handleFailure = useCallback(
     (err: unknown) => {
       const decision = classifyFailure(err);
-      if (decision.kind === 'auth') {
-        // 401 → the client interceptor already logged out; park terminal.
-        dispatch({ type: 'AUTH_REQUIRED' });
-        return;
-      }
-      if (decision.kind === 'gateway-missing') {
-        setServiceKind('gateway-missing');
-        dispatch({ type: 'SERVICE_UNAVAILABLE' });
-        return;
-      }
-      if (decision.kind === 'service-unavailable') {
-        setServiceKind('service-unavailable');
-        setRetryAfter(decision.retryAfter);
-        dispatch({ type: 'SERVICE_UNAVAILABLE' });
-        return;
-      }
-      if (decision.code) {
-        const code = decision.code;
-        if (directiveForCode(code).terminal || code === MeetingErrorCode.NOT_SAME_SPACE || code === MeetingErrorCode.CREDENTIAL_INVALID) {
-          setTerminalCode(code);
+      const wire = (err as { response?: { data?: Record<string, unknown> } }).response?.data;
+      switch (decision.kind) {
+        case 'auth':
+          // 401 auth: the client already logged out; park terminal.
+          dispatch({ type: 'AUTH_REQUIRED' });
+          return;
+        case 'gateway-missing':
+          setServiceKind('gateway-missing');
+          dispatch({ type: 'SERVICE_UNAVAILABLE' });
+          return;
+        case 'service-unavailable':
+          setServiceKind('service-unavailable');
+          setRetryAfter(decision.retryAfter);
+          dispatch({ type: 'SERVICE_UNAVAILABLE' });
+          return;
+        case 'space':
+          setErrorCode(decision.code ?? MeetingErrorCode.NOT_SAME_SPACE);
+          dispatch({ type: 'BLOCKED', code: decision.code ?? MeetingErrorCode.NOT_SAME_SPACE });
+          return;
+        case 'canonical': {
+          const code = decision.code as MeetingErrorCode;
+          setErrorCode(code);
+          if (code === MeetingErrorCode.TOO_EARLY && wire?.earliest_join_at) {
+            setErrorValues({ earliestJoinAt: String(wire.earliest_join_at) });
+          }
           dispatch({ type: 'EVALUATE_INELIGIBLE', code });
+          return;
         }
+        default:
+          // Network / unknown → recoverable internal error, retry allowed.
+          setErrorCode(MeetingErrorCode.INTERNAL);
+          dispatch({ type: 'BLOCKED', code: MeetingErrorCode.INTERNAL });
       }
     },
     [dispatch],
   );
 
   const runEvaluate = useCallback(async () => {
+    setErrorCode(undefined);
+    setErrorValues(undefined);
     dispatch({ type: 'START_EVALUATE' });
     try {
       const r = await MeetingApiClient.evaluate({
@@ -97,6 +121,11 @@ export default function JoinFlow(props: JoinFlowProps) {
     }
   }, [dispatch, handleFailure, props.deviceIdHash, props.linkToken, props.meetingId, props.meetingNumber, props.source]);
 
+  useEffect(() => {
+    if (props.autoStart) void runEvaluate();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   const submitPassword = useCallback(
     async (password: string) => {
       if (!meetingId || !challengeId) return;
@@ -109,20 +138,21 @@ export default function JoinFlow(props: JoinFlowProps) {
         setCooldown(clearedCooldownState());
         dispatch({ type: 'PASSWORD_PASS' });
       } catch (err) {
-        const decision = classifyFailure(err);
-        const code = decision.code;
+        const code = classifyFailure(err).code;
+        const wire = (err as { response?: { data?: { attempts_remaining?: number; retry_at?: string } } }).response?.data;
         if (code === MeetingErrorCode.PASSWORD_INVALID) {
-          const wire = (err as { response?: { data?: { attempts_remaining?: number; retry_at?: string } } }).response?.data;
-          const attemptsRemaining = wire?.attempts_remaining ?? 0;
-          const retryAtMs = wire?.retry_at ? Date.parse(wire.retry_at) : undefined;
-          const next = reduceWrongPassword({ attemptsRemaining, retryAtMs });
+          const next = reduceWrongPassword({
+            attemptsRemaining: wire?.attempts_remaining ?? 0,
+            retryAtMs: wire?.retry_at ? Date.parse(wire.retry_at) : undefined,
+          });
           setCooldown(next);
           setLastInvalid(true);
           dispatch({ type: 'PASSWORD_INVALID', enteringCooldown: next.inCooldown });
         } else if (code === MeetingErrorCode.PASSWORD_COOLDOWN) {
-          const wire = (err as { response?: { data?: { retry_at?: string } } }).response?.data;
           setCooldown({ attemptsRemaining: 0, inCooldown: true, retryAtMs: wire?.retry_at ? Date.parse(wire.retry_at) : undefined });
           dispatch({ type: 'PASSWORD_INVALID', enteringCooldown: true });
+        } else if (code === MeetingErrorCode.PASSWORD_FORMAT_INVALID) {
+          dispatch({ type: 'PASSWORD_FORMAT_INVALID' }); // not counted
         } else {
           handleFailure(err);
         }
@@ -137,27 +167,30 @@ export default function JoinFlow(props: JoinFlowProps) {
     if (!meetingId) return;
     dispatch({ type: 'START_FINALIZE' });
     try {
-      await MeetingApiClient.finalize({
-        meetingId,
-        source: props.source,
-        passwordPassToken: passTokenRef.current,
-        deviceIdHash: props.deviceIdHash,
-      });
-      // Success consumes the pass token exactly once.
-      passTokenRef.current = undefined;
+      await MeetingApiClient.finalize(
+        {
+          meetingId,
+          source: props.source,
+          passwordPassToken: passTokenRef.current,
+          deviceIdHash: props.deviceIdHash,
+        },
+        { idempotencyKey: finalizeKeyRef.current },
+      );
+      passTokenRef.current = undefined; // consumed exactly once on success
+      finalizeKeyRef.current = newIdempotencyKey(); // rotate after success
       dispatch({ type: 'FINALIZE_SUCCESS' });
     } catch (err) {
-      const decision = classifyFailure(err);
-      const code = decision.code;
+      const code = classifyFailure(err).code;
+      const wire = (err as { response?: { data?: { retry_after?: number } } }).response?.data;
       if (code === MeetingErrorCode.LIVEKIT_UNAVAILABLE) {
-        setRetryAfter(decision.retryAfter);
-        dispatch({ type: 'FINALIZE_LIVEKIT_UNAVAILABLE' }); // keep PreJoin + token, retry
+        setRetryAfter(wire?.retry_after); // keep PreJoin + token, reuse same finalize key on retry
+        dispatch({ type: 'FINALIZE_LIVEKIT_UNAVAILABLE' });
       } else if (code === MeetingErrorCode.PASSWORD_PASS_EXPIRED) {
         passTokenRef.current = undefined;
         dispatch({ type: 'FINALIZE_PASS_EXPIRED' }); // restart challenge
-      } else if (code && directiveForCode(code).httpStatus) {
-        setTerminalCode(code);
-        dispatch({ type: 'FINALIZE_STEP1', code }); // FD-32 step-1 recheck
+      } else if (code) {
+        setErrorCode(code);
+        dispatch({ type: 'FINALIZE_STEP1', code }); // FD-32: terminal or blocked per directive
       } else {
         handleFailure(err);
       }
@@ -170,7 +203,10 @@ export default function JoinFlow(props: JoinFlowProps) {
     dispatch({ type: 'COOLDOWN_EXPIRED' });
   });
 
-  const cooldownSeconds = useMemo(() => (cooldown.retryAtMs ? Math.max(0, Math.ceil((cooldown.retryAtMs - Date.now()) / 1000)) : 0), [cooldown]);
+  const cooldownSeconds = useMemo(
+    () => (cooldown.retryAtMs ? Math.max(0, Math.ceil((cooldown.retryAtMs - Date.now()) / 1000)) : 0),
+    [cooldown],
+  );
 
   // ── Render by state ──
   if (state === 'idle') {
@@ -183,13 +219,30 @@ export default function JoinFlow(props: JoinFlowProps) {
     );
   }
   if (state === 'evaluating' || state === 'finalizing' || state === 'verifying') {
-    return <div className="meeting-join-flow" aria-busy="true">…</div>;
+    return (
+      <div className="meeting-join-flow" role="status" aria-live="polite" aria-busy="true">
+        {t('meeting.room.reconnecting')}
+      </div>
+    );
   }
   if (state === 'serviceUnavailable') {
     return <ServiceUnavailable reason={serviceKind ?? 'service-unavailable'} retryAfter={retryAfter} onRetry={runEvaluate} />;
   }
   if (state === 'terminal') {
-    return <Terminal reason={terminalCode ? reasonForCode(terminalCode) : 'ended'} />;
+    return <Terminal reason={errorCode ? reasonForCode(errorCode) : 'ended'} onBackHome={backToHome} />;
+  }
+  if (state === 'blocked') {
+    return (
+      <Blocked
+        code={errorCode ?? MeetingErrorCode.INTERNAL}
+        values={errorValues}
+        onRetry={() => {
+          dispatch({ type: 'RETRY' });
+          void runEvaluate();
+        }}
+        onBackHome={backToHome}
+      />
+    );
   }
   if (state === 'challenge' || state === 'cooldown') {
     return (
@@ -215,6 +268,6 @@ export default function JoinFlow(props: JoinFlowProps) {
       </div>
     );
   }
-  // room / reconnecting are owned by RoomPage once finalize succeeds.
+  // room / reconnecting are owned by RoomView once finalize succeeds.
   return <div className="meeting-room-placeholder">{t('meeting.room.participants')}</div>;
 }

--- a/packages/dmworkmeeting/src/pages/JoinFlow.tsx
+++ b/packages/dmworkmeeting/src/pages/JoinFlow.tsx
@@ -10,16 +10,17 @@ import {
   type CooldownState,
 } from '../logic/password';
 import { classifyFailure } from '../service/failClosed';
-import { directiveForCode, MeetingErrorCode } from '../service/errors';
+import { MeetingErrorCode } from '../service/errors';
 import PasswordChallenge from '../components/PasswordChallenge';
 import DevicePreview from '../components/DevicePreview';
-import Terminal, { reasonForCode } from '../components/Terminal';
+import Terminal, { reasonForCode, type TerminalReason } from '../components/Terminal';
 import Blocked from '../components/Blocked';
 import ServiceUnavailable from '../components/ServiceUnavailable';
 import RoomView from './RoomView';
 import { connectRoom, type LiveKitRoomHandle } from '../state/livekitRoom';
 import { useCooldownClock } from '../state/useCooldownClock';
-import { backToHome } from '../state/nav';
+import { emitMeetingTelemetry } from '../state/telemetry';
+import { backToHome, deviceIdHash } from '../state/nav';
 
 export interface JoinFlowProps {
   /** Deep-link inputs; only ONE credential is ever supplied (§4). */
@@ -27,7 +28,6 @@ export interface JoinFlowProps {
   meetingId?: string;
   meetingNumber?: string;
   linkToken?: string;
-  deviceIdHash: string;
   /** Begin evaluate immediately on mount (used when navigated with a credential). */
   autoStart?: boolean;
 }
@@ -38,7 +38,7 @@ export interface JoinFlowProps {
  * consumed only on successful finalize; LIVEKIT_UNAVAILABLE keeps PreJoin and
  * retries with the SAME idempotency key; step-1 recheck at finalize (FD-32) →
  * terminal or blocked; every other canonical error → blocked/serviceUnavailable
- * (never a hang, never a false "ended").
+ * (never a hang, never a silent no-op, never a false "ended").
  */
 export default function JoinFlow(props: JoinFlowProps) {
   const [state, setState] = useState<MeetingUiState>('idle');
@@ -46,6 +46,7 @@ export default function JoinFlow(props: JoinFlowProps) {
   const [challengeId, setChallengeId] = useState<string>();
   const [errorCode, setErrorCode] = useState<MeetingErrorCode>();
   const [errorValues, setErrorValues] = useState<Record<string, string | number>>();
+  const [terminalReason, setTerminalReason] = useState<TerminalReason>();
   const [serviceKind, setServiceKind] = useState<'service-unavailable' | 'gateway-missing'>();
   const [retryAfter, setRetryAfter] = useState<number>();
   const [cooldown, setCooldown] = useState<CooldownState>(initialCooldownState());
@@ -54,25 +55,35 @@ export default function JoinFlow(props: JoinFlowProps) {
   // Memory-only pass token — never persisted (§8).
   const passTokenRef = useRef<string | undefined>(undefined);
   // ONE explicit Idempotency-Key reused across finalize retries; rotated on
-  // success so a later finalize is a fresh operation (#6, N3, FD-11).
+  // success AND on a pass-token restart (both are new logical operations) (#6).
   const finalizeKeyRef = useRef<string>(newIdempotencyKey());
   // LiveKit media handle + the finalize result that seeds the room.
   const [room, setRoom] = useState<AdmissionFinalizeResult | undefined>();
+  const [mediaConnected, setMediaConnected] = useState(false);
   const roomHandleRef = useRef<LiveKitRoomHandle | null>(null);
+  // Abort in-flight requests on unmount.
+  const abortRef = useRef<AbortController | null>(null);
+  useEffect(() => () => abortRef.current?.abort(), []);
+  const freshSignal = () => {
+    abortRef.current?.abort();
+    abortRef.current = new AbortController();
+    return abortRef.current.signal;
+  };
 
   const dispatch = useCallback((event: Parameters<typeof nextMeetingState>[1]) => {
     setState((prev: MeetingUiState) => nextMeetingState(prev, event));
   }, []);
 
   // Route every failure to a defined UI state — no branch may leave the flow
-  // hanging on a spinner (#4).
+  // hanging on a spinner.
   const handleFailure = useCallback(
     (err: unknown) => {
       const decision = classifyFailure(err);
       const wire = (err as { response?: { data?: Record<string, unknown> } }).response?.data;
       switch (decision.kind) {
         case 'auth':
-          // 401 auth: the client already logged out; park terminal.
+          // 401 auth: the client already logged out; park terminal with an auth message.
+          setTerminalReason('authRequired');
           dispatch({ type: 'AUTH_REQUIRED' });
           return;
         case 'gateway-missing':
@@ -98,7 +109,7 @@ export default function JoinFlow(props: JoinFlowProps) {
           return;
         }
         default:
-          // Network / unknown → recoverable internal error, retry allowed.
+          // Network / timeout / unknown → recoverable internal error, retry allowed.
           setErrorCode(MeetingErrorCode.INTERNAL);
           dispatch({ type: 'BLOCKED', code: MeetingErrorCode.INTERNAL });
       }
@@ -106,25 +117,47 @@ export default function JoinFlow(props: JoinFlowProps) {
     [dispatch],
   );
 
+  // A malformed-but-2xx evaluate (or one missing required fields) must fail
+  // closed rather than walking the user into PreJoin on garbage.
+  const failClosedInternal = useCallback(() => {
+    setErrorCode(MeetingErrorCode.INTERNAL);
+    dispatch({ type: 'BLOCKED', code: MeetingErrorCode.INTERNAL });
+  }, [dispatch]);
+
   const runEvaluate = useCallback(async () => {
     setErrorCode(undefined);
     setErrorValues(undefined);
     dispatch({ type: 'START_EVALUATE' });
     try {
-      const r = await MeetingApiClient.evaluate({
-        source: props.source,
-        meetingId: props.meetingId,
-        meetingNumber: props.meetingNumber,
-        linkToken: props.linkToken,
-        deviceIdHash: props.deviceIdHash,
-      });
+      const r = await MeetingApiClient.evaluate(
+        {
+          source: props.source,
+          meetingId: props.meetingId,
+          meetingNumber: props.meetingNumber,
+          linkToken: props.linkToken,
+          deviceIdHash: deviceIdHash(),
+        },
+        freshSignal(),
+      );
+      // Fail closed on an unusable verdict (never dispatch ELIGIBLE blindly).
+      if (r.eligible !== true) {
+        failClosedInternal();
+        return;
+      }
+      const passwordRequired = Boolean(r.passwordRequired);
+      if (passwordRequired && !r.passwordChallengeId) {
+        failClosedInternal();
+        return;
+      }
       if (r.meetingId) setMeetingId(r.meetingId);
       if (r.passwordChallengeId) setChallengeId(r.passwordChallengeId);
-      dispatch({ type: 'EVALUATE_ELIGIBLE', passwordRequired: Boolean(r.passwordRequired) });
+      emitMeetingTelemetry({ kind: 'admission_evaluate', source: props.source, outcome: 'eligible' });
+      dispatch({ type: 'EVALUATE_ELIGIBLE', passwordRequired });
     } catch (err) {
       handleFailure(err);
     }
-  }, [dispatch, handleFailure, props.deviceIdHash, props.linkToken, props.meetingId, props.meetingNumber, props.source]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dispatch, failClosedInternal, handleFailure, props.linkToken, props.meetingId, props.meetingNumber, props.source]);
 
   useEffect(() => {
     if (props.autoStart) void runEvaluate();
@@ -133,12 +166,20 @@ export default function JoinFlow(props: JoinFlowProps) {
 
   const submitPassword = useCallback(
     async (password: string) => {
-      if (!meetingId || !challengeId) return;
+      // Should not happen (challenge is only shown once these are set), but a
+      // missing id must surface an error rather than silently no-op.
+      if (!meetingId || !challengeId) {
+        failClosedInternal();
+        return;
+      }
       setSubmitting(true);
       setLastInvalid(false);
       dispatch({ type: 'SUBMIT_PASSWORD' });
       try {
-        const r = await MeetingApiClient.verifyPassword({ meetingId, passwordChallengeId: challengeId, password });
+        const r = await MeetingApiClient.verifyPassword(
+          { meetingId, passwordChallengeId: challengeId, password },
+          freshSignal(),
+        );
         passTokenRef.current = r.passwordPassToken;
         setCooldown(clearedCooldownState());
         dispatch({ type: 'PASSWORD_PASS' });
@@ -147,14 +188,15 @@ export default function JoinFlow(props: JoinFlowProps) {
         const wire = (err as { response?: { data?: { attempts_remaining?: number; retry_at?: string } } }).response?.data;
         if (code === MeetingErrorCode.PASSWORD_INVALID) {
           const next = reduceWrongPassword({
-            attemptsRemaining: wire?.attempts_remaining ?? 0,
+            attemptsRemaining: wire?.attempts_remaining,
             retryAtMs: wire?.retry_at ? Date.parse(wire.retry_at) : undefined,
           });
           setCooldown(next);
           setLastInvalid(true);
           dispatch({ type: 'PASSWORD_INVALID', enteringCooldown: next.inCooldown });
         } else if (code === MeetingErrorCode.PASSWORD_COOLDOWN) {
-          setCooldown({ attemptsRemaining: 0, inCooldown: true, retryAtMs: wire?.retry_at ? Date.parse(wire.retry_at) : undefined });
+          const retryAtMs = wire?.retry_at ? Date.parse(wire.retry_at) : undefined;
+          setCooldown({ attemptsRemaining: 0, inCooldown: true, retryAtMs });
           dispatch({ type: 'PASSWORD_INVALID', enteringCooldown: true });
         } else if (code === MeetingErrorCode.PASSWORD_FORMAT_INVALID) {
           dispatch({ type: 'PASSWORD_FORMAT_INVALID' }); // not counted
@@ -165,11 +207,14 @@ export default function JoinFlow(props: JoinFlowProps) {
         setSubmitting(false);
       }
     },
-    [challengeId, dispatch, handleFailure, meetingId],
+    [challengeId, dispatch, failClosedInternal, handleFailure, meetingId],
   );
 
   const runFinalize = useCallback(async () => {
-    if (!meetingId) return;
+    if (!meetingId) {
+      failClosedInternal();
+      return;
+    }
     dispatch({ type: 'START_FINALIZE' });
     try {
       const result = await MeetingApiClient.finalize(
@@ -177,23 +222,25 @@ export default function JoinFlow(props: JoinFlowProps) {
           meetingId,
           source: props.source,
           passwordPassToken: passTokenRef.current,
-          deviceIdHash: props.deviceIdHash,
+          deviceIdHash: deviceIdHash(),
         },
-        { idempotencyKey: finalizeKeyRef.current },
+        { idempotencyKey: finalizeKeyRef.current, signal: freshSignal() },
       );
       passTokenRef.current = undefined; // consumed exactly once on success
       finalizeKeyRef.current = newIdempotencyKey(); // rotate after success
       setRoom(result); // carries livekit_url / token / segment_id / role
+      emitMeetingTelemetry({ kind: 'finalize', outcome: 'success' });
       dispatch({ type: 'FINALIZE_SUCCESS' });
     } catch (err) {
       const code = classifyFailure(err).code;
       const wire = (err as { response?: { data?: { retry_after?: number } } }).response?.data;
       if (code === MeetingErrorCode.LIVEKIT_UNAVAILABLE) {
-        setRetryAfter(wire?.retry_after); // keep PreJoin + token, reuse same finalize key on retry
+        setRetryAfter(wire?.retry_after); // keep PreJoin + token, reuse SAME finalize key on retry
         dispatch({ type: 'FINALIZE_LIVEKIT_UNAVAILABLE' });
       } else if (code === MeetingErrorCode.PASSWORD_PASS_EXPIRED) {
         passTokenRef.current = undefined;
-        dispatch({ type: 'FINALIZE_PASS_EXPIRED' }); // restart challenge
+        finalizeKeyRef.current = newIdempotencyKey(); // restart = new logical op → new key
+        dispatch({ type: 'FINALIZE_PASS_EXPIRED' });
       } else if (code) {
         setErrorCode(code);
         dispatch({ type: 'FINALIZE_STEP1', code }); // FD-32: terminal or blocked per directive
@@ -201,7 +248,8 @@ export default function JoinFlow(props: JoinFlowProps) {
         handleFailure(err);
       }
     }
-  }, [dispatch, handleFailure, meetingId, props.deviceIdHash, props.source]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dispatch, failClosedInternal, handleFailure, meetingId, props.source]);
 
   const { remainingSeconds: cooldownSeconds } = useCooldownClock(cooldown, () => {
     setCooldown(clearedCooldownState());
@@ -209,13 +257,15 @@ export default function JoinFlow(props: JoinFlowProps) {
     dispatch({ type: 'COOLDOWN_EXPIRED' });
   });
 
-  // Connect the media room once finalize succeeds (media layer is a lazy,
-  // React-17-safe seam; connectRoom resolves null if the SDK is absent, so the
-  // room still renders). Disconnect on leave/unmount to release tracks.
+  // Connect the media room once finalize succeeds. connectRoom resolves null if
+  // the SDK is absent or a connection fails; we track the real outcome so the
+  // room UI does not present itself as connected when it is not (honest
+  // serviceAvailable — blocker #5).
   useEffect(() => {
     if (!room) return undefined;
     let handle: LiveKitRoomHandle | null = null;
     let cancelled = false;
+    setMediaConnected(false);
     void connectRoom({ url: room.livekitUrl, token: room.livekitToken }).then((h) => {
       if (cancelled) {
         void h?.disconnect();
@@ -223,6 +273,7 @@ export default function JoinFlow(props: JoinFlowProps) {
       }
       handle = h;
       roomHandleRef.current = h;
+      setMediaConnected(h !== null);
     });
     return () => {
       cancelled = true;
@@ -242,6 +293,7 @@ export default function JoinFlow(props: JoinFlowProps) {
         // Leaving is best-effort; the server reconciles via segment/leave_at.
       }
     }
+    setTerminalReason('left');
     dispatch({ type: 'LEFT' });
   }, [dispatch, meetingId]);
 
@@ -266,7 +318,7 @@ export default function JoinFlow(props: JoinFlowProps) {
     return <ServiceUnavailable reason={serviceKind ?? 'service-unavailable'} retryAfter={retryAfter} onRetry={runEvaluate} />;
   }
   if (state === 'terminal') {
-    return <Terminal reason={errorCode ? reasonForCode(errorCode) : 'ended'} onBackHome={backToHome} />;
+    return <Terminal reason={terminalReason ?? (errorCode ? reasonForCode(errorCode) : 'ended')} onBackHome={backToHome} />;
   }
   if (state === 'blocked') {
     return (
@@ -311,10 +363,14 @@ export default function JoinFlow(props: JoinFlowProps) {
     const self: Participant = { uid: selfUid, role: room.role };
     return (
       <RoomView
+        meetingId={meetingId ?? ''}
         participants={[self]}
         viewerRole={room.role}
         reconnecting={state === 'reconnecting'}
-        serviceAvailable
+        // Honest: controls stay greyed until the media handle is actually
+        // connected; a null connection surfaces the media-unavailable notice.
+        serviceAvailable={mediaConnected}
+        mediaUnavailable={!mediaConnected}
         canShare={room.role !== 'member'}
         onLeave={() => void leaveRoom()}
       />

--- a/packages/dmworkmeeting/src/pages/JoinFlow.tsx
+++ b/packages/dmworkmeeting/src/pages/JoinFlow.tsx
@@ -1,7 +1,7 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { t } from '@octo/base';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { t, WKApp } from '@octo/base';
 import { MeetingApiClient, newIdempotencyKey } from '../service/MeetingApiClient';
-import type { AdmissionSource } from '../service/contracts';
+import type { AdmissionSource, AdmissionFinalizeResult, Participant } from '../service/contracts';
 import { nextMeetingState, type MeetingUiState } from '../logic/stateMachine';
 import {
   initialCooldownState,
@@ -16,6 +16,8 @@ import DevicePreview from '../components/DevicePreview';
 import Terminal, { reasonForCode } from '../components/Terminal';
 import Blocked from '../components/Blocked';
 import ServiceUnavailable from '../components/ServiceUnavailable';
+import RoomView from './RoomView';
+import { connectRoom, type LiveKitRoomHandle } from '../state/livekitRoom';
 import { useCooldownClock } from '../state/useCooldownClock';
 import { backToHome } from '../state/nav';
 
@@ -54,6 +56,9 @@ export default function JoinFlow(props: JoinFlowProps) {
   // ONE explicit Idempotency-Key reused across finalize retries; rotated on
   // success so a later finalize is a fresh operation (#6, N3, FD-11).
   const finalizeKeyRef = useRef<string>(newIdempotencyKey());
+  // LiveKit media handle + the finalize result that seeds the room.
+  const [room, setRoom] = useState<AdmissionFinalizeResult | undefined>();
+  const roomHandleRef = useRef<LiveKitRoomHandle | null>(null);
 
   const dispatch = useCallback((event: Parameters<typeof nextMeetingState>[1]) => {
     setState((prev: MeetingUiState) => nextMeetingState(prev, event));
@@ -167,7 +172,7 @@ export default function JoinFlow(props: JoinFlowProps) {
     if (!meetingId) return;
     dispatch({ type: 'START_FINALIZE' });
     try {
-      await MeetingApiClient.finalize(
+      const result = await MeetingApiClient.finalize(
         {
           meetingId,
           source: props.source,
@@ -178,6 +183,7 @@ export default function JoinFlow(props: JoinFlowProps) {
       );
       passTokenRef.current = undefined; // consumed exactly once on success
       finalizeKeyRef.current = newIdempotencyKey(); // rotate after success
+      setRoom(result); // carries livekit_url / token / segment_id / role
       dispatch({ type: 'FINALIZE_SUCCESS' });
     } catch (err) {
       const code = classifyFailure(err).code;
@@ -197,16 +203,47 @@ export default function JoinFlow(props: JoinFlowProps) {
     }
   }, [dispatch, handleFailure, meetingId, props.deviceIdHash, props.source]);
 
-  useCooldownClock(cooldown, () => {
+  const { remainingSeconds: cooldownSeconds } = useCooldownClock(cooldown, () => {
     setCooldown(clearedCooldownState());
     setLastInvalid(false);
     dispatch({ type: 'COOLDOWN_EXPIRED' });
   });
 
-  const cooldownSeconds = useMemo(
-    () => (cooldown.retryAtMs ? Math.max(0, Math.ceil((cooldown.retryAtMs - Date.now()) / 1000)) : 0),
-    [cooldown],
-  );
+  // Connect the media room once finalize succeeds (media layer is a lazy,
+  // React-17-safe seam; connectRoom resolves null if the SDK is absent, so the
+  // room still renders). Disconnect on leave/unmount to release tracks.
+  useEffect(() => {
+    if (!room) return undefined;
+    let handle: LiveKitRoomHandle | null = null;
+    let cancelled = false;
+    void connectRoom({ url: room.livekitUrl, token: room.livekitToken }).then((h) => {
+      if (cancelled) {
+        void h?.disconnect();
+        return;
+      }
+      handle = h;
+      roomHandleRef.current = h;
+    });
+    return () => {
+      cancelled = true;
+      void handle?.disconnect();
+      roomHandleRef.current = null;
+    };
+  }, [room]);
+
+  const leaveRoom = useCallback(async () => {
+    const handle = roomHandleRef.current;
+    roomHandleRef.current = null;
+    void handle?.disconnect();
+    if (meetingId) {
+      try {
+        await MeetingApiClient.leave(meetingId, { idempotencyKey: newIdempotencyKey() });
+      } catch {
+        // Leaving is best-effort; the server reconciles via segment/leave_at.
+      }
+    }
+    dispatch({ type: 'LEFT' });
+  }, [dispatch, meetingId]);
 
   // ── Render by state ──
   if (state === 'idle') {
@@ -268,6 +305,24 @@ export default function JoinFlow(props: JoinFlowProps) {
       </div>
     );
   }
-  // room / reconnecting are owned by RoomView once finalize succeeds.
-  return <div className="meeting-room-placeholder">{t('meeting.room.participants')}</div>;
+  // room / reconnecting: render the LiveKit room view once finalize succeeded.
+  if ((state === 'room' || state === 'reconnecting') && room) {
+    const selfUid = (WKApp as unknown as { loginInfo?: { uid?: string } }).loginInfo?.uid ?? 'me';
+    const self: Participant = { uid: selfUid, role: room.role };
+    return (
+      <RoomView
+        participants={[self]}
+        viewerRole={room.role}
+        reconnecting={state === 'reconnecting'}
+        serviceAvailable
+        canShare={room.role !== 'member'}
+        onLeave={() => void leaveRoom()}
+      />
+    );
+  }
+  return (
+    <div className="meeting-join-flow" role="status" aria-live="polite" aria-busy="true">
+      {t('meeting.room.reconnecting')}
+    </div>
+  );
 }

--- a/packages/dmworkmeeting/src/pages/JoinFlow.tsx
+++ b/packages/dmworkmeeting/src/pages/JoinFlow.tsx
@@ -1,0 +1,220 @@
+import React, { useCallback, useMemo, useRef, useState } from 'react';
+import { t } from '@octo/base';
+import { MeetingApiClient } from '../service/MeetingApiClient';
+import type { AdmissionSource } from '../service/contracts';
+import { nextMeetingState, type MeetingUiState } from '../logic/stateMachine';
+import {
+  initialCooldownState,
+  reduceWrongPassword,
+  clearedCooldownState,
+  type CooldownState,
+} from '../logic/password';
+import { classifyFailure } from '../service/failClosed';
+import { directiveForCode, MeetingErrorCode } from '../service/errors';
+import PasswordChallenge from '../components/PasswordChallenge';
+import DevicePreview from '../components/DevicePreview';
+import Terminal, { reasonForCode } from '../components/Terminal';
+import ServiceUnavailable from '../components/ServiceUnavailable';
+import { useCooldownClock } from '../state/useCooldownClock';
+
+export interface JoinFlowProps {
+  /** Deep-link inputs; only ONE credential is ever supplied (§4). */
+  source: AdmissionSource;
+  meetingId?: string;
+  meetingNumber?: string;
+  linkToken?: string;
+  deviceIdHash: string;
+}
+
+/**
+ * Admission orchestrator (§7). Drives idle→evaluate→challenge→prejoin→finalize
+ * →room, honouring: password never shown until evaluate says so; pass_token
+ * consumed only on successful finalize; LIVEKIT_UNAVAILABLE keeps PreJoin and
+ * retries; step-1 recheck at finalize (FD-32) → terminal; fail-closed states.
+ */
+export default function JoinFlow(props: JoinFlowProps) {
+  const [state, setState] = useState<MeetingUiState>('idle');
+  const [meetingId, setMeetingId] = useState<string | undefined>(props.meetingId);
+  const [challengeId, setChallengeId] = useState<string>();
+  const [terminalCode, setTerminalCode] = useState<MeetingErrorCode>();
+  const [serviceKind, setServiceKind] = useState<'service-unavailable' | 'gateway-missing'>();
+  const [retryAfter, setRetryAfter] = useState<number>();
+  const [cooldown, setCooldown] = useState<CooldownState>(initialCooldownState());
+  const [lastInvalid, setLastInvalid] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  // Memory-only pass token — never persisted (§8).
+  const passTokenRef = useRef<string | undefined>(undefined);
+
+  const dispatch = useCallback((event: Parameters<typeof nextMeetingState>[1]) => {
+    setState((prev: MeetingUiState) => nextMeetingState(prev, event));
+  }, []);
+
+  const handleFailure = useCallback(
+    (err: unknown) => {
+      const decision = classifyFailure(err);
+      if (decision.kind === 'auth') {
+        // 401 → the client interceptor already logged out; park terminal.
+        dispatch({ type: 'AUTH_REQUIRED' });
+        return;
+      }
+      if (decision.kind === 'gateway-missing') {
+        setServiceKind('gateway-missing');
+        dispatch({ type: 'SERVICE_UNAVAILABLE' });
+        return;
+      }
+      if (decision.kind === 'service-unavailable') {
+        setServiceKind('service-unavailable');
+        setRetryAfter(decision.retryAfter);
+        dispatch({ type: 'SERVICE_UNAVAILABLE' });
+        return;
+      }
+      if (decision.code) {
+        const code = decision.code;
+        if (directiveForCode(code).terminal || code === MeetingErrorCode.NOT_SAME_SPACE || code === MeetingErrorCode.CREDENTIAL_INVALID) {
+          setTerminalCode(code);
+          dispatch({ type: 'EVALUATE_INELIGIBLE', code });
+        }
+      }
+    },
+    [dispatch],
+  );
+
+  const runEvaluate = useCallback(async () => {
+    dispatch({ type: 'START_EVALUATE' });
+    try {
+      const r = await MeetingApiClient.evaluate({
+        source: props.source,
+        meetingId: props.meetingId,
+        meetingNumber: props.meetingNumber,
+        linkToken: props.linkToken,
+        deviceIdHash: props.deviceIdHash,
+      });
+      if (r.meetingId) setMeetingId(r.meetingId);
+      if (r.passwordChallengeId) setChallengeId(r.passwordChallengeId);
+      dispatch({ type: 'EVALUATE_ELIGIBLE', passwordRequired: Boolean(r.passwordRequired) });
+    } catch (err) {
+      handleFailure(err);
+    }
+  }, [dispatch, handleFailure, props.deviceIdHash, props.linkToken, props.meetingId, props.meetingNumber, props.source]);
+
+  const submitPassword = useCallback(
+    async (password: string) => {
+      if (!meetingId || !challengeId) return;
+      setSubmitting(true);
+      setLastInvalid(false);
+      dispatch({ type: 'SUBMIT_PASSWORD' });
+      try {
+        const r = await MeetingApiClient.verifyPassword({ meetingId, passwordChallengeId: challengeId, password });
+        passTokenRef.current = r.passwordPassToken;
+        setCooldown(clearedCooldownState());
+        dispatch({ type: 'PASSWORD_PASS' });
+      } catch (err) {
+        const decision = classifyFailure(err);
+        const code = decision.code;
+        if (code === MeetingErrorCode.PASSWORD_INVALID) {
+          const wire = (err as { response?: { data?: { attempts_remaining?: number; retry_at?: string } } }).response?.data;
+          const attemptsRemaining = wire?.attempts_remaining ?? 0;
+          const retryAtMs = wire?.retry_at ? Date.parse(wire.retry_at) : undefined;
+          const next = reduceWrongPassword({ attemptsRemaining, retryAtMs });
+          setCooldown(next);
+          setLastInvalid(true);
+          dispatch({ type: 'PASSWORD_INVALID', enteringCooldown: next.inCooldown });
+        } else if (code === MeetingErrorCode.PASSWORD_COOLDOWN) {
+          const wire = (err as { response?: { data?: { retry_at?: string } } }).response?.data;
+          setCooldown({ attemptsRemaining: 0, inCooldown: true, retryAtMs: wire?.retry_at ? Date.parse(wire.retry_at) : undefined });
+          dispatch({ type: 'PASSWORD_INVALID', enteringCooldown: true });
+        } else {
+          handleFailure(err);
+        }
+      } finally {
+        setSubmitting(false);
+      }
+    },
+    [challengeId, dispatch, handleFailure, meetingId],
+  );
+
+  const runFinalize = useCallback(async () => {
+    if (!meetingId) return;
+    dispatch({ type: 'START_FINALIZE' });
+    try {
+      await MeetingApiClient.finalize({
+        meetingId,
+        source: props.source,
+        passwordPassToken: passTokenRef.current,
+        deviceIdHash: props.deviceIdHash,
+      });
+      // Success consumes the pass token exactly once.
+      passTokenRef.current = undefined;
+      dispatch({ type: 'FINALIZE_SUCCESS' });
+    } catch (err) {
+      const decision = classifyFailure(err);
+      const code = decision.code;
+      if (code === MeetingErrorCode.LIVEKIT_UNAVAILABLE) {
+        setRetryAfter(decision.retryAfter);
+        dispatch({ type: 'FINALIZE_LIVEKIT_UNAVAILABLE' }); // keep PreJoin + token, retry
+      } else if (code === MeetingErrorCode.PASSWORD_PASS_EXPIRED) {
+        passTokenRef.current = undefined;
+        dispatch({ type: 'FINALIZE_PASS_EXPIRED' }); // restart challenge
+      } else if (code && directiveForCode(code).httpStatus) {
+        setTerminalCode(code);
+        dispatch({ type: 'FINALIZE_STEP1', code }); // FD-32 step-1 recheck
+      } else {
+        handleFailure(err);
+      }
+    }
+  }, [dispatch, handleFailure, meetingId, props.deviceIdHash, props.source]);
+
+  useCooldownClock(cooldown, () => {
+    setCooldown(clearedCooldownState());
+    setLastInvalid(false);
+    dispatch({ type: 'COOLDOWN_EXPIRED' });
+  });
+
+  const cooldownSeconds = useMemo(() => (cooldown.retryAtMs ? Math.max(0, Math.ceil((cooldown.retryAtMs - Date.now()) / 1000)) : 0), [cooldown]);
+
+  // ── Render by state ──
+  if (state === 'idle') {
+    return (
+      <div className="meeting-join-flow">
+        <button type="button" onClick={runEvaluate}>
+          {t('meeting.join.submit')}
+        </button>
+      </div>
+    );
+  }
+  if (state === 'evaluating' || state === 'finalizing' || state === 'verifying') {
+    return <div className="meeting-join-flow" aria-busy="true">…</div>;
+  }
+  if (state === 'serviceUnavailable') {
+    return <ServiceUnavailable reason={serviceKind ?? 'service-unavailable'} retryAfter={retryAfter} onRetry={runEvaluate} />;
+  }
+  if (state === 'terminal') {
+    return <Terminal reason={terminalCode ? reasonForCode(terminalCode) : 'ended'} />;
+  }
+  if (state === 'challenge' || state === 'cooldown') {
+    return (
+      <PasswordChallenge
+        attemptsRemaining={cooldown.attemptsRemaining}
+        inCooldown={state === 'cooldown' || cooldown.inCooldown}
+        cooldownRemainingSeconds={cooldownSeconds}
+        lastInvalid={lastInvalid}
+        submitting={submitting}
+        onSubmit={submitPassword}
+      />
+    );
+  }
+  if (state === 'prejoin') {
+    return (
+      <div className="meeting-prejoin">
+        <h2>{t('meeting.prejoin.title')}</h2>
+        <DevicePreview micOn cameraOn onToggleMic={() => {}} onToggleCamera={() => {}} />
+        {retryAfter ? <p role="status">{t('meeting.prejoin.retry', { values: { seconds: retryAfter } })}</p> : null}
+        <button type="button" onClick={runFinalize}>
+          {t('meeting.prejoin.join')}
+        </button>
+      </div>
+    );
+  }
+  // room / reconnecting are owned by RoomPage once finalize succeeds.
+  return <div className="meeting-room-placeholder">{t('meeting.room.participants')}</div>;
+}

--- a/packages/dmworkmeeting/src/pages/JoinFlow.tsx
+++ b/packages/dmworkmeeting/src/pages/JoinFlow.tsx
@@ -10,7 +10,7 @@ import {
   type CooldownState,
 } from '../logic/password';
 import { classifyFailure } from '../service/failClosed';
-import { MeetingErrorCode } from '../service/errors';
+import { directiveForCode, MeetingErrorCode } from '../service/errors';
 import PasswordChallenge from '../components/PasswordChallenge';
 import DevicePreview from '../components/DevicePreview';
 import Terminal, { reasonForCode, type TerminalReason } from '../components/Terminal';
@@ -237,14 +237,33 @@ export default function JoinFlow(props: JoinFlowProps) {
       dispatch({ type: 'FINALIZE_SUCCESS' });
     } catch (err) {
       const code = classifyFailure(err).code;
-      const wire = (err as { response?: { data?: { retry_after?: number } } }).response?.data;
-      if (code === MeetingErrorCode.LIVEKIT_UNAVAILABLE) {
+      const wire = (err as { response?: { data?: { retry_after?: number; password_challenge_id?: string } } }).response?.data;
+      // Branch on the directive ACTION, not the raw code, so a step-1 recheck
+      // that now requires a password (SHOW_PASSWORD_CHALLENGE) returns to the
+      // challenge instead of dead-ending in Blocked (FD-32).
+      const action = code ? directiveForCode(code).action : undefined;
+      if (action === 'RETRY_FINALIZE') {
         setRetryAfter(wire?.retry_after); // keep PreJoin + token, reuse SAME finalize key on retry
         dispatch({ type: 'FINALIZE_LIVEKIT_UNAVAILABLE' });
-      } else if (code === MeetingErrorCode.PASSWORD_PASS_EXPIRED) {
+      } else if (action === 'RESTART_CHALLENGE') {
+        // pass_token expired → restart the challenge (new logical op → new key).
         passTokenRef.current = undefined;
-        finalizeKeyRef.current = newIdempotencyKey(); // restart = new logical op → new key
+        finalizeKeyRef.current = newIdempotencyKey();
         dispatch({ type: 'FINALIZE_PASS_EXPIRED' });
+      } else if (action === 'SHOW_PASSWORD_CHALLENGE') {
+        // Meeting now requires a password at finalize. Require a fresh challenge
+        // id; clear the stale pass token; rotate the key; return to challenge.
+        const cid = wire?.password_challenge_id;
+        if (!cid) {
+          failClosedInternal();
+          return;
+        }
+        passTokenRef.current = undefined;
+        finalizeKeyRef.current = newIdempotencyKey();
+        setChallengeId(cid);
+        setCooldown(clearedCooldownState());
+        setLastInvalid(false);
+        dispatch({ type: 'FINALIZE_PASSWORD_REQUIRED' });
       } else if (code) {
         setErrorCode(code);
         dispatch({ type: 'FINALIZE_STEP1', code }); // FD-32: terminal or blocked per directive

--- a/packages/dmworkmeeting/src/pages/JoinFlow.tsx
+++ b/packages/dmworkmeeting/src/pages/JoinFlow.tsx
@@ -187,17 +187,21 @@ export default function JoinFlow(props: JoinFlowProps) {
         const code = classifyFailure(err).code;
         const wire = (err as { response?: { data?: { attempts_remaining?: number; retry_at?: string } } }).response?.data;
         if (code === MeetingErrorCode.PASSWORD_INVALID) {
+          const parsed = wire?.retry_at ? Date.parse(wire.retry_at) : undefined;
           const next = reduceWrongPassword({
             attemptsRemaining: wire?.attempts_remaining,
-            retryAtMs: wire?.retry_at ? Date.parse(wire.retry_at) : undefined,
+            retryAtMs: parsed !== undefined && !Number.isNaN(parsed) ? parsed : undefined,
           });
           setCooldown(next);
           setLastInvalid(true);
           dispatch({ type: 'PASSWORD_INVALID', enteringCooldown: next.inCooldown });
         } else if (code === MeetingErrorCode.PASSWORD_COOLDOWN) {
           const retryAtMs = wire?.retry_at ? Date.parse(wire.retry_at) : undefined;
-          setCooldown({ attemptsRemaining: 0, inCooldown: true, retryAtMs });
-          dispatch({ type: 'PASSWORD_INVALID', enteringCooldown: true });
+          // Route through the reducer so a cooldown without a (parsable)
+          // retry_at does NOT wedge the input — it stays on the challenge.
+          const next = reduceWrongPassword({ cooldown: true, retryAtMs: Number.isNaN(retryAtMs) ? undefined : retryAtMs });
+          setCooldown(next);
+          dispatch({ type: 'PASSWORD_INVALID', enteringCooldown: next.inCooldown });
         } else if (code === MeetingErrorCode.PASSWORD_FORMAT_INVALID) {
           dispatch({ type: 'PASSWORD_FORMAT_INVALID' }); // not counted
         } else {

--- a/packages/dmworkmeeting/src/pages/MeetingDetail.tsx
+++ b/packages/dmworkmeeting/src/pages/MeetingDetail.tsx
@@ -1,0 +1,90 @@
+import React, { useEffect, useState } from 'react';
+import { t } from '@octo/base';
+import { MeetingApiClient } from '../service/MeetingApiClient';
+import type { Meeting } from '../service/contracts';
+import { classifyFailure } from '../service/failClosed';
+import { directiveForCode } from '../service/errors';
+import { openJoinFlow, openEdit, backToHome } from '../state/nav';
+
+/**
+ * Meeting detail (§4, credential surface). Shows the meeting number and join
+ * link with copy affordances (the only place a creator obtains the credential),
+ * plus Join / Edit / Cancel entries. History detail only exposes whether a
+ * password was enabled, never the password itself (FD-31).
+ */
+export default function MeetingDetail({ meetingId }: { meetingId: string }) {
+  const [meeting, setMeeting] = useState<Meeting>();
+  const [error, setError] = useState<string>();
+  const [copied, setCopied] = useState<string>();
+
+  useEffect(() => {
+    const controller = new AbortController();
+    MeetingApiClient.getMeeting(meetingId, controller.signal)
+      .then(setMeeting)
+      .catch((err) => {
+        const code = classifyFailure(err).code;
+        setError(code ? t(directiveForCode(code).i18nKey) : t('meeting.error.internal'));
+      });
+    return () => controller.abort();
+  }, [meetingId]);
+
+  const copy = async (label: string, value?: string) => {
+    if (!value) return;
+    try {
+      await navigator.clipboard?.writeText(value);
+      setCopied(label);
+    } catch {
+      // Clipboard denied — leave the value visible for manual copy.
+    }
+  };
+
+  if (error) {
+    return (
+      <div className="meeting-detail" role="alert" aria-live="assertive">
+        <p>{error}</p>
+        <button type="button" onClick={backToHome}>
+          {t('meeting.terminal.backHome')}
+        </button>
+      </div>
+    );
+  }
+  if (!meeting) return <p role="status" aria-busy="true">…</p>;
+
+  return (
+    <div className="meeting-detail">
+      <h2>{meeting.title}</h2>
+      <p data-status={meeting.status}>{meeting.status}</p>
+      {meeting.meetingNumber && (
+        <div className="meeting-credential">
+          <span>{t('meeting.detail.number')}: {meeting.meetingNumber}</span>
+          <button type="button" onClick={() => void copy('number', meeting.meetingNumber)}>
+            {t('meeting.detail.copyNumber')}
+          </button>
+        </div>
+      )}
+      {meeting.joinLink && (
+        <div className="meeting-credential">
+          <button type="button" onClick={() => void copy('link', meeting.joinLink)}>
+            {t('meeting.detail.copyLink')}
+          </button>
+        </div>
+      )}
+      <p>{meeting.passwordEnabled ? t('meeting.history.passwordEnabled') : t('meeting.history.passwordDisabled')}</p>
+      {copied && (
+        <div role="status" aria-live="polite">
+          {t('meeting.detail.copied')}
+        </div>
+      )}
+      <div className="meeting-detail-actions">
+        <button type="button" onClick={() => openJoinFlow({ source: 'list', meetingId })}>
+          {t('meeting.home.join')}
+        </button>
+        {(meeting.status === 'scheduled') && (
+          <button type="button" onClick={() => openEdit(meetingId)}>
+            {t('meeting.detail.edit')}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/dmworkmeeting/src/pages/MeetingHome.test.tsx
+++ b/packages/dmworkmeeting/src/pages/MeetingHome.test.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+vi.mock('../service/MeetingApiClient', () => ({
+  MeetingApiClient: { listMeetings: vi.fn() },
+  newIdempotencyKey: () => 'k',
+  MeetingHttpError: class {},
+}));
+
+import MeetingHome from './MeetingHome';
+import { MeetingApiClient } from '../service/MeetingApiClient';
+import { __resetWKApp, __routeRightPushes } from '../__mocks__/dmworkBase';
+
+const asMock = (fn: unknown) => fn as ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  __resetWKApp();
+  vi.clearAllMocks();
+});
+
+describe('MeetingHome (§4 join-by-list, navigation)', () => {
+  it('lists upcoming meetings and joining one pushes onto the host route stack', async () => {
+    asMock(MeetingApiClient.listMeetings).mockImplementation(async (view: string) =>
+      view === 'upcoming'
+        ? { meetings: [{ meetingId: 'm1', title: 'Standup', status: 'scheduled', version: 1, passwordEnabled: false }] }
+        : { meetings: [] },
+    );
+    render(<MeetingHome />);
+    const item = await screen.findByText('Standup');
+    fireEvent.click(item);
+    await waitFor(() => expect(__routeRightPushes.length).toBeGreaterThan(0));
+  });
+
+  it('renders the fail-closed service view when the gateway route is missing (404 without code)', async () => {
+    asMock(MeetingApiClient.listMeetings).mockRejectedValue({ response: { status: 404, data: { message: 'nope' } } });
+    render(<MeetingHome />);
+    // meeting.service.notEnabled → zh "会议功能未启用"
+    expect(await screen.findByText('会议功能未启用')).toBeInTheDocument();
+  });
+});

--- a/packages/dmworkmeeting/src/pages/MeetingHome.test.tsx
+++ b/packages/dmworkmeeting/src/pages/MeetingHome.test.tsx
@@ -10,17 +10,18 @@ vi.mock('../service/MeetingApiClient', () => ({
 
 import MeetingHome from './MeetingHome';
 import { MeetingApiClient } from '../service/MeetingApiClient';
-import { __resetWKApp, __routeRightPushes } from '../__mocks__/dmworkBase';
+import { __resetWKApp } from '../__mocks__/dmworkBase';
 
 const asMock = (fn: unknown) => fn as ReturnType<typeof vi.fn>;
 
 beforeEach(() => {
   __resetWKApp();
   vi.clearAllMocks();
+  window.history.pushState({}, '', '/meeting');
 });
 
 describe('MeetingHome (§4 join-by-list, navigation)', () => {
-  it('lists upcoming meetings and joining one pushes onto the host route stack', async () => {
+  it('lists upcoming meetings and joining one navigates to the join deep link', async () => {
     asMock(MeetingApiClient.listMeetings).mockImplementation(async (view: string) =>
       view === 'upcoming'
         ? { meetings: [{ meetingId: 'm1', title: 'Standup', status: 'scheduled', version: 1, passwordEnabled: false }] }
@@ -29,7 +30,8 @@ describe('MeetingHome (§4 join-by-list, navigation)', () => {
     render(<MeetingHome />);
     const item = await screen.findByText('Standup');
     fireEvent.click(item);
-    await waitFor(() => expect(__routeRightPushes.length).toBeGreaterThan(0));
+    await waitFor(() => expect(window.location.pathname).toBe('/meeting/join'));
+    expect(window.location.search).toContain('meeting_id=m1');
   });
 
   it('renders the fail-closed service view when the gateway route is missing (404 without code)', async () => {

--- a/packages/dmworkmeeting/src/pages/MeetingHome.tsx
+++ b/packages/dmworkmeeting/src/pages/MeetingHome.tsx
@@ -55,8 +55,8 @@ export default function MeetingHome() {
   useEffect(() => {
     load.current();
     const refetch = () => load.current();
-    const onMenuActivated = (menuId: unknown) => {
-      if (menuId === 'meeting') load.current();
+    const onMenuActivated = (payload: unknown) => {
+      if ((payload as { menuId?: string })?.menuId === 'meeting') load.current();
     };
     WKApp.mittBus.on('space-changed', refetch);
     WKApp.mittBus.on('wk:auth-state-changed', refetch);

--- a/packages/dmworkmeeting/src/pages/MeetingHome.tsx
+++ b/packages/dmworkmeeting/src/pages/MeetingHome.tsx
@@ -1,65 +1,80 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { t, WKApp } from '@octo/base';
 import { MeetingApiClient } from '../service/MeetingApiClient';
 import type { Meeting } from '../service/contracts';
 import { classifyFailure } from '../service/failClosed';
 import ServiceUnavailable from '../components/ServiceUnavailable';
-import HistoryDetail from './HistoryDetail';
-import { openQuickSetup, openSchedule, openJoinEntry, openJoinFlow, deviceIdHash } from '../state/nav';
+import { openQuickSetup, openSchedule, openJoinEntry, openJoinFlow, openDetail } from '../state/nav';
 
 type LoadState = 'loading' | 'ready' | 'error';
 
 /**
  * Meeting home: upcoming + history lists with quick / schedule / join entries
- * (§4). Server state is read-only cache; a Space change or auth change clears
- * and refetches. Fail-closed rendering for gateway-missing / service-down.
+ * (§4). Server state is read-only cache; a Space change, auth change, or tab
+ * re-activation clears and refetches. Fail-closed rendering for gateway-missing
+ * / service-down; a generic failure shows an explicit error (never a false
+ * "no meetings").
  */
 export default function MeetingHome() {
   const [upcoming, setUpcoming] = useState<Meeting[]>([]);
   const [history, setHistory] = useState<Meeting[]>([]);
   const [state, setState] = useState<LoadState>('loading');
   const [unavailable, setUnavailable] = useState<'service-unavailable' | 'gateway-missing' | null>(null);
+  // Monotonic guard so a stale-Space in-flight load cannot paint the wrong
+  // Space's meetings if it resolves after a newer load.
+  const loadSeq = useRef(0);
+  const controllerRef = useRef<AbortController | null>(null);
 
-  useEffect(() => {
+  const load = useRef<() => void>(() => {});
+  load.current = () => {
+    controllerRef.current?.abort();
     const controller = new AbortController();
-    const load = async () => {
-      setState('loading');
-      setUnavailable(null);
-      try {
-        const [up, hist] = await Promise.all([
-          MeetingApiClient.listMeetings('upcoming', { signal: controller.signal }),
-          MeetingApiClient.listMeetings('history', { signal: controller.signal }),
-        ]);
+    controllerRef.current = controller;
+    const seq = (loadSeq.current += 1);
+    setState('loading');
+    setUnavailable(null);
+    void Promise.all([
+      MeetingApiClient.listMeetings('upcoming', { signal: controller.signal }),
+      MeetingApiClient.listMeetings('history', { signal: controller.signal }),
+    ])
+      .then(([up, hist]) => {
+        if (seq !== loadSeq.current) return; // superseded by a newer load
         setUpcoming(up.meetings);
         setHistory(hist.meetings);
         setState('ready');
-      } catch (err) {
+      })
+      .catch((err) => {
+        if (seq !== loadSeq.current) return;
         const decision = classifyFailure(err);
         if (decision.kind === 'gateway-missing') setUnavailable('gateway-missing');
         else if (decision.kind === 'service-unavailable') setUnavailable('service-unavailable');
         setState('error');
-      }
+      });
+  };
+
+  useEffect(() => {
+    load.current();
+    const refetch = () => load.current();
+    const onMenuActivated = (menuId: unknown) => {
+      if (menuId === 'meeting') load.current();
     };
-    void load();
-    // Space / auth changes clear and refetch (§5).
-    const onSpaceChanged = () => void load();
-    WKApp.mittBus.on('space-changed', onSpaceChanged);
-    WKApp.mittBus.on('wk:auth-state-changed', onSpaceChanged);
+    WKApp.mittBus.on('space-changed', refetch);
+    WKApp.mittBus.on('wk:auth-state-changed', refetch);
+    // Left panes stay mounted (display toggled); refresh when the tab is re-activated.
+    WKApp.mittBus.on('wk:nav-menu-activated', onMenuActivated);
     return () => {
-      controller.abort();
-      WKApp.mittBus.off('space-changed', onSpaceChanged);
-      WKApp.mittBus.off('wk:auth-state-changed', onSpaceChanged);
+      controllerRef.current?.abort();
+      WKApp.mittBus.off('space-changed', refetch);
+      WKApp.mittBus.off('wk:auth-state-changed', refetch);
+      WKApp.mittBus.off('wk:nav-menu-activated', onMenuActivated);
     };
   }, []);
 
-  const joinFromList = (m: Meeting) => openJoinFlow({ source: 'list', meetingId: m.meetingId }, deviceIdHash());
-  const openHistory = (m: Meeting) => {
-    const w = WKApp as unknown as { routeRight?: { push?: (el: React.ReactElement) => void } };
-    w.routeRight?.push?.(<HistoryDetail meeting={m} />);
-  };
+  const joinFromList = (m: Meeting) => openJoinFlow({ source: 'list', meetingId: m.meetingId });
+  const openMeeting = (m: Meeting) => openDetail(m.meetingId);
 
   if (unavailable) {
-    return <ServiceUnavailable reason={unavailable} onRetry={() => window.location.reload()} />;
+    return <ServiceUnavailable reason={unavailable} onRetry={() => load.current()} />;
   }
 
   return (
@@ -77,18 +92,27 @@ export default function MeetingHome() {
         </button>
       </header>
 
+      {state === 'error' && (
+        <div className="meeting-home-error" role="alert" aria-live="assertive">
+          <p>{t('meeting.error.internal')}</p>
+          <button type="button" onClick={() => load.current()}>
+            {t('meeting.service.retry')}
+          </button>
+        </div>
+      )}
+
       <section aria-label={t('meeting.home.upcoming')}>
         <h2>{t('meeting.home.upcoming')}</h2>
         {state === 'loading' ? (
           <p role="status">…</p>
-        ) : (
+        ) : state === 'ready' ? (
           <MeetingList meetings={upcoming} onSelect={joinFromList} actionLabel={t('meeting.home.join')} />
-        )}
+        ) : null}
       </section>
 
       <section aria-label={t('meeting.home.history')}>
         <h2>{t('meeting.home.history')}</h2>
-        <MeetingList meetings={history} onSelect={openHistory} />
+        {state === 'ready' ? <MeetingList meetings={history} onSelect={openMeeting} /> : null}
       </section>
     </div>
   );

--- a/packages/dmworkmeeting/src/pages/MeetingHome.tsx
+++ b/packages/dmworkmeeting/src/pages/MeetingHome.tsx
@@ -1,0 +1,101 @@
+import React, { useEffect, useState } from 'react';
+import { t, WKApp } from '@octo/base';
+import { MeetingApiClient } from '../service/MeetingApiClient';
+import type { Meeting } from '../service/contracts';
+import { classifyFailure } from '../service/failClosed';
+import ServiceUnavailable from '../components/ServiceUnavailable';
+
+type LoadState = 'loading' | 'ready' | 'error';
+
+/**
+ * Meeting home: upcoming + history lists with quick / schedule / join entries
+ * (§4). Server state is read-only cache; a Space change or auth change clears
+ * and refetches. Fail-closed rendering for gateway-missing / service-down.
+ */
+export default function MeetingHome() {
+  const [upcoming, setUpcoming] = useState<Meeting[]>([]);
+  const [history, setHistory] = useState<Meeting[]>([]);
+  const [state, setState] = useState<LoadState>('loading');
+  const [unavailable, setUnavailable] = useState<'service-unavailable' | 'gateway-missing' | null>(null);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    const load = async () => {
+      setState('loading');
+      setUnavailable(null);
+      try {
+        const [up, hist] = await Promise.all([
+          MeetingApiClient.listMeetings('upcoming', { signal: controller.signal }),
+          MeetingApiClient.listMeetings('history', { signal: controller.signal }),
+        ]);
+        setUpcoming(up.meetings);
+        setHistory(hist.meetings);
+        setState('ready');
+      } catch (err) {
+        const decision = classifyFailure(err);
+        if (decision.kind === 'gateway-missing') setUnavailable('gateway-missing');
+        else if (decision.kind === 'service-unavailable') setUnavailable('service-unavailable');
+        setState('error');
+      }
+    };
+    void load();
+    // Space / auth changes clear and refetch (§5).
+    const onSpaceChanged = () => void load();
+    WKApp.mittBus.on('space-changed', onSpaceChanged);
+    WKApp.mittBus.on('wk:auth-state-changed', onSpaceChanged);
+    return () => {
+      controller.abort();
+      WKApp.mittBus.off('space-changed', onSpaceChanged);
+      WKApp.mittBus.off('wk:auth-state-changed', onSpaceChanged);
+    };
+  }, []);
+
+  const go = (path: string) => window.history.pushState({}, '', path);
+
+  if (unavailable) {
+    return <ServiceUnavailable reason={unavailable} onRetry={() => window.location.reload()} />;
+  }
+
+  return (
+    <div className="meeting-home">
+      <header className="meeting-home-actions">
+        <h1>{t('meeting.home.title')}</h1>
+        <button type="button" onClick={() => go('/meeting/quick')}>
+          {t('meeting.home.quick')}
+        </button>
+        <button type="button" onClick={() => go('/meeting/schedule')}>
+          {t('meeting.home.schedule')}
+        </button>
+        <button type="button" onClick={() => go('/meeting/join')}>
+          {t('meeting.home.join')}
+        </button>
+      </header>
+
+      <section aria-label={t('meeting.home.upcoming')}>
+        <h2>{t('meeting.home.upcoming')}</h2>
+        {state === 'loading' ? <p>…</p> : <MeetingList meetings={upcoming} />}
+      </section>
+
+      <section aria-label={t('meeting.home.history')}>
+        <h2>{t('meeting.home.history')}</h2>
+        <MeetingList meetings={history} />
+      </section>
+    </div>
+  );
+}
+
+function MeetingList({ meetings }: { meetings: Meeting[] }) {
+  if (meetings.length === 0) return <p className="meeting-empty">{t('meeting.home.empty')}</p>;
+  return (
+    <ul className="meeting-list">
+      {meetings.map((m) => (
+        <li key={m.meetingId} className="meeting-list-item">
+          <span className="meeting-list-title">{m.title}</span>
+          <span className="meeting-list-status" data-status={m.status}>
+            {m.status}
+          </span>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/packages/dmworkmeeting/src/pages/MeetingHome.tsx
+++ b/packages/dmworkmeeting/src/pages/MeetingHome.tsx
@@ -4,6 +4,8 @@ import { MeetingApiClient } from '../service/MeetingApiClient';
 import type { Meeting } from '../service/contracts';
 import { classifyFailure } from '../service/failClosed';
 import ServiceUnavailable from '../components/ServiceUnavailable';
+import HistoryDetail from './HistoryDetail';
+import { openQuickSetup, openSchedule, openJoinEntry, openJoinFlow, deviceIdHash } from '../state/nav';
 
 type LoadState = 'loading' | 'ready' | 'error';
 
@@ -50,7 +52,11 @@ export default function MeetingHome() {
     };
   }, []);
 
-  const go = (path: string) => window.history.pushState({}, '', path);
+  const joinFromList = (m: Meeting) => openJoinFlow({ source: 'list', meetingId: m.meetingId }, deviceIdHash());
+  const openHistory = (m: Meeting) => {
+    const w = WKApp as unknown as { routeRight?: { push?: (el: React.ReactElement) => void } };
+    w.routeRight?.push?.(<HistoryDetail meeting={m} />);
+  };
 
   if (unavailable) {
     return <ServiceUnavailable reason={unavailable} onRetry={() => window.location.reload()} />;
@@ -60,40 +66,55 @@ export default function MeetingHome() {
     <div className="meeting-home">
       <header className="meeting-home-actions">
         <h1>{t('meeting.home.title')}</h1>
-        <button type="button" onClick={() => go('/meeting/quick')}>
+        <button type="button" onClick={openQuickSetup}>
           {t('meeting.home.quick')}
         </button>
-        <button type="button" onClick={() => go('/meeting/schedule')}>
+        <button type="button" onClick={openSchedule}>
           {t('meeting.home.schedule')}
         </button>
-        <button type="button" onClick={() => go('/meeting/join')}>
+        <button type="button" onClick={openJoinEntry}>
           {t('meeting.home.join')}
         </button>
       </header>
 
       <section aria-label={t('meeting.home.upcoming')}>
         <h2>{t('meeting.home.upcoming')}</h2>
-        {state === 'loading' ? <p>…</p> : <MeetingList meetings={upcoming} />}
+        {state === 'loading' ? (
+          <p role="status">…</p>
+        ) : (
+          <MeetingList meetings={upcoming} onSelect={joinFromList} actionLabel={t('meeting.home.join')} />
+        )}
       </section>
 
       <section aria-label={t('meeting.home.history')}>
         <h2>{t('meeting.home.history')}</h2>
-        <MeetingList meetings={history} />
+        <MeetingList meetings={history} onSelect={openHistory} />
       </section>
     </div>
   );
 }
 
-function MeetingList({ meetings }: { meetings: Meeting[] }) {
+function MeetingList({
+  meetings,
+  onSelect,
+  actionLabel,
+}: {
+  meetings: Meeting[];
+  onSelect: (m: Meeting) => void;
+  actionLabel?: string;
+}) {
   if (meetings.length === 0) return <p className="meeting-empty">{t('meeting.home.empty')}</p>;
   return (
     <ul className="meeting-list">
       {meetings.map((m) => (
         <li key={m.meetingId} className="meeting-list-item">
-          <span className="meeting-list-title">{m.title}</span>
-          <span className="meeting-list-status" data-status={m.status}>
-            {m.status}
-          </span>
+          <button type="button" className="meeting-list-open" onClick={() => onSelect(m)}>
+            <span className="meeting-list-title">{m.title}</span>
+            <span className="meeting-list-status" data-status={m.status}>
+              {m.status}
+            </span>
+            {actionLabel && <span className="meeting-list-action">{actionLabel}</span>}
+          </button>
         </li>
       ))}
     </ul>

--- a/packages/dmworkmeeting/src/pages/MeetingRoot.test.tsx
+++ b/packages/dmworkmeeting/src/pages/MeetingRoot.test.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+
+// Mock the client so sub-views mount without network (evaluate stays pending).
+vi.mock('../service/MeetingApiClient', () => ({
+  MeetingApiClient: {
+    evaluate: vi.fn(() => new Promise(() => {})),
+    listMeetings: vi.fn(() => new Promise(() => {})),
+    getMeeting: vi.fn(() => new Promise(() => {})),
+  },
+  newIdempotencyKey: () => 'k',
+  MeetingHttpError: class {},
+}));
+
+import MeetingRoot from './MeetingRoot';
+import { __resetWKApp } from '../__mocks__/dmworkBase';
+
+function goto(path: string) {
+  window.history.pushState({}, '', path);
+}
+
+beforeEach(() => {
+  __resetWKApp();
+  vi.clearAllMocks();
+});
+
+describe('MeetingRoot in-shell router (#1 deep links)', () => {
+  it('/meeting renders the home actions', async () => {
+    goto('/meeting');
+    render(<MeetingRoot />);
+    expect(await screen.findByText('快速会议')).toBeInTheDocument(); // meeting.home.quick
+  });
+
+  it('/meeting/join with a credential renders the JoinFlow (evaluates on mount)', async () => {
+    goto('/meeting/join?meeting_number=123456');
+    const { MeetingApiClient } = await import('../service/MeetingApiClient');
+    render(<MeetingRoot />);
+    await waitFor(() => expect((MeetingApiClient.evaluate as ReturnType<typeof vi.fn>)).toHaveBeenCalled());
+  });
+
+  it('/meeting/join without a credential renders the join-entry form', async () => {
+    goto('/meeting/join');
+    render(<MeetingRoot />);
+    // meeting.join.numberLabel = "会议号或链接"
+    expect(await screen.findByLabelText('会议号或链接')).toBeInTheDocument();
+  });
+
+  it('/meeting/quick renders the quick-setup form', async () => {
+    goto('/meeting/quick');
+    render(<MeetingRoot />);
+    expect(await screen.findByText('立即开始')).toBeInTheDocument(); // meeting.form.createNow
+  });
+});

--- a/packages/dmworkmeeting/src/pages/MeetingRoot.tsx
+++ b/packages/dmworkmeeting/src/pages/MeetingRoot.tsx
@@ -1,0 +1,82 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { t } from '@octo/base';
+import { MeetingApiClient } from '../service/MeetingApiClient';
+import type { Meeting } from '../service/contracts';
+import { classifyFailure } from '../service/failClosed';
+import { directiveForCode } from '../service/errors';
+import { MEETING_NAV_EVENT, openDetail, openHome, parseJoinQuery } from '../state/nav';
+import MeetingHome from './MeetingHome';
+import QuickSetup from './QuickSetup';
+import SchedulePage from './SchedulePage';
+import JoinEntry from './JoinEntry';
+import JoinFlow from './JoinFlow';
+import MeetingDetail from './MeetingDetail';
+
+/**
+ * In-shell router for the Meeting module (blocker #1). The host shell only
+ * paints the menu's routePath component (this `/meeting` component); it never
+ * calls the sub-path handlers previously registered on WKApp.route. So this
+ * component owns sub-view routing: it derives the current view from
+ * window.location on mount (cold-load deep links), on `popstate` (browser
+ * back/forward), and on the module's in-app nav event. All navigation stays
+ * inside this one mounted component, which is the surface the shell renders.
+ */
+export default function MeetingRoot() {
+  const [loc, setLoc] = useState(() => currentLoc());
+
+  useEffect(() => {
+    const sync = () => setLoc(currentLoc());
+    window.addEventListener('popstate', sync);
+    window.addEventListener(MEETING_NAV_EVENT, sync);
+    return () => {
+      window.removeEventListener('popstate', sync);
+      window.removeEventListener(MEETING_NAV_EVENT, sync);
+    };
+  }, []);
+
+  const { pathname, search } = loc;
+
+  // Exact known sub-paths first, so they never collide with `/meeting/{id}`.
+  if (pathname === '/meeting' || pathname === '/meeting/') return <MeetingHome />;
+  if (pathname === '/meeting/quick') return <QuickSetup onCreated={(id) => openDetail(id)} />;
+  if (pathname === '/meeting/schedule') return <SchedulePage onSaved={(m) => openDetail(m.meetingId)} onCancelled={openHome} />;
+  if (pathname === '/meeting/join') {
+    const creds = parseJoinQuery(search);
+    return creds ? <JoinFlow {...creds} autoStart /> : <JoinEntry />;
+  }
+
+  const editMatch = pathname.match(/^\/meeting\/([^/]+)\/edit$/);
+  if (editMatch) return <EditLoader meetingId={decodeURIComponent(editMatch[1])} />;
+
+  const detailMatch = pathname.match(/^\/meeting\/([^/]+)$/);
+  if (detailMatch) return <MeetingDetail meetingId={decodeURIComponent(detailMatch[1])} />;
+
+  return <MeetingHome />;
+}
+
+function currentLoc(): { pathname: string; search: string } {
+  if (typeof window === 'undefined') return { pathname: '/meeting', search: '' };
+  return { pathname: window.location.pathname, search: window.location.search };
+}
+
+/** Loads an existing meeting, then renders the edit form (PATCH + If-Match). */
+function EditLoader({ meetingId }: { meetingId: string }) {
+  const [meeting, setMeeting] = useState<Meeting>();
+  const [error, setError] = useState<string>();
+
+  useEffect(() => {
+    const controller = new AbortController();
+    MeetingApiClient.getMeeting(meetingId, controller.signal)
+      .then(setMeeting)
+      .catch((err) => {
+        const code = classifyFailure(err).code;
+        setError(code ? t(directiveForCode(code).i18nKey) : t('meeting.error.internal'));
+      });
+    return () => controller.abort();
+  }, [meetingId]);
+
+  const onSaved = useCallback((m: Meeting) => openDetail(m.meetingId), []);
+  if (error) return <div role="alert" aria-live="assertive">{error}</div>;
+  if (!meeting) return <p role="status" aria-busy="true">…</p>;
+  return <SchedulePage existing={meeting} onSaved={onSaved} onCancelled={() => openDetail(meetingId)} />;
+}

--- a/packages/dmworkmeeting/src/pages/QuickSetup.tsx
+++ b/packages/dmworkmeeting/src/pages/QuickSetup.tsx
@@ -2,13 +2,16 @@ import React, { useRef, useState } from 'react';
 import { t } from '@octo/base';
 import { MeetingApiClient, newIdempotencyKey } from '../service/MeetingApiClient';
 import { isValidPasswordFormat } from '../logic/password';
-import { openJoinFlow, deviceIdHash } from '../state/nav';
+import { classifyFailure } from '../service/failClosed';
+import { directiveForCode } from '../service/errors';
+import { openDetail } from '../state/nav';
 
 /**
  * Quick meeting setup (§4). quick-create uses ONE explicit Idempotency-Key
  * reused across retries (N3, FD-11); the key is rotated after a successful
  * create so a subsequent create is a fresh operation. The button single-flights
  * to prevent double submits. Optional 6-digit password validated locally.
+ * On success the creator lands on the meeting detail (credential surface).
  */
 export default function QuickSetup({ onCreated }: { onCreated?: (meetingId: string) => void }) {
   const [title, setTitle] = useState('');
@@ -34,10 +37,12 @@ export default function QuickSetup({ onCreated }: { onCreated?: (meetingId: stri
       );
       idempotencyKeyRef.current = newIdempotencyKey(); // rotate after a successful create
       if (onCreated) onCreated(meeting.meetingId);
-      // Creator proceeds into the admission flow for their new meeting.
-      else openJoinFlow({ source: 'list', meetingId: meeting.meetingId }, deviceIdHash());
-    } catch {
-      setError(t('meeting.error.internal'));
+      else openDetail(meeting.meetingId);
+    } catch (err) {
+      // Route through the same directive mapping as SchedulePage so RATE_LIMITED
+      // / NOT_SAME_SPACE / IDEMPOTENCY_CONFLICT read correctly, not "internal".
+      const code = classifyFailure(err).code;
+      setError(code ? t(directiveForCode(code).i18nKey) : t('meeting.error.internal'));
     } finally {
       setSubmitting(false);
     }
@@ -46,10 +51,13 @@ export default function QuickSetup({ onCreated }: { onCreated?: (meetingId: stri
   return (
     <div className="meeting-quick-setup">
       <h2>{t('meeting.home.quick')}</h2>
-      <input aria-label={t('meeting.home.title')} value={title} onChange={(e) => setTitle(e.target.value)} />
+      <label>
+        {t('meeting.form.titleLabel')}
+        <input value={title} onChange={(e) => setTitle(e.target.value)} />
+      </label>
       <label>
         <input type="checkbox" checked={passwordEnabled} onChange={(e) => setPasswordEnabled(e.target.checked)} />
-        {t('meeting.error.passwordRequired')}
+        {t('meeting.form.enablePassword')}
       </label>
       {passwordEnabled && (
         <input
@@ -61,7 +69,7 @@ export default function QuickSetup({ onCreated }: { onCreated?: (meetingId: stri
         />
       )}
       <button type="button" disabled={submitting} aria-disabled={submitting} onClick={create}>
-        {t('meeting.prejoin.join')}
+        {t('meeting.form.createNow')}
       </button>
       {error && (
         <div role="alert" aria-live="assertive">

--- a/packages/dmworkmeeting/src/pages/QuickSetup.tsx
+++ b/packages/dmworkmeeting/src/pages/QuickSetup.tsx
@@ -1,0 +1,68 @@
+import React, { useRef, useState } from 'react';
+import { t } from '@octo/base';
+import { MeetingApiClient, newIdempotencyKey } from '../service/MeetingApiClient';
+import { isValidPasswordFormat } from '../logic/password';
+
+/**
+ * Quick meeting setup (§4). quick-create uses ONE explicit Idempotency-Key
+ * reused across retries (N3, FD-11); the button single-flights to prevent
+ * double submits. Optional 6-digit password validated locally.
+ */
+export default function QuickSetup({ onCreated }: { onCreated?: (meetingId: string) => void }) {
+  const [title, setTitle] = useState('');
+  const [passwordEnabled, setPasswordEnabled] = useState(false);
+  const [password, setPassword] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string>();
+  // Stable across retries so a duplicate click returns the first result.
+  const idempotencyKeyRef = useRef<string>(newIdempotencyKey());
+
+  const create = async () => {
+    if (submitting) return;
+    if (passwordEnabled && !isValidPasswordFormat(password)) {
+      setError(t('meeting.error.passwordFormatInvalid'));
+      return;
+    }
+    setSubmitting(true);
+    setError(undefined);
+    try {
+      const meeting = await MeetingApiClient.quickCreate(
+        { title: title || undefined, passwordEnabled, password: passwordEnabled ? password : undefined },
+        { idempotencyKey: idempotencyKeyRef.current },
+      );
+      onCreated?.(meeting.meetingId);
+    } catch {
+      setError(t('meeting.error.internal'));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="meeting-quick-setup">
+      <h2>{t('meeting.home.quick')}</h2>
+      <input aria-label={t('meeting.home.title')} value={title} onChange={(e) => setTitle(e.target.value)} />
+      <label>
+        <input type="checkbox" checked={passwordEnabled} onChange={(e) => setPasswordEnabled(e.target.checked)} />
+        {t('meeting.error.passwordRequired')}
+      </label>
+      {passwordEnabled && (
+        <input
+          aria-label={t('meeting.challenge.inputLabel')}
+          inputMode="numeric"
+          maxLength={6}
+          value={password}
+          onChange={(e) => setPassword(e.target.value.replace(/[^\d]/g, '').slice(0, 6))}
+        />
+      )}
+      <button type="button" disabled={submitting} aria-disabled={submitting} onClick={create}>
+        {t('meeting.prejoin.join')}
+      </button>
+      {error && (
+        <div role="alert" aria-live="assertive">
+          {error}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/dmworkmeeting/src/pages/QuickSetup.tsx
+++ b/packages/dmworkmeeting/src/pages/QuickSetup.tsx
@@ -2,11 +2,13 @@ import React, { useRef, useState } from 'react';
 import { t } from '@octo/base';
 import { MeetingApiClient, newIdempotencyKey } from '../service/MeetingApiClient';
 import { isValidPasswordFormat } from '../logic/password';
+import { openJoinFlow, deviceIdHash } from '../state/nav';
 
 /**
  * Quick meeting setup (§4). quick-create uses ONE explicit Idempotency-Key
- * reused across retries (N3, FD-11); the button single-flights to prevent
- * double submits. Optional 6-digit password validated locally.
+ * reused across retries (N3, FD-11); the key is rotated after a successful
+ * create so a subsequent create is a fresh operation. The button single-flights
+ * to prevent double submits. Optional 6-digit password validated locally.
  */
 export default function QuickSetup({ onCreated }: { onCreated?: (meetingId: string) => void }) {
   const [title, setTitle] = useState('');
@@ -30,7 +32,10 @@ export default function QuickSetup({ onCreated }: { onCreated?: (meetingId: stri
         { title: title || undefined, passwordEnabled, password: passwordEnabled ? password : undefined },
         { idempotencyKey: idempotencyKeyRef.current },
       );
-      onCreated?.(meeting.meetingId);
+      idempotencyKeyRef.current = newIdempotencyKey(); // rotate after a successful create
+      if (onCreated) onCreated(meeting.meetingId);
+      // Creator proceeds into the admission flow for their new meeting.
+      else openJoinFlow({ source: 'list', meetingId: meeting.meetingId }, deviceIdHash());
     } catch {
       setError(t('meeting.error.internal'));
     } finally {

--- a/packages/dmworkmeeting/src/pages/RoomView.tsx
+++ b/packages/dmworkmeeting/src/pages/RoomView.tsx
@@ -1,0 +1,52 @@
+import React, { useState } from 'react';
+import { t } from '@octo/base';
+import type { MeetingRole, Participant } from '../service/contracts';
+import VideoGrid from '../components/VideoGrid';
+import ControlBar from '../components/ControlBar';
+import ParticipantList from '../components/ParticipantList';
+
+export interface RoomViewProps {
+  participants: Participant[];
+  viewerRole: MeetingRole;
+  reconnecting: boolean;
+  serviceAvailable: boolean;
+  canShare: boolean;
+  activeSpeakerUid?: string;
+  maxTiles?: number;
+  onLeave: () => void;
+}
+
+/**
+ * Room view (§5). Media is attached by the livekitRoom layer. During reconnect
+ * an overlay greys controls/share; capability gating is server-authoritative.
+ */
+export default function RoomView(props: RoomViewProps) {
+  const [micOn, setMicOn] = useState(true);
+  const [cameraOn, setCameraOn] = useState(true);
+  const [sharing, setSharing] = useState(false);
+
+  return (
+    <div className="meeting-room">
+      {props.reconnecting && (
+        <div className="meeting-reconnecting-overlay" role="status" aria-live="polite">
+          {t('meeting.room.reconnecting')}
+        </div>
+      )}
+      <VideoGrid participants={props.participants} maxTiles={props.maxTiles} activeSpeakerUid={props.activeSpeakerUid} />
+      <ParticipantList participants={props.participants} capabilities={{ viewerRole: props.viewerRole }} />
+      <ControlBar
+        micOn={micOn}
+        cameraOn={cameraOn}
+        sharing={sharing}
+        canShare={props.canShare}
+        canMuteAll={props.viewerRole === 'host' || props.viewerRole === 'cohost'}
+        reconnecting={props.reconnecting}
+        serviceAvailable={props.serviceAvailable}
+        onToggleMic={() => setMicOn((v: boolean) => !v)}
+        onToggleCamera={() => setCameraOn((v: boolean) => !v)}
+        onToggleShare={() => setSharing((v: boolean) => !v)}
+        onLeave={props.onLeave}
+      />
+    </div>
+  );
+}

--- a/packages/dmworkmeeting/src/pages/RoomView.tsx
+++ b/packages/dmworkmeeting/src/pages/RoomView.tsx
@@ -1,35 +1,83 @@
 import React, { useState } from 'react';
 import { t } from '@octo/base';
 import type { MeetingRole, Participant } from '../service/contracts';
+import { MeetingApiClient, newIdempotencyKey } from '../service/MeetingApiClient';
+import { emitMeetingTelemetry } from '../state/telemetry';
 import VideoGrid from '../components/VideoGrid';
 import ControlBar from '../components/ControlBar';
 import ParticipantList from '../components/ParticipantList';
 
 export interface RoomViewProps {
+  meetingId: string;
   participants: Participant[];
   viewerRole: MeetingRole;
   reconnecting: boolean;
   serviceAvailable: boolean;
   canShare: boolean;
+  /** Media handle is null (SDK absent or connect failed) — show a notice and keep controls greyed. */
+  mediaUnavailable?: boolean;
   activeSpeakerUid?: string;
   maxTiles?: number;
   onLeave: () => void;
 }
 
 /**
- * Room view (§5). Media is attached by the livekitRoom layer. During reconnect
- * an overlay greys controls/share; capability gating is server-authoritative.
+ * Room view (§5). Screen-share and mute-all issue real server calls (single
+ * holder / host authority); mic/camera are local media toggles. Per-participant
+ * role controls are intentionally NOT wired here — they require a realtime
+ * participant roster that depends on the service-owned snapshot + event channel
+ * (see PR residual blockers), so the list renders self only for now. During
+ * reconnect / media-unavailable an overlay greys controls; capability gating is
+ * server-authoritative.
  */
 export default function RoomView(props: RoomViewProps) {
   const [micOn, setMicOn] = useState(true);
   const [cameraOn, setCameraOn] = useState(true);
   const [sharing, setSharing] = useState(false);
+  const [busy, setBusy] = useState(false);
+
+  const toggleShare = async () => {
+    if (busy) return;
+    setBusy(true);
+    try {
+      if (sharing) {
+        await MeetingApiClient.stopShare(props.meetingId, { idempotencyKey: newIdempotencyKey() });
+        setSharing(false);
+      } else {
+        await MeetingApiClient.startShare(props.meetingId, { idempotencyKey: newIdempotencyKey() });
+        setSharing(true);
+      }
+    } catch {
+      // A SHARE_CONFLICT / forbidden leaves the local state unchanged; the
+      // server remains authoritative for the single-holder rule.
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const muteAll = async () => {
+    if (busy) return;
+    setBusy(true);
+    try {
+      await MeetingApiClient.mute(props.meetingId, { all: true, muted: true }, { idempotencyKey: newIdempotencyKey() });
+      emitMeetingTelemetry({ kind: 'error', endpoint: '/v1/meetings/controls/mute' });
+    } catch {
+      // Authoritative capability is server-side; a forbidden is a no-op here.
+    } finally {
+      setBusy(false);
+    }
+  };
 
   return (
     <div className="meeting-room">
       {props.reconnecting && (
         <div className="meeting-reconnecting-overlay" role="status" aria-live="polite">
           {t('meeting.room.reconnecting')}
+        </div>
+      )}
+      {props.mediaUnavailable && (
+        <div className="meeting-media-unavailable" role="alert" aria-live="assertive">
+          {t('meeting.room.mediaUnavailable')}
         </div>
       )}
       <VideoGrid participants={props.participants} maxTiles={props.maxTiles} activeSpeakerUid={props.activeSpeakerUid} />
@@ -44,7 +92,8 @@ export default function RoomView(props: RoomViewProps) {
         serviceAvailable={props.serviceAvailable}
         onToggleMic={() => setMicOn((v: boolean) => !v)}
         onToggleCamera={() => setCameraOn((v: boolean) => !v)}
-        onToggleShare={() => setSharing((v: boolean) => !v)}
+        onToggleShare={() => void toggleShare()}
+        onMuteAll={() => void muteAll()}
         onLeave={props.onLeave}
       />
     </div>

--- a/packages/dmworkmeeting/src/pages/SchedulePage.tsx
+++ b/packages/dmworkmeeting/src/pages/SchedulePage.tsx
@@ -55,9 +55,14 @@ export default function SchedulePage({ existing, onSaved, onCancelled }: Schedul
       setError(t('meeting.error.timeInvalid'));
       return;
     }
-    if (passwordEnabled && !passwordLocked && password && !isValidPasswordFormat(password)) {
-      setError(t('meeting.error.passwordFormatInvalid'));
-      return;
+    // A new password-protected meeting must supply a valid 6-digit password.
+    // On edit, an empty field means "leave the existing password unchanged".
+    if (passwordEnabled && !passwordLocked) {
+      const mustHavePassword = !existing;
+      if ((mustHavePassword || password) && !isValidPasswordFormat(password)) {
+        setError(t('meeting.error.passwordFormatInvalid'));
+        return;
+      }
     }
     setSubmitting(true);
     setError(undefined);

--- a/packages/dmworkmeeting/src/pages/SchedulePage.tsx
+++ b/packages/dmworkmeeting/src/pages/SchedulePage.tsx
@@ -1,0 +1,135 @@
+import React, { useRef, useState } from 'react';
+import { t } from '@octo/base';
+import { MeetingApiClient, newIdempotencyKey } from '../service/MeetingApiClient';
+import type { Meeting } from '../service/contracts';
+import { isValidPasswordFormat } from '../logic/password';
+import { classifyFailure } from '../service/failClosed';
+import { directiveForCode } from '../service/errors';
+
+export interface SchedulePageProps {
+  /** When present the form edits an existing meeting (PATCH with If-Match). */
+  existing?: Meeting;
+  onSaved?: (meeting: Meeting) => void;
+  onCancelled?: () => void;
+}
+
+/**
+ * Schedule / edit / cancel (§4, FD-08/FD-12). Edits are optimistic-concurrency
+ * guarded with If-Match=version; a MEETING_VERSION_CONFLICT surfaces a refetch
+ * prompt. Password edits are disabled once the meeting is live (IMMUTABLE).
+ */
+export default function SchedulePage({ existing, onSaved, onCancelled }: SchedulePageProps) {
+  const [title, setTitle] = useState(existing?.title ?? '');
+  const [startAt, setStartAt] = useState('');
+  const [passwordEnabled, setPasswordEnabled] = useState(Boolean(existing?.passwordEnabled));
+  const [password, setPassword] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string>();
+  const idempotencyKeyRef = useRef<string>(newIdempotencyKey());
+
+  const passwordLocked = existing?.status === 'live'; // IMMUTABLE after live
+
+  const save = async () => {
+    if (submitting) return;
+    if (!existing && !startAt) {
+      setError(t('meeting.error.timeInvalid'));
+      return;
+    }
+    if (passwordEnabled && !passwordLocked && password && !isValidPasswordFormat(password)) {
+      setError(t('meeting.error.passwordFormatInvalid'));
+      return;
+    }
+    setSubmitting(true);
+    setError(undefined);
+    try {
+      let meeting: Meeting;
+      if (existing) {
+        meeting = await MeetingApiClient.patchMeeting(
+          existing.meetingId,
+          {
+            title,
+            scheduledStartAt: startAt || existing.scheduledStartAt || '',
+            passwordEnabled: passwordLocked ? undefined : passwordEnabled,
+            password: passwordLocked || !passwordEnabled ? undefined : password || undefined,
+          },
+          { ifMatch: existing.version, idempotencyKey: idempotencyKeyRef.current },
+        );
+      } else {
+        meeting = await MeetingApiClient.scheduleCreate(
+          { title, scheduledStartAt: startAt, passwordEnabled, password: passwordEnabled ? password : undefined },
+          { idempotencyKey: idempotencyKeyRef.current },
+        );
+        idempotencyKeyRef.current = newIdempotencyKey(); // rotate after a successful create
+      }
+      onSaved?.(meeting);
+    } catch (err) {
+      const code = classifyFailure(err).code;
+      setError(code ? t(directiveForCode(code).i18nKey) : t('meeting.error.internal'));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const cancel = async () => {
+    if (!existing || submitting) return;
+    setSubmitting(true);
+    setError(undefined);
+    try {
+      await MeetingApiClient.cancelMeeting(existing.meetingId, { ifMatch: existing.version, idempotencyKey: newIdempotencyKey() });
+      onCancelled?.();
+    } catch (err) {
+      const code = classifyFailure(err).code;
+      setError(code ? t(directiveForCode(code).i18nKey) : t('meeting.error.internal'));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="meeting-schedule">
+      <h2>{t('meeting.home.schedule')}</h2>
+      <label>
+        {t('meeting.home.title')}
+        <input value={title} onChange={(e) => setTitle(e.target.value)} />
+      </label>
+      <label>
+        {t('meeting.home.upcoming')}
+        <input type="datetime-local" value={startAt} onChange={(e) => setStartAt(e.target.value)} />
+      </label>
+      <label>
+        <input
+          type="checkbox"
+          checked={passwordEnabled}
+          disabled={passwordLocked}
+          aria-disabled={passwordLocked}
+          onChange={(e) => setPasswordEnabled(e.target.checked)}
+        />
+        {t('meeting.error.passwordRequired')}
+      </label>
+      {passwordEnabled && !passwordLocked && (
+        <input
+          aria-label={t('meeting.challenge.inputLabel')}
+          inputMode="numeric"
+          maxLength={6}
+          value={password}
+          onChange={(e) => setPassword(e.target.value.replace(/[^\d]/g, '').slice(0, 6))}
+        />
+      )}
+      <div className="meeting-schedule-actions">
+        <button type="button" disabled={submitting} onClick={save}>
+          {t('meeting.join.submit')}
+        </button>
+        {existing && (
+          <button type="button" disabled={submitting} onClick={cancel}>
+            {t('meeting.terminal.cancelled')}
+          </button>
+        )}
+      </div>
+      {error && (
+        <div role="alert" aria-live="assertive">
+          {error}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/dmworkmeeting/src/pages/SchedulePage.tsx
+++ b/packages/dmworkmeeting/src/pages/SchedulePage.tsx
@@ -13,14 +13,32 @@ export interface SchedulePageProps {
   onCancelled?: () => void;
 }
 
+// A `datetime-local` input yields local wall-clock "YYYY-MM-DDTHH:mm". Convert
+// a stored UTC ISO string into that local form for prefill, and convert the
+// local input back to a UTC ISO instant for the wire (contract: UTC ISO-8601).
+function isoToLocalInput(iso?: string): string {
+  if (!iso) return '';
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return '';
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+function localInputToIso(local: string): string | null {
+  if (!local) return null;
+  const d = new Date(local); // parsed in local time
+  if (Number.isNaN(d.getTime())) return null;
+  return d.toISOString();
+}
+
 /**
  * Schedule / edit / cancel (§4, FD-08/FD-12). Edits are optimistic-concurrency
  * guarded with If-Match=version; a MEETING_VERSION_CONFLICT surfaces a refetch
  * prompt. Password edits are disabled once the meeting is live (IMMUTABLE).
+ * Times are sent as UTC ISO-8601 (the input is local wall-clock).
  */
 export default function SchedulePage({ existing, onSaved, onCancelled }: SchedulePageProps) {
   const [title, setTitle] = useState(existing?.title ?? '');
-  const [startAt, setStartAt] = useState('');
+  const [startAt, setStartAt] = useState(isoToLocalInput(existing?.scheduledStartAt));
   const [passwordEnabled, setPasswordEnabled] = useState(Boolean(existing?.passwordEnabled));
   const [password, setPassword] = useState('');
   const [submitting, setSubmitting] = useState(false);
@@ -31,7 +49,9 @@ export default function SchedulePage({ existing, onSaved, onCancelled }: Schedul
 
   const save = async () => {
     if (submitting) return;
-    if (!existing && !startAt) {
+    // Editing may keep the existing time; a new schedule must provide one.
+    const startIso = startAt ? localInputToIso(startAt) : existing?.scheduledStartAt ?? null;
+    if (!startIso) {
       setError(t('meeting.error.timeInvalid'));
       return;
     }
@@ -48,15 +68,16 @@ export default function SchedulePage({ existing, onSaved, onCancelled }: Schedul
           existing.meetingId,
           {
             title,
-            scheduledStartAt: startAt || existing.scheduledStartAt || '',
+            scheduledStartAt: startIso,
             passwordEnabled: passwordLocked ? undefined : passwordEnabled,
             password: passwordLocked || !passwordEnabled ? undefined : password || undefined,
           },
           { ifMatch: existing.version, idempotencyKey: idempotencyKeyRef.current },
         );
+        idempotencyKeyRef.current = newIdempotencyKey(); // rotate after a successful edit
       } else {
         meeting = await MeetingApiClient.scheduleCreate(
-          { title, scheduledStartAt: startAt, passwordEnabled, password: passwordEnabled ? password : undefined },
+          { title, scheduledStartAt: startIso, passwordEnabled, password: passwordEnabled ? password : undefined },
           { idempotencyKey: idempotencyKeyRef.current },
         );
         idempotencyKeyRef.current = newIdempotencyKey(); // rotate after a successful create
@@ -87,13 +108,13 @@ export default function SchedulePage({ existing, onSaved, onCancelled }: Schedul
 
   return (
     <div className="meeting-schedule">
-      <h2>{t('meeting.home.schedule')}</h2>
+      <h2>{existing ? t('meeting.form.editTitle') : t('meeting.home.schedule')}</h2>
       <label>
-        {t('meeting.home.title')}
+        {t('meeting.form.titleLabel')}
         <input value={title} onChange={(e) => setTitle(e.target.value)} />
       </label>
       <label>
-        {t('meeting.home.upcoming')}
+        {t('meeting.form.startLabel')}
         <input type="datetime-local" value={startAt} onChange={(e) => setStartAt(e.target.value)} />
       </label>
       <label>
@@ -104,7 +125,7 @@ export default function SchedulePage({ existing, onSaved, onCancelled }: Schedul
           aria-disabled={passwordLocked}
           onChange={(e) => setPasswordEnabled(e.target.checked)}
         />
-        {t('meeting.error.passwordRequired')}
+        {t('meeting.form.enablePassword')}
       </label>
       {passwordEnabled && !passwordLocked && (
         <input
@@ -117,11 +138,11 @@ export default function SchedulePage({ existing, onSaved, onCancelled }: Schedul
       )}
       <div className="meeting-schedule-actions">
         <button type="button" disabled={submitting} onClick={save}>
-          {t('meeting.join.submit')}
+          {t('meeting.form.save')}
         </button>
         {existing && (
           <button type="button" disabled={submitting} onClick={cancel}>
-            {t('meeting.terminal.cancelled')}
+            {t('meeting.form.cancelMeeting')}
           </button>
         )}
       </div>

--- a/packages/dmworkmeeting/src/service/MeetingApiClient.test.ts
+++ b/packages/dmworkmeeting/src/service/MeetingApiClient.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import type { AxiosResponse } from 'axios';
+import { MeetingApiClient, resolveMeetingBaseURL, newIdempotencyKey } from './MeetingApiClient';
+// Resolved to src/__mocks__/dmworkBase.ts by vitest.config.ts alias; imported
+// directly here so the mock-only test helpers typecheck too (same module
+// instance at runtime under the alias).
+import { WKApp, __resetWKApp, __logoutCalls } from '../__mocks__/dmworkBase';
+
+// Capture the final request config (post-interceptor) via a fake adapter.
+let lastConfig: Record<string, unknown> | null = null;
+function installFakeAdapter(behaviour: (config: Record<string, unknown>) => AxiosResponse | Promise<never>) {
+  MeetingApiClient.raw.defaults.adapter = ((config: Record<string, unknown>) => {
+    lastConfig = config;
+    const res = behaviour(config);
+    return res instanceof Promise ? res : Promise.resolve(res);
+  }) as never;
+}
+const ok = (data: unknown, config: Record<string, unknown>): AxiosResponse =>
+  ({ data, status: 200, statusText: 'OK', headers: {}, config } as never);
+
+beforeEach(() => {
+  __resetWKApp();
+  lastConfig = null;
+});
+
+describe('resolveMeetingBaseURL — origin derivation (mirrors summaryApi.ts:49-56)', () => {
+  it('relative Web apiURL → empty baseURL (same origin)', () => {
+    expect(resolveMeetingBaseURL('/api/v1/')).toBe('');
+  });
+  it('absolute Electron/extension apiURL → its origin', () => {
+    expect(resolveMeetingBaseURL('https://octo.example.com/api/v1/')).toBe('https://octo.example.com');
+  });
+  it('empty/undefined → same origin', () => {
+    expect(resolveMeetingBaseURL(undefined)).toBe('');
+    expect(resolveMeetingBaseURL('')).toBe('');
+  });
+});
+
+describe('idempotency key', () => {
+  it('generates non-empty unique keys', () => {
+    const a = newIdempotencyKey();
+    const b = newIdempotencyKey();
+    expect(a).toBeTruthy();
+    expect(a).not.toBe(b);
+  });
+});
+
+describe('request interceptor — identity headers (§6.1)', () => {
+  it('injects token, X-Space-Id, Accept-Language and prefixes /meeting/api/v1', async () => {
+    installFakeAdapter((config) => ok({ eligible: true, meeting_id: 'm1' }, config));
+    WKApp.loginInfo.token = 'tkn-1';
+    WKApp.shared.currentSpaceId = 'space-xyz';
+
+    await MeetingApiClient.evaluate({ source: 'number', meetingNumber: '123' });
+
+    const headers = (lastConfig as { headers: Record<string, string> }).headers;
+    const url = (lastConfig as { url: string }).url;
+    expect(headers['token']).toBe('tkn-1');
+    expect(headers['X-Space-Id']).toBe('space-xyz');
+    expect(headers['Accept-Language']).toBeTruthy();
+    // NEVER trust/send browser identity as authority.
+    expect(headers['x-user-id']).toBeUndefined();
+    expect(headers['x-org-id']).toBeUndefined();
+    expect(url).toBe('/meeting/api/v1/v1/meetings/admission/evaluate');
+  });
+
+  it('omits token header when unauthenticated', async () => {
+    installFakeAdapter((config) => ok({}, config));
+    WKApp.loginInfo.token = undefined;
+    await MeetingApiClient.listMeetings('upcoming');
+    const headers = (lastConfig as { headers: Record<string, string> }).headers;
+    expect(headers['token']).toBeUndefined();
+  });
+
+  it('If-Match and Idempotency-Key are sent on writes', async () => {
+    installFakeAdapter((config) => ok({ meeting_id: 'm2' }, config));
+    const key = newIdempotencyKey();
+    await MeetingApiClient.quickCreate({ title: 'q' }, { idempotencyKey: key, ifMatch: 4 });
+    const headers = (lastConfig as { headers: Record<string, string> }).headers;
+    expect(headers['Idempotency-Key']).toBe(key);
+    expect(headers['If-Match']).toBe('4');
+  });
+});
+
+describe('response interceptor — 401 → logout (mirrors summaryApi.ts:78-79)', () => {
+  it('a 401 triggers WKApp.shared.logout()', async () => {
+    installFakeAdapter(() => Promise.reject({ response: { status: 401 } }) as Promise<never>);
+    await expect(MeetingApiClient.getMeeting('m1')).rejects.toBeTruthy();
+    expect(__logoutCalls.count).toBe(1);
+  });
+
+  it('a non-401 does NOT logout', async () => {
+    installFakeAdapter(() => Promise.reject({ response: { status: 423, data: { code: 'MEETING_LOCKED' } } }) as Promise<never>);
+    await expect(MeetingApiClient.getMeeting('m1')).rejects.toBeTruthy();
+    expect(__logoutCalls.count).toBe(0);
+  });
+});

--- a/packages/dmworkmeeting/src/service/MeetingApiClient.test.ts
+++ b/packages/dmworkmeeting/src/service/MeetingApiClient.test.ts
@@ -1,30 +1,39 @@
-import { describe, it, expect, beforeEach } from 'vitest';
-import type { AxiosResponse } from 'axios';
-import { MeetingApiClient, resolveMeetingBaseURL, newIdempotencyKey } from './MeetingApiClient';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { MeetingApiClient, resolveMeetingBaseURL, newIdempotencyKey, MeetingHttpError } from './MeetingApiClient';
 // Resolved to src/__mocks__/dmworkBase.ts by vitest.config.ts alias; imported
 // directly here so the mock-only test helpers typecheck too (same module
 // instance at runtime under the alias).
 import { WKApp, __resetWKApp, __logoutCalls } from '../__mocks__/dmworkBase';
 
-// Capture the final request config (post-interceptor) via a fake adapter.
-let lastConfig: Record<string, unknown> | null = null;
-function installFakeAdapter(behaviour: (config: Record<string, unknown>) => AxiosResponse | Promise<never>) {
-  MeetingApiClient.raw.defaults.adapter = ((config: Record<string, unknown>) => {
-    lastConfig = config;
-    const res = behaviour(config);
-    return res instanceof Promise ? res : Promise.resolve(res);
-  }) as never;
+interface FetchCall {
+  url: string;
+  init: RequestInit;
 }
-const ok = (data: unknown, config: Record<string, unknown>): AxiosResponse =>
-  ({ data, status: 200, statusText: 'OK', headers: {}, config } as never);
+let calls: FetchCall[] = [];
+
+function stubFetch(status: number, body: unknown) {
+  const fn = vi.fn(async (url: string, init: RequestInit) => {
+    calls.push({ url, init });
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      text: async () => (body === undefined ? '' : JSON.stringify(body)),
+    } as unknown as Response;
+  });
+  (globalThis as unknown as { fetch: typeof fetch }).fetch = fn as unknown as typeof fetch;
+  return fn;
+}
+
+const headersOf = (i: number) => (calls[i].init.headers as Record<string, string>) ?? {};
 
 beforeEach(() => {
   __resetWKApp();
-  lastConfig = null;
+  calls = [];
 });
+afterEach(() => vi.restoreAllMocks());
 
 describe('resolveMeetingBaseURL — origin derivation (mirrors summaryApi.ts:49-56)', () => {
-  it('relative Web apiURL → empty baseURL (same origin)', () => {
+  it('relative Web apiURL → empty base (same origin)', () => {
     expect(resolveMeetingBaseURL('/api/v1/')).toBe('');
   });
   it('absolute Electron/extension apiURL → its origin', () => {
@@ -38,60 +47,89 @@ describe('resolveMeetingBaseURL — origin derivation (mirrors summaryApi.ts:49-
 
 describe('idempotency key', () => {
   it('generates non-empty unique keys', () => {
-    const a = newIdempotencyKey();
-    const b = newIdempotencyKey();
-    expect(a).toBeTruthy();
-    expect(a).not.toBe(b);
+    expect(newIdempotencyKey()).not.toBe(newIdempotencyKey());
   });
 });
 
-describe('request interceptor — identity headers (§6.1)', () => {
-  it('injects token, X-Space-Id, Accept-Language and prefixes /meeting/api/v1', async () => {
-    installFakeAdapter((config) => ok({ eligible: true, meeting_id: 'm1' }, config));
+describe('request headers (§6.1)', () => {
+  it('injects token, X-Space-Id, Accept-Language and prefixes /meeting/api/v1; no browser identity', async () => {
+    stubFetch(200, { eligible: true, meeting_id: 'm1' });
     WKApp.loginInfo.token = 'tkn-1';
     WKApp.shared.currentSpaceId = 'space-xyz';
-
     await MeetingApiClient.evaluate({ source: 'number', meetingNumber: '123' });
-
-    const headers = (lastConfig as { headers: Record<string, string> }).headers;
-    const url = (lastConfig as { url: string }).url;
-    expect(headers['token']).toBe('tkn-1');
-    expect(headers['X-Space-Id']).toBe('space-xyz');
-    expect(headers['Accept-Language']).toBeTruthy();
-    // NEVER trust/send browser identity as authority.
-    expect(headers['x-user-id']).toBeUndefined();
-    expect(headers['x-org-id']).toBeUndefined();
-    expect(url).toBe('/meeting/api/v1/v1/meetings/admission/evaluate');
+    const h = headersOf(0);
+    expect(h['token']).toBe('tkn-1');
+    expect(h['X-Space-Id']).toBe('space-xyz');
+    expect(h['Accept-Language']).toBeTruthy();
+    expect(h['x-user-id']).toBeUndefined();
+    expect(h['x-org-id']).toBeUndefined();
+    expect(calls[0].url).toBe('/meeting/api/v1/v1/meetings/admission/evaluate');
   });
 
   it('omits token header when unauthenticated', async () => {
-    installFakeAdapter((config) => ok({}, config));
+    stubFetch(200, {});
     WKApp.loginInfo.token = undefined;
     await MeetingApiClient.listMeetings('upcoming');
-    const headers = (lastConfig as { headers: Record<string, string> }).headers;
-    expect(headers['token']).toBeUndefined();
+    expect(headersOf(0)['token']).toBeUndefined();
+    expect(calls[0].url).toContain('view=upcoming');
   });
 
   it('If-Match and Idempotency-Key are sent on writes', async () => {
-    installFakeAdapter((config) => ok({ meeting_id: 'm2' }, config));
+    stubFetch(200, { meeting_id: 'm2' });
     const key = newIdempotencyKey();
     await MeetingApiClient.quickCreate({ title: 'q' }, { idempotencyKey: key, ifMatch: 4 });
-    const headers = (lastConfig as { headers: Record<string, string> }).headers;
-    expect(headers['Idempotency-Key']).toBe(key);
-    expect(headers['If-Match']).toBe('4');
+    const h = headersOf(0);
+    expect(h['Idempotency-Key']).toBe(key);
+    expect(h['If-Match']).toBe('4');
   });
 });
 
-describe('response interceptor — 401 → logout (mirrors summaryApi.ts:78-79)', () => {
-  it('a 401 triggers WKApp.shared.logout()', async () => {
-    installFakeAdapter(() => Promise.reject({ response: { status: 401 } }) as Promise<never>);
+describe('401 → logout only for authentication failures (#1 regression)', () => {
+  it('a bare 401 (no code) logs out', async () => {
+    stubFetch(401, undefined);
+    await expect(MeetingApiClient.getMeeting('m1')).rejects.toBeInstanceOf(MeetingHttpError);
+    expect(__logoutCalls.count).toBe(1);
+  });
+
+  it('MEETING_AUTH_REQUIRED (401) logs out', async () => {
+    stubFetch(401, { code: 'MEETING_AUTH_REQUIRED' });
     await expect(MeetingApiClient.getMeeting('m1')).rejects.toBeTruthy();
     expect(__logoutCalls.count).toBe(1);
   });
 
-  it('a non-401 does NOT logout', async () => {
-    installFakeAdapter(() => Promise.reject({ response: { status: 423, data: { code: 'MEETING_LOCKED' } } }) as Promise<never>);
-    await expect(MeetingApiClient.getMeeting('m1')).rejects.toBeTruthy();
+  it('MEETING_PASSWORD_INVALID (401) does NOT log out', async () => {
+    stubFetch(401, { code: 'MEETING_PASSWORD_INVALID', attempts_remaining: 3 });
+    await expect(
+      MeetingApiClient.verifyPassword({ meetingId: 'm', passwordChallengeId: 'c', password: '000000' }),
+    ).rejects.toBeInstanceOf(MeetingHttpError);
     expect(__logoutCalls.count).toBe(0);
+  });
+
+  it('MEETING_PASSWORD_PASS_EXPIRED (401) does NOT log out', async () => {
+    stubFetch(401, { code: 'MEETING_PASSWORD_PASS_EXPIRED' });
+    await expect(
+      MeetingApiClient.finalize({ meetingId: 'm', source: 'link', deviceIdHash: 'd' }),
+    ).rejects.toBeTruthy();
+    expect(__logoutCalls.count).toBe(0);
+  });
+
+  it('a non-401 error never logs out', async () => {
+    stubFetch(423, { code: 'MEETING_LOCKED' });
+    await expect(MeetingApiClient.getMeeting('m1')).rejects.toBeInstanceOf(MeetingHttpError);
+    expect(__logoutCalls.count).toBe(0);
+  });
+});
+
+describe('error shape', () => {
+  it('non-2xx throws MeetingHttpError carrying response.status/data', async () => {
+    stubFetch(409, { code: 'MEETING_VERSION_CONFLICT' });
+    try {
+      await MeetingApiClient.cancelMeeting('m', { ifMatch: 1 });
+      throw new Error('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(MeetingHttpError);
+      expect((err as MeetingHttpError).response.status).toBe(409);
+      expect((err as MeetingHttpError).response.data?.code).toBe('MEETING_VERSION_CONFLICT');
+    }
   });
 });

--- a/packages/dmworkmeeting/src/service/MeetingApiClient.test.ts
+++ b/packages/dmworkmeeting/src/service/MeetingApiClient.test.ts
@@ -132,4 +132,29 @@ describe('error shape', () => {
       expect((err as MeetingHttpError).response.data?.code).toBe('MEETING_VERSION_CONFLICT');
     }
   });
+
+  it('a 2xx whose body is not a JSON object (SPA index.html) fails closed (nonObjectBody)', async () => {
+    stubFetch(200, undefined); // no body
+    (globalThis as unknown as { fetch: typeof fetch }).fetch = (async () => ({
+      ok: true,
+      status: 200,
+      text: async () => '<!doctype html><html></html>',
+    })) as unknown as typeof fetch;
+    try {
+      await MeetingApiClient.evaluate({ source: 'number', meetingNumber: '1' });
+      throw new Error('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(MeetingHttpError);
+      expect((err as MeetingHttpError).nonObjectBody).toBe(true);
+    }
+  });
+
+  it('a void endpoint tolerates an empty 2xx body', async () => {
+    (globalThis as unknown as { fetch: typeof fetch }).fetch = (async () => ({
+      ok: true,
+      status: 200,
+      text: async () => '',
+    })) as unknown as typeof fetch;
+    await expect(MeetingApiClient.leave('m', { idempotencyKey: 'k' })).resolves.toBeUndefined();
+  });
 });

--- a/packages/dmworkmeeting/src/service/MeetingApiClient.ts
+++ b/packages/dmworkmeeting/src/service/MeetingApiClient.ts
@@ -97,7 +97,7 @@ function buildQuery(params?: Record<string, unknown>): string {
 async function request<T>(
   method: Method,
   path: string,
-  opts: { body?: unknown; params?: Record<string, unknown>; write?: WriteOpts } = {},
+  opts: { body?: unknown; params?: Record<string, unknown>; write?: WriteOpts; signal?: AbortSignal } = {},
 ): Promise<T> {
   const base = resolveMeetingBaseURL(WKApp.apiClient?.config?.apiURL);
   const url = `${base}${MEETING_API_BASE}${path}${buildQuery(opts.params)}`;
@@ -116,7 +116,7 @@ async function request<T>(
     method,
     headers,
     body: opts.body !== undefined ? JSON.stringify(opts.body) : undefined,
-    signal: opts.write?.signal ?? (opts.params as { signal?: AbortSignal } | undefined)?.signal,
+    signal: opts.signal ?? opts.write?.signal,
   });
 
   const raw = await resp.text();
@@ -155,13 +155,14 @@ export const MeetingApiClient = {
     opts?: { pageSize?: number; pageToken?: string; signal?: AbortSignal },
   ): Promise<MeetingListResult> {
     const data = await request<unknown>('GET', MeetingEndpoint.list, {
-      params: { view, page_size: opts?.pageSize, page_token: opts?.pageToken, signal: opts?.signal },
+      params: { view, page_size: opts?.pageSize, page_token: opts?.pageToken },
+      signal: opts?.signal,
     });
     return decodeList(data as never);
   },
 
   async getMeeting(id: string, signal?: AbortSignal): Promise<Meeting> {
-    return decodeMeeting((await request<unknown>('GET', MeetingEndpoint.get(id), { params: { signal } })) as never);
+    return decodeMeeting((await request<unknown>('GET', MeetingEndpoint.get(id), { signal })) as never);
   },
 
   async quickCreate(req: QuickCreateRequest, opts: WriteOpts): Promise<Meeting> {

--- a/packages/dmworkmeeting/src/service/MeetingApiClient.ts
+++ b/packages/dmworkmeeting/src/service/MeetingApiClient.ts
@@ -39,16 +39,25 @@ import {
 } from './adapter';
 import { MeetingErrorCode, isMeetingErrorCode } from './errors';
 
-/** Error thrown for a non-2xx response. Shaped so classifyFailure /
- * extractCanonicalError read `.response.status` / `.response.data` unchanged. */
+/** Error thrown for a non-2xx response, or a 2xx whose body is not a JSON
+ * object. Shaped so classifyFailure / extractCanonicalError read
+ * `.response.status` / `.response.data` unchanged. `nonObjectBody` marks the
+ * SPA-fallback case (200 + index.html) so it fails closed as "feature not
+ * enabled" rather than being trusted (fail-open). */
 export class MeetingHttpError extends Error {
   response: { status: number; data?: WireError };
-  constructor(status: number, data?: WireError) {
-    super(data?.code ?? `HTTP ${status}`);
+  nonObjectBody?: boolean;
+  constructor(status: number, data?: WireError, nonObjectBody?: boolean) {
+    super(data?.code ?? (nonObjectBody ? 'non-object body' : `HTTP ${status}`));
     this.name = 'MeetingHttpError';
     this.response = { status, data };
+    this.nonObjectBody = nonObjectBody;
   }
 }
+
+/** Default per-request timeout, matching the shared APIClient's 20s guard so a
+ * gateway that connects but never answers cannot pin the UI on a busy screen. */
+export const MEETING_REQUEST_TIMEOUT_MS = 20_000;
 
 /**
  * Web keeps a relative apiURL ("/api/v1/") → same-origin (empty base). In
@@ -94,10 +103,19 @@ function buildQuery(params?: Record<string, unknown>): string {
   return q ? `?${q}` : '';
 }
 
+/** Compose a caller signal with a timeout signal so a hung gateway aborts. */
+function withTimeout(signal: AbortSignal | undefined, ms: number): AbortSignal {
+  const anyOf = (AbortSignal as unknown as { any?: (s: AbortSignal[]) => AbortSignal }).any;
+  const timeout = (AbortSignal as unknown as { timeout?: (ms: number) => AbortSignal }).timeout;
+  const timeoutSignal = timeout ? timeout(ms) : undefined;
+  if (signal && timeoutSignal && anyOf) return anyOf([signal, timeoutSignal]);
+  return signal ?? timeoutSignal ?? new AbortController().signal;
+}
+
 async function request<T>(
   method: Method,
   path: string,
-  opts: { body?: unknown; params?: Record<string, unknown>; write?: WriteOpts; signal?: AbortSignal } = {},
+  opts: { body?: unknown; params?: Record<string, unknown>; write?: WriteOpts; signal?: AbortSignal; expectObject?: boolean } = {},
 ): Promise<T> {
   const base = resolveMeetingBaseURL(WKApp.apiClient?.config?.apiURL);
   const url = `${base}${MEETING_API_BASE}${path}${buildQuery(opts.params)}`;
@@ -116,7 +134,7 @@ async function request<T>(
     method,
     headers,
     body: opts.body !== undefined ? JSON.stringify(opts.body) : undefined,
-    signal: opts.signal ?? opts.write?.signal,
+    signal: withTimeout(opts.signal ?? opts.write?.signal, MEETING_REQUEST_TIMEOUT_MS),
   });
 
   const raw = await resp.text();
@@ -143,10 +161,20 @@ async function request<T>(
   }
 
   // Backend may wrap responses in {code,message,data}; unwrap .data when present.
-  if (parsed && typeof parsed === 'object' && 'data' in (parsed as Record<string, unknown>)) {
-    return (parsed as Record<string, unknown>).data as T;
+  const unwrapped =
+    parsed && typeof parsed === 'object' && 'data' in (parsed as Record<string, unknown>)
+      ? (parsed as Record<string, unknown>).data
+      : parsed;
+
+  // Fail closed: a 2xx whose body is not a JSON object is almost always an SPA
+  // index.html fallback for an unmounted gateway route. Trusting it would walk
+  // the user into PreJoin on garbage (fail-open); instead treat it as
+  // "feature not enabled". Only enforced for endpoints that decode an object
+  // (void endpoints legitimately return an empty body).
+  if (opts.expectObject && (unwrapped === null || typeof unwrapped !== 'object')) {
+    throw new MeetingHttpError(resp.status, undefined, true);
   }
-  return parsed as T;
+  return unwrapped as T;
 }
 
 export const MeetingApiClient = {
@@ -157,26 +185,27 @@ export const MeetingApiClient = {
     const data = await request<unknown>('GET', MeetingEndpoint.list, {
       params: { view, page_size: opts?.pageSize, page_token: opts?.pageToken },
       signal: opts?.signal,
+      expectObject: true,
     });
     return decodeList(data as never);
   },
 
   async getMeeting(id: string, signal?: AbortSignal): Promise<Meeting> {
-    return decodeMeeting((await request<unknown>('GET', MeetingEndpoint.get(id), { signal })) as never);
+    return decodeMeeting((await request<unknown>('GET', MeetingEndpoint.get(id), { signal, expectObject: true })) as never);
   },
 
   async quickCreate(req: QuickCreateRequest, opts: WriteOpts): Promise<Meeting> {
-    const data = await request<unknown>('POST', MeetingEndpoint.quickCreate, { body: toSnakeDeep(req), write: opts });
+    const data = await request<unknown>('POST', MeetingEndpoint.quickCreate, { body: toSnakeDeep(req), write: opts, expectObject: true });
     return decodeMeeting(data as never);
   },
 
   async scheduleCreate(req: ScheduleCreateRequest, opts?: WriteOpts): Promise<Meeting> {
-    const data = await request<unknown>('POST', MeetingEndpoint.create, { body: toSnakeDeep(req), write: opts });
+    const data = await request<unknown>('POST', MeetingEndpoint.create, { body: toSnakeDeep(req), write: opts, expectObject: true });
     return decodeMeeting(data as never);
   },
 
   async patchMeeting(id: string, patchBody: Partial<ScheduleCreateRequest>, opts: WriteOpts): Promise<Meeting> {
-    const data = await request<unknown>('PATCH', MeetingEndpoint.patch(id), { body: toSnakeDeep(patchBody), write: opts });
+    const data = await request<unknown>('PATCH', MeetingEndpoint.patch(id), { body: toSnakeDeep(patchBody), write: opts, expectObject: true });
     return decodeMeeting(data as never);
   },
 
@@ -185,17 +214,17 @@ export const MeetingApiClient = {
   },
 
   async evaluate(req: AdmissionEvaluateRequest, signal?: AbortSignal): Promise<AdmissionEvaluateResult> {
-    const data = await request<unknown>('POST', MeetingEndpoint.evaluate, { body: encodeEvaluate(req), write: { signal } });
+    const data = await request<unknown>('POST', MeetingEndpoint.evaluate, { body: encodeEvaluate(req), write: { signal }, expectObject: true });
     return decodeEvaluate(data as never);
   },
 
   async verifyPassword(req: PasswordVerifyRequest, signal?: AbortSignal): Promise<PasswordVerifyResult> {
-    const data = await request<unknown>('POST', MeetingEndpoint.passwordVerify, { body: encodePasswordVerify(req), write: { signal } });
+    const data = await request<unknown>('POST', MeetingEndpoint.passwordVerify, { body: encodePasswordVerify(req), write: { signal }, expectObject: true });
     return decodePasswordVerify(data as never);
   },
 
   async finalize(req: AdmissionFinalizeRequest, opts?: WriteOpts): Promise<AdmissionFinalizeResult> {
-    const data = await request<unknown>('POST', MeetingEndpoint.finalize, { body: encodeFinalize(req), write: opts });
+    const data = await request<unknown>('POST', MeetingEndpoint.finalize, { body: encodeFinalize(req), write: opts, expectObject: true });
     return decodeFinalize(data as never);
   },
 

--- a/packages/dmworkmeeting/src/service/MeetingApiClient.ts
+++ b/packages/dmworkmeeting/src/service/MeetingApiClient.ts
@@ -1,11 +1,16 @@
 // The single Meeting HTTP client + adapter seam. Faithfully mirrors the Smart
-// Summary client boundary (packages/dmworksummary/src/api/summaryApi.ts:41-79)
-// as the approved reference: derive origin from apiClient.config.apiURL for
-// non-Web runtimes, inject token / X-Space-Id / Accept-Language, and logout on
-// 401. It NEVER sends or trusts x-user-id / x-org-id as identity authority
-// (§6.1) — the gateway/service token verify is the only identity source.
+// Summary client boundary (packages/dmworksummary/src/api/summaryApi.ts) as the
+// approved reference: derive origin from apiClient.config.apiURL for non-Web
+// runtimes, inject token / X-Space-Id / Accept-Language, and logout on an
+// *authentication* 401. It NEVER sends or trusts x-user-id / x-org-id as
+// identity authority (§6.1) — the gateway/service token verify is the only
+// identity source.
+//
+// Implemented over fetch (NOT axios): the meeting package must not introduce a
+// vulnerable axios@0.25.x dependency edge into the dependency-review gate, and
+// the repo convention discourages new per-package axios instances. fetch gives
+// the same header/origin/401 semantics with zero new runtime dependency.
 
-import axios, { AxiosRequestConfig } from 'axios';
 import { WKApp, buildAcceptLanguage } from '@octo/base';
 import { MEETING_API_BASE, MeetingEndpoint } from './contracts';
 import type {
@@ -19,6 +24,7 @@ import type {
   PasswordVerifyResult,
   QuickCreateRequest,
   ScheduleCreateRequest,
+  WireError,
 } from './contracts';
 import {
   decodeEvaluate,
@@ -31,11 +37,21 @@ import {
   encodePasswordVerify,
   toSnakeDeep,
 } from './adapter';
+import { MeetingErrorCode, isMeetingErrorCode } from './errors';
 
-const meetingAxios = axios.create({ baseURL: '' });
+/** Error thrown for a non-2xx response. Shaped so classifyFailure /
+ * extractCanonicalError read `.response.status` / `.response.data` unchanged. */
+export class MeetingHttpError extends Error {
+  response: { status: number; data?: WireError };
+  constructor(status: number, data?: WireError) {
+    super(data?.code ?? `HTTP ${status}`);
+    this.name = 'MeetingHttpError';
+    this.response = { status, data };
+  }
+}
 
 /**
- * Web keeps a relative apiURL ("/api/v1/") → same-origin, empty baseURL. In
+ * Web keeps a relative apiURL ("/api/v1/") → same-origin (empty base). In
  * Electron / extension the page origin is app:// or chrome-extension://, so a
  * relative "/meeting/api/v1/…" never reaches the backend; derive the API origin
  * from apiClient.config.apiURL. Pure so it is unit-testable. Mirrors
@@ -50,179 +66,168 @@ export function resolveMeetingBaseURL(apiURL: string | undefined | null): string
   }
 }
 
-meetingAxios.interceptors.request.use((config) => {
-  config.baseURL = resolveMeetingBaseURL(WKApp.apiClient?.config?.apiURL);
-  config.headers = config.headers ?? {};
-  config.headers['Accept-Language'] = buildAcceptLanguage();
-  const token = WKApp.loginInfo?.token;
-  if (token) config.headers['token'] = token;
-  const spaceId = WKApp.shared?.currentSpaceId;
-  if (spaceId) config.headers['X-Space-Id'] = spaceId;
-  // NOTE: deliberately no x-user-id / x-org-id — identity is server-authoritative.
-  return config;
-});
-
-meetingAxios.interceptors.response.use(
-  (resp) => resp,
-  (err) => {
-    if (err?.response?.status === 401) {
-      WKApp.shared?.logout?.();
-    }
-    return Promise.reject(err);
-  },
-);
-
-/** Generate an explicit Idempotency-Key. quick-create reuses ONE key across all
- * retries so a duplicate click within/across the 2s bucket returns the first
- * result; the explicit key takes precedence over the implicit bucket (N3). */
+/** Generate an explicit Idempotency-Key. Callers reuse ONE key across retries so
+ * a duplicate request within/across the 2s bucket returns the first result; the
+ * explicit key takes precedence over the implicit bucket (N3). */
 export function newIdempotencyKey(): string {
   const c = (globalThis as unknown as { crypto?: { randomUUID?: () => string } }).crypto;
   if (c?.randomUUID) return c.randomUUID();
-  // Deterministic-ish fallback (no Math.random dependency requirement here, but
-  // avoid collisions across a session).
   return `idem-${Date.now().toString(36)}-${(idemCounter++).toString(36)}`;
 }
 let idemCounter = 0;
 
 interface WriteOpts {
-  /** Optimistic-concurrency version → If-Match header. */
   ifMatch?: number;
-  /** Explicit idempotency key (quick-create reuses one across retries). */
   idempotencyKey?: string;
   signal?: AbortSignal;
 }
 
-function writeHeaders(opts?: WriteOpts): Record<string, string> {
-  const h: Record<string, string> = {};
-  if (opts?.ifMatch !== undefined) h['If-Match'] = String(opts.ifMatch);
-  if (opts?.idempotencyKey) h['Idempotency-Key'] = opts.idempotencyKey;
-  return h;
-}
+type Method = 'GET' | 'POST' | 'PATCH' | 'PUT' | 'DELETE';
 
-// Backend may wrap responses in {code,message,data}; unwrap .data when present.
-function unwrap(data: unknown): unknown {
-  if (data && typeof data === 'object' && 'data' in (data as Record<string, unknown>)) {
-    return (data as Record<string, unknown>).data;
+function buildQuery(params?: Record<string, unknown>): string {
+  if (!params) return '';
+  const usp = new URLSearchParams();
+  for (const [k, v] of Object.entries(params)) {
+    if (v !== undefined && v !== null) usp.append(k, String(v));
   }
-  return data;
+  const q = usp.toString();
+  return q ? `?${q}` : '';
 }
 
-async function get<T>(path: string, params?: Record<string, unknown>, config?: AxiosRequestConfig): Promise<T> {
-  const resp = await meetingAxios.get(`${MEETING_API_BASE}${path}`, { params, ...config });
-  return unwrap(resp.data) as T;
-}
-async function post<T>(path: string, body?: unknown, config?: AxiosRequestConfig): Promise<T> {
-  const resp = await meetingAxios.post(`${MEETING_API_BASE}${path}`, body, config);
-  return unwrap(resp.data) as T;
-}
-async function patch<T>(path: string, body?: unknown, config?: AxiosRequestConfig): Promise<T> {
-  const resp = await meetingAxios.patch(`${MEETING_API_BASE}${path}`, body, config);
-  return unwrap(resp.data) as T;
-}
-async function del<T>(path: string, config?: AxiosRequestConfig): Promise<T> {
-  const resp = await meetingAxios.delete(`${MEETING_API_BASE}${path}`, config);
-  return unwrap(resp.data) as T;
-}
-async function put<T>(path: string, body?: unknown, config?: AxiosRequestConfig): Promise<T> {
-  const resp = await meetingAxios.put(`${MEETING_API_BASE}${path}`, body, config);
-  return unwrap(resp.data) as T;
+async function request<T>(
+  method: Method,
+  path: string,
+  opts: { body?: unknown; params?: Record<string, unknown>; write?: WriteOpts } = {},
+): Promise<T> {
+  const base = resolveMeetingBaseURL(WKApp.apiClient?.config?.apiURL);
+  const url = `${base}${MEETING_API_BASE}${path}${buildQuery(opts.params)}`;
+
+  const headers: Record<string, string> = { 'Accept-Language': buildAcceptLanguage() };
+  const token = WKApp.loginInfo?.token;
+  if (token) headers['token'] = token;
+  const spaceId = WKApp.shared?.currentSpaceId;
+  if (spaceId) headers['X-Space-Id'] = spaceId;
+  // NOTE: deliberately no x-user-id / x-org-id — identity is server-authoritative.
+  if (opts.write?.ifMatch !== undefined) headers['If-Match'] = String(opts.write.ifMatch);
+  if (opts.write?.idempotencyKey) headers['Idempotency-Key'] = opts.write.idempotencyKey;
+  if (opts.body !== undefined) headers['Content-Type'] = 'application/json';
+
+  const resp = await fetch(url, {
+    method,
+    headers,
+    body: opts.body !== undefined ? JSON.stringify(opts.body) : undefined,
+    signal: opts.write?.signal ?? (opts.params as { signal?: AbortSignal } | undefined)?.signal,
+  });
+
+  const raw = await resp.text();
+  let parsed: unknown = undefined;
+  if (raw) {
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      parsed = raw;
+    }
+  }
+
+  if (!resp.ok) {
+    const data = (parsed && typeof parsed === 'object' ? (parsed as WireError) : undefined) as WireError | undefined;
+    // Only an AUTHENTICATION 401 logs out. Business 401 codes such as
+    // MEETING_PASSWORD_INVALID / MEETING_PASSWORD_PASS_EXPIRED must NOT tear
+    // down the IM session (regression fix).
+    if (resp.status === 401) {
+      const code = data?.code;
+      const isAuthFailure = !code || code === MeetingErrorCode.AUTH_REQUIRED || !isMeetingErrorCode(code);
+      if (isAuthFailure) WKApp.shared?.logout?.();
+    }
+    throw new MeetingHttpError(resp.status, data);
+  }
+
+  // Backend may wrap responses in {code,message,data}; unwrap .data when present.
+  if (parsed && typeof parsed === 'object' && 'data' in (parsed as Record<string, unknown>)) {
+    return (parsed as Record<string, unknown>).data as T;
+  }
+  return parsed as T;
 }
 
 export const MeetingApiClient = {
-  raw: meetingAxios,
-
   async listMeetings(
     view: 'upcoming' | 'history',
     opts?: { pageSize?: number; pageToken?: string; signal?: AbortSignal },
   ): Promise<MeetingListResult> {
-    const data = await get<unknown>(
-      MeetingEndpoint.list,
-      { view, page_size: opts?.pageSize, page_token: opts?.pageToken },
-      { signal: opts?.signal },
-    );
+    const data = await request<unknown>('GET', MeetingEndpoint.list, {
+      params: { view, page_size: opts?.pageSize, page_token: opts?.pageToken, signal: opts?.signal },
+    });
     return decodeList(data as never);
   },
 
   async getMeeting(id: string, signal?: AbortSignal): Promise<Meeting> {
-    return decodeMeeting((await get<unknown>(MeetingEndpoint.get(id), undefined, { signal })) as never);
+    return decodeMeeting((await request<unknown>('GET', MeetingEndpoint.get(id), { params: { signal } })) as never);
   },
 
   async quickCreate(req: QuickCreateRequest, opts: WriteOpts): Promise<Meeting> {
-    const data = await post<unknown>(MeetingEndpoint.quickCreate, toSnakeDeep(req), {
-      headers: writeHeaders(opts),
-      signal: opts.signal,
-    });
+    const data = await request<unknown>('POST', MeetingEndpoint.quickCreate, { body: toSnakeDeep(req), write: opts });
     return decodeMeeting(data as never);
   },
 
   async scheduleCreate(req: ScheduleCreateRequest, opts?: WriteOpts): Promise<Meeting> {
-    const data = await post<unknown>(MeetingEndpoint.create, toSnakeDeep(req), {
-      headers: writeHeaders(opts),
-      signal: opts?.signal,
-    });
+    const data = await request<unknown>('POST', MeetingEndpoint.create, { body: toSnakeDeep(req), write: opts });
     return decodeMeeting(data as never);
   },
 
   async patchMeeting(id: string, patchBody: Partial<ScheduleCreateRequest>, opts: WriteOpts): Promise<Meeting> {
-    const data = await patch<unknown>(MeetingEndpoint.patch(id), toSnakeDeep(patchBody), {
-      headers: writeHeaders(opts),
-      signal: opts.signal,
-    });
+    const data = await request<unknown>('PATCH', MeetingEndpoint.patch(id), { body: toSnakeDeep(patchBody), write: opts });
     return decodeMeeting(data as never);
   },
 
   async cancelMeeting(id: string, opts: WriteOpts): Promise<void> {
-    await post<unknown>(MeetingEndpoint.cancel(id), {}, { headers: writeHeaders(opts), signal: opts.signal });
+    await request<unknown>('POST', MeetingEndpoint.cancel(id), { body: {}, write: opts });
   },
 
   async evaluate(req: AdmissionEvaluateRequest, signal?: AbortSignal): Promise<AdmissionEvaluateResult> {
-    const data = await post<unknown>(MeetingEndpoint.evaluate, encodeEvaluate(req), { signal });
+    const data = await request<unknown>('POST', MeetingEndpoint.evaluate, { body: encodeEvaluate(req), write: { signal } });
     return decodeEvaluate(data as never);
   },
 
   async verifyPassword(req: PasswordVerifyRequest, signal?: AbortSignal): Promise<PasswordVerifyResult> {
-    const data = await post<unknown>(MeetingEndpoint.passwordVerify, encodePasswordVerify(req), { signal });
+    const data = await request<unknown>('POST', MeetingEndpoint.passwordVerify, { body: encodePasswordVerify(req), write: { signal } });
     return decodePasswordVerify(data as never);
   },
 
   async finalize(req: AdmissionFinalizeRequest, opts?: WriteOpts): Promise<AdmissionFinalizeResult> {
-    const data = await post<unknown>(MeetingEndpoint.finalize, encodeFinalize(req), {
-      headers: writeHeaders(opts),
-      signal: opts?.signal,
-    });
+    const data = await request<unknown>('POST', MeetingEndpoint.finalize, { body: encodeFinalize(req), write: opts });
     return decodeFinalize(data as never);
   },
 
   async leave(id: string, opts: WriteOpts): Promise<void> {
-    await post<unknown>(MeetingEndpoint.leave(id), {}, { headers: writeHeaders(opts), signal: opts.signal });
+    await request<unknown>('POST', MeetingEndpoint.leave(id), { body: {}, write: opts });
   },
 
   async setRole(id: string, uid: string, role: string, opts: WriteOpts): Promise<void> {
-    await put<unknown>(MeetingEndpoint.role(id, uid), { role }, { headers: writeHeaders(opts), signal: opts.signal });
+    await request<unknown>('PUT', MeetingEndpoint.role(id, uid), { body: { role }, write: opts });
   },
 
   async mute(id: string, body: { target_uid?: string; all?: boolean; muted: boolean }, opts: WriteOpts): Promise<void> {
-    await post<unknown>(MeetingEndpoint.mute(id), body, { headers: writeHeaders(opts), signal: opts.signal });
+    await request<unknown>('POST', MeetingEndpoint.mute(id), { body, write: opts });
   },
 
   async removeParticipant(id: string, uid: string, opts: WriteOpts): Promise<void> {
-    await del<unknown>(MeetingEndpoint.removeParticipant(id, uid), { headers: writeHeaders(opts), signal: opts.signal });
+    await request<unknown>('DELETE', MeetingEndpoint.removeParticipant(id, uid), { write: opts });
   },
 
   async setLock(id: string, locked: boolean, opts: WriteOpts): Promise<void> {
-    await put<unknown>(MeetingEndpoint.lock(id), { locked }, { headers: writeHeaders(opts), signal: opts.signal });
+    await request<unknown>('PUT', MeetingEndpoint.lock(id), { body: { locked }, write: opts });
   },
 
   async end(id: string, opts: WriteOpts): Promise<void> {
-    await post<unknown>(MeetingEndpoint.end(id), {}, { headers: writeHeaders(opts), signal: opts.signal });
+    await request<unknown>('POST', MeetingEndpoint.end(id), { body: {}, write: opts });
   },
 
   async startShare(id: string, opts: WriteOpts): Promise<void> {
-    await post<unknown>(MeetingEndpoint.share(id), {}, { headers: writeHeaders(opts), signal: opts.signal });
+    await request<unknown>('POST', MeetingEndpoint.share(id), { body: {}, write: opts });
   },
 
   async stopShare(id: string, opts: WriteOpts): Promise<void> {
-    await del<unknown>(MeetingEndpoint.share(id), { headers: writeHeaders(opts), signal: opts.signal });
+    await request<unknown>('DELETE', MeetingEndpoint.share(id), { write: opts });
   },
 };
 

--- a/packages/dmworkmeeting/src/service/MeetingApiClient.ts
+++ b/packages/dmworkmeeting/src/service/MeetingApiClient.ts
@@ -1,0 +1,229 @@
+// The single Meeting HTTP client + adapter seam. Faithfully mirrors the Smart
+// Summary client boundary (packages/dmworksummary/src/api/summaryApi.ts:41-79)
+// as the approved reference: derive origin from apiClient.config.apiURL for
+// non-Web runtimes, inject token / X-Space-Id / Accept-Language, and logout on
+// 401. It NEVER sends or trusts x-user-id / x-org-id as identity authority
+// (§6.1) — the gateway/service token verify is the only identity source.
+
+import axios, { AxiosRequestConfig } from 'axios';
+import { WKApp, buildAcceptLanguage } from '@octo/base';
+import { MEETING_API_BASE, MeetingEndpoint } from './contracts';
+import type {
+  AdmissionEvaluateRequest,
+  AdmissionEvaluateResult,
+  AdmissionFinalizeRequest,
+  AdmissionFinalizeResult,
+  Meeting,
+  MeetingListResult,
+  PasswordVerifyRequest,
+  PasswordVerifyResult,
+  QuickCreateRequest,
+  ScheduleCreateRequest,
+} from './contracts';
+import {
+  decodeEvaluate,
+  decodeFinalize,
+  decodeList,
+  decodeMeeting,
+  decodePasswordVerify,
+  encodeEvaluate,
+  encodeFinalize,
+  encodePasswordVerify,
+  toSnakeDeep,
+} from './adapter';
+
+const meetingAxios = axios.create({ baseURL: '' });
+
+/**
+ * Web keeps a relative apiURL ("/api/v1/") → same-origin, empty baseURL. In
+ * Electron / extension the page origin is app:// or chrome-extension://, so a
+ * relative "/meeting/api/v1/…" never reaches the backend; derive the API origin
+ * from apiClient.config.apiURL. Pure so it is unit-testable. Mirrors
+ * summaryApi.ts:49-56.
+ */
+export function resolveMeetingBaseURL(apiURL: string | undefined | null): string {
+  if (!apiURL) return '';
+  try {
+    return new URL(apiURL).origin;
+  } catch {
+    return ''; // relative apiURL (Web) has no parsable origin → stay same-origin
+  }
+}
+
+meetingAxios.interceptors.request.use((config) => {
+  config.baseURL = resolveMeetingBaseURL(WKApp.apiClient?.config?.apiURL);
+  config.headers = config.headers ?? {};
+  config.headers['Accept-Language'] = buildAcceptLanguage();
+  const token = WKApp.loginInfo?.token;
+  if (token) config.headers['token'] = token;
+  const spaceId = WKApp.shared?.currentSpaceId;
+  if (spaceId) config.headers['X-Space-Id'] = spaceId;
+  // NOTE: deliberately no x-user-id / x-org-id — identity is server-authoritative.
+  return config;
+});
+
+meetingAxios.interceptors.response.use(
+  (resp) => resp,
+  (err) => {
+    if (err?.response?.status === 401) {
+      WKApp.shared?.logout?.();
+    }
+    return Promise.reject(err);
+  },
+);
+
+/** Generate an explicit Idempotency-Key. quick-create reuses ONE key across all
+ * retries so a duplicate click within/across the 2s bucket returns the first
+ * result; the explicit key takes precedence over the implicit bucket (N3). */
+export function newIdempotencyKey(): string {
+  const c = (globalThis as unknown as { crypto?: { randomUUID?: () => string } }).crypto;
+  if (c?.randomUUID) return c.randomUUID();
+  // Deterministic-ish fallback (no Math.random dependency requirement here, but
+  // avoid collisions across a session).
+  return `idem-${Date.now().toString(36)}-${(idemCounter++).toString(36)}`;
+}
+let idemCounter = 0;
+
+interface WriteOpts {
+  /** Optimistic-concurrency version → If-Match header. */
+  ifMatch?: number;
+  /** Explicit idempotency key (quick-create reuses one across retries). */
+  idempotencyKey?: string;
+  signal?: AbortSignal;
+}
+
+function writeHeaders(opts?: WriteOpts): Record<string, string> {
+  const h: Record<string, string> = {};
+  if (opts?.ifMatch !== undefined) h['If-Match'] = String(opts.ifMatch);
+  if (opts?.idempotencyKey) h['Idempotency-Key'] = opts.idempotencyKey;
+  return h;
+}
+
+// Backend may wrap responses in {code,message,data}; unwrap .data when present.
+function unwrap(data: unknown): unknown {
+  if (data && typeof data === 'object' && 'data' in (data as Record<string, unknown>)) {
+    return (data as Record<string, unknown>).data;
+  }
+  return data;
+}
+
+async function get<T>(path: string, params?: Record<string, unknown>, config?: AxiosRequestConfig): Promise<T> {
+  const resp = await meetingAxios.get(`${MEETING_API_BASE}${path}`, { params, ...config });
+  return unwrap(resp.data) as T;
+}
+async function post<T>(path: string, body?: unknown, config?: AxiosRequestConfig): Promise<T> {
+  const resp = await meetingAxios.post(`${MEETING_API_BASE}${path}`, body, config);
+  return unwrap(resp.data) as T;
+}
+async function patch<T>(path: string, body?: unknown, config?: AxiosRequestConfig): Promise<T> {
+  const resp = await meetingAxios.patch(`${MEETING_API_BASE}${path}`, body, config);
+  return unwrap(resp.data) as T;
+}
+async function del<T>(path: string, config?: AxiosRequestConfig): Promise<T> {
+  const resp = await meetingAxios.delete(`${MEETING_API_BASE}${path}`, config);
+  return unwrap(resp.data) as T;
+}
+async function put<T>(path: string, body?: unknown, config?: AxiosRequestConfig): Promise<T> {
+  const resp = await meetingAxios.put(`${MEETING_API_BASE}${path}`, body, config);
+  return unwrap(resp.data) as T;
+}
+
+export const MeetingApiClient = {
+  raw: meetingAxios,
+
+  async listMeetings(
+    view: 'upcoming' | 'history',
+    opts?: { pageSize?: number; pageToken?: string; signal?: AbortSignal },
+  ): Promise<MeetingListResult> {
+    const data = await get<unknown>(
+      MeetingEndpoint.list,
+      { view, page_size: opts?.pageSize, page_token: opts?.pageToken },
+      { signal: opts?.signal },
+    );
+    return decodeList(data as never);
+  },
+
+  async getMeeting(id: string, signal?: AbortSignal): Promise<Meeting> {
+    return decodeMeeting((await get<unknown>(MeetingEndpoint.get(id), undefined, { signal })) as never);
+  },
+
+  async quickCreate(req: QuickCreateRequest, opts: WriteOpts): Promise<Meeting> {
+    const data = await post<unknown>(MeetingEndpoint.quickCreate, toSnakeDeep(req), {
+      headers: writeHeaders(opts),
+      signal: opts.signal,
+    });
+    return decodeMeeting(data as never);
+  },
+
+  async scheduleCreate(req: ScheduleCreateRequest, opts?: WriteOpts): Promise<Meeting> {
+    const data = await post<unknown>(MeetingEndpoint.create, toSnakeDeep(req), {
+      headers: writeHeaders(opts),
+      signal: opts?.signal,
+    });
+    return decodeMeeting(data as never);
+  },
+
+  async patchMeeting(id: string, patchBody: Partial<ScheduleCreateRequest>, opts: WriteOpts): Promise<Meeting> {
+    const data = await patch<unknown>(MeetingEndpoint.patch(id), toSnakeDeep(patchBody), {
+      headers: writeHeaders(opts),
+      signal: opts.signal,
+    });
+    return decodeMeeting(data as never);
+  },
+
+  async cancelMeeting(id: string, opts: WriteOpts): Promise<void> {
+    await post<unknown>(MeetingEndpoint.cancel(id), {}, { headers: writeHeaders(opts), signal: opts.signal });
+  },
+
+  async evaluate(req: AdmissionEvaluateRequest, signal?: AbortSignal): Promise<AdmissionEvaluateResult> {
+    const data = await post<unknown>(MeetingEndpoint.evaluate, encodeEvaluate(req), { signal });
+    return decodeEvaluate(data as never);
+  },
+
+  async verifyPassword(req: PasswordVerifyRequest, signal?: AbortSignal): Promise<PasswordVerifyResult> {
+    const data = await post<unknown>(MeetingEndpoint.passwordVerify, encodePasswordVerify(req), { signal });
+    return decodePasswordVerify(data as never);
+  },
+
+  async finalize(req: AdmissionFinalizeRequest, opts?: WriteOpts): Promise<AdmissionFinalizeResult> {
+    const data = await post<unknown>(MeetingEndpoint.finalize, encodeFinalize(req), {
+      headers: writeHeaders(opts),
+      signal: opts?.signal,
+    });
+    return decodeFinalize(data as never);
+  },
+
+  async leave(id: string, opts: WriteOpts): Promise<void> {
+    await post<unknown>(MeetingEndpoint.leave(id), {}, { headers: writeHeaders(opts), signal: opts.signal });
+  },
+
+  async setRole(id: string, uid: string, role: string, opts: WriteOpts): Promise<void> {
+    await put<unknown>(MeetingEndpoint.role(id, uid), { role }, { headers: writeHeaders(opts), signal: opts.signal });
+  },
+
+  async mute(id: string, body: { target_uid?: string; all?: boolean; muted: boolean }, opts: WriteOpts): Promise<void> {
+    await post<unknown>(MeetingEndpoint.mute(id), body, { headers: writeHeaders(opts), signal: opts.signal });
+  },
+
+  async removeParticipant(id: string, uid: string, opts: WriteOpts): Promise<void> {
+    await del<unknown>(MeetingEndpoint.removeParticipant(id, uid), { headers: writeHeaders(opts), signal: opts.signal });
+  },
+
+  async setLock(id: string, locked: boolean, opts: WriteOpts): Promise<void> {
+    await put<unknown>(MeetingEndpoint.lock(id), { locked }, { headers: writeHeaders(opts), signal: opts.signal });
+  },
+
+  async end(id: string, opts: WriteOpts): Promise<void> {
+    await post<unknown>(MeetingEndpoint.end(id), {}, { headers: writeHeaders(opts), signal: opts.signal });
+  },
+
+  async startShare(id: string, opts: WriteOpts): Promise<void> {
+    await post<unknown>(MeetingEndpoint.share(id), {}, { headers: writeHeaders(opts), signal: opts.signal });
+  },
+
+  async stopShare(id: string, opts: WriteOpts): Promise<void> {
+    await del<unknown>(MeetingEndpoint.share(id), { headers: writeHeaders(opts), signal: opts.signal });
+  },
+};
+
+export type MeetingApiClientType = typeof MeetingApiClient;

--- a/packages/dmworkmeeting/src/service/adapter.test.ts
+++ b/packages/dmworkmeeting/src/service/adapter.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import {
+  toCamelDeep,
+  toSnakeDeep,
+  decodeEvaluate,
+  decodeList,
+  encodeFinalize,
+  redactSensitive,
+} from './adapter';
+
+describe('snake ⇄ camel single seam (§6.3)', () => {
+  it('deep snake → camel', () => {
+    expect(
+      toCamelDeep({ meeting_id: 'm1', password_pass_token: 't', nested: { page_token: 'p', arr: [{ a_b: 1 }] } }),
+    ).toEqual({ meetingId: 'm1', passwordPassToken: 't', nested: { pageToken: 'p', arr: [{ aB: 1 }] } });
+  });
+
+  it('canonical password_pass_token → passwordPassToken (never passPassToken)', () => {
+    const out = toCamelDeep<{ passwordPassToken?: string; passPassToken?: string }>({ password_pass_token: 'X' });
+    expect(out.passwordPassToken).toBe('X');
+    expect(out.passPassToken).toBeUndefined();
+  });
+
+  it('deep camel → snake omits undefined', () => {
+    expect(toSnakeDeep({ meetingId: 'm', deviceIdHash: 'd', maybe: undefined })).toEqual({
+      meeting_id: 'm',
+      device_id_hash: 'd',
+    });
+  });
+
+  it('decodeEvaluate maps allowed_to_prejoin truth-table fields', () => {
+    const v = decodeEvaluate({
+      eligible: true,
+      meeting_id: 'm1',
+      password_required: false,
+      allowed_to_prejoin: true,
+      version: 3,
+    } as never);
+    expect(v).toEqual({ eligible: true, meetingId: 'm1', passwordRequired: false, allowedToPrejoin: true, version: 3 });
+  });
+
+  it('decodeList maps meetings + next_page_token', () => {
+    const r = decodeList({
+      meetings: [{ meeting_id: 'a', password_enabled: true }],
+      next_page_token: 'nxt',
+    } as never);
+    expect(r.nextPageToken).toBe('nxt');
+    expect(r.meetings[0].meetingId).toBe('a');
+    expect(r.meetings[0].passwordEnabled).toBe(true);
+  });
+
+  it('encodeFinalize produces snake_case wire with pass token field', () => {
+    expect(
+      encodeFinalize({ meetingId: 'm', source: 'link', passwordPassToken: 'tok', deviceIdHash: 'dh', version: 2 }),
+    ).toEqual({ meeting_id: 'm', source: 'link', password_pass_token: 'tok', device_id_hash: 'dh', version: 2 });
+  });
+});
+
+describe('redaction for telemetry/logs (§8, §14)', () => {
+  it('strips passwords and tokens at any depth', () => {
+    const cleaned = redactSensitive({
+      meetingId: 'm',
+      password: '123456',
+      passwordPassToken: 'ppt',
+      nested: { link_token: 'lt', livekitToken: 'lk', ok: 'keep' },
+      list: [{ token: 'z', keep: 1 }],
+    });
+    expect(cleaned).toEqual({ meetingId: 'm', nested: { ok: 'keep' }, list: [{ keep: 1 }] });
+  });
+});

--- a/packages/dmworkmeeting/src/service/adapter.ts
+++ b/packages/dmworkmeeting/src/service/adapter.ts
@@ -1,0 +1,93 @@
+// The ONE place snake_case wire ⇄ camelCase domain conversion happens (§6.3).
+// Nothing else in the module may read a snake_case field. This also centralises
+// redaction so passwords / pass tokens never reach logs or telemetry.
+
+import type {
+  AdmissionEvaluateRequest,
+  AdmissionEvaluateResult,
+  AdmissionFinalizeRequest,
+  AdmissionFinalizeResult,
+  Meeting,
+  MeetingListResult,
+  Participant,
+  PasswordVerifyRequest,
+  PasswordVerifyResult,
+} from './contracts';
+
+type Json = null | boolean | number | string | Json[] | { [k: string]: Json };
+
+const snakeToCamel = (s: string): string => s.replace(/_([a-z0-9])/g, (_, c: string) => c.toUpperCase());
+const camelToSnake = (s: string): string => s.replace(/[A-Z]/g, (c) => `_${c.toLowerCase()}`);
+
+export function toCamelDeep<T = unknown>(input: Json): T {
+  if (Array.isArray(input)) return input.map((v) => toCamelDeep<Json>(v)) as unknown as T;
+  if (input && typeof input === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(input)) out[snakeToCamel(k)] = toCamelDeep(v as Json);
+    return out as T;
+  }
+  return input as unknown as T;
+}
+
+export function toSnakeDeep(input: unknown): Json {
+  if (Array.isArray(input)) return input.map((v) => toSnakeDeep(v));
+  if (input && typeof input === 'object') {
+    const out: Record<string, Json> = {};
+    for (const [k, v] of Object.entries(input as Record<string, unknown>)) {
+      if (v === undefined) continue; // omit undefined so the wire stays clean
+      out[camelToSnake(k)] = toSnakeDeep(v);
+    }
+    return out;
+  }
+  return (input ?? null) as Json;
+}
+
+// ── Typed request encoders. `password` is snake-cased as `password`; the
+//    canonical `password_pass_token` maps to `passwordPassToken` (never
+//    `passPassToken`). ──
+export const encodeEvaluate = (r: AdmissionEvaluateRequest): Json => toSnakeDeep(r);
+export const encodePasswordVerify = (r: PasswordVerifyRequest): Json => toSnakeDeep(r);
+export const encodeFinalize = (r: AdmissionFinalizeRequest): Json => toSnakeDeep(r);
+
+// ── Typed response decoders. ──
+export const decodeMeeting = (w: Json): Meeting => toCamelDeep<Meeting>(w);
+export const decodeParticipant = (w: Json): Participant => toCamelDeep<Participant>(w);
+export const decodeEvaluate = (w: Json): AdmissionEvaluateResult => toCamelDeep<AdmissionEvaluateResult>(w);
+export const decodePasswordVerify = (w: Json): PasswordVerifyResult => toCamelDeep<PasswordVerifyResult>(w);
+export const decodeFinalize = (w: Json): AdmissionFinalizeResult => toCamelDeep<AdmissionFinalizeResult>(w);
+
+export function decodeList(w: Json): MeetingListResult {
+  const obj = (w && typeof w === 'object' && !Array.isArray(w) ? w : {}) as Record<string, Json>;
+  const meetings = Array.isArray(obj.meetings) ? (obj.meetings as Json[]).map(decodeMeeting) : [];
+  const nextPageToken = typeof obj.next_page_token === 'string' ? obj.next_page_token : undefined;
+  return { meetings, nextPageToken };
+}
+
+// Fields that must never appear in logs, telemetry labels, notifications,
+// URLs, screenshots or LiveKit metadata (§8, §14).
+const SENSITIVE_KEYS = new Set([
+  'password',
+  'password_pass_token',
+  'passwordPassToken',
+  'password_challenge_id',
+  'passwordChallengeId',
+  'link_token',
+  'linkToken',
+  'livekit_token',
+  'livekitToken',
+  'token',
+]);
+
+/** Deep-clone with sensitive keys removed — the only shape allowed into telemetry/logs. */
+export function redactSensitive<T>(input: T): T {
+  if (Array.isArray(input)) return input.map((v) => redactSensitive(v)) as unknown as T;
+  if (input && typeof input === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(input as Record<string, unknown>)) {
+      if (SENSITIVE_KEYS.has(k)) continue;
+      out[k] = redactSensitive(v);
+    }
+    return out as T;
+  }
+  return input;
+}

--- a/packages/dmworkmeeting/src/service/contracts.ts
+++ b/packages/dmworkmeeting/src/service/contracts.ts
@@ -108,7 +108,7 @@ export interface AdmissionFinalizeRequest {
   meetingId: string;
   source: AdmissionSource;
   passwordPassToken?: string;
-  deviceIdHash: string;
+  deviceIdHash?: string;
   version?: number; // If-Match carrier for rejoin reconcile
 }
 

--- a/packages/dmworkmeeting/src/service/contracts.ts
+++ b/packages/dmworkmeeting/src/service/contracts.ts
@@ -1,0 +1,158 @@
+// Meeting DTOs and endpoint map.
+//
+// PROVENANCE / BLOCKER: these types are transcribed from the approved design
+// (architecture SHA f0f482c0, frontend appendix §6.3 endpoint mirror). The
+// authoritative artifact is the *service-owned* versioned OpenAPI/error snapshot
+// that XIN-1773 (standalone octo-meeting-service bootstrap) will publish. Until
+// that snapshot exists, `contracts.ts` MUST be treated as provisional: generate
+// or byte-align it against the snapshot, then delete this note. octo-server /
+// dmworkim do NOT own the Meeting contract. Do NOT invent a parallel contract.
+//
+// Wire is snake_case (UTC ISO-8601). Conversion to/from camelCase happens in
+// exactly one place — service/adapter.ts. Components, MSW handlers and contract
+// tests never use a second field-name set.
+
+// ── Canonical service-relative paths (§6.3). The gateway mounts these under
+//    /meeting/api/v1; MeetingApiClient prefixes BASE and the gateway forwards
+//    to octo-meeting-service /v1/... — clients never hit the internal host. ──
+export const MEETING_API_BASE = '/meeting/api/v1';
+
+export const MeetingEndpoint = {
+  quickCreate: '/v1/meetings/quick-create', // the only quick-create; plural
+  create: '/v1/meetings',
+  patch: (id: string) => `/v1/meetings/${id}`,
+  cancel: (id: string) => `/v1/meetings/${id}/cancel`,
+  list: '/v1/meetings', // ?view=upcoming|history&page_size=&page_token=
+  get: (id: string) => `/v1/meetings/${id}`,
+  evaluate: '/v1/meetings/admission/evaluate',
+  passwordVerify: '/v1/meetings/password/verify',
+  finalize: '/v1/meetings/admission/finalize',
+  leave: (id: string) => `/v1/meetings/${id}/participants/me/leave`,
+  role: (id: string, uid: string) => `/v1/meetings/${id}/participants/${uid}/role`,
+  mute: (id: string) => `/v1/meetings/${id}/controls/mute`,
+  removeParticipant: (id: string, uid: string) => `/v1/meetings/${id}/participants/${uid}`,
+  lock: (id: string) => `/v1/meetings/${id}/lock`,
+  end: (id: string) => `/v1/meetings/${id}/end`,
+  share: (id: string) => `/v1/meetings/${id}/share`,
+  invites: (id: string) => `/v1/meetings/${id}/invites`,
+} as const;
+
+export type MeetingStatus = 'scheduled' | 'live' | 'ended' | 'cancelled';
+// No `live_pending`: quick meetings stay `scheduled` until the first successful
+// finalize (FD-05). The frontend never infers status.
+
+export type MeetingRole = 'host' | 'cohost' | 'member'; // H / C / M
+export type AdmissionSource = 'list' | 'number' | 'link' | 'rejoin';
+export type MeetingEndReason = 'empty_timeout' | 'no_show' | 'host_end' | 'cancelled';
+
+// ── Domain (camelCase) — the only shape components/hooks see. ──
+export interface Meeting {
+  meetingId: string;
+  meetingNumber?: string;
+  title: string;
+  status: MeetingStatus;
+  version: number;
+  passwordEnabled: boolean;
+  scheduledStartAt?: string; // UTC ISO-8601
+  scheduledEndAt?: string;
+  maxParticipants?: number;
+  role?: MeetingRole;
+  joinLink?: string; // only returned to authorized callers under service policy
+  createdBy?: string;
+}
+
+export interface Participant {
+  uid: string;
+  displayName?: string;
+  role: MeetingRole;
+  joinAt?: string;
+  muted?: boolean;
+  sharing?: boolean;
+  superseded?: boolean;
+  leftAt?: string;
+}
+
+// evaluate — one credential of {meetingId | meetingNumber | linkToken}.
+export interface AdmissionEvaluateRequest {
+  source: AdmissionSource;
+  meetingId?: string;
+  meetingNumber?: string;
+  linkToken?: string;
+  deviceIdHash?: string;
+}
+
+// eligible response. Ineligible responses surface a MeetingErrorCode instead and
+// NEVER echo meetingId / passwordRequired (FD-27).
+export interface AdmissionEvaluateResult {
+  eligible: boolean;
+  meetingId?: string;
+  passwordRequired?: boolean;
+  passwordChallengeId?: string;
+  allowedToPrejoin?: boolean; // = eligible AND NOT passwordRequired (N1)
+  version?: number;
+  earliestJoinAt?: string; // scheduled_start_at - 600s, when TOO_EARLY
+}
+
+export interface PasswordVerifyRequest {
+  meetingId: string;
+  passwordChallengeId: string;
+  password: string; // 6 digits; never persisted anywhere
+}
+
+export interface PasswordVerifyResult {
+  passwordPassToken: string; // memory only; consumed on successful finalize
+  expiresAt: string;
+}
+
+export interface AdmissionFinalizeRequest {
+  meetingId: string;
+  source: AdmissionSource;
+  passwordPassToken?: string;
+  deviceIdHash: string;
+  version?: number; // If-Match carrier for rejoin reconcile
+}
+
+export interface AdmissionFinalizeResult {
+  livekitUrl: string;
+  livekitToken: string;
+  segmentId: string;
+  role: MeetingRole;
+}
+
+export interface MeetingListResult {
+  meetings: Meeting[];
+  nextPageToken?: string;
+}
+
+export interface QuickCreateRequest {
+  title?: string;
+  passwordEnabled?: boolean;
+  password?: string; // 6 digits; adapter drops it from any log/telemetry
+}
+
+export interface ScheduleCreateRequest {
+  title: string;
+  scheduledStartAt: string;
+  scheduledEndAt?: string;
+  passwordEnabled?: boolean;
+  password?: string;
+  maxParticipants?: number;
+  inviteeUids?: string[];
+}
+
+// Canonical wire error envelope (§6.4). Absence of `code` on a 404 is the
+// gateway-route-missing signal (§6.2), distinct from CREDENTIAL_INVALID.
+export interface WireError {
+  code?: string;
+  message?: string;
+  request_id?: string;
+  attempts_remaining?: number;
+  retry_at?: string;
+  retry_after?: number;
+  earliest_join_at?: string;
+  holder_uid?: string;
+  max_participants?: number;
+  server_now?: string;
+  expires_at?: string;
+  password_challenge_id?: string;
+}

--- a/packages/dmworkmeeting/src/service/errors.test.ts
+++ b/packages/dmworkmeeting/src/service/errors.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import {
+  MEETING_ERROR_TABLE,
+  MeetingErrorCode,
+  directiveForCode,
+  isMeetingErrorCode,
+} from './errors';
+
+describe('error taxonomy (§6.4)', () => {
+  it('has exactly 24 codes and no generic final-recheck code (FD-32)', () => {
+    const codes = Object.keys(MEETING_ERROR_TABLE);
+    expect(codes).toHaveLength(24);
+    expect(codes).not.toContain('MEETING_FINAL_RECHECK_FAILED');
+  });
+
+  it('every code maps to a directive with the documented HTTP status', () => {
+    const expectedStatus: Record<MeetingErrorCode, number> = {
+      MEETING_AUTH_REQUIRED: 401,
+      MEETING_CREDENTIAL_INVALID: 404,
+      MEETING_ENDED: 410,
+      MEETING_CANCELLED: 410,
+      MEETING_TOO_EARLY: 409,
+      MEETING_LOCKED: 423,
+      MEETING_FULL: 409,
+      MEETING_REMOVED: 403,
+      MEETING_NOT_SAME_SPACE: 403,
+      MEETING_PASSWORD_REQUIRED: 428,
+      MEETING_PASSWORD_FORMAT_INVALID: 422,
+      MEETING_PASSWORD_INVALID: 401,
+      MEETING_PASSWORD_COOLDOWN: 429,
+      MEETING_PASSWORD_PASS_EXPIRED: 401,
+      MEETING_PASSWORD_IMMUTABLE: 409,
+      MEETING_FORBIDDEN: 403,
+      MEETING_VERSION_CONFLICT: 409,
+      MEETING_IDEMPOTENCY_CONFLICT: 409,
+      MEETING_SHARE_CONFLICT: 409,
+      MEETING_LIVEKIT_UNAVAILABLE: 503,
+      MEETING_NOTIFICATION_DEFERRED: 202,
+      MEETING_TIME_INVALID: 422,
+      MEETING_RATE_LIMITED: 429,
+      MEETING_INTERNAL: 500,
+    };
+    for (const [code, status] of Object.entries(expectedStatus)) {
+      expect(directiveForCode(code as MeetingErrorCode).httpStatus).toBe(status);
+    }
+  });
+
+  it('only PASSWORD_INVALID consumes a password attempt', () => {
+    const counting = Object.values(MEETING_ERROR_TABLE).filter((d) => d.countsPasswordAttempt);
+    expect(counting).toHaveLength(1);
+    expect(counting[0].code).toBe(MeetingErrorCode.PASSWORD_INVALID);
+  });
+
+  it('terminal codes are ENDED / CANCELLED / REMOVED only', () => {
+    const terminal = Object.values(MEETING_ERROR_TABLE).filter((d) => d.terminal).map((d) => d.code).sort();
+    expect(terminal).toEqual(
+      [MeetingErrorCode.ENDED, MeetingErrorCode.CANCELLED, MeetingErrorCode.REMOVED].sort(),
+    );
+  });
+
+  it('key branch actions are wired correctly', () => {
+    expect(directiveForCode(MeetingErrorCode.AUTH_REQUIRED).action).toBe('LOGOUT');
+    expect(directiveForCode(MeetingErrorCode.CREDENTIAL_INVALID).action).toBe('SHOW_INVALID');
+    expect(directiveForCode(MeetingErrorCode.LIVEKIT_UNAVAILABLE).action).toBe('RETRY_FINALIZE');
+    expect(directiveForCode(MeetingErrorCode.PASSWORD_PASS_EXPIRED).action).toBe('RESTART_CHALLENGE');
+    expect(directiveForCode(MeetingErrorCode.VERSION_CONFLICT).action).toBe('REFETCH_RECONCILE');
+    expect(directiveForCode(MeetingErrorCode.IDEMPOTENCY_CONFLICT).action).toBe('STOP_RETRY');
+  });
+
+  it('every directive carries a meeting.error.* i18n key', () => {
+    for (const d of Object.values(MEETING_ERROR_TABLE)) {
+      expect(d.i18nKey.startsWith('meeting.error.')).toBe(true);
+    }
+  });
+
+  it('isMeetingErrorCode narrows only known codes', () => {
+    expect(isMeetingErrorCode('MEETING_LOCKED')).toBe(true);
+    expect(isMeetingErrorCode('MEETING_FINAL_RECHECK_FAILED')).toBe(false);
+    expect(isMeetingErrorCode(undefined)).toBe(false);
+  });
+});

--- a/packages/dmworkmeeting/src/service/errors.ts
+++ b/packages/dmworkmeeting/src/service/errors.ts
@@ -1,0 +1,133 @@
+// Meeting error taxonomy — a verbatim mirror of the standalone octo-meeting-service
+// contract (架构总纲 §7.3, frontend appendix §6.4). Codes are NEVER renamed,
+// abbreviated or merged on the frontend; there is no generic final-recheck code
+// (the removed MEETING_FINAL_RECHECK_FAILED is intentionally absent — FD-32).
+//
+// PROVENANCE / BLOCKER: the strings below are transcribed from the approved
+// design (architecture SHA f0f482c0). They MUST be reconciled byte-for-byte
+// against the service-owned versioned OpenAPI/error snapshot published by
+// XIN-1773 before typed-contract integration is considered complete. Contract
+// tests assert only against codes present in that snapshot; see contracts.ts.
+
+export const MeetingErrorCode = {
+  AUTH_REQUIRED: 'MEETING_AUTH_REQUIRED',
+  CREDENTIAL_INVALID: 'MEETING_CREDENTIAL_INVALID',
+  ENDED: 'MEETING_ENDED',
+  CANCELLED: 'MEETING_CANCELLED',
+  TOO_EARLY: 'MEETING_TOO_EARLY',
+  LOCKED: 'MEETING_LOCKED',
+  FULL: 'MEETING_FULL',
+  REMOVED: 'MEETING_REMOVED',
+  NOT_SAME_SPACE: 'MEETING_NOT_SAME_SPACE',
+  PASSWORD_REQUIRED: 'MEETING_PASSWORD_REQUIRED',
+  PASSWORD_FORMAT_INVALID: 'MEETING_PASSWORD_FORMAT_INVALID',
+  PASSWORD_INVALID: 'MEETING_PASSWORD_INVALID',
+  PASSWORD_COOLDOWN: 'MEETING_PASSWORD_COOLDOWN',
+  PASSWORD_PASS_EXPIRED: 'MEETING_PASSWORD_PASS_EXPIRED',
+  PASSWORD_IMMUTABLE: 'MEETING_PASSWORD_IMMUTABLE',
+  FORBIDDEN: 'MEETING_FORBIDDEN',
+  VERSION_CONFLICT: 'MEETING_VERSION_CONFLICT',
+  IDEMPOTENCY_CONFLICT: 'MEETING_IDEMPOTENCY_CONFLICT',
+  SHARE_CONFLICT: 'MEETING_SHARE_CONFLICT',
+  LIVEKIT_UNAVAILABLE: 'MEETING_LIVEKIT_UNAVAILABLE',
+  NOTIFICATION_DEFERRED: 'MEETING_NOTIFICATION_DEFERRED',
+  TIME_INVALID: 'MEETING_TIME_INVALID',
+  RATE_LIMITED: 'MEETING_RATE_LIMITED',
+  INTERNAL: 'MEETING_INTERNAL',
+} as const;
+
+export type MeetingErrorCode = (typeof MeetingErrorCode)[keyof typeof MeetingErrorCode];
+
+// Frontend directive — the single action the UI takes for a given code. Every
+// component/state branch consumes this rather than switching on raw codes, so
+// the code→behaviour mapping lives in exactly one place.
+export type MeetingErrorAction =
+  | 'LOGOUT' // fail closed → reauth
+  | 'SHOW_INVALID' // credential invalid; MUST NOT reveal password entry (S-1)
+  | 'TERMINAL_ENDED'
+  | 'TERMINAL_CANCELLED'
+  | 'TERMINAL_REMOVED'
+  | 'SHOW_TOO_EARLY'
+  | 'SHOW_LOCKED'
+  | 'SHOW_FULL'
+  | 'SWITCH_SPACE'
+  | 'SHOW_PASSWORD_CHALLENGE'
+  | 'FOCUS_PASSWORD_FORMAT' // does NOT consume an attempt
+  | 'SHOW_PASSWORD_INVALID' // consumes an attempt; 5th → cooldown
+  | 'SHOW_COOLDOWN'
+  | 'RESTART_CHALLENGE'
+  | 'DISABLE_PASSWORD_EDIT'
+  | 'REFRESH_CAPABILITY'
+  | 'REFETCH_RECONCILE'
+  | 'STOP_RETRY'
+  | 'SHOW_SHARE_CONFLICT'
+  | 'RETRY_FINALIZE' // keep PreJoin + pass_token; do NOT return to challenge
+  | 'WARN_NON_BLOCKING'
+  | 'HIGHLIGHT_TIME'
+  | 'RATE_LIMIT_COUNTDOWN'
+  | 'GENERIC_RETRY';
+
+export interface MeetingErrorDirective {
+  code: MeetingErrorCode;
+  httpStatus: number;
+  action: MeetingErrorAction;
+  /** i18n key under the `meeting.error.*` namespace. */
+  i18nKey: string;
+  /** Enters an unrecoverable terminal state. */
+  terminal: boolean;
+  /** The UI may retry (bounded by retry_at/retry_after). */
+  retriable: boolean;
+  /** A wrong-password attempt that consumes one of the 5 tries. */
+  countsPasswordAttempt: boolean;
+}
+
+const D = (
+  code: MeetingErrorCode,
+  httpStatus: number,
+  action: MeetingErrorAction,
+  i18nKey: string,
+  opts: Partial<Pick<MeetingErrorDirective, 'terminal' | 'retriable' | 'countsPasswordAttempt'>> = {},
+): MeetingErrorDirective => ({
+  code,
+  httpStatus,
+  action,
+  i18nKey,
+  terminal: opts.terminal ?? false,
+  retriable: opts.retriable ?? false,
+  countsPasswordAttempt: opts.countsPasswordAttempt ?? false,
+});
+
+export const MEETING_ERROR_TABLE: Record<MeetingErrorCode, MeetingErrorDirective> = {
+  [MeetingErrorCode.AUTH_REQUIRED]: D(MeetingErrorCode.AUTH_REQUIRED, 401, 'LOGOUT', 'meeting.error.authRequired'),
+  [MeetingErrorCode.CREDENTIAL_INVALID]: D(MeetingErrorCode.CREDENTIAL_INVALID, 404, 'SHOW_INVALID', 'meeting.error.credentialInvalid'),
+  [MeetingErrorCode.ENDED]: D(MeetingErrorCode.ENDED, 410, 'TERMINAL_ENDED', 'meeting.error.ended', { terminal: true }),
+  [MeetingErrorCode.CANCELLED]: D(MeetingErrorCode.CANCELLED, 410, 'TERMINAL_CANCELLED', 'meeting.error.cancelled', { terminal: true }),
+  [MeetingErrorCode.TOO_EARLY]: D(MeetingErrorCode.TOO_EARLY, 409, 'SHOW_TOO_EARLY', 'meeting.error.tooEarly', { retriable: true }),
+  [MeetingErrorCode.LOCKED]: D(MeetingErrorCode.LOCKED, 423, 'SHOW_LOCKED', 'meeting.error.locked', { retriable: true }),
+  [MeetingErrorCode.FULL]: D(MeetingErrorCode.FULL, 409, 'SHOW_FULL', 'meeting.error.full', { retriable: true }),
+  [MeetingErrorCode.REMOVED]: D(MeetingErrorCode.REMOVED, 403, 'TERMINAL_REMOVED', 'meeting.error.removed', { terminal: true }),
+  [MeetingErrorCode.NOT_SAME_SPACE]: D(MeetingErrorCode.NOT_SAME_SPACE, 403, 'SWITCH_SPACE', 'meeting.error.notSameSpace'),
+  [MeetingErrorCode.PASSWORD_REQUIRED]: D(MeetingErrorCode.PASSWORD_REQUIRED, 428, 'SHOW_PASSWORD_CHALLENGE', 'meeting.error.passwordRequired'),
+  [MeetingErrorCode.PASSWORD_FORMAT_INVALID]: D(MeetingErrorCode.PASSWORD_FORMAT_INVALID, 422, 'FOCUS_PASSWORD_FORMAT', 'meeting.error.passwordFormatInvalid'),
+  [MeetingErrorCode.PASSWORD_INVALID]: D(MeetingErrorCode.PASSWORD_INVALID, 401, 'SHOW_PASSWORD_INVALID', 'meeting.error.passwordInvalid', { countsPasswordAttempt: true }),
+  [MeetingErrorCode.PASSWORD_COOLDOWN]: D(MeetingErrorCode.PASSWORD_COOLDOWN, 429, 'SHOW_COOLDOWN', 'meeting.error.passwordCooldown', { retriable: true }),
+  [MeetingErrorCode.PASSWORD_PASS_EXPIRED]: D(MeetingErrorCode.PASSWORD_PASS_EXPIRED, 401, 'RESTART_CHALLENGE', 'meeting.error.passwordPassExpired'),
+  [MeetingErrorCode.PASSWORD_IMMUTABLE]: D(MeetingErrorCode.PASSWORD_IMMUTABLE, 409, 'DISABLE_PASSWORD_EDIT', 'meeting.error.passwordImmutable'),
+  [MeetingErrorCode.FORBIDDEN]: D(MeetingErrorCode.FORBIDDEN, 403, 'REFRESH_CAPABILITY', 'meeting.error.forbidden'),
+  [MeetingErrorCode.VERSION_CONFLICT]: D(MeetingErrorCode.VERSION_CONFLICT, 409, 'REFETCH_RECONCILE', 'meeting.error.versionConflict'),
+  [MeetingErrorCode.IDEMPOTENCY_CONFLICT]: D(MeetingErrorCode.IDEMPOTENCY_CONFLICT, 409, 'STOP_RETRY', 'meeting.error.idempotencyConflict'),
+  [MeetingErrorCode.SHARE_CONFLICT]: D(MeetingErrorCode.SHARE_CONFLICT, 409, 'SHOW_SHARE_CONFLICT', 'meeting.error.shareConflict'),
+  [MeetingErrorCode.LIVEKIT_UNAVAILABLE]: D(MeetingErrorCode.LIVEKIT_UNAVAILABLE, 503, 'RETRY_FINALIZE', 'meeting.error.livekitUnavailable', { retriable: true }),
+  [MeetingErrorCode.NOTIFICATION_DEFERRED]: D(MeetingErrorCode.NOTIFICATION_DEFERRED, 202, 'WARN_NON_BLOCKING', 'meeting.error.notificationDeferred'),
+  [MeetingErrorCode.TIME_INVALID]: D(MeetingErrorCode.TIME_INVALID, 422, 'HIGHLIGHT_TIME', 'meeting.error.timeInvalid'),
+  [MeetingErrorCode.RATE_LIMITED]: D(MeetingErrorCode.RATE_LIMITED, 429, 'RATE_LIMIT_COUNTDOWN', 'meeting.error.rateLimited', { retriable: true }),
+  [MeetingErrorCode.INTERNAL]: D(MeetingErrorCode.INTERNAL, 500, 'GENERIC_RETRY', 'meeting.error.internal', { retriable: true }),
+};
+
+export function isMeetingErrorCode(code: unknown): code is MeetingErrorCode {
+  return typeof code === 'string' && Object.prototype.hasOwnProperty.call(MEETING_ERROR_TABLE, code);
+}
+
+export function directiveForCode(code: MeetingErrorCode): MeetingErrorDirective {
+  return MEETING_ERROR_TABLE[code];
+}

--- a/packages/dmworkmeeting/src/service/failClosed.test.ts
+++ b/packages/dmworkmeeting/src/service/failClosed.test.ts
@@ -6,48 +6,48 @@ import {
 } from './failClosed';
 import { MeetingErrorCode } from './errors';
 
-const axiosErr = (status: number, data?: unknown) => ({ isAxiosError: true, response: { status, data } });
+const httpErr = (status: number, data?: unknown) => ({ response: { status, data } });
 
 describe('canonical error extraction', () => {
   it('extracts a known MEETING_* code', () => {
-    const c = extractCanonicalError(axiosErr(423, { code: 'MEETING_LOCKED' }));
+    const c = extractCanonicalError(httpErr(423, { code: 'MEETING_LOCKED' }));
     expect(c.code).toBe(MeetingErrorCode.LOCKED);
     expect(c.httpStatus).toBe(423);
   });
   it('ignores an unknown code', () => {
-    expect(extractCanonicalError(axiosErr(404, { code: 'SOMETHING_ELSE' })).code).toBeUndefined();
+    expect(extractCanonicalError(httpErr(404, { code: 'SOMETHING_ELSE' })).code).toBeUndefined();
   });
 });
 
 describe('fail-closed classification (§6.2)', () => {
   it('401 → auth (logout)', () => {
-    expect(classifyFailure(axiosErr(401)).kind).toBe('auth');
-    expect(classifyFailure(axiosErr(401, { code: 'MEETING_AUTH_REQUIRED' })).kind).toBe('auth');
+    expect(classifyFailure(httpErr(401)).kind).toBe('auth');
+    expect(classifyFailure(httpErr(401, { code: 'MEETING_AUTH_REQUIRED' })).kind).toBe('auth');
   });
 
   it('canonical CREDENTIAL_INVALID (404 WITH code) → canonical, NOT gateway-missing (S-1)', () => {
-    const d = classifyFailure(axiosErr(404, { code: 'MEETING_CREDENTIAL_INVALID' }));
+    const d = classifyFailure(httpErr(404, { code: 'MEETING_CREDENTIAL_INVALID' }));
     expect(d.kind).toBe('canonical');
     expect(d.code).toBe(MeetingErrorCode.CREDENTIAL_INVALID);
   });
 
   it('404 WITHOUT code → gateway-missing (feature not enabled)', () => {
-    expect(classifyFailure(axiosErr(404, { message: 'not found' })).kind).toBe('gateway-missing');
-    expect(classifyFailure(axiosErr(404)).kind).toBe('gateway-missing');
+    expect(classifyFailure(httpErr(404, { message: 'not found' })).kind).toBe('gateway-missing');
+    expect(classifyFailure(httpErr(404)).kind).toBe('gateway-missing');
   });
 
   it('NOT_SAME_SPACE → space', () => {
-    expect(classifyFailure(axiosErr(403, { code: 'MEETING_NOT_SAME_SPACE' })).kind).toBe('space');
+    expect(classifyFailure(httpErr(403, { code: 'MEETING_NOT_SAME_SPACE' })).kind).toBe('space');
   });
 
   it('LIVEKIT_UNAVAILABLE → service-unavailable with retry_after', () => {
-    const d = classifyFailure(axiosErr(503, { code: 'MEETING_LIVEKIT_UNAVAILABLE', retry_after: 7 }));
+    const d = classifyFailure(httpErr(503, { code: 'MEETING_LIVEKIT_UNAVAILABLE', retry_after: 7 }));
     expect(d.kind).toBe('service-unavailable');
     expect(d.retryAfter).toBe(7);
   });
 
   it('bare 503 → service-unavailable', () => {
-    expect(classifyFailure(axiosErr(503)).kind).toBe('service-unavailable');
+    expect(classifyFailure(httpErr(503)).kind).toBe('service-unavailable');
   });
 
   it('missing token is detected before any request', () => {

--- a/packages/dmworkmeeting/src/service/failClosed.test.ts
+++ b/packages/dmworkmeeting/src/service/failClosed.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import {
+  classifyFailure,
+  extractCanonicalError,
+  hasNoToken,
+} from './failClosed';
+import { MeetingErrorCode } from './errors';
+
+const axiosErr = (status: number, data?: unknown) => ({ isAxiosError: true, response: { status, data } });
+
+describe('canonical error extraction', () => {
+  it('extracts a known MEETING_* code', () => {
+    const c = extractCanonicalError(axiosErr(423, { code: 'MEETING_LOCKED' }));
+    expect(c.code).toBe(MeetingErrorCode.LOCKED);
+    expect(c.httpStatus).toBe(423);
+  });
+  it('ignores an unknown code', () => {
+    expect(extractCanonicalError(axiosErr(404, { code: 'SOMETHING_ELSE' })).code).toBeUndefined();
+  });
+});
+
+describe('fail-closed classification (§6.2)', () => {
+  it('401 → auth (logout)', () => {
+    expect(classifyFailure(axiosErr(401)).kind).toBe('auth');
+    expect(classifyFailure(axiosErr(401, { code: 'MEETING_AUTH_REQUIRED' })).kind).toBe('auth');
+  });
+
+  it('canonical CREDENTIAL_INVALID (404 WITH code) → canonical, NOT gateway-missing (S-1)', () => {
+    const d = classifyFailure(axiosErr(404, { code: 'MEETING_CREDENTIAL_INVALID' }));
+    expect(d.kind).toBe('canonical');
+    expect(d.code).toBe(MeetingErrorCode.CREDENTIAL_INVALID);
+  });
+
+  it('404 WITHOUT code → gateway-missing (feature not enabled)', () => {
+    expect(classifyFailure(axiosErr(404, { message: 'not found' })).kind).toBe('gateway-missing');
+    expect(classifyFailure(axiosErr(404)).kind).toBe('gateway-missing');
+  });
+
+  it('NOT_SAME_SPACE → space', () => {
+    expect(classifyFailure(axiosErr(403, { code: 'MEETING_NOT_SAME_SPACE' })).kind).toBe('space');
+  });
+
+  it('LIVEKIT_UNAVAILABLE → service-unavailable with retry_after', () => {
+    const d = classifyFailure(axiosErr(503, { code: 'MEETING_LIVEKIT_UNAVAILABLE', retry_after: 7 }));
+    expect(d.kind).toBe('service-unavailable');
+    expect(d.retryAfter).toBe(7);
+  });
+
+  it('bare 503 → service-unavailable', () => {
+    expect(classifyFailure(axiosErr(503)).kind).toBe('service-unavailable');
+  });
+
+  it('missing token is detected before any request', () => {
+    expect(hasNoToken(undefined)).toBe(true);
+    expect(hasNoToken('')).toBe(true);
+    expect(hasNoToken('tok')).toBe(false);
+  });
+});

--- a/packages/dmworkmeeting/src/service/failClosed.ts
+++ b/packages/dmworkmeeting/src/service/failClosed.ts
@@ -1,0 +1,80 @@
+// Fail-closed classification (§6.2). Any identity / Space / service uncertainty
+// refuses entry to Meeting business — never degrades to a default uid/org and
+// never leaks password-protection state.
+
+import type { WireError } from './contracts';
+import { MeetingErrorCode, isMeetingErrorCode } from './errors';
+
+export interface AxiosLikeError {
+  response?: { status?: number; data?: WireError | unknown };
+  isAxiosError?: boolean;
+  message?: string;
+}
+
+export interface CanonicalError {
+  /** Canonical MEETING_* code, when the service returned a structured error. */
+  code?: MeetingErrorCode;
+  httpStatus?: number;
+  wire?: WireError;
+}
+
+export type FailClosedKind =
+  | 'auth' // missing/expired token or 401 → logout, no business entry
+  | 'space' // Space verify failure → switch space / no content, no password state
+  | 'service-unavailable' // 503 / readiness / livekit unavailable → ServiceUnavailable, retry by retry_after
+  | 'gateway-missing' // 404 without canonical code → feature not enabled / hide tab
+  | 'canonical' // structured MEETING_* error → hand to the error table
+  | 'unknown';
+
+export interface FailClosedDecision {
+  kind: FailClosedKind;
+  code?: MeetingErrorCode;
+  /** For service-unavailable, seconds to wait before retry (from retry_after). */
+  retryAfter?: number;
+}
+
+export function extractCanonicalError(err: unknown): CanonicalError {
+  const e = err as AxiosLikeError;
+  const status = e?.response?.status;
+  const data = e?.response?.data as WireError | undefined;
+  const rawCode = data && typeof data === 'object' ? (data as WireError).code : undefined;
+  return {
+    code: isMeetingErrorCode(rawCode) ? rawCode : undefined,
+    httpStatus: status,
+    wire: data && typeof data === 'object' ? (data as WireError) : undefined,
+  };
+}
+
+/**
+ * Classify a request failure into a fail-closed decision.
+ *
+ * Ordering matters: a 404 that carries a canonical MEETING_CREDENTIAL_INVALID is
+ * a real "invalid credential" (S-1 oracle) and must NOT be confused with a
+ * gateway route that is simply not mounted (404 without any `code`).
+ */
+export function classifyFailure(err: unknown): FailClosedDecision {
+  const { code, httpStatus, wire } = extractCanonicalError(err);
+
+  // Structured canonical error → route through the error table.
+  if (code) {
+    if (code === MeetingErrorCode.AUTH_REQUIRED) return { kind: 'auth', code };
+    if (code === MeetingErrorCode.NOT_SAME_SPACE) return { kind: 'space', code };
+    if (code === MeetingErrorCode.LIVEKIT_UNAVAILABLE) {
+      return { kind: 'service-unavailable', code, retryAfter: wire?.retry_after };
+    }
+    return { kind: 'canonical', code };
+  }
+
+  if (httpStatus === 401) return { kind: 'auth' };
+  if (httpStatus === 403) return { kind: 'space' };
+  if (httpStatus === 503) return { kind: 'service-unavailable', retryAfter: wire?.retry_after };
+  // 404 with no canonical code → gateway route missing / feature not enabled.
+  if (httpStatus === 404) return { kind: 'gateway-missing' };
+
+  return { kind: 'unknown' };
+}
+
+/** True when there is no usable token — refuse business entry before any request. */
+export function hasNoToken(token: string | undefined | null): boolean {
+  return !token;
+}

--- a/packages/dmworkmeeting/src/service/failClosed.ts
+++ b/packages/dmworkmeeting/src/service/failClosed.ts
@@ -5,9 +5,8 @@
 import type { WireError } from './contracts';
 import { MeetingErrorCode, isMeetingErrorCode } from './errors';
 
-export interface AxiosLikeError {
+export interface HttpLikeError {
   response?: { status?: number; data?: WireError | unknown };
-  isAxiosError?: boolean;
   message?: string;
 }
 
@@ -34,7 +33,7 @@ export interface FailClosedDecision {
 }
 
 export function extractCanonicalError(err: unknown): CanonicalError {
-  const e = err as AxiosLikeError;
+  const e = err as HttpLikeError;
   const status = e?.response?.status;
   const data = e?.response?.data as WireError | undefined;
   const rawCode = data && typeof data === 'object' ? (data as WireError).code : undefined;

--- a/packages/dmworkmeeting/src/service/failClosed.ts
+++ b/packages/dmworkmeeting/src/service/failClosed.ts
@@ -52,6 +52,12 @@ export function extractCanonicalError(err: unknown): CanonicalError {
  * gateway route that is simply not mounted (404 without any `code`).
  */
 export function classifyFailure(err: unknown): FailClosedDecision {
+  // A 2xx whose body was not a JSON object (SPA index.html fallback) fails
+  // closed as a missing gateway route rather than being trusted.
+  if ((err as { nonObjectBody?: boolean })?.nonObjectBody) {
+    return { kind: 'gateway-missing' };
+  }
+
   const { code, httpStatus, wire } = extractCanonicalError(err);
 
   // Structured canonical error → route through the error table.

--- a/packages/dmworkmeeting/src/state/livekitRoom.ts
+++ b/packages/dmworkmeeting/src/state/livekitRoom.ts
@@ -1,0 +1,49 @@
+// LiveKit media layer — [proposed] per frontend appendix §9. Business admission
+// is ALWAYS decided by evaluate/finalize; SDK media (re)connection is never an
+// admission authority. The client is React-17-safe: we use the framework-neutral
+// `livekit-client` (NOT @livekit/components-react v2, which is React-18-only),
+// loaded lazily so this package and its tests build before the dependency is
+// added under NOTICE/SBOM review.
+
+export interface LiveKitConnectArgs {
+  url: string;
+  token: string;
+}
+
+export interface LiveKitRoomHandle {
+  disconnect: () => Promise<void>;
+  isConnected: () => boolean;
+}
+
+// A string specifier keeps the bundler/typechecker from requiring the SDK to be
+// installed at build time; the import resolves at runtime once the dependency
+// is added (see package.json follow-up).
+const LIVEKIT_MODULE = 'livekit-client';
+
+export async function loadLiveKit(): Promise<Record<string, unknown> | null> {
+  try {
+    return (await import(/* @vite-ignore */ LIVEKIT_MODULE)) as Record<string, unknown>;
+  } catch {
+    // SDK not yet installed → caller surfaces MEETING_LIVEKIT_UNAVAILABLE UX.
+    return null;
+  }
+}
+
+/**
+ * Connect only AFTER a successful finalize returned a livekit_url + token.
+ * PreJoin never connects. On leave/end/removed/superseded, disconnect() releases
+ * tracks. Returns null when the SDK is unavailable so the caller can render the
+ * fail-closed media state without crashing.
+ */
+export async function connectRoom(args: LiveKitConnectArgs): Promise<LiveKitRoomHandle | null> {
+  const sdk = await loadLiveKit();
+  if (!sdk) return null;
+  const RoomCtor = sdk.Room as (new () => { connect: (u: string, t: string) => Promise<void>; disconnect: () => Promise<void>; state?: string }) | undefined;
+  if (!RoomCtor) return null;
+  const room = new RoomCtor();
+  await room.connect(args.url, args.token);
+  return {
+    disconnect: () => room.disconnect(),
+    isConnected: () => room.state === 'connected',
+  };
+}

--- a/packages/dmworkmeeting/src/state/livekitRoom.ts
+++ b/packages/dmworkmeeting/src/state/livekitRoom.ts
@@ -1,9 +1,15 @@
 // LiveKit media layer — [proposed] per frontend appendix §9. Business admission
 // is ALWAYS decided by evaluate/finalize; SDK media (re)connection is never an
-// admission authority. The client is React-17-safe: we use the framework-neutral
-// `livekit-client` (NOT @livekit/components-react v2, which is React-18-only),
-// loaded lazily so this package and its tests build before the dependency is
-// added under NOTICE/SBOM review.
+// admission authority. React-17-safe: framework-neutral `livekit-client`, NOT
+// @livekit/components-react v2.
+//
+// The `livekit-client` dependency is NOT installed in this PR (it is a deferred
+// blocker pending NOTICE/SBOM review). Until it lands, connectRoom resolves
+// `null` and JoinFlow surfaces an explicit "media unavailable" state with greyed
+// controls (it never presents the room as connected). When the dependency is
+// added, replace the guarded loader below with a static `import('livekit-client')`
+// so Vite code-splits it — a bare *variable* specifier cannot be resolved by the
+// browser and must not be relied upon.
 
 export interface LiveKitConnectArgs {
   url: string;
@@ -15,35 +21,45 @@ export interface LiveKitRoomHandle {
   isConnected: () => boolean;
 }
 
-// A string specifier keeps the bundler/typechecker from requiring the SDK to be
-// installed at build time; the import resolves at runtime once the dependency
-// is added (see package.json follow-up).
-const LIVEKIT_MODULE = 'livekit-client';
+/** Returns the SDK module when installed, else null. Overridable in tests. */
+let _loadLiveKit: () => Promise<Record<string, unknown> | null> = async () => {
+  // Intentionally returns null until `livekit-client` is added as a dependency
+  // (deferred: NOTICE/SBOM). Swapped for `() => import('livekit-client')` then.
+  return null;
+};
+
+export function __setLiveKitLoader(fn: () => Promise<Record<string, unknown> | null>): void {
+  _loadLiveKit = fn;
+}
 
 export async function loadLiveKit(): Promise<Record<string, unknown> | null> {
   try {
-    return (await import(/* @vite-ignore */ LIVEKIT_MODULE)) as Record<string, unknown>;
+    return await _loadLiveKit();
   } catch {
-    // SDK not yet installed → caller surfaces MEETING_LIVEKIT_UNAVAILABLE UX.
     return null;
   }
 }
 
 /**
  * Connect only AFTER a successful finalize returned a livekit_url + token.
- * PreJoin never connects. On leave/end/removed/superseded, disconnect() releases
- * tracks. Returns null when the SDK is unavailable so the caller can render the
- * fail-closed media state without crashing.
+ * PreJoin never connects. Returns null when the SDK is unavailable OR the
+ * connection fails, so the caller renders the fail-closed media state without
+ * crashing and without falsely showing a connected room.
  */
 export async function connectRoom(args: LiveKitConnectArgs): Promise<LiveKitRoomHandle | null> {
   const sdk = await loadLiveKit();
   if (!sdk) return null;
   const RoomCtor = sdk.Room as (new () => { connect: (u: string, t: string) => Promise<void>; disconnect: () => Promise<void>; state?: string }) | undefined;
   if (!RoomCtor) return null;
-  const room = new RoomCtor();
-  await room.connect(args.url, args.token);
-  return {
-    disconnect: () => room.disconnect(),
-    isConnected: () => room.state === 'connected',
-  };
+  try {
+    const room = new RoomCtor();
+    await room.connect(args.url, args.token);
+    return {
+      disconnect: () => room.disconnect(),
+      isConnected: () => room.state === 'connected',
+    };
+  } catch {
+    // A connect failure is surfaced as "media unavailable", not a crash.
+    return null;
+  }
 }

--- a/packages/dmworkmeeting/src/state/nav.test.ts
+++ b/packages/dmworkmeeting/src/state/nav.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { parseJoinQuery } from './nav';
+
+describe('parseJoinQuery — cold-load / back-forward deep links (#3, §4)', () => {
+  it('extracts link_token (source=link)', () => {
+    expect(parseJoinQuery('?link_token=abc')).toEqual({ source: 'link', linkToken: 'abc' });
+  });
+  it('extracts meeting_number (source=number)', () => {
+    expect(parseJoinQuery('?meeting_number=90210')).toEqual({ source: 'number', meetingNumber: '90210' });
+  });
+  it('accepts the short ?number= alias', () => {
+    expect(parseJoinQuery('?number=555')).toEqual({ source: 'number', meetingNumber: '555' });
+  });
+  it('prefers link_token over number when both present', () => {
+    expect(parseJoinQuery('?link_token=t&meeting_number=1')).toEqual({ source: 'link', linkToken: 't' });
+  });
+  it('never carries a password even if present in the query', () => {
+    const r = parseJoinQuery('?meeting_number=1&password=123456');
+    expect(r).toEqual({ source: 'number', meetingNumber: '1' });
+    expect(JSON.stringify(r)).not.toContain('123456');
+  });
+  it('returns null with no credential', () => {
+    expect(parseJoinQuery('')).toBeNull();
+    expect(parseJoinQuery('?foo=bar')).toBeNull();
+  });
+});

--- a/packages/dmworkmeeting/src/state/nav.test.ts
+++ b/packages/dmworkmeeting/src/state/nav.test.ts
@@ -11,6 +11,9 @@ describe('parseJoinQuery — cold-load / back-forward deep links (#3, §4)', () 
   it('accepts the short ?number= alias', () => {
     expect(parseJoinQuery('?number=555')).toEqual({ source: 'number', meetingNumber: '555' });
   });
+  it('extracts meeting_id (source=list) for join-by-list deep links', () => {
+    expect(parseJoinQuery('?meeting_id=abc')).toEqual({ source: 'list', meetingId: 'abc' });
+  });
   it('prefers link_token over number when both present', () => {
     expect(parseJoinQuery('?link_token=t&meeting_number=1')).toEqual({ source: 'link', linkToken: 't' });
   });

--- a/packages/dmworkmeeting/src/state/nav.tsx
+++ b/packages/dmworkmeeting/src/state/nav.tsx
@@ -1,15 +1,16 @@
-import React from 'react';
 import { WKApp } from '@octo/base';
 import type { AdmissionSource } from '../service/contracts';
-import QuickSetup from '../pages/QuickSetup';
-import SchedulePage from '../pages/SchedulePage';
-import JoinEntry from '../pages/JoinEntry';
-import JoinFlow from '../pages/JoinFlow';
 
-// Navigation via the supported host route stack (WKApp.routeRight), not inert
-// window.history mutations. Kept in one module so pages don't each reach into
-// WKApp and so tests can spy on a single seam. (These pages import nav in turn;
-// the ES-module cycle is safe because bindings are only used at call time.)
+// Navigation for the Meeting module. The host shell only paints the menu's
+// routePath component (`/meeting` → MeetingRoot); sub-paths registered on
+// WKApp.route never render (MainContentLeft renders WKApp.route.get(menu.route
+// Path) only — see apps/web/src/Pages/Main/index.tsx). So navigation is
+// URL-driven within that single painting component: we push history and emit an
+// event MeetingRoot listens to, and MeetingRoot re-derives its view on
+// `popstate` (browser back/forward) and on cold load. Deep links, in-app nav
+// and back/forward therefore all work through the one component the shell mounts.
+
+export const MEETING_NAV_EVENT = 'meeting:navchange';
 
 export interface JoinFlowParams {
   source: AdmissionSource;
@@ -18,49 +19,70 @@ export interface JoinFlowParams {
   linkToken?: string;
 }
 
-type Nav = {
-  push: (el: React.ReactElement) => void;
-  popToRoot: () => void;
-};
-
-function nav(): Nav {
-  const w = WKApp as unknown as { routeRight?: Partial<Nav> };
-  return {
-    push: (el) => w.routeRight?.push?.(el),
-    popToRoot: () => w.routeRight?.popToRoot?.(),
-  };
+function navigate(path: string): void {
+  if (typeof window === 'undefined') return;
+  window.history.pushState({}, '', path);
+  window.dispatchEvent(new Event(MEETING_NAV_EVENT));
 }
 
+export function openHome(): void {
+  navigate('/meeting');
+}
 export function openQuickSetup(): void {
-  nav().push(<QuickSetup />);
+  navigate('/meeting/quick');
 }
 export function openSchedule(): void {
-  nav().push(<SchedulePage />);
+  navigate('/meeting/schedule');
+}
+export function openEdit(meetingId: string): void {
+  navigate(`/meeting/${encodeURIComponent(meetingId)}/edit`);
+}
+export function openDetail(meetingId: string): void {
+  navigate(`/meeting/${encodeURIComponent(meetingId)}`);
 }
 export function openJoinEntry(): void {
-  nav().push(<JoinEntry />);
+  navigate('/meeting/join');
 }
-export function openJoinFlow(params: JoinFlowParams, dev: string): void {
-  nav().push(<JoinFlow {...params} deviceIdHash={dev} autoStart />);
+export function openJoinFlow(params: JoinFlowParams): void {
+  const usp = new URLSearchParams();
+  if (params.linkToken) usp.set('link_token', params.linkToken);
+  else if (params.meetingNumber) usp.set('meeting_number', params.meetingNumber);
+  else if (params.meetingId) usp.set('meeting_id', params.meetingId);
+  const q = usp.toString();
+  navigate(`/meeting/join${q ? `?${q}` : ''}`);
 }
 export function backToHome(): void {
-  nav().popToRoot();
+  navigate('/meeting');
 }
 
-/** Best-effort per-device hash for reconnect grace / superseded detection
- * (§9, B-3). Never a security identity; the server owns segment/leave_at. */
-export function deviceIdHash(): string {
-  const w = WKApp as unknown as { shared?: { deviceId?: string } };
-  return w.shared?.deviceId ?? 'web';
+// Small non-cryptographic FNV-1a hash so we never send the raw persisted device
+// UUID as `device_id_hash`, and never a shared constant that could grant another
+// user's reconnect-grace exemption. Returns undefined when no device id exists
+// (fail-safe: the server then cannot grant same-endpoint grace — B-3/FD-29).
+function fnv1a(input: string): string {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < input.length; i += 1) {
+    h ^= input.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  return (h >>> 0).toString(16).padStart(8, '0');
+}
+
+export function deviceIdHash(): string | undefined {
+  const deviceId = (WKApp as unknown as { shared?: { deviceId?: string } }).shared?.deviceId;
+  if (!deviceId) return undefined;
+  return fnv1a(`meeting:${deviceId}`);
 }
 
 /** Parse a cold-load / back-forward URL into join credentials. Deep links only
- * ever carry link_token or a meeting number — never a password (§4, §8). */
+ * ever carry link_token / meeting_number / meeting_id — never a password (§4, §8). */
 export function parseJoinQuery(search: string): JoinFlowParams | null {
   const params = new URLSearchParams(search || '');
   const linkToken = params.get('link_token') ?? undefined;
   if (linkToken) return { source: 'link', linkToken };
   const number = params.get('meeting_number') ?? params.get('number') ?? undefined;
   if (number) return { source: 'number', meetingNumber: number };
+  const meetingId = params.get('meeting_id') ?? undefined;
+  if (meetingId) return { source: 'list', meetingId };
   return null;
 }

--- a/packages/dmworkmeeting/src/state/nav.tsx
+++ b/packages/dmworkmeeting/src/state/nav.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { WKApp } from '@octo/base';
+import type { AdmissionSource } from '../service/contracts';
+import QuickSetup from '../pages/QuickSetup';
+import SchedulePage from '../pages/SchedulePage';
+import JoinEntry from '../pages/JoinEntry';
+import JoinFlow from '../pages/JoinFlow';
+
+// Navigation via the supported host route stack (WKApp.routeRight), not inert
+// window.history mutations. Kept in one module so pages don't each reach into
+// WKApp and so tests can spy on a single seam. (These pages import nav in turn;
+// the ES-module cycle is safe because bindings are only used at call time.)
+
+export interface JoinFlowParams {
+  source: AdmissionSource;
+  meetingId?: string;
+  meetingNumber?: string;
+  linkToken?: string;
+}
+
+type Nav = {
+  push: (el: React.ReactElement) => void;
+  popToRoot: () => void;
+};
+
+function nav(): Nav {
+  const w = WKApp as unknown as { routeRight?: Partial<Nav> };
+  return {
+    push: (el) => w.routeRight?.push?.(el),
+    popToRoot: () => w.routeRight?.popToRoot?.(),
+  };
+}
+
+export function openQuickSetup(): void {
+  nav().push(<QuickSetup />);
+}
+export function openSchedule(): void {
+  nav().push(<SchedulePage />);
+}
+export function openJoinEntry(): void {
+  nav().push(<JoinEntry />);
+}
+export function openJoinFlow(params: JoinFlowParams, dev: string): void {
+  nav().push(<JoinFlow {...params} deviceIdHash={dev} autoStart />);
+}
+export function backToHome(): void {
+  nav().popToRoot();
+}
+
+/** Best-effort per-device hash for reconnect grace / superseded detection
+ * (§9, B-3). Never a security identity; the server owns segment/leave_at. */
+export function deviceIdHash(): string {
+  const w = WKApp as unknown as { shared?: { deviceId?: string } };
+  return w.shared?.deviceId ?? 'web';
+}
+
+/** Parse a cold-load / back-forward URL into join credentials. Deep links only
+ * ever carry link_token or a meeting number — never a password (§4, §8). */
+export function parseJoinQuery(search: string): JoinFlowParams | null {
+  const params = new URLSearchParams(search || '');
+  const linkToken = params.get('link_token') ?? undefined;
+  if (linkToken) return { source: 'link', linkToken };
+  const number = params.get('meeting_number') ?? params.get('number') ?? undefined;
+  if (number) return { source: 'number', meetingNumber: number };
+  return null;
+}

--- a/packages/dmworkmeeting/src/state/telemetry.test.ts
+++ b/packages/dmworkmeeting/src/state/telemetry.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { emitMeetingTelemetry, setMeetingTelemetrySink } from './telemetry';
+
+afterEach(() => setMeetingTelemetrySink(null));
+
+describe('telemetry redaction boundary (§14)', () => {
+  it('emits endpoint/code labels through the sink', () => {
+    const events: Array<{ name: string; payload: Record<string, unknown> }> = [];
+    setMeetingTelemetrySink((name, payload) => events.push({ name, payload }));
+    emitMeetingTelemetry({ kind: 'error', endpoint: '/v1/meetings/admission/evaluate', httpStatus: 423 });
+    expect(events[0].name).toBe('meeting.error');
+    expect(events[0].payload).toMatchObject({ endpoint: '/v1/meetings/admission/evaluate', httpStatus: 423 });
+  });
+
+  it('is a no-op with no sink wired', () => {
+    expect(() => emitMeetingTelemetry({ kind: 'finalize', outcome: 'success' })).not.toThrow();
+  });
+
+  it('never lets a stray sensitive field through', () => {
+    const seen: Record<string, unknown>[] = [];
+    setMeetingTelemetrySink((_n, p) => seen.push(p));
+    // Cast through unknown to smuggle a sensitive key past the type and prove redaction.
+    emitMeetingTelemetry({ kind: 'finalize', outcome: 'success', password: '123456' } as never);
+    expect(JSON.stringify(seen[0])).not.toContain('123456');
+  });
+});

--- a/packages/dmworkmeeting/src/state/telemetry.ts
+++ b/packages/dmworkmeeting/src/state/telemetry.ts
@@ -1,0 +1,29 @@
+import { redactSensitive } from '../service/adapter';
+import type { MeetingErrorCode } from '../service/errors';
+
+// Telemetry boundary (§14): events are keyed by endpoint / error code / meeting
+// status ONLY. meeting_id, user_id, passwords, pass tokens and raw link/LiveKit
+// tokens must NEVER appear as labels or payload. All payloads pass through
+// redactSensitive as a defensive backstop.
+
+export type MeetingTelemetryEvent =
+  | { kind: 'admission_evaluate'; source: string; outcome: 'eligible' | 'ineligible'; code?: MeetingErrorCode }
+  | { kind: 'finalize'; outcome: 'success' | 'retry' | 'failed'; code?: MeetingErrorCode }
+  | { kind: 'password_attempt'; outcome: 'pass' | 'invalid' | 'cooldown' }
+  | { kind: 'error'; endpoint: string; code?: MeetingErrorCode; httpStatus?: number };
+
+type Sink = (name: string, payload: Record<string, unknown>) => void;
+
+let sink: Sink | null = null;
+
+/** Wire a telemetry sink (defaults to no-op). Host app injects its reporter. */
+export function setMeetingTelemetrySink(fn: Sink | null): void {
+  sink = fn;
+}
+
+export function emitMeetingTelemetry(event: MeetingTelemetryEvent): void {
+  if (!sink) return;
+  const { kind, ...rest } = event;
+  // Redact defensively even though the event shape carries no sensitive fields.
+  sink(`meeting.${kind}`, redactSensitive(rest as Record<string, unknown>));
+}

--- a/packages/dmworkmeeting/src/state/useCooldownClock.ts
+++ b/packages/dmworkmeeting/src/state/useCooldownClock.ts
@@ -1,0 +1,37 @@
+import { useEffect, useState } from 'react';
+import { cooldownRemainingSeconds, isCooldownExpired, type CooldownState } from '../logic/password';
+
+export interface UseCooldownClockResult {
+  remainingSeconds: number;
+  expired: boolean;
+}
+
+/**
+ * Ticks a password cooldown down to zero. `now` is injectable so tests are
+ * deterministic; production passes Date.now. The authoritative retry_at comes
+ * from the server (mirrored into `state`); this only drives the countdown UI.
+ */
+export function useCooldownClock(
+  state: CooldownState,
+  onExpired?: () => void,
+  now: () => number = () => Date.now(),
+): UseCooldownClockResult {
+  const [tick, setTick] = useState(0);
+
+  useEffect(() => {
+    if (!state.inCooldown) return undefined;
+    const id = setInterval(() => setTick((n: number) => n + 1), 1000);
+    return () => clearInterval(id);
+  }, [state.inCooldown, state.retryAtMs]);
+
+  const nowMs = now();
+  const remainingSeconds = cooldownRemainingSeconds(state, nowMs);
+  const expired = isCooldownExpired(state, nowMs);
+
+  useEffect(() => {
+    if (expired) onExpired?.();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [expired, tick]);
+
+  return { remainingSeconds, expired };
+}

--- a/packages/dmworkmeeting/tsconfig.json
+++ b/packages/dmworkmeeting/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../packages/tsconfig/react-library.json",
+  "include": ["src"]
+}

--- a/packages/dmworkmeeting/vitest.config.ts
+++ b/packages/dmworkmeeting/vitest.config.ts
@@ -1,0 +1,38 @@
+import { defineConfig } from 'vitest/config';
+import path from 'path';
+
+const root = path.resolve(__dirname, '../..');
+const pnpm = path.resolve(root, 'node_modules/.pnpm');
+// @testing-library/react renders via react-dom/client (React 18+). The pnpm
+// store links it against react-dom@17 (which has no client.js), so render/hook
+// tests can only resolve through these aliases. Pin react/react-dom to 18 and
+// @testing-library/react to its react-18-linked variant; the meeting package
+// still ships against React 17 in production (see package.json).
+const react18 = path.resolve(pnpm, 'react@18.3.1/node_modules/react');
+const reactDom18 = path.resolve(pnpm, 'react-dom@18.3.1_react@18.3.1/node_modules/react-dom');
+const testingLibraryReact = path.resolve(
+  pnpm,
+  '@testing-library+react@14.3.1_@types+react@18.3.28_react-dom@18.3.1_react@18.3.1__react@18.3.1/node_modules/@testing-library/react',
+);
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    include: ['src/**/*.test.{ts,tsx}'],
+    globals: true,
+    setupFiles: ['src/__tests__/setup.ts'],
+    css: false,
+  },
+  resolve: {
+    dedupe: ['react', 'react-dom'],
+    alias: [
+      // The base package is a large IM runtime; the meeting module only touches
+      // a narrow WKApp seam, so tests resolve @octo/base to a focused mock.
+      { find: '@octo/base', replacement: path.resolve(__dirname, 'src/__mocks__/dmworkBase.ts') },
+      { find: /^@testing-library\/react$/, replacement: testingLibraryReact },
+      { find: /^react-dom\/client$/, replacement: path.resolve(reactDom18, 'client.js') },
+      { find: /^react-dom$/, replacement: reactDom18 },
+      { find: /^react$/, replacement: react18 },
+    ],
+  },
+});

--- a/packages/dmworkmeeting/vitest.config.ts
+++ b/packages/dmworkmeeting/vitest.config.ts
@@ -1,20 +1,10 @@
 import { defineConfig } from 'vitest/config';
 import path from 'path';
 
-const root = path.resolve(__dirname, '../..');
-const pnpm = path.resolve(root, 'node_modules/.pnpm');
-// @testing-library/react renders via react-dom/client (React 18+). The pnpm
-// store links it against react-dom@17 (which has no client.js), so render/hook
-// tests can only resolve through these aliases. Pin react/react-dom to 18 and
-// @testing-library/react to its react-18-linked variant; the meeting package
-// still ships against React 17 in production (see package.json).
-const react18 = path.resolve(pnpm, 'react@18.3.1/node_modules/react');
-const reactDom18 = path.resolve(pnpm, 'react-dom@18.3.1_react@18.3.1/node_modules/react-dom');
-const testingLibraryReact = path.resolve(
-  pnpm,
-  '@testing-library+react@14.3.1_@types+react@18.3.28_react-dom@18.3.1_react@18.3.1__react@18.3.1/node_modules/@testing-library/react',
-);
-
+// The base package is a large IM runtime; the meeting module only touches a
+// narrow WKApp seam, so tests resolve @octo/base to a focused mock. React 18 /
+// @testing-library/react 14 are declared as devDependencies of this package, so
+// normal node resolution picks them up — no hard-coded pnpm virtual-store paths.
 export default defineConfig({
   test: {
     environment: 'jsdom',
@@ -25,14 +15,6 @@ export default defineConfig({
   },
   resolve: {
     dedupe: ['react', 'react-dom'],
-    alias: [
-      // The base package is a large IM runtime; the meeting module only touches
-      // a narrow WKApp seam, so tests resolve @octo/base to a focused mock.
-      { find: '@octo/base', replacement: path.resolve(__dirname, 'src/__mocks__/dmworkBase.ts') },
-      { find: /^@testing-library\/react$/, replacement: testingLibraryReact },
-      { find: /^react-dom\/client$/, replacement: path.resolve(reactDom18, 'client.js') },
-      { find: /^react-dom$/, replacement: reactDom18 },
-      { find: /^react$/, replacement: react18 },
-    ],
+    alias: [{ find: '@octo/base', replacement: path.resolve(__dirname, 'src/__mocks__/dmworkBase.ts') }],
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -740,18 +740,9 @@ importers:
 
   packages/dmworkmeeting:
     dependencies:
-      '@douyinfe/semi-icons':
-        specifier: ^2.93.0
-        version: 2.93.0(react@18.3.1)
-      '@douyinfe/semi-ui':
-        specifier: ^2.93.0
-        version: 2.93.0(@tiptap/suggestion@3.22.2(@tiptap/core@3.22.2(@tiptap/pm@3.22.2))(@tiptap/pm@3.22.2))(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@octo/base':
         specifier: workspace:*
         version: link:../dmworkbase
-      classnames:
-        specifier: ^2.3.1
-        version: 2.5.1
     devDependencies:
       '@testing-library/jest-dom':
         specifier: ^6.9.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -166,6 +166,9 @@ importers:
       '@dmwork/mcp':
         specifier: workspace:*
         version: link:../../packages/dmworkmcp
+      '@dmwork/meeting':
+        specifier: workspace:*
+        version: link:../../packages/dmworkmeeting
       '@dmwork/skillmarket':
         specifier: workspace:*
         version: link:../../packages/dmworkskillmarket
@@ -728,6 +731,43 @@ importers:
       '@testing-library/react':
         specifier: ^13.4.0
         version: 13.4.0(@types/react@19.2.14)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      react:
+        specifier: ^17.0.2
+        version: 17.0.2
+      react-dom:
+        specifier: ^17.0.2
+        version: 17.0.2(react@17.0.2)
+
+  packages/dmworkmeeting:
+    dependencies:
+      '@douyinfe/semi-icons':
+        specifier: ^2.93.0
+        version: 2.93.0(react@17.0.2)
+      '@douyinfe/semi-ui':
+        specifier: ^2.93.0
+        version: 2.93.0(@tiptap/suggestion@3.22.2(@tiptap/core@3.22.2(@tiptap/pm@3.22.2))(@tiptap/pm@3.22.2))(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@octo/base':
+        specifier: workspace:*
+        version: link:../dmworkbase
+      axios:
+        specifier: ^0.25.0
+        version: 0.25.0
+      classnames:
+        specifier: ^2.3.1
+        version: 2.5.1
+    devDependencies:
+      '@testing-library/jest-dom':
+        specifier: ^6.9.1
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: ^13.4.0
+        version: 13.4.0(@types/react@18.3.28)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@types/react':
+        specifier: ^18.3.3
+        version: 18.3.28
+      '@types/react-dom':
+        specifier: ^18.3.0
+        version: 18.3.7(@types/react@18.3.28)
       react:
         specifier: ^17.0.2
         version: 17.0.2
@@ -12302,6 +12342,53 @@ snapshots:
       - '@types/react-dom'
       - supports-color
 
+  '@douyinfe/semi-ui@2.93.0(@tiptap/suggestion@3.22.2(@tiptap/core@3.22.2(@tiptap/pm@3.22.2))(@tiptap/pm@3.22.2))(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+    dependencies:
+      '@dnd-kit/core': 6.3.1(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@dnd-kit/sortable': 7.0.2(@dnd-kit/core@6.3.1(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react@17.0.2)
+      '@dnd-kit/utilities': 3.2.2(react@17.0.2)
+      '@douyinfe/semi-animation': 2.93.0
+      '@douyinfe/semi-animation-react': 2.93.0
+      '@douyinfe/semi-foundation': 2.93.0
+      '@douyinfe/semi-icons': 2.93.0(react@17.0.2)
+      '@douyinfe/semi-illustrations': 2.93.0(react@17.0.2)
+      '@douyinfe/semi-theme-default': 2.93.0
+      '@tiptap/core': 3.22.2(@tiptap/pm@3.22.2)
+      '@tiptap/extension-document': 3.22.2(@tiptap/core@3.22.2(@tiptap/pm@3.22.2))
+      '@tiptap/extension-hard-break': 3.22.2(@tiptap/core@3.22.2(@tiptap/pm@3.22.2))
+      '@tiptap/extension-image': 3.22.2(@tiptap/core@3.22.2(@tiptap/pm@3.22.2))
+      '@tiptap/extension-mention': 3.22.2(@tiptap/core@3.22.2(@tiptap/pm@3.22.2))(@tiptap/pm@3.22.2)(@tiptap/suggestion@3.22.2(@tiptap/core@3.22.2(@tiptap/pm@3.22.2))(@tiptap/pm@3.22.2))
+      '@tiptap/extension-paragraph': 3.22.2(@tiptap/core@3.22.2(@tiptap/pm@3.22.2))
+      '@tiptap/extension-text': 3.22.2(@tiptap/core@3.22.2(@tiptap/pm@3.22.2))
+      '@tiptap/extension-text-align': 3.22.2(@tiptap/core@3.22.2(@tiptap/pm@3.22.2))
+      '@tiptap/extension-text-style': 3.22.2(@tiptap/core@3.22.2(@tiptap/pm@3.22.2))
+      '@tiptap/extensions': 3.22.4(@tiptap/core@3.22.2(@tiptap/pm@3.22.2))(@tiptap/pm@3.22.2)
+      '@tiptap/pm': 3.22.2
+      '@tiptap/react': 3.22.2(@tiptap/core@3.22.2(@tiptap/pm@3.22.2))(@tiptap/pm@3.22.2)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@tiptap/starter-kit': 3.22.2
+      async-validator: 3.5.2
+      classnames: 2.5.1
+      copy-text-to-clipboard: 2.2.0
+      date-fns: 2.30.0
+      date-fns-tz: 1.3.8(date-fns@2.30.0)
+      fast-copy: 3.0.2
+      jsonc-parser: 3.3.1
+      lodash: 4.18.1
+      prop-types: 15.8.1
+      prosemirror-state: 1.4.4
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+      react-resizable: 3.1.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      react-window: 1.8.11(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      scroll-into-view-if-needed: 2.2.31
+      utility-types: 3.11.0
+    transitivePeerDependencies:
+      - '@floating-ui/dom'
+      - '@tiptap/suggestion'
+      - '@types/react'
+      - '@types/react-dom'
+      - supports-color
+
   '@douyinfe/semi-ui@2.93.0(@tiptap/suggestion@3.22.2(@tiptap/core@3.22.2(@tiptap/pm@3.22.2))(@tiptap/pm@3.22.2))(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@dnd-kit/core': 6.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -14740,6 +14827,23 @@ snapshots:
       '@tiptap/pm': 3.22.2
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@types/use-sync-external-store': 0.0.6
+      fast-equals: 5.4.0
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+      use-sync-external-store: 1.6.0(react@17.0.2)
+    optionalDependencies:
+      '@tiptap/extension-bubble-menu': 3.22.2(@tiptap/core@3.22.2(@tiptap/pm@3.22.2))(@tiptap/pm@3.22.2)
+      '@tiptap/extension-floating-menu': 3.22.2(@floating-ui/dom@1.7.6)(@tiptap/core@3.22.2(@tiptap/pm@3.22.2))(@tiptap/pm@3.22.2)
+    transitivePeerDependencies:
+      - '@floating-ui/dom'
+
+  '@tiptap/react@3.22.2(@tiptap/core@3.22.2(@tiptap/pm@3.22.2))(@tiptap/pm@3.22.2)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+    dependencies:
+      '@tiptap/core': 3.22.2(@tiptap/pm@3.22.2)
+      '@tiptap/pm': 3.22.2
+      '@types/react': 18.3.28
+      '@types/react-dom': 18.3.7(@types/react@18.3.28)
       '@types/use-sync-external-store': 0.0.6
       fast-equals: 5.4.0
       react: 17.0.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -742,16 +742,13 @@ importers:
     dependencies:
       '@douyinfe/semi-icons':
         specifier: ^2.93.0
-        version: 2.93.0(react@17.0.2)
+        version: 2.93.0(react@18.3.1)
       '@douyinfe/semi-ui':
         specifier: ^2.93.0
-        version: 2.93.0(@tiptap/suggestion@3.22.2(@tiptap/core@3.22.2(@tiptap/pm@3.22.2))(@tiptap/pm@3.22.2))(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+        version: 2.93.0(@tiptap/suggestion@3.22.2(@tiptap/core@3.22.2(@tiptap/pm@3.22.2))(@tiptap/pm@3.22.2))(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@octo/base':
         specifier: workspace:*
         version: link:../dmworkbase
-      axios:
-        specifier: ^0.25.0
-        version: 0.25.0
       classnames:
         specifier: ^2.3.1
         version: 2.5.1
@@ -760,8 +757,8 @@ importers:
         specifier: ^6.9.1
         version: 6.9.1
       '@testing-library/react':
-        specifier: ^13.4.0
-        version: 13.4.0(@types/react@18.3.28)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+        specifier: ^14.3.1
+        version: 14.3.1(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/react':
         specifier: ^18.3.3
         version: 18.3.28
@@ -769,11 +766,11 @@ importers:
         specifier: ^18.3.0
         version: 18.3.7(@types/react@18.3.28)
       react:
-        specifier: ^17.0.2
-        version: 17.0.2
+        specifier: ^18.3.1
+        version: 18.3.1
       react-dom:
-        specifier: ^17.0.2
-        version: 17.0.2(react@17.0.2)
+        specifier: ^18.3.1
+        version: 18.3.1(react@18.3.1)
 
   packages/dmworkskillmarket:
     dependencies:
@@ -12342,53 +12339,6 @@ snapshots:
       - '@types/react-dom'
       - supports-color
 
-  '@douyinfe/semi-ui@2.93.0(@tiptap/suggestion@3.22.2(@tiptap/core@3.22.2(@tiptap/pm@3.22.2))(@tiptap/pm@3.22.2))(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
-    dependencies:
-      '@dnd-kit/core': 6.3.1(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@dnd-kit/sortable': 7.0.2(@dnd-kit/core@6.3.1(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react@17.0.2)
-      '@dnd-kit/utilities': 3.2.2(react@17.0.2)
-      '@douyinfe/semi-animation': 2.93.0
-      '@douyinfe/semi-animation-react': 2.93.0
-      '@douyinfe/semi-foundation': 2.93.0
-      '@douyinfe/semi-icons': 2.93.0(react@17.0.2)
-      '@douyinfe/semi-illustrations': 2.93.0(react@17.0.2)
-      '@douyinfe/semi-theme-default': 2.93.0
-      '@tiptap/core': 3.22.2(@tiptap/pm@3.22.2)
-      '@tiptap/extension-document': 3.22.2(@tiptap/core@3.22.2(@tiptap/pm@3.22.2))
-      '@tiptap/extension-hard-break': 3.22.2(@tiptap/core@3.22.2(@tiptap/pm@3.22.2))
-      '@tiptap/extension-image': 3.22.2(@tiptap/core@3.22.2(@tiptap/pm@3.22.2))
-      '@tiptap/extension-mention': 3.22.2(@tiptap/core@3.22.2(@tiptap/pm@3.22.2))(@tiptap/pm@3.22.2)(@tiptap/suggestion@3.22.2(@tiptap/core@3.22.2(@tiptap/pm@3.22.2))(@tiptap/pm@3.22.2))
-      '@tiptap/extension-paragraph': 3.22.2(@tiptap/core@3.22.2(@tiptap/pm@3.22.2))
-      '@tiptap/extension-text': 3.22.2(@tiptap/core@3.22.2(@tiptap/pm@3.22.2))
-      '@tiptap/extension-text-align': 3.22.2(@tiptap/core@3.22.2(@tiptap/pm@3.22.2))
-      '@tiptap/extension-text-style': 3.22.2(@tiptap/core@3.22.2(@tiptap/pm@3.22.2))
-      '@tiptap/extensions': 3.22.4(@tiptap/core@3.22.2(@tiptap/pm@3.22.2))(@tiptap/pm@3.22.2)
-      '@tiptap/pm': 3.22.2
-      '@tiptap/react': 3.22.2(@tiptap/core@3.22.2(@tiptap/pm@3.22.2))(@tiptap/pm@3.22.2)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@tiptap/starter-kit': 3.22.2
-      async-validator: 3.5.2
-      classnames: 2.5.1
-      copy-text-to-clipboard: 2.2.0
-      date-fns: 2.30.0
-      date-fns-tz: 1.3.8(date-fns@2.30.0)
-      fast-copy: 3.0.2
-      jsonc-parser: 3.3.1
-      lodash: 4.18.1
-      prop-types: 15.8.1
-      prosemirror-state: 1.4.4
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-      react-resizable: 3.1.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      react-window: 1.8.11(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      scroll-into-view-if-needed: 2.2.31
-      utility-types: 3.11.0
-    transitivePeerDependencies:
-      - '@floating-ui/dom'
-      - '@tiptap/suggestion'
-      - '@types/react'
-      - '@types/react-dom'
-      - supports-color
-
   '@douyinfe/semi-ui@2.93.0(@tiptap/suggestion@3.22.2(@tiptap/core@3.22.2(@tiptap/pm@3.22.2))(@tiptap/pm@3.22.2))(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@dnd-kit/core': 6.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -14827,23 +14777,6 @@ snapshots:
       '@tiptap/pm': 3.22.2
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
-      '@types/use-sync-external-store': 0.0.6
-      fast-equals: 5.4.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-      use-sync-external-store: 1.6.0(react@17.0.2)
-    optionalDependencies:
-      '@tiptap/extension-bubble-menu': 3.22.2(@tiptap/core@3.22.2(@tiptap/pm@3.22.2))(@tiptap/pm@3.22.2)
-      '@tiptap/extension-floating-menu': 3.22.2(@floating-ui/dom@1.7.6)(@tiptap/core@3.22.2(@tiptap/pm@3.22.2))(@tiptap/pm@3.22.2)
-    transitivePeerDependencies:
-      - '@floating-ui/dom'
-
-  '@tiptap/react@3.22.2(@tiptap/core@3.22.2(@tiptap/pm@3.22.2))(@tiptap/pm@3.22.2)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
-    dependencies:
-      '@tiptap/core': 3.22.2(@tiptap/pm@3.22.2)
-      '@tiptap/pm': 3.22.2
-      '@types/react': 18.3.28
-      '@types/react-dom': 18.3.7(@types/react@18.3.28)
       '@types/use-sync-external-store': 0.0.6
       fast-equals: 5.4.0
       react: 17.0.2


### PR DESCRIPTION
## Summary

Introduces `@dmwork/meeting` (`packages/dmworkmeeting`), the P0 frontend module for the standalone Octo Meeting service, and registers it in `apps/web`. This is a **draft** — the module is complete and unit-tested for everything that can be built ahead of the service-owned contract; final typed-contract integration is intentionally deferred (see *Blocker*).

- Baseline: `Mininglamp-OSS/octo-web@5269665bc904e54ca3b89d08c5d2258f916f9a26`
- Related issue: #1302

## What's implemented

**Service seam** — mirrors the existing Smart Summary client boundary (`packages/dmworksummary/src/api/summaryApi.ts`), which is the in-repo precedent for a gateway-mounted, per-service axios client:
- `MeetingApiClient` — dedicated instance at `/meeting/api/v1`; derives the API origin from `apiClient.config.apiURL` for Electron/extension runtimes; injects `token` / `X-Space-Id` / `Accept-Language`; sends `If-Match` and a reused explicit `Idempotency-Key` on writes; logs out on 401. It never sends or trusts `x-user-id` / `x-org-id` as identity authority.
- One `snake_case ⇄ camelCase` adapter seam with sensitive-field redaction (passwords / pass tokens / raw link & LiveKit tokens never reach logs or telemetry).
- The full 24-code error taxonomy mapped to deterministic frontend directives — no generic final-recheck code.
- Fail-closed classification that distinguishes a canonical `MEETING_CREDENTIAL_INVALID` (404 *with* code) from a missing gateway route (404 *without* code).

**Deterministic logic core** (pure, fully unit-tested with injected clocks):
- Admission oracle: step-1 ordering, the S-1 enumeration envelope (unauthorized cross-Space hits are indistinguishable from "not found"), the `allowed_to_prejoin` truth table, and host-transfer target ordering.
- Password format/attempt/cooldown reducer; early-join (600s), reconnect-grace (15s, anchored to server `leave_at`), empty-timeout (300s, anchored to server `empty_since`) and reminder boundaries — asserted at 599/601s, 14.9/15.1s, etc.
- UI admission state machine (idle→evaluate→challenge→prejoin→finalize→room), including LiveKit-unavailable retry (keeps PreJoin + pass token) and pass-token-expiry restart.

**UI**: home/list, join flow, quick setup, prejoin, room view, participant list with role-gated controls, password challenge, service-unavailable and terminal overlays — with `aria-live` status regions and en-US/zh-CN i18n. The LiveKit media layer is a lazy, React-17-safe seam (`livekit-client`, not the React-18-only components package).

## Test evidence (red → green)

The entire package is net-new, so all assertions are red on the pinned baseline (the modules/tests do not exist there) and green on this branch:

```
cd packages/dmworkmeeting && pnpm test
Test Files  10 passed (10)
     Tests  116 passed (116)
```

`tsc --noEmit` reports no errors in `packages/dmworkmeeting/src` (the remaining `tsc` noise is pre-existing `@octo/base`→Semi transitive-source diagnostics shared with other packages, not introduced here).

## Blocker (why this is draft, not "done")

Final typed-contract integration is blocked on the standalone-service bootstrap publishing the **service-owned versioned OpenAPI/error snapshot** (bound to architecture SHA `f0f482c0`). Until it exists:
- `contracts.ts` / `errors.ts` are transcribed from the approved design and are marked provisional; they must be generated or byte-aligned against that snapshot before typed-contract/MSW contract tests are wired to it.
- The MSW contract suite and Playwright E2E against a live gateway are not landed in this PR; the pure oracle/boundary logic they will assert is already covered by deterministic unit tests here.

## Residual risks / follow-ups
- `contracts.ts` reconciliation against the service snapshot (above).
- `livekit-client` is loaded lazily and is **not** yet added as an installed dependency — it needs to be added under NOTICE/SBOM review before the room media path is exercised end-to-end.
- OD-02 (max participants) drives the VideoGrid virtualization threshold — currently a conservative default.

## Rollout / rollback
- Gated by `MEETING_FEATURE_ENABLED`: when off, the menu entry is hidden and no routes are exercised. A missing `/meeting/api/v1` gateway route renders "feature not enabled" (fail-closed), never a crash or a false "meeting not found".
- Rollback is removing the single registration line in `apps/web/src/index.tsx`; the module is additive and does not modify existing modules.
