### PR TITLE
fix(skillmarket): show authoritative total in skill list summary

### DIFF
--- a/packages/dmworkskillmarket/src/pages/SkillListPage.tsx
+++ b/packages/dmworkskillmarket/src/pages/SkillListPage.tsx
@@ -150,6 +150,16 @@ export default function SkillListPage() {
     setDetailId(item.id);
   }
 
+  // The paginated /skills response carries no real total, so list.total falls
+  // back to the loaded page size (e.g. 20). The /skill_categories counts are
+  // authoritative — on the skills tab show the active category's skillCount
+  // (for "全部" this equals the summed total shown in the chip). The "我的" tab
+  // has no category chips and a different scope, so keep list.total there.
+  const summaryTotal = mine
+    ? list.total
+    : list.categories.find((category) => category.id === list.categoryId)
+        ?.skillCount ?? list.total;
+
   return (
     <div className="skill-market-page">
       <header className="skill-market-topbar">
@@ -250,7 +260,7 @@ export default function SkillListPage() {
           <div className="skill-market-result-summary">
             <span className="skill-market-result-summary__total" aria-live="polite">
               {t("skillMarket.list.totalCount", {
-                values: { count: list.total },
+                values: { count: summaryTotal },
               })}
             </span>
             {!mine && (


### PR DESCRIPTION
## Summary

The skill market list summary ("共 N 个 Skill") undercounts the catalog. It
reads `list.total`, which comes from the `/skills` paginated response — but
that response carries no real total, so the mapping falls back to the loaded
page size (e.g. 20). The result: the "全部 47" category chip and the "共 20 个
Skill" summary disagree.

This uses the authoritative count already available on the client: the active
category's `skillCount` from `/skill_categories` (the same source that renders
"全部 N"). On the skills tab the summary now matches the chip and updates per
category/search/tag filter. The "我的" tab has no category chips and a
different scope, so it keeps `list.total`.

One-line change in `SkillListPage.tsx`; no API or type changes.

## How verified

- `pnpm vitest run src/pages/__tests__/SkillListPage.test.tsx` — 14/14 pass.
- Manual: ran the app against real backend data; the summary now shows the
  full catalog total and matches the "全部" chip instead of the page size.