### PR TITLE
fix(login): support OIDC across web and Electron

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -3,6 +3,9 @@
 # Example: https://api.example.com (not https://api.example.com/api/v1/)
 VITE_API_URL=https://api.example.com
 
+# Enables the enterprise OIDC/SSO login entry on the web and Electron login page.
+VITE_ENABLE_ENTERPRISE_SSO=true
+
 # Marketplace (octo-marketplace) service URL for local dev.
 # The Vite proxy rewrites /market/api/v1/* → target/api/v1/*
 # For local development with octo-marketplace running on :8092:

--- a/apps/web/electron-builder.js
+++ b/apps/web/electron-builder.js
@@ -41,12 +41,6 @@ module.exports = {
       NSMicrophoneUsageDescription: "授权访问麦克风",
       NSCameraUsageDescription: "授权访问摄像头",
     },
-    protocols: [
-      {
-        name: "OCTO",
-        schemes: ["dmwork"],
-      },
-    ],
     hardenedRuntime: true,
     entitlements: "resources/mac/entitlements.mac.plist",
     entitlementsInherit: "resources/mac/entitlements.mac.plist",
@@ -80,12 +74,6 @@ module.exports = {
     icon: "resources/icons/icon.ico",
     verifyUpdateCodeSignature: false,
     target: ["nsis", "zip"],
-    protocols: [
-      {
-        name: "OCTO",
-        schemes: ["dmwork"],
-      },
-    ],
     // eslint-disable-next-line no-template-curly-in-string
     artifactName: "${productName}-Setup-${version}.${ext}"
   },
@@ -104,14 +92,6 @@ module.exports = {
     target: ["AppImage", "deb"],
     icon: "resources/icons/512x512.png",
     category: "Network;InstantMessaging;",
-    // Registers `x-scheme-handler/dmwork` in the .desktop file so xdg-open
-    // dispatches dmwork:// links to the packaged binary. Mirrors the
-    // mac.protocols / win.protocols entries above.
-    desktop: {
-      entry: {
-        MimeType: "x-scheme-handler/dmwork",
-      },
-    },
     // eslint-disable-next-line no-template-curly-in-string
     artifactName: '${productName}-${version}-linux-${arch}.${ext}',
   },

--- a/apps/web/electron-builder.js
+++ b/apps/web/electron-builder.js
@@ -41,6 +41,12 @@ module.exports = {
       NSMicrophoneUsageDescription: "授权访问麦克风",
       NSCameraUsageDescription: "授权访问摄像头",
     },
+    protocols: [
+      {
+        name: "OCTO",
+        schemes: ["dmwork"],
+      },
+    ],
     hardenedRuntime: true,
     entitlements: "resources/mac/entitlements.mac.plist",
     entitlementsInherit: "resources/mac/entitlements.mac.plist",
@@ -74,6 +80,12 @@ module.exports = {
     icon: "resources/icons/icon.ico",
     verifyUpdateCodeSignature: false,
     target: ["nsis", "zip"],
+    protocols: [
+      {
+        name: "OCTO",
+        schemes: ["dmwork"],
+      },
+    ],
     // eslint-disable-next-line no-template-curly-in-string
     artifactName: "${productName}-Setup-${version}.${ext}"
   },
@@ -92,6 +104,14 @@ module.exports = {
     target: ["AppImage", "deb"],
     icon: "resources/icons/512x512.png",
     category: "Network;InstantMessaging;",
+    // Registers `x-scheme-handler/dmwork` in the .desktop file so xdg-open
+    // dispatches dmwork:// links to the packaged binary. Mirrors the
+    // mac.protocols / win.protocols entries above.
+    desktop: {
+      entry: {
+        MimeType: "x-scheme-handler/dmwork",
+      },
+    },
     // eslint-disable-next-line no-template-curly-in-string
     artifactName: '${productName}-${version}-linux-${arch}.${ext}',
   },

--- a/apps/web/src-election/__tests__/preload.test.ts
+++ b/apps/web/src-election/__tests__/preload.test.ts
@@ -43,17 +43,10 @@ function setLocation(url: string): void {
   })
 }
 
-function setResourcesPath(value: string | undefined): void {
-  Object.defineProperty(process, 'resourcesPath', {
+function setRuntimeArgs(...args: string[]): void {
+  Object.defineProperty(process, 'argv', {
     configurable: true,
-    value,
-  })
-}
-
-function setDefaultApp(value: boolean): void {
-  Object.defineProperty(process, 'defaultApp', {
-    configurable: true,
-    value,
+    value: ['electron', 'app', ...args],
   })
 }
 
@@ -83,8 +76,7 @@ describe('preload IPC origin gate', () => {
   })
 
   it('allows ipc.send from packaged file:// shell', async () => {
-    setDefaultApp(false)
-    setResourcesPath(packagedResourcesPath)
+    setRuntimeArgs('--octo-dev=false', `--octo-shell-path=${packagedResourcesPath}/app.asar/build/index.html`)
     setLocation('file:///Applications/OCTO.app/Contents/Resources/app.asar/build/index.html')
     const { ipc } = await loadPreloadFresh()
 
@@ -94,8 +86,7 @@ describe('preload IPC origin gate', () => {
   })
 
   it('allows ipc.send from dev localhost shell', async () => {
-    setDefaultApp(true)
-    setResourcesPath(undefined)
+    setRuntimeArgs('--octo-dev=true', '--octo-shell-path=')
     setLocation('http://localhost:3000/')
     const { ipc } = await loadPreloadFresh()
 
@@ -105,7 +96,7 @@ describe('preload IPC origin gate', () => {
   })
 
   it('blocks ipc.send from a third-party IdP origin', async () => {
-    setResourcesPath(undefined)
+    setRuntimeArgs('--octo-dev=false', '--octo-shell-path=')
     setLocation('https://idp.example.com/authorize?client_id=octo')
     const { ipc } = await loadPreloadFresh()
 
@@ -118,7 +109,7 @@ describe('preload IPC origin gate', () => {
   })
 
   it('blocks ipc.invoke from a third-party IdP origin', async () => {
-    setResourcesPath(undefined)
+    setRuntimeArgs('--octo-dev=false', '--octo-shell-path=')
     setLocation('https://idp.example.com/authorize')
     const { ipc } = await loadPreloadFresh()
 
@@ -127,7 +118,7 @@ describe('preload IPC origin gate', () => {
   })
 
   it('blocks ipc.on subscription from a third-party origin', async () => {
-    setResourcesPath(undefined)
+    setRuntimeArgs('--octo-dev=false', '--octo-shell-path=')
     setLocation('https://idp.example.com/authorize')
     const { ipc } = await loadPreloadFresh()
 
@@ -139,7 +130,7 @@ describe('preload IPC origin gate', () => {
   })
 
   it('blocks electronNotification invocations from a third-party origin', async () => {
-    setResourcesPath(undefined)
+    setRuntimeArgs('--octo-dev=false', '--octo-shell-path=')
     setLocation('https://idp.example.com/authorize')
     const { notif } = await loadPreloadFresh()
 
@@ -150,7 +141,7 @@ describe('preload IPC origin gate', () => {
   })
 
   it('blocks an arbitrary local file even though it uses file://', async () => {
-    setResourcesPath(packagedResourcesPath)
+    setRuntimeArgs('--octo-dev=false', `--octo-shell-path=${packagedResourcesPath}/app.asar/build/index.html`)
     setLocation('file:///tmp/attacker.html')
     const { ipc } = await loadPreloadFresh()
 
@@ -160,7 +151,7 @@ describe('preload IPC origin gate', () => {
   })
 
   it('blocks a non-configured localhost port', async () => {
-    setResourcesPath(undefined)
+    setRuntimeArgs('--octo-dev=false', '--octo-shell-path=')
     setLocation('http://localhost:4173/')
     const { ipc } = await loadPreloadFresh()
 
@@ -170,12 +161,12 @@ describe('preload IPC origin gate', () => {
   })
 
   it('exposes __POWERED_ELECTRON__ only on trusted shell origins', async () => {
-    setResourcesPath(packagedResourcesPath)
+    setRuntimeArgs('--octo-dev=false', `--octo-shell-path=${packagedResourcesPath}/app.asar/build/index.html`)
     setLocation('file:///Applications/OCTO.app/Contents/Resources/app.asar/build/index.html')
     await loadPreloadFresh()
     expect(exposed.get('__POWERED_ELECTRON__')).toBe(true)
 
-    setResourcesPath(undefined)
+    setRuntimeArgs('--octo-dev=false', '--octo-shell-path=')
     setLocation('https://im.deepminer.com.cn/login')
     await loadPreloadFresh()
     // Remote octo-web bundle served by the API host must NOT see the flag,

--- a/apps/web/src-election/__tests__/preload.test.ts
+++ b/apps/web/src-election/__tests__/preload.test.ts
@@ -50,6 +50,13 @@ function setResourcesPath(value: string | undefined): void {
   })
 }
 
+function setDefaultApp(value: boolean): void {
+  Object.defineProperty(process, 'defaultApp', {
+    configurable: true,
+    value,
+  })
+}
+
 async function loadPreloadFresh() {
   exposed.clear()
   sendMock.mockClear()
@@ -76,6 +83,7 @@ describe('preload IPC origin gate', () => {
   })
 
   it('allows ipc.send from packaged file:// shell', async () => {
+    setDefaultApp(false)
     setResourcesPath(packagedResourcesPath)
     setLocation('file:///Applications/OCTO.app/Contents/Resources/app.asar/build/index.html')
     const { ipc } = await loadPreloadFresh()
@@ -86,6 +94,7 @@ describe('preload IPC origin gate', () => {
   })
 
   it('allows ipc.send from dev localhost shell', async () => {
+    setDefaultApp(true)
     setResourcesPath(undefined)
     setLocation('http://localhost:3000/')
     const { ipc } = await loadPreloadFresh()

--- a/apps/web/src-election/__tests__/preload.test.ts
+++ b/apps/web/src-election/__tests__/preload.test.ts
@@ -1,0 +1,177 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Capture whatever the preload exposes via contextBridge.
+const exposed = new Map<string, any>()
+
+const sendMock = vi.fn()
+const invokeMock = vi.fn().mockResolvedValue(undefined)
+const onMock = vi.fn()
+const onceMock = vi.fn()
+const removeListenerMock = vi.fn()
+
+const packagedResourcesPath = '/Applications/OCTO.app/Contents/Resources'
+
+vi.mock('electron', () => ({
+  contextBridge: {
+    exposeInMainWorld: (key: string, value: unknown) => {
+      exposed.set(key, value)
+    },
+  },
+  ipcRenderer: {
+    send: sendMock,
+    invoke: invokeMock,
+    on: onMock,
+    once: onceMock,
+    removeListener: removeListenerMock,
+  },
+}))
+
+function setLocation(url: string): void {
+  // jsdom disallows cross-origin history rewrites; fully replace location.
+  // The preload only reads protocol/hostname, so a minimal stub is enough.
+  const parsed = new URL(url)
+  Object.defineProperty(window, 'location', {
+    configurable: true,
+    value: {
+      href: parsed.href,
+      protocol: parsed.protocol,
+      hostname: parsed.hostname,
+      pathname: parsed.pathname,
+      port: parsed.port,
+      origin: parsed.origin,
+    },
+  })
+}
+
+function setResourcesPath(value: string | undefined): void {
+  Object.defineProperty(process, 'resourcesPath', {
+    configurable: true,
+    value,
+  })
+}
+
+async function loadPreloadFresh() {
+  exposed.clear()
+  sendMock.mockClear()
+  invokeMock.mockClear()
+  onMock.mockClear()
+  onceMock.mockClear()
+  removeListenerMock.mockClear()
+  vi.resetModules()
+  await import('../preload/index')
+  const ipc = exposed.get('ipc') as {
+    send: (channel: string, ...args: unknown[]) => void
+    invoke: (channel: string, ...args: unknown[]) => Promise<unknown>
+    on: (channel: string, listener: (...args: unknown[]) => void) => void
+    once: (channel: string, listener: (...args: unknown[]) => void) => void
+    removeListener: (channel: string, listener: (...args: unknown[]) => void) => void
+  }
+  return { ipc, notif: exposed.get('electronNotification') as any }
+}
+
+describe('preload IPC origin gate', () => {
+  beforeEach(() => {
+    // Silence intentional warn output.
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+  })
+
+  it('allows ipc.send from packaged file:// shell', async () => {
+    setResourcesPath(packagedResourcesPath)
+    setLocation('file:///Applications/OCTO.app/Contents/Resources/app.asar/build/index.html')
+    const { ipc } = await loadPreloadFresh()
+
+    ipc.send('oidc-authorize-start', 'https://api.example.com/v1/')
+
+    expect(sendMock).toHaveBeenCalledWith('oidc-authorize-start', 'https://api.example.com/v1/')
+  })
+
+  it('allows ipc.send from dev localhost shell', async () => {
+    setResourcesPath(undefined)
+    setLocation('http://localhost:3000/')
+    const { ipc } = await loadPreloadFresh()
+
+    ipc.send('restart-app')
+
+    expect(sendMock).toHaveBeenCalledWith('restart-app')
+  })
+
+  it('blocks ipc.send from a third-party IdP origin', async () => {
+    setResourcesPath(undefined)
+    setLocation('https://idp.example.com/authorize?client_id=octo')
+    const { ipc } = await loadPreloadFresh()
+
+    ipc.send('oidc-authorize-start', 'https://attacker.example.com/')
+    ipc.send('restart-app')
+    ipc.send('update-app')
+    ipc.send('screenshots-start')
+
+    expect(sendMock).not.toHaveBeenCalled()
+  })
+
+  it('blocks ipc.invoke from a third-party IdP origin', async () => {
+    setResourcesPath(undefined)
+    setLocation('https://idp.example.com/authorize')
+    const { ipc } = await loadPreloadFresh()
+
+    await expect(ipc.invoke('is-window-focused')).rejects.toThrow(/not allowed from this origin/)
+    expect(invokeMock).not.toHaveBeenCalled()
+  })
+
+  it('blocks ipc.on subscription from a third-party origin', async () => {
+    setResourcesPath(undefined)
+    setLocation('https://idp.example.com/authorize')
+    const { ipc } = await loadPreloadFresh()
+
+    ipc.on('deep-link', () => undefined)
+    ipc.once('deep-link', () => undefined)
+
+    expect(onMock).not.toHaveBeenCalled()
+    expect(onceMock).not.toHaveBeenCalled()
+  })
+
+  it('blocks electronNotification invocations from a third-party origin', async () => {
+    setResourcesPath(undefined)
+    setLocation('https://idp.example.com/authorize')
+    const { notif } = await loadPreloadFresh()
+
+    await expect(notif.show({ title: 'x' })).rejects.toThrow(/not allowed from this origin/)
+    await expect(notif.closeAll()).rejects.toThrow(/not allowed from this origin/)
+    await expect(notif.isWindowFocused()).rejects.toThrow(/not allowed from this origin/)
+    expect(invokeMock).not.toHaveBeenCalled()
+  })
+
+  it('blocks an arbitrary local file even though it uses file://', async () => {
+    setResourcesPath(packagedResourcesPath)
+    setLocation('file:///tmp/attacker.html')
+    const { ipc } = await loadPreloadFresh()
+
+    ipc.send('restart-app')
+
+    expect(sendMock).not.toHaveBeenCalled()
+  })
+
+  it('blocks a non-configured localhost port', async () => {
+    setResourcesPath(undefined)
+    setLocation('http://localhost:4173/')
+    const { ipc } = await loadPreloadFresh()
+
+    ipc.send('restart-app')
+
+    expect(sendMock).not.toHaveBeenCalled()
+  })
+
+  it('exposes __POWERED_ELECTRON__ only on trusted shell origins', async () => {
+    setResourcesPath(packagedResourcesPath)
+    setLocation('file:///Applications/OCTO.app/Contents/Resources/app.asar/build/index.html')
+    await loadPreloadFresh()
+    expect(exposed.get('__POWERED_ELECTRON__')).toBe(true)
+
+    setResourcesPath(undefined)
+    setLocation('https://im.deepminer.com.cn/login')
+    await loadPreloadFresh()
+    // Remote octo-web bundle served by the API host must NOT see the flag,
+    // otherwise its isDesktopRuntime check flips true and resolveApiURL throws
+    // because VITE_API_URL is not inlined into the web build.
+    expect(exposed.has('__POWERED_ELECTRON__')).toBe(false)
+  })
+})

--- a/apps/web/src-election/main/__tests__/oidcRedirect.test.ts
+++ b/apps/web/src-election/main/__tests__/oidcRedirect.test.ts
@@ -29,4 +29,31 @@ describe('Electron OIDC callback redirect', () => {
       sid: 'window-sid',
     })
   })
+
+  // Regression: without this, a `/login` callback carrying
+  // `__octo_route=/oidc/bind` (from a hostile IdP or open redirect) would be
+  // passed straight to the packaged shell with a trusted sid attached, and
+  // BindModule.init() would enter the bind flow with an attacker-controlled
+  // token. `withTrustedSessionSid` must derive `__octo_route` purely from
+  // `callback.path`, never inherit it from the callback query.
+  it('never inherits __octo_route from a /login callback query', () => {
+    const callback = parseOidcCallback(
+      'https://api.example.com/login?__octo_route=/oidc/bind&token=attacker',
+      'https://api.example.com',
+    )!
+    const forwarded = withTrustedSessionSid(callback, 'window-sid')
+    expect(forwarded.__octo_route).toBeUndefined()
+    expect(forwarded.token).toBe('attacker')
+    expect(forwarded.sid).toBe('window-sid')
+  })
+
+  it('drops query params outside the forwarding allowlist', () => {
+    const callback = parseOidcCallback(
+      'https://api.example.com/login?oidc_error=1&extra=leaked&sid=x',
+      'https://api.example.com',
+    )!
+    const forwarded = withTrustedSessionSid(callback, 'window-sid')
+    expect(forwarded).toEqual({ sid: 'window-sid', oidc_error: '1' })
+    expect(forwarded.extra).toBeUndefined()
+  })
 })

--- a/apps/web/src-election/main/__tests__/oidcRedirect.test.ts
+++ b/apps/web/src-election/main/__tests__/oidcRedirect.test.ts
@@ -43,7 +43,7 @@ describe('Electron OIDC callback redirect', () => {
     )!
     const forwarded = withTrustedSessionSid(callback, 'window-sid')
     expect(forwarded.__octo_route).toBeUndefined()
-    expect(forwarded.token).toBe('attacker')
+    expect(forwarded.token).toBeUndefined()
     expect(forwarded.sid).toBe('window-sid')
   })
 
@@ -55,5 +55,19 @@ describe('Electron OIDC callback redirect', () => {
     const forwarded = withTrustedSessionSid(callback, 'window-sid')
     expect(forwarded).toEqual({ sid: 'window-sid', oidc_error: '1' })
     expect(forwarded.extra).toBeUndefined()
+  })
+
+  it('uses a bind-specific allowlist and never forwards login-only errors', () => {
+    const callback = parseOidcCallback(
+      'https://api.example.com/oidc/bind?token=t&authcode=a&provider=p&oidc_error=1&code=secret',
+      'https://api.example.com',
+    )!
+    expect(withTrustedSessionSid(callback, 'window-sid')).toEqual({
+      __octo_route: '/oidc/bind',
+      token: 't',
+      authcode: 'a',
+      provider: 'p',
+      sid: 'window-sid',
+    })
   })
 })

--- a/apps/web/src-election/main/__tests__/oidcRedirect.test.ts
+++ b/apps/web/src-election/main/__tests__/oidcRedirect.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import { parseOidcCallback, withTrustedSessionSid } from '../oidcRedirect'
+
+describe('Electron OIDC callback redirect', () => {
+  it('accepts the backend callback and rejects an IdP /login page', () => {
+    expect(parseOidcCallback('https://api.example.com/login?oidc_error=1', 'https://api.example.com')?.path).toBe('/login')
+    expect(parseOidcCallback('https://idp.example.com/login', 'https://api.example.com')).toBeUndefined()
+  })
+
+  it('keeps the window sid authoritative over callback query parameters', () => {
+    const callback = parseOidcCallback(
+      'https://api.example.com/login?sid=attacker&oidc_error=1',
+      'https://api.example.com',
+    )!
+    expect(withTrustedSessionSid(callback, 'window-sid')).toEqual({
+      sid: 'window-sid',
+      oidc_error: '1',
+    })
+  })
+
+  it('marks bind callbacks so the packaged renderer enters the bind route', () => {
+    const callback = parseOidcCallback(
+      'https://api.example.com/oidc/bind?token=t&return_to=%2F',
+      'https://api.example.com',
+    )!
+    expect(withTrustedSessionSid(callback, 'window-sid')).toMatchObject({
+      __octo_route: '/oidc/bind',
+      token: 't',
+      sid: 'window-sid',
+    })
+  })
+})

--- a/apps/web/src-election/main/index.ts
+++ b/apps/web/src-election/main/index.ts
@@ -21,6 +21,7 @@ import {
   IPC_CONVERSATION_UNREAD_COUNT,
   IPC_DEEP_LINK_READY,
   IPC_OIDC_AUTHORIZE_START,
+  IPC_OIDC_AUTHORIZE_START_INVOKE,
 } from "../shared/ipc-channels";
 import OCTO_CONFIG from "./config";
 import {
@@ -71,7 +72,6 @@ interface OidcFlowContext {
 }
 
 const oidcExpectedOrigins = new WeakMap<BrowserWindow, OidcFlowContext>();
-const oidcProviderOrigins = new WeakMap<BrowserWindow, string>();
 
 function parseHttpOrigin(value: unknown): string | undefined {
   if (typeof value !== "string") return undefined;
@@ -85,17 +85,34 @@ function parseHttpOrigin(value: unknown): string | undefined {
   }
 }
 
-ipcMain.on(
-  IPC_OIDC_AUTHORIZE_START,
-  (event, apiURL: unknown, authcode: unknown, providerId: unknown) => {
-    const win = BrowserWindow.fromWebContents(event.sender);
-    const origin = parseHttpOrigin(apiURL);
-    if (!win || !origin || typeof authcode !== "string" || !authcode) return;
-    if (typeof providerId !== "string" || !providerId) return;
-    oidcExpectedOrigins.set(win, { apiOrigin: origin, authcode, providerId });
-    oidcProviderOrigins.delete(win);
-  },
-);
+function normalizeFilePath(value: string): string {
+  try {
+    return decodeURIComponent(value).replace(/\\/g, "/").replace(/\/+$/, "");
+  } catch {
+    return value.replace(/\\/g, "/").replace(/\/+$/, "");
+  }
+}
+
+function armOidcFlow(
+  event: Electron.IpcMainEvent | Electron.IpcMainInvokeEvent,
+  apiURL: unknown,
+  authcode: unknown,
+  providerId: unknown,
+): boolean {
+  const win = BrowserWindow.fromWebContents(event.sender);
+  const origin = parseHttpOrigin(apiURL);
+  if (!win || !origin || typeof authcode !== "string" || !authcode) return false;
+  if (typeof providerId !== "string" || !providerId) return false;
+  oidcExpectedOrigins.set(win, { apiOrigin: origin, authcode, providerId });
+  return true;
+}
+
+ipcMain.on(IPC_OIDC_AUTHORIZE_START, (event, ...args: unknown[]) => {
+  armOidcFlow(event, args[0], args[1], args[2]);
+});
+ipcMain.handle(IPC_OIDC_AUTHORIZE_START_INVOKE, (event, ...args: unknown[]) => {
+  return armOidcFlow(event, args[0], args[1], args[2]);
+});
 
 function registerOidcReturnRedirect(win: BrowserWindow, webUrl: string, sid: string) {
   // The OIDC provider is loaded in this window for compatibility with the
@@ -117,22 +134,12 @@ function registerOidcReturnRedirect(win: BrowserWindow, webUrl: string, sid: str
       event.preventDefault();
       return;
     }
-    const isShell = parsed.protocol === "file:" && url.includes("/build/index.html");
+    const isShell = parsed.protocol === "file:" && normalizeFilePath(parsed.pathname) === normalizeFilePath(webUrl);
     const devOrigin = parseHttpOrigin(DEV_SERVER_URL);
     const isDevShell = isDevelopment && devOrigin === parsed.origin;
     const flow = oidcExpectedOrigins.get(win);
     const isExpectedApi = flow !== undefined && parsed.origin === flow.apiOrigin;
-    let providerOrigin = oidcProviderOrigins.get(win);
-    if (
-      !providerOrigin &&
-      flow &&
-      parsed.protocol === "https:" &&
-      parsed.origin !== flow.apiOrigin
-    ) {
-      providerOrigin = parsed.origin;
-      oidcProviderOrigins.set(win, providerOrigin);
-    }
-    const isOidcProviderHop = flow !== undefined && parsed.origin === providerOrigin;
+    const isOidcProviderHop = flow !== undefined && parsed.protocol === "https:" && parsed.origin !== flow.apiOrigin;
     if (!isShell && !isDevShell && !isExpectedApi && !isOidcProviderHop) {
       event.preventDefault();
     }
@@ -144,11 +151,12 @@ function registerOidcReturnRedirect(win: BrowserWindow, webUrl: string, sid: str
       const callback = parseOidcCallback(url, flow.apiOrigin);
       if (!callback) return;
       if (callback.path === "/oidc/bind") {
-        const hasAuthcode = Boolean(callback.query.authcode);
-        const hasProvider = Boolean(callback.query.provider);
-        if (!hasAuthcode && !hasProvider) return;
-        if (hasAuthcode && callback.query.authcode !== flow.authcode) return;
-        if (hasProvider && callback.query.provider !== flow.providerId) return;
+        if (callback.query.authcode !== flow.authcode || callback.query.provider !== flow.providerId) {
+          event.preventDefault();
+          oidcExpectedOrigins.delete(win);
+          win.loadFile(webUrl, { query: { sid, oidc_error: "1" } });
+          return;
+        }
       }
 
       // The OIDC backend accepts the server-relative `/login` return target,
@@ -161,7 +169,6 @@ function registerOidcReturnRedirect(win: BrowserWindow, webUrl: string, sid: str
       // sid from getURL() would lose the original file:// page's sid.
       const query = withTrustedSessionSid(callback, sid);
       oidcExpectedOrigins.delete(win);
-      oidcProviderOrigins.delete(win);
       win.loadFile(webUrl, { query });
     };
 
@@ -515,6 +522,10 @@ const getWindowConfig = () => {
       nodeIntegration: false,
       contextIsolation: true,
       devTools: isDevelopment,
+      additionalArguments: [
+        `--octo-dev=${String(isDevelopment)}`,
+        `--octo-shell-path=${join(__dirname, "../build/index.html")}`,
+      ],
     },
     // frame: !isWin,
   };
@@ -687,7 +698,13 @@ const DEEP_LINK_SCHEME = "dmwork";
 // the configured dev-server origin).
 function isShellWebContentsUrl(url: string): boolean {
   if (!url) return false;
-  if (url.startsWith("file://")) return url.includes("/build/index.html");
+  if (url.startsWith("file://")) {
+    try {
+      return normalizeFilePath(new URL(url).pathname) === normalizeFilePath(join(__dirname, "../build/index.html"));
+    } catch {
+      return false;
+    }
+  }
   // In a packaged build there is no legitimate dev-server document. Refuse to
   // treat any http(s) origin as a shell URL so a malicious page cannot pose
   // as the shell to receive buffered deep-link URLs.

--- a/apps/web/src-election/main/index.ts
+++ b/apps/web/src-election/main/index.ts
@@ -16,11 +16,15 @@ import Screenshots from "electron-screenshots";
 import { join } from "path";
 
 import logo, { getNoMessageTrayIcon } from "./logo";
-import { IPC_CONVERSATION_UNREAD_COUNT } from "../shared/ipc-channels";
+import {
+  IPC_CONVERSATION_UNREAD_COUNT,
+  IPC_OIDC_AUTHORIZE_START,
+} from "../shared/ipc-channels";
 import OCTO_CONFIG from "./config";
 import checkUpdate from './update';
 import { electronNotificationManager } from './notification';
 import { getRandomSid } from "./utils/search";
+import { parseOidcCallback, withTrustedSessionSid } from "./oidcRedirect";
 
 let forceQuit = false;
 let mainWindow: any;
@@ -44,16 +48,33 @@ const DEV_SERVER_URL = process.env.VITE_DEV_SERVER_URL || "http://localhost:3000
 const APP_EXIT_DELAY_MS = 1000;
 const TRAY_FLASH_INTERVAL_MS = 1000;
 
+const oidcExpectedOrigins = new WeakMap<BrowserWindow, string>();
+
+function parseHttpOrigin(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  try {
+    const parsed = new URL(value);
+    return parsed.protocol === "http:" || parsed.protocol === "https:"
+      ? parsed.origin
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+ipcMain.on(IPC_OIDC_AUTHORIZE_START, (event, apiURL: unknown) => {
+  const win = BrowserWindow.fromWebContents(event.sender);
+  const origin = parseHttpOrigin(apiURL);
+  if (win && origin) oidcExpectedOrigins.set(win, origin);
+});
+
 function registerOidcReturnRedirect(win: BrowserWindow, webUrl: string, sid: string) {
   if (!isDevelopment) {
     win.webContents.on("will-redirect", (event, url) => {
-      let parsed: URL;
-      try {
-        parsed = new URL(url);
-      } catch {
-        return;
-      }
-      if (parsed.pathname !== "/login") return;
+      const expectedOrigin = oidcExpectedOrigins.get(win);
+      if (!expectedOrigin) return;
+      const callback = parseOidcCallback(url, expectedOrigin);
+      if (!callback) return;
 
       // The OIDC backend accepts the server-relative `/login` return target,
       // but Electron production pages are hosted from file://. Bring the
@@ -63,10 +84,8 @@ function registerOidcReturnRedirect(win: BrowserWindow, webUrl: string, sid: str
       // Reuse the sid captured when this window was created. At this point
       // webContents may already be on the IdP/API redirect URL, so reading
       // sid from getURL() would lose the original file:// page's sid.
-      const query: Record<string, string> = { sid };
-      parsed.searchParams.forEach((value, key) => {
-        query[key] = value;
-      });
+      const query = withTrustedSessionSid(callback, sid);
+      oidcExpectedOrigins.delete(win);
       win.loadFile(webUrl, { query });
     });
   }

--- a/apps/web/src-election/main/index.ts
+++ b/apps/web/src-election/main/index.ts
@@ -19,9 +19,9 @@ import { join, dirname } from "path";
 import logo, { getNoMessageTrayIcon } from "./logo";
 import {
   IPC_CONVERSATION_UNREAD_COUNT,
-  IPC_DEEP_LINK_READY,
   IPC_OIDC_AUTHORIZE_START,
   IPC_OIDC_AUTHORIZE_START_INVOKE,
+  IPC_OIDC_AUTHORIZE_CANCEL,
 } from "../shared/ipc-channels";
 import OCTO_CONFIG from "./config";
 import {
@@ -67,11 +67,20 @@ const TRAY_FLASH_INTERVAL_MS = 1000;
 
 interface OidcFlowContext {
   apiOrigin: string;
+  callbackOrigins: Set<string>;
   authcode: string;
   providerId: string;
 }
 
 const oidcExpectedOrigins = new WeakMap<BrowserWindow, OidcFlowContext>();
+const oidcDisarmTimers = new WeakMap<BrowserWindow, NodeJS.Timeout>();
+
+function disarmOidcFlow(win: BrowserWindow): void {
+  const timer = oidcDisarmTimers.get(win);
+  if (timer) clearTimeout(timer);
+  oidcDisarmTimers.delete(win);
+  oidcExpectedOrigins.delete(win);
+}
 
 function parseHttpOrigin(value: unknown): string | undefined {
   if (typeof value !== "string") return undefined;
@@ -98,20 +107,30 @@ function armOidcFlow(
   apiURL: unknown,
   authcode: unknown,
   providerId: unknown,
+  callbackOrigin: unknown,
 ): boolean {
   const win = BrowserWindow.fromWebContents(event.sender);
   const origin = parseHttpOrigin(apiURL);
   if (!win || !origin || typeof authcode !== "string" || !authcode) return false;
   if (typeof providerId !== "string" || !providerId) return false;
-  oidcExpectedOrigins.set(win, { apiOrigin: origin, authcode, providerId });
+  disarmOidcFlow(win);
+  const callbackOrigins = new Set([origin]);
+  const configuredCallbackOrigin = parseHttpOrigin(callbackOrigin);
+  if (configuredCallbackOrigin) callbackOrigins.add(configuredCallbackOrigin);
+  oidcExpectedOrigins.set(win, { apiOrigin: origin, callbackOrigins, authcode, providerId });
+  oidcDisarmTimers.set(win, setTimeout(() => disarmOidcFlow(win), 5 * 60 * 1000));
   return true;
 }
 
 ipcMain.on(IPC_OIDC_AUTHORIZE_START, (event, ...args: unknown[]) => {
-  armOidcFlow(event, args[0], args[1], args[2]);
+  armOidcFlow(event, args[0], args[1], args[2], args[3]);
 });
 ipcMain.handle(IPC_OIDC_AUTHORIZE_START_INVOKE, (event, ...args: unknown[]) => {
-  return armOidcFlow(event, args[0], args[1], args[2]);
+  return armOidcFlow(event, args[0], args[1], args[2], args[3]);
+});
+ipcMain.on(IPC_OIDC_AUTHORIZE_CANCEL, (event) => {
+  const win = BrowserWindow.fromWebContents(event.sender);
+  if (win) disarmOidcFlow(win);
 });
 
 function registerOidcReturnRedirect(win: BrowserWindow, webUrl: string, sid: string) {
@@ -120,12 +139,16 @@ function registerOidcReturnRedirect(win: BrowserWindow, webUrl: string, sid: str
   // privileged Electron window, and reject arbitrary non-HTTPS top-level
   // navigations while the flow is not armed. The preload still gates IPC by
   // origin; this is the main-process navigation boundary complement.
-  win.webContents.setWindowOpenHandler(() => ({
-    // Preserve the app's existing popup behavior outside OIDC, but prevent a
-    // remote IdP document from opening another privileged window while the
-    // flow is armed.
-    action: oidcExpectedOrigins.has(win) ? "deny" : "allow",
-  }));
+  win.webContents.setWindowOpenHandler(() => {
+    const current = win.webContents.getURL();
+    let isShell = false;
+    try {
+      isShell = current.startsWith("file:") &&
+        normalizeFilePath(new URL(current).pathname) === normalizeFilePath(webUrl);
+    } catch { /* malformed current URL stays untrusted */ }
+    const isDevShell = isDevelopment && parseHttpOrigin(current) === parseHttpOrigin(DEV_SERVER_URL);
+    return { action: oidcExpectedOrigins.has(win) && !isShell && !isDevShell ? "deny" : "allow" };
+  });
   win.webContents.on("will-navigate", (event, url) => {
     let parsed: URL;
     try {
@@ -138,9 +161,10 @@ function registerOidcReturnRedirect(win: BrowserWindow, webUrl: string, sid: str
     const devOrigin = parseHttpOrigin(DEV_SERVER_URL);
     const isDevShell = isDevelopment && devOrigin === parsed.origin;
     const flow = oidcExpectedOrigins.get(win);
-    const isExpectedApi = flow !== undefined && parsed.origin === flow.apiOrigin;
-    const isOidcProviderHop = flow !== undefined && parsed.protocol === "https:" && parsed.origin !== flow.apiOrigin;
-    if (!isShell && !isDevShell && !isExpectedApi && !isOidcProviderHop) {
+    const isExpectedCallback = flow !== undefined && flow.callbackOrigins.has(parsed.origin);
+    const isOidcProviderHop = flow !== undefined && parsed.protocol === "https:" && !flow.callbackOrigins.has(parsed.origin);
+    if (flow && (isShell || isDevShell)) disarmOidcFlow(win);
+    if (!isShell && !isDevShell && !isExpectedCallback && !isOidcProviderHop) {
       event.preventDefault();
     }
   });
@@ -148,12 +172,14 @@ function registerOidcReturnRedirect(win: BrowserWindow, webUrl: string, sid: str
     const handleReturnNavigation = (event: Electron.Event, url: string) => {
       const flow = oidcExpectedOrigins.get(win);
       if (!flow) return;
-      const callback = parseOidcCallback(url, flow.apiOrigin);
+      const callback = Array.from(flow.callbackOrigins)
+        .map((origin) => parseOidcCallback(url, origin))
+        .find((value) => value !== undefined);
       if (!callback) return;
       if (callback.path === "/oidc/bind") {
         if (callback.query.authcode !== flow.authcode || callback.query.provider !== flow.providerId) {
           event.preventDefault();
-          oidcExpectedOrigins.delete(win);
+          disarmOidcFlow(win);
           win.loadFile(webUrl, { query: { sid, oidc_error: "1" } });
           return;
         }
@@ -168,7 +194,7 @@ function registerOidcReturnRedirect(win: BrowserWindow, webUrl: string, sid: str
       // webContents may already be on the IdP/API redirect URL, so reading
       // sid from getURL() would lose the original file:// page's sid.
       const query = withTrustedSessionSid(callback, sid);
-      oidcExpectedOrigins.delete(win);
+      disarmOidcFlow(win);
       win.loadFile(webUrl, { query });
     };
 
@@ -575,29 +601,9 @@ const createMainWindow = async () => {
     mainWindow.focus();
   });
 
-  // Flush any buffered deep-link URLs after navigation completes. The renderer
-  // gates its own `deep-link-ready` on the React tree mounting (see
-  // Layout/deepLink.ts), which is the authoritative signal — `did-finish-load`
-  // by itself is not, because React 18's async root can leave
-  // componentDidMount pending when this fires. We still listen here as a
-  // safety net after the ready handshake has already occurred at least once.
-  mainWindow.webContents.on("did-finish-load", () => {
-    dispatchPendingDeepLink();
-  });
-  // Every navigation invalidates the previous renderer's listener. Force the
-  // next shell to re-announce readiness before we flush the queue, otherwise
-  // an IdP-side navigation followed by a shell reload could try to dispatch
-  // to a listener that has not attached yet.
-  mainWindow.webContents.on("did-start-loading", () => {
-    rendererDeepLinkReady = false;
-  });
-
   mainWindow.on("close", (e: any) => {
     if (forceQuit || !tray) {
       mainWindow = null;
-      // A new mainWindow will start fresh: its renderer has not yet attached
-      // a deep-link listener, so the readiness flag must not carry over.
-      rendererDeepLinkReady = false;
     } else {
       e.preventDefault();
       if (mainWindow.isFullScreen()) {
@@ -684,138 +690,7 @@ function restartApp() {
   app.exit(0);
 }
 
-const ALLOWED_DEEP_LINK_SCHEMES = ["dmwork:"];
-const DEEP_LINK_SCHEME = "dmwork";
-
-// A deep link is meaningful only inside our own renderer document. During the
-// OIDC login flow the main BrowserWindow transiently navigates to the IdP
-// origin and back — every one of those transitions fires did-finish-load.
-// If we naively flush pendingDeepLinkUrl there, `webContents.send("deep-link")`
-// dispatches to the IdP page whose preload never attached our listener
-// (isTrustedShellOrigin() blocks it), the buffer is cleared, and the URL is
-// gone by the time the file:// shell reloads. Gate the flush on the current
-// webContents URL matching our shell (packaged file:// build/index.html, or
-// the configured dev-server origin).
-function isShellWebContentsUrl(url: string): boolean {
-  if (!url) return false;
-  if (url.startsWith("file://")) {
-    try {
-      return normalizeFilePath(new URL(url).pathname) === normalizeFilePath(join(__dirname, "../build/index.html"));
-    } catch {
-      return false;
-    }
-  }
-  // In a packaged build there is no legitimate dev-server document. Refuse to
-  // treat any http(s) origin as a shell URL so a malicious page cannot pose
-  // as the shell to receive buffered deep-link URLs.
-  if (!isDevelopment) return false;
-  try {
-    const parsed = new URL(url);
-    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return false;
-    return parsed.origin === new URL(DEV_SERVER_URL).origin;
-  } catch {
-    return false;
-  }
-}
-
-// The renderer's `deep-link` IPC listener only attaches after the React tree
-// mounts (see Layout/deepLink.ts). At cold-boot the main process may already
-// have a URL from `process.argv` / `open-url` / `second-instance` before the
-// renderer preload has parsed, so a naive `webContents.send` there is dropped
-// on the floor. Buffer pending URLs and flush them once the renderer signals
-// readiness via `deep-link-ready` (or as a safety net when `did-finish-load`
-// fires on a shell URL).
-//
-// A small queue rather than a single slot: on macOS a second `dmwork://` can
-// arrive via `open-url` while the previous callback is still in flight, and
-// the callback that would be lost with a single slot is usually the one the
-// user just completed, not the stale one.
-const DEEP_LINK_QUEUE_MAX = 8;
-let pendingDeepLinkQueue: string[] = [];
-let rendererDeepLinkReady = false;
-
-function enqueueDeepLink(url: string): void {
-  if (pendingDeepLinkQueue.length >= DEEP_LINK_QUEUE_MAX) {
-    // Drop the OLDEST — a stale IdP redirect is less valuable than the most
-    // recent user-initiated callback.
-    pendingDeepLinkQueue.shift();
-  }
-  pendingDeepLinkQueue.push(url);
-}
-
-function isValidDeepLink(url: string): boolean {
-  try {
-    const parsed = new URL(url);
-    if (!ALLOWED_DEEP_LINK_SCHEMES.includes(parsed.protocol)) {
-      return false;
-    }
-    const dangerousPatterns = /javascript:|data:|vbscript:|file:/i;
-    if (dangerousPatterns.test(url)) {
-      return false;
-    }
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-function dispatchPendingDeepLink() {
-  if (pendingDeepLinkQueue.length === 0) return;
-  if (!mainWindow || mainWindow.isDestroyed()) return;
-  // Keep buffering while the renderer sits on the IdP / any non-shell page.
-  // The next shell load will fire did-finish-load again and flush then.
-  if (!isShellWebContentsUrl(mainWindow.webContents.getURL())) return;
-  // Require an explicit renderer readiness signal so we do not clear the
-  // buffer before the React listener has actually attached. `did-finish-load`
-  // fires before componentDidMount under React 18's async root, which would
-  // otherwise silently drop the URL on cold boot.
-  if (!rendererDeepLinkReady) return;
-
-  const urls = pendingDeepLinkQueue;
-  pendingDeepLinkQueue = [];
-  for (const url of urls) {
-    mainWindow.webContents.send("deep-link", url);
-  }
-}
-
-function onDeepLink(url: string) {
-  if (!isValidDeepLink(url)) {
-    console.warn("Rejected invalid deep link:", url);
-    return;
-  }
-  console.log("onOpenDeepLink", url);
-  // Buffer FIRST, then attempt to flush. macOS `open-url` can arrive before
-  // `ready` / createMainWindow, and the app can also legitimately have no
-  // main window when the user closed it while tray is disabled — in both
-  // cases we must retain the URL so the eventual (re)mount can consume it.
-  // The argv fallback does NOT cover this: on macOS scheme launches deliver
-  // via `open-url`, not `process.argv`.
-  enqueueDeepLink(url);
-  if (mainWindow && !mainWindow.isDestroyed() && !mainWindow.webContents.isLoading()) {
-    // dispatchPendingDeepLink still gates on the current URL being a shell URL
-    // AND rendererDeepLinkReady, so this is safe to call mid-OIDC — the
-    // queue is preserved until the file:// shell reload completes and the
-    // renderer re-announces readiness.
-    dispatchPendingDeepLink();
-  }
-}
-
-// Renderer announces readiness after its `deep-link` IPC listener attaches
-// (Layout/deepLink.ts). Only the trusted shell origin can reach this channel
-// — the preload gates every send on `isTrustedShellOrigin`.
-ipcMain.on(IPC_DEEP_LINK_READY, () => {
-  rendererDeepLinkReady = true;
-  dispatchPendingDeepLink();
-});
-
 app.setName(OCTO_CONFIG.name);
-
-// Register the callback scheme used by the web SSO hand-off. The packaged
-// electron-builder config declares the scheme via mac.protocols / win.protocols
-// / linux mimeType. This runtime call registers the current binary as the
-// default handler regardless of platform, which also covers development
-// (unsigned) runs and already-installed packaged clients across upgrades.
-app.setAsDefaultProtocolClient(DEEP_LINK_SCHEME);
 
 // The migration plan below owns the userData path selection, replacing the
 // temporary legacy-path fallback from #1258 now that #1265 has landed.
@@ -1054,15 +929,6 @@ function runStartupMigration(userDataPlan: MigrationPlan): void {
   }
 }
 
-// isDevelopment && app.dock && app.dock.setIcon(logo);
-app.on("open-url", (event, url) => {
-  // Round-8 P1-1: the losing process may still receive app events between
-  // `ready` and its async quit — onDeepLink dereferences mainWindow, which
-  // never exists here.
-  if (!gotTheLock) return;
-  onDeepLink(url);
-});
-
 // 单例模式启动
 const gotTheLock = app.requestSingleInstanceLock();
 if (!gotTheLock) {
@@ -1076,9 +942,7 @@ if (!gotTheLock) {
   // window or renderer initialization.
 } else {
   runStartupMigration(userDataPlan);
-  app.on("second-instance", (event, argv) => {
-    const deepLink = argv.find((arg) => isValidDeepLink(arg));
-    if (deepLink) onDeepLink(deepLink);
+  app.on("second-instance", () => {
     if (mainWindow) {
       mainWindow.show();
       if (mainWindow.isMinimized()) {
@@ -1107,9 +971,6 @@ app.on("ready", () => {
   regShortcut();
   registerWindowFocusHandler();
   createMainWindow(); // 创建窗口
-
-  const initialDeepLink = process.argv.find((arg) => isValidDeepLink(arg));
-  if (initialDeepLink) onDeepLink(initialDeepLink);
 
   if (isWin) {
     app.setAppUserModelId(OCTO_CONFIG.appId);

--- a/apps/web/src-election/main/index.ts
+++ b/apps/web/src-election/main/index.ts
@@ -19,6 +19,7 @@ import { join, dirname } from "path";
 import logo, { getNoMessageTrayIcon } from "./logo";
 import {
   IPC_CONVERSATION_UNREAD_COUNT,
+  IPC_DEEP_LINK_READY,
   IPC_OIDC_AUTHORIZE_START,
 } from "../shared/ipc-channels";
 import OCTO_CONFIG from "./config";
@@ -63,7 +64,14 @@ const DEV_SERVER_URL = process.env.VITE_DEV_SERVER_URL || "http://localhost:3000
 const APP_EXIT_DELAY_MS = 1000;
 const TRAY_FLASH_INTERVAL_MS = 1000;
 
-const oidcExpectedOrigins = new WeakMap<BrowserWindow, string>();
+interface OidcFlowContext {
+  apiOrigin: string;
+  authcode: string;
+  providerId: string;
+}
+
+const oidcExpectedOrigins = new WeakMap<BrowserWindow, OidcFlowContext>();
+const oidcProviderOrigins = new WeakMap<BrowserWindow, string>();
 
 function parseHttpOrigin(value: unknown): string | undefined {
   if (typeof value !== "string") return undefined;
@@ -77,19 +85,71 @@ function parseHttpOrigin(value: unknown): string | undefined {
   }
 }
 
-ipcMain.on(IPC_OIDC_AUTHORIZE_START, (event, apiURL: unknown) => {
-  const win = BrowserWindow.fromWebContents(event.sender);
-  const origin = parseHttpOrigin(apiURL);
-  if (win && origin) oidcExpectedOrigins.set(win, origin);
-});
+ipcMain.on(
+  IPC_OIDC_AUTHORIZE_START,
+  (event, apiURL: unknown, authcode: unknown, providerId: unknown) => {
+    const win = BrowserWindow.fromWebContents(event.sender);
+    const origin = parseHttpOrigin(apiURL);
+    if (!win || !origin || typeof authcode !== "string" || !authcode) return;
+    if (typeof providerId !== "string" || !providerId) return;
+    oidcExpectedOrigins.set(win, { apiOrigin: origin, authcode, providerId });
+    oidcProviderOrigins.delete(win);
+  },
+);
 
 function registerOidcReturnRedirect(win: BrowserWindow, webUrl: string, sid: string) {
+  // The OIDC provider is loaded in this window for compatibility with the
+  // existing polling flow. Do not let that remote document open another
+  // privileged Electron window, and reject arbitrary non-HTTPS top-level
+  // navigations while the flow is not armed. The preload still gates IPC by
+  // origin; this is the main-process navigation boundary complement.
+  win.webContents.setWindowOpenHandler(() => ({
+    // Preserve the app's existing popup behavior outside OIDC, but prevent a
+    // remote IdP document from opening another privileged window while the
+    // flow is armed.
+    action: oidcExpectedOrigins.has(win) ? "deny" : "allow",
+  }));
+  win.webContents.on("will-navigate", (event, url) => {
+    let parsed: URL;
+    try {
+      parsed = new URL(url);
+    } catch {
+      event.preventDefault();
+      return;
+    }
+    const isShell = parsed.protocol === "file:" && url.includes("/build/index.html");
+    const devOrigin = parseHttpOrigin(DEV_SERVER_URL);
+    const isDevShell = isDevelopment && devOrigin === parsed.origin;
+    const flow = oidcExpectedOrigins.get(win);
+    const isExpectedApi = flow !== undefined && parsed.origin === flow.apiOrigin;
+    let providerOrigin = oidcProviderOrigins.get(win);
+    if (
+      !providerOrigin &&
+      flow &&
+      parsed.protocol === "https:" &&
+      parsed.origin !== flow.apiOrigin
+    ) {
+      providerOrigin = parsed.origin;
+      oidcProviderOrigins.set(win, providerOrigin);
+    }
+    const isOidcProviderHop = flow !== undefined && parsed.origin === providerOrigin;
+    if (!isShell && !isDevShell && !isExpectedApi && !isOidcProviderHop) {
+      event.preventDefault();
+    }
+  });
   if (!isDevelopment) {
     const handleReturnNavigation = (event: Electron.Event, url: string) => {
-      const expectedOrigin = oidcExpectedOrigins.get(win);
-      if (!expectedOrigin) return;
-      const callback = parseOidcCallback(url, expectedOrigin);
+      const flow = oidcExpectedOrigins.get(win);
+      if (!flow) return;
+      const callback = parseOidcCallback(url, flow.apiOrigin);
       if (!callback) return;
+      if (callback.path === "/oidc/bind") {
+        const hasAuthcode = Boolean(callback.query.authcode);
+        const hasProvider = Boolean(callback.query.provider);
+        if (!hasAuthcode && !hasProvider) return;
+        if (hasAuthcode && callback.query.authcode !== flow.authcode) return;
+        if (hasProvider && callback.query.provider !== flow.providerId) return;
+      }
 
       // The OIDC backend accepts the server-relative `/login` return target,
       // but Electron production pages are hosted from file://. Bring the
@@ -101,6 +161,7 @@ function registerOidcReturnRedirect(win: BrowserWindow, webUrl: string, sid: str
       // sid from getURL() would lose the original file:// page's sid.
       const query = withTrustedSessionSid(callback, sid);
       oidcExpectedOrigins.delete(win);
+      oidcProviderOrigins.delete(win);
       win.loadFile(webUrl, { query });
     };
 
@@ -503,18 +564,29 @@ const createMainWindow = async () => {
     mainWindow.focus();
   });
 
-  // Flush any buffered deep-link URL after every navigation completes. The
-  // renderer's `ipc.on("deep-link", ...)` listener needs the React tree to
-  // mount first, so URLs delivered before then (cold-boot via process.argv,
-  // second-instance argv, macOS open-url before did-finish-load) get held in
-  // `pendingDeepLinkUrl` and dispatched here.
+  // Flush any buffered deep-link URLs after navigation completes. The renderer
+  // gates its own `deep-link-ready` on the React tree mounting (see
+  // Layout/deepLink.ts), which is the authoritative signal — `did-finish-load`
+  // by itself is not, because React 18's async root can leave
+  // componentDidMount pending when this fires. We still listen here as a
+  // safety net after the ready handshake has already occurred at least once.
   mainWindow.webContents.on("did-finish-load", () => {
     dispatchPendingDeepLink();
+  });
+  // Every navigation invalidates the previous renderer's listener. Force the
+  // next shell to re-announce readiness before we flush the queue, otherwise
+  // an IdP-side navigation followed by a shell reload could try to dispatch
+  // to a listener that has not attached yet.
+  mainWindow.webContents.on("did-start-loading", () => {
+    rendererDeepLinkReady = false;
   });
 
   mainWindow.on("close", (e: any) => {
     if (forceQuit || !tray) {
       mainWindow = null;
+      // A new mainWindow will start fresh: its renderer has not yet attached
+      // a deep-link listener, so the readiness flag must not carry over.
+      rendererDeepLinkReady = false;
     } else {
       e.preventDefault();
       if (mainWindow.isFullScreen()) {
@@ -616,6 +688,10 @@ const DEEP_LINK_SCHEME = "dmwork";
 function isShellWebContentsUrl(url: string): boolean {
   if (!url) return false;
   if (url.startsWith("file://")) return url.includes("/build/index.html");
+  // In a packaged build there is no legitimate dev-server document. Refuse to
+  // treat any http(s) origin as a shell URL so a malicious page cannot pose
+  // as the shell to receive buffered deep-link URLs.
+  if (!isDevelopment) return false;
   try {
     const parsed = new URL(url);
     if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return false;
@@ -629,10 +705,26 @@ function isShellWebContentsUrl(url: string): boolean {
 // mounts (see Layout/deepLink.ts). At cold-boot the main process may already
 // have a URL from `process.argv` / `open-url` / `second-instance` before the
 // renderer preload has parsed, so a naive `webContents.send` there is dropped
-// on the floor. Buffer the most recent URL and flush it once the renderer's
-// `did-finish-load` fires — by then the preload has run and the React root
-// has had a tick to attach its listener.
-let pendingDeepLinkUrl: string | null = null;
+// on the floor. Buffer pending URLs and flush them once the renderer signals
+// readiness via `deep-link-ready` (or as a safety net when `did-finish-load`
+// fires on a shell URL).
+//
+// A small queue rather than a single slot: on macOS a second `dmwork://` can
+// arrive via `open-url` while the previous callback is still in flight, and
+// the callback that would be lost with a single slot is usually the one the
+// user just completed, not the stale one.
+const DEEP_LINK_QUEUE_MAX = 8;
+let pendingDeepLinkQueue: string[] = [];
+let rendererDeepLinkReady = false;
+
+function enqueueDeepLink(url: string): void {
+  if (pendingDeepLinkQueue.length >= DEEP_LINK_QUEUE_MAX) {
+    // Drop the OLDEST — a stale IdP redirect is less valuable than the most
+    // recent user-initiated callback.
+    pendingDeepLinkQueue.shift();
+  }
+  pendingDeepLinkQueue.push(url);
+}
 
 function isValidDeepLink(url: string): boolean {
   try {
@@ -651,14 +743,22 @@ function isValidDeepLink(url: string): boolean {
 }
 
 function dispatchPendingDeepLink() {
-  if (!pendingDeepLinkUrl) return;
+  if (pendingDeepLinkQueue.length === 0) return;
   if (!mainWindow || mainWindow.isDestroyed()) return;
   // Keep buffering while the renderer sits on the IdP / any non-shell page.
   // The next shell load will fire did-finish-load again and flush then.
   if (!isShellWebContentsUrl(mainWindow.webContents.getURL())) return;
-  const url = pendingDeepLinkUrl;
-  pendingDeepLinkUrl = null;
-  mainWindow.webContents.send("deep-link", url);
+  // Require an explicit renderer readiness signal so we do not clear the
+  // buffer before the React listener has actually attached. `did-finish-load`
+  // fires before componentDidMount under React 18's async root, which would
+  // otherwise silently drop the URL on cold boot.
+  if (!rendererDeepLinkReady) return;
+
+  const urls = pendingDeepLinkQueue;
+  pendingDeepLinkQueue = [];
+  for (const url of urls) {
+    mainWindow.webContents.send("deep-link", url);
+  }
 }
 
 function onDeepLink(url: string) {
@@ -667,21 +767,29 @@ function onDeepLink(url: string) {
     return;
   }
   console.log("onOpenDeepLink", url);
-  // macOS can deliver open-url before `ready` / createMainWindow. Do not
-  // dereference webContents in that case; the ready handler will process
-  // initial argv links once the window exists.
-  if (!mainWindow || mainWindow.isDestroyed()) {
-    console.warn("Deep link dropped: main window not ready:", url);
-    return;
-  }
-  pendingDeepLinkUrl = url;
-  if (!mainWindow.webContents.isLoading()) {
-    // dispatchPendingDeepLink still gates on the current URL being a shell URL,
-    // so this is safe to call mid-OIDC — it will re-buffer until the file://
-    // shell reload completes.
+  // Buffer FIRST, then attempt to flush. macOS `open-url` can arrive before
+  // `ready` / createMainWindow, and the app can also legitimately have no
+  // main window when the user closed it while tray is disabled — in both
+  // cases we must retain the URL so the eventual (re)mount can consume it.
+  // The argv fallback does NOT cover this: on macOS scheme launches deliver
+  // via `open-url`, not `process.argv`.
+  enqueueDeepLink(url);
+  if (mainWindow && !mainWindow.isDestroyed() && !mainWindow.webContents.isLoading()) {
+    // dispatchPendingDeepLink still gates on the current URL being a shell URL
+    // AND rendererDeepLinkReady, so this is safe to call mid-OIDC — the
+    // queue is preserved until the file:// shell reload completes and the
+    // renderer re-announces readiness.
     dispatchPendingDeepLink();
   }
 }
+
+// Renderer announces readiness after its `deep-link` IPC listener attaches
+// (Layout/deepLink.ts). Only the trusted shell origin can reach this channel
+// — the preload gates every send on `isTrustedShellOrigin`.
+ipcMain.on(IPC_DEEP_LINK_READY, () => {
+  rendererDeepLinkReady = true;
+  dispatchPendingDeepLink();
+});
 
 app.setName(OCTO_CONFIG.name);
 

--- a/apps/web/src-election/main/index.ts
+++ b/apps/web/src-election/main/index.ts
@@ -44,6 +44,34 @@ const DEV_SERVER_URL = process.env.VITE_DEV_SERVER_URL || "http://localhost:3000
 const APP_EXIT_DELAY_MS = 1000;
 const TRAY_FLASH_INTERVAL_MS = 1000;
 
+function registerOidcReturnRedirect(win: BrowserWindow, webUrl: string, sid: string) {
+  if (!isDevelopment) {
+    win.webContents.on("will-redirect", (event, url) => {
+      let parsed: URL;
+      try {
+        parsed = new URL(url);
+      } catch {
+        return;
+      }
+      if (parsed.pathname !== "/login") return;
+
+      // The OIDC backend accepts the server-relative `/login` return target,
+      // but Electron production pages are hosted from file://. Bring the
+      // renderer back to the packaged app while preserving oidc_error (and
+      // any future callback query parameters) for the pending-login handler.
+      event.preventDefault();
+      // Reuse the sid captured when this window was created. At this point
+      // webContents may already be on the IdP/API redirect URL, so reading
+      // sid from getURL() would lose the original file:// page's sid.
+      const query: Record<string, string> = { sid };
+      parsed.searchParams.forEach((value, key) => {
+        query[key] = value;
+      });
+      win.loadFile(webUrl, { query });
+    });
+  }
+}
+
 const registerWindowFocusHandler = () => {
   if (isWindowFocusHandlerRegistered) return;
 
@@ -410,7 +438,9 @@ const createNewWindow = () => {
   } else {
     process.env.DIST_ELECTRON = join(__dirname, "../");
     const WEB_URL = join(process.env.DIST_ELECTRON, "../build/index.html");
-    newWindow.loadFile(WEB_URL, { query: { sid: getRandomSid() } });
+    const sid = getRandomSid();
+    registerOidcReturnRedirect(newWindow, WEB_URL, sid);
+    newWindow.loadFile(WEB_URL, { query: { sid } });
   }
 
   // 为新窗口设置菜单（Windows 需要）
@@ -449,7 +479,9 @@ const createMainWindow = async () => {
   if (NODE_ENV !== "development") {
     process.env.DIST_ELECTRON = join(__dirname, "../");
     const WEB_URL = join(process.env.DIST_ELECTRON, "../build/index.html");
-    mainWindow.loadFile(WEB_URL, { query: { sid: getRandomSid() } });
+    const sid = getRandomSid();
+    registerOidcReturnRedirect(mainWindow, WEB_URL, sid);
+    mainWindow.loadFile(WEB_URL, { query: { sid } });
   }
 
   ipcMain.on("screenshots-start", (event, args) => {

--- a/apps/web/src-election/main/index.ts
+++ b/apps/web/src-election/main/index.ts
@@ -40,7 +40,11 @@ let isOsx = process.platform === "darwin";
 let isWin = process.platform === "win32";
 let isWindowFocusHandlerRegistered = false;
 
-const isDevelopment = process.env.NODE_ENV !== "production";
+// `NODE_ENV` is not guaranteed to be set when an installed Electron app is
+// launched from Finder/Explorer. Use Electron's authoritative packaging flag
+// so production builds always load the bundled file:// shell and install the
+// OIDC callback interceptor.
+const isDevelopment = !app.isPackaged && process.env.NODE_ENV !== "production";
 // dev 模式下渲染层 dev server 地址。端口需与 vite dev server 一致，
 // 默认 3000（对齐旧 dev-ele 脚本）；可用 VITE_DEV_SERVER_URL 覆盖，
 // 避免与机器上其它占用 3000 的进程（如 e2e vite）冲突。
@@ -70,7 +74,7 @@ ipcMain.on(IPC_OIDC_AUTHORIZE_START, (event, apiURL: unknown) => {
 
 function registerOidcReturnRedirect(win: BrowserWindow, webUrl: string, sid: string) {
   if (!isDevelopment) {
-    win.webContents.on("will-redirect", (event, url) => {
+    const handleReturnNavigation = (event: Electron.Event, url: string) => {
       const expectedOrigin = oidcExpectedOrigins.get(win);
       if (!expectedOrigin) return;
       const callback = parseOidcCallback(url, expectedOrigin);
@@ -87,7 +91,16 @@ function registerOidcReturnRedirect(win: BrowserWindow, webUrl: string, sid: str
       const query = withTrustedSessionSid(callback, sid);
       oidcExpectedOrigins.delete(win);
       win.loadFile(webUrl, { query });
-    });
+    };
+
+    // Depending on whether the IdP returns through an HTTP 30x or a browser
+    // navigation, Electron reports the callback as will-redirect or
+    // will-navigate. Handle both so the packaged file:// renderer never lands
+    // on the backend's server-relative /login page. If both events fire for
+    // the same navigation, the first invocation deletes the expected-origin
+    // entry, causing the second to return early — that's the dedupe guard.
+    win.webContents.on("will-redirect", handleReturnNavigation);
+    win.webContents.on("will-navigate", handleReturnNavigation);
   }
 }
 
@@ -437,7 +450,6 @@ const getWindowConfig = () => {
 
 // 创建新窗口
 const createNewWindow = () => {
-  const NODE_ENV = process.env.NODE_ENV;
   const newWindow = new BrowserWindow(getWindowConfig());
 
   newWindow.center();
@@ -452,7 +464,7 @@ const createNewWindow = () => {
   });
 
   // 加载相同的页面
-  if (NODE_ENV == "development") {
+  if (isDevelopment) {
     newWindow.loadURL(`${DEV_SERVER_URL}?sid=${getRandomSid()}`);
   } else {
     process.env.DIST_ELECTRON = join(__dirname, "../");
@@ -472,13 +484,21 @@ const createNewWindow = () => {
 };
 
 const createMainWindow = async () => {
-  const NODE_ENV = process.env.NODE_ENV;
   mainWindow = new BrowserWindow(getWindowConfig());
   mainWindow.center();
   mainWindow.once("ready-to-show", () => {
     mainWindow.setTitle(OCTO_CONFIG.name);
     mainWindow.show(); // 显示窗口
     mainWindow.focus();
+  });
+
+  // Flush any buffered deep-link URL after every navigation completes. The
+  // renderer's `ipc.on("deep-link", ...)` listener needs the React tree to
+  // mount first, so URLs delivered before then (cold-boot via process.argv,
+  // second-instance argv, macOS open-url before did-finish-load) get held in
+  // `pendingDeepLinkUrl` and dispatched here.
+  mainWindow.webContents.on("did-finish-load", () => {
+    dispatchPendingDeepLink();
   });
 
   mainWindow.on("close", (e: any) => {
@@ -494,8 +514,8 @@ const createMainWindow = async () => {
       }
     }
   });
-  if (NODE_ENV === "development") mainWindow.loadURL(DEV_SERVER_URL);
-  if (NODE_ENV !== "development") {
+  if (isDevelopment) mainWindow.loadURL(DEV_SERVER_URL);
+  if (!isDevelopment) {
     process.env.DIST_ELECTRON = join(__dirname, "../");
     const WEB_URL = join(process.env.DIST_ELECTRON, "../build/index.html");
     const sid = getRandomSid();
@@ -571,6 +591,37 @@ function restartApp() {
 }
 
 const ALLOWED_DEEP_LINK_SCHEMES = ["dmwork:"];
+const DEEP_LINK_SCHEME = "dmwork";
+
+// A deep link is meaningful only inside our own renderer document. During the
+// OIDC login flow the main BrowserWindow transiently navigates to the IdP
+// origin and back — every one of those transitions fires did-finish-load.
+// If we naively flush pendingDeepLinkUrl there, `webContents.send("deep-link")`
+// dispatches to the IdP page whose preload never attached our listener
+// (isTrustedShellOrigin() blocks it), the buffer is cleared, and the URL is
+// gone by the time the file:// shell reloads. Gate the flush on the current
+// webContents URL matching our shell (packaged file:// build/index.html, or
+// the configured dev-server origin).
+function isShellWebContentsUrl(url: string): boolean {
+  if (!url) return false;
+  if (url.startsWith("file://")) return url.includes("/build/index.html");
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return false;
+    return parsed.origin === new URL(DEV_SERVER_URL).origin;
+  } catch {
+    return false;
+  }
+}
+
+// The renderer's `deep-link` IPC listener only attaches after the React tree
+// mounts (see Layout/deepLink.ts). At cold-boot the main process may already
+// have a URL from `process.argv` / `open-url` / `second-instance` before the
+// renderer preload has parsed, so a naive `webContents.send` there is dropped
+// on the floor. Buffer the most recent URL and flush it once the renderer's
+// `did-finish-load` fires — by then the preload has run and the React root
+// has had a tick to attach its listener.
+let pendingDeepLinkUrl: string | null = null;
 
 function isValidDeepLink(url: string): boolean {
   try {
@@ -588,16 +639,40 @@ function isValidDeepLink(url: string): boolean {
   }
 }
 
+function dispatchPendingDeepLink() {
+  if (!pendingDeepLinkUrl) return;
+  if (!mainWindow || mainWindow.isDestroyed()) return;
+  // Keep buffering while the renderer sits on the IdP / any non-shell page.
+  // The next shell load will fire did-finish-load again and flush then.
+  if (!isShellWebContentsUrl(mainWindow.webContents.getURL())) return;
+  const url = pendingDeepLinkUrl;
+  pendingDeepLinkUrl = null;
+  mainWindow.webContents.send("deep-link", url);
+}
+
 function onDeepLink(url: string) {
   if (!isValidDeepLink(url)) {
     console.warn("Rejected invalid deep link:", url);
     return;
   }
   console.log("onOpenDeepLink", url);
-  mainWindow.webContents.send("deep-link", url);
+  pendingDeepLinkUrl = url;
+  if (mainWindow && !mainWindow.isDestroyed() && !mainWindow.webContents.isLoading()) {
+    // dispatchPendingDeepLink still gates on the current URL being a shell URL,
+    // so this is safe to call mid-OIDC — it will re-buffer until the file://
+    // shell reload completes.
+    dispatchPendingDeepLink();
+  }
 }
 
 app.setName(OCTO_CONFIG.name);
+
+// Register the callback scheme used by the web SSO hand-off. The packaged
+// electron-builder config declares the scheme via mac.protocols / win.protocols
+// / linux mimeType. This runtime call registers the current binary as the
+// default handler regardless of platform, which also covers development
+// (unsigned) runs and already-installed packaged clients across upgrades.
+app.setAsDefaultProtocolClient(DEEP_LINK_SCHEME);
 
 // NOTE: the one-time userData migration from the legacy <appData>/DMWork profile
 // to <appData>/OCTO is intentionally NOT part of this PR. It lives in the
@@ -624,6 +699,8 @@ if (!gotTheLock) {
   app.quit();
 } else {
   app.on("second-instance", (event, argv) => {
+    const deepLink = argv.find((arg) => isValidDeepLink(arg));
+    if (deepLink) onDeepLink(deepLink);
     if (mainWindow) {
       mainWindow.show();
       if (mainWindow.isMinimized()) {
@@ -638,6 +715,9 @@ app.on("ready", () => {
   regShortcut();
   registerWindowFocusHandler();
   createMainWindow(); // 创建窗口
+
+  const initialDeepLink = process.argv.find((arg) => isValidDeepLink(arg));
+  if (initialDeepLink) onDeepLink(initialDeepLink);
 
   if (isWin) {
     app.setAppUserModelId(OCTO_CONFIG.appId);

--- a/apps/web/src-election/main/oidcRedirect.ts
+++ b/apps/web/src-election/main/oidcRedirect.ts
@@ -1,5 +1,22 @@
 export type OidcCallbackPath = '/login' | '/oidc/bind'
 
+// Allowlist of query params that may be forwarded from the IdP/backend callback
+// URL into the packaged shell. Anything outside this list is dropped so a
+// hostile IdP/open-redirect can't smuggle attacker-chosen params into the
+// renderer (e.g. `__octo_route=/oidc/bind&token=…` on a `/login` callback).
+// Keep this list in sync with the shell entry points that actually read
+// callback params: OidcResumeEffect (`oidc_error`), the bind entry
+// (`token`, `authcode`, `return_to`, `provider`), and the OIDC state param.
+const FORWARDABLE_QUERY_KEYS: ReadonlySet<string> = new Set([
+  'code',
+  'state',
+  'oidc_error',
+  'token',
+  'authcode',
+  'return_to',
+  'provider',
+])
+
 export function parseOidcCallback(url: string, expectedOrigin: string): {
   path: OidcCallbackPath
   query: Record<string, string>
@@ -24,7 +41,19 @@ export function withTrustedSessionSid(
   callback: { path: OidcCallbackPath; query: Record<string, string> },
   sid: string,
 ): Record<string, string> {
-  const query = { ...callback.query }
+  // Rebuild the query from an explicit allowlist rather than spreading the
+  // callback query. Two things this closes:
+  //   1. `__octo_route` — always derived from `callback.path`, never inherited
+  //      from the callback query. Without this, a `/login` callback could
+  //      carry `__octo_route=/oidc/bind&token=…` and land in the bind flow
+  //      with a trusted sid attached.
+  //   2. Any future param an IdP or open-redirect could add: dropped by
+  //      default rather than silently reaching the renderer.
+  const query: Record<string, string> = {}
+  FORWARDABLE_QUERY_KEYS.forEach((key) => {
+    const value = callback.query[key]
+    if (typeof value === 'string') query[key] = value
+  })
   if (callback.path === '/oidc/bind') query.__octo_route = '/oidc/bind'
   query.sid = sid
   return query

--- a/apps/web/src-election/main/oidcRedirect.ts
+++ b/apps/web/src-election/main/oidcRedirect.ts
@@ -1,0 +1,31 @@
+export type OidcCallbackPath = '/login' | '/oidc/bind'
+
+export function parseOidcCallback(url: string, expectedOrigin: string): {
+  path: OidcCallbackPath
+  query: Record<string, string>
+} | undefined {
+  let parsed: URL
+  try {
+    parsed = new URL(url)
+  } catch {
+    return undefined
+  }
+  if (parsed.origin !== expectedOrigin) return undefined
+  if (parsed.pathname !== '/login' && parsed.pathname !== '/oidc/bind') return undefined
+
+  const query: Record<string, string> = {}
+  parsed.searchParams.forEach((value, key) => {
+    query[key] = value
+  })
+  return { path: parsed.pathname, query }
+}
+
+export function withTrustedSessionSid(
+  callback: { path: OidcCallbackPath; query: Record<string, string> },
+  sid: string,
+): Record<string, string> {
+  const query = { ...callback.query }
+  if (callback.path === '/oidc/bind') query.__octo_route = '/oidc/bind'
+  query.sid = sid
+  return query
+}

--- a/apps/web/src-election/main/oidcRedirect.ts
+++ b/apps/web/src-election/main/oidcRedirect.ts
@@ -4,18 +4,12 @@ export type OidcCallbackPath = '/login' | '/oidc/bind'
 // URL into the packaged shell. Anything outside this list is dropped so a
 // hostile IdP/open-redirect can't smuggle attacker-chosen params into the
 // renderer (e.g. `__octo_route=/oidc/bind&token=…` on a `/login` callback).
-// Keep this list in sync with the shell entry points that actually read
-// callback params: OidcResumeEffect (`oidc_error`), the bind entry
-// (`token`, `authcode`, `return_to`, `provider`), and the OIDC state param.
-const FORWARDABLE_QUERY_KEYS: ReadonlySet<string> = new Set([
-  'code',
-  'state',
-  'oidc_error',
-  'token',
-  'authcode',
-  'return_to',
-  'provider',
-])
+const FORWARDABLE_QUERY_KEYS: Record<OidcCallbackPath, ReadonlySet<string>> = {
+  // /login consumes only the failure marker. Credentials and bind material
+  // must never be copied into the shell on this path.
+  '/login': new Set(['oidc_error']),
+  '/oidc/bind': new Set(['token', 'authcode', 'return_to', 'provider']),
+}
 
 export function parseOidcCallback(url: string, expectedOrigin: string): {
   path: OidcCallbackPath
@@ -50,7 +44,7 @@ export function withTrustedSessionSid(
   //   2. Any future param an IdP or open-redirect could add: dropped by
   //      default rather than silently reaching the renderer.
   const query: Record<string, string> = {}
-  FORWARDABLE_QUERY_KEYS.forEach((key) => {
+  FORWARDABLE_QUERY_KEYS[callback.path].forEach((key) => {
     const value = callback.query[key]
     if (typeof value === 'string') query[key] = value
   })

--- a/apps/web/src-election/preload/index.ts
+++ b/apps/web/src-election/preload/index.ts
@@ -1,9 +1,29 @@
 import { contextBridge, ipcRenderer } from "electron";
-import { subscribeDisposable } from "./notificationListeners";
-import {
-  IPC_CONVERSATION_UNREAD_COUNT,
-  IPC_OIDC_AUTHORIZE_START,
-} from "../shared/ipc-channels";
+
+// Keep the preload entry fully self-contained. Sandboxed preload inside
+// app.asar cannot reliably resolve relative CommonJS imports, and any throw
+// here happens *before* contextBridge.exposeInMainWorld runs — which cascades
+// to `window.__POWERED_ELECTRON__` being undefined, WKApp.shared.isPC staying
+// false, and the OIDC login flow building `file:///v1/...` URLs (white
+// screen). Do NOT re-add imports from ../shared/*; duplicate the constants
+// here and keep them in sync with apps/web/src-election/shared/ipc-channels.ts.
+const IPC_CONVERSATION_UNREAD_COUNT = "conversation-manager-unread-count";
+const IPC_OIDC_AUTHORIZE_START = "oidc-authorize-start";
+
+function subscribeDisposable<T = any>(
+  renderer: Pick<typeof ipcRenderer, "on" | "removeListener">,
+  channel: string,
+  callback: (data: T) => void,
+): () => void {
+  const handler = (_event: unknown, data: T) => callback(data);
+  renderer.on(channel, handler);
+  let disposed = false;
+  return () => {
+    if (disposed) return;
+    disposed = true;
+    renderer.removeListener(channel, handler);
+  };
+}
 
 const ALLOWED_SEND_CHANNELS = [
   "check-update",
@@ -37,10 +57,91 @@ const ALLOWED_RECEIVE_CHANNELS = [
   "update-downloaded",
 ];
 
-contextBridge.exposeInMainWorld("__POWERED_ELECTRON__", true);
+// The OIDC login flow drives the main BrowserWindow through a third-party IdP
+// origin before redirecting back to the packaged shell. The preload script
+// re-attaches on every navigation in that webContents, so the IdP document
+// (and anything it further redirects through) also gets `window.ipc` — and
+// with it access to privileged channels like `restart-app`, `update-app`,
+// `screenshots-start`, and `oidc-authorize-start` (self-referential: an IdP
+// page could reset the expected origin used by the main-process redirect
+// interceptor). Gate every renderer→main IPC call on the current document's
+// origin so only the packaged shell (file://) and the dev server can reach it.
+//
+// The dev server port is configurable in main/index.ts. Keep the default as a
+// fallback, but do not trust every localhost port: another local process may
+// be serving attacker-controlled HTML.
+const DEFAULT_DEV_ORIGIN = "http://localhost:3000";
+
+function configuredDevOrigins(): Set<string> {
+  const origins = new Set([DEFAULT_DEV_ORIGIN]);
+  const configured = process.env.VITE_DEV_SERVER_URL;
+  if (configured) {
+    try {
+      const url = new URL(configured);
+      if (url.protocol === "http:" || url.protocol === "https:") {
+        origins.add(url.origin);
+      }
+    } catch {
+      // Ignore malformed environment input and retain the safe default.
+    }
+  }
+  return origins;
+}
+
+const TRUSTED_DEV_ORIGINS = configuredDevOrigins();
+
+function normalizeFilePath(value: string): string {
+  try {
+    return decodeURIComponent(value)
+      .replace(/\\/g, "/")
+      .replace(/^\/(?:[A-Za-z]:)/, (drive) => drive.slice(1))
+      .replace(/\/+$/, "");
+  } catch {
+    return value.replace(/\\/g, "/").replace(/\/+$/, "");
+  }
+}
+
+function isPackagedShellFile(): boolean {
+  try {
+    const resourcesPath = process.resourcesPath;
+    if (typeof resourcesPath !== "string" || !resourcesPath) return false;
+
+    const pathname = normalizeFilePath(window.location.pathname);
+    const resources = normalizeFilePath(resourcesPath);
+    return pathname === `${resources}/app.asar/build/index.html`;
+  } catch {
+    return false;
+  }
+}
+
+function isTrustedShellOrigin(): boolean {
+  try {
+    const { protocol, origin } = window.location;
+    if (protocol === "file:") return isPackagedShellFile();
+    return TRUSTED_DEV_ORIGINS.has(origin);
+  } catch {
+    return false;
+  }
+}
+
+// Expose the runtime flag only to the packaged shell (file://) and configured
+// dev server. During OIDC the main window transiently navigates to the remote
+// IdP/API origin; preload re-attaches to that navigation, and if we expose
+// `__POWERED_ELECTRON__` there too, any octo-web bundle served from that
+// origin false-positives on its Electron detection (see
+// apps/web/src/index.tsx isDesktopRuntime) and reads
+// `import.meta.env.VITE_API_URL` — which the web build does not inline — and
+// then throws in resolveApiURL. Gate this the same way as `ipc` below.
+if (isTrustedShellOrigin()) {
+  contextBridge.exposeInMainWorld("__POWERED_ELECTRON__", true);
+}
 
 contextBridge.exposeInMainWorld("ipc", {
   send: (channel: string, ...args: any[]) => {
+    if (!isTrustedShellOrigin()) {
+      console.warn(`[preload] Blocked send from untrusted origin: ${channel}`);
+      return;
+    }
     if (ALLOWED_SEND_CHANNELS.includes(channel)) {
       ipcRenderer.send(channel, ...args);
     } else {
@@ -48,6 +149,10 @@ contextBridge.exposeInMainWorld("ipc", {
     }
   },
   invoke: (channel: string, ...args: any[]): Promise<any> => {
+    if (!isTrustedShellOrigin()) {
+      console.warn(`[preload] Blocked invoke from untrusted origin: ${channel}`);
+      return Promise.reject(new Error(`IPC channel not allowed from this origin: ${channel}`));
+    }
     if (ALLOWED_INVOKE_CHANNELS.includes(channel)) {
       return ipcRenderer.invoke(channel, ...args);
     }
@@ -58,6 +163,10 @@ contextBridge.exposeInMainWorld("ipc", {
     channel: string,
     listener: (event: Electron.IpcRendererEvent, ...args: any[]) => void
   ) => {
+    if (!isTrustedShellOrigin()) {
+      console.warn(`[preload] Blocked listener from untrusted origin: ${channel}`);
+      return;
+    }
     if (ALLOWED_RECEIVE_CHANNELS.includes(channel)) {
       ipcRenderer.on(channel, listener);
     } else {
@@ -68,6 +177,10 @@ contextBridge.exposeInMainWorld("ipc", {
     channel: string,
     listener: (event: Electron.IpcRendererEvent, ...args: any[]) => void
   ) => {
+    if (!isTrustedShellOrigin()) {
+      console.warn(`[preload] Blocked once-listener from untrusted origin: ${channel}`);
+      return;
+    }
     if (ALLOWED_RECEIVE_CHANNELS.includes(channel)) {
       ipcRenderer.once(channel, listener);
     } else {
@@ -78,6 +191,7 @@ contextBridge.exposeInMainWorld("ipc", {
     channel: string,
     listener: (event: Electron.IpcRendererEvent, ...args: any[]) => void
   ) => {
+    if (!isTrustedShellOrigin()) return;
     if (ALLOWED_RECEIVE_CHANNELS.includes(channel)) {
       ipcRenderer.removeListener(channel, listener);
     } else {
@@ -86,18 +200,30 @@ contextBridge.exposeInMainWorld("ipc", {
   },
 });
 
-// Expose native notification API
+// Expose native notification API. These endpoints all funnel through
+// `invoke("...")`, which is already origin-gated in the `ipc` wrapper above;
+// duplicate the check here so a third-party origin cannot bypass the wrapper
+// by calling this alias directly.
+function invokeIfTrusted<T = unknown>(channel: string, ...args: unknown[]): Promise<T> {
+  if (!isTrustedShellOrigin()) {
+    return Promise.reject(new Error(`electronNotification not allowed from this origin: ${channel}`));
+  }
+  return ipcRenderer.invoke(channel, ...args) as Promise<T>;
+}
+
+function subscribeIfTrusted(channel: string, callback: (data: any) => void): () => void {
+  if (!isTrustedShellOrigin()) return () => undefined;
+  return subscribeDisposable(ipcRenderer, channel, callback);
+}
+
 contextBridge.exposeInMainWorld("electronNotification", {
-  show: (options: any) =>
-    ipcRenderer.invoke("show-native-notification", options),
-  close: (tag: string) => ipcRenderer.invoke("close-native-notification", tag),
-  closeAll: () => ipcRenderer.invoke("close-all-native-notifications"),
+  show: (options: any) => invokeIfTrusted("show-native-notification", options),
+  close: (tag: string) => invokeIfTrusted("close-native-notification", tag),
+  closeAll: () => invokeIfTrusted("close-all-native-notifications"),
   onClicked: (callback: (data: any) => void) =>
-    subscribeDisposable(ipcRenderer, "notification-clicked", callback),
+    subscribeIfTrusted("notification-clicked", callback),
   onActionClicked: (callback: (data: any) => void) =>
-    subscribeDisposable(ipcRenderer, "notification-action-clicked", callback),
-  // Test notification icon
-  testNotificationIcon: () => ipcRenderer.invoke("test-notification-icon"),
-  // Query real window focus state from main process
-  isWindowFocused: () => ipcRenderer.invoke("is-window-focused"),
+    subscribeIfTrusted("notification-action-clicked", callback),
+  testNotificationIcon: () => invokeIfTrusted("test-notification-icon"),
+  isWindowFocused: () => invokeIfTrusted("is-window-focused"),
 });

--- a/apps/web/src-election/preload/index.ts
+++ b/apps/web/src-election/preload/index.ts
@@ -10,7 +10,7 @@ import { contextBridge, ipcRenderer } from "electron";
 const IPC_CONVERSATION_UNREAD_COUNT = "conversation-manager-unread-count";
 const IPC_OIDC_AUTHORIZE_START = "oidc-authorize-start";
 const IPC_OIDC_AUTHORIZE_START_INVOKE = "oidc-authorize-start-invoke";
-const IPC_DEEP_LINK_READY = "deep-link-ready";
+const IPC_OIDC_AUTHORIZE_CANCEL = "oidc-authorize-cancel";
 
 function subscribeDisposable<T = any>(
   renderer: Pick<typeof ipcRenderer, "on" | "removeListener">,
@@ -34,7 +34,7 @@ const ALLOWED_SEND_CHANNELS = [
   IPC_CONVERSATION_UNREAD_COUNT,
   IPC_OIDC_AUTHORIZE_START,
   IPC_OIDC_AUTHORIZE_START_INVOKE,
-  IPC_DEEP_LINK_READY,
+  IPC_OIDC_AUTHORIZE_CANCEL,
   "screenshots-start",
   "restart-app",
 ];
@@ -52,7 +52,6 @@ const ALLOWED_RECEIVE_CHANNELS = [
   "notification-clicked",
   "notification-action-clicked",
   "screenshots-ok",
-  "deep-link",
   "show-conversations",
   "update-error",
   "update-available",

--- a/apps/web/src-election/preload/index.ts
+++ b/apps/web/src-election/preload/index.ts
@@ -1,12 +1,16 @@
 import { contextBridge, ipcRenderer } from "electron";
 import { subscribeDisposable } from "./notificationListeners";
-import { IPC_CONVERSATION_UNREAD_COUNT } from "../shared/ipc-channels";
+import {
+  IPC_CONVERSATION_UNREAD_COUNT,
+  IPC_OIDC_AUTHORIZE_START,
+} from "../shared/ipc-channels";
 
 const ALLOWED_SEND_CHANNELS = [
   "check-update",
   "install-update",
   "update-app",
   IPC_CONVERSATION_UNREAD_COUNT,
+  IPC_OIDC_AUTHORIZE_START,
   "screenshots-start",
   "restart-app",
 ];

--- a/apps/web/src-election/preload/index.ts
+++ b/apps/web/src-election/preload/index.ts
@@ -9,6 +9,7 @@ import { contextBridge, ipcRenderer } from "electron";
 // here and keep them in sync with apps/web/src-election/shared/ipc-channels.ts.
 const IPC_CONVERSATION_UNREAD_COUNT = "conversation-manager-unread-count";
 const IPC_OIDC_AUTHORIZE_START = "oidc-authorize-start";
+const IPC_OIDC_AUTHORIZE_START_INVOKE = "oidc-authorize-start-invoke";
 const IPC_DEEP_LINK_READY = "deep-link-ready";
 
 function subscribeDisposable<T = any>(
@@ -32,6 +33,7 @@ const ALLOWED_SEND_CHANNELS = [
   "update-app",
   IPC_CONVERSATION_UNREAD_COUNT,
   IPC_OIDC_AUTHORIZE_START,
+  IPC_OIDC_AUTHORIZE_START_INVOKE,
   IPC_DEEP_LINK_READY,
   "screenshots-start",
   "restart-app",
@@ -72,10 +74,15 @@ const ALLOWED_RECEIVE_CHANNELS = [
 // In a PACKAGED build, no legitimate document is served from a dev-server
 // origin — any http://localhost:3000 document there is either an accidentally
 // running local server or an attacker-controlled page. Gate the dev-origin
-// allowlist on `process.defaultApp` (Electron's dev-mode flag) so production
-// trusts only the packaged file:// shell.
+// allowlist on a main-process-provided runtime argument so production trusts
+// only the packaged file:// shell, including sandboxed preloads.
 const DEFAULT_DEV_ORIGIN = "http://localhost:3000";
-const IS_DEV_RUNTIME = Boolean((process as unknown as { defaultApp?: boolean }).defaultApp);
+function getArgValue(prefix: string): string | undefined {
+  const arg = process.argv.find((value) => value.startsWith(prefix));
+  return arg ? arg.slice(prefix.length) : undefined;
+}
+
+const IS_DEV_RUNTIME = getArgValue("--octo-dev=") === "true";
 
 function configuredDevOrigins(): Set<string> {
   const origins = new Set<string>();
@@ -111,12 +118,9 @@ function normalizeFilePath(value: string): string {
 
 function isPackagedShellFile(): boolean {
   try {
-    const resourcesPath = process.resourcesPath;
-    if (typeof resourcesPath !== "string" || !resourcesPath) return false;
-
     const pathname = normalizeFilePath(window.location.pathname);
-    const resources = normalizeFilePath(resourcesPath);
-    return pathname === `${resources}/app.asar/build/index.html`;
+    const shellPath = getArgValue("--octo-shell-path=");
+    return typeof shellPath === "string" && pathname === normalizeFilePath(shellPath);
   } catch {
     return false;
   }

--- a/apps/web/src-election/preload/index.ts
+++ b/apps/web/src-election/preload/index.ts
@@ -9,6 +9,7 @@ import { contextBridge, ipcRenderer } from "electron";
 // here and keep them in sync with apps/web/src-election/shared/ipc-channels.ts.
 const IPC_CONVERSATION_UNREAD_COUNT = "conversation-manager-unread-count";
 const IPC_OIDC_AUTHORIZE_START = "oidc-authorize-start";
+const IPC_DEEP_LINK_READY = "deep-link-ready";
 
 function subscribeDisposable<T = any>(
   renderer: Pick<typeof ipcRenderer, "on" | "removeListener">,
@@ -31,6 +32,7 @@ const ALLOWED_SEND_CHANNELS = [
   "update-app",
   IPC_CONVERSATION_UNREAD_COUNT,
   IPC_OIDC_AUTHORIZE_START,
+  IPC_DEEP_LINK_READY,
   "screenshots-start",
   "restart-app",
 ];
@@ -67,13 +69,19 @@ const ALLOWED_RECEIVE_CHANNELS = [
 // interceptor). Gate every renderer→main IPC call on the current document's
 // origin so only the packaged shell (file://) and the dev server can reach it.
 //
-// The dev server port is configurable in main/index.ts. Keep the default as a
-// fallback, but do not trust every localhost port: another local process may
-// be serving attacker-controlled HTML.
+// In a PACKAGED build, no legitimate document is served from a dev-server
+// origin — any http://localhost:3000 document there is either an accidentally
+// running local server or an attacker-controlled page. Gate the dev-origin
+// allowlist on `process.defaultApp` (Electron's dev-mode flag) so production
+// trusts only the packaged file:// shell.
 const DEFAULT_DEV_ORIGIN = "http://localhost:3000";
+const IS_DEV_RUNTIME = Boolean((process as unknown as { defaultApp?: boolean }).defaultApp);
 
 function configuredDevOrigins(): Set<string> {
-  const origins = new Set([DEFAULT_DEV_ORIGIN]);
+  const origins = new Set<string>();
+  // Dev origins are meaningless — and dangerous — in packaged builds.
+  if (!IS_DEV_RUNTIME) return origins;
+  origins.add(DEFAULT_DEV_ORIGIN);
   const configured = process.env.VITE_DEV_SERVER_URL;
   if (configured) {
     try {

--- a/apps/web/src-election/shared/ipc-channels.ts
+++ b/apps/web/src-election/shared/ipc-channels.ts
@@ -12,6 +12,9 @@ export const IPC_CONVERSATION_UNREAD_COUNT = "conversation-manager-unread-count"
 /** Renderer → Main: register the API origin expected for the OIDC callback. */
 export const IPC_OIDC_AUTHORIZE_START = "oidc-authorize-start";
 
+/** Renderer → Main: arm the OIDC navigation boundary before leaving the shell. */
+export const IPC_OIDC_AUTHORIZE_START_INVOKE = "oidc-authorize-start-invoke";
+
 /**
  * Renderer → Main: the deep-link IPC listener has attached and any buffered
  * URLs may be flushed. The main process resets its readiness flag on every

--- a/apps/web/src-election/shared/ipc-channels.ts
+++ b/apps/web/src-election/shared/ipc-channels.ts
@@ -11,3 +11,10 @@ export const IPC_CONVERSATION_UNREAD_COUNT = "conversation-manager-unread-count"
 
 /** Renderer → Main: register the API origin expected for the OIDC callback. */
 export const IPC_OIDC_AUTHORIZE_START = "oidc-authorize-start";
+
+/**
+ * Renderer → Main: the deep-link IPC listener has attached and any buffered
+ * URLs may be flushed. The main process resets its readiness flag on every
+ * navigation, so the renderer must re-announce after each shell load.
+ */
+export const IPC_DEEP_LINK_READY = "deep-link-ready";

--- a/apps/web/src-election/shared/ipc-channels.ts
+++ b/apps/web/src-election/shared/ipc-channels.ts
@@ -8,3 +8,6 @@
 
 /** Renderer → Main: sync the current unread-message count to the tray. */
 export const IPC_CONVERSATION_UNREAD_COUNT = "conversation-manager-unread-count";
+
+/** Renderer → Main: register the API origin expected for the OIDC callback. */
+export const IPC_OIDC_AUTHORIZE_START = "oidc-authorize-start";

--- a/apps/web/src-election/shared/ipc-channels.ts
+++ b/apps/web/src-election/shared/ipc-channels.ts
@@ -15,9 +15,5 @@ export const IPC_OIDC_AUTHORIZE_START = "oidc-authorize-start";
 /** Renderer → Main: arm the OIDC navigation boundary before leaving the shell. */
 export const IPC_OIDC_AUTHORIZE_START_INVOKE = "oidc-authorize-start-invoke";
 
-/**
- * Renderer → Main: the deep-link IPC listener has attached and any buffered
- * URLs may be flushed. The main process resets its readiness flag on every
- * navigation, so the renderer must re-announce after each shell load.
- */
-export const IPC_DEEP_LINK_READY = "deep-link-ready";
+/** Renderer → Main: cancel an armed OIDC navigation flow. */
+export const IPC_OIDC_AUTHORIZE_CANCEL = "oidc-authorize-cancel";

--- a/apps/web/src/Layout/__tests__/deepLink.test.ts
+++ b/apps/web/src/Layout/__tests__/deepLink.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest'
+import { buildShellUrlForDeepLink } from '../deepLink'
+
+describe('buildShellUrlForDeepLink', () => {
+  const shell =
+    'file:///Applications/OCTO.app/Contents/Resources/app.asar/build/index.html?sid=window-sid'
+
+  it('routes dmwork://oidc/bind through __octo_route so BindModule.init() picks it up', () => {
+    const out = buildShellUrlForDeepLink(
+      'dmwork://oidc/bind?token=abc&provider=aegis',
+      shell,
+    )
+    expect(out).not.toBeNull()
+    const url = new URL(out!)
+    expect(url.protocol).toBe('file:')
+    expect(url.pathname).toBe('/Applications/OCTO.app/Contents/Resources/app.asar/build/index.html')
+    expect(url.searchParams.get('__octo_route')).toBe('/oidc/bind')
+    expect(url.searchParams.get('token')).toBe('abc')
+    expect(url.searchParams.get('provider')).toBe('aegis')
+    // sid from the shell URL must survive — main.ts owns that value.
+    expect(url.searchParams.get('sid')).toBe('window-sid')
+  })
+
+  it('refuses to overwrite the trusted sid captured by main.ts', () => {
+    const out = buildShellUrlForDeepLink(
+      'dmwork://oidc/bind?token=abc&sid=attacker-sid',
+      shell,
+    )
+    expect(out).not.toBeNull()
+    const url = new URL(out!)
+    expect(url.searchParams.get('sid')).toBe('window-sid')
+  })
+
+  it('returns null for non-dmwork schemes', () => {
+    expect(buildShellUrlForDeepLink('https://example.com/oidc/bind?token=abc', shell))
+      .toBeNull()
+    expect(buildShellUrlForDeepLink('javascript:alert(1)', shell)).toBeNull()
+  })
+
+  it('returns null for malformed URLs', () => {
+    expect(buildShellUrlForDeepLink('not-a-url', shell)).toBeNull()
+    expect(buildShellUrlForDeepLink('', shell)).toBeNull()
+  })
+
+  it('works when the shell URL is http (dev mode)', () => {
+    const out = buildShellUrlForDeepLink(
+      'dmwork://oidc/bind?token=abc',
+      'http://localhost:3000/?sid=dev-sid',
+    )
+    expect(out).not.toBeNull()
+    const url = new URL(out!)
+    expect(url.origin).toBe('http://localhost:3000')
+    expect(url.searchParams.get('__octo_route')).toBe('/oidc/bind')
+    expect(url.searchParams.get('token')).toBe('abc')
+    expect(url.searchParams.get('sid')).toBe('dev-sid')
+  })
+
+  it('normalizes dmwork:oidc/bind (no double slash) to the same route as dmwork://oidc/bind', () => {
+    // The URL parser collapses both forms to `host=oidc, pathname=/bind` on
+    // any WHATWG-compliant runtime, so downstream handling is identical.
+    // Documenting the invariant here catches future parser changes.
+    const slashed = buildShellUrlForDeepLink('dmwork://oidc/bind?token=abc', shell)
+    const bare = buildShellUrlForDeepLink('dmwork:oidc/bind?token=abc', shell)
+    expect(slashed).not.toBeNull()
+    expect(bare).not.toBeNull()
+    expect(new URL(slashed!).searchParams.get('__octo_route')).toBe('/oidc/bind')
+    expect(new URL(bare!).searchParams.get('__octo_route')).toBe('/oidc/bind')
+  })
+
+  it('strips a trailing slash so `dmwork://oidc/bind/` still matches BindModule', () => {
+    // BindModule.init() uses exact equality on `__octo_route === '/oidc/bind'`.
+    // Some protocol handlers / OS shells may normalize URIs with a trailing
+    // slash; without stripping it here the latch never sets and the bind
+    // token is dropped on the floor.
+    const out = buildShellUrlForDeepLink('dmwork://oidc/bind/?token=abc', shell)
+    expect(out).not.toBeNull()
+    expect(new URL(out!).searchParams.get('__octo_route')).toBe('/oidc/bind')
+  })
+})

--- a/apps/web/src/Layout/__tests__/deepLink.test.ts
+++ b/apps/web/src/Layout/__tests__/deepLink.test.ts
@@ -1,13 +1,31 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { buildShellUrlForDeepLink } from '../deepLink'
+
+// Every non-null assertion below needs a valid pending-bind marker to survive
+// the P1-2 correlation check. `dmwork://oidc/bind` is rejected outright
+// without one — see the dedicated block at the bottom of this file.
+function seedPendingBind(): void {
+  localStorage.setItem(
+    'pending_oidc_bind',
+    JSON.stringify({ providerId: 'aegis', authcode: 'auth-code', savedAt: Date.now() }),
+  )
+}
 
 describe('buildShellUrlForDeepLink', () => {
   const shell =
     'file:///Applications/OCTO.app/Contents/Resources/app.asar/build/index.html?sid=window-sid'
 
+  beforeEach(() => {
+    seedPendingBind()
+  })
+
+  afterEach(() => {
+    localStorage.clear()
+  })
+
   it('routes dmwork://oidc/bind through __octo_route so BindModule.init() picks it up', () => {
     const out = buildShellUrlForDeepLink(
-      'dmwork://oidc/bind?token=abc&provider=aegis',
+      'dmwork://oidc/bind?token=abc&provider=aegis&authcode=auth-code',
       shell,
     )
     expect(out).not.toBeNull()
@@ -23,12 +41,21 @@ describe('buildShellUrlForDeepLink', () => {
 
   it('refuses to overwrite the trusted sid captured by main.ts', () => {
     const out = buildShellUrlForDeepLink(
-      'dmwork://oidc/bind?token=abc&sid=attacker-sid',
+      'dmwork://oidc/bind?token=abc&provider=aegis&authcode=auth-code&sid=attacker-sid',
       shell,
     )
     expect(out).not.toBeNull()
     const url = new URL(out!)
     expect(url.searchParams.get('sid')).toBe('window-sid')
+  })
+
+  it('refuses to overwrite the route derived from the deep-link path', () => {
+    const out = buildShellUrlForDeepLink(
+      'dmwork://oidc/bind?token=abc&__octo_route=/login',
+      shell,
+    )
+    expect(out).not.toBeNull()
+    expect(new URL(out!).searchParams.get('__octo_route')).toBe('/oidc/bind')
   })
 
   it('returns null for non-dmwork schemes', () => {
@@ -44,7 +71,7 @@ describe('buildShellUrlForDeepLink', () => {
 
   it('works when the shell URL is http (dev mode)', () => {
     const out = buildShellUrlForDeepLink(
-      'dmwork://oidc/bind?token=abc',
+      'dmwork://oidc/bind?token=abc&provider=aegis&authcode=auth-code',
       'http://localhost:3000/?sid=dev-sid',
     )
     expect(out).not.toBeNull()
@@ -59,8 +86,8 @@ describe('buildShellUrlForDeepLink', () => {
     // The URL parser collapses both forms to `host=oidc, pathname=/bind` on
     // any WHATWG-compliant runtime, so downstream handling is identical.
     // Documenting the invariant here catches future parser changes.
-    const slashed = buildShellUrlForDeepLink('dmwork://oidc/bind?token=abc', shell)
-    const bare = buildShellUrlForDeepLink('dmwork:oidc/bind?token=abc', shell)
+    const slashed = buildShellUrlForDeepLink('dmwork://oidc/bind?token=abc&provider=aegis&authcode=auth-code', shell)
+    const bare = buildShellUrlForDeepLink('dmwork:oidc/bind?token=abc&provider=aegis&authcode=auth-code', shell)
     expect(slashed).not.toBeNull()
     expect(bare).not.toBeNull()
     expect(new URL(slashed!).searchParams.get('__octo_route')).toBe('/oidc/bind')
@@ -72,8 +99,81 @@ describe('buildShellUrlForDeepLink', () => {
     // Some protocol handlers / OS shells may normalize URIs with a trailing
     // slash; without stripping it here the latch never sets and the bind
     // token is dropped on the floor.
-    const out = buildShellUrlForDeepLink('dmwork://oidc/bind/?token=abc', shell)
+    const out = buildShellUrlForDeepLink('dmwork://oidc/bind/?token=abc&provider=aegis&authcode=auth-code', shell)
     expect(out).not.toBeNull()
     expect(new URL(out!).searchParams.get('__octo_route')).toBe('/oidc/bind')
+  })
+})
+
+// P1-2: the `dmwork://` scheme is registered as an OS-level protocol handler
+// (electron-builder.js mac/win/linux). Any web page can trigger it. Without
+// a client-side correlation check, an attacker could pre-craft a bind link
+// whose token binds the attacker's external identity to the victim's account
+// once the victim clears the password/OTP challenge — mirrored on the login
+// side in login_vm.tsx:650 via `pending_oidc_login`. The bind side gets its
+// own persistent marker (localStorage, survives cold restart) so the same
+// property holds when SSO round-trips through an external browser.
+describe('buildShellUrlForDeepLink — bind correlation check (P1-2)', () => {
+  const shell =
+    'file:///Applications/OCTO.app/Contents/Resources/app.asar/build/index.html?sid=window-sid'
+
+  afterEach(() => {
+    localStorage.clear()
+  })
+
+  it('rejects dmwork://oidc/bind when no OIDC flow was locally initiated', () => {
+    // No marker written — this is the attack scenario.
+    const out = buildShellUrlForDeepLink(
+      'dmwork://oidc/bind?token=ATTACKER_TOKEN',
+      shell,
+    )
+    expect(out).toBeNull()
+  })
+
+  it('rejects dmwork://oidc/bind when the marker has expired', () => {
+    // OIDC_AUTHCODE_TTL_MS is 5 minutes. Backdate the marker past the TTL.
+    localStorage.setItem(
+      'pending_oidc_bind',
+      JSON.stringify({ providerId: 'aegis', savedAt: Date.now() - 10 * 60 * 1000 }),
+    )
+    const out = buildShellUrlForDeepLink(
+      'dmwork://oidc/bind?token=STALE_TOKEN&provider=aegis&authcode=auth-code',
+      shell,
+    )
+    expect(out).toBeNull()
+  })
+
+  it('rejects dmwork://oidc/bind when the marker is malformed', () => {
+    localStorage.setItem('pending_oidc_bind', 'not-json')
+    const out = buildShellUrlForDeepLink(
+      'dmwork://oidc/bind?token=BOGUS',
+      shell,
+    )
+    expect(out).toBeNull()
+  })
+
+  it('accepts dmwork://oidc/bind when a valid unexpired marker is present', () => {
+    localStorage.setItem(
+      'pending_oidc_bind',
+      JSON.stringify({ providerId: 'aegis', authcode: 'auth-code', savedAt: Date.now() }),
+    )
+    const out = buildShellUrlForDeepLink(
+      'dmwork://oidc/bind?token=LEGITIMATE_TOKEN&provider=aegis&authcode=auth-code',
+      shell,
+    )
+    expect(out).not.toBeNull()
+    expect(new URL(out!).searchParams.get('token')).toBe('LEGITIMATE_TOKEN')
+  })
+
+  it('accepts a bind callback when only provider is returned', () => {
+    localStorage.setItem(
+      'pending_oidc_bind',
+      JSON.stringify({ providerId: 'aegis', savedAt: Date.now() }),
+    )
+    const out = buildShellUrlForDeepLink(
+      'dmwork://oidc/bind?token=LEGITIMATE_TOKEN&provider=aegis',
+      shell,
+    )
+    expect(out).not.toBeNull()
   })
 })

--- a/apps/web/src/Layout/__tests__/deepLink.test.ts
+++ b/apps/web/src/Layout/__tests__/deepLink.test.ts
@@ -1,6 +1,22 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { buildShellUrlForDeepLink } from '../deepLink'
 
+// Node 25 can disable jsdom's storage when no --localstorage-file is passed.
+// Keep this focused helper runnable in CI without changing the app's storage
+// contract or requiring a persistent test file.
+if (typeof globalThis.localStorage === 'undefined') {
+  const values = new Map<string, string>()
+  Object.defineProperty(globalThis, 'localStorage', {
+    configurable: true,
+    value: {
+      getItem: (key: string) => values.get(key) ?? null,
+      setItem: (key: string, value: string) => values.set(key, value),
+      removeItem: (key: string) => values.delete(key),
+      clear: () => values.clear(),
+    },
+  })
+}
+
 // Every non-null assertion below needs a valid pending-bind marker to survive
 // the P1-2 correlation check. `dmwork://oidc/bind` is rejected outright
 // without one — see the dedicated block at the bottom of this file.
@@ -51,7 +67,7 @@ describe('buildShellUrlForDeepLink', () => {
 
   it('refuses to overwrite the route derived from the deep-link path', () => {
     const out = buildShellUrlForDeepLink(
-      'dmwork://oidc/bind?token=abc&__octo_route=/login',
+      'dmwork://oidc/bind?token=abc&provider=aegis&authcode=auth-code&__octo_route=/login',
       shell,
     )
     expect(out).not.toBeNull()
@@ -87,6 +103,7 @@ describe('buildShellUrlForDeepLink', () => {
     // any WHATWG-compliant runtime, so downstream handling is identical.
     // Documenting the invariant here catches future parser changes.
     const slashed = buildShellUrlForDeepLink('dmwork://oidc/bind?token=abc&provider=aegis&authcode=auth-code', shell)
+    seedPendingBind()
     const bare = buildShellUrlForDeepLink('dmwork:oidc/bind?token=abc&provider=aegis&authcode=auth-code', shell)
     expect(slashed).not.toBeNull()
     expect(bare).not.toBeNull()
@@ -165,15 +182,15 @@ describe('buildShellUrlForDeepLink — bind correlation check (P1-2)', () => {
     expect(new URL(out!).searchParams.get('token')).toBe('LEGITIMATE_TOKEN')
   })
 
-  it('accepts a bind callback when only provider is returned', () => {
+  it('rejects a bind callback when authcode is missing', () => {
     localStorage.setItem(
       'pending_oidc_bind',
-      JSON.stringify({ providerId: 'aegis', savedAt: Date.now() }),
+      JSON.stringify({ providerId: 'aegis', authcode: 'auth-code', savedAt: Date.now() }),
     )
     const out = buildShellUrlForDeepLink(
       'dmwork://oidc/bind?token=LEGITIMATE_TOKEN&provider=aegis',
       shell,
     )
-    expect(out).not.toBeNull()
+    expect(out).toBeNull()
   })
 })

--- a/apps/web/src/Layout/__tests__/postLoginRedirect.test.ts
+++ b/apps/web/src/Layout/__tests__/postLoginRedirect.test.ts
@@ -37,4 +37,15 @@ describe("buildPostLoginRedirectUrl", () => {
       )
     ).toBe("https://octo.example.com/");
   });
+
+  it("preserves a sub-path deployment when appending the post-login query", () => {
+    expect(
+      buildPostLoginRedirectUrl(
+        "https://octo.example.com/foo/login",
+        "https://octo.example.com",
+        "foo",
+        "?doc=d_1"
+      )
+    ).toBe("https://octo.example.com/foo?doc=d_1");
+  });
 });

--- a/apps/web/src/Layout/__tests__/postLoginRedirect.test.ts
+++ b/apps/web/src/Layout/__tests__/postLoginRedirect.test.ts
@@ -26,4 +26,15 @@ describe("buildPostLoginRedirectUrl", () => {
       )
     ).toBe("https://octo.example.com/?doc=d_1");
   });
+
+  it("does not generate a double slash when the login path normalizes to /", () => {
+    expect(
+      buildPostLoginRedirectUrl(
+        "https://octo.example.com/login",
+        "https://octo.example.com",
+        "/",
+        ""
+      )
+    ).toBe("https://octo.example.com/");
+  });
 });

--- a/apps/web/src/Layout/deepLink.ts
+++ b/apps/web/src/Layout/deepLink.ts
@@ -1,8 +1,9 @@
 // Renderer-side receiver for the `deep-link` IPC channel wired in
-// src-election/main/index.ts. The main process buffers the URL until
-// did-finish-load, so the listener attached here always sees every
-// dmwork:// entry — cold-boot (process.argv), second-instance argv, or
-// macOS open-url after the app is running.
+// src-election/main/index.ts. The main process buffers URLs and waits for
+// the `deep-link-ready` signal before flushing, so the listener attached
+// here is guaranteed to see every dmwork:// entry — cold-boot
+// (process.argv), second-instance argv, or macOS open-url after the app
+// is running.
 //
 // The routing convention matches BindModule.init(): reload the shell
 // with `__octo_route=<path>&<remaining query>` so the module reads the
@@ -10,9 +11,14 @@
 // This works uniformly under file:// (packaged) and http(s):// (dev) —
 // changing pathname directly would fail on file:// with SecurityError.
 
+import { consumePendingBindIfMatches } from "@octo/login";
+
 const CALLBACK_SCHEME = "dmwork:";
+const IPC_DEEP_LINK_READY = "deep-link-ready";
+const BIND_ROUTE = "/oidc/bind";
 
 interface OctoIpc {
+  send?: (channel: string, ...args: unknown[]) => void;
   on: (channel: string, listener: (event: unknown, ...args: unknown[]) => void) => void;
   removeListener: (
     channel: string,
@@ -32,6 +38,13 @@ function getIpc(): OctoIpc | undefined {
  *
  * Any keys the deep-link supplies overwrite the shell's current query,
  * matching how OIDC callbacks replace the pre-existing search string.
+ *
+ * The `/oidc/bind` route is only accepted when this client has recently
+ * called startOidcLogin() — the persisted pending-bind marker proves the
+ * flow originated in this app. Without that check, registering `dmwork://`
+ * as an OS-level scheme handler would let any web page trigger the bind
+ * page against a signed-in victim by simply navigating to
+ * `dmwork://oidc/bind?token=ATTACKER_BIND_TOKEN` (see review round 5 P1-2).
  */
 export function buildShellUrlForDeepLink(
   deepLinkUrl: string,
@@ -57,6 +70,19 @@ export function buildShellUrlForDeepLink(
       .join("/")
       .replace(/\/+$/, "");
 
+  if (
+    routePath === BIND_ROUTE &&
+    !consumePendingBindIfMatches({
+      providerId: parsed.searchParams.get("provider") ?? undefined,
+      authcode: parsed.searchParams.get("authcode") ?? undefined,
+    })
+  ) {
+    // No locally-initiated OIDC flow in the last OIDC_AUTHCODE_TTL_MS.
+    // Reject rather than silently strand the user on the bind page with an
+    // attacker-supplied token.
+    return null;
+  }
+
   const shellUrl = new URL(currentHref);
   shellUrl.searchParams.set("__octo_route", routePath);
   for (const [key, value] of parsed.searchParams) {
@@ -64,16 +90,20 @@ export function buildShellUrlForDeepLink(
     // when it loaded the shell — deep-links from a compromised browser
     // could otherwise reroute applyLoginResp().save() to an attacker
     // storage bucket. sid is only writable via the loadFile query.
-    if (key === "sid") continue;
+    // The route is derived from the validated protocol host/path above. Do
+    // not let a query parameter replace that trusted value (for example
+    // `dmwork://oidc/bind?__octo_route=/login`).
+    if (key === "sid" || key === "__octo_route") continue;
     shellUrl.searchParams.set(key, value);
   }
   return shellUrl.toString();
 }
 
 /**
- * Attach the `deep-link` listener. Returns a disposer for callers that
- * unmount (Layout in the React tree). Safe to call in non-Electron
- * environments — becomes a no-op when window.ipc is absent.
+ * Attach the `deep-link` listener and announce readiness to the main
+ * process so any buffered URLs are flushed. Returns a disposer for
+ * callers that unmount (Layout in the React tree). Safe to call in
+ * non-Electron environments — becomes a no-op when window.ipc is absent.
  */
 export function registerDeepLinkHandler(): () => void {
   const ipc = getIpc();
@@ -88,6 +118,16 @@ export function registerDeepLinkHandler(): () => void {
   };
 
   ipc.on("deep-link", handler);
+  // Tell main it can flush the buffer now. Main resets its readiness flag
+  // on every `did-start-loading`, so this must run after every mount —
+  // including after an OIDC-callback shell reload.
+  try {
+    ipc.send?.(IPC_DEEP_LINK_READY);
+  } catch {
+    // Preload not attached / channel not allowed: leave the buffer with
+    // main; it will flush on the next navigation if the environment
+    // recovers.
+  }
   return () => {
     ipc.removeListener("deep-link", handler);
   };

--- a/apps/web/src/Layout/deepLink.ts
+++ b/apps/web/src/Layout/deepLink.ts
@@ -1,0 +1,94 @@
+// Renderer-side receiver for the `deep-link` IPC channel wired in
+// src-election/main/index.ts. The main process buffers the URL until
+// did-finish-load, so the listener attached here always sees every
+// dmwork:// entry — cold-boot (process.argv), second-instance argv, or
+// macOS open-url after the app is running.
+//
+// The routing convention matches BindModule.init(): reload the shell
+// with `__octo_route=<path>&<remaining query>` so the module reads the
+// route via URLSearchParams and picks it up on the fresh document load.
+// This works uniformly under file:// (packaged) and http(s):// (dev) —
+// changing pathname directly would fail on file:// with SecurityError.
+
+const CALLBACK_SCHEME = "dmwork:";
+
+interface OctoIpc {
+  on: (channel: string, listener: (event: unknown, ...args: unknown[]) => void) => void;
+  removeListener: (
+    channel: string,
+    listener: (event: unknown, ...args: unknown[]) => void
+  ) => void;
+}
+
+function getIpc(): OctoIpc | undefined {
+  const w = window as unknown as { ipc?: OctoIpc };
+  return w.ipc;
+}
+
+/**
+ * Convert `dmwork://oidc/bind?token=abc&sid=xyz` into a reload URL that
+ * BindModule.init() will accept:
+ *   file:///.../index.html?__octo_route=/oidc/bind&token=abc&sid=xyz
+ *
+ * Any keys the deep-link supplies overwrite the shell's current query,
+ * matching how OIDC callbacks replace the pre-existing search string.
+ */
+export function buildShellUrlForDeepLink(
+  deepLinkUrl: string,
+  currentHref: string,
+): string | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(deepLinkUrl);
+  } catch {
+    return null;
+  }
+  if (parsed.protocol !== CALLBACK_SCHEME) return null;
+
+  // `dmwork://oidc/bind` → host=oidc, pathname=/bind → route=/oidc/bind.
+  // Trailing slash is stripped so `dmwork://oidc/bind/` still matches
+  // BindModule.init()'s exact-equality check on `__octo_route`.
+  const host = parsed.host.replace(/\/+$/, "");
+  const path = parsed.pathname.replace(/^\/+/, "/");
+  const routePath =
+    "/" +
+    [host, path.replace(/^\/+/, "")]
+      .filter(Boolean)
+      .join("/")
+      .replace(/\/+$/, "");
+
+  const shellUrl = new URL(currentHref);
+  shellUrl.searchParams.set("__octo_route", routePath);
+  for (const [key, value] of parsed.searchParams) {
+    // Never let a deep-link overwrite the trusted sid captured by main.ts
+    // when it loaded the shell — deep-links from a compromised browser
+    // could otherwise reroute applyLoginResp().save() to an attacker
+    // storage bucket. sid is only writable via the loadFile query.
+    if (key === "sid") continue;
+    shellUrl.searchParams.set(key, value);
+  }
+  return shellUrl.toString();
+}
+
+/**
+ * Attach the `deep-link` listener. Returns a disposer for callers that
+ * unmount (Layout in the React tree). Safe to call in non-Electron
+ * environments — becomes a no-op when window.ipc is absent.
+ */
+export function registerDeepLinkHandler(): () => void {
+  const ipc = getIpc();
+  if (!ipc) return () => undefined;
+
+  const handler = (_event: unknown, ...args: unknown[]) => {
+    const url = typeof args[0] === "string" ? args[0] : "";
+    if (!url) return;
+    const next = buildShellUrlForDeepLink(url, window.location.href);
+    if (!next) return;
+    window.location.replace(next);
+  };
+
+  ipc.on("deep-link", handler);
+  return () => {
+    ipc.removeListener("deep-link", handler);
+  };
+}

--- a/apps/web/src/Layout/deepLink.ts
+++ b/apps/web/src/Layout/deepLink.ts
@@ -11,7 +11,10 @@
 // This works uniformly under file:// (packaged) and http(s):// (dev) —
 // changing pathname directly would fail on file:// with SecurityError.
 
-import { consumePendingBindIfMatches } from "@octo/login";
+// Import the small bridge directly. The login barrel also exports React UI and
+// react-virtuoso, which makes this route helper untestable in the lightweight
+// jsdom environment and needlessly pulls the whole login surface into Layout.
+import { consumePendingBindIfMatches } from "@octo/login/src/oidc/pendingBind";
 
 const CALLBACK_SCHEME = "dmwork:";
 const IPC_DEEP_LINK_READY = "deep-link-ready";

--- a/apps/web/src/Layout/index.tsx
+++ b/apps/web/src/Layout/index.tsx
@@ -21,7 +21,6 @@ import { SummaryDetailPage, SummaryShareDetailPage } from "@dmwork/summary";
 import { adoptStoredSession, findSidForToken, clearSessionsWithToken } from "./recoverSession";
 import { buildPostLoginRedirectUrl } from "./postLoginRedirect";
 import { consumeStandaloneReturn, persistStandaloneReturn, prepareDriveLandingReturn, clearStandaloneReturn } from "./standaloneReturn";
-import { registerDeepLinkHandler } from "./deepLink";
 import {
   ShareLandingPage,
   InviteLandingPage,
@@ -134,7 +133,6 @@ export default class AppLayout extends Component<{}, AppLayoutState> {
     onNeedJoinSpace!: () => void
     onJoinApproval!: (status: JoinApprovalStatus, inviteCode: string) => void
     private _spaceChecked = false; // 冷启动 Space 检测只跑一次
-    private _deepLinkDispose?: () => void
 
     componentDidMount() {
         // Wave 2: 无 Space 时触发 JoinSpacePage 覆盖层
@@ -142,11 +140,6 @@ export default class AppLayout extends Component<{}, AppLayoutState> {
             this.setState({ showJoinSpace: true });
         };
         WKApp.endpoints.addOnNeedJoinSpace(this.onNeedJoinSpace);
-
-        // Electron custom-scheme (dmwork://) inbound URLs — see Layout/deepLink.ts.
-        // Attaches once per Layout mount; main-process buffers cold-boot URLs
-        // until this listener is live via did-finish-load.
-        this._deepLinkDispose = registerDeepLinkHandler();
 
         // 审批结果统一渲染：任何入口 join 返回 NEED_APPROVAL/PENDING 都走这里
         this.onJoinApproval = (status, inviteCode) => {
@@ -294,7 +287,6 @@ export default class AppLayout extends Component<{}, AppLayoutState> {
         WKApp.endpoints.removeOnLogin(this.onLogin);
         WKApp.endpoints.removeOnNeedJoinSpace(this.onNeedJoinSpace);
         WKApp.endpoints.removeOnJoinApproval(this.onJoinApproval);
-        this._deepLinkDispose?.();
     }
 
     /**

--- a/apps/web/src/Layout/index.tsx
+++ b/apps/web/src/Layout/index.tsx
@@ -1,5 +1,6 @@
 import React, { Component } from "react";
 import { WKApp, WKBase, Provider, ErrorBoundary, t } from "@octo/base"
+import { isBindEntry } from "@octo/login"
 import { listen } from '@tauri-apps/api/event'
 import { MainPage } from "../Pages/Main";
 import SpaceGate from "../Components/SpaceGate";
@@ -20,6 +21,7 @@ import { SummaryDetailPage, SummaryShareDetailPage } from "@dmwork/summary";
 import { adoptStoredSession, findSidForToken, clearSessionsWithToken } from "./recoverSession";
 import { buildPostLoginRedirectUrl } from "./postLoginRedirect";
 import { consumeStandaloneReturn, persistStandaloneReturn, prepareDriveLandingReturn, clearStandaloneReturn } from "./standaloneReturn";
+import { registerDeepLinkHandler } from "./deepLink";
 import {
   ShareLandingPage,
   InviteLandingPage,
@@ -132,6 +134,7 @@ export default class AppLayout extends Component<{}, AppLayoutState> {
     onNeedJoinSpace!: () => void
     onJoinApproval!: (status: JoinApprovalStatus, inviteCode: string) => void
     private _spaceChecked = false; // 冷启动 Space 检测只跑一次
+    private _deepLinkDispose?: () => void
 
     componentDidMount() {
         // Wave 2: 无 Space 时触发 JoinSpacePage 覆盖层
@@ -139,6 +142,11 @@ export default class AppLayout extends Component<{}, AppLayoutState> {
             this.setState({ showJoinSpace: true });
         };
         WKApp.endpoints.addOnNeedJoinSpace(this.onNeedJoinSpace);
+
+        // Electron custom-scheme (dmwork://) inbound URLs — see Layout/deepLink.ts.
+        // Attaches once per Layout mount; main-process buffers cold-boot URLs
+        // until this listener is live via did-finish-load.
+        this._deepLinkDispose = registerDeepLinkHandler();
 
         // 审批结果统一渲染：任何入口 join 返回 NEED_APPROVAL/PENDING 都走这里
         this.onJoinApproval = (status, inviteCode) => {
@@ -286,6 +294,7 @@ export default class AppLayout extends Component<{}, AppLayoutState> {
         WKApp.endpoints.removeOnLogin(this.onLogin);
         WKApp.endpoints.removeOnNeedJoinSpace(this.onNeedJoinSpace);
         WKApp.endpoints.removeOnJoinApproval(this.onJoinApproval);
+        this._deepLinkDispose?.();
     }
 
     /**
@@ -402,7 +411,14 @@ export default class AppLayout extends Component<{}, AppLayoutState> {
         // otherwise the bind token gets silently dropped on the floor. Defense
         // in depth even though no documented flow constructs such a URL today.
         // PR #72 review yujiawei #2.
-        if (window.location.pathname === '/oidc/bind') {
+        //
+        // The isBindEntry() latch is the packaged-Electron path: under file://
+        // Chromium rejects any history.replaceState() that changes the path, so
+        // pathname stays as .../build/index.html even when the callback arrived
+        // via __octo_route=/oidc/bind. bindModule sets the latch synchronously
+        // on init based on the raw entry URL, so this gate renders BindPage
+        // regardless of what the address bar looks like.
+        if (window.location.pathname === '/oidc/bind' || isBindEntry()) {
             const bindComponent = WKApp.route.get('/oidc/bind')
             if (bindComponent) {
                 return bindComponent

--- a/apps/web/src/Layout/index.tsx
+++ b/apps/web/src/Layout/index.tsx
@@ -163,7 +163,7 @@ export default class AppLayout extends Component<{}, AppLayoutState> {
                 .replace(/\/index\.html$/, '') || '/'
             const basePath = rawPath
                 .replace(/^\/api(?:\/v\d+)?(?=\/|$)/, '')
-                .replace(/\/+$/, '')
+                .replace(/^\/+|\/+$/g, '')
             // #511 problem 2 (附带必修): a forwarded-doc link is `/docs?...&doc=<id>&sid=<space>`.
             // A first-time recipient logs in, then the post-login redirect used to keep only ?sid=
             // and drop ?doc=, landing them on the empty document list instead of the document they
@@ -212,7 +212,7 @@ export default class AppLayout extends Component<{}, AppLayoutState> {
                 window.location.href = buildPostLoginRedirectUrl(
                     window.location.href,
                     window.location.origin,
-                    basePath,
+                    basePath ? `/${basePath}` : '',
                     redirectSearch
                 )
             }

--- a/apps/web/src/Layout/postLoginRedirect.ts
+++ b/apps/web/src/Layout/postLoginRedirect.ts
@@ -12,5 +12,6 @@ export function buildPostLoginRedirectUrl(
     return currentUrl.toString();
   }
 
-  return `${origin}${basePath}/${query}`;
+  const normalizedBasePath = basePath ? `/${basePath.replace(/^\/+|\/+$/g, "")}` : "";
+  return `${origin}${normalizedBasePath || "/"}${query}`;
 }

--- a/apps/web/src/vite-env.d.ts
+++ b/apps/web/src/vite-env.d.ts
@@ -11,6 +11,8 @@ interface ImportMetaEnv {
   readonly VITE_ENABLE_ENTERPRISE_SSO?: string
   // Dev-only override for OIDC logout callback when using a remote backend from localhost.
   readonly VITE_OIDC_POST_LOGOUT_REDIRECT_URI?: string
+  /** Origin used by the server for Electron OIDC callback redirects. */
+  readonly VITE_OIDC_CALLBACK_ORIGIN?: string
   readonly VITE_DISABLE_BUILTIN_DOCS?: string
 }
 

--- a/packages/dmworkbase/src/App.tsx
+++ b/packages/dmworkbase/src/App.tsx
@@ -499,6 +499,36 @@ export type MessageDeleteListener = (
   preMessage?: Message
 ) => void;
 
+/**
+ * Single predicate for "this document is a desktop shell". Callers that must
+ * treat desktop the same way — startup() setting `isPC`, LoginInfo.save()
+ * writing the device flag, and LoginInfo.load()'s forced-clean-login guard —
+ * must all see the same answer, otherwise a packaging edge case can flip
+ * one path and not the other and leave a slot-1 token reused under a
+ * slot-2 CONNECT (silent IM auth failure).
+ *
+ * Signals:
+ *  - `__POWERED_ELECTRON__` — preload-injected marker; primary source of truth.
+ *  - `__TAURI_IPC__` — same shape for the Tauri variant of the desktop shell.
+ *  - `file:` protocol — defensive backstop: if a packaging regression makes
+ *    preload throw before `contextBridge.exposeInMainWorld` runs, we still
+ *    detect the desktop shell. Web (http/https) never runs on file://, and
+ *    only the packaged desktop shell loads via file://.
+ */
+export function isDesktopRuntime(): boolean {
+  if (typeof window === "undefined") return false;
+  const w = window as unknown as {
+    __POWERED_ELECTRON__?: unknown;
+    __TAURI_IPC__?: unknown;
+  };
+  if (w.__POWERED_ELECTRON__ || w.__TAURI_IPC__) return true;
+  try {
+    return window.location.protocol === "file:";
+  } catch {
+    return false;
+  }
+}
+
 export class LoginInfo {
   private static readonly DEVICE_FLAG_KEY = "im_device_flag";
   appID!: string;
@@ -555,7 +585,7 @@ export class LoginInfo {
     this.setStorageItemForSID("is_work", this.isWork ? "1" : "0");
     this.setStorageItemForSID("sex", this.sex === 1 ? "1" : "0");
     this.setStorageItemForSID("login_provider", this.loginProvider ?? "");
-    this.setStorageItemForSID(LoginInfo.DEVICE_FLAG_KEY, WKApp.shared.isPC ? "2" : "1");
+    this.setStorageItemForSID(LoginInfo.DEVICE_FLAG_KEY, isDesktopRuntime() ? "2" : "1");
     // 实名认证状态 — 严格 tri-state 持久化。
     //   undefined → 删除 key（区别于「明确未实名」）
     //   true      → "1"
@@ -636,8 +666,7 @@ export class LoginInfo {
     // minted in slot 1 and cannot be safely reused, so force one clean login
     // after this migration instead of silently losing the IM connection.
     const storedDeviceFlag = this.getStorageItemForSID(LoginInfo.DEVICE_FLAG_KEY);
-    const isDesktop = Boolean((window as any)?.__POWERED_ELECTRON__ || (window as any)?.__TAURI_IPC__);
-    if (isDesktop && this.token && storedDeviceFlag !== "2") {
+    if (isDesktopRuntime() && this.token && storedDeviceFlag !== "2") {
       this.logout();
       return;
     }
@@ -900,11 +929,12 @@ export default class WKApp extends ProviderListener {
     // runs, we still detect the desktop shell — otherwise isPC=false silently
     // routes OIDC login through the Web branch and produces `file:///v1/...`
     // URLs (white screen). Web (http/https) never runs on file://.
-    if (
-      (window as any)?.__POWERED_ELECTRON__ ||
-      (window as any).__TAURI_IPC__ ||
-      (typeof window !== "undefined" && window.location.protocol === "file:")
-    ) {
+    //
+    // All three "is desktop?" call sites (this startup(), LoginInfo.save(),
+    // LoginInfo.load()) route through `isDesktopRuntime()` so the answer is
+    // consistent — a mismatch here vs there is what previously left a slot-1
+    // token reused under a slot-2 CONNECT.
+    if (isDesktopRuntime()) {
       this.isPC = true;
     }
     WKApp.loginInfo.load(); // 加载登录信息

--- a/packages/dmworkbase/src/App.tsx
+++ b/packages/dmworkbase/src/App.tsx
@@ -890,6 +890,13 @@ export default class WKApp extends ProviderListener {
     ) {
       this.isPC = true;
     }
+    // Keep the IM CONNECT device slot aligned with the login API's flag.
+    // WuKongIM JS SDK defaults to web (1), including inside Electron.
+    // Values mirror OIDC_FLAG_WEB / OIDC_FLAG_PC in dmworklogin:
+    //   1 = web, 2 = pc (desktop / Electron)
+    const IM_DEVICE_FLAG_WEB = 1
+    const IM_DEVICE_FLAG_PC = 2
+    WKSDK.shared().config.deviceFlag = this.isPC ? IM_DEVICE_FLAG_PC : IM_DEVICE_FLAG_WEB;
     this.deviceId = this.getDeviceIdFromStorage();
     this.deviceName = this.getOSAndVersion();
     this.deviceModel = this.getBrandsFromUserAgent();

--- a/packages/dmworkbase/src/App.tsx
+++ b/packages/dmworkbase/src/App.tsx
@@ -500,6 +500,7 @@ export type MessageDeleteListener = (
 ) => void;
 
 export class LoginInfo {
+  private static readonly DEVICE_FLAG_KEY = "im_device_flag";
   appID!: string;
   shortNo!: string; // 短号
   token?: string;
@@ -554,6 +555,7 @@ export class LoginInfo {
     this.setStorageItemForSID("is_work", this.isWork ? "1" : "0");
     this.setStorageItemForSID("sex", this.sex === 1 ? "1" : "0");
     this.setStorageItemForSID("login_provider", this.loginProvider ?? "");
+    this.setStorageItemForSID(LoginInfo.DEVICE_FLAG_KEY, WKApp.shared.isPC ? "2" : "1");
     // 实名认证状态 — 严格 tri-state 持久化。
     //   undefined → 删除 key（区别于「明确未实名」）
     //   true      → "1"
@@ -630,6 +632,15 @@ export class LoginInfo {
     this.uid = this.getStorageItemForSID("uid") || "";
     this.shortNo = this.getStorageItemForSID("short_no") || "";
     this.token = this.getStorageItemForSID("token") || "";
+    // Desktop CONNECT now uses device_flag=2. Existing desktop tokens were
+    // minted in slot 1 and cannot be safely reused, so force one clean login
+    // after this migration instead of silently losing the IM connection.
+    const storedDeviceFlag = this.getStorageItemForSID(LoginInfo.DEVICE_FLAG_KEY);
+    const isDesktop = Boolean((window as any)?.__POWERED_ELECTRON__ || (window as any)?.__TAURI_IPC__);
+    if (isDesktop && this.token && storedDeviceFlag !== "2") {
+      this.logout();
+      return;
+    }
     this.name = this.getStorageItemForSID("name") || "";
     this.appID = this.getStorageItemForSID("app_id") || "";
     this.role = this.getStorageItemForSID("role") || "";
@@ -700,6 +711,7 @@ export class LoginInfo {
     this.removeStorageItemForSID("name");
     this.removeStorageItemForSID("sex");
     this.removeStorageItemForSID("login_provider");
+    this.removeStorageItemForSID(LoginInfo.DEVICE_FLAG_KEY);
     // 清除实名认证缓存
     this.realnameVerified = undefined;
     this.realName = undefined;
@@ -881,8 +893,6 @@ export default class WKApp extends ProviderListener {
     if (consumeOidcPostLogoutCleanup()) {
       this.clearLocalLoginState();
     }
-    WKApp.loginInfo.load(); // 加载登录信息
-
     // 是否是PC端
     if (
       (window as any)?.__POWERED_ELECTRON__ ||
@@ -890,6 +900,7 @@ export default class WKApp extends ProviderListener {
     ) {
       this.isPC = true;
     }
+    WKApp.loginInfo.load(); // 加载登录信息
     // Keep the IM CONNECT device slot aligned with the login API's flag.
     // WuKongIM JS SDK defaults to web (1), including inside Electron.
     // Values mirror OIDC_FLAG_WEB / OIDC_FLAG_PC in dmworklogin:

--- a/packages/dmworkbase/src/App.tsx
+++ b/packages/dmworkbase/src/App.tsx
@@ -894,9 +894,16 @@ export default class WKApp extends ProviderListener {
       this.clearLocalLoginState();
     }
     // 是否是PC端
+    // Primary signal is the preload-injected __POWERED_ELECTRON__ / Tauri
+    // marker. The file:// fallback is a defensive backstop: if a packaging
+    // regression makes preload throw before contextBridge.exposeInMainWorld
+    // runs, we still detect the desktop shell — otherwise isPC=false silently
+    // routes OIDC login through the Web branch and produces `file:///v1/...`
+    // URLs (white screen). Web (http/https) never runs on file://.
     if (
       (window as any)?.__POWERED_ELECTRON__ ||
-      (window as any).__TAURI_IPC__
+      (window as any).__TAURI_IPC__ ||
+      (typeof window !== "undefined" && window.location.protocol === "file:")
     ) {
       this.isPC = true;
     }

--- a/packages/dmworklogin/src/__tests__/login_presentation.test.ts
+++ b/packages/dmworklogin/src/__tests__/login_presentation.test.ts
@@ -32,13 +32,13 @@ describe("login page presentation", () => {
     const enUS = readRepoFile("packages/dmworklogin/src/i18n/en-US.json");
 
     expect(source).toContain(
-      "const ssoConfigPending = ENTERPRISE_SSO_ENABLED && !WKApp.remoteConfig.requestSuccess && !WKApp.remoteConfig.requestFailed"
+      "const ssoConfigPending = OIDC_LOGIN_ENABLED && !WKApp.remoteConfig.requestSuccess && !WKApp.remoteConfig.requestFailed"
     );
     expect(source).toContain(
-      "const ssoConfigFallback = ENTERPRISE_SSO_ENABLED && WKApp.remoteConfig.requestFailed"
+      "const ssoConfigFallback = OIDC_LOGIN_ENABLED && WKApp.remoteConfig.requestFailed"
     );
     expect(source).toContain(
-      "const showSsoLogin = ENTERPRISE_SSO_ENABLED && !ssoConfigPending && !ssoConfigFallback && hasSsoProvider"
+      "const showSsoLogin = OIDC_LOGIN_ENABLED && !ssoConfigPending && !ssoConfigFallback && hasSsoProvider"
     );
     expect(source).toContain("aria-busy={ssoConfigPending}");
     expect(source).toContain('role="status"');

--- a/packages/dmworklogin/src/__tests__/login_vm_oidc.test.ts
+++ b/packages/dmworklogin/src/__tests__/login_vm_oidc.test.ts
@@ -225,6 +225,7 @@ describe('LoginVM.startOidcLogin (Electron desktop)', () => {
       'https://api.example.com/v1/',
       'AC-ipc',
       'acme-sso',
+      undefined,
     )
   })
 

--- a/packages/dmworklogin/src/__tests__/login_vm_oidc.test.ts
+++ b/packages/dmworklogin/src/__tests__/login_vm_oidc.test.ts
@@ -18,6 +18,7 @@ vi.mock('@octo/base', () => {
       save: vi.fn(),
     },
     apiClient: {
+      config: { apiURL: 'https://api.example.com/v1/' },
       get: vi.fn().mockResolvedValue([]),
       post: vi.fn().mockResolvedValue({}),
     },
@@ -26,6 +27,7 @@ vi.mock('@octo/base', () => {
       onNeedJoinSpace: vi.fn(),
     },
     shared: {
+      isPC: false,
       deviceId: 'd',
       deviceName: 'n',
       deviceModel: 'm',
@@ -71,6 +73,8 @@ vi.mock('../oidc', async () => {
 })
 
 import { LoginVM } from '../login_vm'
+import { WKApp } from '@octo/base'
+import { OIDC_FLAG_WEB, OIDC_FLAG_PC } from '../oidc'
 import {
   clearPendingOidcLogin,
   getPendingOidcLogin,
@@ -82,7 +86,7 @@ import {
 
 const ORIGINAL_LOCATION = window.location
 
-function stubLocation() {
+function stubLocation(overrides: Partial<typeof window.location> = {}) {
   // Replace window.location with a plain object so .href assignments don't
   // actually navigate jsdom (which would terminate the test).
   Object.defineProperty(window, 'location', {
@@ -92,6 +96,7 @@ function stubLocation() {
       origin: 'http://localhost',
       href: 'http://localhost/login',
       search: '',
+      ...overrides,
     },
   })
 }
@@ -111,14 +116,17 @@ beforeEach(() => {
   pollAuthStatusMock.mockReset()
   vi.useFakeTimers()
   stubLocation()
+  // Ensure Electron flag is off by default
+  delete (window as any).__POWERED_ELECTRON__
 })
 
 afterEach(() => {
   vi.useRealTimers()
   restoreLocation()
+  delete (window as any).__POWERED_ELECTRON__
 })
 
-describe('LoginVM.startOidcLogin', () => {
+describe('LoginVM.startOidcLogin (web)', () => {
   it('fetches authcode, persists pending, and redirects to authorize URL', async () => {
     fetchAuthcodeMock.mockResolvedValue('AC-123')
     const vm = new LoginVM()
@@ -129,6 +137,16 @@ describe('LoginVM.startOidcLogin', () => {
     expect(window.location.href).toContain('/v1/auth/oidc/acme-sso/authorize')
     expect(window.location.href).toContain('authcode=AC-123')
     expect(vm.oidcLoading).toBe(true)
+  })
+
+  it('uses the backend-relative returnTo for the local-debug production-login flow', async () => {
+    fetchAuthcodeMock.mockResolvedValue('AC-web')
+    stubLocation({ origin: 'https://app.example.com', href: 'https://app.example.com/login', search: '' })
+    const vm = new LoginVM()
+    await vm.startOidcLogin('acme-sso')
+    const qs = new URLSearchParams(window.location.href.split('?')[1])
+    expect(qs.get('flag')).toBe(OIDC_FLAG_WEB)
+    expect(qs.get('return_to')).toBe('/login')
   })
 
   it('flips oidcLoading off via the fallback timer if redirect is intercepted', async () => {
@@ -161,6 +179,46 @@ describe('LoginVM.startOidcLogin', () => {
     vm.oidcLoading = true
     await vm.startOidcLogin('acme-sso')
     expect(fetchAuthcodeMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('LoginVM.startOidcLogin (Electron desktop)', () => {
+  beforeEach(() => {
+    // Simulate Electron preload injection
+    ;(window as any).__POWERED_ELECTRON__ = true
+    ;(WKApp.shared as any).isPC = true
+    // Simulate file:// origin that Electron prod build exposes
+    stubLocation({ origin: 'file://', href: 'file:///login', search: '' })
+  })
+
+  afterEach(() => {
+    ;(WKApp.shared as any).isPC = false
+  })
+
+  it('uses flag=2 (pc) in Electron', async () => {
+    fetchAuthcodeMock.mockResolvedValue('AC-pc')
+    const vm = new LoginVM()
+    await vm.startOidcLogin('acme-sso')
+    const qs = new URLSearchParams(window.location.href.split('?')[1])
+    expect(qs.get('flag')).toBe(OIDC_FLAG_PC)
+  })
+
+  it('uses relative /login as returnTo in packaged Electron', async () => {
+    fetchAuthcodeMock.mockResolvedValue('AC-pc')
+    const vm = new LoginVM()
+    await vm.startOidcLogin('acme-sso')
+    const qs = new URLSearchParams(window.location.href.split('?')[1])
+
+    expect(qs.get('return_to')).toBe('/login')
+  })
+
+  it('still persists pending and redirects', async () => {
+    fetchAuthcodeMock.mockResolvedValue('AC-pc2')
+    const vm = new LoginVM()
+    await vm.startOidcLogin('acme-sso')
+    const pending = getPendingOidcLogin()
+    expect(pending?.authcode).toBe('AC-pc2')
+    expect(window.location.href).toContain('https://api.example.com/v1/auth/oidc/acme-sso/authorize')
   })
 })
 

--- a/packages/dmworklogin/src/__tests__/login_vm_oidc.test.ts
+++ b/packages/dmworklogin/src/__tests__/login_vm_oidc.test.ts
@@ -95,6 +95,7 @@ function stubLocation(overrides: Partial<typeof window.location> = {}) {
     value: {
       origin: 'http://localhost',
       href: 'http://localhost/login',
+      protocol: 'http:',
       search: '',
       ...overrides,
     },
@@ -188,7 +189,7 @@ describe('LoginVM.startOidcLogin (Electron desktop)', () => {
     ;(window as any).__POWERED_ELECTRON__ = true
     ;(WKApp.shared as any).isPC = true
     // Simulate file:// origin that Electron prod build exposes
-    stubLocation({ origin: 'file://', href: 'file:///login', search: '' })
+    stubLocation({ origin: 'file://', href: 'file:///login', protocol: 'file:', search: '' })
   })
 
   afterEach(() => {
@@ -219,6 +220,31 @@ describe('LoginVM.startOidcLogin (Electron desktop)', () => {
     const pending = getPendingOidcLogin()
     expect(pending?.authcode).toBe('AC-pc2')
     expect(window.location.href).toContain('https://api.example.com/v1/auth/oidc/acme-sso/authorize')
+  })
+
+  it('uses the absolute API base for the file:// OIDC client', async () => {
+    const originalFetch = globalThis.fetch
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ ok: true }),
+    })
+    globalThis.fetch = fetchMock as never
+    fetchAuthcodeMock.mockResolvedValue('AC-file')
+
+    try {
+      const vm = new LoginVM()
+      await vm.startOidcLogin('acme-sso')
+      const client = fetchAuthcodeMock.mock.calls[0][0] as {
+        get: (path: string) => Promise<unknown>
+      }
+      await client.get('/v1/auth/oidc/acme-sso/authcode')
+      expect(fetchMock.mock.calls[0][0]).toBe(
+        'https://api.example.com/v1/auth/oidc/acme-sso/authcode',
+      )
+    } finally {
+      globalThis.fetch = originalFetch
+    }
   })
 })
 

--- a/packages/dmworklogin/src/__tests__/login_vm_oidc.test.ts
+++ b/packages/dmworklogin/src/__tests__/login_vm_oidc.test.ts
@@ -187,7 +187,7 @@ describe('LoginVM.startOidcLogin (Electron desktop)', () => {
   beforeEach(() => {
     // Simulate Electron preload injection
     ;(window as any).__POWERED_ELECTRON__ = true
-    ;(window as any).ipc = { send: vi.fn() }
+    ;(window as any).ipc = { invoke: vi.fn().mockResolvedValue(true) }
     ;(WKApp.shared as any).isPC = true
     // Simulate file:// origin that Electron prod build exposes
     stubLocation({ origin: 'file://', href: 'file:///login', protocol: 'file:', search: '' })
@@ -220,8 +220,8 @@ describe('LoginVM.startOidcLogin (Electron desktop)', () => {
     const vm = new LoginVM()
     await vm.startOidcLogin('acme-sso')
 
-    expect((window as any).ipc.send).toHaveBeenCalledWith(
-      'oidc-authorize-start',
+    expect((window as any).ipc.invoke).toHaveBeenCalledWith(
+      'oidc-authorize-start-invoke',
       'https://api.example.com/v1/',
       'AC-ipc',
       'acme-sso',

--- a/packages/dmworklogin/src/__tests__/login_vm_oidc.test.ts
+++ b/packages/dmworklogin/src/__tests__/login_vm_oidc.test.ts
@@ -187,6 +187,7 @@ describe('LoginVM.startOidcLogin (Electron desktop)', () => {
   beforeEach(() => {
     // Simulate Electron preload injection
     ;(window as any).__POWERED_ELECTRON__ = true
+    ;(window as any).ipc = { send: vi.fn() }
     ;(WKApp.shared as any).isPC = true
     // Simulate file:// origin that Electron prod build exposes
     stubLocation({ origin: 'file://', href: 'file:///login', protocol: 'file:', search: '' })
@@ -194,6 +195,7 @@ describe('LoginVM.startOidcLogin (Electron desktop)', () => {
 
   afterEach(() => {
     ;(WKApp.shared as any).isPC = false
+    delete (window as any).ipc
   })
 
   it('uses flag=2 (pc) in Electron', async () => {
@@ -211,6 +213,19 @@ describe('LoginVM.startOidcLogin (Electron desktop)', () => {
     const qs = new URLSearchParams(window.location.href.split('?')[1])
 
     expect(qs.get('return_to')).toBe('/login')
+  })
+
+  it('arms the main process with the provider id string', async () => {
+    fetchAuthcodeMock.mockResolvedValue('AC-ipc')
+    const vm = new LoginVM()
+    await vm.startOidcLogin('acme-sso')
+
+    expect((window as any).ipc.send).toHaveBeenCalledWith(
+      'oidc-authorize-start',
+      'https://api.example.com/v1/',
+      'AC-ipc',
+      'acme-sso',
+    )
   })
 
   it('still persists pending and redirects', async () => {

--- a/packages/dmworklogin/src/__tests__/login_vm_oidc.test.ts
+++ b/packages/dmworklogin/src/__tests__/login_vm_oidc.test.ts
@@ -139,14 +139,14 @@ describe('LoginVM.startOidcLogin (web)', () => {
     expect(vm.oidcLoading).toBe(true)
   })
 
-  it('uses the backend-relative returnTo for the local-debug production-login flow', async () => {
+  it('keeps the web returnTo on the current deployment origin', async () => {
     fetchAuthcodeMock.mockResolvedValue('AC-web')
     stubLocation({ origin: 'https://app.example.com', href: 'https://app.example.com/login', search: '' })
     const vm = new LoginVM()
     await vm.startOidcLogin('acme-sso')
     const qs = new URLSearchParams(window.location.href.split('?')[1])
     expect(qs.get('flag')).toBe(OIDC_FLAG_WEB)
-    expect(qs.get('return_to')).toBe('/login')
+    expect(qs.get('return_to')).toBe('https://app.example.com/login')
   })
 
   it('flips oidcLoading off via the fallback timer if redirect is intercepted', async () => {

--- a/packages/dmworklogin/src/__tests__/login_vm_scanlogin.test.ts
+++ b/packages/dmworklogin/src/__tests__/login_vm_scanlogin.test.ts
@@ -18,7 +18,7 @@ vi.mock('@octo/base', () => {
       post: (...args: unknown[]) => apiPost(...args),
     },
     endpoints: { callOnLogin: vi.fn(), onNeedJoinSpace: vi.fn() },
-    shared: { deviceId: 'd', deviceName: 'n', deviceModel: 'm' },
+    shared: { isPC: false, deviceId: 'd', deviceName: 'n', deviceModel: 'm' },
     config: { themeColor: '#000', appName: 'Test' },
     remoteConfig: { oidcProviders: [] },
   }
@@ -31,6 +31,7 @@ vi.mock('@octo/base', () => {
 })
 
 import { LoginVM, LoginStatus, LoginType } from '../login_vm'
+import { WKApp } from '@octo/base'
 
 /** Put the VM in QR mode without letting didMount kick off real polling. */
 function newQRCodeVM(): LoginVM {
@@ -53,6 +54,17 @@ beforeEach(() => {
 })
 
 describe('scan-login poll credential', () => {
+  it('sends the matching device flag when redeeming a QR login', async () => {
+    const vm = newQRCodeVM()
+    apiPost.mockResolvedValue({ uid: 'u', token: 't' })
+    ;(WKApp.shared as any).isPC = true
+
+    await vm.requestLogin('auth-code')
+
+    expect(apiPost).toHaveBeenCalledWith('user/login_authcode/auth-code', { flag: 2 })
+    ;(WKApp.shared as any).isPC = false
+  })
+
   it('sends poll_secret on the status poll', async () => {
     const vm = newQRCodeVM()
     apiGet.mockResolvedValue(INERT)

--- a/packages/dmworklogin/src/__tests__/login_vm_scanlogin.test.ts
+++ b/packages/dmworklogin/src/__tests__/login_vm_scanlogin.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 
 // Stub @octo/base so LoginVM can be instantiated in jsdom without the real
 // WKApp / apiClient. Mirrors login_vm_oidc.test.ts — only the surface LoginVM
@@ -53,6 +53,14 @@ beforeEach(() => {
   apiPost.mockReset()
 })
 
+// The scan-login flag test toggles WKApp.shared.isPC. Reset in afterEach so a
+// failing assertion inside the it() block does not leak the mutation into
+// later tests in this file (previously the reset lived on the last line and
+// never ran on failure, turning one real failure into a confusing cascade).
+afterEach(() => {
+  ;(WKApp.shared as any).isPC = false
+})
+
 describe('scan-login poll credential', () => {
   it('sends the matching device flag when redeeming a QR login', async () => {
     const vm = newQRCodeVM()
@@ -61,8 +69,7 @@ describe('scan-login poll credential', () => {
 
     await vm.requestLogin('auth-code')
 
-    expect(apiPost).toHaveBeenCalledWith('user/login_authcode/auth-code', { flag: 2 })
-    ;(WKApp.shared as any).isPC = false
+    expect(apiPost).toHaveBeenCalledWith('user/login_authcode/auth-code?flag=2')
   })
 
   it('sends poll_secret on the status poll', async () => {

--- a/packages/dmworklogin/src/__tests__/setup.ts
+++ b/packages/dmworklogin/src/__tests__/setup.ts
@@ -6,6 +6,28 @@ if (typeof ResizeObserver === 'undefined') {
   }
 }
 
+// vitest 4.x + Node.js 22 native storage: `localStorage` is gated behind
+// `--localstorage-file`, so bare `localStorage` in production code (invite
+// codes, pending-bind marker) reads as undefined and every branch that
+// touches it throws instead of returning null. Provide a minimal in-memory
+// polyfill so tests exercise the real code path. sessionStorage is already
+// wired by jsdom.
+if (typeof (globalThis as unknown as { localStorage?: Storage }).localStorage === 'undefined') {
+  const store = new Map<string, string>()
+  const localStorage: Storage = {
+    get length() { return store.size },
+    key(i) { return Array.from(store.keys())[i] ?? null },
+    getItem(k) { return store.has(k) ? store.get(k)! : null },
+    setItem(k, v) { store.set(String(k), String(v)) },
+    removeItem(k) { store.delete(k) },
+    clear() { store.clear() },
+  }
+  Object.defineProperty(globalThis, 'localStorage', { value: localStorage, configurable: true })
+  if (typeof window !== 'undefined') {
+    Object.defineProperty(window, 'localStorage', { value: localStorage, configurable: true })
+  }
+}
+
 if (typeof HTMLCanvasElement !== 'undefined') {
   const proto = HTMLCanvasElement.prototype as unknown as {
     getContext: (...args: unknown[]) => unknown

--- a/packages/dmworklogin/src/bind/BindPage.tsx
+++ b/packages/dmworklogin/src/bind/BindPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react'
+import React, { useEffect, useMemo, useRef, useState } from 'react'
 import { Button, Input, Spin, Toast } from '@douyinfe/semi-ui'
 import { WKApp } from '@octo/base'
 import {
@@ -26,6 +26,7 @@ import { applyLoginResp, parseLoginResp } from '../loginSession'
 import { mapBindError, type BindEndpoint, type BindErrorDisplay } from './errorMessages'
 import { loginT as t } from '../i18n'
 import { resolveBindNavigationUrl } from './navigation'
+import { resetBindEntry } from './bindModule'
 import './bind.css'
 
 type Stage =
@@ -71,13 +72,25 @@ interface BindPageProps {
   // RouteManager 会在 pageshow 时 push 一个带 sid= 的 URL, 把 bind 入口参数
   // 全部丢掉.
   initialSearch: string
+  // BindModule.init() captures the real packaged index.html URL before the
+  // Electron route scrub changes window.location.href to file:///oidc/bind.
+  // Navigation must keep using that shell URL after the scrub.
+  initialHref: string
 }
 
-const BindPage = ({ initialSearch }: BindPageProps) => {
+const BindPage = ({ initialSearch, initialHref }: BindPageProps) => {
   // bind_token 与 entry 参数全程只在 useRef 持有, 不进 React state, 不进任何 store.
   // 见 oidc-bind-frontend.md §2.2 — 这是 bind_token-in-URL 已知 limitation 的核心缓解.
   const entryRef = useRef<BindEntryParams | null>(null)
   const initRanRef = useRef(false)
+  // Memoise so the string identity is stable across renders and avoids a
+  // fresh URL parse per render inside resolveBindNavigationUrl. The
+  // fallback is intentionally captured once at mount; if BindPage remounts
+  // (Layout re-mount) the module-level initialHref is refreshed by init().
+  const navigationBaseHref = useMemo(
+    () => initialHref || (typeof window !== 'undefined' ? window.location.href : ''),
+    [initialHref],
+  )
 
   const [stage, setStage] = useState<Stage>({ kind: 'init' })
   const [identifier, setIdentifier] = useState('')
@@ -111,6 +124,17 @@ const BindPage = ({ initialSearch }: BindPageProps) => {
     }
 
     void loadInfo(params)
+  }, [])
+
+  // Clear the module-level bind-entry latch on unmount so the app layout
+  // stops force-rendering BindPage after the flow ends. The OIDC exit
+  // paths (resolveBindNavigationUrl().replace) trigger a full-page reload
+  // that would reset the latch anyway; this covers SPA-only exits where
+  // the document survives (e.g. future navigation flows or dev HMR).
+  useEffect(() => {
+    return () => {
+      resetBindEntry()
+    }
   }, [])
 
   const apiOpts = (): BindApiOptions => ({
@@ -302,7 +326,7 @@ const BindPage = ({ initialSearch }: BindPageProps) => {
         window.history.replaceState(
           {},
           '',
-          resolveBindNavigationUrl('/', window.location.href),
+          resolveBindNavigationUrl('/', navigationBaseHref),
         )
       } catch {
         /* noop: SSR / legacy host */
@@ -312,7 +336,7 @@ const BindPage = ({ initialSearch }: BindPageProps) => {
       } catch (e) {
         console.warn('callOnLogin error suppressed:', e)
         // Last-resort fallback so the user isn't stranded on the success stage.
-        window.location.replace(resolveBindNavigationUrl('/', window.location.href))
+        window.location.replace(resolveBindNavigationUrl('/', navigationBaseHref))
       }
       return
     }
@@ -320,7 +344,7 @@ const BindPage = ({ initialSearch }: BindPageProps) => {
     // No invite — keep the original behaviour: short paint window then navigate
     // to the originally-requested return_to.
     window.setTimeout(() => {
-      const safeReturnTo = resolveBindNavigationUrl(returnTo, window.location.href)
+      const safeReturnTo = resolveBindNavigationUrl(returnTo, navigationBaseHref)
       try {
         window.location.replace(safeReturnTo)
       } catch {
@@ -393,7 +417,7 @@ const BindPage = ({ initialSearch }: BindPageProps) => {
 
   function goBackToLogin(): void {
     entryRef.current = null
-    window.location.replace(resolveBindNavigationUrl('/login', window.location.href))
+    window.location.replace(resolveBindNavigationUrl('/login', navigationBaseHref))
   }
 
   // ---- render ------------------------------------------------------------

--- a/packages/dmworklogin/src/bind/BindPage.tsx
+++ b/packages/dmworklogin/src/bind/BindPage.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useRef, useState } from 'react'
 import { Button, Input, Spin, Toast } from '@douyinfe/semi-ui'
 import { WKApp } from '@octo/base'
 import {
+  clearPendingOidcBind,
   clearPendingOidcLogin,
   createFetchHttpClient,
   fetchHttpClient,
@@ -307,6 +308,9 @@ const BindPage = ({ initialSearch, initialHref }: BindPageProps) => {
   // a safe slug. Anything else falls through to the plain returnTo navigation.
   function finalizeBindSuccess(returnTo: string): void {
     setStage({ kind: 'success' })
+    // The bind flow is concluding — retire the deep-link allowlist marker
+    // so the next `dmwork://oidc/bind` requires a fresh startOidcLogin().
+    clearPendingOidcBind()
 
     let pendingInvite: string | null = null
     try {
@@ -417,6 +421,10 @@ const BindPage = ({ initialSearch, initialHref }: BindPageProps) => {
 
   function goBackToLogin(): void {
     entryRef.current = null
+    // User is abandoning the bind flow — retire the deep-link marker so a
+    // stray `dmwork://oidc/bind` cannot silently re-enter this page after
+    // they return to login.
+    clearPendingOidcBind()
     window.location.replace(resolveBindNavigationUrl('/login', navigationBaseHref))
   }
 

--- a/packages/dmworklogin/src/bind/BindPage.tsx
+++ b/packages/dmworklogin/src/bind/BindPage.tsx
@@ -3,6 +3,7 @@ import { Button, Input, Spin, Toast } from '@douyinfe/semi-ui'
 import { WKApp } from '@octo/base'
 import {
   clearPendingOidcLogin,
+  createFetchHttpClient,
   fetchHttpClient,
   OidcBindHttpError,
 } from '../oidc'
@@ -84,6 +85,13 @@ const BindPage = ({ initialSearch }: BindPageProps) => {
   const [busy, setBusy] = useState(false)
   const [inlineError, setInlineError] = useState<string | null>(null)
 
+  const bindHttpClient =
+    typeof window !== 'undefined' &&
+    window.location.protocol === 'file:' &&
+    /^https?:\/\//i.test(WKApp.apiClient.config.apiURL)
+      ? createFetchHttpClient(WKApp.apiClient.config.apiURL)
+      : fetchHttpClient
+
   useEffect(() => {
     if (initRanRef.current) return
     initRanRef.current = true
@@ -124,7 +132,7 @@ const BindPage = ({ initialSearch }: BindPageProps) => {
     setStage({ kind: 'loading_info' })
     setInlineError(null)
     try {
-      const info = await fetchBindInfo(fetchHttpClient, params.token, apiOpts())
+      const info = await fetchBindInfo(bindHttpClient, params.token, apiOpts())
       const createState = deriveCreateState(info)
       // 用户能进入选择阶段的条件: 至少有一个可用的 verify method OR create 可点.
       // create 被 block 但仍渲染原因文字时, 只要还有 verify methods 也能进 choose_method;
@@ -172,7 +180,7 @@ const BindPage = ({ initialSearch }: BindPageProps) => {
     try {
       const token = entryRef.current?.token
       if (!token) return
-      await sendBindOtp(fetchHttpClient, token, apiOpts())
+      await sendBindOtp(bindHttpClient, token, apiOpts())
       setStage({ kind: 'verify_otp', info: stage.info, sent: true, sending: false })
       Toast.success(t('bind.otp.sent'))
     } catch (err) {
@@ -188,7 +196,7 @@ const BindPage = ({ initialSearch }: BindPageProps) => {
     setBusy(true)
     setInlineError(null)
     try {
-      await sendBindOtp(fetchHttpClient, token, apiOpts())
+      await sendBindOtp(bindHttpClient, token, apiOpts())
       Toast.success(t('bind.otp.resent'))
       setStage({ ...stage, sent: true })
     } catch (err) {
@@ -217,7 +225,7 @@ const BindPage = ({ initialSearch }: BindPageProps) => {
     setBusy(true)
     setInlineError(null)
     try {
-      await verifyBindPassword(fetchHttpClient, token, identifier, password, apiOpts())
+      await verifyBindPassword(bindHttpClient, token, identifier, password, apiOpts())
       // verify 通过后立即清密码, 不留在 React state 里
       setPassword('')
       await runConfirm(stage.info)
@@ -246,7 +254,7 @@ const BindPage = ({ initialSearch }: BindPageProps) => {
     setBusy(true)
     setInlineError(null)
     try {
-      await checkBindOtp(fetchHttpClient, token, otp, apiOpts())
+      await checkBindOtp(bindHttpClient, token, otp, apiOpts())
       setOtp('')
       await runConfirm(stage.info)
     } catch (err) {
@@ -327,7 +335,7 @@ const BindPage = ({ initialSearch }: BindPageProps) => {
     }
     setStage({ kind: 'confirming', info })
     try {
-      const resp = await confirmBind(fetchHttpClient, token, apiOpts())
+      const resp = await confirmBind(bindHttpClient, token, apiOpts())
       // login_resp 是 JSON-encoded string, JSON.parse 后与老 OIDC authstatus.result 同 schema.
       const data = parseLoginResp(resp.login_resp)
       // loginProvider 必须落到真实 IdP id, 下游 NavSettingsPanel /
@@ -361,7 +369,7 @@ const BindPage = ({ initialSearch }: BindPageProps) => {
     }
     setStage({ kind: 'creating', info })
     try {
-      const resp = await createBind(fetchHttpClient, token, apiOpts())
+      const resp = await createBind(bindHttpClient, token, apiOpts())
       // 与 confirm 同 schema 同 builder, login_resp 直接 parseLoginResp + applyLoginResp.
       const data = parseLoginResp(resp.login_resp)
       // 同 runConfirm — loginProvider 必须是真实 IdP id, 不是

--- a/packages/dmworklogin/src/bind/BindPage.tsx
+++ b/packages/dmworklogin/src/bind/BindPage.tsx
@@ -25,6 +25,7 @@ import {
 import { applyLoginResp, parseLoginResp } from '../loginSession'
 import { mapBindError, type BindEndpoint, type BindErrorDisplay } from './errorMessages'
 import { loginT as t } from '../i18n'
+import { resolveBindNavigationUrl } from './navigation'
 import './bind.css'
 
 type Stage =
@@ -298,7 +299,11 @@ const BindPage = ({ initialSearch }: BindPageProps) => {
       // We replaceState pathname to '/' so basePath resolves to '/' instead of
       // '/oidc/bind' (which would loop the user back to BindPage).
       try {
-        window.history.replaceState({}, '', '/')
+        window.history.replaceState(
+          {},
+          '',
+          resolveBindNavigationUrl('/', window.location.href),
+        )
       } catch {
         /* noop: SSR / legacy host */
       }
@@ -307,7 +312,7 @@ const BindPage = ({ initialSearch }: BindPageProps) => {
       } catch (e) {
         console.warn('callOnLogin error suppressed:', e)
         // Last-resort fallback so the user isn't stranded on the success stage.
-        window.location.replace('/')
+        window.location.replace(resolveBindNavigationUrl('/', window.location.href))
       }
       return
     }
@@ -315,10 +320,11 @@ const BindPage = ({ initialSearch }: BindPageProps) => {
     // No invite — keep the original behaviour: short paint window then navigate
     // to the originally-requested return_to.
     window.setTimeout(() => {
+      const safeReturnTo = resolveBindNavigationUrl(returnTo, window.location.href)
       try {
-        window.location.replace(returnTo)
+        window.location.replace(safeReturnTo)
       } catch {
-        window.location.href = returnTo
+        window.location.href = safeReturnTo
       }
     }, 200)
   }
@@ -387,7 +393,7 @@ const BindPage = ({ initialSearch }: BindPageProps) => {
 
   function goBackToLogin(): void {
     entryRef.current = null
-    window.location.replace('/login')
+    window.location.replace(resolveBindNavigationUrl('/login', window.location.href))
   }
 
   // ---- render ------------------------------------------------------------

--- a/packages/dmworklogin/src/bind/__tests__/bindModule.test.ts
+++ b/packages/dmworklogin/src/bind/__tests__/bindModule.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Stub @octo/base — bindModule only touches WKApp.route.register during init.
+vi.mock('@octo/base', () => {
+  const routes = new Map<string, () => JSX.Element>()
+  return {
+    WKApp: {
+      route: {
+        register: (path: string, factory: () => JSX.Element) => {
+          routes.set(path, factory)
+        },
+        get: (path: string) => routes.get(path)?.(),
+      },
+    },
+  }
+})
+
+// Skip BindPage's real module — it pulls in @douyinfe/semi-ui → @tiptap/react,
+// whose ESM package.json exports break the jsdom test loader. We only care
+// about init's URL side-effects here.
+vi.mock('../BindPage', () => ({
+  default: () => null,
+}))
+
+async function loadModuleFresh() {
+  vi.resetModules()
+  const mod = await import('../bindModule')
+  return mod
+}
+
+function setLocation(url: string): void {
+  // jsdom lets us rewrite the URL via history.replaceState as long as the
+  // origin is unchanged. Prime the origin with a jsdom-friendly base first.
+  window.history.replaceState({}, '', url)
+}
+
+describe('bindModule / isBindEntry latch', () => {
+  beforeEach(() => {
+    setLocation('/')
+  })
+
+  it('sets the latch when pathname is /oidc/bind (web flow)', async () => {
+    setLocation('/oidc/bind?token=abc&sid=window-sid')
+
+    const { default: BindModule, isBindEntry } = await loadModuleFresh()
+    new BindModule().init()
+
+    expect(isBindEntry()).toBe(true)
+  })
+
+  it('sets the latch when __octo_route=/oidc/bind is present (packaged Electron)', async () => {
+    // In packaged Electron, Chromium rejects history.replaceState() that
+    // changes the path on a file:// document. Simulate the resulting state
+    // where pathname stays at the shell path but __octo_route carries the
+    // logical route.
+    setLocation('/index.html?__octo_route=/oidc/bind&token=abc&sid=window-sid')
+
+    const { default: BindModule, isBindEntry } = await loadModuleFresh()
+    new BindModule().init()
+
+    expect(isBindEntry()).toBe(true)
+  })
+
+  it('does not set the latch for unrelated pages', async () => {
+    setLocation('/login?sid=window-sid')
+
+    const { default: BindModule, isBindEntry } = await loadModuleFresh()
+    new BindModule().init()
+
+    expect(isBindEntry()).toBe(false)
+  })
+
+  it('scrub preserves the pathname and only strips bind-entry params', async () => {
+    setLocation('/index.html?__octo_route=/oidc/bind&token=secret&provider=acme&sid=window-sid')
+
+    const { default: BindModule } = await loadModuleFresh()
+    new BindModule().init()
+
+    // Pathname is untouched (survives file:// where path changes throw).
+    expect(window.location.pathname).toBe('/index.html')
+    // Bind-entry keys are gone.
+    const params = new URLSearchParams(window.location.search)
+    expect(params.has('__octo_route')).toBe(false)
+    expect(params.has('token')).toBe(false)
+    expect(params.has('provider')).toBe(false)
+    // Non-bind keys (like sid) are preserved so applyLoginResp().save()
+    // continues to write into the same storage bucket.
+    expect(params.get('sid')).toBe('window-sid')
+  })
+
+  it('latch survives a subsequent clearBindUrl call from BindPage', async () => {
+    setLocation('/oidc/bind?token=abc&sid=window-sid')
+
+    const { default: BindModule, isBindEntry } = await loadModuleFresh()
+    const { clearBindUrl } = await import('../../oidc/bind')
+
+    new BindModule().init()
+    // Simulate BindPage's on-mount scrub.
+    clearBindUrl()
+
+    expect(isBindEntry()).toBe(true)
+  })
+
+  it('resetBindEntry() clears the latch — invoked by BindPage on unmount', async () => {
+    setLocation('/oidc/bind?token=abc&sid=window-sid')
+
+    const { default: BindModule, isBindEntry, resetBindEntry } = await loadModuleFresh()
+    new BindModule().init()
+    expect(isBindEntry()).toBe(true)
+
+    resetBindEntry()
+    expect(isBindEntry()).toBe(false)
+  })
+})

--- a/packages/dmworklogin/src/bind/__tests__/navigation.test.ts
+++ b/packages/dmworklogin/src/bind/__tests__/navigation.test.ts
@@ -16,6 +16,15 @@ describe('resolveBindNavigationUrl', () => {
     )
   })
 
+  it('does not use the scrubbed Electron route as the navigation base', () => {
+    const scrubbed = 'file:///oidc/bind'
+
+    expect(resolveBindNavigationUrl('/', shell)).toBe(
+      'file:///Applications/OCTO.app/Contents/Resources/app.asar/build/index.html'
+    )
+    expect(resolveBindNavigationUrl('/', scrubbed)).toBe('file:///oidc/bind')
+  })
+
   it('does not change normal web navigation', () => {
     expect(resolveBindNavigationUrl('/space', 'https://octo.example.com/oidc/bind')).toBe('/space')
   })

--- a/packages/dmworklogin/src/bind/__tests__/navigation.test.ts
+++ b/packages/dmworklogin/src/bind/__tests__/navigation.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import { resolveBindNavigationUrl } from '../navigation'
+
+describe('resolveBindNavigationUrl', () => {
+  const shell = 'file:///Applications/OCTO.app/Contents/Resources/app.asar/build/index.html?sid=window-sid'
+
+  it('keeps packaged bind success on index.html instead of file:///', () => {
+    expect(resolveBindNavigationUrl('/', shell)).toBe(
+      'file:///Applications/OCTO.app/Contents/Resources/app.asar/build/index.html'
+    )
+  })
+
+  it('preserves a safe return query and hash in the packaged shell', () => {
+    expect(resolveBindNavigationUrl('/space?joined=1#done', shell)).toBe(
+      'file:///Applications/OCTO.app/Contents/Resources/app.asar/build/index.html?joined=1#done'
+    )
+  })
+
+  it('does not change normal web navigation', () => {
+    expect(resolveBindNavigationUrl('/space', 'https://octo.example.com/oidc/bind')).toBe('/space')
+  })
+})

--- a/packages/dmworklogin/src/bind/bindModule.tsx
+++ b/packages/dmworklogin/src/bind/bindModule.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { WKApp, IModule } from '@octo/base'
 import BindPage from './BindPage'
+import { clearBindUrl } from '../oidc/bind'
 
 // 在 module init 时 (startup 同步阶段, 早于 RouteManager 的 pageshow handler)
 // 抓住 location.search 快照. RouteManager 的 pageshow 监听器会 push 一个带
@@ -10,6 +11,59 @@ import BindPage from './BindPage'
 // 这个 snapshot 在 BindModule.init() 调用瞬间 capture, 然后通过 prop 注入,
 // 比 useEffect 里读 window.location.search 更早, 也更确定.
 let bindInitialSearch = ''
+let bindInitialHref = ''
+
+// Module-level latch set by init() when the current document is an OIDC bind
+// entry. Layout gates BindPage on this in addition to pathname, because in
+// packaged Electron (file://) Chromium rejects any history.replaceState() that
+// changes the path — so pathname stays as .../build/index.html no matter what
+// scrub we run. The latch is derived once at init and survives clearBindUrl()
+// in BindPage's mount.
+//
+// Reset triggers:
+//  - Full document load re-imports this module and re-initializes the latch
+//    (the OIDC exit paths — resolveBindNavigationUrl().replace — do this).
+//  - BindPage unmount (SPA route exit without full reload) calls
+//    resetBindEntry() so the layout doesn't keep re-rendering BindPage after
+//    the flow ends.
+let bindEntryActive = false
+
+export function isBindEntry(): boolean {
+  return bindEntryActive
+}
+
+/**
+ * Clear the bind-entry latch and drop the captured URL snapshot. Called by
+ * BindPage on unmount to end the "route to BindPage regardless of pathname"
+ * override; BindPage's exit paths issue full-page reloads that would also
+ * reset the module, but this makes SPA-only navigation safe as well.
+ */
+export function resetBindEntry(): void {
+  bindEntryActive = false
+  bindInitialSearch = ''
+  bindInitialHref = ''
+}
+
+// Legacy alias used by unit tests; kept for compatibility with existing specs.
+export const __resetBindEntryForTests = resetBindEntry
+
+/**
+ * Reduce the pre-scrub entry URL to origin + pathname so the bind token,
+ * authcode, and other query params never live inside a React prop. Only
+ * origin/pathname are consulted by resolveBindNavigationUrl (search is
+ * overwritten by the target's search), so dropping the query loses nothing
+ * downstream while stripping the credential retention path.
+ */
+function reduceInitialHref(href: string): string {
+  try {
+    const url = new URL(href)
+    url.search = ''
+    url.hash = ''
+    return url.toString()
+  } catch {
+    return ''
+  }
+}
 
 export default class BindModule implements IModule {
   id(): string {
@@ -24,29 +78,31 @@ export default class BindModule implements IModule {
     // snapshot — falling cleanly to the "链接无效" fatal stage rather than
     // silently picking up stale params. Acceptable trade-off given the
     // documented flow.
-    const isElectronBindEntry =
-      typeof window !== 'undefined' &&
-      new URLSearchParams(window.location.search).get('__octo_route') === '/oidc/bind'
-    if (typeof window !== 'undefined' && (window.location.pathname === '/oidc/bind' || isElectronBindEntry)) {
-      bindInitialSearch = window.location.search
-      // Scrub the live URL *synchronously* here, before RouteManager's
-      // pageshow handler runs window.history.pushState to add the sid URL on
-      // top. If we wait for BindPage's useEffect, the current entry is
-      // already the sid URL (see Route.tsx push()), and replaceState there
-      // leaves the original `?token=...` entry behind in the Back stack —
-      // pressing Back exposes the bind token via address bar / referrer.
-      // The snapshot above keeps the params available to BindPage via prop,
-      // so wiping window.location.search is safe.
-      try {
-        window.history.replaceState({}, '', '/oidc/bind')
-      } catch {
-        /* SSR / legacy host without history API — clearBindUrl in BindPage is
-           still defense-in-depth for the current entry, even if it can't fix
-           the back-stack leak. */
+    if (typeof window !== 'undefined') {
+      const isElectronBindEntry =
+        new URLSearchParams(window.location.search).get('__octo_route') === '/oidc/bind'
+      if (window.location.pathname === '/oidc/bind' || isElectronBindEntry) {
+        bindInitialSearch = window.location.search
+        bindInitialHref = reduceInitialHref(window.location.href)
+        bindEntryActive = true
+        // Scrub the live URL *synchronously* here, before RouteManager's
+        // pageshow handler runs window.history.pushState to add the sid URL
+        // on top. If we wait for BindPage's useEffect, the current entry is
+        // already the sid URL (see Route.tsx push()), and replaceState there
+        // leaves the original `?token=...` entry behind in the Back stack —
+        // pressing Back exposes the bind token via address bar / referrer.
+        //
+        // Use the path-preserving BIND_QUERY_KEYS strip: on Electron file://
+        // Chromium throws SecurityError on any history.replaceState() that
+        // changes the path, so the previous replaceState('/oidc/bind') was a
+        // silent no-op — leaving the bind token in the packaged document URL
+        // for the rest of the session. clearBindUrl edits only the search
+        // and works uniformly on http(s) and file://.
+        clearBindUrl()
       }
     }
     WKApp.route.register('/oidc/bind', (): JSX.Element => {
-      return <BindPage initialSearch={bindInitialSearch} />
+      return <BindPage initialSearch={bindInitialSearch} initialHref={bindInitialHref} />
     })
   }
 }

--- a/packages/dmworklogin/src/bind/bindModule.tsx
+++ b/packages/dmworklogin/src/bind/bindModule.tsx
@@ -24,7 +24,10 @@ export default class BindModule implements IModule {
     // snapshot — falling cleanly to the "链接无效" fatal stage rather than
     // silently picking up stale params. Acceptable trade-off given the
     // documented flow.
-    if (typeof window !== 'undefined' && window.location.pathname === '/oidc/bind') {
+    const isElectronBindEntry =
+      typeof window !== 'undefined' &&
+      new URLSearchParams(window.location.search).get('__octo_route') === '/oidc/bind'
+    if (typeof window !== 'undefined' && (window.location.pathname === '/oidc/bind' || isElectronBindEntry)) {
       bindInitialSearch = window.location.search
       // Scrub the live URL *synchronously* here, before RouteManager's
       // pageshow handler runs window.history.pushState to add the sid URL on
@@ -35,7 +38,7 @@ export default class BindModule implements IModule {
       // The snapshot above keeps the params available to BindPage via prop,
       // so wiping window.location.search is safe.
       try {
-        window.history.replaceState({}, '', window.location.pathname)
+        window.history.replaceState({}, '', '/oidc/bind')
       } catch {
         /* SSR / legacy host without history API — clearBindUrl in BindPage is
            still defense-in-depth for the current entry, even if it can't fix

--- a/packages/dmworklogin/src/bind/navigation.ts
+++ b/packages/dmworklogin/src/bind/navigation.ts
@@ -1,0 +1,15 @@
+/**
+ * Resolve a bind-success destination without escaping the packaged Electron
+ * app shell. A root-relative path such as `/` resolves to `file:///` when
+ * assigned directly from a file:// document; keep the loaded index.html path
+ * and only carry the destination query/hash across.
+ */
+export function resolveBindNavigationUrl(returnTo: string, currentHref: string): string {
+  const current = new URL(currentHref)
+  if (current.protocol !== 'file:') return returnTo
+
+  const target = new URL(returnTo, 'https://octo.local')
+  current.search = target.search
+  current.hash = target.hash
+  return current.toString()
+}

--- a/packages/dmworklogin/src/index.tsx
+++ b/packages/dmworklogin/src/index.tsx
@@ -1,2 +1,2 @@
 export { default as LoginModule } from "./module"
-export { default as BindModule } from "./bind/bindModule"
+export { default as BindModule, isBindEntry, resetBindEntry } from "./bind/bindModule"

--- a/packages/dmworklogin/src/index.tsx
+++ b/packages/dmworklogin/src/index.tsx
@@ -1,2 +1,8 @@
 export { default as LoginModule } from "./module"
 export { default as BindModule, isBindEntry, resetBindEntry } from "./bind/bindModule"
+export {
+  hasValidPendingBind,
+  consumePendingBindIfMatches,
+  getPendingOidcBind,
+  clearPendingOidcBind,
+} from "./oidc"

--- a/packages/dmworklogin/src/login.tsx
+++ b/packages/dmworklogin/src/login.tsx
@@ -20,6 +20,20 @@ import loginLogo from "./assets/login-logo.png";
 
 const ENTERPRISE_SSO_ENABLED =
     import.meta.env.VITE_ENABLE_ENTERPRISE_SSO === 'true'
+// Local development uses the legacy password flow because the shared backend
+// does not allow localhost as an OIDC return_to. Packaged Electron and
+// production Web builds continue to use OIDC.
+//
+// OIDC_BUTTON_ENABLED: controls the SSO login button and related UI.
+//   Disabled in local dev — the shared dev backend does not whitelist
+//   localhost return_to values, so the button would never complete.
+// OIDC_RESUME_ENABLED: controls the OIDC callback-resume effect.
+//   Kept on in dev so that testing the resume flow against a production
+//   backend (via VITE_API_URL) still works without changing the flag.
+const OIDC_BUTTON_ENABLED = ENTERPRISE_SSO_ENABLED && !import.meta.env.DEV
+const OIDC_RESUME_ENABLED = ENTERPRISE_SSO_ENABLED
+// Backward-compat alias used throughout this file for the button/UI path.
+const OIDC_LOGIN_ENABLED = OIDC_BUTTON_ENABLED
 // Register URL 从当前 provider 的 accountUrl 派生，避免把 test/prod 用户带到
 // 错误的 IdP 环境。若后续接入新的 OIDC provider 或非 Aegis 登录方式，入口配置
 // 应改为由 appconfig 下发。
@@ -440,9 +454,9 @@ class Login extends Component<any, LoginState> {
             // 按 loginInfo.loginProvider 路由各自的 reset URL, 同步检查 login.tsx:513。
             const ssoProvider = getSSOProviders()[0]
             const hasSsoProvider = !!ssoProvider
-            const ssoConfigPending = ENTERPRISE_SSO_ENABLED && !WKApp.remoteConfig.requestSuccess && !WKApp.remoteConfig.requestFailed
-            const ssoConfigFallback = ENTERPRISE_SSO_ENABLED && WKApp.remoteConfig.requestFailed
-            const showSsoLogin = ENTERPRISE_SSO_ENABLED && !ssoConfigPending && !ssoConfigFallback && hasSsoProvider
+            const ssoConfigPending = OIDC_LOGIN_ENABLED && !WKApp.remoteConfig.requestSuccess && !WKApp.remoteConfig.requestFailed
+            const ssoConfigFallback = OIDC_LOGIN_ENABLED && WKApp.remoteConfig.requestFailed
+            const showSsoLogin = OIDC_LOGIN_ENABLED && !ssoConfigPending && !ssoConfigFallback && hasSsoProvider
             const showDefaultSloganSub = !showSsoLogin
             const renderLocalPasswordLogin = () => (
                 <div className="wk-login-content-form">
@@ -551,8 +565,8 @@ class Login extends Component<any, LoginState> {
 
                 {/* Right form panel */}
                 <div className="wk-login-panel">
-                    {ENTERPRISE_SSO_ENABLED && <OidcResumeEffect vm={vm} />}
-                    {ENTERPRISE_SSO_ENABLED && <OidcResumingOverlay vm={vm} />}
+                    {OIDC_RESUME_ENABLED && <OidcResumeEffect vm={vm} />}
+                    {OIDC_RESUME_ENABLED && <OidcResumingOverlay vm={vm} />}
                     {/* 顶部小面包屑: 紫色圆点 + 当前登录目标. 给到达 /login 的人一个
                         "我在哪 / 这个表单会把我送去哪" 的轻确认, 不抢主标题视觉权重. */}
                     <div className="wk-login-panel-breadcrumb">
@@ -698,7 +712,7 @@ class Login extends Component<any, LoginState> {
                         <div className="wk-login-content-phonelogin" style={{ "display": vm.loginType === LoginType.forgetPassword ? "block" : "none" }}>
                             <div className="wk-login-content-slogan">{t('reset.title')}</div>
                             <div className="wk-login-content-slogan-sub">{t('reset.sub')}</div>
-                            {ENTERPRISE_SSO_ENABLED && ssoProvider?.resetPasswordUrl && (
+                            {OIDC_BUTTON_ENABLED && ssoProvider?.resetPasswordUrl && (
                                 <div className="wk-login-content-form-oidc-hint">
                                     {t('reset.oidcHintPrefix')}
                                     <a

--- a/packages/dmworklogin/src/login_vm.tsx
+++ b/packages/dmworklogin/src/login_vm.tsx
@@ -30,6 +30,12 @@ function clearPendingOidcState(): void {
     // leave the `dmwork://oidc/bind` gate open longer than intended.
     clearPendingOidcLogin()
     clearPendingOidcBind()
+    try {
+        const ipc = (window as any).ipc
+        if (typeof ipc?.send === 'function') ipc.send('oidc-authorize-cancel')
+    } catch {
+        // Web and non-Electron runtimes do not expose the native bridge.
+    }
 }
 
 function getOidcHttpClient() {
@@ -637,7 +643,8 @@ export class LoginVM extends ProviderListener {
             if (isDesktop) {
                 const ipc = (window as any).ipc
                 if (typeof ipc?.invoke !== 'function') throw new Error('Electron OIDC IPC is unavailable')
-                await ipc.invoke('oidc-authorize-start-invoke', apiURL, authcode, providerId)
+                const callbackOrigin = (import.meta.env.VITE_OIDC_CALLBACK_ORIGIN as string | undefined)
+                await ipc.invoke('oidc-authorize-start-invoke', apiURL, authcode, providerId, callbackOrigin)
             }
 
             // Schedule a fallback reset before navigating so a blocked redirect

--- a/packages/dmworklogin/src/login_vm.tsx
+++ b/packages/dmworklogin/src/login_vm.tsx
@@ -635,7 +635,7 @@ export class LoginVM extends ProviderListener {
                 ? apiURL
                 : undefined
             if (isDesktop) {
-                ;(window as any).ipc?.send?.('oidc-authorize-start', apiURL, authcode, provider)
+                ;(window as any).ipc?.send?.('oidc-authorize-start', apiURL, authcode, providerId)
             }
 
             // Schedule a fallback reset before navigating so a blocked redirect

--- a/packages/dmworklogin/src/login_vm.tsx
+++ b/packages/dmworklogin/src/login_vm.tsx
@@ -8,6 +8,8 @@ import {
     getPendingOidcLogin,
     getProviderById,
     isPendingExpired,
+    OIDC_FLAG_PC,
+    OIDC_FLAG_WEB,
     OidcPollCancelledError,
     OidcPollNetworkError,
     OidcPollTimeoutError,
@@ -15,8 +17,17 @@ import {
     parseOidcUrlState,
     pollAuthStatus,
     savePendingOidcLogin,
+    createFetchHttpClient,
 } from "./oidc";
 import { loginT as t } from "./i18n";
+
+function getOidcHttpClient() {
+    const apiURL = WKApp.apiClient.config.apiURL
+    if (window.location.protocol === 'file:' && /^https?:\/\//i.test(apiURL)) {
+        return createFetchHttpClient(apiURL)
+    }
+    return fetchHttpClient
+}
 
 
 export class LoginStatus {
@@ -252,11 +263,7 @@ export class LoginVM extends ProviderListener {
         this.loginLoading = true
         this.notifyListener()
         const device = this.getDevice()
-        let deviceFlag = 1 // web
-        // if(WKApp.shared.isPC) {
-        //     deviceFlag = 2 // pc
-
-        // }
+        const deviceFlag = WKApp.shared.isPC ? Number(OIDC_FLAG_PC) : Number(OIDC_FLAG_WEB)
         return WKApp.apiClient.post(`user/login`, { "username": username, "password": password, "flag": deviceFlag,"device":device }).then((result)=>{
             this.loginSuccess(result)
         }).finally(()=>{
@@ -273,7 +280,7 @@ export class LoginVM extends ProviderListener {
             "username": username,
             "name": name,
             "password": password,
-            "flag": 1,
+            "flag": Number(WKApp.shared.isPC ? OIDC_FLAG_PC : OIDC_FLAG_WEB),
             "device": device,
         }).then((result) => {
             this.loginSuccess(result)
@@ -331,7 +338,7 @@ export class LoginVM extends ProviderListener {
         this.notifyListener()
         const device = this.getDevice()
         return WKApp.apiClient.post('user/emailregister', {
-            email, password, name, code, flag: 1, device,
+            email, password, name, code, flag: Number(WKApp.shared.isPC ? OIDC_FLAG_PC : OIDC_FLAG_WEB), device,
         }).then((result) => {
             // emailregister wraps response in {data: ...}
             this.loginSuccess(result)
@@ -346,7 +353,7 @@ export class LoginVM extends ProviderListener {
         this.notifyListener()
         const device = this.getDevice()
         return WKApp.apiClient.post('user/emaillogin', {
-            email, password, flag: 1, device,
+            email, password, flag: Number(WKApp.shared.isPC ? OIDC_FLAG_PC : OIDC_FLAG_WEB), device,
         }).then((result) => {
             // emaillogin wraps response in {data: ...}
             this.loginSuccess(result)
@@ -580,13 +587,31 @@ export class LoginVM extends ProviderListener {
         this.oidcLoading = true
         this.notifyListener()
         try {
-            const authcode = await fetchAuthcode(fetchHttpClient)
+            const authcode = await fetchAuthcode(getOidcHttpClient())
             savePendingOidcLogin({
                 providerId,
                 authcode,
                 savedAt: Date.now(),
             })
-            const returnTo = `${window.location.origin}/login`
+
+            // Local development intentionally uses the backend-relative callback.
+            // The shared dev backend does not whitelist localhost return_to
+            // values, so it resolves `/login` to the production login page.
+            // This preserves the existing local-debug flow. Packaged Electron
+            // also uses this callback; main/index.ts intercepts the production
+            // callback and reloads the packaged app while preserving its query.
+            const isDesktop = WKApp.shared.isPC
+            const flag = isDesktop ? OIDC_FLAG_PC : OIDC_FLAG_WEB
+            const returnTo = '/login'
+            // Electron production pages use file://, so a server-relative
+            // authorize path would resolve to file:///v1/... instead of the
+            // configured backend. Dev Electron still uses the Vite proxy and
+            // intentionally keeps the relative URL.
+            const apiURL = WKApp.apiClient.config.apiURL
+            const authorizeBaseURL = isDesktop && /^https?:\/\//i.test(apiURL)
+                ? apiURL
+                : undefined
+
             // Schedule a fallback reset before navigating so a blocked redirect
             // does not leave the SSO button stuck in a loading state forever.
             if (this._oidcLoadingResetTimer) clearTimeout(this._oidcLoadingResetTimer)
@@ -597,7 +622,13 @@ export class LoginVM extends ProviderListener {
                     this.notifyListener()
                 }
             }, LoginVM.OIDC_LOADING_RESET_MS)
-            window.location.href = buildAuthorizeURL(provider, authcode, returnTo)
+            window.location.href = buildAuthorizeURL(
+                provider,
+                authcode,
+                returnTo,
+                flag,
+                authorizeBaseURL,
+            )
         } catch (e) {
             this.oidcLoading = false
             this.notifyListener()
@@ -636,7 +667,7 @@ export class LoginVM extends ProviderListener {
         this.notifyListener()
         try {
             const result = await pollAuthStatus({
-                client: fetchHttpClient,
+                client: getOidcHttpClient(),
                 authcode: pending.authcode,
                 intervalMs: 2000,
                 maxAttempts: 150,

--- a/packages/dmworklogin/src/login_vm.tsx
+++ b/packages/dmworklogin/src/login_vm.tsx
@@ -635,7 +635,9 @@ export class LoginVM extends ProviderListener {
                 ? apiURL
                 : undefined
             if (isDesktop) {
-                ;(window as any).ipc?.send?.('oidc-authorize-start', apiURL, authcode, providerId)
+                const ipc = (window as any).ipc
+                if (typeof ipc?.invoke !== 'function') throw new Error('Electron OIDC IPC is unavailable')
+                await ipc.invoke('oidc-authorize-start-invoke', apiURL, authcode, providerId)
             }
 
             // Schedule a fallback reset before navigating so a blocked redirect

--- a/packages/dmworklogin/src/login_vm.tsx
+++ b/packages/dmworklogin/src/login_vm.tsx
@@ -2,6 +2,7 @@ import { WKApp, ProviderListener } from "@octo/base";
 import { applyLoginResp } from "./loginSession";
 import {
     buildAuthorizeURL,
+    clearPendingOidcBind,
     clearPendingOidcLogin,
     fetchAuthcode,
     fetchHttpClient,
@@ -16,10 +17,20 @@ import {
     OIDC_AUTH_STATUS,
     parseOidcUrlState,
     pollAuthStatus,
+    savePendingOidcBind,
     savePendingOidcLogin,
     createFetchHttpClient,
 } from "./oidc";
 import { loginT as t } from "./i18n";
+
+function clearPendingOidcState(): void {
+    // Clear both the in-flight login poll marker and the deep-link bind
+    // allowlist. They are minted together in startOidcLogin() and should
+    // decay together — a stray bind marker after login concludes would
+    // leave the `dmwork://oidc/bind` gate open longer than intended.
+    clearPendingOidcLogin()
+    clearPendingOidcBind()
+}
 
 function getOidcHttpClient() {
     const apiURL = WKApp.apiClient.config.apiURL
@@ -248,7 +259,11 @@ export class LoginVM extends ProviderListener {
         this.notifyListener()
         try {
             const flag = WKApp.shared.isPC ? Number(OIDC_FLAG_PC) : Number(OIDC_FLAG_WEB)
-            const resp = await WKApp.apiClient.post(`user/login_authcode/${authCode}`, { flag });
+            // login_authcode reads `flag` from the query string (unlike the
+            // password/register endpoints, which read it from JSON). Keep
+            // the client and server contracts aligned so desktop QR login
+            // mints the same device-slot token that Electron uses to CONNECT.
+            const resp = await WKApp.apiClient.post(`user/login_authcode/${authCode}?flag=${flag}`);
             if (resp) {
                 this.loginSuccess(resp)
             }
@@ -594,6 +609,17 @@ export class LoginVM extends ProviderListener {
                 authcode,
                 savedAt: Date.now(),
             })
+            // Mark that this client legitimately started an OIDC flow. Read
+            // by the packaged-Electron deep-link handler to reject
+            // `dmwork://oidc/bind` links that were not triggered from
+            // inside this app (see Layout/deepLink.ts and pendingBind.ts).
+            // Stored in localStorage so it survives a cold restart if the
+            // SSO round trip involves an external browser.
+            savePendingOidcBind({
+                providerId,
+                authcode,
+                savedAt: Date.now(),
+            })
 
             const isDesktop = WKApp.shared.isPC
             const flag = isDesktop ? OIDC_FLAG_PC : OIDC_FLAG_WEB
@@ -609,7 +635,7 @@ export class LoginVM extends ProviderListener {
                 ? apiURL
                 : undefined
             if (isDesktop) {
-                ;(window as any).ipc?.send?.('oidc-authorize-start', apiURL)
+                ;(window as any).ipc?.send?.('oidc-authorize-start', apiURL, authcode, provider)
             }
 
             // Schedule a fallback reset before navigating so a blocked redirect
@@ -651,12 +677,12 @@ export class LoginVM extends ProviderListener {
         // Otherwise an external link could clear another flow or fake-toast a user.
         if (urlState.error && pending) {
             const name = getProviderById(pending.providerId)?.name || 'SSO'
-            clearPendingOidcLogin()
+            clearPendingOidcState()
             return { handled: true, success: false, error: t('oidc.failedWithProvider', { values: { provider: name } }) }
         }
         if (!pending) return { handled: false }
         if (isPendingExpired(pending)) {
-            clearPendingOidcLogin()
+            clearPendingOidcState()
             return { handled: true, success: false, error: t('oidc.timeout') }
         }
         const providerName = getProviderById(pending.providerId)?.name || 'SSO'
@@ -676,16 +702,16 @@ export class LoginVM extends ProviderListener {
                 signal: this._oidcAbort.signal,
             })
             if (result.status === OIDC_AUTH_STATUS.SUCCESS && result.result) {
-                clearPendingOidcLogin()
+                clearPendingOidcState()
                 this._resetOidcResume()
                 this.loginSuccess(result.result, pending.providerId)
                 return { handled: true, success: true }
             }
-            clearPendingOidcLogin()
+            clearPendingOidcState()
             this._resetOidcResume()
             return { handled: true, success: false, error: result.msg || t('oidc.failedWithProvider', { values: { provider: providerName } }) }
         } catch (e) {
-            clearPendingOidcLogin()
+            clearPendingOidcState()
             this._resetOidcResume()
             if (e instanceof OidcPollTimeoutError) {
                 return { handled: true, success: false, error: t('oidc.timeout') }
@@ -704,7 +730,7 @@ export class LoginVM extends ProviderListener {
         this._oidcCancelled = true
         // Clear pending up front so a refresh during the sleep window does not
         // resume the just-cancelled session.
-        clearPendingOidcLogin()
+        clearPendingOidcState()
         // Abort any in-flight fetch so cancel propagates without waiting for
         // the next sleep tick. (If the poll is currently inside `sleep`, cancel
         // is still felt one interval later — the sleep itself isn't abortable.)

--- a/packages/dmworklogin/src/login_vm.tsx
+++ b/packages/dmworklogin/src/login_vm.tsx
@@ -247,7 +247,8 @@ export class LoginVM extends ProviderListener {
         this.loginLoading = true
         this.notifyListener()
         try {
-            const resp = await WKApp.apiClient.post(`user/login_authcode/${authCode}`);
+            const flag = WKApp.shared.isPC ? Number(OIDC_FLAG_PC) : Number(OIDC_FLAG_WEB)
+            const resp = await WKApp.apiClient.post(`user/login_authcode/${authCode}`, { flag });
             if (resp) {
                 this.loginSuccess(resp)
             }
@@ -594,15 +595,11 @@ export class LoginVM extends ProviderListener {
                 savedAt: Date.now(),
             })
 
-            // Local development intentionally uses the backend-relative callback.
-            // The shared dev backend does not whitelist localhost return_to
-            // values, so it resolves `/login` to the production login page.
-            // This preserves the existing local-debug flow. Packaged Electron
-            // also uses this callback; main/index.ts intercepts the production
-            // callback and reloads the packaged app while preserving its query.
             const isDesktop = WKApp.shared.isPC
             const flag = isDesktop ? OIDC_FLAG_PC : OIDC_FLAG_WEB
-            const returnTo = '/login'
+            const returnTo = isDesktop
+                ? '/login'
+                : `${window.location.origin}/login`
             // Electron production pages use file://, so a server-relative
             // authorize path would resolve to file:///v1/... instead of the
             // configured backend. Dev Electron still uses the Vite proxy and
@@ -611,6 +608,9 @@ export class LoginVM extends ProviderListener {
             const authorizeBaseURL = isDesktop && /^https?:\/\//i.test(apiURL)
                 ? apiURL
                 : undefined
+            if (isDesktop) {
+                ;(window as any).ipc?.send?.('oidc-authorize-start', apiURL)
+            }
 
             // Schedule a fallback reset before navigating so a blocked redirect
             // does not leave the SSO button stuck in a loading state forever.

--- a/packages/dmworklogin/src/oidc/__tests__/http.test.ts
+++ b/packages/dmworklogin/src/oidc/__tests__/http.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { fetchHttpClient, OidcBindHttpError } from '../http'
+import { createFetchHttpClient, fetchHttpClient, OidcBindHttpError } from '../http'
 
 describe('fetchHttpClient', () => {
   const realFetch = globalThis.fetch
@@ -15,6 +15,19 @@ describe('fetchHttpClient', () => {
     }) as never
     const r = await fetchHttpClient.get<{ x: number }>('/u')
     expect(r.x).toBe(1)
+  })
+
+  it('resolves relative URLs against an Electron API base URL', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ ok: true }),
+    })
+    globalThis.fetch = fetchMock as never
+
+    await createFetchHttpClient('https://api.example.com/v1/').get('/v1/auth/oidc/acme/authcode')
+
+    expect(fetchMock.mock.calls[0][0]).toBe('https://api.example.com/v1/auth/oidc/acme/authcode')
   })
 
   it('GET throws OidcBindHttpError on non-2xx with msg body', async () => {

--- a/packages/dmworklogin/src/oidc/__tests__/pendingBind.test.ts
+++ b/packages/dmworklogin/src/oidc/__tests__/pendingBind.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  clearPendingOidcBind,
+  consumePendingBindIfMatches,
+  getPendingOidcBind,
+  hasValidPendingBind,
+  isPendingBindExpired,
+  savePendingOidcBind,
+} from '../pendingBind'
+import { OIDC_AUTHCODE_TTL_MS } from '../types'
+
+describe('pendingOidcBind', () => {
+  afterEach(() => {
+    localStorage.clear()
+  })
+
+  it('round-trips a marker through localStorage', () => {
+    savePendingOidcBind({ providerId: 'aegis', authcode: 'auth-code', savedAt: 1000 })
+    expect(getPendingOidcBind()).toEqual({ providerId: 'aegis', authcode: 'auth-code', savedAt: 1000 })
+  })
+
+  it('returns null when nothing is saved', () => {
+    expect(getPendingOidcBind()).toBeNull()
+  })
+
+  it('returns null when the stored value is not valid JSON', () => {
+    localStorage.setItem('pending_oidc_bind', 'not-json')
+    expect(getPendingOidcBind()).toBeNull()
+  })
+
+  it('returns null when required fields are missing', () => {
+    localStorage.setItem('pending_oidc_bind', JSON.stringify({ providerId: '', authcode: 'a', savedAt: 1 }))
+    expect(getPendingOidcBind()).toBeNull()
+    localStorage.setItem('pending_oidc_bind', JSON.stringify({ providerId: 'a', authcode: 'b' }))
+    expect(getPendingOidcBind()).toBeNull()
+    localStorage.setItem('pending_oidc_bind', JSON.stringify({ savedAt: 1 }))
+    expect(getPendingOidcBind()).toBeNull()
+  })
+
+  it('reports expiry against OIDC_AUTHCODE_TTL_MS', () => {
+    const now = 1_000_000
+    expect(isPendingBindExpired({ providerId: 'a', authcode: 'b', savedAt: now }, now)).toBe(false)
+    expect(
+      isPendingBindExpired({ providerId: 'a', authcode: 'b', savedAt: now - OIDC_AUTHCODE_TTL_MS + 1 }, now),
+    ).toBe(false)
+    expect(
+      isPendingBindExpired({ providerId: 'a', authcode: 'b', savedAt: now - OIDC_AUTHCODE_TTL_MS }, now),
+    ).toBe(true)
+  })
+
+  it('hasValidPendingBind clears expired markers as a side effect', () => {
+    const past = Date.now() - 10 * 60 * 1000
+    savePendingOidcBind({ providerId: 'aegis', authcode: 'auth-code', savedAt: past })
+    expect(hasValidPendingBind()).toBe(false)
+    // The stale marker is retired so a later legitimate flow does not have to
+    // race the TTL against a leftover value.
+    expect(getPendingOidcBind()).toBeNull()
+  })
+
+  it('hasValidPendingBind returns true for an unexpired marker', () => {
+    savePendingOidcBind({ providerId: 'aegis', authcode: 'auth-code', savedAt: Date.now() })
+    expect(hasValidPendingBind()).toBe(true)
+  })
+
+  it('clearPendingOidcBind removes the marker', () => {
+    savePendingOidcBind({ providerId: 'aegis', authcode: 'auth-code', savedAt: Date.now() })
+    clearPendingOidcBind()
+    expect(getPendingOidcBind()).toBeNull()
+  })
+
+  it('consumes only a matching provider/authcode pair', () => {
+    savePendingOidcBind({ providerId: 'aegis', authcode: 'auth-code', savedAt: Date.now() })
+    expect(consumePendingBindIfMatches({ providerId: 'aegis', authcode: 'wrong' })).toBe(false)
+    expect(consumePendingBindIfMatches({ providerId: 'aegis', authcode: 'auth-code' })).toBe(true)
+    expect(getPendingOidcBind()).toBeNull()
+  })
+
+  it('accepts a callback when the backend supplies either correlation field', () => {
+    savePendingOidcBind({ providerId: 'aegis', savedAt: Date.now() })
+    expect(consumePendingBindIfMatches({ providerId: 'aegis' })).toBe(true)
+
+    savePendingOidcBind({ providerId: 'aegis', authcode: 'auth-code', savedAt: Date.now() })
+    expect(consumePendingBindIfMatches({ authcode: 'auth-code' })).toBe(true)
+  })
+
+})

--- a/packages/dmworklogin/src/oidc/__tests__/pendingBind.test.ts
+++ b/packages/dmworklogin/src/oidc/__tests__/pendingBind.test.ts
@@ -75,12 +75,11 @@ describe('pendingOidcBind', () => {
     expect(getPendingOidcBind()).toBeNull()
   })
 
-  it('accepts a callback when the backend supplies either correlation field', () => {
-    savePendingOidcBind({ providerId: 'aegis', savedAt: Date.now() })
-    expect(consumePendingBindIfMatches({ providerId: 'aegis' })).toBe(true)
-
+  it('requires both provider and authcode correlation fields', () => {
     savePendingOidcBind({ providerId: 'aegis', authcode: 'auth-code', savedAt: Date.now() })
-    expect(consumePendingBindIfMatches({ authcode: 'auth-code' })).toBe(true)
+    expect(consumePendingBindIfMatches({ providerId: 'aegis' })).toBe(false)
+    expect(consumePendingBindIfMatches({ authcode: 'auth-code' })).toBe(false)
+    expect(consumePendingBindIfMatches({ providerId: 'aegis', authcode: 'auth-code' })).toBe(true)
   })
 
 })

--- a/packages/dmworklogin/src/oidc/__tests__/url.test.ts
+++ b/packages/dmworklogin/src/oidc/__tests__/url.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { buildAuthorizeURL, parseOidcUrlState } from '../url'
+import { buildAuthorizeURL, parseOidcUrlState, OIDC_FLAG_WEB, OIDC_FLAG_PC } from '../url'
 import type { SSOProvider } from '../types'
 
 const acmeSso: SSOProvider = {
@@ -30,6 +30,34 @@ describe('buildAuthorizeURL', () => {
   it('encodes special characters in authcode', () => {
     const url = buildAuthorizeURL(acmeSso, 'a b&c')
     expect(url).toContain('authcode=a+b%26c')
+  })
+
+  it('uses flag=2 (pc) for Electron desktop when explicitly passed', () => {
+    const url = buildAuthorizeURL(
+      acmeSso,
+      'AC-pc',
+      'https://api.example.com/login',
+      OIDC_FLAG_PC,
+    )
+    const qs = new URLSearchParams(url.split('?')[1])
+    expect(qs.get('flag')).toBe('2')
+    expect(qs.get('return_to')).toBe('https://api.example.com/login')
+  })
+
+  it('resolves the server-relative authorize path against an Electron API origin', () => {
+    const url = buildAuthorizeURL(
+      acmeSso,
+      'AC-pc',
+      '/login',
+      OIDC_FLAG_PC,
+      'https://api.example.com/v1/',
+    )
+    expect(url).toMatch(/^https:\/\/api\.example\.com\/v1\/auth\/oidc\/acme-sso\/authorize\?/)
+  })
+
+  it('OIDC_FLAG_WEB is "1" and OIDC_FLAG_PC is "2"', () => {
+    expect(OIDC_FLAG_WEB).toBe('1')
+    expect(OIDC_FLAG_PC).toBe('2')
   })
 })
 

--- a/packages/dmworklogin/src/oidc/bind/__tests__/url.test.ts
+++ b/packages/dmworklogin/src/oidc/bind/__tests__/url.test.ts
@@ -167,6 +167,26 @@ describe('clearBindUrl', () => {
     expect(replaceState).not.toHaveBeenCalled()
   })
 
+  // Packaged Electron loads the shell from file:// where any replaceState
+  // that touches pathname throws SecurityError. clearBindUrl edits only the
+  // search string so it is safe under file:// — this invariant guards the
+  // Electron bind path.
+  it('preserves the shell pathname under file:// (packaged Electron)', () => {
+    const { win, replaceState } = makeWin(
+      '/Applications/OCTO.app/Contents/Resources/app.asar/build/index.html',
+      '?__octo_route=/oidc/bind&token=tok&sid=window-sid',
+    )
+    clearBindUrl(win)
+    expect(replaceState).toHaveBeenCalledTimes(1)
+    const newUrl = replaceState.mock.calls[0][2] as string
+    expect(newUrl.startsWith('/Applications/OCTO.app/Contents/Resources/app.asar/build/index.html'))
+      .toBe(true)
+    const search = new URLSearchParams(newUrl.split('?')[1] ?? '')
+    expect(search.has('__octo_route')).toBe(false)
+    expect(search.has('token')).toBe(false)
+    expect(search.get('sid')).toBe('window-sid')
+  })
+
   it('does not throw when history is unavailable', () => {
     const win = {
       history: {

--- a/packages/dmworklogin/src/oidc/bind/url.ts
+++ b/packages/dmworklogin/src/oidc/bind/url.ts
@@ -86,6 +86,7 @@ const BIND_QUERY_KEYS: ReadonlySet<string> = new Set([
   'authcode',
   'return_to',
   'provider',
+  '__octo_route',
 ])
 
 /**

--- a/packages/dmworklogin/src/oidc/http.ts
+++ b/packages/dmworklogin/src/oidc/http.ts
@@ -69,40 +69,40 @@ function resolveOidcUrl(url: string, baseURL?: string): string {
 
 export function createFetchHttpClient(baseURL?: string): OidcHttpClient {
   return {
-  async get<T>(url: string, init?: { signal?: AbortSignal }): Promise<T> {
-    const signal = combineSignals(init?.signal, DEFAULT_REQUEST_TIMEOUT_MS)
-    const resp = await fetch(resolveOidcUrl(url, baseURL), {
-      method: 'GET',
-      credentials: 'same-origin',
-      headers: { Accept: 'application/json' },
-      signal,
-    })
-    if (!resp.ok) {
-      throw new OidcBindHttpError(resp.status, await parseErrorMsg(resp))
-    }
-    return (await resp.json()) as T
-  },
-  async post<T>(
-    url: string,
-    body: unknown,
-    init?: { signal?: AbortSignal },
-  ): Promise<T> {
-    const signal = combineSignals(init?.signal, DEFAULT_REQUEST_TIMEOUT_MS)
-    const resp = await fetch(resolveOidcUrl(url, baseURL), {
-      method: 'POST',
-      credentials: 'same-origin',
-      headers: {
-        Accept: 'application/json',
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify(body ?? {}),
-      signal,
-    })
-    if (!resp.ok) {
-      throw new OidcBindHttpError(resp.status, await parseErrorMsg(resp))
-    }
-    return (await resp.json()) as T
-  },
+    async get<T>(url: string, init?: { signal?: AbortSignal }): Promise<T> {
+      const signal = combineSignals(init?.signal, DEFAULT_REQUEST_TIMEOUT_MS)
+      const resp = await fetch(resolveOidcUrl(url, baseURL), {
+        method: 'GET',
+        credentials: 'same-origin',
+        headers: { Accept: 'application/json' },
+        signal,
+      })
+      if (!resp.ok) {
+        throw new OidcBindHttpError(resp.status, await parseErrorMsg(resp))
+      }
+      return (await resp.json()) as T
+    },
+    async post<T>(
+      url: string,
+      body: unknown,
+      init?: { signal?: AbortSignal },
+    ): Promise<T> {
+      const signal = combineSignals(init?.signal, DEFAULT_REQUEST_TIMEOUT_MS)
+      const resp = await fetch(resolveOidcUrl(url, baseURL), {
+        method: 'POST',
+        credentials: 'same-origin',
+        headers: {
+          Accept: 'application/json',
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(body ?? {}),
+        signal,
+      })
+      if (!resp.ok) {
+        throw new OidcBindHttpError(resp.status, await parseErrorMsg(resp))
+      }
+      return (await resp.json()) as T
+    },
   }
 }
 

--- a/packages/dmworklogin/src/oidc/http.ts
+++ b/packages/dmworklogin/src/oidc/http.ts
@@ -62,10 +62,16 @@ async function parseErrorMsg(resp: Response): Promise<string | undefined> {
  * Each request is wrapped in a 10s timeout, ORed with an optional caller
  * signal so cancellation aborts the in-flight request immediately.
  */
-export const fetchHttpClient: OidcHttpClient = {
+function resolveOidcUrl(url: string, baseURL?: string): string {
+  if (!baseURL || /^[a-z][a-z\d+.-]*:/i.test(url)) return url
+  return new URL(url, baseURL.endsWith('/') ? baseURL : `${baseURL}/`).toString()
+}
+
+export function createFetchHttpClient(baseURL?: string): OidcHttpClient {
+  return {
   async get<T>(url: string, init?: { signal?: AbortSignal }): Promise<T> {
     const signal = combineSignals(init?.signal, DEFAULT_REQUEST_TIMEOUT_MS)
-    const resp = await fetch(url, {
+    const resp = await fetch(resolveOidcUrl(url, baseURL), {
       method: 'GET',
       credentials: 'same-origin',
       headers: { Accept: 'application/json' },
@@ -82,7 +88,7 @@ export const fetchHttpClient: OidcHttpClient = {
     init?: { signal?: AbortSignal },
   ): Promise<T> {
     const signal = combineSignals(init?.signal, DEFAULT_REQUEST_TIMEOUT_MS)
-    const resp = await fetch(url, {
+    const resp = await fetch(resolveOidcUrl(url, baseURL), {
       method: 'POST',
       credentials: 'same-origin',
       headers: {
@@ -97,4 +103,7 @@ export const fetchHttpClient: OidcHttpClient = {
     }
     return (await resp.json()) as T
   },
+  }
 }
+
+export const fetchHttpClient: OidcHttpClient = createFetchHttpClient()

--- a/packages/dmworklogin/src/oidc/index.ts
+++ b/packages/dmworklogin/src/oidc/index.ts
@@ -6,7 +6,8 @@ export type {
 export { OIDC_AUTH_STATUS, OIDC_AUTHCODE_TTL_MS } from './types'
 
 export { getSSOProviders, getProviderById } from './providers'
-export { buildAuthorizeURL, parseOidcUrlState } from './url'
+export { buildAuthorizeURL, parseOidcUrlState, OIDC_FLAG_WEB, OIDC_FLAG_PC } from './url'
+export { createFetchHttpClient } from './http'
 export type { OidcUrlState } from './url'
 export {
   savePendingOidcLogin,

--- a/packages/dmworklogin/src/oidc/index.ts
+++ b/packages/dmworklogin/src/oidc/index.ts
@@ -16,6 +16,16 @@ export {
   isPendingExpired,
 } from './pending'
 
+export {
+  savePendingOidcBind,
+  getPendingOidcBind,
+  clearPendingOidcBind,
+  isPendingBindExpired,
+  hasValidPendingBind,
+  consumePendingBindIfMatches,
+} from './pendingBind'
+export type { PendingOidcBind } from './pendingBind'
+
 export { fetchAuthcode, fetchAuthStatus } from './api'
 export type {
   AuthcodeResponse,

--- a/packages/dmworklogin/src/oidc/pendingBind.ts
+++ b/packages/dmworklogin/src/oidc/pendingBind.ts
@@ -109,9 +109,9 @@ export function consumePendingBindIfMatches(
   }
   const hasProvider = typeof expected.providerId === 'string' && expected.providerId !== ''
   const hasAuthcode = typeof expected.authcode === 'string' && expected.authcode !== ''
-  if (!hasProvider && !hasAuthcode) return false
-  if (hasProvider && expected.providerId !== pending.providerId) return false
-  if (hasAuthcode && expected.authcode !== pending.authcode) return false
+  if (!hasProvider || !hasAuthcode) return false
+  if (expected.providerId !== pending.providerId) return false
+  if (expected.authcode !== pending.authcode) return false
   clearPendingOidcBind()
   return true
 }

--- a/packages/dmworklogin/src/oidc/pendingBind.ts
+++ b/packages/dmworklogin/src/oidc/pendingBind.ts
@@ -1,0 +1,117 @@
+// Marker written by startOidcLogin() before navigating to the IdP, read by
+// the packaged-Electron deep-link handler to reject `dmwork://oidc/bind`
+// callbacks that were not initiated locally.
+//
+// Registering `dmwork://` as an OS-level protocol handler (electron-builder.js
+// mac.protocols / win.protocols / linux mimeType) makes the bind route
+// reachable from ANY web origin: any page can execute
+// `location = 'dmwork://oidc/bind?token=ATTACKER_TOKEN'`. Without a
+// correlation check, the bind page then loads with an attacker-supplied
+// token and — after the victim clears a password/OTP challenge — binds the
+// attacker's external identity to the victim's account.
+//
+// Persisted to localStorage rather than sessionStorage because a real
+// external-browser SSO round trip can outlive the packaged app process.
+// TTL is short (matches OIDC_AUTHCODE_TTL_MS) and the marker is cleared on
+// bind success / failure / login success, so this is not a lasting grant.
+
+const STORAGE_KEY = 'pending_oidc_bind'
+
+// Reuse the same TTL as the authcode / login-pending window. See
+// packages/dmworklogin/src/oidc/types.ts.
+import { OIDC_AUTHCODE_TTL_MS } from './types'
+
+export interface PendingOidcBind {
+  providerId: string
+  authcode?: string
+  savedAt: number
+}
+
+function isPendingOidcBind(value: unknown): value is PendingOidcBind {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false
+  const v = value as Record<string, unknown>
+  return (
+    typeof v.providerId === 'string' &&
+    v.providerId !== '' &&
+    (v.authcode === undefined || (typeof v.authcode === 'string' && v.authcode !== '')) &&
+    typeof v.savedAt === 'number' &&
+    Number.isFinite(v.savedAt)
+  )
+}
+
+export function savePendingOidcBind(value: PendingOidcBind): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(value))
+  } catch {
+    // Storage disabled (private mode, quota exceeded): leave the deep-link
+    // path closed for this client — a legitimate flow still works via the
+    // in-window will-redirect intercept.
+  }
+}
+
+export function getPendingOidcBind(): PendingOidcBind | null {
+  let raw: string | null
+  try {
+    raw = localStorage.getItem(STORAGE_KEY)
+  } catch {
+    return null
+  }
+  if (!raw) return null
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return null
+  }
+  return isPendingOidcBind(parsed) ? parsed : null
+}
+
+export function clearPendingOidcBind(): void {
+  try {
+    localStorage.removeItem(STORAGE_KEY)
+  } catch {
+    /* noop */
+  }
+}
+
+export function isPendingBindExpired(
+  pending: PendingOidcBind,
+  now: number = Date.now(),
+): boolean {
+  return now - pending.savedAt >= OIDC_AUTHCODE_TTL_MS
+}
+
+/**
+ * Return true iff a valid unexpired bind marker is present. Convenience
+ * wrapper used by the deep-link handler; also clears expired markers so
+ * they don't linger past the OIDC TTL.
+ */
+export function hasValidPendingBind(now: number = Date.now()): boolean {
+  const pending = getPendingOidcBind()
+  if (!pending) return false
+  if (isPendingBindExpired(pending, now)) {
+    clearPendingOidcBind()
+    return false
+  }
+  return true
+}
+
+/** Consume the marker only for the exact flow started by this client. */
+export function consumePendingBindIfMatches(
+  expected: { providerId?: string; authcode?: string },
+  now: number = Date.now(),
+): boolean {
+  const pending = getPendingOidcBind()
+  if (!pending) return false
+  if (isPendingBindExpired(pending, now)) {
+    clearPendingOidcBind()
+    return false
+  }
+  const hasProvider = typeof expected.providerId === 'string' && expected.providerId !== ''
+  const hasAuthcode = typeof expected.authcode === 'string' && expected.authcode !== ''
+  if (!hasProvider && !hasAuthcode) return false
+  if (hasProvider && expected.providerId !== pending.providerId) return false
+  if (hasAuthcode && expected.authcode !== pending.authcode) return false
+  clearPendingOidcBind()
+  return true
+}

--- a/packages/dmworklogin/src/oidc/url.ts
+++ b/packages/dmworklogin/src/oidc/url.ts
@@ -2,24 +2,33 @@ import type { SSOProvider } from './types'
 
 const DEFAULT_RETURN_TO = '/login'
 // `flag` is forwarded to the backend OIDC callback and recorded on the IM
-// device-token row that the WS CONNECT packet later looks up. WuKongIM JS SDK
-// hardcodes `deviceFlag = 1` (web), so the authorize call must also send 1 —
-// otherwise the IM server can't find the (uid, device_flag, token) tuple at
-// connect time and silently closes the socket without a CONNACK.
-// Values per WuKongIM: 0 = app, 1 = web, 2 = pc. Mirror the value normal
-// password login sends in `user/login` (login_vm.tsx → flag: 1).
-const DEFAULT_FLAG = '1'
+// device-token row that the WS CONNECT packet later looks up.
+// Values per WuKongIM: 0 = app, 1 = web, 2 = pc.
+// Web:      flag=1 (WuKongIM JS SDK hardcodes deviceFlag=1)
+// Electron: flag=2 (desktop PC client)
+// Mirror the value normal password login sends in `user/login`.
+export const OIDC_FLAG_WEB = '1'
+export const OIDC_FLAG_PC = '2'
 
 export function buildAuthorizeURL(
   provider: SSOProvider,
   authcode: string,
   returnTo: string = DEFAULT_RETURN_TO,
+  flag: string = OIDC_FLAG_WEB,
+  baseURL?: string,
 ): string {
   const params = new URLSearchParams()
   params.set('authcode', authcode)
   params.set('return_to', returnTo)
-  params.set('flag', DEFAULT_FLAG)
-  return `${provider.authorizePath}?${params.toString()}`
+  params.set('flag', flag)
+  const relativePath = `${provider.authorizePath}?${params.toString()}`
+  if (!baseURL) return relativePath
+  // Ensure baseURL ends with "/" so that new URL() resolves a path-relative
+  // authorizePath correctly and does not strip the last path segment.
+  // If authorizePath starts with "/" it is treated as server-root-relative,
+  // which is intentional and consistent with browser fetch semantics.
+  const base = baseURL.endsWith('/') ? baseURL : `${baseURL}/`
+  return new URL(relativePath, base).toString()
 }
 
 export interface OidcUrlState {


### PR DESCRIPTION
## Summary

- support OIDC login flow in web and packaged Electron builds
- keep web/Electron device flags aligned for WuKongIM authentication, including QR login
- preserve deployment-specific web return URLs and post-login query parameters
- restrict Electron callback interception to the API origin registered by the renderer
- preserve the trusted Electron session sid and support the OIDC bind callback in packaged builds
- force one clean login for pre-migration desktop sessions

## Validation

- `packages/dmworklogin`: 91 targeted tests passed
- `apps/web`: 6 targeted tests passed
- `apps/web`: Electron TypeScript compilation passed
- `apps/web`: production build passed

## Scope

This changes login behavior only; no duplicate user-facing entry point is added. The branch is rebased onto the latest `main`.