### PR TITLE
feat(docs): open document URLs without space parameter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,10 +103,15 @@ jobs:
           src/editor/Toolbar.test.tsx
           src/editor/styles.test.ts
           src/pages/DocsHome.test.tsx
+          src/pages/StandaloneDocPage.test.tsx
+          src/pages/docsApi.test.ts
+          src/auth/collabToken.test.ts
           src/pages/docsApi.export.test.ts
           src/pages/docsApi.import.test.ts
       - name: Verify Excalidraw patch
         run: pnpm verify:excalidraw-patch
+      - name: APIClient request interceptor tests
+        run: pnpm --filter @octo/base exec vitest run src/Service/__tests__/APIClient.headers.test.ts
       - name: Verify Web build cache key
         run: pnpm verify:web-build-cache-key
       - name: Board and comment unit tests

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -129,7 +129,7 @@ jobs:
           #  6. PW_EXIT!=0 但 junit 无 business fail → playwright 本身 crash/OOM/timeout, block
           #  7. 仅视觉 fail (无 @p0 交叉) 且 playwright 干净退出 → allow
           #  8. 全绿 → success
-          EXPECTED_P0=5
+          EXPECTED_P0=11
           EXPECTED_VISUAL=0
           EXPECTED_TOTAL=$((EXPECTED_P0 + EXPECTED_VISUAL))
           if [[ "$TOTAL_TESTS" -eq 0 ]]; then

--- a/apps/web/e2e-kit/tests/standalone-doc/standalone-doc.spec.ts
+++ b/apps/web/e2e-kit/tests/standalone-doc/standalone-doc.spec.ts
@@ -38,9 +38,19 @@ async function stubBackend(page: Page): Promise<void> {
   await page.route('**/api/v1/**', (route: Route) =>
     route.fulfill({ status: 200, contentType: 'application/json', body: '{}' }),
   )
+  // Playwright routes are LIFO: register this after the catch-all. A signed-in
+  // standalone recipient still belongs to a viewer Space; returning one keeps
+  // the host cold-start guard from replacing `/d/:docId` with JoinSpacePage.
+  await page.route('**/api/v1/space/my', (route: Route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([{ space_id: 'space-viewer', name: 'Viewer Space', role: 1, status: 1 }]),
+    }),
+  )
 }
 
-/** Route the per-doc preflight (GET /api/v1/docs/:id) to a specific status/body. */
+/** Route the docId-global preflight to a specific status/body. */
 async function routeDocPreflight(
   page: Page,
   docId: string,
@@ -48,7 +58,7 @@ async function routeDocPreflight(
   body: object = {},
 ): Promise<{ tokenHeaderOf: () => string | undefined }> {
   let seenToken: string | undefined
-  await page.route(`**/api/v1/docs/${docId}`, (route: Route) => {
+  await page.route(`**/api/v1/docs/${docId}/open-context`, (route: Route) => {
     seenToken = route.request().headers()['token']
     route.fulfill({ status, contentType: 'application/json', body: JSON.stringify(body) })
   })
@@ -85,7 +95,7 @@ async function seedAnonymous(page: Page): Promise<void> {
   })
 }
 
-test.describe('standalone /d/:docId — clean cold-load (no in-app sid route)', () => {
+test.describe('standalone /d/:docId — clean cold-load (no in-app sid route) @p0', () => {
   test('AC-3: a signed-in user opening a clean link authenticates the preflight (no 401 wall)', async ({
     page,
   }) => {
@@ -93,6 +103,9 @@ test.describe('standalone /d/:docId — clean cold-load (no in-app sid route)', 
     await stubBackend(page)
     const probe = await routeDocPreflight(page, 'd_ok', 200, {
       docId: 'd_ok',
+      homeSpaceId: 'space-doc',
+      documentName: 'octo:space-doc:f_default:html:d_ok',
+      docType: 'html',
       title: 'Shared Doc',
       ownerId: 'u_e2e',
       role: 'admin',
@@ -103,11 +116,13 @@ test.describe('standalone /d/:docId — clean cold-load (no in-app sid route)', 
 
     // The recovered session token rides the preflight — not an anonymous 401-bound request.
     await expect.poll(() => probe.tokenHeaderOf()).toBe(USER_TOKEN)
-    // The clean path did NOT dead-end on the sign-in terminal.
-    await expect(page.locator('.octo-terminal-msg')).toHaveCount(0)
+    // Assert a real document surface mounts; absence of a terminal alone could
+    // also pass on an unrelated host overlay such as JoinSpacePage. Use the HTML
+    // surface here because it has no WebSocket-sync prerequisite in this HTTP E2E.
+    await expect(page.getByTestId('html-doc-view')).toBeVisible()
   })
 
-  test('AC-7: a 403 renders the access-denied terminal with a Back control, editor not mounted', async ({
+  test('AC-7: a 403 renders the access-denied landing with request access, editor not mounted', async ({
     page,
   }) => {
     await seedSignedInSession(page)
@@ -116,9 +131,10 @@ test.describe('standalone /d/:docId — clean cold-load (no in-app sid route)', 
 
     await page.goto('/d/d_forbidden')
 
-    await expect(page.locator('.octo-terminal')).toBeVisible()
-    await expect(page.locator('.octo-terminal-msg')).toHaveText(/no longer have access|无权访问/)
-    await expect(page.locator('.octo-doc-back')).toBeVisible()
+    await expect(page.locator('.octo-standalone-forbidden')).toBeVisible()
+    await expect(page.locator('.octo-standalone-card-msg')).toHaveText(/no longer have access|无权访问/)
+    await expect(page.locator('.octo-access-request-btn')).toBeVisible()
+    await expect(page.locator('.octo-doc-back')).toHaveCount(0)
     await expect(page.locator('.octo-doc--editor')).toHaveCount(0)
   })
 
@@ -199,10 +215,12 @@ test.describe('standalone /d/:docId — records a view in the viewer space (XIN-
       }
     })
     await stubBackend(page)
-    // Cross-space share: the link carries the DOC's own space (`?sp=space-doc`), which the page uses
-    // to address the preflight — deliberately different from the viewer's current space.
+    // Cross-space share: the legacy link still carries the DOC's old `?sp=space-doc`, but the
+    // docId-global preflight ignores it. It is deliberately different from the viewer's space.
     await routeDocPreflight(page, 'd_ok', 200, {
       docId: 'd_ok',
+      homeSpaceId: 'space-doc',
+      documentName: 'octo:space-doc:f_default:d_ok',
       title: 'Shared Doc',
       ownerId: 'u_owner',
       role: 'reader',
@@ -239,7 +257,7 @@ test.describe('standalone /d/:docId — records a view in the viewer space (XIN-
 
     await page.goto('/d/d_forbidden')
 
-    await expect(page.locator('.octo-terminal')).toBeVisible()
+    await expect(page.locator('.octo-standalone-forbidden')).toBeVisible()
     expect(viewCalls).toBe(0)
   })
 })

--- a/apps/web/src/Layout/__tests__/standaloneReturn.test.ts
+++ b/apps/web/src/Layout/__tests__/standaloneReturn.test.ts
@@ -9,12 +9,12 @@ afterEach(() => {
 });
 
 describe("standalone return target", () => {
-    it("persists the current path and query", () => {
-        window.history.replaceState(null, "", "/loop/cli-authorize?code=abc");
+    it("persists the current path, query, and hash", () => {
+        window.history.replaceState(null, "", "/loop/cli-authorize?code=abc#resume");
 
         persistStandaloneReturn();
 
-        expect(window.sessionStorage.getItem(KEY)).toBe("/loop/cli-authorize?code=abc");
+        expect(window.sessionStorage.getItem(KEY)).toBe("/loop/cli-authorize?code=abc#resume");
     });
 
     it("keeps existing docs and summary return targets valid", () => {

--- a/apps/web/src/Layout/standaloneReturn.ts
+++ b/apps/web/src/Layout/standaloneReturn.ts
@@ -71,7 +71,7 @@ export function persistStandaloneReturn(): void {
     try {
         window.sessionStorage.setItem(
             STANDALONE_RETURN_KEY,
-            window.location.pathname + window.location.search
+            window.location.pathname + window.location.search + window.location.hash
         );
     } catch {
         // sessionStorage unavailable: the deep-link still stays on the login page, but cannot

--- a/packages/dmworkbase/src/Messages/DocumentShareCard/DocumentShareCardContent.ts
+++ b/packages/dmworkbase/src/Messages/DocumentShareCard/DocumentShareCardContent.ts
@@ -41,9 +41,9 @@ function asPermission(v: unknown): DocSharePermission {
  * reader 接口（/content、/scene、/sheet）现取，无权限则接口 403/404、卡片落 no_access 态。
  */
 export class DocumentShareCardContent extends MessageContent {
-  /** 文档 id，映射 /d/{docId}?sp={spaceId}。 */
+  /** 文档 id，映射 /d/{docId}（Phase-1 已取消 sp）。 */
   docId = "";
-  /** 文档所属 space id（预览与 deep-link 都要）。 */
+  /** 文档所属 space id（仍用于 ACL-safe 首屏预览；deep-link 不再携带）。 */
   spaceId = "";
   /** 资源类型：doc/board/sheet。 */
   kind: DocShareKind = "doc";

--- a/packages/dmworkbase/src/Messages/DocumentShareCard/__tests__/DocumentShareCardContent.test.ts
+++ b/packages/dmworkbase/src/Messages/DocumentShareCard/__tests__/DocumentShareCardContent.test.ts
@@ -37,23 +37,24 @@ describe("asDocIdentifier — decode-boundary narrowing", () => {
   });
 });
 
-describe("buildDocNavUrl — locally rebuilt safe nav URL (P1-b)", () => {
-  it("builds a same-origin relative /d/ path from validated ids", () => {
-    expect(buildDocNavUrl("d1", "sp1")).toBe("/d/d1?sp=sp1");
+describe("buildDocNavUrl — locally rebuilt safe nav URL (P1-b, Phase-1 no sp)", () => {
+  it("builds a same-origin relative /d/ path from the validated docId (no sp — design §5.3)", () => {
+    expect(buildDocNavUrl("d1")).toBe("/d/d1");
+    expect(buildDocNavUrl("DOC-9_x")).toBe("/d/DOC-9_x");
   });
 
-  it("omits sp when spaceId is absent or invalid", () => {
-    expect(buildDocNavUrl("d1", "")).toBe("/d/d1");
-    expect(buildDocNavUrl("d1", "../x")).toBe("/d/d1");
+  it("never emits a `?sp=` query (Phase-1 removed the doc Space from ordinary links)", () => {
+    expect(buildDocNavUrl("d1")).not.toContain("sp=");
+    expect(buildDocNavUrl("d1")).not.toContain("?");
   });
 
   it("returns empty (no navigation) for an invalid docId", () => {
-    expect(buildDocNavUrl("../admin", "sp1")).toBe("");
-    expect(buildDocNavUrl("", "sp1")).toBe("");
+    expect(buildDocNavUrl("../admin")).toBe("");
+    expect(buildDocNavUrl("")).toBe("");
   });
 
   it("never emits a scheme or a wire-controlled absolute URL", () => {
-    const url = buildDocNavUrl("d1", "sp1");
+    const url = buildDocNavUrl("d1");
     expect(url.startsWith("/d/")).toBe(true);
     expect(url).not.toMatch(/^https?:|^javascript:|^data:/i);
   });

--- a/packages/dmworkbase/src/Messages/DocumentShareCard/docIdentity.ts
+++ b/packages/dmworkbase/src/Messages/DocumentShareCard/docIdentity.ts
@@ -19,13 +19,15 @@ export function asDocIdentifier(v: unknown): string {
 
 /**
  * 本地重建的**安全导航 URL**。P1-b：绝不信任 wire 传来的 `url`（`isSafeUrl` 只挡 scheme
- * 不绑 origin，真预览 + 攻击者 url 可拼成可信钓鱼卡）。改为只用**已校验的 docId/spaceId**
- * 拼相对路径（同源、无 scheme，天然安全）；docId 非法则返回空串，调用方不导航/不显链接。
+ * 不绑 origin，真预览 + 攻击者 url 可拼成可信钓鱼卡）。改为只用**已校验的 docId**拼相对路径
+ * （同源、无 scheme，天然安全）；docId 非法则返回空串，调用方不导航/不显链接。
+ *
+ * Phase-1 取消 `sp`（设计 §5.3）：普通文档链接不再携带文档 Space——接收端的 open-context
+ * 预检按 docId 在服务端解析文档归属，故这里只产出 `/d/{docId}`，不再拼 `?sp=`。
  */
-export function buildDocNavUrl(docId: string, spaceId: string): string {
+export function buildDocNavUrl(docId: string): string {
   if (!isValidDocIdentifier(docId)) return "";
-  const sp = isValidDocIdentifier(spaceId) ? `?sp=${encodeURIComponent(spaceId)}` : "";
-  return `/d/${encodeURIComponent(docId)}${sp}`;
+  return `/d/${encodeURIComponent(docId)}`;
 }
 
 // 类型仅用于签名，`import type` 在运行时被擦除，不会拉入 ui 组件的 React/CSS 加载链。

--- a/packages/dmworkbase/src/Messages/DocumentShareCard/index.tsx
+++ b/packages/dmworkbase/src/Messages/DocumentShareCard/index.tsx
@@ -64,15 +64,15 @@ export class DocumentShareCardCell extends MessageCell<MessageBaseCellProps> {
 
   private handleOpen = (): void => {
     const content = this.props.message.content as DocumentShareCardContent;
-    // P1-b：不信任 wire url，用已校验的 docId/spaceId 本地重建同源相对路径再导航。
-    const url = buildDocNavUrl(content.docId, content.spaceId);
+    // P1-b：不信任 wire url，用已校验的 docId 本地重建同源相对路径再导航（Phase-1 已去 sp）。
+    const url = buildDocNavUrl(content.docId);
     if (url) window.open(url, "_blank", "noopener,noreferrer");
   };
 
-  /** 复制文档链接：用已校验 docId/spaceId 在本源重建绝对链接（不回显 wire url，安全且可分享）。 */
+  /** 复制文档链接：用已校验 docId 在本源重建绝对链接（不回显 wire url，安全且可分享；无 sp）。 */
   private handleCopy = (): void => {
     const content = this.props.message.content as DocumentShareCardContent;
-    const rel = buildDocNavUrl(content.docId, content.spaceId);
+    const rel = buildDocNavUrl(content.docId);
     if (!rel) return;
     void navigator.clipboard?.writeText(`${window.location.origin}${rel}`);
   };

--- a/packages/dmworkbase/src/Pages/Chat/index.tsx
+++ b/packages/dmworkbase/src/Pages/Chat/index.tsx
@@ -1720,8 +1720,8 @@ export default class ChatPage extends Component<any, ChatPageState> {
                     }}
                     onOpenDoc={(item) => {
                       // Open the clicked cloud-doc in the standalone `/d/:docId`
-                      // page, carrying the doc's real space on `?sp=` so the
-                      // preflight addresses the right space (buildDocLink). The
+                      // page. buildDocLink intentionally emits no Space locator;
+                      // authenticated open-context resolves canonical addressing. The
                       // `/d` namespace is intercepted by apps/web Layout OUTSIDE
                       // the app shell and is not a RouteManager route, so it can't
                       // be reached by an in-shell soft push — open it in a new tab

--- a/packages/dmworkbase/src/Service/APIClient.ts
+++ b/packages/dmworkbase/src/Service/APIClient.ts
@@ -2,6 +2,13 @@ import axios, { AxiosResponse } from "axios";
 import { buildAcceptLanguage } from "./apiLanguage";
 import { isAuthExpiredApiError, normalizeApiError, NormalizedApiError } from "./apiError";
 
+declare module "axios" {
+    interface AxiosRequestConfig {
+        /** Internal host-client flag; never serialized as an HTTP header. */
+        suppressSpaceId?: boolean;
+    }
+}
+
 export interface APIClientRejectedError {
     error: unknown;
     msg: string;
@@ -93,7 +100,7 @@ export default class APIClient {
             // X-Space-Id（如 standalone /d/:docId 冷启动 preflight），拦截器不覆盖它；
             // 仅在显式头缺省时用 currentSpaceId 兜底注入。这样显式头与拦截器头永远一致
             // （显式为准/拦截器兜底），不会互相冲突。
-            if (self.config.spaceIdCallback && !config.headers!["X-Space-Id"]) {
+            if (!config.suppressSpaceId && self.config.spaceIdCallback && !config.headers!["X-Space-Id"]) {
                 const spaceId = self.config.spaceIdCallback()
                 if (spaceId && spaceId !== "") {
                     config.headers!["X-Space-Id"] = spaceId;
@@ -133,6 +140,7 @@ export default class APIClient {
         responseType: config?.responseType,
         timeout: config?.timeout,
         signal: config?.signal,
+        suppressSpaceId: config?.suppressSpaceId,
     }), config)
     }
     post(path: string, data?: any, config?: RequestConfig) {
@@ -141,6 +149,7 @@ export default class APIClient {
             responseType: config?.responseType,
             timeout: config?.timeout,
             signal: config?.signal,
+            suppressSpaceId: config?.suppressSpaceId,
         }), config)
     }
 
@@ -148,6 +157,7 @@ export default class APIClient {
         return this.wrapResult(axios.put(path, data, {
             params: config?.param,
             headers: config?.headers,
+            suppressSpaceId: config?.suppressSpaceId,
         }), config)
     }
 
@@ -155,6 +165,7 @@ export default class APIClient {
         return this.wrapResult(axios.patch(path, data, {
             params: config?.param,
             headers: config?.headers,
+            suppressSpaceId: config?.suppressSpaceId,
         }), config)
     }
 
@@ -163,6 +174,7 @@ export default class APIClient {
             params: config?.param,
             data: config?.data,
             headers: config?.headers,
+            suppressSpaceId: config?.suppressSpaceId,
         }), config)
     }
 
@@ -208,6 +220,8 @@ export class RequestConfig {
      * 保持既有无显式头行为。
      */
     headers?: Record<string, string>
+    /** Suppress the global X-Space-Id injector for docId-global endpoints. */
+    suppressSpaceId?: boolean
     /**
      * Per-request axios responseType passthrough. Defaults to axios' `'json'`.
      * `'arraybuffer'` is required for binary endpoints (e.g. server-side PDF

--- a/packages/dmworkbase/src/Service/SearchService.ts
+++ b/packages/dmworkbase/src/Service/SearchService.ts
@@ -471,8 +471,8 @@ const SearchService = {
   //      positive-millis-in-plausible-range-or-null so a stray seconds value or
   //      garbage can't render as an Invalid Date.
   //   4. `spaceId` — returned on every item; search is single-space scoped
-  //      (OS term space_id, injected by the gateway, never from the body). We
-  //      pass it through unchanged for buildDocLink's `?sp=`.
+  //      (OS term space_id, injected by the gateway, never from the body).
+  //      Retained as result metadata; ordinary document links no longer serialize it.
   async searchDocs(query: DocSearchQuery): Promise<DocSearchResponse> {
     const body: Record<string, unknown> = {
       q: query.keyword,

--- a/packages/dmworkbase/src/Service/SearchTypes.ts
+++ b/packages/dmworkbase/src/Service/SearchTypes.ts
@@ -217,10 +217,10 @@ export interface DocSearchItem {
    */
   updatedAt: number | null;
   /**
-   * The doc's real space id (backend `spaceId`), passed to buildDocLink's
-   * `?sp=` so the standalone preflight addresses the doc's own space. The
-   * backend returns it on every item (search is single-space scoped, space_id
-   * injected by the gateway); optional only so DataSource fakes/tests may omit it.
+   * The doc's home Space id (backend `spaceId`). Search remains Space-scoped,
+   * but buildDocLink intentionally ignores this field and emits bare `/d/:docId`;
+   * authenticated open-context resolves canonical addressing. Optional only so
+   * DataSource fakes/tests may omit it.
    */
   spaceId?: string;
   /**

--- a/packages/dmworkbase/src/Service/__tests__/APIClient.headers.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/APIClient.headers.test.ts
@@ -118,4 +118,17 @@ describe("request interceptor X-Space-Id merge (explicit header wins, intercepto
     const out = holder.requestInterceptor!({ headers: {} });
     expect(out.headers["X-Space-Id"]).toBeUndefined();
   });
+
+  it("does not inject X-Space-Id when the typed request config suppresses it", () => {
+    client.config.spaceIdCallback = () => "interceptor-space";
+    const out = holder.requestInterceptor!({ headers: {}, suppressSpaceId: true });
+    expect(out.headers["X-Space-Id"]).toBeUndefined();
+  });
+
+  it("forwards suppressSpaceId to axios without forging an empty header", async () => {
+    await client.get("/docs/d1/open-context", { suppressSpaceId: true });
+    const [, cfg] = getMock.mock.calls.at(-1)!;
+    expect(cfg).toMatchObject({ suppressSpaceId: true });
+    expect((cfg as any).headers).toBeUndefined();
+  });
 });

--- a/packages/dmworkbase/src/Utils/docLink.ts
+++ b/packages/dmworkbase/src/Utils/docLink.ts
@@ -31,16 +31,15 @@
 export interface DocLinkTarget {
   docId: string
   /**
-   * The document's REAL space id (doc_meta.space_id — a 32-hex docs-backend space, e.g.
-   * `105d4a60…`), known to the sharer at forward time (the in-shell EditorShell space prop, which
-   * is the live currentSpaceId). Embedded on the link as `?sp=` (XIN-501) so the recipient's
-   * standalone preflight can address `GET /docs/:docId` at the doc's own space. This is NOT the same
-   * value as the octo `?sid` token-bucket key: `?sp` is the docs space the backend matches against in
-   * requireDocRole's cross-space guard, whereas `?sid` (no longer minted on this link, XIN-513) only
-   * scoped the token store. Optional: a link built without it degrades to the recipient resolving the
-   * space from their own session.
+   * @deprecated Phase-1 remove-`sp` (design §5.3): ordinary document links no longer carry the
+   * doc's Space. The receiver's standalone preflight now resolves the doc's Space server-side from
+   * `docId` alone via `GET /docs/:docId/open-context`, so this field is IGNORED by buildDocLink and
+   * no `?sp=` is emitted. The field is retained (accepted-but-unused) purely so existing callers
+   * that still pass it compile unchanged during the cutover; it will be dropped once every caller
+   * stops supplying it. It never was the octo `?sid` token-bucket key — see the module note above.
    */
   space?: string
+  /** @deprecated Same as `space`: accepted-but-unused post Phase-1; no folder is emitted on the link. */
   folder?: string
 }
 
@@ -50,25 +49,22 @@ function origin(): string {
 }
 
 /**
- * Build `${origin}/d/<docId>` — the standalone doc-page share form — carrying, when available:
- *   - `?sp=<space id>`    the doc's REAL space (doc_meta.space_id) so the receiver's preflight
- *                         (`GET /docs/:docId`) addresses the doc's own space (XIN-501).
+ * Build `${origin}/d/<docId>` — the standalone doc-page share form (Phase-1 remove-`sp`, design
+ * §5.3). The link carries ONLY the docId in the path and NO query: no `?sp=` (the doc's Space is
+ * resolved server-side from the docId by the open-context reader) and no `?sid=` (the recipient's
+ * session is recovered from storage independently of the URL, XIN-513).
  *
- * The link deliberately carries NO `?sid=` (XIN-513): an already-logged-in recipient's session is
- * recovered from storage independently of the URL (apps/web Layout → recoverSession.ts
- * findStoredSessions scans the `token<sid>` buckets and adopts a valid session), so the token-bucket
- * sid does not need to ride on the shared link. `?sp` is still needed and DISTINCT: it is the space
- * the docs backend matches in requireDocRole's cross-space guard. XIN-497 reused `?sid` as the
- * preflight space, but a token-bucket sid never equals the doc's space_id, so the preflight 404'd
- * for every recipient (including the owner's own doc). Carrying the real space on its own `?sp` param
- * fixes that without touching the `token<sid>` logic. The receiver opens it → Layout intercepts the
- * `/d` namespace → the stored session is recovered → preflight against `?sp` → StandaloneDocPage
- * mounts the editor (reader / writer / forbidden-with-request / not-found / archived), all outside the
- * app shell and immune to the host's query-wiping re-push (the docId lives in the path, not the query).
+ * This is the single source of truth for ordinary document links; every entry point (share panel,
+ * search, recent, Drive, chat card / forward, Doc / Sheet / Board, HTML) funnels through it, so the
+ * `sp` removal lands everywhere at once. It deliberately does NOT touch invite-token, drive-share,
+ * space-invite, PPT (`/ppt/d/:docId`) or summary (`/s/share`) links — those are separate namespaces
+ * with their own auth/Space chains (design §12.4).
+ *
+ * The receiver opens it → the host Layout intercepts the `/d` namespace → the stored session is
+ * recovered → the standalone page runs the docId-first open-context preflight → StandaloneDocPage
+ * mounts the surface (reader / writer / forbidden-with-request / not-found / archived), all outside
+ * the app shell and immune to the host's query-wiping re-push (the docId lives in the path).
  */
-export function buildDocLink({ docId, space }: DocLinkTarget): string {
-  const path = `/d/${encodeURIComponent(docId)}`
-  const docSpace = (space || '').trim()
-  const query = docSpace ? `?sp=${encodeURIComponent(docSpace)}` : ''
-  return `${origin()}${path}${query}`
+export function buildDocLink({ docId }: DocLinkTarget): string {
+  return `${origin()}/d/${encodeURIComponent(docId)}`
 }

--- a/packages/dmworkbase/src/__tests__/docLink.test.ts
+++ b/packages/dmworkbase/src/__tests__/docLink.test.ts
@@ -1,56 +1,36 @@
 import { describe, it, expect } from 'vitest'
 import { buildDocLink } from '../Utils/docLink'
 
-describe('buildDocLink — standalone `/d/:docId` share form (bypasses the host query-wipe, XIN-450)', () => {
+describe('buildDocLink — standalone `/d/:docId` share form (Phase-1 no-sp reader)', () => {
   it('points at the standalone `/d/<docId>` page, not the in-shell `/docs?doc=` route', () => {
     const link = buildDocLink({ docId: 'd_1', space: 'demo', folder: 'f_default' })
     expect(link).toContain('/d/d_1')
-    // The doc no longer rides on a wipeable query param.
     expect(link).not.toContain('/docs?')
     expect(link).not.toContain('doc=d_1')
-    // The legacy `space=`/`folder=` in-shell params are gone; the doc's real space rides on the
-    // dedicated `?sp=` param instead (XIN-501), so the recipient's preflight can address the doc's
-    // own space.
     expect(link).not.toContain('space=')
     expect(link).not.toContain('folder=')
   })
 
-  it('embeds the doc real space as `?sp=` so the recipient preflight addresses the doc space (XIN-501)', () => {
+  it('never emits `?sp=` even when a document space is supplied', () => {
     const link = buildDocLink({ docId: 'd_1', space: '105d4a60d0fc4d55a5cfc3c2d0501361' })
-    expect(link).toContain('sp=105d4a60d0fc4d55a5cfc3c2d0501361')
+    expect(link).toBe('http://localhost:3000/d/d_1')
+    expect(link).not.toContain('sp=')
   })
 
-  it('never carries the token-bucket `?sid`, even when a currentSpaceId is persisted (XIN-513)', () => {
-    // The link no longer mints `?sid` — an already-logged-in recipient's session is recovered from
-    // storage independently of the URL. Only the doc's real space rides along, on `?sp`.
+  it('never carries the token-bucket `?sid`, even when currentSpaceId is persisted', () => {
     try {
       window.localStorage.setItem('currentSpaceId', 'sp_current')
-      const link = buildDocLink({ docId: 'd_1', space: '105d4a60d0fc4d55a5cfc3c2d0501361' })
+      const link = buildDocLink({ docId: 'd_1', space: 'space_doc' })
+      expect(link).toBe('http://localhost:3000/d/d_1')
       expect(link).not.toContain('sid=')
-      expect(link).toContain('sp=105d4a60d0fc4d55a5cfc3c2d0501361')
+      expect(link).not.toContain('sp=')
     } finally {
       window.localStorage.removeItem('currentSpaceId')
     }
   })
 
-  it('omits `?sp` when no space is provided', () => {
-    expect(buildDocLink({ docId: 'd_1b' })).not.toContain('sp=')
-  })
-
-  it('works with only a docId', () => {
-    expect(buildDocLink({ docId: 'd_2' })).toContain('/d/d_2')
-  })
-
-  it('never appends `?sid`, so a sid-less link works with only a docId (XIN-513)', () => {
-    try {
-      window.localStorage.setItem('currentSpaceId', 'sp_current')
-      expect(buildDocLink({ docId: 'd_3' })).not.toContain('sid=')
-    } finally {
-      window.localStorage.removeItem('currentSpaceId')
-    }
-  })
-
-  it('omits sid when neither the URL nor currentSpaceId provides one', () => {
-    expect(buildDocLink({ docId: 'd_4' })).not.toContain('sid=')
+  it('works with only a docId and URL-encodes it', () => {
+    expect(buildDocLink({ docId: 'd_2' })).toBe('http://localhost:3000/d/d_2')
+    expect(buildDocLink({ docId: 'a b' })).toBe('http://localhost:3000/d/a%20b')
   })
 })

--- a/packages/dmworkdrive/src/__mocks__/dmworkBase.ts
+++ b/packages/dmworkdrive/src/__mocks__/dmworkBase.ts
@@ -48,10 +48,10 @@ export const buildAcceptLanguage = () => 'zh-CN,zh;q=0.9,en-US;q=0.8,en;q=0.7';
  *  isolated-axios timeout hardening is exercised under test. */
 export const DEFAULT_REQUEST_TIMEOUT_MS = 20_000;
 
-export const buildDocLink = ({ docId, space }: { docId: string; space?: string }) => {
-  const sp = (space || '').trim();
-  const query = sp ? `?sp=${encodeURIComponent(sp)}` : '';
-  return `https://test.local/d/${encodeURIComponent(docId)}${query}`;
+export const buildDocLink = ({ docId }: { docId: string; space?: string; folder?: string }) => {
+  // Phase-1 remove-`sp`: ordinary doc links carry only the docId path (space is accepted-but-ignored,
+  // mirroring the real @octo/base buildDocLink).
+  return `https://test.local/d/${encodeURIComponent(docId)}`;
 };
 
 export const t = (key: string) => key;

--- a/packages/dmworkdrive/src/bridge/types.ts
+++ b/packages/dmworkdrive/src/bridge/types.ts
@@ -71,9 +71,8 @@ export interface DriveEntry {
   type: FileType;
   ref_type?: FileType;
   ref_id?: string;
-  /** doc-only: the doc's OWN octo space (docs-backend doc_meta.space_id), for
-   *  building `/d/:docId?sp=`. Absent for blobs/folders and when NULL server-side
-   *  (omitempty). NOT space_id — that is drive's mount space, wrong across tenants. */
+  /** doc-only legacy metadata: the doc's own octo Space. Ordinary links no longer
+   * serialize it; retained on the wire for compatibility and non-link consumers. */
   doc_space_id?: string;
   size: number;
   content_type?: string;
@@ -107,8 +106,8 @@ export interface DocRef {
   parent_id: number;
   doc_id: string;
   title: string;
-  /** the doc's OWN octo space (docs-backend doc_meta.space_id), for `/d/:docId?sp=`.
-   *  Absent when NULL server-side (omitempty). See DriveEntry.doc_space_id. */
+  /** Legacy doc-home-Space metadata; ordinary `/d/:docId` links do not serialize it.
+   * Absent when NULL server-side (omitempty). See DriveEntry.doc_space_id. */
   doc_space_id?: string;
   source: string;
   owner_uid: string;

--- a/packages/dmworkdrive/src/pages/DriveContent.tsx
+++ b/packages/dmworkdrive/src/pages/DriveContent.tsx
@@ -58,10 +58,9 @@ export default function DriveContent({ vm }: { vm: DriveVM }) {
   );
 
   // Type-1 doc: jump to the standalone docs page (preview/editor). The mounted
-  // entry carries the doc id in ref_id; buildDocLink is the same /d/:docId form
-  // used by forwarded-doc links (@octo/base). Carry the doc's OWN space as ?sp=
-  // so cross-space recipients hit the right doc; when absent, omit sp (do NOT
-  // fall back to entry.space_id — that is drive's mount space, wrong across tenants).
+  // entry carries the doc id in ref_id; buildDocLink emits the same bare /d/:docId
+  // form used by forwarded-doc links (@octo/base). The reader resolves canonical
+  // addressing through authenticated open-context, never from the Drive mount Space.
   const handleOpenDoc = useCallback(
     (entry: DriveEntry) => {
       if (!entry.ref_id) {

--- a/packages/dmworkdrive/src/pages/__tests__/DriveContent.test.tsx
+++ b/packages/dmworkdrive/src/pages/__tests__/DriveContent.test.tsx
@@ -220,7 +220,7 @@ describe('DriveContent — reset modals on space switch (Q8)', () => {
   });
 });
 
-describe('DriveContent — open doc carries the doc\'s real space (Round-12)', () => {
+describe('DriveContent — open doc builds the canonical no-sp link (Phase-1 remove-`sp`, design §5.3)', () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   function docEntry(over: Record<string, unknown>): any {
     return {
@@ -240,7 +240,7 @@ describe('DriveContent — open doc carries the doc\'s real space (Round-12)', (
     };
   }
 
-  it('opens /d/:docId?sp=<doc_space_id> when the doc carries its real space', async () => {
+  it('opens the bare /d/:docId (no ?sp) even when the doc carries its real space', async () => {
     stubMembers({ canDownload: true });
     const openSpy = vi.spyOn(window, 'open').mockReturnValue(null);
     render(<DriveContent vm={vmWith(space('mountSpace', 'shared'))} />);
@@ -248,11 +248,16 @@ describe('DriveContent — open doc carries the doc\'s real space (Round-12)', (
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (fileListRef.current!.onOpenDoc as any)(docEntry({ doc_space_id: 'realDocSpace' }));
+    // Phase-1: the doc's Space is resolved server-side from the docId by the open-context reader, so
+    // the link carries no `?sp` — doc_space_id is accepted-but-ignored by buildDocLink.
     expect(openSpy).toHaveBeenCalledWith(
-      'https://test.local/d/doc-9?sp=realDocSpace',
+      'https://test.local/d/doc-9',
       '_blank',
       'noopener,noreferrer',
     );
+    const url = openSpy.mock.calls[0][0] as string;
+    expect(url).not.toContain('sp=');
+    expect(url).not.toContain('realDocSpace');
     openSpy.mockRestore();
   });
 

--- a/packages/dmworkdrive/src/ui/ShareModal/__tests__/ShareModal.test.tsx
+++ b/packages/dmworkdrive/src/ui/ShareModal/__tests__/ShareModal.test.tsx
@@ -123,7 +123,7 @@ describe('ShareModal (WeCom one-shot)', () => {
     unmount();
   });
 
-  it('doc: carries the real doc space as ?sp= when doc_space_id is present', async () => {
+  it('doc: never emits ?sp= even when doc_space_id is present (Phase-1 remove-`sp`, design §5.3)', async () => {
     const { getByText, container, unmount } = render(
       <ShareModal
         visible
@@ -134,7 +134,10 @@ describe('ShareModal (WeCom one-shot)', () => {
     await waitFor(() => getByText('drive.share.docGenerated'));
     const input = container.querySelector('input') as HTMLInputElement;
     expect(input.value).toContain('/d/doc-9');
-    expect(input.value).toContain('?sp=realDocSpace');
+    // The doc's Space is now resolved server-side from the docId by the open-context reader, so the
+    // ordinary link carries no `?sp` — the doc_space_id is accepted-but-ignored by buildDocLink.
+    expect(input.value).not.toContain('sp=');
+    expect(input.value).not.toContain('realDocSpace');
     unmount();
   });
 

--- a/packages/dmworkdrive/src/ui/ShareModal/index.tsx
+++ b/packages/dmworkdrive/src/ui/ShareModal/index.tsx
@@ -48,9 +48,9 @@ export default function ShareModal({ visible, entry, onClose }: ShareModalProps)
     (async () => {
       let url = '';
       if (isDoc) {
-        // Pure frontend: same /d/:docId address used to open the mounted doc,
-        // carrying the doc's OWN space as ?sp= (entry.doc_space_id). Absent ⇒ omit
-        // sp; never fall back to entry.space_id (drive mount space, cross-tenant wrong).
+        // Pure frontend: same bare /d/:docId address used to open the mounted doc.
+        // buildDocLink ignores Space inputs; authenticated open-context resolves the
+        // canonical home Space instead of trusting the Drive mount context.
         url = entry.ref_id ? buildDocLink({ docId: entry.ref_id, space: entry.doc_space_id }) : '';
       } else {
         const share = await ensure();

--- a/packages/docs/src/access-request/api.test.ts
+++ b/packages/docs/src/access-request/api.test.ts
@@ -31,6 +31,12 @@ describe('access-request API (screen 4c, contract 4 — pull-based, bare-relativ
     })
     // Zero Bots preserves the legacy request shape: an undefined body, never `{ botUids: [] }`.
     expect(api.calls[0].body).toBeUndefined()
+    expect(api.calls[0].config).toMatchObject({ suppressSpaceId: true })
+  })
+
+  it('uses an explicit supplied Space instead of suppression for legacy by-space callers', async () => {
+    await requestAccess('d_1', { spaceId: 's_home' })
+    expect(api.calls[0].config).toMatchObject({ headers: { 'X-Space-Id': 's_home' } })
   })
 
   it('submits a de-duplicated Bot snapshot body only when Bots are present', async () => {

--- a/packages/docs/src/access-request/api.ts
+++ b/packages/docs/src/access-request/api.ts
@@ -40,13 +40,15 @@ export class AccessRequestConflictError extends Error {
  * 200/201 → submitted; 409 → already requested (surfaced as AccessRequestConflictError so the
  * button can show "Request submitted" without treating it as a failure).
  *
- * `spaceId` MUST be passed on the standalone `/d/:docId` surface: that page mounts before the app
- * shell restores `currentSpaceId`, so the global interceptor injects no `X-Space-Id` and the
- * backend's by-space middleware rejects a bare request (same fix getDoc uses). In-shell callers can
- * omit it — the interceptor supplies the header there.
+ * `spaceId` is for legacy/in-shell by-space callers only. The standalone forbidden landing omits
+ * it deliberately: a 403 open-context response does not reveal the document home Space, and the
+ * docId-global backend resolves the target (and validates any owned Bots) from doc_meta.space_id.
+ * Sending the viewer's unrelated current Space would reject a valid cross-Space request.
  */
 export async function requestAccess(docId: string, opts?: { spaceId?: string; botUids?: string[] }): Promise<void> {
-  const config = opts?.spaceId ? { headers: { 'X-Space-Id': opts.spaceId } } : undefined
+  const config = opts?.spaceId
+    ? { headers: { 'X-Space-Id': opts.spaceId } }
+    : { suppressSpaceId: true }
   // Zero Bots → send NO body (preserves the pre-feature request shape); only attach a body once
   // the requester actually carries at least one Bot.
   const uids = [...new Set(opts?.botUids ?? [])]

--- a/packages/docs/src/attachments/api.test.ts
+++ b/packages/docs/src/attachments/api.test.ts
@@ -120,6 +120,19 @@ describe('uploadImage — end-to-end flow yields attachId + signed src, never ba
     api.calls.length = 0
   })
 
+  it('preserves SVG metadata headers when a compatibility Space header is present', async () => {
+    api.responder = () => ({ data: { attachId: 'att_svg', url: null }, status: 200 })
+    const file = new File(['<svg/>'], 'space diagram.svg', { type: 'image/svg+xml' })
+
+    await uploadImage('d_1', file, { spaceId: 's_home' })
+
+    expect(api.calls[0].config?.headers).toMatchObject({
+      'Content-Type': 'image/svg+xml',
+      'X-File-Name': 'space%20diagram.svg',
+      'X-Space-Id': 's_home',
+    })
+  })
+
   it('does not route a non-SVG MIME to the SVG endpoint merely because the name ends in .svg', async () => {
     vi.stubGlobal('fetch', vi.fn(async () => new Response(null, { status: 200 })))
     api.responder = (method, url) => {

--- a/packages/docs/src/attachments/api.ts
+++ b/packages/docs/src/attachments/api.ts
@@ -54,11 +54,12 @@ export class AttachmentRejectedError extends Error {
 }
 
 /** POST /docs/{docId}/attachments/presign (needs writer). 400 -> AttachmentRejectedError. */
-export async function presignUpload(docId: string, req: PresignRequest): Promise<PresignResult> {
+export async function presignUpload(docId: string, req: PresignRequest, opts?: { spaceId?: string }): Promise<PresignResult> {
   try {
     const { data } = await apiClient().post<PresignResult>(
       `/docs/${docId}/attachments/presign`,
       req,
+      opts?.spaceId ? { headers: { 'X-Space-Id': opts.spaceId } } : undefined,
     )
     return data
   } catch (e) {
@@ -87,8 +88,9 @@ export async function uploadBinary(presign: PresignResult, file: Blob): Promise<
 }
 
 /** GET /docs/{docId}/attachments/{attachId} (needs reader) -> freshly signed GET url. */
-export async function getReadUrl(docId: string, attachId: string): Promise<ReadResult> {
-  const { data } = await apiClient().get<ReadResult>(`/docs/${docId}/attachments/${attachId}`)
+export async function getReadUrl(docId: string, attachId: string, opts?: { spaceId?: string }): Promise<ReadResult> {
+  const config = opts?.spaceId ? { headers: { 'X-Space-Id': opts.spaceId } } : undefined
+  const { data } = await apiClient().get<ReadResult>(`/docs/${docId}/attachments/${attachId}`, config)
   return data
 }
 
@@ -118,11 +120,13 @@ export interface ResolveResult {
 export async function resolveAttachments(
   docId: string,
   attachIds: string[],
+  opts?: { spaceId?: string },
 ): Promise<ResolveResult> {
   try {
     const { data } = await apiClient().post<ResolveResult>(
       `/docs/${docId}/attachments/resolve`,
       { attachIds },
+      opts?.spaceId ? { headers: { 'X-Space-Id': opts.spaceId } } : undefined,
     )
     return { items: data.items ?? [], notFound: data.notFound ?? [] }
   } catch (e) {
@@ -146,7 +150,7 @@ export interface UploadedImage {
  * (null if the read endpoint is briefly unavailable — the NodeView re-resolves it
  * from attachId at render time). Never emits base64 (constraint §2).
  */
-export async function uploadImage(docId: string, file: File): Promise<UploadedImage> {
+export async function uploadImage(docId: string, file: File, opts?: { spaceId?: string }): Promise<UploadedImage> {
   const declaredType = file.type.trim().toLowerCase()
   // Some platforms leave SVG's File.type empty; use the extension only in that
   // case. Never let a misleading .svg name override a non-SVG declared MIME.
@@ -163,6 +167,7 @@ export async function uploadImage(docId: string, file: File): Promise<UploadedIm
         headers: {
           'Content-Type': 'image/svg+xml',
           'X-File-Name': encodeURIComponent(file.name || 'image.svg'),
+          ...(opts?.spaceId ? { 'X-Space-Id': opts.spaceId } : {}),
         },
       },
     )
@@ -172,11 +177,11 @@ export async function uploadImage(docId: string, file: File): Promise<UploadedIm
     fileName: file.name || 'image',
     mime: file.type,
     sizeBytes: file.size,
-  })
+  }, opts)
   await uploadBinary(presign, file)
   let src: string | null = null
   try {
-    src = (await getReadUrl(docId, presign.attachId)).url
+    src = (await getReadUrl(docId, presign.attachId, opts)).url
   } catch {
     src = null
   }

--- a/packages/docs/src/auth/collabToken.test.ts
+++ b/packages/docs/src/auth/collabToken.test.ts
@@ -41,7 +41,8 @@ describe('collab-token cache', () => {
   })
 
   it('uses tokenCacheKey form `${uid}::${documentName}`', () => {
-    expect(tokenCacheKey('u_self', 'octo:s:f:d1')).toBe('u_self::octo:s:f:d1')
+    expect(tokenCacheKey('u_self', 'octo:s:f:d1')).toBe('u_self::octo:s:f:d1::legacy')
+    expect(tokenCacheKey('u_self', 'octo:s:f:d1', 'd1')).toBe('u_self::octo:s:f:d1::doc:d1')
   })
 
   it('coalesces concurrent issuance into a single in-flight request', async () => {
@@ -123,5 +124,90 @@ describe('collab-token cache', () => {
     await Promise.resolve()
     disposeToken('octo:s:f:d7')
     expect(abortSpy).toHaveBeenCalled()
+  })
+})
+
+describe('collab-token docId-first issuance (design §7.1)', () => {
+  it('POSTs to /docs/:docId/collab-token with no redundant client locator body', async () => {
+    api.responder = () => tokenResponse('writer', 2, 'jwt-docid')
+    const entry = await getCollabTokenEntry('octo:s:f:d_x', 'd_x')
+    expect(entry.token).toBe('jwt-docid')
+    // The docId-scoped endpoint is used — NOT the legacy /docs/collab-token.
+    const call = api.calls.find((c) => c.method === 'post')
+    expect(call?.url).toBe('/docs/d_x/collab-token')
+    expect(api.calls.some((c) => c.url === '/docs/collab-token')).toBe(false)
+    // The backend derives documentName and home Space from the path docId.
+    expect(call?.body).toEqual({})
+    expect(call?.config).toMatchObject({ suppressSpaceId: true })
+  })
+
+  it('percent-encodes the docId in the path', async () => {
+    api.responder = () => tokenResponse()
+    await getCollabTokenEntry('octo:s:f:d_slash', 'a b')
+    const call = api.calls.find((c) => c.method === 'post')
+    expect(call?.url).toBe('/docs/a%20b/collab-token')
+  })
+
+  it('falls back to the legacy endpoint and sends documentName when no docId is supplied', async () => {
+    api.responder = () => tokenResponse()
+    await getCollabTokenEntry('octo:s:f:d_legacy')
+    const call = api.calls.find((c) => c.method === 'post')
+    expect(call?.url).toBe('/docs/collab-token')
+    expect(call?.body).toEqual({ documentName: 'octo:s:f:d_legacy' })
+    expect(call?.config?.suppressSpaceId).toBeUndefined()
+  })
+
+  it('keeps docId and legacy endpoint cache identities separate', async () => {
+    api.responder = () => tokenResponse()
+    const a = await getCollabTokenEntry('octo:s:f:d_cache', 'd_cache')
+    // A legacy request must not reuse a token issued under the docId-first contract.
+    const b = await getCollabTokenEntry('octo:s:f:d_cache')
+    expect(a).not.toBe(b)
+    expect(api.calls.filter((c) => c.method === 'post')).toHaveLength(2)
+  })
+
+  it('getCollabToken forwards the docId to the docId-scoped endpoint', async () => {
+    api.responder = () => tokenResponse('reader', 1, 'jwt-str')
+    expect(await getCollabToken('octo:s:f:d_g', 'd_g')).toBe('jwt-str')
+    expect(api.calls.find((c) => c.method === 'post')?.url).toBe('/docs/d_g/collab-token')
+  })
+
+  it('re-issues a docId-first token after disposing the matching cache slot', async () => {
+    api.responder = () => tokenResponse()
+    await getCollabTokenEntry('octo:s:f:d_dispose', 'd_dispose')
+    disposeToken('octo:s:f:d_dispose', { docId: 'd_dispose' })
+    await getCollabTokenEntry('octo:s:f:d_dispose', 'd_dispose')
+    expect(api.calls.filter((c) => c.url === '/docs/d_dispose/collab-token')).toHaveLength(2)
+  })
+
+  it('aborts an in-flight docId-first issuance when its matching slot is disposed', async () => {
+    const abortSpy = vi.fn()
+    api.responder = (_m, _u, _b, config) => {
+      config?.signal?.addEventListener('abort', abortSpy)
+      return new Promise(() => {})
+    }
+    void getCollabTokenEntry('octo:s:f:d_abort', 'd_abort')
+    await Promise.resolve()
+    disposeToken('octo:s:f:d_abort', { docId: 'd_abort' })
+    expect(abortSpy).toHaveBeenCalledOnce()
+  })
+
+  it('keeps a reissued docId-first request cached when the disposed request settles late', async () => {
+    const resolvers: Array<(v: ReturnType<typeof tokenResponse>) => void> = []
+    api.responder = () => new Promise((resolve) => resolvers.push(resolve))
+
+    const stale = getCollabTokenEntry('octo:s:f:d_race', 'd_race')
+    await Promise.resolve()
+    disposeToken('octo:s:f:d_race', { docId: 'd_race' })
+    const replacement = getCollabTokenEntry('octo:s:f:d_race', 'd_race')
+    await Promise.resolve()
+
+    resolvers[1](tokenResponse('writer', 2, 'jwt-fresh'))
+    await expect(replacement).resolves.toMatchObject({ token: 'jwt-fresh' })
+    resolvers[0](tokenResponse('writer', 1, 'jwt-stale'))
+    await expect(stale).rejects.toThrow(/disposed/)
+
+    expect(await getCollabToken('octo:s:f:d_race', 'd_race')).toBe('jwt-fresh')
+    expect(api.calls.filter((c) => c.url === '/docs/d_race/collab-token')).toHaveLength(2)
   })
 })

--- a/packages/docs/src/auth/collabToken.ts
+++ b/packages/docs/src/auth/collabToken.ts
@@ -5,7 +5,7 @@
 // octo token is never attached to the WS — the function-style provider getter holds the
 // collab token.
 //
-// Cache/in-flight key is `${uid}::${documentName}` (NOT documentName alone): keying by
+// Cache/in-flight key includes uid, canonical documentName, and issuance endpoint identity:
 // documentName only would let a previous uid's token pollute a new session's slot after an
 // account switch (P1-6). Concurrent issuance is coalesced via an in-flight promise; the
 // AbortController cancels in-flight issuance on dispose; on resolve we re-check uid and drop
@@ -45,8 +45,8 @@ const tokenCache = new Map<string, TokenEntry>()
 const inflight = new Map<string, { promise: Promise<TokenEntry>; ac: AbortController }>()
 
 // Named distinctly from the IndexedDB cacheKey (§6) to avoid shadowing.
-export function tokenCacheKey(uid: string, documentName: string): string {
-  return `${uid}::${documentName}`
+export function tokenCacheKey(uid: string, documentName: string, docId?: string): string {
+  return `${uid}::${documentName}::${docId ? `doc:${docId}` : 'legacy'}`
 }
 
 function isExpiringSoon(expiresAt: number): boolean {
@@ -63,13 +63,16 @@ async function issueCollabToken(
   documentName: string,
   uid: string,
   signal: AbortSignal,
+  docId?: string,
 ): Promise<TokenEntry> {
-  // Bare-relative -> /api/v1/docs/collab-token. The interceptor injects the octo `token` header.
-  const { data } = await apiClient().post<CollabTokenResponse>(
-    COLLAB_TOKEN_PATH,
-    { documentName },
-    { signal },
-  )
+  // docId-first issuance (Phase-1 remove-`sp` design §7.1): when the caller knows the stable docId,
+  // the path is the complete locator and the backend derives canonical documentName + home Space from
+  // doc_meta. Do not send a redundant client documentName that could be mistaken for authoritative.
+  // The legacy endpoint still needs `{ documentName }` during its compatibility window.
+  const path = docId ? `/docs/${encodeURIComponent(docId)}/collab-token` : COLLAB_TOKEN_PATH
+  const body = docId ? {} : { documentName }
+  const config = docId ? { signal, suppressSpaceId: true } : { signal }
+  const { data } = await apiClient().post<CollabTokenResponse>(path, body, config)
   if (!isRole(data.role)) {
     throw new Error(`collab-token returned an invalid role: ${String(data.role)}`)
   }
@@ -88,10 +91,17 @@ async function issueCollabToken(
 /**
  * Return a fresh collab token entry, coalescing concurrent issuance and isolating by uid.
  * Used both by the provider token getter and to set the initial editable state before connect.
+ *
+ * The cache identity includes endpoint mode so a legacy token can never satisfy a docId-first
+ * request for the same canonical name. `docId`, when supplied, routes issuance to
+ * `/docs/:docId/collab-token`; omit it for the legacy documentName-only endpoint.
  */
-export async function getCollabTokenEntry(documentName: string): Promise<TokenEntry> {
+export async function getCollabTokenEntry(
+  documentName: string,
+  docId?: string,
+): Promise<TokenEntry> {
   const uid = getCurrentUid()
-  const key = tokenCacheKey(uid, documentName)
+  const key = tokenCacheKey(uid, documentName, docId)
 
   const hit = tokenCache.get(key)
   if (hit && !isExpiringSoon(hit.expiresAt)) return hit
@@ -99,14 +109,20 @@ export async function getCollabTokenEntry(documentName: string): Promise<TokenEn
   let f = inflight.get(key)
   if (!f) {
     const ac = new AbortController()
-    const promise = issueCollabToken(documentName, uid, ac.signal).finally(() => {
-      inflight.delete(key)
+    let promise: Promise<TokenEntry>
+    promise = issueCollabToken(documentName, uid, ac.signal, docId).finally(() => {
+      // A disposed request may settle after a replacement issuance has occupied the same key.
+      // Only remove our own record; otherwise the stale finally would de-coalesce the replacement.
+      if (inflight.get(key)?.promise === promise) inflight.delete(key)
     })
     f = { promise, ac }
     inflight.set(key, f)
   }
 
   const fresh = await f.promise
+  // Some API adapters/mocks do not reject when AbortSignal fires. Disposal is still authoritative:
+  // never let such a late response repopulate the slot that was explicitly invalidated.
+  if (f.ac.signal.aborted) throw new Error('collab-token issuance was disposed')
   // Re-check uid before writing back: if the account switched while issuance was in flight,
   // dropping the stale token prevents cross-uid pollution of the new session's slot.
   if (getCurrentUid() !== uid) {
@@ -117,8 +133,8 @@ export async function getCollabTokenEntry(documentName: string): Promise<TokenEn
 }
 
 /** Provider token getter form — returns only the token string. */
-export async function getCollabToken(documentName: string): Promise<string> {
-  return (await getCollabTokenEntry(documentName)).token
+export async function getCollabToken(documentName: string, docId?: string): Promise<string> {
+  return (await getCollabTokenEntry(documentName, docId)).token
 }
 
 /**
@@ -126,8 +142,14 @@ export async function getCollabToken(documentName: string): Promise<string> {
  * Called on document destroy, account switch, and on downgrade (so the next reconnect
  * re-issues rather than reusing an unexpired token carrying the old role/epoch — P1-5).
  */
-export function disposeToken(documentName: string, uid: string = getCurrentUid()): void {
-  const key = tokenCacheKey(uid, documentName)
+export interface DisposeTokenOptions {
+  uid?: string
+  /** Must match the issuance mode; docId-first tokens live in a distinct cache slot. */
+  docId?: string
+}
+
+export function disposeToken(documentName: string, opts: DisposeTokenOptions = {}): void {
+  const key = tokenCacheKey(opts.uid ?? getCurrentUid(), documentName, opts.docId)
   tokenCache.delete(key)
   const f = inflight.get(key)
   if (f) {

--- a/packages/docs/src/board/BoardShell.tsx
+++ b/packages/docs/src/board/BoardShell.tsx
@@ -896,7 +896,7 @@ export function BoardShell(props: BoardShellProps): ReactElement {
   // just won't show the created-on row / falls back to a short uid on failure.
   useEffect(() => {
     let cancelled = false
-    getDoc(docId)
+    getDoc(docId, space ? { spaceId: space } : undefined)
       .then((meta) => {
         if (cancelled) return
         if (typeof meta?.ownerId === 'string' && meta.ownerId) setOwnerId(meta.ownerId)
@@ -908,7 +908,7 @@ export function BoardShell(props: BoardShellProps): ReactElement {
     return () => {
       cancelled = true
     }
-  }, [docId])
+  }, [docId, space])
 
   // Resolve the creator's display name: from the already-loaded space-member map first (free), else
   // via GET /users/:uid. Any failure leaves it undefined and the menu falls back to a short uid.
@@ -1018,7 +1018,7 @@ export function BoardShell(props: BoardShellProps): ReactElement {
     // keyed by this user's uid (persistBoardScene(docId, scene, uid)), never another user's and
     // never an auth-denied doc, and it self-heals the moment the server answers (a 403 downgrades
     // to reader). So do not mistake this branch for the P1-3 gap it deliberately is not.
-    getDoc(docId)
+    getDoc(docId, space ? { spaceId: space } : undefined)
       .then((meta) => {
         if (cancelled) return
         if (meta?.role) setRole(meta.role)
@@ -1031,7 +1031,7 @@ export function BoardShell(props: BoardShellProps): ReactElement {
     return () => {
       cancelled = true
     }
-  }, [docId, collabSession, collabMode])
+  }, [docId, space, collabSession, collabMode])
 
   // Debounced local persistence of scene edits. The timer is cleared on unmount and a final flush
   // is forced so a quick draw-then-close still saves (the close/reopen acceptance path).
@@ -1228,24 +1228,24 @@ export function BoardShell(props: BoardShellProps): ReactElement {
       }
       if (isSvg) {
         const svgFile = new File([blob], `${file.id}.svg`, { type: mime })
-        return (await uploadImage(docId, svgFile)).attachId
+        return (await uploadImage(docId, svgFile, { spaceId: space })).attachId
       }
       const presign = await presignUpload(docId, {
         fileName: file.id,
         mime,
         sizeBytes: blob.size,
-      })
+      }, { spaceId: space })
       await uploadBinary(presign, blob)
       return presign.attachId
     },
-    [docId],
+    [docId, space],
   )
   // Batch-resolve fresh signed GET urls in ONE round trip (contract: POST /attachments/resolve),
   // then download each binary. Shared with the version-history preview (boardFiles.ts) so the live
   // canvas and the historical preview can never drift onto different fetch/decoding paths.
   const fetchBoardFiles = useCallback(
-    (refs: readonly FileFetchRef[]): Promise<BinaryFileData[]> => fetchBoardFileBinaries(docId, refs),
-    [docId],
+    (refs: readonly FileFetchRef[]): Promise<BinaryFileData[]> => fetchBoardFileBinaries(docId, refs, space),
+    [docId, space],
   )
 
   // P1a: gate the imperative binding replay (setApi → applyRemote → updateScene) and the
@@ -1826,7 +1826,7 @@ export function BoardShell(props: BoardShellProps): ReactElement {
     },
     [onDeleted, returnToList, uid],
   )
-  const del = useDocDelete(docId, handleDeleted)
+  const del = useDocDelete(docId, handleDeleted, space ? { spaceId: space } : undefined)
 
   // P1-3: a runtime access-loss on the collab socket (4403 → 'deleted', or 'not-found') means the
   // board this user was editing is gone. Mirror the doc editor's terminal handling and return them

--- a/packages/docs/src/board/boardFiles.ts
+++ b/packages/docs/src/board/boardFiles.ts
@@ -24,13 +24,14 @@ import { blobToDataURL, type BinaryFileData, type FileFetchRef } from './collab/
 export async function fetchBoardFileBinaries(
   docId: string,
   refs: readonly FileFetchRef[],
+  spaceId?: string,
 ): Promise<BinaryFileData[]> {
   if (refs.length === 0) return []
   const refByAttach = new Map(refs.map((r) => [r.attachId, r]))
-  const { items } = await resolveAttachments(
-    docId,
-    refs.map((r) => r.attachId),
-  )
+  const attachIds = refs.map((r) => r.attachId)
+  const { items } = spaceId
+    ? await resolveAttachments(docId, attachIds, { spaceId })
+    : await resolveAttachments(docId, attachIds)
   const out: BinaryFileData[] = []
   await Promise.all(
     items.map(async (item) => {

--- a/packages/docs/src/board/collab/connect.test.ts
+++ b/packages/docs/src/board/collab/connect.test.ts
@@ -53,6 +53,7 @@ const BASE = {
   uid: 'u_self',
   url: 'wss://collab.example.com',
   token: () => 'wb-jwt',
+  disposeToken: vi.fn(),
 }
 const DOC_NAME = 'octo:demo:f_default:wb:d_board1'
 
@@ -108,7 +109,7 @@ describe('createWhiteboardSession — runtime permission wiring (P1-1 / P1-3)', 
     expect(s.canEdit()).toBe(false)
     expect(roles).toEqual(['reader'])
     // Downgrade invalidates the cached token so a reconnect re-issues with the new role/epoch.
-    expect(disposeToken).toHaveBeenCalledWith(DOC_NAME)
+    expect(disposeToken).toHaveBeenCalledWith()
   })
 
   it('notifies comment subscribers only for this board', () => {
@@ -177,7 +178,7 @@ describe('createWhiteboardSession — runtime permission wiring (P1-1 / P1-3)', 
     s.destroy()
     // Mirrors createCollabEditor.destroyAll: a normal teardown drops the cached token so it is not
     // left to expire (hygiene/parity — the 4403 revoke path already disposes on its own).
-    expect(disposeToken).toHaveBeenCalledWith(DOC_NAME)
+    expect(disposeToken).toHaveBeenCalledWith()
   })
 })
 

--- a/packages/docs/src/board/collab/connect.ts
+++ b/packages/docs/src/board/collab/connect.ts
@@ -68,8 +68,8 @@ export interface WhiteboardSessionOptions {
    * scene for a user the backend just denied (P1-3, combined with the P1-1 teardown).
    */
   initialTerminal?: BoardTerminal
-  /** Injectable token disposer (defaults to the real collab-token disposer via RoleController). */
-  disposeToken?: (documentName: string) => void
+  /** Required, already-scoped token invalidation closure. */
+  disposeToken: () => void
 }
 
 export interface WhiteboardSession {
@@ -169,7 +169,6 @@ export function createWhiteboardSession(opts: WhiteboardSessionOptions): Whitebo
   // Fail closed: an unknown initial role (token not primed) starts as reader, so the board is
   // read-only until an authoritative role is known (P1-2). A primed token supplies the real role.
   const roleController = new RoleController({
-    documentName,
     initialRole: opts.initialRole ?? 'reader',
     initialEpoch: opts.initialEpoch ?? 0,
     onRole: (role) => notifyRole(role),
@@ -177,7 +176,7 @@ export function createWhiteboardSession(opts: WhiteboardSessionOptions): Whitebo
   })
 
   const closeMachine = new CloseCodeMachine({
-    disposeToken: () => (opts.disposeToken ?? (() => {}))(documentName),
+    disposeToken: opts.disposeToken,
     connect: () => provider.connect(),
     disconnect: () => provider.disconnect(),
     goLogin: () => notifyTerminal({ kind: 'login' }),
@@ -280,7 +279,7 @@ export function createWhiteboardSession(opts: WhiteboardSessionOptions): Whitebo
       // the JWT is dropped promptly instead of lingering until it expires. Hygiene only, not a
       // security fix — a true revoke already disposes via the 4403 close-code path and the
       // role-downgrade frame, and the backend flips the connection read-only to reject stale writes.
-      opts.disposeToken?.(documentName)
+      opts.disposeToken()
     },
   }
 }

--- a/packages/docs/src/board/collab/useWhiteboardSession.test.ts
+++ b/packages/docs/src/board/collab/useWhiteboardSession.test.ts
@@ -113,11 +113,11 @@ describe('useWhiteboardSession — board collab wiring (XIN-55)', () => {
     expect(created[1]!.opts.board).toBe('d_board2')
   })
 
-  it('token getter exchanges the whiteboard documentName via POST /docs/collab-token', async () => {
+  it('token getter exchanges the whiteboard documentName via POST /docs/:docId/collab-token', async () => {
     const useWhiteboardSession = await importHook()
     let seen: { url: string; body: any } | null = null
     wk.apiClient.responder = (method, url, body) => {
-      if (method === 'post' && url === '/docs/collab-token') {
+      if (method === 'post' && url === '/docs/d_board1/collab-token') {
         seen = { url, body }
         return { data: { token: 'wb-jwt', expiresAt: Date.now() + 60_000, role: 'writer', permission_epoch: 1 }, status: 200 }
       }
@@ -130,13 +130,13 @@ describe('useWhiteboardSession — board collab wiring (XIN-55)', () => {
     const token = await created[0]!.opts.token()
     expect(token).toBe('wb-jwt')
     expect(seen).not.toBeNull()
-    expect(seen!.body).toEqual({ documentName: 'octo:demo:f_default:wb:d_board1' })
+    expect(seen!.body).toEqual({})
   })
 
   it('sources the WS origin + initial role/epoch from the primed collab-token (P1-3 / P1-4)', async () => {
     const useWhiteboardSession = await importHook()
     wk.apiClient.responder = (method, url) => {
-      if (method === 'post' && url === '/docs/collab-token') {
+      if (method === 'post' && url === '/docs/d_board1/collab-token') {
         return {
           data: {
             token: 'wb-jwt',
@@ -163,7 +163,7 @@ describe('useWhiteboardSession — board collab wiring (XIN-55)', () => {
   it('falls back to WS_ENDPOINT with no pre-connect role when the token prime fails', async () => {
     const useWhiteboardSession = await importHook()
     wk.apiClient.responder = (method, url) => {
-      if (method === 'post' && url === '/docs/collab-token') {
+      if (method === 'post' && url === '/docs/d_board1/collab-token') {
         // Invalid role → getCollabTokenEntry throws → prime fails → origin-derived fallback.
         return { data: { token: 't', expiresAt: Date.now() + 60_000, role: 'nope', permission_epoch: 0 }, status: 200 }
       }
@@ -183,7 +183,7 @@ describe('useWhiteboardSession — board collab wiring (XIN-55)', () => {
   it('P1-3: a 403 prime builds a terminal, cache-disabled session — no hydration for a denied user', async () => {
     const useWhiteboardSession = await importHook()
     wk.apiClient.responder = (method, url) => {
-      if (method === 'post' && url === '/docs/collab-token') {
+      if (method === 'post' && url === '/docs/d_board1/collab-token') {
         // Backend DENIES (revoked / forbidden). getCollabTokenEntry rejects with an HTTP 403.
         throw Object.assign(new Error('forbidden'), { response: { status: 403 } })
       }
@@ -203,7 +203,7 @@ describe('useWhiteboardSession — board collab wiring (XIN-55)', () => {
     const opts = { uid: 'u_race', space: 'demo', folder: 'f_default', board: 'd_race' }
     const tokenResolvers: Array<(value: { data: unknown; status: number }) => void> = []
     wk.apiClient.responder = (method, url) => {
-      if (method === 'post' && url === '/docs/collab-token') {
+      if (method === 'post' && url === '/docs/d_race/collab-token') {
         return new Promise((resolve) => tokenResolvers.push(resolve))
       }
       return { data: {}, status: 200 }

--- a/packages/docs/src/board/collab/useWhiteboardSession.ts
+++ b/packages/docs/src/board/collab/useWhiteboardSession.ts
@@ -81,7 +81,7 @@ async function buildSession(
   let initialRole: Role | undefined
   let initialEpoch = 0
   try {
-    const entry = await getCollabTokenEntry(documentName)
+    const entry = await getCollabTokenEntry(documentName, opts.board)
     url = resolveBoardWsUrl(entry.collabWsUrl)
     initialRole = entry.role
     initialEpoch = entry.permission_epoch
@@ -96,10 +96,10 @@ async function buildSession(
         folder: opts.folder,
         board: opts.board,
         url,
-        token: () => getCollabToken(documentName),
+        token: () => getCollabToken(documentName, opts.board),
         initialTerminal: terminal,
         disableOfflineCache: true,
-        disposeToken,
+        disposeToken: () => disposeToken(documentName, { docId: opts.board }),
       })
     }
     // Prime failed for a NON-auth reason (offline / no backend / pre-contract): keep the origin-
@@ -112,11 +112,11 @@ async function buildSession(
     folder: opts.folder,
     board: opts.board,
     url,
-    token: () => getCollabToken(documentName),
+    token: () => getCollabToken(documentName, opts.board),
     initialRole,
     initialEpoch,
     disableOfflineCache: opts.disableOfflineCache,
-    disposeToken,
+    disposeToken: () => disposeToken(documentName, { docId: opts.board }),
   })
 }
 

--- a/packages/docs/src/collab/createCollabEditor.ts
+++ b/packages/docs/src/collab/createCollabEditor.ts
@@ -54,6 +54,8 @@ export interface CollabEditorOptions {
 
 export class CollabEditor {
   readonly documentName: string
+  /** Stable doc id used to issue the collab token docId-first (design §7.1); '' falls back to legacy. */
+  private readonly docId: string
   readonly ydoc: Y.Doc
   readonly provider: HocuspocusProvider
   readonly editor: Editor
@@ -76,6 +78,7 @@ export class CollabEditor {
   ) {
     const scope: DocScope = { uid: opts.uid, space: opts.space, folder: opts.folder, doc: opts.doc }
     this.documentName = buildDocumentName(opts.space, opts.folder, opts.doc)
+    this.docId = opts.docId || ''
     this.cacheKeyStr = cacheKey(scope)
 
     // 1) single Y.Doc
@@ -93,7 +96,7 @@ export class CollabEditor {
       url: wsUrl,
       name: this.documentName,
       document: this.ydoc,
-      token: () => getCollabToken(this.documentName),
+      token: () => getCollabToken(this.documentName, this.docId || undefined),
       connect: false,
     })
 
@@ -105,18 +108,18 @@ export class CollabEditor {
 
     // Role controller: runtime stateless role changes (monotonic epoch).
     this.roleController = new RoleController({
-      documentName: this.documentName,
       initialRole,
       initialEpoch,
       onRole: (role) => {
         this.editor.setEditable(canEdit(role))
         opts.onRole?.(role)
       },
+      disposeToken: () => disposeToken(this.documentName, { docId: this.docId || undefined }),
     })
 
     // Close-code state machine: the only auth-recovery source is event.code.
     this.closeMachine = new CloseCodeMachine({
-      disposeToken: () => disposeToken(this.documentName),
+      disposeToken: () => disposeToken(this.documentName, { docId: this.docId || undefined }),
       connect: () => this.provider.connect(),
       disconnect: () => this.provider.disconnect(),
       goLogin: () => opts.onTerminal?.({ kind: 'login' }),
@@ -180,7 +183,7 @@ export class CollabEditor {
    */
   static async create(opts: CollabEditorOptions): Promise<CollabEditor> {
     const documentName = buildDocumentName(opts.space, opts.folder, opts.doc)
-    const entry = await getCollabTokenEntry(documentName)
+    const entry = await getCollabTokenEntry(documentName, opts.docId || undefined)
     // The collab-token response is the single source of truth for the WS origin: the
     // backend-issued `collabWsUrl` is required. resolveCollabWsUrl throws when it is absent, so a
     // misconfigured backend fails loudly here instead of silently connecting to a placeholder.
@@ -238,6 +241,6 @@ export class CollabEditor {
     this.provider.destroy()
     void this.persistence?.destroy()
     this.ydoc.destroy()
-    disposeToken(this.documentName, /* uid implicit current */ undefined)
+    disposeToken(this.documentName, { docId: this.docId || undefined })
   }
 }

--- a/packages/docs/src/collab/statelessRole.test.ts
+++ b/packages/docs/src/collab/statelessRole.test.ts
@@ -6,7 +6,6 @@ function make(initialRole: Role = 'writer', initialEpoch = 1) {
   const onRole = vi.fn()
   const disposeToken = vi.fn()
   const ctrl = new RoleController({
-    documentName: 'octo:s:f:d',
     initialRole,
     initialEpoch,
     onRole,
@@ -68,7 +67,7 @@ describe('RoleController — stateless role-change handling', () => {
   it('disposes the token on downgrade (role can no longer edit)', () => {
     const { ctrl, disposeToken } = make('writer', 1)
     ctrl.handleStatelessFrame(frame({ type: 'role-change', role: 'reader', permission_epoch: 2 }))
-    expect(disposeToken).toHaveBeenCalledWith('octo:s:f:d')
+    expect(disposeToken).toHaveBeenCalledWith()
   })
 
   it('does not dispose the token when role remains editable (e.g. writer->admin)', () => {

--- a/packages/docs/src/collab/statelessRole.ts
+++ b/packages/docs/src/collab/statelessRole.ts
@@ -13,31 +13,27 @@
 //     re-issues rather than reusing an unexpired token with the old role/epoch.
 
 import { canEdit, isRole, type Role } from '../auth/roles.ts'
-import { disposeToken as defaultDisposeToken } from '../auth/collabToken.ts'
-
 export interface RoleControllerOptions {
-  documentName: string
   initialRole: Role
   initialEpoch: number
   /** Called whenever the effective role changes (re-arm editable / banners / manage UI). */
   onRole: (role: Role) => void
-  /** Injectable for tests; defaults to the real token disposer. */
-  disposeToken?: (documentName: string) => void
+  /** Required, already-scoped invalidation closure. Binding the docId at construction prevents
+   * docId-first tokens from accidentally being disposed through the legacy cache slot. */
+  disposeToken: () => void
 }
 
 export class RoleController {
   private role: Role
   private epoch: number
-  private readonly documentName: string
   private readonly onRole: (role: Role) => void
-  private readonly disposeToken: (documentName: string) => void
+  private readonly disposeToken: () => void
 
   constructor(opts: RoleControllerOptions) {
     this.role = opts.initialRole
     this.epoch = opts.initialEpoch
-    this.documentName = opts.documentName
     this.onRole = opts.onRole
-    this.disposeToken = opts.disposeToken ?? defaultDisposeToken
+    this.disposeToken = opts.disposeToken
   }
 
   getRole(): Role {
@@ -73,7 +69,7 @@ export class RoleController {
 
     // Downgrade -> invalidate cached token so reconnect re-issues with current role/epoch.
     if (!canEdit(nextRole)) {
-      this.disposeToken(this.documentName)
+      this.disposeToken()
     }
 
     this.onRole(nextRole)

--- a/packages/docs/src/documentName/index.test.ts
+++ b/packages/docs/src/documentName/index.test.ts
@@ -44,8 +44,21 @@ describe('parseDocumentName — 5-segment whiteboard key (non-symmetric)', () =>
     expect(parsed).toEqual({ kind: 'whiteboard', space: 's_001', folder: 'f_888', board: 'board_7' })
   })
 
-  it('a 5-segment key whose 4th part is NOT "wb" is invalid (not a doc, not a wb)', () => {
+  it('rejects an unknown 5-segment key type', () => {
     expect(() => parseDocumentName('octo:s:f:x:y')).toThrow()
+  })
+})
+
+describe('parseDocumentName — standalone typed keys', () => {
+  it.each([
+    ['octo:s_001:f_888:html:d_html', 'html'],
+    ['octo:s_001:f_888:ppt:d_ppt', 'ppt'],
+  ] as const)('parses %s as %s rather than an ordinary document', (name, kind) => {
+    expect(parseDocumentName(name)).toEqual({ kind, space: 's_001', folder: 'f_888', doc: name.split(':')[4] })
+  })
+
+  it.each(['octo:s:f:html:d:extra', 'octo:s:f:unknown:d'])('rejects malformed typed key %s', (name) => {
+    expect(() => parseDocumentName(name)).toThrow()
   })
 })
 

--- a/packages/docs/src/documentName/index.ts
+++ b/packages/docs/src/documentName/index.ts
@@ -1,7 +1,9 @@
 // documentName addressing contract (frontend-design §7.2 / §9.1, backend §8.1).
 //
-//   document key (4 segments):  octo:{space}:{folder}:{doc}
-//   whiteboard key (5 segments): octo:{space}:{folder}:wb:{board}   (NOT built this round)
+//   document key (4 segments):   octo:{space}:{folder}:{doc}
+//   whiteboard key (5 segments): octo:{space}:{folder}:wb:{board}
+//   HTML key (5 segments):       octo:{space}:{folder}:html:{doc}
+//   PPT key (5 segments):        octo:{space}:{folder}:ppt:{doc}
 //
 // v2.1: segment 3 is the docs-native {folder} (organization/routing dimension).
 // It is NOT an octo group_no and the frontend NEVER derives permissions from it.
@@ -14,6 +16,8 @@
 export type ParsedDocumentName =
   | { kind: 'document'; space: string; folder: string; doc: string }
   | { kind: 'whiteboard'; space: string; folder: string; board: string }
+  | { kind: 'html'; space: string; folder: string; doc: string }
+  | { kind: 'ppt'; space: string; folder: string; doc: string }
 
 // Each segment is a restricted charset: no ':' separators, no empty segments.
 const SEGMENT = /^[A-Za-z0-9_-]+$/
@@ -46,10 +50,8 @@ export function buildDocumentName(space: string, folder: string, doc: string): s
 }
 
 /**
- * Parse a documentName using the non-symmetric rule: a 5-segment key whose 4th
- * segment is the literal `wb` is a whiteboard key; otherwise it must be exactly a
- * 4-segment document key. The whiteboard branch is parsed correctly but no
- * whiteboard UI is built this round (deferred).
+ * Parse a canonical documentName. Typed 5-segment keys use `wb`, `html`, or
+ * `ppt`; the shared collaborative document namespace uses exactly 4 segments.
  */
 export function parseDocumentName(name: string): ParsedDocumentName {
   if (typeof name !== 'string' || name.length === 0) {
@@ -60,13 +62,15 @@ export function parseDocumentName(name: string): ParsedDocumentName {
     throw new Error('documentName must start with the "octo" namespace')
   }
 
-  // Whiteboard key (positional, length===5 && parts[3]==='wb') — checked first.
-  if (parts.length === 5 && parts[3] === 'wb') {
-    const [, space, folder, , board] = parts
+  // Typed five-segment keys are positional. `html` and `ppt` are standalone, non-Yjs surfaces;
+  // they must not be collapsed into the ordinary collaborative-document kind.
+  if (parts.length === 5 && ['wb', 'html', 'ppt'].includes(parts[3])) {
+    const [, space, folder, type, resourceId] = parts
     assertSegment(space, 'space')
     assertSegment(folder, 'folder')
-    assertSegment(board, 'board')
-    return { kind: 'whiteboard', space, folder, board }
+    assertSegment(resourceId, type === 'wb' ? 'board' : 'doc')
+    if (type === 'wb') return { kind: 'whiteboard', space, folder, board: resourceId }
+    return { kind: type as 'html' | 'ppt', space, folder, doc: resourceId }
   }
 
   // Document key must be exactly 4 segments.

--- a/packages/docs/src/editor/EditorShell.test.tsx
+++ b/packages/docs/src/editor/EditorShell.test.tsx
@@ -156,7 +156,7 @@ describe('EditorShell — export filename uses the live title, not the stale pro
     fireEvent.click(screen.getByText('docs.toolbar.export'))
     fireEvent.click(screen.getByText('docs.toolbar.exportMarkdown'))
 
-    await waitFor(() => expect(exportSpy).toHaveBeenCalledWith('d_1', 'md'))
+    await waitFor(() => expect(exportSpy).toHaveBeenCalledWith('d_1', 'md', { spaceId: 's_1' }))
     await waitFor(() => expect(createdAnchors.length).toBeGreaterThan(0))
     const a = createdAnchors[createdAnchors.length - 1]
     expect(a.download).toBe('Live Title.md')
@@ -185,7 +185,7 @@ describe('EditorShell — export filename uses the live title, not the stale pro
 
     fakeProvider.hasUnsyncedChanges = false
     fakeProvider.emit('unsyncedChanges', 0)
-    await waitFor(() => expect(exportSpy).toHaveBeenCalledWith('d_1', 'md'))
+    await waitFor(() => expect(exportSpy).toHaveBeenCalledWith('d_1', 'md', { spaceId: 's_1' }))
   })
 })
 

--- a/packages/docs/src/editor/EditorShell.tsx
+++ b/packages/docs/src/editor/EditorShell.tsx
@@ -153,12 +153,15 @@ export function waitForExportSync(
  */
 export function DocTitle({
   docId,
+  spaceId,
   initialTitle,
   canEdit,
   onSaved,
   onTitleLoaded,
 }: {
   docId: string
+  /** Explicit document home Space for standalone mounts where the shell interceptor is empty. */
+  spaceId?: string
   initialTitle: string
   canEdit: boolean
   onSaved?: (docId: string, title: string) => void
@@ -183,7 +186,7 @@ export function DocTitle({
   // like the export filename.
   useEffect(() => {
     let cancelled = false
-    getDoc(docId)
+    getDoc(docId, spaceId ? { spaceId } : undefined)
       .then((meta) => {
         if (!cancelled && typeof meta?.title === 'string') {
           setTitle(meta.title)
@@ -196,7 +199,7 @@ export function DocTitle({
     return () => {
       cancelled = true
     }
-  }, [docId])
+  }, [docId, spaceId])
 
   useEffect(() => {
     if (editing) inputRef.current?.focus()
@@ -226,7 +229,7 @@ export function DocTitle({
     committingRef.current = true
     setSaving(true)
     try {
-      await updateDocTitle(docId, next)
+      await updateDocTitle(docId, next, spaceId ? { spaceId } : undefined)
       doneRef.current = true
       setTitle(next)
       setDraft(next)
@@ -349,7 +352,7 @@ export function EditorShell(props: EditorShellProps) {
     // The page-load read is authoritative only while no commit has bumped the version past this
     // snapshot; a commit landing mid-flight makes this getDoc stale and it must not write.
     const versionAtLoad = shareSeedVersionRef.current
-    getDoc(docId)
+    getDoc(docId, collabOpts.space ? { spaceId: collabOpts.space } : undefined)
       .then((meta) => {
         if (cancelled) return
         if (typeof meta?.ownerId === 'string' && meta.ownerId) setOwnerId(meta.ownerId)
@@ -368,7 +371,7 @@ export function EditorShell(props: EditorShellProps) {
     return () => {
       cancelled = true
     }
-  }, [docId])
+  }, [docId, collabOpts.space])
 
   // Import injection (#import): when a doc was just created by a Markdown/Word import in DocsHome,
   // the parsed ProseMirror document is stashed in sessionStorage keyed by docId. Once the editor
@@ -511,7 +514,7 @@ export function EditorShell(props: EditorShellProps) {
     },
     [onDeleted, returnToList],
   )
-  const del = useDocDelete(docId, handleDeleted)
+  const del = useDocDelete(docId, handleDeleted, collabOpts.space ? { spaceId: collabOpts.space } : undefined)
 
   // All downloadable document formats come from one authenticated backend
   // endpoint. The backend reads the authoritative live Y.Doc; the browser does
@@ -525,7 +528,7 @@ export function EditorShell(props: EditorShellProps) {
     try {
       if (!instance) throw new Error('document_not_ready')
       await waitForExportSync(instance.provider, connState)
-      const bytes = await exportDocFile(docId, format)
+      const bytes = await exportDocFile(docId, format, collabOpts.space ? { spaceId: collabOpts.space } : undefined)
       const mime = format === 'md'
         ? 'text/markdown;charset=utf-8'
         : format === 'docx'
@@ -690,6 +693,7 @@ export function EditorShell(props: EditorShellProps) {
         )}
         <DocTitle
           docId={docId}
+          spaceId={collabOpts.space}
           initialTitle={title}
           canEdit={manage}
           onSaved={(id, t) => {

--- a/packages/docs/src/forward/forward.test.ts
+++ b/packages/docs/src/forward/forward.test.ts
@@ -124,26 +124,29 @@ describe('buildDocLink — standalone `/d/:docId` share form (bypasses the host 
     // The doc no longer rides on a wipeable query param.
     expect(link).not.toContain('/docs?')
     expect(link).not.toContain('doc=d_1')
-    // The legacy `space=`/`folder=` in-shell params are gone; the doc's real space rides on the
-    // dedicated `?sp=` param instead (XIN-501), so the recipient's preflight can address the doc's
-    // own space.
+    // Phase-1 remove-`sp` (design §5.3): ordinary doc links carry ONLY the docId path — no in-shell
+    // `space=`/`folder=`, and no `?sp=`. `space`/`folder` are accepted-but-ignored during the caller
+    // cutover; the recipient's open-context preflight resolves the doc's Space server-side by docId.
     expect(link).not.toContain('space=')
     expect(link).not.toContain('folder=')
+    expect(link).not.toContain('sp=')
   })
 
-  it('embeds the doc real space as `?sp=` so the recipient preflight addresses the doc space (XIN-501)', () => {
+  it('never emits `?sp=` even when a space is supplied (design §5.3 — space is accepted-but-ignored)', () => {
     const link = buildDocLink({ docId: 'd_1', space: '105d4a60d0fc4d55a5cfc3c2d0501361' })
-    expect(link).toContain('sp=105d4a60d0fc4d55a5cfc3c2d0501361')
+    expect(link).toContain('/d/d_1')
+    expect(link).not.toContain('sp=')
+    expect(link).not.toContain('105d4a60d0fc4d55a5cfc3c2d0501361')
   })
 
-  it('never carries the token-bucket `?sid`, even when a currentSpaceId is persisted (XIN-513)', () => {
-    // The link no longer mints `?sid` — an already-logged-in recipient's session is recovered from
-    // storage independently of the URL. Only the doc's real space rides along, on `?sp`.
+  it('never carries the token-bucket `?sid` nor a doc `?sp`, even when a currentSpaceId is persisted (XIN-513 + §5.3)', () => {
+    // The link no longer mints `?sid` (session recovered from storage) nor `?sp` (Space resolved
+    // server-side from docId) — it is the bare canonical `/d/:docId`.
     try {
       window.localStorage.setItem('currentSpaceId', 'sp_current')
       const link = buildDocLink({ docId: 'd_1', space: '105d4a60d0fc4d55a5cfc3c2d0501361' })
       expect(link).not.toContain('sid=')
-      expect(link).toContain('sp=105d4a60d0fc4d55a5cfc3c2d0501361')
+      expect(link).not.toContain('sp=')
     } finally {
       window.localStorage.removeItem('currentSpaceId')
     }

--- a/packages/docs/src/forward/link.ts
+++ b/packages/docs/src/forward/link.ts
@@ -1,6 +1,6 @@
 // The canonical doc-share-link builder now lives in `@octo/base`
 // (packages/dmworkbase/src/Utils/docLink.ts) as the single source of truth for the
-// `${origin}/d/<docId>?sp=<spaceId>` format (XIN-450 / XIN-501 / XIN-513). This module stays as a
+// `${origin}/d/<docId>` no-Space format. This module stays as a
 // thin re-export so existing docs-side imports (`./link.ts`) keep working; the full implementation
 // and its rationale comment block live in the base util.
 

--- a/packages/docs/src/html/HtmlDocView.test.tsx
+++ b/packages/docs/src/html/HtmlDocView.test.tsx
@@ -1222,7 +1222,7 @@ describe('HtmlDocView — creator/created head sourced from docs-backend (OCT-19
     expect(screen.getByText(/2026-07-15/)).toBeTruthy()
   })
 
-  it('passes X-Space-Id on the docs-backend GET so the standalone /d/:docId space-required middleware accepts it', async () => {
+  it('passes the optional compatibility X-Space-Id on the docs-backend metadata GET', async () => {
     wk.apiClient.responder = () => ({ data: {}, status: 200 })
     serveDoc('<p>body</p>')
     render(<HtmlDocView docId="d1" space="sp_42" />)

--- a/packages/docs/src/html/HtmlDocView.tsx
+++ b/packages/docs/src/html/HtmlDocView.tsx
@@ -326,7 +326,7 @@ export function HtmlDocView({
   const canOpenPanel = isAuthor || canManageBackend
   const pendingAccess = useAccessRequests(docId, canManageBackend)
   // Browser-openable address for forwarding this doc to chat. Build the PATH-style standalone
-  // link (/d/<docId>?sp=<space>) like every other kind (buildDocLink), NOT window.location.href:
+  // no-Space link (`/d/<docId>`) like every other ordinary kind, NOT window.location.href:
   // the in-shell address is the legacy /docs?doc= query form, whose docId is wiped by the host's
   // pathname-only route re-push, so a forwarded query link lands the recipient on the wrong page.
   // The path form carries the docId in the path (survives the re-push), routes through

--- a/packages/docs/src/octoweb/types.ts
+++ b/packages/docs/src/octoweb/types.ts
@@ -34,6 +34,8 @@ export interface ApiError<T = unknown> {
 
 export interface ApiRequestConfig {
   signal?: AbortSignal
+  /** Suppress the host's global X-Space-Id interceptor for docId-global endpoints. */
+  suppressSpaceId?: boolean
   /**
    * Axios responseType passthrough. The version-history `…/state` endpoint returns a
    * binary Yjs state blob, so the client passes `'arraybuffer'` to get an ArrayBuffer
@@ -46,13 +48,7 @@ export interface ApiRequestConfig {
    */
   timeout?: number
   /**
-   * Per-request headers, merged over the global request interceptor's headers by axios
-   * (request-config headers win). The standalone `/d/:docId` preflight uses this to carry an
-   * explicit `X-Space-Id`: it mounts via the Layout early-return, before the app shell restores
-   * `currentSpaceId`, so the global `spaceIdCallback` interceptor reads an empty space and injects
-   * no `X-Space-Id` — the backend's by-space middleware then rejects the bare `getDoc` (400
-   * space_required / 404 space mismatch). Passing the space here makes the preflight the source of
-   * truth for its own space header. In-shell callers omit this and keep relying on the interceptor.
+   * Per-request headers, merged over the global request interceptor's headers by axios.
    */
   headers?: Record<string, string>
 }

--- a/packages/docs/src/pages/DocsHome.test.tsx
+++ b/packages/docs/src/pages/DocsHome.test.tsx
@@ -676,30 +676,29 @@ describe('DocsHome navigation (split-pane)', () => {
     const entry = await waitFor(() => screen.getByTestId('editor-open-new-page'))
     fireEvent.click(entry)
 
-    // It opens the clean standalone deep-link in a new tab — no in-app navigation. The link carries
-    // the doc's real space as `?sp` (XIN-519 blocker 1); with no active space the shell falls back to
-    // the default doc space ('demo'). No `?sid` — the opener's session is recovered from storage.
-    expect(openSpy).toHaveBeenCalledWith('/d/d_a?sp=demo', '_blank', 'noopener,noreferrer')
+    // It opens the clean canonical standalone deep-link in a new tab — no in-app navigation. Phase-1
+    // (design §5.3): the link is the bare `/d/:docId` with NO query — no `?sp` (the reader resolves
+    // the doc's Space server-side from the docId) and no `?sid` (the opener's session is recovered
+    // from storage).
+    expect(openSpy).toHaveBeenCalledWith('/d/d_a', '_blank', 'noopener,noreferrer')
     expect(assignSpy).not.toHaveBeenCalled()
   })
 
-  it('XIN-513/519: the standalone link opens with `?sp` (doc space) but no `?sid`, even when the in-shell URL carries a sid', async () => {
+  it('XIN-513/519 + §5.3: the standalone link opens with NO query — neither `?sp` nor `?sid` — even when the in-shell URL carries a sid', async () => {
     const openSpy = vi.fn()
     Object.defineProperty(window, 'open', { configurable: true, writable: true, value: openSpy })
     // In-shell URL carries the active session's sid (the host's RouteManager re-push collapses the
     // docs route to `/docs?sid=…`). The opened standalone link must NOT copy that sid forward: an
-    // already-logged-in user's session is recovered from storage independently of the URL (XIN-513),
-    // so a sid-less `/d/:docId` opens the document directly. It MUST, however, carry `?sp` (the doc's
-    // real space) so the recipient's standalone preflight can address the doc's own space — dropping
-    // it (XIN-519 blocker 1) sent the login-return path into the cross-space not_found terminal.
+    // already-logged-in user's session is recovered from storage independently of the URL (XIN-513).
+    // Phase-1 (design §5.3) also drops `?sp`: the standalone reader resolves the doc's Space
+    // server-side from the docId via open-context, so the active DocsHome space no longer rides along.
     Object.defineProperty(window, 'location', {
       configurable: true,
       writable: true,
       value: { origin: 'https://app.example.com', search: '?sid=s_active', assign: assignSpy },
     })
     const wk = createMockWKApp()
-    // Give the shell an active space so DocsHome's space (spaceRef) resolves to a real doc space id,
-    // which the opened standalone link must carry as `?sp`.
+    // An active space is present, but it must NOT be stamped onto the standalone link anymore.
     wk.shared.currentSpaceId = '105d4a60d0fc4d55a5cfc3c2d0501361'
     setWKApp(wk)
     wk.apiClient.responder = (method, url) => {
@@ -721,14 +720,9 @@ describe('DocsHome navigation (split-pane)', () => {
     // The list item carries no docType, so the editor mounts only after the async open resolves.
     fireEvent.click(await waitFor(() => screen.getByTestId('editor-open-new-page')))
 
-    // The standalone link carries `?sp` (the doc's real space) so the recipient's preflight addresses
-    // the doc's own space — but NO `?sid`; the opener's session is recovered from storage (XIN-513).
-    // (The multi-session wrong-space-session recovery edge is tracked separately as octo-web #551.)
-    expect(openSpy).toHaveBeenCalledWith(
-      '/d/d_a?sp=105d4a60d0fc4d55a5cfc3c2d0501361',
-      '_blank',
-      'noopener,noreferrer',
-    )
+    // Bare canonical link: no `?sp` (Space resolved from docId server-side, §5.3) and no `?sid`
+    // (session recovered from storage, XIN-513).
+    expect(openSpy).toHaveBeenCalledWith('/d/d_a', '_blank', 'noopener,noreferrer')
     expect(assignSpy).not.toHaveBeenCalled()
   })
 
@@ -3328,10 +3322,10 @@ describe('DocsHome — row context menu: 复制文档链接 / 转发', () => {
 
     await waitFor(() => expect(writeText).toHaveBeenCalled())
     const copied = writeText.mock.calls[0][0] as string
-    // The doc's own address (buildDocLink), not an invite token.
+    // The doc's canonical address (buildDocLink), not an invite token. Ordinary
+    // document URLs no longer expose or depend on the home Space query.
     expect(copied).toContain('/d/d_b')
-    // Pin the Space query too — without this the case would still pass if `space` were dropped.
-    expect(copied).toContain('sp=')
+    expect(copied).not.toContain('sp=')
     expect(copied).not.toContain('invite')
     // And no request was made: minting an invite is what the old entry did.
     expect(

--- a/packages/docs/src/pages/DocsHome.tsx
+++ b/packages/docs/src/pages/DocsHome.tsx
@@ -627,8 +627,8 @@ function DocsList({
     })
   }
 
-  // Copy the document's own address — `${origin}/d/<docId>?sp=<space>` via buildDocLink, a pure
-  // string builder with no request behind it.
+  // Copy the document's canonical bare address — `${origin}/d/<docId>` via buildDocLink, a pure
+  // string builder with no request behind it. Open Context resolves its home Space on load.
   //
   // This REPLACES an earlier "复制链接" that called createInvite() and copied an invite token
   // (#537). That entry was gated on canManage because the backend only lets an admin mint an
@@ -1835,23 +1835,18 @@ export function DocsHome() {
   // in a new browser tab — the clean, shareable cold-load entry that lives outside the app shell.
   // The id only ever contains documentName-safe chars, so the built path stays a valid /d/ route.
   //
-  // The link carries NO `?sid=` (XIN-513): an already-logged-in user's session is recovered from
-  // storage independently of the URL — apps/web Layout runs recoverOctoSessionFromStorage on the
-  // `/d` path, which scans the `token<sid>` buckets and adopts a valid stored session — so the new
-  // tab opens the document directly without a login detour.
-  //
-  // It DOES carry `?sp=` (XIN-519 blocker 1): the doc's real space — the active DocsHome space, which
-  // the resident list is scoped to, so the open document lives in it — exactly as the other two minted
-  // `/d/:docId` links do (buildDocLink forward link, StandaloneDocPage Copy-link). Without `?sp` the
-  // recipient's standalone preflight (`GET /docs/:docId`) has no space to address and hits the
-  // cross-space guard's not_found ("该文档不存在或已被删除"), notably on the unauthenticated
-  // login-return path. We read spaceRef (the authoritative current space id, kept in sync by
-  // onSpaceChanged) so the callback stays deps-free. We drop only `?sid`, never `?sp`.
+  // The link carries NO query at all (Phase-1 remove-`sp`, design §5.3):
+  //   - NO `?sid=` (XIN-513): an already-logged-in user's session is recovered from storage
+  //     independently of the URL — apps/web Layout runs recoverOctoSessionFromStorage on the `/d`
+  //     path, which scans the `token<sid>` buckets and adopts a valid stored session — so the new
+  //     tab opens the document directly without a login detour.
+  //   - NO `?sp=`: the standalone reader resolves the doc's Space server-side from `docId` alone via
+  //     `GET /docs/:docId/open-context`, so the active DocsHome space no longer needs to ride on the
+  //     link. This matches the other minted `/d/:docId` links (buildDocLink forward link,
+  //     StandaloneDocPage Copy-link), which all stopped emitting `sp` this phase.
   const onOpenInNewPage = useCallback((id: string) => {
     if (typeof window !== 'undefined') {
-      const sp = (spaceRef.current || '').trim()
-      const query = sp ? `?sp=${encodeURIComponent(sp)}` : ''
-      window.open(`/d/${encodeURIComponent(id)}${query}`, '_blank', 'noopener,noreferrer')
+      window.open(`/d/${encodeURIComponent(id)}`, '_blank', 'noopener,noreferrer')
     }
   }, [])
 

--- a/packages/docs/src/pages/StandaloneDocPage.test.tsx
+++ b/packages/docs/src/pages/StandaloneDocPage.test.tsx
@@ -67,13 +67,37 @@ vi.mock('../members/useMemberNames.ts', () => ({
   useMemberNames: () => new Map<string, string>(),
 }))
 
+// Replace the collaborative spreadsheet host (Univer + Yjs + Hocuspocus) with a marker so a
+// docType:'sheet' open-context lands on SheetView without mounting the heavy grid / opening a WS —
+// exactly like the editor + board markers above. Echoes the docId/space it was addressed with.
+vi.mock('../sheet/SheetView.tsx', () => ({
+  SheetView: (props: { docId: string; space?: string; folder?: string }) => (
+    <div data-testid="sheet-view">
+      <span data-testid="sheet-doc">{props.docId}</span>
+      <span data-testid="sheet-space">{props.space}</span>
+      <span data-testid="sheet-folder">{props.folder}</span>
+    </div>
+  ),
+}))
+
+vi.mock('../html/HtmlDocView.tsx', () => ({
+  HtmlDocView: (props: { docId: string; space?: string }) => (
+    <div data-testid="html-view"><span>{props.docId}</span><span>{props.space}</span></div>
+  ),
+}))
+
+vi.mock('../ppt/PptDocView.tsx', () => ({
+  PptDocView: (props: { docId: string; space?: string }) => (
+    <div data-testid="ppt-view"><span>{props.docId}</span><span>{props.space}</span></div>
+  ),
+}))
+
 import {
   StandaloneDocPage,
   parseStandaloneDocId,
   isStandaloneDocPath,
-  standaloneFallbackSpace,
   viewerCurrentSpace,
-  standaloneLinkSpace,
+  stripSpFromUrl,
   persistStandaloneReturn,
   consumeStandaloneReturn,
   withReturnSid,
@@ -93,7 +117,7 @@ beforeEach(() => {
   window.sessionStorage.clear();
   window.localStorage.clear();
   // Reset the URL between tests so a `?sid=`/`?sp=` pushed by one test (Copy-link / return-target /
-  // space-resolution cases) cannot leak into the next, which reads the link's `?sp=` (standaloneLinkSpace).
+  // legacy-link cleanup cases) cannot leak into the next.
   window.history.pushState({}, '', '/')
   wk = createMockWKApp()
   setWKApp(wk)
@@ -154,7 +178,7 @@ describe('StandaloneDocPage — preflight boundary states (no WebSocket)', () =>
     // 'locked' terminal via terminalForCreateError, with only a Back control — no collab editor,
     // hence no WebSocket, is mounted.
     wk.apiClient.responder = (method, url) => {
-      if (method === 'get' && url === '/docs/d_locked') throw apiError(409)
+      if (method === 'get' && url === '/docs/d_locked/open-context') throw apiError(409)
       return { data: {}, status: 200 }
     }
 
@@ -174,7 +198,7 @@ describe('StandaloneDocPage — preflight boundary states (no WebSocket)', () =>
 
   it('AC-7: a GET 403 renders the access-denied terminal, editor not mounted', async () => {
     wk.apiClient.responder = (method, url) => {
-      if (method === 'get' && url === '/docs/d_forbidden') throw apiError(403)
+      if (method === 'get' && url === '/docs/d_forbidden/open-context') throw apiError(403)
       return { data: {}, status: 200 }
     }
 
@@ -191,12 +215,12 @@ describe('StandaloneDocPage — preflight boundary states (no WebSocket)', () =>
     // permission can ask for it. The standalone /d/:docId deep link is the surface most recipients
     // arrive through, yet it used to dead-end on a bare terminal (Back only). It must now render the
     // in-shell RequestAccessButton so the receiver can request access without leaving the page.
+    window.localStorage.setItem('currentSpaceId', 's_viewer')
     wk.apiClient.responder = (method, url) => {
-      if (method === 'get' && url === '/docs/d_forbidden') throw apiError(403)
+      if (method === 'get' && url === '/docs/d_forbidden/open-context') throw apiError(403)
       // The owned-Bot lookup must return a LEGAL empty list: this case asserts the requester can ask
       // for access, which is orthogonal to the Bot dimension. The catch-all `{}` reaches the strict
       // loader as a malformed body and blocks submission, which would test the wrong thing.
-      if (method === 'get' && url.startsWith('/robot/owned_bots')) return { data: [], status: 200 }
       return { data: {}, status: 200 }
     }
 
@@ -223,11 +247,34 @@ describe('StandaloneDocPage — preflight boundary states (no WebSocket)', () =>
         ),
       ).toBe(true),
     )
+    const post = wk.apiClient.calls.find(
+      (c) => c.method === 'post' && c.url === '/docs/d_forbidden/access-requests',
+    )!
+    expect(post.body).toBeUndefined()
+    expect(post.config?.headers?.['X-Space-Id']).toBeUndefined()
+    expect(wk.apiClient.calls.some((c) => c.url.startsWith('/robot/owned_bots'))).toBe(false)
+  })
+
+  it('keeps a first-time cross-Space access request human-only with no viewer-space lookup/header', async () => {
+    wk.shared.currentSpaceId = 's_viewer'
+    wk.apiClient.responder = (method, url) => {
+      if (method === 'get' && url === '/docs/d_cross/open-context') throw apiError(403)
+      return { data: {}, status: 200 }
+    }
+
+    render(<StandaloneDocPage docId="d_cross" />)
+    fireEvent.click(await screen.findByText('docs.forward.requestAccess'))
+    await waitFor(() => expect(wk.apiClient.calls.some((c) => c.url === '/docs/d_cross/access-requests')).toBe(true))
+
+    const post = wk.apiClient.calls.find((c) => c.url === '/docs/d_cross/access-requests')!
+    expect(post.body).toBeUndefined()
+    expect(post.config?.headers?.['X-Space-Id']).toBeUndefined()
+    expect(wk.apiClient.calls.some((c) => c.url.startsWith('/robot/owned_bots'))).toBe(false)
   })
 
   it('AC-10: a GET 404 renders the not-found terminal, editor not mounted', async () => {
     wk.apiClient.responder = (method, url) => {
-      if (method === 'get' && url === '/docs/d_missing') throw apiError(404)
+      if (method === 'get' && url === '/docs/d_missing/open-context') throw apiError(404)
       return { data: {}, status: 200 }
     }
 
@@ -244,7 +291,7 @@ describe('StandaloneDocPage — preflight boundary states (no WebSocket)', () =>
 
   it('AC-11: a GET 401 renders the sign-in terminal and stashes the return target', async () => {
     wk.apiClient.responder = (method, url) => {
-      if (method === 'get' && url === '/docs/d_locked_out') throw apiError(401)
+      if (method === 'get' && url === '/docs/d_locked_out/open-context') throw apiError(401)
       return { data: {}, status: 200 }
     }
 
@@ -266,7 +313,7 @@ describe('StandaloneDocPage — preflight boundary states (no WebSocket)', () =>
     // reloads into the real login screen) rather than rendering the terminal.
     const onSessionExpired = vi.fn()
     wk.apiClient.responder = (method, url) => {
-      if (method === 'get' && url === '/docs/d_expired') throw apiError(401)
+      if (method === 'get' && url === '/docs/d_expired/open-context') throw apiError(401)
       return { data: {}, status: 200 }
     }
 
@@ -300,8 +347,8 @@ describe('StandaloneDocPage — preflight boundary states (no WebSocket)', () =>
 
   it('mounts the editor with Copy link pinned as the first ≡ menu row (no resident button, no "Open in App")', async () => {
     wk.apiClient.responder = (method, url) => {
-      if (method === 'get' && url === '/docs/d_ok') {
-        return { data: { docId: 'd_ok', title: 'Shared Doc', ownerId: 'u_owner' }, status: 200 }
+      if (method === 'get' && url === '/docs/d_ok/open-context') {
+        return { data: { docId: 'd_ok', homeSpaceId: 's_home', documentName: 'octo:s_home:f_default:d_ok', title: 'Shared Doc', ownerId: 'u_owner' }, status: 200 }
       }
       return { data: {}, status: 200 }
     }
@@ -343,8 +390,8 @@ describe('StandaloneDocPage — preflight boundary states (no WebSocket)', () =>
 
   it('falls back to the module title when the document title is empty', async () => {
     wk.apiClient.responder = (method, url) => {
-      if (method === 'get' && url === '/docs/d_untitled') {
-        return { data: { docId: 'd_untitled', title: '   ', ownerId: 'u_owner' }, status: 200 }
+      if (method === 'get' && url === '/docs/d_untitled/open-context') {
+        return { data: { docId: 'd_untitled', homeSpaceId: 's_home', documentName: 'octo:s_home:f_default:d_untitled', title: '   ', ownerId: 'u_owner' }, status: 200 }
       }
       return { data: {}, status: 200 }
     }
@@ -365,8 +412,8 @@ describe('StandaloneDocPage — preflight boundary states (no WebSocket)', () =>
     Object.assign(navigator, { clipboard: { writeText } })
 
     wk.apiClient.responder = (method, url) => {
-      if (method === 'get' && url === '/docs/d_ok') {
-        return { data: { docId: 'd_ok', title: 'Shared Doc', ownerId: 'u_owner' }, status: 200 }
+      if (method === 'get' && url === '/docs/d_ok/open-context') {
+        return { data: { docId: 'd_ok', homeSpaceId: 's_home', documentName: 'octo:s_home:f_default:d_ok', title: 'Shared Doc', ownerId: 'u_owner' }, status: 200 }
       }
       return { data: {}, status: 200 }
     }
@@ -384,18 +431,18 @@ describe('StandaloneDocPage — preflight boundary states (no WebSocket)', () =>
     expect(copied).not.toContain('?')
   })
 
-  it('XIN-513: Copy link keeps the doc space `?sp` but strips the session `?sid`', async () => {
-    // The standalone page was opened from a share link carrying `?sp=` (the doc's real space, XIN-501)
-    // and the live URL may also carry the sharer's own `?sid=`. The copied canonical link must
-    // preserve `?sp` — the next recipient's preflight needs it to address the doc's space — while
-    // dropping the session-scoped `?sid`.
+  it('Phase-1: Copy link drops BOTH the session `?sid` and a legacy doc-space `?sp`', async () => {
+    // The standalone page may be reached from a legacy link carrying `?sp=` (the doc's old space)
+    // and the live URL may also carry the sharer's own `?sid=`. The Phase-1 canonical link is the
+    // bare `/d/:docId` (design §5.3): the reader resolves the doc's Space server-side from the docId,
+    // so the copied link must drop `?sp` as well as the session-scoped `?sid`.
     window.history.pushState({}, '', '/d/d_ok?sid=sharer-secret&sp=105d4a60d0fc4d55a5cfc3c2d0501361')
     const writeText = vi.fn().mockResolvedValue(undefined)
     Object.assign(navigator, { clipboard: { writeText } })
 
     wk.apiClient.responder = (method, url) => {
-      if (method === 'get' && url === '/docs/d_ok') {
-        return { data: { docId: 'd_ok', title: 'Shared Doc', ownerId: 'u_owner' }, status: 200 }
+      if (method === 'get' && url === '/docs/d_ok/open-context') {
+        return { data: { docId: 'd_ok', homeSpaceId: 's_home', documentName: 'octo:s_home:f_default:d_ok', title: 'Shared Doc' }, status: 200 }
       }
       return { data: {}, status: 200 }
     }
@@ -407,8 +454,10 @@ describe('StandaloneDocPage — preflight boundary states (no WebSocket)', () =>
 
     await waitFor(() => expect(writeText).toHaveBeenCalledTimes(1))
     const copied = writeText.mock.calls[0][0] as string
-    expect(copied).toBe(`${window.location.origin}/d/d_ok?sp=105d4a60d0fc4d55a5cfc3c2d0501361`)
+    expect(copied).toBe(`${window.location.origin}/d/d_ok`)
     expect(copied).not.toContain('sid')
+    expect(copied).not.toContain('sp')
+    expect(copied).not.toContain('?')
   })
 
   it('AC-6: after copying, a menu-external "Link copied" toast appears (visible even though the menu row closes)', async () => {
@@ -420,8 +469,8 @@ describe('StandaloneDocPage — preflight boundary states (no WebSocket)', () =>
     Object.assign(navigator, { clipboard: { writeText } })
 
     wk.apiClient.responder = (method, url) => {
-      if (method === 'get' && url === '/docs/d_ok') {
-        return { data: { docId: 'd_ok', title: 'Shared Doc', ownerId: 'u_owner' }, status: 200 }
+      if (method === 'get' && url === '/docs/d_ok/open-context') {
+        return { data: { docId: 'd_ok', homeSpaceId: 's_home', documentName: 'octo:s_home:f_default:d_ok', title: 'Shared Doc', ownerId: 'u_owner' }, status: 200 }
       }
       return { data: {}, status: 200 }
     }
@@ -461,9 +510,9 @@ describe('StandaloneDocPage — board-kind resolved from authoritative docType (
     expect(window.localStorage.getItem('octo.board.ids.')).toBeNull()
 
     wk.apiClient.responder = (method, url) => {
-      if (method === 'get' && url === '/docs/b_shared') {
+      if (method === 'get' && url === '/docs/b_shared/open-context') {
         return {
-          data: { docId: 'b_shared', title: 'Shared Board', ownerId: 'u_owner', docType: 'board' },
+          data: { docId: 'b_shared', homeSpaceId: 's_home', documentName: 'octo:s_home:f_default:wb:b_shared', title: 'Shared Board', ownerId: 'u_owner', docType: 'board' },
           status: 200,
         }
       }
@@ -482,8 +531,8 @@ describe('StandaloneDocPage — board-kind resolved from authoritative docType (
     // Regression guard: a plain document (or a legacy backend that omits docType) must keep opening
     // in the Tiptap editor — the board branch must not swallow the default doc path.
     wk.apiClient.responder = (method, url) => {
-      if (method === 'get' && url === '/docs/d_plain') {
-        return { data: { docId: 'd_plain', title: 'Plain Doc', ownerId: 'u_owner', docType: 'doc' }, status: 200 }
+      if (method === 'get' && url === '/docs/d_plain/open-context') {
+        return { data: { docId: 'd_plain', homeSpaceId: 's_home', documentName: 'octo:s_home:f_default:d_plain', title: 'Plain Doc', ownerId: 'u_owner', docType: 'doc' }, status: 200 }
       }
       return { data: {}, status: 200 }
     }
@@ -503,14 +552,15 @@ describe('StandaloneDocPage — board-kind resolved from authoritative docType (
     // standalone share link derived a DIFFERENT room than the REST preflight authorized (wrong collab
     // token / WS room / uid-scoped cache) for any board outside the default folder.
     wk.apiClient.responder = (method, url) => {
-      if (method === 'get' && url === '/docs/b_infolder') {
+      if (method === 'get' && url === '/docs/b_infolder/open-context') {
         return {
           data: {
             docId: 'b_infolder',
+            homeSpaceId: 's_auth',
             title: 'Board In Folder',
             ownerId: 'u_owner',
             docType: 'board',
-            documentName: 'octo:s_auth:f_team:wb:board_xyz',
+            documentName: 'octo:s_auth:f_team:wb:b_infolder',
           },
           status: 200,
         }
@@ -521,31 +571,11 @@ describe('StandaloneDocPage — board-kind resolved from authoritative docType (
     render(<StandaloneDocPage docId="b_infolder" />)
 
     await waitFor(() => expect(screen.getByTestId('board-session')).toBeTruthy())
-    // Board segment comes from parsed.board, NOT the URL docId; folder/space from the parsed key.
-    expect(screen.getByTestId('board-doc').textContent).toBe('board_xyz')
+    // Backend invariant: canonical wb segment equals docId.
+    expect(screen.getByTestId('board-doc').textContent).toBe('b_infolder')
     expect(screen.getByTestId('board-folder').textContent).toBe('f_team')
     expect(screen.getByTestId('board-folder').textContent).not.toBe('f_default')
     expect(screen.getByTestId('board-space').textContent).toBe('s_auth')
-  })
-})
-
-describe('standaloneFallbackSpace — cold-start cross-space addressing (blocker 3)', () => {
-  it('prefers the live currentSpaceId when the shell has one', () => {
-    window.localStorage.setItem('currentSpaceId', 's_cached')
-    expect(standaloneFallbackSpace('s_live')).toBe('s_live')
-  })
-
-  it('falls back to the cached localStorage currentSpaceId when the shell has none', () => {
-    // The standalone page mounts via the Layout early-return, BEFORE the shell restores
-    // currentSpaceId — so wk.shared.currentSpaceId is empty on a cold cross-space deep link. The
-    // cached key is the user's real last space; using it avoids addressing the wrong room.
-    window.localStorage.setItem('currentSpaceId', 's_cached')
-    expect(standaloneFallbackSpace('')).toBe('s_cached')
-    expect(standaloneFallbackSpace(undefined)).toBe('s_cached')
-  })
-
-  it('falls back to the deploy default only when neither is available', () => {
-    expect(standaloneFallbackSpace('')).toBe('demo') // DEFAULT_DOC_SPACE
   })
 })
 
@@ -562,92 +592,39 @@ describe('viewerCurrentSpace — the space a recorded view is written to (XIN-12
   })
 
   it('returns empty (NOT the deploy default) when there is no viewer signal, so the caller omits the header', () => {
-    // Unlike standaloneFallbackSpace (used for room addressing, where a default is a safe last
-    // resort), the view record must never be written to a space we cannot confirm the viewer is in.
+    // The view record must never be written to a space we cannot confirm the viewer is in, so with
+    // no live and no cached signal we return '' and the caller omits the explicit X-Space-Id.
     expect(viewerCurrentSpace('')).toBe('')
     expect(viewerCurrentSpace(undefined)).toBe('')
   })
 })
 
-describe('StandaloneDocPage — cold-start addressing uses the cached space, not the deploy default (blocker 3)', () => {
-  it('addresses the EditorShell to the cached currentSpaceId when the preflight carries no documentName', async () => {
-    // Repro: 200 preflight WITHOUT documentName + a cached currentSpaceId in localStorage. Before
-    // the fix the page addressed DEFAULT_DOC_SPACE ("demo"), mounting the editor against the wrong
-    // room. It must instead use the cached space so the shared doc opens in the right space.
-    window.localStorage.setItem('currentSpaceId', 's_real')
+describe('StandaloneDocPage — addresses the editor from the open-context, never a client-guessed space (design §5.2)', () => {
+  it('fails closed when the open-context carries no canonical documentName', async () => {
+    // Canonical addressing is mandatory. A partial 200 must not fall back to a cached client Space,
+    // the deploy default, or homeSpaceId plus a guessed folder.
+    window.localStorage.setItem('currentSpaceId', 's_viewer') // a DIFFERENT viewer space; must NOT win
     wk.apiClient.responder = (method, url) => {
-      if (method === 'get' && url === '/docs/d_ok') {
-        // No documentName in the payload → the addressing memo hits the fallback branch.
-        return { data: { docId: 'd_ok', title: 'Shared Doc', ownerId: 'u_owner' }, status: 200 }
+      if (method === 'get' && url === '/docs/d_ok/open-context') {
+        return { data: { docId: 'd_ok', title: 'Shared Doc' }, status: 200 }
       }
       return { data: {}, status: 200 }
     }
 
     render(<StandaloneDocPage docId="d_ok" />)
 
-    await waitFor(() => expect(screen.getByTestId('editor-shell')).toBeTruthy())
-    expect(screen.getByTestId('editor-space').textContent).toBe('s_real')
-    expect(screen.getByTestId('editor-space').textContent).not.toBe('demo')
-  })
-})
-
-describe('StandaloneDocPage — cold-start preflight carries X-Space-Id from the cached space (by-space isolation)', () => {
-  it('sends GET /docs/:id with header X-Space-Id = cached currentSpaceId even though wk.shared.currentSpaceId is empty', async () => {
-    // Root cause: the standalone page mounts via the Layout early-return, BEFORE the app shell
-    // restores currentSpaceId, so wk.shared.currentSpaceId is empty and the global spaceIdCallback
-    // interceptor injects NO X-Space-Id. The backend's by-space middleware then rejects the bare
-    // preflight (400 space_required / 404 space mismatch) and the page shows the not-found terminal.
-    // The fix resolves the space from the SAME cached localStorage key the room addressing uses and
-    // passes it as an explicit header on the preflight. This asserts the DOCS-SIDE contract (the page
-    // puts the resolved space into the preflight config header); the real wire-level forwarding — host
-    // APIClient forwarding config.headers to axios, which was the XIN-424 fake-green — is covered by
-    // packages/dmworkbase/src/Service/__tests__/APIClient.headers.test.ts.
-    window.localStorage.setItem('currentSpaceId', 'space-abc')
-    expect(wk.shared.currentSpaceId).toBeFalsy() // shell has not restored the live space yet
-
-    wk.apiClient.responder = (method, url) => {
-      if (method === 'get' && url === '/docs/d_ok') {
-        return { data: { docId: 'd_ok', title: 'Shared Doc', ownerId: 'u_owner' }, status: 200 }
-      }
-      return { data: {}, status: 200 }
-    }
-
-    render(<StandaloneDocPage docId="d_ok" />)
-
-    await waitFor(() => expect(screen.getByTestId('editor-shell')).toBeTruthy())
-    const preflight = wk.apiClient.calls.find((c) => c.method === 'get' && c.url === '/docs/d_ok')
-    expect(preflight).toBeTruthy()
-    expect(preflight!.config?.headers?.['X-Space-Id']).toBe('space-abc')
-    // Consistency: the room the editor joins uses the same resolved space as the preflight header.
-    expect(screen.getByTestId('editor-space').textContent).toBe('space-abc')
+    await waitFor(() => expect(screen.getByText('docs.error.permission.notFound')).toBeTruthy())
+    expect(screen.queryByTestId('editor-shell')).toBeNull()
   })
 
-  it('seeds the empty live currentSpaceId from the cached value at standalone mount (defense in depth)', async () => {
-    // The primary fix is the explicit header, but the page also restores wk.shared.currentSpaceId
-    // from the cached key when empty, so any in-shell-shared logic the EditorShell touches sees it.
-    window.localStorage.setItem('currentSpaceId', 'space-abc')
-    wk.apiClient.responder = (method, url) => {
-      if (method === 'get' && url === '/docs/d_ok') {
-        return { data: { docId: 'd_ok', title: 'Shared Doc', ownerId: 'u_owner' }, status: 200 }
-      }
-      return { data: {}, status: 200 }
-    }
-
-    render(<StandaloneDocPage docId="d_ok" />)
-
-    await waitFor(() => expect(screen.getByTestId('editor-shell')).toBeTruthy())
-    expect(wk.shared.currentSpaceId).toBe('space-abc')
-  })
-
-  it('never overwrites a real live currentSpaceId with the cached value', async () => {
-    // In-shell (or any mount where the live space is already set) must be unaffected: the guarded
-    // restore only fills an EMPTY space, so a real current space is preserved and the preflight
-    // header/room follow the live space, not the stale cached one.
+  it('sends the open-context preflight with NO X-Space-Id — docId is the sole locator (design §4/§8.3)', async () => {
+    // Phase-1: a wrong/stale `?sp` on an old link must never steer resolution, so the preflight
+    // carries no space header at all. The backend resolves the doc from the docId path alone.
+    window.history.pushState({}, '', '/d/d_ok?sp=space-wrong')
     window.localStorage.setItem('currentSpaceId', 'space-cached')
-    wk.shared.currentSpaceId = 'space-live'
     wk.apiClient.responder = (method, url) => {
-      if (method === 'get' && url === '/docs/d_ok') {
-        return { data: { docId: 'd_ok', title: 'Shared Doc', ownerId: 'u_owner' }, status: 200 }
+      if (method === 'get' && url === '/docs/d_ok/open-context') {
+        return { data: { docId: 'd_ok', homeSpaceId: 's_home', documentName: 'octo:s_home:f_default:d_ok', title: 'Shared Doc' }, status: 200 }
       }
       return { data: {}, status: 200 }
     }
@@ -655,155 +632,192 @@ describe('StandaloneDocPage — cold-start preflight carries X-Space-Id from the
     render(<StandaloneDocPage docId="d_ok" />)
 
     await waitFor(() => expect(screen.getByTestId('editor-shell')).toBeTruthy())
-    expect(wk.shared.currentSpaceId).toBe('space-live')
-    const preflight = wk.apiClient.calls.find((c) => c.method === 'get' && c.url === '/docs/d_ok')
-    expect(preflight!.config?.headers?.['X-Space-Id']).toBe('space-live')
-    expect(screen.getByTestId('editor-space').textContent).toBe('space-live')
+    const preflight = wk.apiClient.calls.find(
+      (c) => c.method === 'get' && c.url === '/docs/d_ok/open-context',
+    )
+    expect(preflight).toBeTruthy()
+    expect(preflight!.config?.headers?.['X-Space-Id']).toBeUndefined()
+  })
+
+  it('never mutates the global currentSpaceId — opening an external /d/:docId cannot pollute the shell Space (design §5.2)', async () => {
+    // The old flow seeded the doc's link space into wk.shared.currentSpaceId; Phase-1 removed that.
+    // A cold deep link (empty live space) must leave currentSpaceId untouched so the shell's
+    // Sidebar / list / search / recent stay on the viewer's own Space.
+    window.history.pushState({}, '', '/d/d_ok?sp=space-doc')
+    expect(wk.shared.currentSpaceId).toBeFalsy()
+    wk.apiClient.responder = (method, url) => {
+      if (method === 'get' && url === '/docs/d_ok/open-context') {
+        return { data: { docId: 'd_ok', homeSpaceId: 's_home', documentName: 'octo:s_home:f_default:d_ok', title: 'Shared Doc' }, status: 200 }
+      }
+      return { data: {}, status: 200 }
+    }
+
+    const { unmount } = render(<StandaloneDocPage docId="d_ok" />)
+    await waitFor(() => expect(screen.getByTestId('editor-shell')).toBeTruthy())
+    // The doc's home space addressed the editor locally, but the global current space was never set.
+    expect(wk.shared.currentSpaceId).toBeFalsy()
+    unmount()
+    expect(wk.shared.currentSpaceId).toBeFalsy()
   })
 })
 
-describe('XIN-501 — preflight addresses the doc space from the link ?sp, never the token-bucket ?sid', () => {
-  it('standaloneLinkSpace reads the dedicated ?sp param (the doc space), NOT ?sid (the token bucket)', () => {
-    // ?sp carries the doc's real space_id; ?sid is only the token-bucket key. They are distinct, and
-    // the preflight space must come from ?sp — feeding ?sid was the XIN-497 regression.
-    window.history.pushState({}, '', '/d/d_x?sid=2b60d3&sp=105d4a60d0fc4d55a5cfc3c2d0501361')
-    expect(standaloneLinkSpace()).toBe('105d4a60d0fc4d55a5cfc3c2d0501361')
-    // Trimmed.
-    window.history.pushState({}, '', '/d/d_x?sp=%20space-doc%20')
-    expect(standaloneLinkSpace()).toBe('space-doc')
-    // A link with only the token-bucket ?sid (no ?sp) must NOT be treated as a space → empty, so
-    // callers fall back to currentSpaceId/cached/default.
-    window.history.pushState({}, '', '/d/d_x?sid=2b60d3')
-    expect(standaloneLinkSpace()).toBe('')
-    // No query at all → empty.
-    window.history.pushState({}, '', '/d/d_x')
-    expect(standaloneLinkSpace()).toBe('')
+describe('stripSpFromUrl — legacy `?sp` cleanup preserves every other param (design §8.4)', () => {
+  it('removes ONLY sp, keeping sid / other query / hash intact', () => {
+    window.history.pushState({}, '', '/d/d_ok?sid=abc&sp=space-old&foo=bar#sec2')
+    stripSpFromUrl()
+    const url = new URL(window.location.href)
+    expect(url.searchParams.has('sp')).toBe(false)
+    // sid, arbitrary other query, and the hash all survive — each has its own lifecycle (§8.4).
+    expect(url.searchParams.get('sid')).toBe('abc')
+    expect(url.searchParams.get('foo')).toBe('bar')
+    expect(url.hash).toBe('#sec2')
+    // The path is untouched.
+    expect(url.pathname).toBe('/d/d_ok')
   })
 
-  it('own doc (boss regression): preflight addresses the doc space from ?sp → 200, editor mounts', async () => {
-    // Scenario B (severest boss repro): the owner opens their OWN doc via a `/d/:docId` link. The
-    // link carries the doc's real space as ?sp and the short token key as ?sid. The preflight MUST
-    // send X-Space-Id = the ?sp value; sending the ?sid (as XIN-497 did) trips requireDocRole's
-    // cross-space 404 gate and 404s the owner's own doc.
-    window.history.pushState({}, '', '/d/d_own?sid=2b60d3&sp=105d4a60d0fc4d55a5cfc3c2d0501361')
+  it('is a no-op when there is no sp (the common new-link case) — URL unchanged', () => {
+    window.history.pushState({}, '', '/d/d_ok?sid=abc#sec2')
+    const before = window.location.href
+    stripSpFromUrl()
+    expect(window.location.href).toBe(before)
+  })
+
+  it('removes a repeated sp entirely while preserving order of the rest', () => {
+    window.history.pushState({}, '', '/d/d_ok?sp=a&keep=1&sp=b')
+    stripSpFromUrl()
+    const url = new URL(window.location.href)
+    expect(url.searchParams.has('sp')).toBe(false)
+    expect(url.searchParams.get('keep')).toBe('1')
+  })
+
+  it('preserves untouched query bytes, duplicates, blanks, separators, and hash exactly', () => {
+    window.history.pushState({}, '', '/d/d_ok?a=%2f&sp=x&a=%2F&&blank=&sp=y#h%20x')
+    stripSpFromUrl()
+    expect(window.location.pathname + window.location.search + window.location.hash)
+      .toBe('/d/d_ok?a=%2f&a=%2F&&blank=#h%20x')
+  })
+
+  it('removes bare and percent-encoded sp keys without re-encoding other params', () => {
+    window.history.pushState({}, '', '/d/d_ok?sp&keep=hello+world&%73p=old&x=%7e')
+    stripSpFromUrl()
+    expect(window.location.search).toBe('?keep=hello+world&x=%7e')
+  })
+})
+
+describe('StandaloneDocPage — legacy `?sp` link: wrong/correct/missing sp all resolve identically (design §8.2/§8.3)', () => {
+  // Same user, same docId. A legacy link may carry a correct `?sp`, a wrong `?sp`, or none at all.
+  // open-context locates the doc by docId ALONE, so all three must issue the identical request (no
+  // X-Space-Id, same URL) and reach the identical ready state; after opening, `sp` is stripped from
+  // the address bar while everything else is preserved.
+  const okContext = {
+    docId: 'd_ok',
+    homeSpaceId: 's_home',
+    documentName: 'octo:s_home:f_default:d_ok',
+    title: 'Shared Doc',
+  }
+
+  async function openWith(search: string) {
+    window.history.pushState({}, '', `/d/d_ok${search}`)
     wk.apiClient.responder = (method, url) => {
-      if (method === 'get' && url === '/docs/d_own') {
+      if (method === 'get' && url === '/docs/d_ok/open-context') return { data: okContext, status: 200 }
+      return { data: {}, status: 200 }
+    }
+    render(<StandaloneDocPage docId="d_ok" />)
+    await waitFor(() => expect(screen.getByTestId('editor-shell')).toBeTruthy())
+    const preflight = wk.apiClient.calls.find(
+      (c) => c.method === 'get' && c.url === '/docs/d_ok/open-context',
+    )
+    return preflight!
+  }
+
+  it('correct sp: opens, sends no X-Space-Id, strips sp from the address bar', async () => {
+    const preflight = await openWith('?sp=s_home')
+    expect(preflight.config?.headers?.['X-Space-Id']).toBeUndefined()
+    // The editor is addressed from the authoritative homeSpaceId, not the link `sp`.
+    expect(screen.getByTestId('editor-space').textContent).toBe('s_home')
+    expect(new URL(window.location.href).searchParams.has('sp')).toBe(false)
+  })
+
+  it('wrong sp: still opens the same doc, sp cannot steer resolution, and is stripped', async () => {
+    const preflight = await openWith('?sp=s_totally_wrong')
+    expect(preflight.config?.headers?.['X-Space-Id']).toBeUndefined()
+    // Wrong link space never leaks into addressing — the backend's homeSpaceId wins.
+    expect(screen.getByTestId('editor-space').textContent).toBe('s_home')
+    expect(new URL(window.location.href).searchParams.has('sp')).toBe(false)
+  })
+
+  it('missing sp (canonical new link): opens identically with no cleanup needed', async () => {
+    const preflight = await openWith('')
+    expect(preflight.config?.headers?.['X-Space-Id']).toBeUndefined()
+    expect(screen.getByTestId('editor-space').textContent).toBe('s_home')
+    expect(window.location.search).toBe('')
+  })
+
+  it('legacy sp alongside sid: opens, strips sp, and PRESERVES sid for session recovery', async () => {
+    await openWith('?sid=keepme&sp=s_wrong')
+    const url = new URL(window.location.href)
+    expect(url.searchParams.has('sp')).toBe(false)
+    expect(url.searchParams.get('sid')).toBe('keepme')
+  })
+})
+
+describe('StandaloneDocPage — a docType:sheet open-context mounts the collaborative SheetView', () => {
+  it('opens the spreadsheet surface addressed from the canonical documentName', async () => {
+    wk.apiClient.responder = (method, url) => {
+      if (method === 'get' && url === '/docs/d_sheet/open-context') {
         return {
-          data: { docId: 'd_own', title: 'My Doc', ownerId: 'u_self', role: 'admin' },
+          data: {
+            docId: 'd_sheet',
+            homeSpaceId: 's_auth',
+            title: 'Shared Sheet',
+            docType: 'sheet',
+            documentName: 'octo:s_auth:f_team:d_sheet',
+          },
           status: 200,
         }
       }
       return { data: {}, status: 200 }
     }
 
-    render(<StandaloneDocPage docId="d_own" />)
+    render(<StandaloneDocPage docId="d_sheet" />)
 
-    await waitFor(() => expect(screen.getByTestId('editor-shell')).toBeTruthy())
-    const preflight = wk.apiClient.calls.find((c) => c.method === 'get' && c.url === '/docs/d_own')
-    expect(preflight!.config?.headers?.['X-Space-Id']).toBe('105d4a60d0fc4d55a5cfc3c2d0501361')
-    // Never the token-bucket sid.
-    expect(preflight!.config?.headers?.['X-Space-Id']).not.toBe('2b60d3')
-  })
-
-  it('a no-permission recipient whose OWN space differs from the doc: preflight uses ?sp so the backend returns 403 (forbidden + request-access), not a cross-space 404', async () => {
-    // Scenario A: logged in, no permission on THIS doc, recipient's own last space (cached
-    // currentSpaceId) is a DIFFERENT space. The preflight must address the doc's space from ?sp so
-    // the backend evaluates the caller's role in the doc's space and returns 403 — reaching the
-    // request-access entry — instead of the cross-space 404 dead-end.
-    window.history.pushState({}, '', '/d/d_shared?sid=2b60d3&sp=space-doc')
-    window.localStorage.setItem('currentSpaceId', 'space-mine') // recipient's own last space, NOT the doc's
-
-    wk.apiClient.responder = (method, url) => {
-      // Real backend: same-space + no role → 403 forbidden; a mismatched space would be 404.
-      if (method === 'get' && url === '/docs/d_shared') throw apiError(403)
-      return { data: {}, status: 200 }
-    }
-
-    render(<StandaloneDocPage docId="d_shared" />)
-
-    await waitFor(() =>
-      expect(screen.getByText('docs.error.permission.forbidden')).toBeTruthy(),
-    )
-    // The preflight addressed the doc's space (from ?sp), NOT the recipient's own cached space.
-    const preflight = wk.apiClient.calls.find((c) => c.method === 'get' && c.url === '/docs/d_shared')
-    expect(preflight!.config?.headers?.['X-Space-Id']).toBe('space-doc')
-    expect(preflight!.config?.headers?.['X-Space-Id']).not.toBe('space-mine')
-    // gap2 request-access entry is reached (the whole point of the fix).
-    expect(screen.getByText('docs.forward.requestAccess')).toBeTruthy()
+    await waitFor(() => expect(screen.getByTestId('sheet-view')).toBeTruthy())
+    expect(screen.getByTestId('sheet-doc').textContent).toBe('d_sheet')
+    // Space/folder come from the authoritative documentName the backend authorized.
+    expect(screen.getByTestId('sheet-space').textContent).toBe('s_auth')
+    expect(screen.getByTestId('sheet-folder').textContent).toBe('f_team')
     expect(screen.queryByTestId('editor-shell')).toBeNull()
   })
+})
 
-  it('a genuinely deleted doc still lands on not-found even with a valid ?sp', async () => {
-    // With the correct space, a 404 now means the doc is truly gone (status 0), not a cross-space
-    // artifact — so not-found is the correct terminal.
-    window.history.pushState({}, '', '/d/d_gone?sid=2b60d3&sp=space-doc')
+describe('StandaloneDocPage — non-Yjs HTML surfaces', () => {
+  it.each([
+    ['html', 'html-view'],
+    ['html_ppt', 'ppt-view'],
+  ])('opens standalone %s from canonical addressing without mounting Yjs surfaces', async (docType, testId) => {
     wk.apiClient.responder = (method, url) => {
-      if (method === 'get' && url === '/docs/d_gone') throw apiError(404)
-      return { data: {}, status: 200 }
-    }
-
-    render(<StandaloneDocPage docId="d_gone" />)
-
-    await waitFor(() => expect(screen.getByText('docs.error.permission.notFound')).toBeTruthy())
-    expect(screen.queryByTestId('editor-shell')).toBeNull()
-  })
-
-  it('an older link with only ?sid (no ?sp) falls back to the cached currentSpaceId, so the owner opening their own doc still works', async () => {
-    // Backward compatibility: links minted before XIN-501 carry only the token-bucket ?sid. The
-    // preflight must NOT send that sid as the space; it falls back to the cached currentSpaceId,
-    // which is the doc's space whenever the opener is already in it (owner / same-space recipient).
-    window.history.pushState({}, '', '/d/d_legacy?sid=2b60d3')
-    window.localStorage.setItem('currentSpaceId', 'space-doc') // opener is in the doc's space
-    wk.apiClient.responder = (method, url) => {
-      if (method === 'get' && url === '/docs/d_legacy') {
-        return { data: { docId: 'd_legacy', title: 'Legacy', ownerId: 'u_self' }, status: 200 }
+      if (method === 'get' && url === `/docs/d_${docType}/open-context`) {
+        return {
+          data: {
+            docId: `d_${docType}`,
+            homeSpaceId: 's_home',
+            documentName: `octo:s_home:f_default:${docType === 'html' ? 'html' : 'ppt'}:d_${docType}`,
+            docType,
+            octoDocSlug: `slug-${docType}`,
+          },
+          status: 200,
+        }
       }
       return { data: {}, status: 200 }
     }
 
-    render(<StandaloneDocPage docId="d_legacy" />)
+    render(<StandaloneDocPage docId={`d_${docType}`} />)
 
-    await waitFor(() => expect(screen.getByTestId('editor-shell')).toBeTruthy())
-    const preflight = wk.apiClient.calls.find((c) => c.method === 'get' && c.url === '/docs/d_legacy')
-    // The cached space is used — never the token-bucket sid.
-    expect(preflight!.config?.headers?.['X-Space-Id']).toBe('space-doc')
-    expect(preflight!.config?.headers?.['X-Space-Id']).not.toBe('2b60d3')
-  })
-
-  it('a real expired/invalid token still 401s → login handoff, unaffected by the space (AC-4)', async () => {
-    // The space only steers requireDocRole's cross-space (404) vs role (403) branches; the auth
-    // middleware returns 401 for a bad token regardless of X-Space-Id. So a genuine stale token still
-    // hands off to onSessionExpired (login re-auth) — the space fix does not swallow real 401s.
-    window.history.pushState({}, '', '/d/d_expired?sid=2b60d3&sp=space-doc')
-    const onSessionExpired = vi.fn()
-    wk.apiClient.responder = (method, url) => {
-      if (method === 'get' && url === '/docs/d_expired') throw apiError(401)
-      return { data: {}, status: 200 }
-    }
-
-    render(<StandaloneDocPage docId="d_expired" onSessionExpired={onSessionExpired} />)
-
-    await waitFor(() => expect(onSessionExpired).toHaveBeenCalledTimes(1))
-    expect(screen.queryByText('docs.error.permission.forbidden')).toBeNull()
+    await waitFor(() => expect(screen.getByTestId(testId)).toBeTruthy())
     expect(screen.queryByTestId('editor-shell')).toBeNull()
-  })
-
-  it('seeds the empty live currentSpaceId from the link ?sp so follow-up requests match the preflight', async () => {
-    window.history.pushState({}, '', '/d/d_ok?sid=2b60d3&sp=space-doc')
-    window.localStorage.setItem('currentSpaceId', 'space-mine') // recipient's own; must NOT win over ?sp
-    wk.apiClient.responder = (method, url) => {
-      if (method === 'get' && url === '/docs/d_ok') {
-        return { data: { docId: 'd_ok', title: 'Shared Doc', ownerId: 'u_owner' }, status: 200 }
-      }
-      return { data: {}, status: 200 }
-    }
-
-    render(<StandaloneDocPage docId="d_ok" />)
-
-    await waitFor(() => expect(screen.getByTestId('editor-shell')).toBeTruthy())
-    expect(wk.shared.currentSpaceId).toBe('space-doc')
-    const preflight = wk.apiClient.calls.find((c) => c.method === 'get' && c.url === '/docs/d_ok')
-    expect(preflight!.config?.headers?.['X-Space-Id']).toBe('space-doc')
+    expect(screen.queryByTestId('sheet-view')).toBeNull()
+    expect(screen.queryByTestId('board-session')).toBeNull()
+    expect(wk.apiClient.calls.some((c) => c.url.includes('collab-token'))).toBe(false)
   })
 })
 
@@ -868,10 +882,10 @@ describe('resolveSameOriginPath — PPT editorUrl normalise (P2-1)', () => {
 
 describe('standalone return target — open-redirect-safe post-login bounce (blocker 4)', () => {
   it('round-trips a safe same-origin /d/:docId target through persist → consume', () => {
-    window.history.pushState({}, '', '/d/d_abc?sid=xyz')
+    window.history.pushState({}, '', '/d/d_abc?sid=xyz#comment-1')
     persistStandaloneReturn()
-    expect(window.sessionStorage.getItem(STANDALONE_RETURN_KEY)).toBe('/d/d_abc?sid=xyz')
-    expect(consumeStandaloneReturn()).toBe('/d/d_abc?sid=xyz')
+    expect(window.sessionStorage.getItem(STANDALONE_RETURN_KEY)).toBe('/d/d_abc?sid=xyz#comment-1')
+    expect(consumeStandaloneReturn()).toBe('/d/d_abc?sid=xyz#comment-1')
     // Consumed once — the key is cleared so a later unrelated login can't inherit a stale target.
     expect(window.sessionStorage.getItem(STANDALONE_RETURN_KEY)).toBeNull()
     expect(consumeStandaloneReturn()).toBeNull()
@@ -926,7 +940,7 @@ describe('standalone return target — open-redirect-safe post-login bounce (blo
   it('AC-11 anonymous entry: the sign-in terminal stashes a safe, consumable return target', async () => {
     window.history.pushState({}, '', '/d/d_locked_out')
     wk.apiClient.responder = (method, url) => {
-      if (method === 'get' && url === '/docs/d_locked_out') throw { response: { status: 401 } }
+      if (method === 'get' && url === '/docs/d_locked_out/open-context') throw { response: { status: 401 } }
       return { data: {}, status: 200 }
     }
 
@@ -988,8 +1002,8 @@ describe('withReturnSid — carry the current session sid on the post-login /d/:
 describe('StandaloneDocPage — creator name is nickname-only on the shared surface (blocker 5)', () => {
   it('tells the EditorShell to resolve the creator from the nickname, never the verified real name', async () => {
     wk.apiClient.responder = (method, url) => {
-      if (method === 'get' && url === '/docs/d_ok') {
-        return { data: { docId: 'd_ok', title: 'Shared Doc', ownerId: 'u_owner' }, status: 200 }
+      if (method === 'get' && url === '/docs/d_ok/open-context') {
+        return { data: { docId: 'd_ok', homeSpaceId: 's_home', documentName: 'octo:s_home:f_default:d_ok', title: 'Shared Doc', ownerId: 'u_owner' }, status: 200 }
       }
       return { data: {}, status: 200 }
     }
@@ -1004,19 +1018,20 @@ describe('StandaloneDocPage — creator name is nickname-only on the shared surf
 })
 
 describe('StandaloneDocPage — records a view so share-link opens surface in 最近查看 (XIN-1238)', () => {
-  it('fires POST /docs/:id/view once the doc is ready, written to the VIEWER current space, not the doc link space', async () => {
+  it('fires POST /docs/:id/view once the doc is ready, written to the VIEWER current space, not the doc home space', async () => {
     // XIN-1234 root cause: the standalone page never recorded a view, so a doc opened from a chat
     // share link never appeared in the opener's 最近查看. XIN-1237 write/read space contract: the
     // view must be written under the VIEWER's current space (X-Space-Id), which 最近查看 reads back
-    // by — NOT the doc's own space the standalone page seeds for preflight addressing.
-    // Cross-space share: the link carries the doc space `?sp=space-doc`, but the viewer is currently
-    // in space-viewer (their cached/live current space).
+    // by — NOT the doc's own home space. Phase-1 no longer seeds the doc space into currentSpaceId
+    // (design §5.2), so the viewer space stays the shell's own throughout.
+    // Cross-space: a legacy link may still carry `?sp=space-doc` (now ignored), but the viewer is
+    // currently in space-viewer (their cached/live current space).
     window.history.pushState({}, '', '/d/d_ok?sp=space-doc')
     window.localStorage.setItem('currentSpaceId', 'space-viewer')
 
     wk.apiClient.responder = (method, url) => {
-      if (method === 'get' && url === '/docs/d_ok') {
-        return { data: { docId: 'd_ok', title: 'Shared Doc', ownerId: 'u_owner' }, status: 200 }
+      if (method === 'get' && url === '/docs/d_ok/open-context') {
+        return { data: { docId: 'd_ok', homeSpaceId: 's_home', documentName: 'octo:s_home:f_default:d_ok', title: 'Shared Doc' }, status: 200 }
       }
       return { data: {}, status: 200 }
     }
@@ -1028,10 +1043,10 @@ describe('StandaloneDocPage — records a view so share-link opens surface in �
       expect(wk.apiClient.calls.some((c) => c.method === 'post' && c.url === '/docs/d_ok/view')).toBe(true),
     )
     const view = wk.apiClient.calls.find((c) => c.method === 'post' && c.url === '/docs/d_ok/view')
-    // The preflight is addressed to the doc's own space (link `?sp`), but the view ingest must go to
-    // the viewer's current space so it surfaces in the viewer's recent list.
-    const preflight = wk.apiClient.calls.find((c) => c.method === 'get' && c.url === '/docs/d_ok')
-    expect(preflight!.config?.headers?.['X-Space-Id']).toBe('space-doc')
+    // The open-context preflight sends NO space header (docId is the sole locator, design §8.3); the
+    // view ingest goes to the viewer's OWN current space so it surfaces in the viewer's recent list.
+    const preflight = wk.apiClient.calls.find((c) => c.method === 'get' && c.url === '/docs/d_ok/open-context')
+    expect(preflight!.config?.headers?.['X-Space-Id']).toBeUndefined()
     expect(view!.config?.headers?.['X-Space-Id']).toBe('space-viewer')
   })
 
@@ -1044,8 +1059,8 @@ describe('StandaloneDocPage — records a view so share-link opens surface in �
     window.localStorage.setItem('currentSpaceId', 'space-team')
 
     wk.apiClient.responder = (method, url) => {
-      if (method === 'get' && url === '/docs/d_ok') {
-        return { data: { docId: 'd_ok', title: 'Team Doc', ownerId: 'u_owner' }, status: 200 }
+      if (method === 'get' && url === '/docs/d_ok/open-context') {
+        return { data: { docId: 'd_ok', homeSpaceId: 's_home', documentName: 'octo:s_home:f_default:d_ok', title: 'Team Doc', ownerId: 'u_owner' }, status: 200 }
       }
       return { data: {}, status: 200 }
     }
@@ -1067,8 +1082,8 @@ describe('StandaloneDocPage — records a view so share-link opens surface in �
     // the global interceptor decide, exactly as the in-shell entry does.
     window.history.pushState({}, '', '/d/d_ok?sp=space-doc')
     wk.apiClient.responder = (method, url) => {
-      if (method === 'get' && url === '/docs/d_ok') {
-        return { data: { docId: 'd_ok', title: 'Shared Doc', ownerId: 'u_owner' }, status: 200 }
+      if (method === 'get' && url === '/docs/d_ok/open-context') {
+        return { data: { docId: 'd_ok', homeSpaceId: 's_home', documentName: 'octo:s_home:f_default:d_ok', title: 'Shared Doc', ownerId: 'u_owner' }, status: 200 }
       }
       return { data: {}, status: 200 }
     }
@@ -1087,8 +1102,8 @@ describe('StandaloneDocPage — records a view so share-link opens surface in �
   it('uses the live current space as the viewer space when the shell already restored it (in-shell mount)', async () => {
     wk.shared.currentSpaceId = 'space-live'
     wk.apiClient.responder = (method, url) => {
-      if (method === 'get' && url === '/docs/d_ok') {
-        return { data: { docId: 'd_ok', title: 'Shared Doc', ownerId: 'u_owner' }, status: 200 }
+      if (method === 'get' && url === '/docs/d_ok/open-context') {
+        return { data: { docId: 'd_ok', homeSpaceId: 's_home', documentName: 'octo:s_home:f_default:d_ok', title: 'Shared Doc', ownerId: 'u_owner' }, status: 200 }
       }
       return { data: {}, status: 200 }
     }
@@ -1106,8 +1121,8 @@ describe('StandaloneDocPage — records a view so share-link opens surface in �
   it('records the view at most once (idempotent — never in a render loop)', async () => {
     window.localStorage.setItem('currentSpaceId', 'space-viewer')
     wk.apiClient.responder = (method, url) => {
-      if (method === 'get' && url === '/docs/d_ok') {
-        return { data: { docId: 'd_ok', title: 'Shared Doc', ownerId: 'u_owner' }, status: 200 }
+      if (method === 'get' && url === '/docs/d_ok/open-context') {
+        return { data: { docId: 'd_ok', homeSpaceId: 's_home', documentName: 'octo:s_home:f_default:d_ok', title: 'Shared Doc', ownerId: 'u_owner' }, status: 200 }
       }
       return { data: {}, status: 200 }
     }
@@ -1125,7 +1140,7 @@ describe('StandaloneDocPage — records a view so share-link opens surface in �
 
   it('does NOT record a view when the preflight fails to a terminal (forbidden / not-found)', async () => {
     wk.apiClient.responder = (method, url) => {
-      if (method === 'get' && url === '/docs/d_forbidden') {
+      if (method === 'get' && url === '/docs/d_forbidden/open-context') {
         return Promise.reject(apiError(403))
       }
       return { data: {}, status: 200 }
@@ -1134,58 +1149,8 @@ describe('StandaloneDocPage — records a view so share-link opens surface in �
     render(<StandaloneDocPage docId="d_forbidden" />)
 
     await waitFor(() =>
-      expect(wk.apiClient.calls.some((c) => c.method === 'get' && c.url === '/docs/d_forbidden')).toBe(true),
+      expect(wk.apiClient.calls.some((c) => c.method === 'get' && c.url === '/docs/d_forbidden/open-context')).toBe(true),
     )
     expect(wk.apiClient.calls.some((c) => c.url === '/docs/d_forbidden/view')).toBe(false)
-  })
-})
-
-describe('StandaloneDocPage — restores the viewer current space on teardown so 最近查看 is not left scoped to the doc space (XIN-1254)', () => {
-  it('reverts the doc-link space it seeded back to the viewer current space when the page unmounts', async () => {
-    // Cross-space share (老板 real-device repro): the viewer (大棍子) is in space-viewer; the link
-    // carries the DOC owner's (大背头) space `?sp=space-doc`. On this cold deep link
-    // wk.shared.currentSpaceId is empty, so the seed effect overwrites it with space-doc for the
-    // interceptor to address the editor's cross-space collab requests. Left in place, returning to
-    // the docs list scopes 最近查看's read (derived from the live currentSpaceId via the interceptor)
-    // to space-doc — but the view was recorded under space-viewer (viewerSpaceRef), so it stays
-    // invisible: the XIN-1234 write/read space split reintroduced by the seed.
-    window.history.pushState({}, '', '/d/d_ok?sp=space-doc')
-    window.localStorage.setItem('currentSpaceId', 'space-viewer')
-    wk.apiClient.responder = (method, url) => {
-      if (method === 'get' && url === '/docs/d_ok') {
-        return { data: { docId: 'd_ok', title: 'Shared Doc', ownerId: 'u_owner' }, status: 200 }
-      }
-      return { data: {}, status: 200 }
-    }
-
-    const { unmount } = render(<StandaloneDocPage docId="d_ok" />)
-    await waitFor(() => expect(screen.getByTestId('editor-shell')).toBeTruthy())
-    // Seed applied while the standalone editor is mounted (cross-space collab addressing).
-    expect(wk.shared.currentSpaceId).toBe('space-doc')
-
-    // On teardown the viewer's real space is restored, so the shell's recent-view read matches the
-    // space the view was written to (space-viewer) and the doc surfaces in 最近查看.
-    unmount()
-    expect(wk.shared.currentSpaceId).toBe('space-viewer')
-  })
-
-  it('only reverts the value it seeded — never clobbers a space the shell switched to meanwhile', async () => {
-    window.history.pushState({}, '', '/d/d_ok?sp=space-doc')
-    window.localStorage.setItem('currentSpaceId', 'space-viewer')
-    wk.apiClient.responder = (method, url) => {
-      if (method === 'get' && url === '/docs/d_ok') {
-        return { data: { docId: 'd_ok', title: 'Shared Doc', ownerId: 'u_owner' }, status: 200 }
-      }
-      return { data: {}, status: 200 }
-    }
-
-    const { unmount } = render(<StandaloneDocPage docId="d_ok" />)
-    await waitFor(() => expect(screen.getByTestId('editor-shell')).toBeTruthy())
-    expect(wk.shared.currentSpaceId).toBe('space-doc')
-
-    // A genuine space switch happened while the page was open; the teardown restore must be a no-op.
-    wk.shared.currentSpaceId = 'space-switched'
-    unmount()
-    expect(wk.shared.currentSpaceId).toBe('space-switched')
   })
 })

--- a/packages/docs/src/pages/StandaloneDocPage.tsx
+++ b/packages/docs/src/pages/StandaloneDocPage.tsx
@@ -10,7 +10,7 @@ import { DocTerminal, type TerminalKind } from '../editor/DocTerminal.tsx'
 import { RequestAccessButton } from '../access-request/RequestAccessButton.tsx'
 import { LinkIcon, type DocMoreMenuItem } from '../editor/DocMoreMenu.tsx'
 import { terminalForCreateError } from '../collab/useCollabEditor.ts'
-import { getDoc, recordDocView, type DocMeta } from './docsApi.ts'
+import { getOpenContext, recordDocView, type DocRequestContext } from './docsApi.ts'
 import { parseDocumentName } from '../documentName/index.ts'
 import { DEFAULT_DOC_SPACE, DEFAULT_DOC_FOLDER } from '../config.ts'
 import { useMemberNames } from '../members/useMemberNames.ts'
@@ -62,11 +62,42 @@ export function persistStandaloneReturn(): void {
   try {
     window.sessionStorage.setItem(
       STANDALONE_RETURN_KEY,
-      window.location.pathname + window.location.search,
+      window.location.pathname + window.location.search + window.location.hash,
     )
   } catch {
     // sessionStorage unavailable (private mode / disabled): the deep-link still works on a fresh
     // open; we just can't auto-return after login.
+  }
+}
+
+/**
+ * Old-link compatibility cleanup (octo-web #1317). A legacy link is
+ * `/d/:docId?sp=:spaceId`; the new reader locates the doc by `docId` alone and IGNORES `sp` as an
+ * authoritative input, so once the doc has opened successfully we strip ONLY the
+ * `sp` param from the address bar and PRESERVE everything else — `sid`, the login-return params,
+ * any other query, and the hash — each of which has its own lifecycle and must not be swept away by
+ * this step. Uses history.replaceState so the cleanup does not create a back-stack
+ * entry. No-op when there is no `sp` (the common new-link case) or under SSR / a malformed URL.
+ */
+export function stripSpFromUrl(): void {
+  if (typeof window === 'undefined') return
+  try {
+    const { pathname, search, hash } = window.location
+    if (!search) return
+    const parts = search.slice(1).split('&')
+    const kept = parts.filter((part) => {
+      const rawKey = part.slice(0, part.indexOf('=') < 0 ? undefined : part.indexOf('='))
+      try {
+        return decodeURIComponent(rawKey.replace(/\+/g, ' ')) !== 'sp'
+      } catch {
+        return rawKey !== 'sp'
+      }
+    })
+    if (kept.length === parts.length) return
+    window.history.replaceState(null, '', pathname + (kept.length ? `?${kept.join('&')}` : '') + hash)
+  } catch {
+    // Malformed location / history unavailable: leave the address bar as-is (harmless — `sp` is
+    // ignored for resolution regardless of whether it lingers in the URL).
   }
 }
 
@@ -217,7 +248,7 @@ export function withReturnSid(target: string, sid: string | null | undefined): s
     const url = new URL(target, window.location.origin)
     if (url.searchParams.has('sid')) return target
     url.searchParams.set('sid', sid)
-    const rebuilt = url.pathname + url.search
+    const rebuilt = url.pathname + url.search + url.hash
     return isSafeReturnPath(rebuilt) ? rebuilt : target
   } catch {
     return target
@@ -249,43 +280,18 @@ function LockIcon(): ReactElement {
 }
 
 /**
- * Resolve the fallback space for the standalone editor when the preflight carries no
- * documentName to address from.
- *
- * The standalone page mounts via the host Layout's EARLY RETURN — before the app-shell logic that
- * restores `currentSpaceId` from localStorage runs (Layout's Provider branch / Main's space
- * bootstrap are both skipped). So on a cold-start cross-space deep link, `wk.shared.currentSpaceId`
- * is still empty and falling straight to DEFAULT_DOC_SPACE would mount the EditorShell against the
- * wrong room (`octo:<DEFAULT_DOC_SPACE>:f_default:docId`) → not-found / wrong document. Read the
- * cached `currentSpaceId` localStorage key (the same key the shell persists) as the middle
- * fallback so the shared link addresses the user's real last space, not the deploy default.
- */
-export function standaloneFallbackSpace(currentSpaceId: string | undefined): string {
-  if (currentSpaceId) return currentSpaceId
-  if (typeof window !== 'undefined') {
-    try {
-      const cached = window.localStorage.getItem('currentSpaceId')
-      if (cached) return cached
-    } catch {
-      // localStorage unavailable (private mode / disabled): fall back to the deploy default below.
-    }
-  }
-  return DEFAULT_DOC_SPACE
-}
-
-/**
  * The VIEWER's real current space, resolved from a genuine viewer signal ONLY: the live
  * `currentSpaceId`, else the cached `currentSpaceId` localStorage key the shell persists. Returns
- * '' when neither exists — deliberately WITHOUT standaloneFallbackSpace's DEFAULT_DOC_SPACE tail.
+ * '' when neither exists — deliberately WITHOUT a DEFAULT_DOC_SPACE tail.
  *
  * This is the space recordDocView writes the "最近查看" ingest into (XIN-1237 write/read contract):
  * the backend writes and reads the recent list by X-Space-Id = the viewer's current space, so the
- * view MUST be recorded under the viewer's space, NOT the doc's link space (`?sp=`). Where the doc
- * space is used (preflight/room addressing) the deploy default is a safe last resort, but for the
- * view record it is NOT: recording into DEFAULT_DOC_SPACE when we cannot confirm the viewer is
- * actually there would (a) write the view into a space the viewer isn't in — breaking the
- * per-space isolation the recent list relies on — and (b) still never surface in the viewer's own
- * recent list. So when there is no real viewer signal we return '' and the caller omits the
+ * view MUST be recorded under the viewer's OWN space. Phase-1 remove-`sp` (design §5.2) no longer
+ * seeds the doc's home space into the global `currentSpaceId`, so the viewer signal here stays the
+ * shell's own throughout the page's life. Recording into DEFAULT_DOC_SPACE when we cannot confirm
+ * the viewer is actually there would (a) write the view into a space the viewer isn't in — breaking
+ * the per-space isolation the recent list relies on — and (b) still never surface in the viewer's
+ * own recent list. So when there is no real viewer signal we return '' and the caller omits the
  * explicit header, letting the global interceptor decide (exactly as the in-shell entry does),
  * rather than forcing a wrong space.
  */
@@ -302,44 +308,9 @@ export function viewerCurrentSpace(currentSpaceId: string | undefined): string {
   return ''
 }
 
-/**
- * The doc's OWN space, as carried by the standalone share link's dedicated `?sp=` query param.
- *
- * buildDocLink (forward/link.ts) embeds the shared document's REAL space id as `?sp=` — the space
- * the doc actually lives in (doc_meta.space_id, a 32-hex docs-backend id), known to the sharer at
- * forward time (the in-shell EditorShell space prop = the live currentSpaceId). It is the
- * AUTHORITATIVE space for the standalone preflight, ahead of the recipient's own live/cached
- * currentSpaceId (which, for a cross-space share, is a DIFFERENT space).
- *
- * Why a DEDICATED `?sp` and NOT the link's `?sid` (XIN-501, boss real-device evidence): `?sid` is
- * the token-bucket key (`token<sid>`, #511 problem 2) — a short octo session/space id (e.g.
- * `2b60d3`), which is NOT the docs backend space_id (e.g. `105d4a60d0fc4d55a5cfc3c2d0501361`).
- * XIN-497 fed `?sid` in as X-Space-Id; the backend gates GET /docs/:docId behind requireDocRole,
- * which checks the CROSS-SPACE guard (`meta.space_id !== req.spaceId` → 404 not_found) BEFORE the
- * role guard (role `none` → 403 forbidden). Because the sid never equals the doc's space_id, that
- * preflight returned 404 for EVERY recipient — including the owner opening their OWN doc (the boss
- * regression) — and never reached the intended 403 forbidden + request-access landing. Addressing
- * the preflight from the doc's real space (`?sp`) lets the backend evaluate the caller's role in the
- * doc's space: 200 for a member/owner, 403 for a no-permission caller (→ request-access), 404 only
- * when the doc is genuinely gone. The `token<sid>` logic is untouched — `?sid` still keys the token.
- *
- * Returns '' when the link carries no `?sp=` (older links minted before XIN-501, or under SSR);
- * callers then fall back to standaloneFallbackSpace (live currentSpaceId → cached → deploy default),
- * which still addresses the doc correctly whenever the opener is already in the doc's space (the
- * owner opening their own doc, or a same-space recipient).
- */
-export function standaloneLinkSpace(): string {
-  if (typeof window === 'undefined') return ''
-  try {
-    return (new URLSearchParams(window.location.search).get('sp') || '').trim()
-  } catch {
-    return ''
-  }
-}
-
 type Phase =
   | { status: 'loading' }
-  | { status: 'ready'; meta: DocMeta }
+  | { status: 'ready'; ctx: DocRequestContext }
   | { status: 'terminal'; kind: TerminalKind }
 
 /**
@@ -359,13 +330,18 @@ type Phase =
  * menu-external toast rendered by this page instead (reusing the docs package's document-external
  * transient-toast convention, the same fixed overlay style as the image upload status/error toasts).
  *
- * A GET /api/v1/docs/{docId} preflight runs BEFORE the collaborative editor mounts. This is the
- * single deterministic gate for every boundary state, and it needs no WebSocket:
- *   - 200          -> mount the editor.
+ * A GET /api/v1/docs/{docId}/open-context preflight runs BEFORE the collaborative editor mounts
+ * (Phase-1 remove-`sp` design §4/§5.1). It is the single deterministic gate for every boundary
+ * state, needs no WebSocket, and — crucially — locates the doc by `docId` ALONE: no `?sp`, no
+ * `X-Space-Id`, no client-supplied Space. It returns the canonical DocRequestContext (home Space +
+ * documentName + type + role), which the page uses to address the editor LOCALLY and NEVER writes
+ * into the global currentSpaceId (design §5.2, so an external link cannot pollute the shell Space):
+ *   - 200          -> mount the editor from the canonical documentName; strip a legacy `?sp` from
+ *                     the address bar, preserving everything else (design §8.4).
  *   - 403 forbidden (AC-7), 404 not-found (AC-10), 401 login (AC-11), 409 locked/archived (AC-12)
  *     -> render the matching terminal screen (a centered card; the forbidden landing adds Request
- *     access, XIN-505). 409 is the archived signal the collab-token path never reports, which is
- *     exactly why the preflight exists.
+ *     access by docId alone, no Space, design §6.1). 409 is the archived signal the collab-token
+ *     path never reports, which is exactly why the preflight exists.
  *
  * `docId` is nullable: the host Layout claims the whole `/d` namespace, so a malformed / empty id
  * (`/d/`, `/d/a:b`) arrives here as null and short-circuits to the not-found terminal instead of
@@ -395,7 +371,7 @@ export function StandaloneDocPage({
   const titleContextOwner = useRef(Symbol('standalone-doc-title-context'))
 
   useEffect(() => {
-    const primaryTitle = phase.status === 'ready' ? phase.meta.title?.trim() : ''
+    const primaryTitle = phase.status === 'ready' ? phase.ctx.title?.trim() : ''
     if (!primaryTitle) {
       titleContextStore.clear('docs', titleContextOwner.current)
       return
@@ -411,86 +387,18 @@ export function StandaloneDocPage({
     return () => titleContextStore.clear('docs', titleContextOwner.current)
   }, [locale, phase])
 
-  // Resolve the standalone space ONCE, and address BOTH the preflight's explicit X-Space-Id header
-  // and the EditorShell room fallback from it, so preflight and room can never target different
-  // spaces. Priority (XIN-501): the doc's real space carried by the share link's dedicated `?sp=`
-  // (standaloneLinkSpace — the doc_meta.space_id embedded by buildDocLink, authoritative for a
-  // `/d/:docId` deep link) → live currentSpaceId → cached localStorage → deploy default. Do NOT use
-  // the link's `?sid` here: `?sid` is the token-bucket key, a short octo session/space id, not the
-  // doc's space_id, so feeding it as X-Space-Id trips requireDocRole's cross-space 404 gate BEFORE
-  // the role check — 404'ing every recipient, including the owner opening their own doc (XIN-497
-  // regression). Older links minted without `?sp` fall through to currentSpaceId, which still
-  // addresses the doc correctly when the opener is already in the doc's space (owner / same-space).
-  const preflightSpace = standaloneLinkSpace() || standaloneFallbackSpace(wk.shared?.currentSpaceId)
-
-  // XIN-1237 write/read space contract: a view is written into the space carried by the request's
-  // X-Space-Id and "最近查看" reads back by that SAME viewer space. recordDocView must therefore be
-  // written to the VIEWER's current space, NOT the doc's own space. But the seed effect below
-  // overwrites wk.shared.currentSpaceId to the doc's link space (`?sp=`) for preflight/room
-  // addressing, so by the time the doc is ready that value no longer reflects the viewer. Capture
-  // the viewer's real current space ONCE on first render — before the seed effect runs — resolving
-  // live currentSpaceId → cached localStorage (viewerCurrentSpace). Do NOT source it from the link
-  // `?sp=` and do NOT fall through to the deploy default: an empty result means "no viewer signal",
-  // which the record path treats as "omit the explicit header", never as "write to DEFAULT space".
-  // Lazy null-init so the resolution runs exactly once and is immune to the later seed mutation.
+  // The VIEWER's own current space, resolved from a genuine viewer signal ONLY (live
+  // currentSpaceId → cached localStorage key; '' when neither). This is the space recordDocView
+  // writes "最近查看" into (XIN-1237 write/read contract). Phase-1 no longer seeds the doc's home
+  // space into the global currentSpaceId (design §5.2 — opening an external /d/:docId must not
+  // pollute the shell's Space), so this value stays the viewer's own throughout the page's life and
+  // no teardown restore is needed. Captured once via lazy null-init to keep the record path stable
+  // across re-renders; '' means "no viewer signal" → the record path omits the explicit header
+  // rather than writing to the deploy-default space (design §7.1).
   const viewerSpaceRef = useRef<string | null>(null)
   if (viewerSpaceRef.current === null) {
     viewerSpaceRef.current = viewerCurrentSpace(wk.shared?.currentSpaceId)
   }
-
-  // Genuine defense in depth (second, independent path — NOT the only working one): the standalone
-  // page mounts via the Layout early-return, before the app shell restores currentSpaceId from
-  // localStorage, so any in-shell-shared logic the EditorShell touches would see an empty space. If —
-  // and only if — the live space is empty and a cached value exists, seed it from the same cached key.
-  // Never overwrite a real current space, so in-shell mounts (where it is already set) are unaffected.
-  //
-  // Both paths now really carry the space to the backend: the preflight's EXPLICIT X-Space-Id header
-  // (primary — APIClient forwards config.headers since XIN-424, so it truly reaches the wire) AND this
-  // seeding, which repopulates currentSpaceId so the global request interceptor injects X-Space-Id on
-  // every OTHER request the shell fires. Before XIN-424 the explicit header was silently dropped by
-  // APIClient, so this seeding was in fact the ONLY thing that made same-space docs open; with the
-  // header fixed the two are now independent, mutually-reinforcing paths (explicit header wins per
-  // request; interceptor is the fallback), which is what real defense in depth means.
-  useEffect(() => {
-    const shared = wk.shared
-    if (!shared || shared.currentSpaceId) return
-    // Prefer the doc's real space carried by the share link (`?sp=`, standaloneLinkSpace) so the
-    // global interceptor injects the SAME space on the editor's follow-up requests as the preflight
-    // header used (XIN-501); fall back to the cached last space when the link carries no `?sp`.
-    // Never overwrite a real live space, so in-shell mounts (where it is already set) are unaffected.
-    const linkSpace = standaloneLinkSpace()
-    let seeded: string | undefined
-    if (linkSpace) {
-      seeded = linkSpace
-    } else if (typeof window !== 'undefined') {
-      try {
-        const cached = window.localStorage.getItem('currentSpaceId')
-        if (cached) seeded = cached
-      } catch {
-        // localStorage unavailable: the explicit preflight header (primary fix) still carries the space.
-      }
-    }
-    if (!seeded) return
-    shared.currentSpaceId = seeded
-
-    // XIN-1254 (XIN-1234 variant): the seed above overwrites the shared `currentSpaceId` — which the
-    // app shell reads as "the VIEWER's current space" — with the DOC's link space so the global
-    // interceptor addresses the standalone editor's cross-space collab requests. Left in place after
-    // the page tears down, returning to the docs list scopes "最近查看"'s read to the DOC space (the
-    // recent feed derives its space from the live currentSpaceId via the interceptor). A view we
-    // recorded under the VIEWER's real space (viewerSpaceRef) is then invisible in that read — the
-    // exact write/read space split of XIN-1234, reintroduced by this seed for a CROSS-space share
-    // (opening someone else's doc, `?sp=` ≠ the viewer's space). Restore the viewer's real space on
-    // teardown so the shell's recent-view read matches the space the view was written to. React runs
-    // an unmounted tree's effect cleanups before the newly-mounted tree's effects within the same
-    // commit, so this restore lands before DocsHome's recent-view request fires. Only revert the
-    // value WE seeded — never clobber a space the shell legitimately switched to meanwhile.
-    return () => {
-      if (shared.currentSpaceId === seeded) {
-        shared.currentSpaceId = viewerSpaceRef.current ?? ''
-      }
-    }
-  }, [wk.shared])
 
   useEffect(() => {
     let cancelled = false
@@ -502,11 +410,19 @@ export function StandaloneDocPage({
       return
     }
     setPhase({ status: 'loading' })
-    // Carry an explicit X-Space-Id on the preflight (docsApi getDoc): on a cold standalone deep link
-    // the global interceptor's space is empty, so this resolved space is the header's only source.
-    getDoc(docId, { spaceId: preflightSpace })
-      .then((meta) => {
-        if (!cancelled) setPhase({ status: 'ready', meta })
+    // Phase-1 docId-first preflight (design §4/§5.1): GET /docs/:docId/open-context. NO space input
+    // is sent — the backend resolves the doc from `docId` alone and returns the canonical
+    // DocRequestContext (home Space + documentName + type + role). A legacy link's `?sp` is neither
+    // read nor forwarded, so a wrong/stale `?sp` cannot steer resolution (design §8.3). The returned
+    // context addresses the editor LOCALLY (props below); it is never written to the global
+    // currentSpaceId (design §5.2).
+    getOpenContext(docId)
+      .then((ctx) => {
+        if (cancelled) return
+        setPhase({ status: 'ready', ctx })
+        // Old-link compatibility: the doc opened by docId, so drop only the now-vestigial `sp` from
+        // the address bar, preserving sid / login-return params / other query / hash (design §8.4).
+        stripSpFromUrl()
       })
       .catch((err: unknown) => {
         if (cancelled) return
@@ -531,13 +447,14 @@ export function StandaloneDocPage({
     return () => {
       cancelled = true
     }
-  }, [docId, onSessionExpired, preflightSpace])
+  }, [docId, onSessionExpired])
 
   // XIN-1238 / XIN-1234: the standalone `/d/:docId` page never recorded a view, so a doc opened from
   // a chat share link never surfaced in the opener's "最近查看". Mirror the in-shell entry
   // (DocsHome.commitOpen): once the doc is READY, fire a single view ingest. It is written to the
-  // VIEWER's real current space (viewerSpaceRef), per the XIN-1237 write/read space contract — NOT
-  // the doc space (`?sp=`) the page seeds for addressing. When no viewer signal was resolvable
+  // VIEWER's real current space (viewerSpaceRef), per the XIN-1237 write/read space contract — never
+  // the doc's home space. Phase-1 no longer seeds the doc space into currentSpaceId (design §5.2),
+  // so the viewer space is simply the shell's own. When no viewer signal was resolvable
   // (viewerSpaceRef === ''), omit the explicit X-Space-Id and let the global interceptor decide,
   // exactly as the in-shell entry does — never force the deploy-default space, which would record
   // the view under a space the viewer isn't in and break per-space isolation. Guarded by docId so
@@ -563,16 +480,14 @@ export function StandaloneDocPage({
   const onCopyLink = useCallback(async () => {
     if (typeof window === 'undefined') return
     try {
-      // Copy the CANONICAL share link — origin + `/d/:docId` — carrying only the doc's real space
-      // `?sp=` and NEVER the session-scoped `?sid=`. The live URL can carry `?sid=` (the sharer's
-      // own token-bucket key, added when opening a doc in a new page / returning post-login); copying
-      // window.location.href verbatim would leak the sharer's session id into the shared link. So we
-      // rebuild from the path and re-attach ONLY `?sp` (the doc's own space, XIN-501 preflight
-      // addressing), which every recipient needs and which is safe to share. The recipient's own
-      // session is recovered from storage independently of the link (XIN-513), so no `?sid` is needed.
+      // Copy the CANONICAL Phase-1 share link — origin + `/d/:docId` — with NO query at all. The
+      // link no longer carries `?sp` (the reader resolves the doc's Space server-side from docId,
+      // design §5.3), and it must never leak the sharer's session-scoped `?sid` (the live URL can
+      // carry one, added when opening a doc in a new page / returning post-login). Rebuilding from
+      // origin + pathname drops both; the recipient's own session is recovered from storage
+      // independently of the link (XIN-513).
       const here = new URL(window.location.href)
-      const sp = standaloneLinkSpace()
-      const canonical = here.origin + here.pathname + (sp ? `?sp=${encodeURIComponent(sp)}` : '')
+      const canonical = here.origin + here.pathname
       await navigator.clipboard?.writeText(canonical)
       // Drive the menu-external "Link copied" toast (below). The menu closes on selection, so this
       // confirmation must live outside the (now-unmounted) menu panel — hence page-level state, not
@@ -587,32 +502,39 @@ export function StandaloneDocPage({
   }, [])
 
   // Resolve display names for the doc's space so the presence caret shows a real name (parity
-  // with the in-shell path). Space comes from the preflight documentName when available, else the
-  // SAME resolved `preflightSpace` the preflight header used — so the room the editor joins matches
-  // the space the preflight was authorized against. Derived from `phase` so it re-resolves once the
-  // doc meta lands.
+  // with the in-shell path). Space/folder/resource id come exclusively from the open-context's
+  // canonical documentName (design §4/§5.2), which getOpenContext validates before ready. There is
+  // no home-Space/default-folder fallback. Everything here is LOCAL addressing passed as surface
+  // props; it is never written to global currentSpaceId. Derived from `phase` so it re-resolves once
+  // the context lands.
   const addressing = useMemo(() => {
-    if (phase.status === 'ready' && phase.meta.documentName) {
-      try {
-        const parsed = parseDocumentName(phase.meta.documentName)
-        if (parsed.kind === 'document') {
-          return { space: parsed.space, folder: parsed.folder, doc: parsed.doc, board: undefined }
+    if (phase.status === 'ready') {
+      const ctx = phase.ctx
+      if (ctx.documentName) {
+        try {
+          const parsed = parseDocumentName(ctx.documentName)
+          if (parsed.kind === 'document' || parsed.kind === 'html' || parsed.kind === 'ppt') {
+            return { space: parsed.space, folder: parsed.folder, doc: parsed.doc, board: undefined }
+          }
+          // A whiteboard key (octo:{space}:{folder}:wb:{board}) is authoritative for the board
+          // surface just as the document key is for the editor: honor it symmetrically. Falling
+          // through to DEFAULT_DOC_FOLDER here derived a DIFFERENT whiteboard key than the
+          // open-context authorized for any board in a non-default folder — a wrong collab token / WS
+          // room / uid-scoped cache on the cross-node/cross-user `/d/:docId` share surface (XIN-634
+          // P1-a). It only worked before because in-app boards hardcode DEFAULT_DOC_FOLDER.
+          if (parsed.kind === 'whiteboard') {
+            return { space: parsed.space, folder: parsed.folder, doc: docId ?? '', board: parsed.board }
+          }
+        } catch {
+          // Defensive only: getOpenContext rejects malformed canonical addressing before ready.
         }
-        // A whiteboard key (octo:{space}:{folder}:wb:{board}) is authoritative for the board
-        // surface just as the document key is for the editor: honor it symmetrically. Falling
-        // through to DEFAULT_DOC_FOLDER here derived a DIFFERENT whiteboard key than the REST
-        // preflight authorized for any board in a non-default folder — a wrong collab token / WS
-        // room / uid-scoped cache on the cross-node/cross-user `/d/:docId` share surface (XIN-634
-        // P1-a). It only worked before because in-app boards hardcode DEFAULT_DOC_FOLDER.
-        if (parsed.kind === 'whiteboard') {
-          return { space: parsed.space, folder: parsed.folder, doc: docId ?? '', board: parsed.board }
-        }
-      } catch {
-        // Malformed documentName from the backend: fall back to the caller's space + default folder.
       }
+      // Unreachable defense: getOpenContext parses the canonical key and verifies its doc/home
+      // Space identity before setting ready. Never guess a different room if that contract changes.
+      return { space: '', folder: '', doc: '', board: undefined }
     }
-    return { space: preflightSpace, folder: DEFAULT_DOC_FOLDER, doc: docId ?? '', board: undefined }
-  }, [phase, preflightSpace, docId])
+    return { space: DEFAULT_DOC_SPACE, folder: DEFAULT_DOC_FOLDER, doc: docId ?? '', board: undefined }
+  }, [phase, docId])
 
   const names = useMemberNames(addressing.space)
 
@@ -637,6 +559,7 @@ export function StandaloneDocPage({
       // title — the reason line, and the reused RequestAccessButton whose action is the centered
       // primary CTA. docId is guaranteed non-null here: a null id short-circuits to the not-found
       // terminal before any preflight runs, so it can never reach a forbidden terminal.
+      //
       return (
         <div className="octo-doc-standalone octo-doc-standalone--terminal">
           <div className="octo-standalone-card octo-standalone-forbidden" role="alert">
@@ -645,7 +568,10 @@ export function StandaloneDocPage({
             </span>
             <h1 className="octo-standalone-card-title">{t('docs.forward.forbiddenTitle')}</h1>
             <p className="octo-standalone-card-msg">{t('docs.error.permission.forbidden')}</p>
-            <RequestAccessButton docId={docId} spaceId={preflightSpace} />
+            {/* A forbidden response does not reveal the document's home Space. Keep this request
+                human-only: the backend validates owned Bots against doc_meta.space_id, so a viewer
+                Space header/snapshot would be both unauthoritative and incorrect. */}
+            <RequestAccessButton docId={docId} />
           </div>
         </div>
       )
@@ -661,10 +587,10 @@ export function StandaloneDocPage({
     )
   }
 
-  const meta = phase.meta
+  const ctx = phase.ctx
   // In the ready phase the addressed id is guaranteed non-null (a null id short-circuits to the
-  // not-found terminal above); prefer the id echoed by the preflight, falling back to it.
-  const editorDocId = meta.docId || (docId as string)
+  // not-found terminal above); prefer the id echoed by the open-context, falling back to it.
+  const editorDocId = ctx.docId || (docId as string)
 
   // Board-kind is resolved from the AUTHORITATIVE backend docType the preflight already carried —
   // NOT a node-local registry (XIN-530, boss real-device). A `/d/:docId` share link opens on any
@@ -679,13 +605,13 @@ export function StandaloneDocPage({
   // falls through to the collab EditorShell, which has no yjs data for it and reports "not found".
   // The preflight already ran (reader gate) and recordDocView above logged the view, so a shared
   // /d/<docId> html link opens AND lands in "recently viewed" like every other kind.
-  if (meta.docType === 'html') {
+  if (ctx.docType === 'html') {
     return (
       <div className="octo-doc-standalone">
         <HtmlDocView
           key={editorDocId}
           docId={editorDocId}
-          slug={meta.octoDocSlug}
+          slug={ctx.octoDocSlug}
           space={addressing.space}
           creatorNicknameOnly
         />
@@ -697,31 +623,30 @@ export function StandaloneDocPage({
   // NOT fall through to the collab EditorShell below — a Bento deck has no Yjs data and would 404
   // there, and the standalone editor would otherwise try to open a Hocuspocus room for it. The
   // preflight reader gate already ran and recordDocView logged the view, same as every other kind.
-  if (meta.docType === 'html_ppt') {
+  if (ctx.docType === 'html_ppt') {
     return (
       <div className="octo-doc-standalone">
         <PptDocView
           key={editorDocId}
           docId={editorDocId}
-          slug={meta.octoDocSlug}
+          slug={ctx.octoDocSlug}
           space={addressing.space}
-          title={meta.title}
+          title={ctx.title}
         />
       </div>
     )
   }
-  if (meta.docType === 'board') {
+  if (ctx.docType === 'board') {
     // The whiteboard {board} segment is BoardSession's `docId` (it becomes octo:{space}:{folder}:
-    // wb:{board}). Prefer the authoritative segment parsed from the preflight documentName so the
-    // key matches what REST authorized; fall back to the addressed id for legacy backends whose
-    // preflight omitted the documentName (XIN-634 P1-a).
-    const boardId = addressing.board || editorDocId
+    // wb:{board}). Prefer the authoritative segment parsed from the open-context documentName so the
+    // key matches what the backend authorized. getOpenContext validated this before ready.
+    const boardId = addressing.board!
     return (
       <div className="octo-doc-standalone">
         <BoardSession
           key={boardId}
           docId={boardId}
-          title={meta.title || t('docs.state.untitled')}
+          title={ctx.title || t('docs.state.untitled')}
           uid={uid}
           space={addressing.space}
           folder={addressing.folder}
@@ -746,7 +671,7 @@ export function StandaloneDocPage({
 
   return (
     <div className="octo-doc-standalone">
-      {meta.docType === 'sheet' ? (
+      {ctx.docType === 'sheet' ? (
         // A shared /d/:docId that resolves to a spreadsheet mounts the collaborative SheetView, not
         // the Tiptap EditorShell — so forwarded / open-in-new-page sheet links open correctly (parity
         // with the in-shell docType branch in DocsHome). Same standalone chrome: "Copy link" as the ≡
@@ -767,7 +692,7 @@ export function StandaloneDocPage({
         <EditorShell
           key={editorDocId}
           docId={editorDocId}
-          title={meta.title || t('docs.state.untitled')}
+          title={ctx.title || t('docs.state.untitled')}
           uid={uid}
           space={addressing.space}
           folder={addressing.folder}

--- a/packages/docs/src/pages/docsApi.test.ts
+++ b/packages/docs/src/pages/docsApi.test.ts
@@ -6,6 +6,7 @@ import {
   listRecentDocs,
   listRecentCreators,
   createDoc,
+  getOpenContext,
   getDoc,
   getUserName,
   updateDocTitle,
@@ -23,6 +24,63 @@ beforeEach(() => {
 })
 
 describe('docs list/create API (bare-relative /docs)', () => {
+  it('open-context suppresses the production space interceptor and accepts complete addressing', async () => {
+    api.responder = () => ({
+      data: { docId: 'd_open', homeSpaceId: 's_home', documentName: 'octo:s_home:f_default:d_open' },
+      status: 200,
+    })
+    await expect(getOpenContext('d_open')).resolves.toMatchObject({ homeSpaceId: 's_home' })
+    expect(api.calls.at(-1)).toMatchObject({
+      url: '/docs/d_open/open-context',
+      config: { suppressSpaceId: true },
+    })
+  })
+
+  it('fails closed when a 200 open-context omits addressing core', async () => {
+    api.responder = () => ({ data: { docId: 'd_open', title: 'Incomplete' }, status: 200 })
+    await expect(getOpenContext('d_open')).rejects.toThrow(/incomplete addressing/)
+  })
+
+  it.each([
+    ['unparseable name', { docId: 'd_open', homeSpaceId: 's_home', documentName: 'not-canonical' }],
+    ['wrong home space', { docId: 'd_open', homeSpaceId: 's_other', documentName: 'octo:s_home:f_default:d_open' }],
+    ['wrong document segment', { docId: 'd_open', homeSpaceId: 's_home', documentName: 'octo:s_home:f_default:d_other' }],
+    ['wrong board segment', { docId: 'd_open', homeSpaceId: 's_home', documentName: 'octo:s_home:f_default:wb:b_other' }],
+  ])('fails closed for %s in open-context', async (_name, data) => {
+    api.responder = () => ({ data, status: 200 })
+    await expect(getOpenContext('d_open')).rejects.toThrow(/canonical addressing/)
+  })
+
+  it.each([
+    ['html', 'html'],
+    ['html_ppt', 'ppt'],
+  ])('accepts a canonical typed documentName for %s', async (docType, kind) => {
+    api.responder = () => ({
+      data: { docId: 'd_open', homeSpaceId: 's_home', documentName: `octo:s_home:f_default:${kind}:d_open`, docType },
+      status: 200,
+    })
+    await expect(getOpenContext('d_open')).resolves.toMatchObject({ docType })
+  })
+
+  it.each([
+    ['doc', 'octo:s_home:f_default:html:d_open'],
+    ['sheet', 'octo:s_home:f_default:ppt:d_open'],
+    ['board', 'octo:s_home:f_default:d_open'],
+    ['html', 'octo:s_home:f_default:d_open'],
+    ['html_ppt', 'octo:s_home:f_default:html:d_open'],
+  ])('rejects docType %s with mismatched canonical kind', async (docType, documentName) => {
+    api.responder = () => ({ data: { docId: 'd_open', homeSpaceId: 's_home', documentName, docType }, status: 200 })
+    await expect(getOpenContext('d_open')).rejects.toThrow(/mismatched document type/)
+  })
+
+  it.each(['', 'document', 'markdown', 'DOC'])('accepts legacy docType %j in the shared document namespace', async (docType) => {
+    api.responder = () => ({
+      data: { docId: 'd_legacy', homeSpaceId: 's_home', documentName: 'octo:s_home:f_default:d_legacy', docType },
+      status: 200,
+    })
+    await expect(getOpenContext('d_legacy')).resolves.toMatchObject({ docId: 'd_legacy', docType })
+  })
+
   it('lists docs via GET /docs with query params', async () => {
     api.responder = () => ({
       data: {
@@ -109,7 +167,7 @@ describe('docs list/create API (bare-relative /docs)', () => {
     expect(call.config?.headers?.['X-Space-Id']).toBeUndefined()
   })
 
-  it('carries an explicit X-Space-Id header when getDoc is given a spaceId (standalone by-space preflight)', async () => {
+  it('carries an explicit compatibility X-Space-Id header when getDoc is given a spaceId', async () => {
     // Scope: this asserts the DOCS-SIDE contract — getDoc puts the explicit header into the request
     // config. That the header then really reaches the wire (host APIClient forwards config.headers to
     // axios, and the interceptor lets the explicit header win) is covered by the host unit test at
@@ -140,6 +198,12 @@ describe('docs list/create API (bare-relative /docs)', () => {
     expect(call.method).toBe('patch')
     expect(call.url).toBe('/docs/d_real')
     expect((call.body as { title: string }).title).toBe('New Name')
+  })
+
+  it('threads explicit canonical Space on standalone rename and export writes', async () => {
+    api.responder = () => ({ data: { docId: 'd_real', title: 'New Name' }, status: 200 })
+    await updateDocTitle('d_real', 'New Name', { spaceId: 's_home' })
+    expect(api.calls.at(-1)?.config?.headers?.['X-Space-Id']).toBe('s_home')
   })
 
   it('deletes a doc via DELETE /docs/{docId}', async () => {

--- a/packages/docs/src/pages/docsApi.ts
+++ b/packages/docs/src/pages/docsApi.ts
@@ -6,6 +6,7 @@
 
 import { apiClient } from '../octoweb/index.ts'
 import type { Role } from '../auth/roles.ts'
+import { parseDocumentName } from '../documentName/index.ts'
 
 /**
  * Document kind enum — the wire contract for `doc_type`, authored in lockstep with the backend
@@ -228,10 +229,9 @@ export async function listRecentCreators(q?: string): Promise<CreatorOption[]> {
  * `opts.spaceId` (standalone need, XIN-1237): the backend writes the view into the space carried by
  * the request's `X-Space-Id` and "最近查看" reads back by that same viewer space. In-shell callers
  * omit it and rely on the global interceptor (spaceIdCallback → currentSpaceId, the viewer's live
- * space). The standalone `/d/:docId` page seeds currentSpaceId to the DOC's own space for preflight
- * addressing, so it must pass the viewer's real current space here explicitly — otherwise the view
- * would be written under the doc space and never surface in a cross-space recipient's recent list.
- * Axios merges this header over (and thus wins against) the interceptor's value.
+ * space). The standalone `/d/:docId` path deliberately does not mutate `currentSpaceId`, so it must
+ * pass the independently established viewer Space explicitly when one is available. Axios merges
+ * this header over (and thus wins against) the interceptor's value.
  */
 export async function recordDocView(docId: string, opts?: { spaceId?: string }): Promise<void> {
   try {
@@ -290,19 +290,118 @@ export interface DocMeta {
 }
 
 /**
+ * Canonical document open context returned by `GET /api/v1/docs/:docId/open-context`
+ * (Phase-1 remove-`sp` design §4/§5.2). The backend locates the document by `docId` ALONE — no
+ * `sp` query, no `X-Space-Id` header, no client-supplied Space participates in resolution or
+ * authorization — and returns the AUTHORITATIVE addressing the standalone page needs to open the
+ * doc: its real home Space, canonical `documentName`, kind, the caller's effective role, and the
+ * permission epoch. This is the permanent no-`sp` reader foundation: the page consumes it as a
+ * per-request `DocRequestContext` and NEVER writes `homeSpaceId` into the global `currentSpaceId`,
+ * so opening an external `/d/:docId` link cannot pollute the shell's Sidebar / list / search /
+ * recent Space (design §5.2).
+ *
+ * `role`/`permissionEpoch`/`docType`/`title`/`folderId` are optional; the addressing core
+ * (`docId`/`homeSpaceId`/`documentName`) is mandatory and validated fail-closed. This contract is
+ * publicly reviewable in octo-web issue #1317. A failure response (403/404/409) carries none of
+ * these fields — see getOpenContext.
+ */
+export interface DocRequestContext {
+  docId: string
+  /**
+   * The document's REAL home Space (`doc_meta.space_id`), resolved server-side from `docId`. Used
+   * ONLY to address THIS document request (room/name resolution); it must never be promoted to the
+   * viewer's global current Space.
+   */
+  homeSpaceId: string
+  /**
+   * Canonical key: 4-segment `octo:{space}:{folder}:{doc}` for the shared document namespace,
+   * or a typed 5-segment `:wb:`, `:html:`, or `:ppt:` key.
+   */
+  documentName: string
+  /** Folder segment echoed for convenience; the canonical value is inside `documentName`. */
+  folderId?: string
+  /**
+   * Usually a {@link DocType}; legacy 4-segment rows may carry an arbitrary historical free-string.
+   * Typed `wb`/`html`/`ppt` keys are still required to match `board`/`html`/`html_ppt` exactly.
+   */
+  docType?: string
+  /** The caller's effective role on the doc (owner/admin/writer/reader), computed server-side. */
+  role?: Role
+  /** Monotonic permission epoch bound into the collab token (design §7.3 WS verification). */
+  permissionEpoch?: number
+  /** Document title — present only on the 200 success path. */
+  title?: string
+  /** Present only for html docs: the octo-doc slug used to fetch/render the read-only body. */
+  octoDocSlug?: string
+}
+
+/**
+ * GET /api/v1/docs/{docId}/open-context — the docId-first preflight for the standalone `/d/:docId`
+ * page (Phase-1 remove-`sp` design §4). Unlike getDoc, it takes NO space input: the backend locates
+ * the doc by `docId` and returns the canonical {@link DocRequestContext}. The standalone page calls
+ * this instead of the by-space `GET /docs/:docId` so a shared link opens without the sharer's `?sp`.
+ *
+ * Status contract (design §5.1 / §12) — the caller maps rejections to terminals via
+ * terminalForCreateError, exactly as the old getDoc preflight did:
+ *   - 200 → resolve the context (mount the editor from `documentName`/`homeSpaceId`).
+ *   - 401 → login handoff (return to /d/:docId after sign-in).
+ *   - 403 → the doc exists but the caller has no role → forbidden landing + request-access.
+ *   - 404 → illegal / missing / deleted docId → not-found.
+ *   - 409 → archived / locked state conflict.
+ * No `X-Space-Id` is sent: `docId` is the sole locator, so a wrong/stale `?sp` on an old link can
+ * never steer resolution (design §8.3). Deliberately does NOT swallow failures — the boundary
+ * states depend on the status propagating.
+ */
+export async function getOpenContext(docId: string): Promise<DocRequestContext> {
+  const { data } = await apiClient().get<DocRequestContext>(
+    `/docs/${encodeURIComponent(docId)}/open-context`,
+    { suppressSpaceId: true },
+  )
+  if (
+    !data ||
+    typeof data.docId !== 'string' ||
+    data.docId !== docId ||
+    typeof data.homeSpaceId !== 'string' ||
+    !data.homeSpaceId ||
+    typeof data.documentName !== 'string' ||
+    !data.documentName
+  ) {
+    throw new Error('open-context returned incomplete addressing')
+  }
+  let parsed: ReturnType<typeof parseDocumentName>
+  try {
+    parsed = parseDocumentName(data.documentName)
+  } catch {
+    throw new Error('open-context returned invalid canonical addressing')
+  }
+  const canonicalDocId = parsed.kind === 'whiteboard' ? parsed.board : parsed.doc
+  if (parsed.space !== data.homeSpaceId || canonicalDocId !== docId) {
+    throw new Error('open-context returned inconsistent canonical addressing')
+  }
+  // Mirror the backend's deny-list rather than treating doc_type as a closed
+  // runtime enum. Historical rows may contain arbitrary free-string values in
+  // the shared 4-segment document namespace; only the three typed namespaces
+  // (`wb`, `html`, `ppt`) require an exact persisted kind.
+  const consistentType =
+    parsed.kind === 'whiteboard' ? data.docType === 'board'
+      : parsed.kind === 'html' ? data.docType === 'html'
+        : parsed.kind === 'ppt' ? data.docType === HTML_PPT_DOC_TYPE
+          : data.docType !== 'board' && data.docType !== 'html' && data.docType !== HTML_PPT_DOC_TYPE
+  if (!consistentType) {
+    throw new Error('open-context returned mismatched document type and canonical addressing')
+  }
+  return data
+}
+
+/**
  * GET /api/v1/docs/{docId} — fetch a single document's metadata (title etc).
  * Used to render the real title in the editor header instead of a hardcoded
  * placeholder. Resilient: callers fall back to a passed-in title if this throws
  * (e.g. the backend has no per-doc GET in a given environment).
  *
- * `opts.spaceId` (standalone by-space need): the backend gates `/docs/:docId` behind a by-space
- * middleware — a request with no `X-Space-Id` header is rejected (400 space_required) and a header
- * that does not match the doc's space returns 404. In-shell callers omit `opts` and rely on the
- * global request interceptor (spaceIdCallback → WKApp.shared.currentSpaceId) to inject the header.
- * The standalone `/d/:docId` page mounts before that space is restored, so the interceptor injects
- * nothing; it passes the resolved space here to carry an explicit `X-Space-Id` on the preflight,
- * which axios merges over (and thus wins against) the interceptor's absent header. A non-empty
- * `opts.spaceId` is the only trigger — omitting it preserves the exact prior no-header behavior.
+ * Phase-1 human document-resource routes locate and authorize by docId; `X-Space-Id` is not a
+ * locator or authorization input there. `spaceId` remains an optional compatibility carrier for
+ * older backend nodes and Bot mounts, whose same-Space boundary is still enforced server-side.
  */
 export async function getDoc(docId: string, opts?: { spaceId?: string }): Promise<DocMeta> {
   const config =
@@ -339,8 +438,9 @@ export async function getUserName(
  * PATCH /api/v1/docs/{docId} — rename a document. Backend confirmed 200 + DB
  * persistence. Manage-role only (enforced server-side; UI also gates on canManage).
  */
-export async function updateDocTitle(docId: string, title: string): Promise<DocMeta> {
-  const { data } = await apiClient().patch<DocMeta>(`/docs/${docId}`, { title })
+export async function updateDocTitle(docId: string, title: string, opts?: { spaceId?: string }): Promise<DocMeta> {
+  const config = opts?.spaceId ? { headers: { 'X-Space-Id': opts.spaceId } } : undefined
+  const { data } = await apiClient().patch<DocMeta>(`/docs/${docId}`, { title }, config)
   return data
 }
 
@@ -360,10 +460,11 @@ export async function deleteDoc(docId: string, opts?: { spaceId?: string }): Pro
 export type DocExportFormat = 'md' | 'docx' | 'pdf'
 
 /** GET the unified backend file export through the authenticated host client. */
-export async function exportDocFile(docId: string, format: DocExportFormat): Promise<ArrayBuffer> {
+export async function exportDocFile(docId: string, format: DocExportFormat, opts?: { spaceId?: string }): Promise<ArrayBuffer> {
+  const headers = opts?.spaceId ? { 'X-Space-Id': opts.spaceId } : undefined
   const { data } = await apiClient().get<ArrayBuffer>(
     `/docs/${encodeURIComponent(docId)}/export/file?format=${format}`,
-    { responseType: 'arraybuffer', timeout: 120_000 },
+    { responseType: 'arraybuffer', timeout: 120_000, headers },
   )
   return data
 }

--- a/packages/docs/src/ppt/PptSurfacePage.tsx
+++ b/packages/docs/src/ppt/PptSurfacePage.tsx
@@ -97,12 +97,12 @@ export function resolveDeckSpace(): string {
 
 /**
  * The deck's own space as carried by the deep-link's dedicated `?sp=` query param — the same carrier
- * the standalone doc route reads (StandaloneDocPage.standaloneLinkSpace). On the PPT routes this `?sp=`
- * is minted by `withDeckSpace` (pptLink.ts): the create flow stamps the deck's space onto the
- * forwarded editor link (`/ppt/d/:docId?sp=`), so a cross-space cold deep-link resolves the right
- * `X-Space-Id` before the shell restores currentSpaceId. (Note `buildDocLink` mints `?sp=` for the
- * STANDALONE `/d/:docId` route only, a different route — it does NOT produce these PPT paths. The
- * present route has no `?sp=` minter yet, so cross-space present-share is not resolved — see
+ * the legacy standalone reader can consume during cleanup. On PPT routes this `?sp=` is minted by
+ * `withDeckSpace` (pptLink.ts): the create flow stamps the deck's space onto the forwarded editor
+ * link (`/ppt/d/:docId?sp=`), so a cross-space cold deep-link resolves the right `X-Space-Id` before
+ * the shell restores currentSpaceId. Ordinary `buildDocLink` now produces `/d/:docId` without Space
+ * and does not produce these PPT paths. The present route has no `?sp=` minter yet, so cross-space
+ * present-share is not resolved — see
  * pptLink.ts.) Returns '' when the link carries no `?sp=` (an editor link the backend forwarded
  * without one, an older/hand-built link, or SSR); the caller then falls back to live/cached
  * currentSpaceId.

--- a/packages/docs/src/ppt/pptLink.ts
+++ b/packages/docs/src/ppt/pptLink.ts
@@ -3,16 +3,16 @@
 // P1-1 (round-5): `resolveDeckSpace()` (PptSurfacePage.tsx) reads a deep-link's dedicated `?sp=`
 // carrier FIRST so a cross-space cold open resolves the deck's REAL space before the app shell has
 // restored `currentSpaceId`. That read is only useful if something on the FE actually PRODUCES a PPT
-// link carrying `?sp=` — and until this module, nothing did: `buildDocLink` mints `/d/:docId?sp=` for
-// the STANDALONE rich-text route (a different route), the peer editor link arrives from the backend
+// link carrying `?sp=` — and until this module, nothing did: ordinary `buildDocLink` deliberately
+// mints `/d/:docId` without Space, while the peer editor link arrives from the backend
 // `editorUrl` verbatim, and the present route had no minting site at all. So a cross-space share fell
 // through to the recipient's last-visited space and 404'd on the backend cross-space guard.
 //
 // `withDeckSpace` is the PPT-route analogue of `buildDocLink`: it stamps the deck's owning space onto
 // the `?sp=` carrier the PPT routes read, so a link the FE produces resolves the right `X-Space-Id` on
 // a cross-space cold open. It is pure (only rewrites the query string) so it is unit-testable and
-// reusable from any producer. It mints the SAME `?sp=` param the standalone route uses (docs-backend
-// space_id), never the octo `?sid` token-bucket key.
+// reusable from any producer. It mints the PPT route's dedicated `?sp=` carrier (docs-backend
+// space_id), never the octo `?sid` token-bucket key or an ordinary-document locator.
 //
 // SCOPE (round-6, XIN-1630 — honesty): the ONLY wired producer today is the create flow, which stamps
 // the deck's space onto the backend-forwarded editor link (`/ppt/d/:docId?sp=`) via `withDeckSpace`

--- a/packages/docs/src/sheet/CollabSheet.ts
+++ b/packages/docs/src/sheet/CollabSheet.ts
@@ -176,6 +176,8 @@ export interface CollabSheetOptions {
 
 export class CollabSheet {
   readonly documentName: string
+  /** Stable doc id used to issue the collab token docId-first (design §7.1); '' falls back to legacy. */
+  private readonly docId: string
   readonly ydoc: Y.Doc
   readonly provider: HocuspocusProvider
   readonly persistence: IndexeddbPersistence | null
@@ -233,6 +235,7 @@ export class CollabSheet {
   private constructor(opts: CollabSheetOptions, initialRole: Role, initialEpoch: number, wsUrl: string) {
     const scope: DocScope = { uid: opts.uid, space: opts.space, folder: opts.folder, doc: opts.doc }
     this.documentName = buildDocumentName(opts.space, opts.folder, opts.doc)
+    this.docId = opts.docId || ''
     this.cacheKeyStr = cacheKey(scope)
     this.currentRole = initialRole
 
@@ -249,7 +252,7 @@ export class CollabSheet {
       url: wsUrl,
       name: this.documentName,
       document: this.ydoc,
-      token: () => getCollabToken(this.documentName),
+      token: () => getCollabToken(this.documentName, this.docId || undefined),
       connect: false,
     })
 
@@ -826,7 +829,6 @@ export class CollabSheet {
     )
     // Role controller: runtime stateless role changes (monotonic epoch).
     this.roleController = new RoleController({
-      documentName: this.documentName,
       initialRole,
       initialEpoch,
       onRole: (role) => {
@@ -837,11 +839,12 @@ export class CollabSheet {
         this.setUniverEditable(canEdit(role))
         opts.onRole?.(role)
       },
+      disposeToken: () => disposeToken(this.documentName, { docId: this.docId || undefined }),
     })
 
     // Close-code state machine: the only auth-recovery source is event.code.
     this.closeMachine = new CloseCodeMachine({
-      disposeToken: () => disposeToken(this.documentName),
+      disposeToken: () => disposeToken(this.documentName, { docId: this.docId || undefined }),
       connect: () => this.provider.connect(),
       disconnect: () => this.provider.disconnect(),
       goLogin: () => opts.onTerminal?.({ kind: 'login' }),
@@ -893,7 +896,7 @@ export class CollabSheet {
   /** Identity-first construction (§6.1): confirm identity + role BEFORE wiring network. */
   static async create(opts: CollabSheetOptions): Promise<CollabSheet> {
     const documentName = buildDocumentName(opts.space, opts.folder, opts.doc)
-    const entry = await getCollabTokenEntry(documentName)
+    const entry = await getCollabTokenEntry(documentName, opts.docId || undefined)
     const wsUrl = resolveCollabWsUrl(entry.collabWsUrl)
     return new CollabSheet(opts, entry.role, entry.permission_epoch, wsUrl)
   }
@@ -1574,6 +1577,6 @@ export class CollabSheet {
     this.provider.destroy()
     void this.persistence?.destroy()
     this.ydoc.destroy()
-    disposeToken(this.documentName)
+    disposeToken(this.documentName, { docId: this.docId || undefined })
   }
 }

--- a/packages/docs/src/sheet/SheetView.tsx
+++ b/packages/docs/src/sheet/SheetView.tsx
@@ -296,14 +296,14 @@ export function SheetView(props: SheetViewProps) {
   // Load the real title so it's editable (docs have an inline DocTitle; the sheet
   // reuses the same rename REST endpoint). Also lift ownerId + createdAt for the ≡ menu head.
   useEffect(() => {
-    getDoc(docId)
+    getDoc(docId, props.space ? { spaceId: props.space } : undefined)
       .then((m) => {
         setTitle(m.title || '')
         if (typeof m.ownerId === 'string' && m.ownerId) setOwnerId(m.ownerId)
         if (typeof m.createdAt === 'string' && m.createdAt) setCreatedAt(m.createdAt)
       })
       .catch(() => {})
-  }, [docId])
+  }, [docId, props.space])
 
   // Resolve the creator's display name for the ≡ menu head: first from the already-loaded
   // space-member map (free), then GET /users/:uid. Resilient — any failure leaves it undefined
@@ -342,7 +342,7 @@ export function SheetView(props: SheetViewProps) {
   const saveTitle = () => {
     if (!manage) return
     const next = title.trim()
-    void updateDocTitle(docId, next || t('docs.state.untitled'))
+    void updateDocTitle(docId, next || t('docs.state.untitled'), space ? { spaceId: space } : undefined)
       .then(() => onTitleSaved?.(docId, next))
       .catch(() => {})
   }
@@ -350,7 +350,7 @@ export function SheetView(props: SheetViewProps) {
   // Delete the sheet (soft delete, owner/admin) — reuses the docs delete hook + shared centered
   // ConfirmModal, so a sheet delete and a document delete pop the SAME dialog in the middle of the
   // screen (replacing the old native window.confirm). deleteDoc works for a sheet doc unchanged.
-  const del = useDocDelete(docId, onDeleted)
+  const del = useDocDelete(docId, onDeleted, space ? { spaceId: space } : undefined)
 
   useEffect(() => {
     const el = containerRef.current

--- a/packages/docs/types/octo-base.shim.d.ts
+++ b/packages/docs/types/octo-base.shim.d.ts
@@ -136,8 +136,9 @@ declare module '@octo/base' {
 
   // Canonical doc-share-link builder, promoted to `@octo/base`
   // (packages/dmworkbase/src/Utils/docLink.ts) as the single source of truth for the
-  // `${origin}/d/<docId>?sp=<spaceId>` format (XIN-450 / XIN-501 / XIN-513). Re-exported from
-  // dmworkbase/src/index.tsx; docs' forward/link.ts is now a thin re-export of these.
+  // `${origin}/d/<docId>` format (Phase-1 remove-`sp`, design §5.3 — no `?sp=`/`?sid=`). Re-exported
+  // from dmworkbase/src/index.tsx; docs' forward/link.ts is now a thin re-export of these. `space`/
+  // `folder` are accepted-but-ignored during the caller cutover.
   export interface DocLinkTarget {
     docId: string
     space?: string


### PR DESCRIPTION
## Summary
- open `/d/:docId` through authenticated Open Context
- keep canonical document request context separate from the global current Space
- use docId-first collaboration tokens for Doc, Sheet, and Board
- stop ordinary share, search, Drive, recent, forward, and chat-card links from emitting `sp`
- accept legacy links and remove only `sp`, preserving all other query/hash state
- keep PPT-specific Space behavior unchanged

## Linked Spec
- Fixes #1317
- `docs/design/octo-doc-remove-sp-phase1-2026-08-10.md` (reviewed Phase 1 design)
- Depends on the matching `octo-docs-backend` PR: https://github.com/Mininglamp-OSS/octo-docs-backend/pull/170

## How verified
- Docs focused suites: 210/210
- `@octo/base`: 27/27
- `@octo/drive`: 15/15
- `git diff --check`

## COMPREHENSION
### What does this change actually do?
Before, ordinary document links carried the home Space and the standalone reader used it to construct document context. After, links contain only `docId`; the reader requests canonical context from the backend and uses it for REST and collaboration without switching the user's global Space. Historical `?sp=` links still open and are normalized.

### What could break?
The blast radius includes standalone opening, login return, Doc/Sheet/Board collaboration startup, link builders, sharing, search, Drive, recent documents, forwarding, and document cards. Incorrect cleanup could remove unrelated query/hash state, and accidental reuse of global current Space could break cross-Space cold starts. PPT is deliberately excluded.

### How do you know it works?
Focused tests cover Open Context status handling, login return, legacy URL cleanup, docId-first tokens across Doc/Sheet/Board, and all changed link-generation surfaces. Tests also pin preservation of unrelated query/hash values and PPT-specific behavior.

## Rollout note
Do not enable no-`sp` link generation until every backend instance supports Open Context, Human document-resource routing, and v2 collaboration-token verification. Do not later roll back below that reader compatibility floor.
