### PR TITLE
feat(drive): save chat file to any space/folder, unify icon+menu state

### DIFF
--- a/packages/dmworkbase/src/App.tsx
+++ b/packages/dmworkbase/src/App.tsx
@@ -772,6 +772,10 @@ export default class WKApp extends ProviderListener {
   // Returns the resulting drive file coordinates so the caller can flip its UI
   // state to "view in drive" without a follow-up query.
   static saveMessageToDrive?: (params: { im_group_no: string; im_channel_type: number; im_msg_id: string }) => Promise<{ file_id: number; space_id: string; parent_id: number }>;
+  // Save-to-drive with a target picker. Opens a modal where the caller
+  // chooses target space + folder; resolves after the transfer POST returns.
+  // Rejects on cancel or backend failure (the picker stays open on failure).
+  static saveMessageToDriveAt?: (params: { im_group_no: string; im_channel_type: number; im_msg_id: string }) => Promise<{ file_id: number; space_id: string; parent_id: number }>;
   // Query whether an IM file (identified by the (channelType, channelID, msgID)
   // triple the backend uses to derive its source_key) is already transferred
   // into the caller's personal drive space. Registered by DriveModule; the chat

--- a/packages/dmworkbase/src/App.tsx
+++ b/packages/dmworkbase/src/App.tsx
@@ -67,6 +67,21 @@ export type MittEvents = {
   /** Login, logout or account replacement changed the identity that owns page-level state. */
   'wk:auth-state-changed': undefined;
   /**
+   * A chat file's drive-transferred state flipped (unsaved → saved) — either
+   * via the icon (quick-save personal root) or the right-click picker (chosen
+   * space + folder). The payload carries the `source_key`
+   * (channelType#channelID#msgID, the IM identity used as the drive cache key)
+   * plus the resulting drive coordinates so listeners can update in place
+   * without a follow-up backend call. FileCell subscribes and setState on a
+   * matching source_key so its icon flips the moment ANY save path wins,
+   * regardless of which entry the user used. See dmworkdrive/module.tsx
+   * driveTransferredCache.
+   */
+  'wk:drive-transferred-changed': {
+    sourceKey: string;
+    entry: { file_id: number; space_id: string; parent_id: number };
+  };
+  /**
    * dmloop 派单(quick-create)后的看板补刷协议。派单是异步的(agent 稍后建 issue,dmloop 暂无 WS 推送):
    * NewLoopPage 派单成功发 `wk:loop-issues-dispatched`;常驻的 LoopPage 据此有界补发 `wk:loop-issues-refresh`,
    * 当前挂载的看板(IssuePage)订阅后重取,使新回路自动出现——统一覆盖看板内/侧栏两个建单入口。
@@ -781,6 +796,13 @@ export default class WKApp extends ProviderListener {
   // into the caller's personal drive space. Registered by DriveModule; the chat
   // file card uses it to switch its icon action between "save" and "view".
   static checkDriveTransferred?: (msg: { im_group_no: string; im_channel_type: number; im_msg_id: string }) => Promise<{ file_id: number; space_id: string; parent_id: number } | null>;
+  // Synchronous cache probe of the drive-transferred state — returns the
+  // known entry, `null` for confirmed-not-transferred, or `undefined` when
+  // the cache has no answer yet. Registered by DriveModule; the right-click
+  // menu factory uses this because it runs synchronously (can't await the
+  // async checkDriveTransferred) and needs the current answer, if any, to
+  // decide between "存到云盘…" and "在云盘中查看" at menu open time.
+  static getDriveTransferred?: (msg: { im_group_no: string; im_channel_type: number; im_msg_id: string }) => { file_id: number; space_id: string; parent_id: number } | null | undefined;
   // Open the drive UI and focus/flash a specific file. Registered by DriveModule.
   // parent_id is optional — when the file lives at the space root pass 0 or omit;
   // when the file is buried in nested folders pass the immediate parent so the

--- a/packages/dmworkbase/src/App.tsx
+++ b/packages/dmworkbase/src/App.tsx
@@ -788,13 +788,19 @@ export default class WKApp extends ProviderListener {
   // state to "view in drive" without a follow-up query.
   static saveMessageToDrive?: (params: { im_group_no: string; im_channel_type: number; im_msg_id: string }) => Promise<{ file_id: number; space_id: string; parent_id: number }>;
   // Save-to-drive with a target picker. Opens a modal where the caller
-  // chooses target space + folder; resolves after the transfer POST returns.
-  // Rejects on cancel or backend failure (the picker stays open on failure).
+  // chooses target space + folder; resolves after the transfer POST
+  // returns. Rejects ONLY on cancel — a backend failure surfaces via
+  // Toast.error and leaves the modal open for retry (a later successful
+  // retry then resolves the same promise). This inversion vs the earlier
+  // "reject on any failure" contract matches how the picker actually
+  // stays interactive; see PR #1322 review discussion.
   static saveMessageToDriveAt?: (params: { im_group_no: string; im_channel_type: number; im_msg_id: string }) => Promise<{ file_id: number; space_id: string; parent_id: number }>;
   // Query whether an IM file (identified by the (channelType, channelID, msgID)
   // triple the backend uses to derive its source_key) is already transferred
-  // into the caller's personal drive space. Registered by DriveModule; the chat
-  // file card uses it to switch its icon action between "save" and "view".
+  // into ANY drive space the caller can see. Cross-space evolution of the
+  // earlier personal-only lookup: personal wins the tie-break, then the
+  // freshest shared save. Registered by DriveModule; the chat file card
+  // uses it to switch its icon action between "save" and "view".
   static checkDriveTransferred?: (msg: { im_group_no: string; im_channel_type: number; im_msg_id: string }) => Promise<{ file_id: number; space_id: string; parent_id: number } | null>;
   // Synchronous cache probe of the drive-transferred state — returns the
   // known entry, `null` for confirmed-not-transferred, or `undefined` when

--- a/packages/dmworkbase/src/App.tsx
+++ b/packages/dmworkbase/src/App.tsx
@@ -778,8 +778,10 @@ export default class WKApp extends ProviderListener {
   // file card uses it to switch its icon action between "save" and "view".
   static checkDriveTransferred?: (msg: { im_group_no: string; im_channel_type: number; im_msg_id: string }) => Promise<{ file_id: number; space_id: string; parent_id: number } | null>;
   // Open the drive UI and focus/flash a specific file. Registered by DriveModule.
-  // Only the space root is entered — the caller does not thread parent_id.
-  static openDriveFile?: (params: { space_id: string; file_id: number }) => void;
+  // parent_id is optional — when the file lives at the space root pass 0 or omit;
+  // when the file is buried in nested folders pass the immediate parent so the
+  // drive VM can rebuild the breadcrumb via GET /files/:id/ancestors.
+  static openDriveFile?: (params: { space_id: string; file_id: number; parent_id?: number }) => void;
   // Id of the currently active sidebar menu (kept in sync by Main page)
   static currentMenuId?: string;
   static apiClient = APIClient.shared; // api客户端

--- a/packages/dmworkbase/src/Messages/File/index.tsx
+++ b/packages/dmworkbase/src/Messages/File/index.tsx
@@ -13,7 +13,8 @@ import MessageRow from "../../ui/message/MessageRow";
 import { getFileMessageUI } from "../../bridge/message/useFileMessageUI";
 import { isMessageSelectable } from "../../Service/messageSelection";
 import { isSafeUrl } from "../../Utils/security";
-import { isDriveTransferSupportedChannel } from "../../Service/SpacePrefix";
+import { isDriveTransferSupportedChannel, stripSpacePrefix, hasSpacePrefix } from "../../Service/SpacePrefix";
+import { ChannelTypePerson } from "wukongimjssdk";
 import { I18nContext } from "../../i18n";
 
 export { FileContent } from "./FileContent";
@@ -362,6 +363,12 @@ export class FileCell extends MessageCell<any, FileCellState> {
   private _task?: RestartableTask;
   private _mounted = false;
   private _unsubscribeConfig?: () => void;
+  // mittBus listener for cross-path drive-transferred flip. Held so
+  // componentWillUnmount can detach.
+  private _driveTransferredListener?: (payload: {
+    sourceKey: string;
+    entry: { file_id: number; space_id: string; parent_id: number };
+  }) => void;
   private _checkInFlight = false;
 
   private _taskListener = (task: Task) => {
@@ -429,6 +436,44 @@ export class FileCell extends MessageCell<any, FileCellState> {
     this._unsubscribeConfig = WKApp.remoteConfig.addConfigChangeListener(() => {
       if (this._mounted) this.forceUpdate();
     });
+
+    // 单向对齐：任何路径(图标/右键 picker/其他 tab 的 batch 查询)成功后，
+    // dmworkdrive 会在 mittBus 广播 sourceKey + entry。凡是匹配本 FileCell
+    // 的消息就 setState，让图标(以及右键菜单下次打开时通过 cache 查)一起切
+    // "已存"。核心目的:两个入口共享一份 saved-state，杜绝"图标不切"和"右键
+    // 与图标状态不一致"这两种漂移。
+    this._driveTransferredListener = (payload: {
+      sourceKey: string;
+      entry: { file_id: number; space_id: string; parent_id: number };
+    }) => {
+      if (!this._mounted) return;
+      if (payload.sourceKey !== this.driveSourceKey()) return;
+      if (this.state.imTransferred?.exists === true) return; // already saved, no-op
+      this.setState({
+        imTransferred: {
+          exists: true,
+          file_id: payload.entry.file_id,
+          space_id: payload.entry.space_id,
+          parent_id: payload.entry.parent_id,
+        },
+      });
+    };
+    WKApp.mittBus.on("wk:drive-transferred-changed", this._driveTransferredListener);
+  }
+
+  // sourceKey = `${channelType}#${normalisedChannelID}#${msgID}` — same formula
+  // as dmworkdrive/bridge/types.ts `imTransferredSourceKey` after
+  // `normaliseImChannelID`. Kept inline here so dmworkbase does not depend on
+  // dmworkdrive (dmworkdrive is a plugin on top). If either side ever
+  // changes the format, ALL sourceKey producers must move together.
+  private driveSourceKey(): string {
+    const { message } = this.props;
+    const ct = message.channel.channelType;
+    let cid = message.channel.channelID;
+    if (ct === ChannelTypePerson && hasSpacePrefix(cid)) {
+      cid = stripSpacePrefix(cid);
+    }
+    return `${ct}#${cid}#${message.messageID}`;
   }
 
   componentDidUpdate() {
@@ -512,6 +557,10 @@ export class FileCell extends MessageCell<any, FileCellState> {
     if (this._unsubscribeConfig) {
       this._unsubscribeConfig();
       this._unsubscribeConfig = undefined;
+    }
+    if (this._driveTransferredListener) {
+      WKApp.mittBus.off("wk:drive-transferred-changed", this._driveTransferredListener);
+      this._driveTransferredListener = undefined;
     }
   }
 

--- a/packages/dmworkbase/src/Messages/File/index.tsx
+++ b/packages/dmworkbase/src/Messages/File/index.tsx
@@ -13,8 +13,7 @@ import MessageRow from "../../ui/message/MessageRow";
 import { getFileMessageUI } from "../../bridge/message/useFileMessageUI";
 import { isMessageSelectable } from "../../Service/messageSelection";
 import { isSafeUrl } from "../../Utils/security";
-import { isDriveTransferSupportedChannel, stripSpacePrefix, hasSpacePrefix } from "../../Service/SpacePrefix";
-import { ChannelTypePerson } from "wukongimjssdk";
+import { isDriveTransferSupportedChannel, imDriveTransferSourceKey } from "../../Service/SpacePrefix";
 import { I18nContext } from "../../i18n";
 
 export { FileContent } from "./FileContent";
@@ -461,19 +460,20 @@ export class FileCell extends MessageCell<any, FileCellState> {
     WKApp.mittBus.on("wk:drive-transferred-changed", this._driveTransferredListener);
   }
 
-  // sourceKey = `${channelType}#${normalisedChannelID}#${msgID}` — same formula
-  // as dmworkdrive/bridge/types.ts `imTransferredSourceKey` after
-  // `normaliseImChannelID`. Kept inline here so dmworkbase does not depend on
-  // dmworkdrive (dmworkdrive is a plugin on top). If either side ever
-  // changes the format, ALL sourceKey producers must move together.
+  // sourceKey is derived by @octo/base's `imDriveTransferSourceKey` — the
+  // SAME implementation dmworkdrive uses to construct the wire source_key
+  // and to key the mittBus 'wk:drive-transferred-changed' fan-out. Hosting
+  // both derivations in one place makes it impossible for FileCell's
+  // subscriber-side key to drift from the emitter-side key (Octo-Q /
+  // yujiawei review PR #1322 P2-6 — the earlier local inline version was
+  // an obvious silent-drift trap).
   private driveSourceKey(): string {
     const { message } = this.props;
-    const ct = message.channel.channelType;
-    let cid = message.channel.channelID;
-    if (ct === ChannelTypePerson && hasSpacePrefix(cid)) {
-      cid = stripSpacePrefix(cid);
-    }
-    return `${ct}#${cid}#${message.messageID}`;
+    return imDriveTransferSourceKey(
+      message.channel.channelType,
+      message.channel.channelID,
+      message.messageID,
+    );
   }
 
   componentDidUpdate() {

--- a/packages/dmworkbase/src/Messages/File/index.tsx
+++ b/packages/dmworkbase/src/Messages/File/index.tsx
@@ -554,6 +554,7 @@ export class FileCell extends MessageCell<any, FileCellState> {
       WKApp.openDriveFile?.({
         space_id: known.space_id,
         file_id: known.file_id,
+        parent_id: known.parent_id,
       });
       return;
     }

--- a/packages/dmworkbase/src/Service/SpacePrefix.ts
+++ b/packages/dmworkbase/src/Service/SpacePrefix.ts
@@ -41,3 +41,63 @@ export function stripSpacePrefix(id: string): string {
 export function isDriveTransferSupportedChannel(channelType: number): boolean {
     return channelType === 1 || channelType === 2 || channelType === 5
 }
+
+// ChannelTypePerson from wukongimjssdk — inlined so this module stays free of
+// runtime imports and callers don't need to bring in the sdk barrel just to
+// build a source_key.
+const CHANNEL_TYPE_PERSON = 1
+
+/**
+ * Normalise a channel's raw `channelID` for the drive-transfer wire format:
+ * on Person channels strip a leading `s<32-hex>_` Space prefix if present
+ * (drive backend + octo-server both key on the bare peer uid); on other
+ * channel types return the id unchanged.
+ *
+ * ⚠️ Uses the SAME regex capture as `normaliseImChannelID` in
+ * `packages/dmworkdrive/src/bridge/types.ts` (kept there for wire-contract
+ * co-location) — but implemented against the shared `SPACE_PREFIX_RE` so both
+ * definitions cannot drift. The two producers of a source_key
+ * (FileCell listener in dmworkbase, transferFromIm/checkDriveTransferred in
+ * dmworkdrive) MUST both call this same helper and `imDriveTransferSourceKey`
+ * so the mittBus fan-out key match holds — divergence here is what the icon
+ * ↔ right-click menu unify-state design (PR #1322) is guarding against.
+ */
+export function normaliseImDriveChannelID(channelType: number, channelID: string): string {
+    if (channelType !== CHANNEL_TYPE_PERSON) return channelID
+    if (!hasSpacePrefix(channelID)) return channelID
+    // stripSpacePrefix uses indexOf('_') so a degenerate `s<32-hex>_` with an
+    // empty remainder would return ''; here we prefer to return the original
+    // string in that case (matches dmworkdrive/bridge/types.ts regex-capture
+    // behaviour where the empty capture group yields undefined and we fall
+    // through to the original id). Callers see a bare uid for real inputs
+    // and the untouched id for pathological ones.
+    const bare = stripSpacePrefix(channelID)
+    return bare === '' ? channelID : bare
+}
+
+/**
+ * Materialise the canonical source_key for an IM → drive transfer:
+ * `${channelType}#${normalisedChannelID}#${msgID}`. This is the storage
+ * key octo-drive uses on `drive_file.source_key` (see
+ * `internal/modules/imtransfer/service.go` `buildSourceKey`) and it doubles
+ * as the mittBus fan-out key for `wk:drive-transferred-changed`.
+ *
+ * ⚠️ This is the ONLY place in octo-web that constructs a source_key.
+ * Both FileCell (dmworkbase, listener that flips the icon when a save
+ * lands) and dmworkdrive's module.tsx (save/check paths that emit) call
+ * this. Do NOT inline `${...}#${...}#${...}` elsewhere — a drift produces
+ * a silent failure mode where the fan-out event's key stops matching the
+ * subscriber's derived key and the icon stops flipping (which is precisely
+ * the bug PR #1322 exists to eliminate).
+ *
+ * The `channelID` argument may be prefixed; this function normalises via
+ * `normaliseImDriveChannelID` before formatting, so callers can hand raw
+ * `message.channel.channelID` and get the right key.
+ */
+export function imDriveTransferSourceKey(
+    channelType: number,
+    channelID: string,
+    msgID: string,
+): string {
+    return `${channelType}#${normaliseImDriveChannelID(channelType, channelID)}#${msgID}`
+}

--- a/packages/dmworkbase/src/index.tsx
+++ b/packages/dmworkbase/src/index.tsx
@@ -157,4 +157,4 @@ export { Channel, ChannelTypePerson } from 'wukongimjssdk'
 // Drive-transfer Space-prefix + supported-channel helpers used by both
 // dmworkbase (FileCell) and dmworkdrive (module.tsx). Single source of truth
 // for the channel-normalisation contract (#1261 review round 6).
-export { hasSpacePrefix, stripSpacePrefix, isDriveTransferSupportedChannel } from './Service/SpacePrefix'
+export { hasSpacePrefix, stripSpacePrefix, isDriveTransferSupportedChannel, normaliseImDriveChannelID, imDriveTransferSourceKey } from './Service/SpacePrefix'

--- a/packages/dmworkdrive/src/__mocks__/dmworkBase.ts
+++ b/packages/dmworkdrive/src/__mocks__/dmworkBase.ts
@@ -68,6 +68,23 @@ export const stripSpacePrefix = (id: string) =>
 export const isDriveTransferSupportedChannel = (t: number) =>
   t === 1 || t === 2 || t === 5;
 
+// Mirror the real @octo/base helpers for the drive-transfer source_key.
+// Kept in sync with `packages/dmworkbase/src/Service/SpacePrefix.ts` — the
+// tests in driveApi.test.ts pin the format, so if the real helper drifts
+// these mocks must move too (that is exactly the drift-catching property
+// the parity test exists for).
+export const normaliseImDriveChannelID = (channelType: number, channelID: string): string => {
+  if (channelType !== 1) return channelID;
+  if (!hasSpacePrefix(channelID)) return channelID;
+  const bare = stripSpacePrefix(channelID);
+  return bare === '' ? channelID : bare;
+};
+export const imDriveTransferSourceKey = (
+  channelType: number,
+  channelID: string,
+  msgID: string,
+): string => `${channelType}#${normaliseImDriveChannelID(channelType, channelID)}#${msgID}`;
+
 export class Menus {
   constructor(
     public id: string,

--- a/packages/dmworkdrive/src/api/__tests__/driveApi.test.ts
+++ b/packages/dmworkdrive/src/api/__tests__/driveApi.test.ts
@@ -321,6 +321,23 @@ describe('auth-header interceptor', () => {
     }
   });
 
+  it('preserves a pre-set X-Space-Id header instead of clobbering it with the host tab (postWithSpace path)', () => {
+    // save-to-drive posts into an arbitrary target space and passes the target
+    // as a per-request X-Space-Id override. The interceptor must NOT overwrite
+    // it with WKApp.shared.currentSpaceId, or the transfer's RequireSpace
+    // middleware would reverse-check the wrong space and 403.
+    const requestUse = inst.interceptors.request.use as ReturnType<typeof vi.fn>;
+    const onRequest = requestUse.mock.calls[0][0];
+    const original = WKApp.shared.currentSpaceId;
+    try {
+      WKApp.shared.currentSpaceId = 'host-space';
+      const config = onRequest({ headers: { 'X-Space-Id': 'target-space' } });
+      expect(config.headers['X-Space-Id']).toBe('target-space');
+    } finally {
+      WKApp.shared.currentSpaceId = original;
+    }
+  });
+
   it('logs out on a 401 from a normal drive API', async () => {
     const logout = vi.spyOn(WKApp.shared, 'logout');
     const responseUse = inst.interceptors.response.use as ReturnType<typeof vi.fn>;
@@ -542,8 +559,8 @@ describe('IM -> drive transferred-state wire contract (source_key)', () => {
       target_parent_id: 0,
     };
     await driveApi.transferFromIm(req);
-    // Full body pin: any field rename / drop / added-required field on either
-    // side must update both — that is the point of this assertion.
+    // Empty target_space_id → plain post (2-arg call); the request interceptor
+    // fills X-Space-Id with the host tab's current space by default.
     expect(inst.post).toHaveBeenCalledWith('/v1/drive/blobs/transfer-from-im', {
       im_group_no: 'group_abc',
       im_channel_type: 2,
@@ -551,6 +568,42 @@ describe('IM -> drive transferred-state wire contract (source_key)', () => {
       target_space_id: '',
       target_parent_id: 0,
     });
+    // No per-request config → no X-Space-Id override was set.
+    const call = inst.post.mock.calls[0];
+    expect(call.length).toBe(2);
+  });
+
+  it('transferFromIm passes target_space_id as an X-Space-Id header override', async () => {
+    inst.post.mockResolvedValue(ok({ id: 99, space_id: 'sp_shared', parent_id: 0 }));
+    const req = {
+      im_group_no: 'group_abc',
+      im_channel_type: 2,
+      im_msg_id: '17012345678901234',
+      target_space_id: 'sp_shared',
+      target_parent_id: 42,
+    };
+    await driveApi.transferFromIm(req);
+    // Non-empty target_space_id → the request must carry that target as
+    // X-Space-Id so RequireSpace reverse-checks against MySpaces for the
+    // TARGET space, not the host tab's current space. The interceptor is
+    // configured to preserve a pre-set X-Space-Id header (see driveApi.ts).
+    expect(inst.post).toHaveBeenCalledWith(
+      '/v1/drive/blobs/transfer-from-im',
+      req,
+      { headers: { 'X-Space-Id': 'sp_shared' } },
+    );
+  });
+
+  it('getAncestors GETs /files/:id/ancestors and unwraps .ancestors', async () => {
+    inst.get.mockResolvedValue(ok({ ancestors: [{ id: 10, name: 'A' }, { id: 20, name: 'B' }] }));
+    const res = await driveApi.getAncestors(42);
+    expect(inst.get).toHaveBeenCalledWith('/v1/drive/files/42/ancestors', { params: {} });
+    expect(res).toEqual([{ id: 10, name: 'A' }, { id: 20, name: 'B' }]);
+  });
+
+  it('getAncestors returns [] for a root file (empty ancestors response)', async () => {
+    inst.get.mockResolvedValue(ok({ ancestors: [] }));
+    expect(await driveApi.getAncestors(1)).toEqual([]);
   });
 
   it('checkImTransferredBatch POSTs /blobs/im-transferred/batch with items[] triples', async () => {

--- a/packages/dmworkdrive/src/api/__tests__/driveApi.test.ts
+++ b/packages/dmworkdrive/src/api/__tests__/driveApi.test.ts
@@ -321,18 +321,21 @@ describe('auth-header interceptor', () => {
     }
   });
 
-  it('preserves a pre-set X-Space-Id header instead of clobbering it with the host tab (postWithSpace path)', () => {
-    // save-to-drive posts into an arbitrary target space and passes the target
-    // as a per-request X-Space-Id override. The interceptor must NOT overwrite
-    // it with WKApp.shared.currentSpaceId, or the transfer's RequireSpace
-    // middleware would reverse-check the wrong space and 403.
+  it('always overwrites the X-Space-Id header with the host tab, even when a caller pre-sets a different value', () => {
+    // X-Space-Id identifies the TENANT space to the drive RequireSpace middleware,
+    // NOT the drive-space uuid a body payload targets. If a caller pre-set the
+    // header (an older save-to-drive path did), the interceptor MUST still
+    // clobber it back to the host tab, or RequireSpace would reverse-check the
+    // wrong tenant space against octo-server's MySpaces and 403 the whole
+    // request. Drive space uuids travel in the body; the backend service layer
+    // resolves them itself.
     const requestUse = inst.interceptors.request.use as ReturnType<typeof vi.fn>;
     const onRequest = requestUse.mock.calls[0][0];
     const original = WKApp.shared.currentSpaceId;
     try {
       WKApp.shared.currentSpaceId = 'host-space';
-      const config = onRequest({ headers: { 'X-Space-Id': 'target-space' } });
-      expect(config.headers['X-Space-Id']).toBe('target-space');
+      const config = onRequest({ headers: { 'X-Space-Id': 'looks-like-a-drive-uuid' } });
+      expect(config.headers['X-Space-Id']).toBe('host-space');
     } finally {
       WKApp.shared.currentSpaceId = original;
     }
@@ -573,7 +576,7 @@ describe('IM -> drive transferred-state wire contract (source_key)', () => {
     expect(call.length).toBe(2);
   });
 
-  it('transferFromIm passes target_space_id as an X-Space-Id header override', async () => {
+  it('transferFromIm passes target_space_id in the request body only — no X-Space-Id override', async () => {
     inst.post.mockResolvedValue(ok({ id: 99, space_id: 'sp_shared', parent_id: 0 }));
     const req = {
       im_group_no: 'group_abc',
@@ -583,15 +586,15 @@ describe('IM -> drive transferred-state wire contract (source_key)', () => {
       target_parent_id: 42,
     };
     await driveApi.transferFromIm(req);
-    // Non-empty target_space_id → the request must carry that target as
-    // X-Space-Id so RequireSpace reverse-checks against MySpaces for the
-    // TARGET space, not the host tab's current space. The interceptor is
-    // configured to preserve a pre-set X-Space-Id header (see driveApi.ts).
-    expect(inst.post).toHaveBeenCalledWith(
-      '/v1/drive/blobs/transfer-from-im',
-      req,
-      { headers: { 'X-Space-Id': 'sp_shared' } },
-    );
+    // target_space_id (a DRIVE space uuid) travels in the body — the drive
+    // service resolves it in its own space table via assertUploader. It must
+    // NOT be threaded into X-Space-Id: RequireSpace would then reverse-check
+    // the drive uuid against octo-server's MySpaces (tenant spaces) and 403.
+    // Callsite is a plain 2-arg post; the interceptor fills X-Space-Id with
+    // the host tab's tenant space, same as any other body-scoped drive call.
+    expect(inst.post).toHaveBeenCalledWith('/v1/drive/blobs/transfer-from-im', req);
+    const call = inst.post.mock.calls[0];
+    expect(call.length).toBe(2);
   });
 
   it('getAncestors GETs /files/:id/ancestors and unwraps .ancestors', async () => {

--- a/packages/dmworkdrive/src/api/driveApi.ts
+++ b/packages/dmworkdrive/src/api/driveApi.ts
@@ -79,11 +79,13 @@ function resolveBaseURL(): string {
 }
 
 // Inject auth headers at request time (so the token stays fresh after refresh).
-// X-Space-Id defaults to WKApp.shared.currentSpaceId (the host tab's space).
-// Callers may pre-set config.headers['X-Space-Id'] to override for a single
-// request when acting on a space other than the host tab — e.g. save-to-drive
-// posting into a chosen target space; the interceptor preserves that override
-// instead of clobbering it back to the host space.
+// X-Space-Id is ALWAYS the host tab's tenant space — this header identifies
+// the octo tenant to the RequireSpace middleware, not the drive space the
+// operation targets. Drive spaces (personal/shared uuids) travel in request
+// bodies (e.g. transferFromIm.target_space_id) and the backend service layer
+// resolves them itself. An earlier version pre-set X-Space-Id to the drive
+// target_space_id and it 403'd because RequireSpace's MySpaces upstream
+// returned tenant spaces, not drive spaces.
 driveAxios.interceptors.request.use((config) => {
   config.baseURL = resolveBaseURL();
   config.headers = config.headers ?? {};
@@ -92,11 +94,9 @@ driveAxios.interceptors.request.use((config) => {
   if (token) {
     config.headers['token'] = token;
   }
-  if (config.headers['X-Space-Id'] == null || config.headers['X-Space-Id'] === '') {
-    const spaceId = WKApp.shared.currentSpaceId;
-    if (spaceId) {
-      config.headers['X-Space-Id'] = spaceId;
-    }
+  const spaceId = WKApp.shared.currentSpaceId;
+  if (spaceId) {
+    config.headers['X-Space-Id'] = spaceId;
   }
   return config;
 });
@@ -245,23 +245,6 @@ async function get<T>(
 async function post<T>(path: string, data?: unknown): Promise<T> {
   try {
     const resp = await driveAxios.post<T>(`${BASE}${path}`, data);
-    return resp.data;
-  } catch (err) {
-    throw extractApiError(err);
-  }
-}
-
-// postWithSpace is the single-request X-Space-Id override path. Used by
-// save-to-drive when the caller targets a space different from the host tab's
-// current space: transfer's RequireSpace middleware reverse-checks the header
-// against octo-server's MySpaces, so the request must carry the TARGET space,
-// not the host space. See driveAxios request interceptor for the "preserve
-// pre-set header" behavior this depends on.
-async function postWithSpace<T>(path: string, spaceId: string, data?: unknown): Promise<T> {
-  try {
-    const resp = await driveAxios.post<T>(`${BASE}${path}`, data, {
-      headers: { 'X-Space-Id': spaceId },
-    });
     return resp.data;
   } catch (err) {
     throw extractApiError(err);
@@ -447,13 +430,12 @@ export async function deleteBlob(blobId: number): Promise<void> {
 }
 
 export async function transferFromIm(req: TransferFromImReq): Promise<TransferResult> {
-  // When target_space_id is a non-current space, the request must carry that
-  // target as X-Space-Id (see postWithSpace / driveAxios interceptor comments).
-  // Empty target_space_id falls back to the host space via the interceptor's
-  // default, which is what the personal-space fallback path needs.
-  if (req.target_space_id) {
-    return postWithSpace<TransferResult>('/blobs/transfer-from-im', req.target_space_id, req);
-  }
+  // target_space_id travels in the body — the drive service resolves it in
+  // its own space table (via imtransfer.Service.assertUploader). X-Space-Id
+  // is the tenant space (host tab), unrelated to drive space uuids, and is
+  // filled by the request interceptor. Do NOT thread target_space_id into
+  // X-Space-Id: RequireSpace would then check drive-space membership
+  // against octo-server's MySpaces (tenant spaces) and 403.
   return post<TransferResult>('/blobs/transfer-from-im', req);
 }
 

--- a/packages/dmworkdrive/src/api/driveApi.ts
+++ b/packages/dmworkdrive/src/api/driveApi.ts
@@ -31,6 +31,7 @@ import type {
   PrepareUploadReq,
   ConfirmUploadReq,
   TransferFromImReq,
+  DriveAncestor,
   CreateShareReq,
   CreateInviteReq,
   DriveRole,
@@ -78,6 +79,11 @@ function resolveBaseURL(): string {
 }
 
 // Inject auth headers at request time (so the token stays fresh after refresh).
+// X-Space-Id defaults to WKApp.shared.currentSpaceId (the host tab's space).
+// Callers may pre-set config.headers['X-Space-Id'] to override for a single
+// request when acting on a space other than the host tab — e.g. save-to-drive
+// posting into a chosen target space; the interceptor preserves that override
+// instead of clobbering it back to the host space.
 driveAxios.interceptors.request.use((config) => {
   config.baseURL = resolveBaseURL();
   config.headers = config.headers ?? {};
@@ -86,9 +92,11 @@ driveAxios.interceptors.request.use((config) => {
   if (token) {
     config.headers['token'] = token;
   }
-  const spaceId = WKApp.shared.currentSpaceId;
-  if (spaceId) {
-    config.headers['X-Space-Id'] = spaceId;
+  if (config.headers['X-Space-Id'] == null || config.headers['X-Space-Id'] === '') {
+    const spaceId = WKApp.shared.currentSpaceId;
+    if (spaceId) {
+      config.headers['X-Space-Id'] = spaceId;
+    }
   }
   return config;
 });
@@ -237,6 +245,23 @@ async function get<T>(
 async function post<T>(path: string, data?: unknown): Promise<T> {
   try {
     const resp = await driveAxios.post<T>(`${BASE}${path}`, data);
+    return resp.data;
+  } catch (err) {
+    throw extractApiError(err);
+  }
+}
+
+// postWithSpace is the single-request X-Space-Id override path. Used by
+// save-to-drive when the caller targets a space different from the host tab's
+// current space: transfer's RequireSpace middleware reverse-checks the header
+// against octo-server's MySpaces, so the request must carry the TARGET space,
+// not the host space. See driveAxios request interceptor for the "preserve
+// pre-set header" behavior this depends on.
+async function postWithSpace<T>(path: string, spaceId: string, data?: unknown): Promise<T> {
+  try {
+    const resp = await driveAxios.post<T>(`${BASE}${path}`, data, {
+      headers: { 'X-Space-Id': spaceId },
+    });
     return resp.data;
   } catch (err) {
     throw extractApiError(err);
@@ -422,7 +447,23 @@ export async function deleteBlob(blobId: number): Promise<void> {
 }
 
 export async function transferFromIm(req: TransferFromImReq): Promise<TransferResult> {
+  // When target_space_id is a non-current space, the request must carry that
+  // target as X-Space-Id (see postWithSpace / driveAxios interceptor comments).
+  // Empty target_space_id falls back to the host space via the interceptor's
+  // default, which is what the personal-space fallback path needs.
+  if (req.target_space_id) {
+    return postWithSpace<TransferResult>('/blobs/transfer-from-im', req.target_space_id, req);
+  }
   return post<TransferResult>('/blobs/transfer-from-im', req);
+}
+
+/** Root-first folder path from a target file's owning space root to its
+ *  immediate parent — powers the "在云盘中查看" jump when the file lives
+ *  in a deep folder in any space. Empty array when parent_id=0 (root).
+ *  See DriveAncestor doc. */
+export async function getAncestors(fileId: number): Promise<DriveAncestor[]> {
+  const data = await get<{ ancestors: DriveAncestor[] }>(`/files/${fileId}/ancestors`);
+  return data.ancestors ?? [];
 }
 
 // Wire types for the IM -> drive transferred-state check now live in

--- a/packages/dmworkdrive/src/bridge/types.ts
+++ b/packages/dmworkdrive/src/bridge/types.ts
@@ -44,6 +44,12 @@ export interface Space {
   super_admin_uid: string;
   created_at: string;
   updated_at: string;
+  /** Caller's own role in this space. Present only on member-scoped list
+   *  responses (GET /v1/drive/spaces); empty string on single-space reads
+   *  (GET /v1/drive/spaces/:id). Front-end save-to-drive picker disables
+   *  target spaces whose viewer_role rank is below uploader_downloader.
+   *  Empty string means "unknown" — the caller should not gate on it. */
+  viewer_role?: DriveRole | '';
 }
 
 export interface Member {
@@ -318,6 +324,15 @@ export interface TransferFromImReq {
   target_space_id: string;
   target_parent_id: number;
   name_override?: string;
+}
+
+/** One folder on the root-to-parent path returned by GET /v1/drive/files/:id/ancestors.
+ *  Root-first ordering; the target file itself is not included; parent_id=0 root
+ *  means an empty array. Front-end save-to-drive "在云盘中查看" uses this to
+ *  rebuild the breadcrumb when jumping into a deep folder in any space. */
+export interface DriveAncestor {
+  id: number;
+  name: string;
 }
 
 export interface CreateShareReq {

--- a/packages/dmworkdrive/src/bridge/types.ts
+++ b/packages/dmworkdrive/src/bridge/types.ts
@@ -454,49 +454,40 @@ export interface ImTransferredItem {
 // wukongimjssdk ChannelType numeric enum, duplicated here to avoid dragging
 // the runtime `wukongimjssdk` dependency into a pure-type wire-contract file.
 // Any drift would fail the source_key format test in driveApi.test.ts.
-const CHANNEL_TYPE_PERSON = 1;
+// (`isDriveTransferSupportedChannel` moved to `@octo/base` `Service/SpacePrefix.ts`
+// long ago; the normalise + source_key helpers below now delegate there so
+// there is a single authoritative implementation shared by dmworkbase and
+// dmworkdrive. See Octo-Q / yujiawei review PR #1322 P2-6: duplicating the
+// formula reintroduces the icon/menu divergence this feature exists to fix.)
 
-// Note: `isDriveTransferSupportedChannel` lives in `@octo/base`
-// (`Service/SpacePrefix.ts`) and is the single source of truth for the
-// supported channel set. Kept out of this file deliberately: bridge/types.ts
-// stays free of runtime imports from `@octo/base`, so the wire-contract tests
-// exercise this module without pulling the base package's mock surface into
-// scope (see #1261 review round 7 P0-3).
+import { normaliseImDriveChannelID, imDriveTransferSourceKey } from '@octo/base';
 
 /**
- * Normalise `channelID` to the shape octo-drive / octo-server key on. See
- * `ImTransferredItem` doc block for the per-channelType contract. This is the
- * ONE authoritative normalisation entry point for the drive-transfer path;
- * callers must not hand-strip.
+ * @deprecated Thin re-export of `@octo/base` `normaliseImDriveChannelID`. Kept
+ * under the original name so existing dmworkdrive call sites don't churn; new
+ * code should import from `@octo/base` directly. The two producers of a
+ * source_key (FileCell in dmworkbase, module.tsx save/check in dmworkdrive)
+ * MUST agree on this normalisation — hosting it in `@octo/base` makes that
+ * impossible to violate.
  */
 export function normaliseImChannelID(channelType: number, channelID: string): string {
-  if (channelType === CHANNEL_TYPE_PERSON) {
-    // Person only: strip `s<32-hex>_` Space prefix if present. No-op otherwise.
-    // Inlined against the SpacePrefix regex so `bridge/types.ts` stays free of
-    // runtime imports from `dmworkbase`.
-    const m = channelID.match(/^s[0-9a-f]{32}_(.+)$/);
-    return m ? m[1] : channelID;
-  }
-  return channelID;
+  return normaliseImDriveChannelID(channelType, channelID);
 }
 
 /**
- * Materialize the source_key string exactly as octo-drive's `buildSourceKey`
- * does: `${im_channel_type}#${im_group_no}#${im_msg_id}`.
- *
- * ⚠️  This is the ONLY place in octo-web that constructs a source_key. Callers
- * (module.tsx's batch dedupe / results read-back) MUST route through this
- * function so any future backend format change is localized to one edit
- * instead of drifting across call sites. Do not inline `${...}#${...}#${...}`
- * elsewhere.
- *
- * The Person path expects a **normalised** (unprefixed) `im_group_no`. Callers
- * building an ImTransferredItem from a `Channel` should use `normaliseImChannelID`
- * to strip the Space prefix on Person; #1261 review round 6 P1-1.
- *
- * Backend anchor: octo-drive `internal/modules/imtransfer/service.go`
- * `buildSourceKey`, migration `db/migrations/007_add_file_source_key.up.sql`.
+ * @deprecated Thin re-export of `@octo/base` `imDriveTransferSourceKey`.
+ * Same rationale as `normaliseImChannelID` above. Keeps this module's API
+ * stable while making it structurally impossible for the formula to drift
+ * between dmworkbase and dmworkdrive. Callers in this package should keep
+ * using this shape (it takes an `ImTransferredItem` for wire-parity with
+ * the batch request payload); the underlying key derivation is the single
+ * `@octo/base` implementation.
  */
 export function imTransferredSourceKey(item: ImTransferredItem): string {
-  return `${item.im_channel_type}#${item.im_group_no}#${item.im_msg_id}`;
+  // Callers hand this an ALREADY-normalised `im_group_no` (they pass through
+  // `normaliseImChannelID` upstream). `imDriveTransferSourceKey` normalises
+  // again defensively, which is a no-op for an already-bare id — so the
+  // resulting key is identical for well-formed callers, and safer for any
+  // future caller that forgets the pre-normalisation.
+  return imDriveTransferSourceKey(item.im_channel_type, item.im_group_no, item.im_msg_id);
 }

--- a/packages/dmworkdrive/src/i18n/en-US.json
+++ b/packages/dmworkdrive/src/i18n/en-US.json
@@ -42,6 +42,15 @@
   "copy": {
     "title": "Copy to"
   },
+  "saveModal": {
+    "title": "Save to drive",
+    "selectSpace": "Choose target space",
+    "noSubfolder": "No subfolders here"
+  },
+  "contextMenus": {
+    "saveToDrive": "Save to drive…",
+    "viewInDrive": "View in drive"
+  },
   "delete": {
     "title": "Confirm deletion",
     "content": "Delete"

--- a/packages/dmworkdrive/src/i18n/en-US.json
+++ b/packages/dmworkdrive/src/i18n/en-US.json
@@ -4,7 +4,8 @@
   },
   "common": {
     "confirm": "Confirm",
-    "cancel": "Cancel"
+    "cancel": "Cancel",
+    "retry": "Retry"
   },
   "space": {
     "personal": "Personal",
@@ -45,7 +46,8 @@
   "saveModal": {
     "title": "Save to drive",
     "selectSpace": "Choose target space",
-    "noSubfolder": "No subfolders here"
+    "noSubfolder": "No subfolders here",
+    "folderTruncated": "Showing the first 200 folders; drill into a subfolder to keep browsing"
   },
   "contextMenus": {
     "saveToDrive": "Save to drive…",
@@ -187,6 +189,7 @@
     "moved": "Moved",
     "copied": "Copied",
     "deleted": "Deleted",
+    "saveToDriveSuccess": "Saved to Drive",
     "spaceNotFound": "Space no longer exists or you lost access"
   }
 }

--- a/packages/dmworkdrive/src/i18n/en-US.json
+++ b/packages/dmworkdrive/src/i18n/en-US.json
@@ -177,6 +177,7 @@
     "renamed": "Renamed",
     "moved": "Moved",
     "copied": "Copied",
-    "deleted": "Deleted"
+    "deleted": "Deleted",
+    "spaceNotFound": "Space no longer exists or you lost access"
   }
 }

--- a/packages/dmworkdrive/src/i18n/zh-CN.json
+++ b/packages/dmworkdrive/src/i18n/zh-CN.json
@@ -177,6 +177,7 @@
     "renamed": "重命名成功",
     "moved": "移动成功",
     "copied": "复制成功",
-    "deleted": "删除成功"
+    "deleted": "删除成功",
+    "spaceNotFound": "该空间不存在或已无访问权限"
   }
 }

--- a/packages/dmworkdrive/src/i18n/zh-CN.json
+++ b/packages/dmworkdrive/src/i18n/zh-CN.json
@@ -42,6 +42,15 @@
   "copy": {
     "title": "复制到"
   },
+  "saveModal": {
+    "title": "存到云盘",
+    "selectSpace": "选择目标空间",
+    "noSubfolder": "该文件夹下没有子文件夹"
+  },
+  "contextMenus": {
+    "saveToDrive": "存到云盘…",
+    "viewInDrive": "在云盘中查看"
+  },
   "delete": {
     "title": "确认删除",
     "content": "确定删除"

--- a/packages/dmworkdrive/src/i18n/zh-CN.json
+++ b/packages/dmworkdrive/src/i18n/zh-CN.json
@@ -4,7 +4,8 @@
   },
   "common": {
     "confirm": "确定",
-    "cancel": "取消"
+    "cancel": "取消",
+    "retry": "重试"
   },
   "space": {
     "personal": "个人空间",
@@ -45,7 +46,8 @@
   "saveModal": {
     "title": "存到云盘",
     "selectSpace": "选择目标空间",
-    "noSubfolder": "该文件夹下没有子文件夹"
+    "noSubfolder": "该文件夹下没有子文件夹",
+    "folderTruncated": "仅显示前 200 个文件夹，进入子文件夹继续浏览"
   },
   "contextMenus": {
     "saveToDrive": "存到云盘…",
@@ -187,6 +189,7 @@
     "moved": "移动成功",
     "copied": "复制成功",
     "deleted": "删除成功",
+    "saveToDriveSuccess": "已存到云盘",
     "spaceNotFound": "该空间不存在或已无访问权限"
   }
 }

--- a/packages/dmworkdrive/src/module.tsx
+++ b/packages/dmworkdrive/src/module.tsx
@@ -90,6 +90,39 @@ type DriveTransferredState =
   | { status: 'saved'; entry: DriveTransferredEntry };
 const driveTransferredCache = new Map<string, DriveTransferredState>();
 
+// Per-key monotonic write generation. Every write bumps its key's counter;
+// `seedDriveCache` refuses to overwrite when the write it was based on
+// (the batch RTT it was issued for) is older than a subsequent
+// `markDriveSaved`. Without this guard, a save that landed BEFORE a
+// pre-save batch RTT resolved would be silently downgraded to `notfound`
+// when the batch response arrived, and the right-click menu (which reads
+// the cache synchronously via getDriveTransferred) would flip back to
+// "存到云盘…" while the icon still shows "在云盘中查看". Reviewer flagged
+// this as the stale-seed downgrade race (Octo-Q PR #1322 P2). Note the
+// dual constraint: batch-seeded `notfound` MUST still be able to
+// overwrite a stale `saved` (that's how drive-side deletes reflect on
+// next FileCell mount, per c1f3071d), so a blanket "never downgrade"
+// isn't correct. Generation-based ordering is.
+const driveWriteGen = new Map<string, number>();
+
+function nextWriteGen(sourceKey: string): number {
+  const next = (driveWriteGen.get(sourceKey) ?? 0) + 1;
+  driveWriteGen.set(sourceKey, next);
+  return next;
+}
+
+// Identity epoch — bumped by every tenant / auth change. Each in-flight batch
+// captures the epoch at enqueue time; if the response arrives after a
+// clear() the epochs disagree and seedDriveCache/waiter resolvers drop the
+// stale-identity payload rather than repopulating the fresh session's cache
+// with the previous tenant's drive coordinates (Jerry-Xin round-2 blocking
+// on PR #1322). Clearing driveTransferredCache alone is not enough — an
+// old-identity batch that resolves AFTER the clear would seed right back in.
+let driveIdentityEpoch = 0;
+function bumpDriveIdentityEpoch(): void {
+  driveIdentityEpoch++;
+}
+
 function readDriveCache(sourceKey: string): DriveTransferredState {
   return driveTransferredCache.get(sourceKey) ?? { status: 'unknown' };
 }
@@ -98,8 +131,10 @@ function readDriveCache(sourceKey: string): DriveTransferredState {
  *  save path (icon quick-save, picker save) and by the batch-lookup response
  *  handler. Idempotent: repeated writes with the same entry stay 'saved' and
  *  still emit — a FileCell that mounted after the last emission wouldn't have
- *  received it, so we don't dedupe. */
+ *  received it, so we don't dedupe. Bumps the per-key write gen so later
+ *  in-flight batch responses can't overwrite this. */
 function markDriveSaved(sourceKey: string, entry: DriveTransferredEntry): void {
+  nextWriteGen(sourceKey);
   driveTransferredCache.set(sourceKey, { status: 'saved', entry });
   WKApp.mittBus.emit('wk:drive-transferred-changed', { sourceKey, entry });
 }
@@ -108,8 +143,22 @@ function markDriveSaved(sourceKey: string, entry: DriveTransferredEntry): void {
  *  Called from flushBatch AFTER the API response — the batch is the primary
  *  cache filler on first render of a chat file list. Emits on a `saved` seed
  *  so any FileCell whose async check landed after another card's cache-hit
- *  render still picks up the answer. */
-function seedDriveCache(sourceKey: string, entry: ImTransferredEntry | null): void {
+ *  render still picks up the answer.
+ *
+ *  Skips the write if a `markDriveSaved` landed on this key while the batch
+ *  RTT was in flight (the `issuedAtGen` argument captures the write-gen at
+ *  enqueue time; if the current gen has moved past it a save has since won
+ *  and the batch's answer is stale). This preserves the c1f3071d guarantee
+ *  that a `notfound` seed CAN overwrite a stale `saved` (drive-side delete
+ *  refresh) — the check is generation-based, not "never downgrade". */
+function seedDriveCache(sourceKey: string, issuedAtGen: number, entry: ImTransferredEntry | null): void {
+  const currentGen = driveWriteGen.get(sourceKey) ?? 0;
+  if (currentGen > issuedAtGen) {
+    // A markDriveSaved committed after this batch was issued. Drop the
+    // seed rather than downgrade the freshly-saved state.
+    return;
+  }
+  nextWriteGen(sourceKey);
   if (entry) {
     const compact: DriveTransferredEntry = {
       file_id: entry.file_id,
@@ -151,13 +200,29 @@ interface SaveToDriveModalHostProps {
 }
 function SaveToDriveModalHost({ vm, onClose, onConfirm }: SaveToDriveModalHostProps): JSX.Element {
   const live = useDriveVM(vm);
+  // Failure state: `listSpaces` failed under cold-start conditions, so
+  // `spaces` is [], `spacesLoading` is false, and `spacesError` is set. The
+  // earlier version only branched on `spaces.length === 0`, which meant the
+  // spinner shell rendered forever with only a `Toast.error` to signal the
+  // problem (Octo-Q round-2 P2). Give the user an explicit error card with
+  // a Retry action so a transient network blip doesn't dead-end the picker.
+  if (live.spaces.length === 0 && live.spacesError) {
+    return (
+      <SaveToDriveModal
+        visible
+        spaces={[]}
+        defaultSpaceId={null}
+        spacesError={live.spacesError}
+        onRetry={() => void live.loadSpaces()}
+        onClose={onClose}
+        onConfirm={onConfirm}
+      />
+    );
+  }
   if (live.spaces.length === 0) {
-    // Loading state: use the SAME modal shell (visible + onClose) so the
-    // user can cancel out of the picker while spaces are still loading.
-    // Empty spaces + our own loading marker keeps SaveToDriveModal's
-    // existing "waiting" branch (Confirm disabled) from ever being shown
-    // — that branch is only reachable via tests that mock spaces=[] AND
-    // don't wire the VM, which the wrapper now prevents in prod.
+    // Cold-start loading shell: spaces haven't arrived yet. The modal shell
+    // stays mounted so Cancel is clickable; the host re-renders once
+    // vm.notifyListener fires.
     return (
       <SaveToDriveModal
         visible
@@ -250,27 +315,44 @@ export default class DriveModule implements IModule {
     });
 
     // Right-click on a supported chat file message → "存到云盘…" / "在云盘中查看".
-    // Same visibility gate as the file card's icon (see Messages/File): driveOn
-    // remoteConfig ON, message is a File, channel type supports drive transfer.
-    // The registered handler runs on EVERY registered message type, so an
-    // early type-guard return keeps the menu list from getting a spurious
-    // entry for text/image/reply messages. There's a small window between
-    // mount and the transferred-state batch resolving where imTransferred is
-    // unknown — the message class holds that state, not this factory, so
-    // this handler defaults to the "存到云盘…" label + saveMessageToDriveAt
-    // path when it can't see the resolved state; the icon path continues to
-    // paint the two-state resolution in the message body regardless. In
-    // practice the user right-clicking a file they SAVED already went via
-    // the icon at least once — clicking the menu item's "存到云盘…" is a
-    // deliberate "save AGAIN into a different space", which is legal
-    // (drive dedupes per space) and consistent with the picker's semantics.
+    // Visibility gate FULLY mirrors the file card's icon
+    // (dmworkbase/Messages/File/index.tsx isMessagePersisted + display gates):
+    // driveOn remoteConfig ON, message is a File, channel type supports
+    // drive transfer, server messageID landed, and status===Normal (not
+    // Wait/Fail). The handler runs against every registered message type,
+    // so these early guards keep the menu list from getting a spurious
+    // entry for text/image/reply messages. Once the gates pass we ALSO
+    // read the cross-path saved-state cache synchronously
+    // (WKApp.getDriveTransferred): a known-saved file offers a "在云盘中查看"
+    // jump (no "save again" — issue #1321 Alternatives Considered
+    // deliberately rejects a re-save entry: the backend
+    // (target_space_id, ref_id) idempotency key silently returns the
+    // original row, so a second save into a different folder appears to
+    // do nothing). Unknown/notfound falls back to "存到云盘…" via the
+    // picker; that unknown branch is only reachable when the mount-time
+    // batch hasn't resolved yet, in which case a saved file's icon also
+    // still shows "存到云盘" pending the flip.
     WKApp.endpoints.registerMessageContextMenus(
       'contextmenus.driveSave',
       (message) => {
         if (!WKApp.remoteConfig?.driveOn) return null;
         if (message.contentType !== MessageContentTypeConst.file) return null;
         if (!isDriveTransferSupportedChannel(message.channel.channelType)) return null;
-        if (!message.messageID) return null; // unsent / send-ack pending
+        // Full parity with the icon's isMessagePersisted() gate
+        // (dmworkbase/Messages/File/index.tsx): the icon requires BOTH a
+        // server messageID (send-ack landed) AND status===Normal (not
+        // Wait/Fail). The earlier version checked only messageID, so a
+        // send-in-flight or send-failed message still offered the menu
+        // entry — the backend would then 404 on the empty/foreign
+        // im_msg_id. Reviewer yujiawei round-2 P2-4 on PR #1322.
+        if (!message.messageID) return null;
+        // MessageStatus.Normal === 1 (Wait=0, Normal=1, Fail=2 per
+        // wukongimjssdk lib/model.d.ts). Inlined as a numeric literal
+        // rather than imported: dmworkdrive doesn't declare `wukongimjssdk`
+        // as a dependency (the plugin talks to WKApp / mittBus surfaces only),
+        // and adding a runtime import here breaks the isolated web build
+        // Rolldown pass ("failed to resolve import 'wukongimjssdk'").
+        if (message.status !== 1) return null;
         // Two-state menu: mirror the icon. If the cache says the file is
         // already saved somewhere the caller can reach, offer "在云盘中查看"
         // that jumps to the winner. Otherwise (notfound / unknown) offer
@@ -303,11 +385,12 @@ export default class DriveModule implements IModule {
               im_channel_type: message.channel.channelType,
               im_msg_id: message.messageID,
             }).catch(() => {
-              // Cancel or backend failure: swallow — the picker's inner catch
-              // already left the modal open on failure; a plain cancel is a
-              // no-op. Toasts on success live inside the modal's onConfirm
-              // path (FileCell's existing success path also toasts when the
-              // icon triggers save, but the picker owns its own UX).
+              // Cancel or backend failure: swallow — the picker's inner
+              // handler already surfaced the failure via Toast.error and
+              // keeps the modal open for retry; a plain cancel is a no-op.
+              // Success toasts fire inside onConfirm (see Toast.success on
+              // the transferFromIm success path), so this outer .catch has
+              // nothing to add.
             });
           },
         };
@@ -325,6 +408,17 @@ export default class DriveModule implements IModule {
     // normalisation point for the drive-transfer path (see bridge/types).
     WKApp.saveMessageToDrive = async ({ im_group_no, im_channel_type, im_msg_id }: { im_group_no: string; im_channel_type: number; im_msg_id: string }) => {
       const normalised = normaliseImChannelID(im_channel_type, im_group_no);
+      // Snapshot the identity epoch BEFORE the POST so a tenant/auth
+      // switch mid-flight (space-changed / wk:auth-state-changed → clear
+      // + bumpDriveIdentityEpoch) makes this write skip the cache/emit.
+      // Otherwise the response would repopulate the fresh session's cache
+      // with the previous identity's drive coordinates and mittBus would
+      // flip a FileCell to "view in drive" pointing at the old tenant's
+      // file — reviewer Jerry-Xin / yujiawei / Octo-Q round-4 P2. The
+      // caller still gets the entry back so the icon path's own setState
+      // shows optimistic success (they can retry on next mount / refresh
+      // if the tenant switch made the drive-side row inaccessible).
+      const savedAtEpoch = driveIdentityEpoch;
       const result = await transferFromIm({
         im_group_no: normalised,
         im_channel_type,
@@ -335,13 +429,16 @@ export default class DriveModule implements IModule {
       const entry = { file_id: result.id, space_id: result.space_id, parent_id: result.parent_id };
       // Fan out to the cache + mittBus so the message's own FileCell icon
       // and any other subscribers (e.g. the right-click menu factory next
-      // time it opens) all see the saved state without a round-trip.
-      const sourceKey = imTransferredSourceKey({
-        im_channel_type,
-        im_group_no: normalised,
-        im_msg_id,
-      });
-      markDriveSaved(sourceKey, entry);
+      // time it opens) all see the saved state without a round-trip —
+      // ONLY when the identity hasn't switched during the RTT.
+      if (driveIdentityEpoch === savedAtEpoch) {
+        const sourceKey = imTransferredSourceKey({
+          im_channel_type,
+          im_group_no: normalised,
+          im_msg_id,
+        });
+        markDriveSaved(sourceKey, entry);
+      }
       return entry;
     };
 
@@ -406,6 +503,11 @@ export default class DriveModule implements IModule {
                 return true;
               }
               try {
+                // Snapshot the identity epoch BEFORE the POST — same
+                // stale-identity guard as saveMessageToDrive; picker
+                // sessions can straddle a tenant switch too. See
+                // saveMessageToDrive above for the full rationale.
+                const savedAtEpoch = driveIdentityEpoch;
                 const result = await transferFromIm({
                   im_group_no: normalised,
                   im_channel_type,
@@ -414,7 +516,28 @@ export default class DriveModule implements IModule {
                   target_parent_id: targetParentId,
                 });
                 const entry = { file_id: result.id, space_id: result.space_id, parent_id: result.parent_id };
+                if (driveIdentityEpoch !== savedAtEpoch) {
+                  // Tenant switched during the transfer POST. Don't
+                  // repopulate the fresh session's cache with the old
+                  // identity's coordinates, don't emit the fan-out, and
+                  // don't toast success (the "saved to drive" claim
+                  // would be misleading under the new identity). Silently
+                  // resolve the outer promise so the caller's cleanup
+                  // still runs; nothing else on the fresh session's UI
+                  // was ever wired to this file.
+                  done(() => resolve(entry));
+                  return true;
+                }
                 markDriveSaved(sourceKey, entry);
+                // Success toast — matches the icon path's Toast.success at
+                // dmworkbase/Messages/File/index.tsx (i18n key
+                // `base.messageFile.saveToDriveSuccess`) so both entry
+                // points give the user the same "yes it landed" signal
+                // (Jerry-Xin / yujiawei / Octo-Q round-2: the module.tsx
+                // comment used to claim the modal owns success toasts, but
+                // no Toast.success actually fired — silence on the happy
+                // path was as confusing as the earlier silence on failure).
+                Toast.success(translate('drive.toast.saveToDriveSuccess'));
                 done(() => resolve(entry));
                 return true;
               } catch (err) {
@@ -464,6 +587,15 @@ export default class DriveModule implements IModule {
     // storage key `${channelType}#${channelID}#${msgID}`.
     let pendingBatch: Map<string, {
       item: { im_group_no: string; im_channel_type: number; im_msg_id: string };
+      // Write-gen snapshot at enqueue time. If a save on this same key
+      // commits before the batch response returns, the current gen will
+      // be > issuedAtGen and seedDriveCache will drop the stale seed.
+      issuedAtGen: number;
+      // Identity epoch snapshot at enqueue time. Guards against
+      // tenant/auth change during the batch RTT — cache is cleared on
+      // the switch, but this in-flight response would otherwise repopulate
+      // it with the previous tenant's drive coordinates.
+      issuedAtEpoch: number;
       waiters: Array<{
         resolve: (v: ImTransferredEntry | null) => void;
         reject: (err: unknown) => void;
@@ -479,11 +611,25 @@ export default class DriveModule implements IModule {
       checkImTransferredBatch(items)
         .then((results) => {
           for (const [key, entry] of batch) {
+            // Identity check: if the tenant/user switched during the RTT,
+            // this response is answering under the previous identity and
+            // MUST NOT populate the fresh session's cache. Resolve the
+            // waiter with `null` (safer than throwing — FileCell will
+            // simply not flip to saved; a fresh mount under the new
+            // identity re-issues the check with the new epoch).
+            if (entry.issuedAtEpoch !== driveIdentityEpoch) {
+              for (const w of entry.waiters) w.resolve(null);
+              continue;
+            }
             const found = results[key] ?? null;
             // Fill the module-level cache BEFORE resolving waiters: FileCell
-            // resolvers will call readDriveCache to decide setState, so the
-            // seed must land first. Emits on 'saved' via seedDriveCache.
-            seedDriveCache(key, found);
+            // resolvers consume the resolved entry directly, but the cache
+            // must be up-to-date for concurrent synchronous readers
+            // (right-click menu factory via getDriveTransferred) that race
+            // with this microtask. Emits on 'saved' via seedDriveCache.
+            // The per-key gen check inside seedDriveCache guards against a
+            // save that landed while this RTT was in flight.
+            seedDriveCache(key, entry.issuedAtGen, found);
             for (const w of entry.waiters) w.resolve(found);
           }
         })
@@ -529,7 +675,14 @@ export default class DriveModule implements IModule {
         if (existing) {
           existing.waiters.push({ resolve, reject });
         } else {
-          pendingBatch.set(sourceKey, { item, waiters: [{ resolve, reject }] });
+          // Snapshot the current write-gen for this key. If a save on this
+          // key wins before the batch RTT returns, seedDriveCache will
+          // observe (driveWriteGen[key] > issuedAtGen) and drop the seed.
+          // Also snapshot the identity epoch so a tenant switch during
+          // the RTT invalidates this entry (see flushBatch).
+          const issuedAtGen = driveWriteGen.get(sourceKey) ?? 0;
+          const issuedAtEpoch = driveIdentityEpoch;
+          pendingBatch.set(sourceKey, { item, issuedAtGen, issuedAtEpoch, waiters: [{ resolve, reject }] });
         }
         if (!flushScheduled) {
           flushScheduled = true;
@@ -607,6 +760,8 @@ export default class DriveModule implements IModule {
     // (Jerry-Xin review 2026-08-10 non-blocking finding on PR #1322.)
     _spaceChangedHandler = () => {
       driveTransferredCache.clear();
+      driveWriteGen.clear();
+      bumpDriveIdentityEpoch();
       vm.reset();
     };
     WKApp.mittBus.on('space-changed', _spaceChangedHandler);
@@ -618,6 +773,8 @@ export default class DriveModule implements IModule {
     // space-changed, and we still need a clean cache.
     _authStateChangedHandler = () => {
       driveTransferredCache.clear();
+      driveWriteGen.clear();
+      bumpDriveIdentityEpoch();
     };
     WKApp.mittBus.on('wk:auth-state-changed', _authStateChangedHandler);
 

--- a/packages/dmworkdrive/src/module.tsx
+++ b/packages/dmworkdrive/src/module.tsx
@@ -5,6 +5,8 @@ import {
   Menus,
   i18n,
   t as translate,
+  MessageContentTypeConst,
+  isDriveTransferSupportedChannel,
 } from '@octo/base';
 import type { IModule } from '@octo/base';
 import DriveSidebar from './pages/DriveSidebar';
@@ -13,6 +15,7 @@ import { DriveVM } from './pages/DriveVM';
 import { transferFromIm, checkImTransferredBatch, getAncestors } from './api/driveApi';
 import type { ImTransferredEntry } from './api/driveApi';
 import { imTransferredSourceKey, normaliseImChannelID } from './bridge/types';
+import SaveToDriveModal from './ui/SaveToDriveModal';
 
 import enUS from './i18n/en-US.json';
 import zhCN from './i18n/zh-CN.json';
@@ -110,6 +113,50 @@ export default class DriveModule implements IModule {
       'en-US': enUS,
     });
 
+    // Right-click on a supported chat file message → "存到云盘…" / "在云盘中查看".
+    // Same visibility gate as the file card's icon (see Messages/File): driveOn
+    // remoteConfig ON, message is a File, channel type supports drive transfer.
+    // The registered handler runs on EVERY registered message type, so an
+    // early type-guard return keeps the menu list from getting a spurious
+    // entry for text/image/reply messages. There's a small window between
+    // mount and the transferred-state batch resolving where imTransferred is
+    // unknown — the message class holds that state, not this factory, so
+    // this handler defaults to the "存到云盘…" label + saveMessageToDriveAt
+    // path when it can't see the resolved state; the icon path continues to
+    // paint the two-state resolution in the message body regardless. In
+    // practice the user right-clicking a file they SAVED already went via
+    // the icon at least once — clicking the menu item's "存到云盘…" is a
+    // deliberate "save AGAIN into a different space", which is legal
+    // (drive dedupes per space) and consistent with the picker's semantics.
+    WKApp.endpoints.registerMessageContextMenus(
+      'contextmenus.driveSave',
+      (message) => {
+        if (!WKApp.remoteConfig?.driveOn) return null;
+        if (message.contentType !== MessageContentTypeConst.file) return null;
+        if (!isDriveTransferSupportedChannel(message.channel.channelType)) return null;
+        if (!message.messageID) return null; // unsent / send-ack pending
+        return {
+          title: translate('drive.contextMenus.saveToDrive'),
+          onClick: () => {
+            const save = WKApp.saveMessageToDriveAt;
+            if (!save) return;
+            void save({
+              im_group_no: message.channel.channelID,
+              im_channel_type: message.channel.channelType,
+              im_msg_id: message.messageID,
+            }).catch(() => {
+              // Cancel or backend failure: swallow — the picker's inner catch
+              // already left the modal open on failure; a plain cancel is a
+              // no-op. Toasts on success live inside the modal's onConfirm
+              // path (FileCell's existing success path also toasts when the
+              // icon triggers save, but the picker owns its own UX).
+            });
+          },
+        };
+      },
+      1500,
+    );
+
     // Bridge for the chat file card's "save to Drive" action. Backend accepts
     // an empty target_space_id and defaults to the caller's personal space,
     // so we don't pre-resolve it (one fewer round-trip). Person channelIDs
@@ -127,6 +174,75 @@ export default class DriveModule implements IModule {
         target_parent_id: 0,
       });
       return { file_id: result.id, space_id: result.space_id, parent_id: result.parent_id };
+    };
+
+    // Save-with-picker: same trigger, but the caller wants to choose target
+    // space + folder rather than the default personal-space-root fallback.
+    // Opens SaveToDriveModal via the global-modal singleton so it renders
+    // outside the message list (WKBase.showGlobalModal is the shared modal
+    // slot used by summary-share preview + confirmation flows). Resolves
+    // when the user confirms and the transfer POST returns, or rejects if
+    // they cancel. The returned shape matches saveMessageToDrive so both
+    // callers can reuse the same "flip icon + open drive" post-processing.
+    WKApp.saveMessageToDriveAt = ({ im_group_no, im_channel_type, im_msg_id }: { im_group_no: string; im_channel_type: number; im_msg_id: string }) => {
+      return new Promise<{ file_id: number; space_id: string; parent_id: number }>((resolve, reject) => {
+        // Ensure vm.spaces is loaded before the picker opens — the modal
+        // takes the space list as a prop and expects it non-empty. The
+        // picker also gates rank on viewer_role, which only exists on the
+        // list response; a stale vm.spaces would gate wrong.
+        vm.ensureLoaded();
+        const close = (): void => WKApp.shared.baseContext.hideGlobalModal();
+        let settled = false;
+        WKApp.shared.baseContext.showGlobalModal({
+          width: '480px',
+          closable: false,
+          footer: null,
+          onCancel: () => {
+            if (settled) return;
+            settled = true;
+            close();
+            reject(new Error('save-to-drive cancelled'));
+          },
+          body: (
+            <SaveToDriveModal
+              visible
+              spaces={vm.spaces}
+              defaultSpaceId={vm.activeSpaceId}
+              onClose={() => {
+                if (settled) return;
+                settled = true;
+                close();
+                reject(new Error('save-to-drive cancelled'));
+              }}
+              onConfirm={async (targetSpaceId, targetParentId) => {
+                try {
+                  const result = await transferFromIm({
+                    im_group_no: normaliseImChannelID(im_channel_type, im_group_no),
+                    im_channel_type,
+                    im_msg_id,
+                    target_space_id: targetSpaceId,
+                    target_parent_id: targetParentId,
+                  });
+                  settled = true;
+                  resolve({
+                    file_id: result.id,
+                    space_id: result.space_id,
+                    parent_id: result.parent_id,
+                  });
+                  return true;
+                } catch (err) {
+                  // Leave the modal open so the user can retry / choose a
+                  // different target — a 403 here means they picked a space
+                  // the backend refused (rank changed between listSpaces and
+                  // the POST); the picker still shows the same list.
+                  reject(err);
+                  return false;
+                }
+              }}
+            />
+          ),
+        });
+      });
     };
 
     // Chat file card mount-time check: has this IM file already been transferred?

--- a/packages/dmworkdrive/src/module.tsx
+++ b/packages/dmworkdrive/src/module.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import ReactDOM from 'react-dom';
 import {
   WKApp,
   ChatPage,
@@ -43,6 +44,73 @@ if (import.meta.hot) {
 // per module load; the `/drive` route factory and the menu's onPress both close
 // over it so the two WKViewQueue subtrees stay in sync.
 const vm = new DriveVM();
+
+// ---------------------------------------------------------------------------
+// Drive-transferred cache (module-scope singleton, spans FileCell lifetimes).
+// ---------------------------------------------------------------------------
+// Single source of truth for "has THIS IM file been saved to any drive space
+// I can see?" across every entry point (file-card icon, right-click menu,
+// picker modal). Keyed by the wire `source_key`
+// (channelType#channelID#msgID) so the key matches the backend storage key and
+// the request payload without an extra translation step.
+//
+// Why a module singleton, not React state:
+//   - Icon lives inside a FileCell (component state) — one per rendered
+//     message. Right-click menu is registered via WKApp.endpoints as a plain
+//     factory with no component instance to read state from. Both entry
+//     points must agree, and the agreement must survive scroll-out unmounts
+//     (the same file scrolls back into view later — the cache prevents a
+//     re-batch and prevents a stale "unsaved" flicker on the second mount
+//     before the async check resolves).
+//   - Cross-cutting event bus (WKApp.mittBus 'wk:drive-transferred-changed')
+//     is the fan-out: any write to this cache emits, subscribers (FileCell)
+//     setState so their icons and dropdowns update in place.
+//
+// Design choice: NO "list of locations". Product decision — a chat file is
+// either saved (any single canonical winner returned by backend
+// LookupBatchAcrossMySpaces' tie-break: personal > freshest shared) or not.
+// Existing entry points do not offer "save AGAIN elsewhere" once saved;
+// moving/copying is a drive-app concern, not IM's. Simplification comes from
+// that product invariant, not a tech shortcut.
+type DriveTransferredEntry = { file_id: number; space_id: string; parent_id: number };
+type DriveTransferredState =
+  | { status: 'unknown' } // never checked or check failed — treat as unsaved for UI
+  | { status: 'notfound' } // backend confirmed no drive row
+  | { status: 'saved'; entry: DriveTransferredEntry };
+const driveTransferredCache = new Map<string, DriveTransferredState>();
+
+function readDriveCache(sourceKey: string): DriveTransferredState {
+  return driveTransferredCache.get(sourceKey) ?? { status: 'unknown' };
+}
+
+/** Write a `saved` entry into the cache and broadcast the flip. Used by every
+ *  save path (icon quick-save, picker save) and by the batch-lookup response
+ *  handler. Idempotent: repeated writes with the same entry stay 'saved' and
+ *  still emit — a FileCell that mounted after the last emission wouldn't have
+ *  received it, so we don't dedupe. */
+function markDriveSaved(sourceKey: string, entry: DriveTransferredEntry): void {
+  driveTransferredCache.set(sourceKey, { status: 'saved', entry });
+  WKApp.mittBus.emit('wk:drive-transferred-changed', { sourceKey, entry });
+}
+
+/** Store the batch-lookup result: `saved` for hits, `notfound` for misses.
+ *  Called from flushBatch AFTER the API response — the batch is the primary
+ *  cache filler on first render of a chat file list. Emits on a `saved` seed
+ *  so any FileCell whose async check landed after another card's cache-hit
+ *  render still picks up the answer. */
+function seedDriveCache(sourceKey: string, entry: ImTransferredEntry | null): void {
+  if (entry) {
+    const compact: DriveTransferredEntry = {
+      file_id: entry.file_id,
+      space_id: entry.space_id,
+      parent_id: entry.parent_id,
+    };
+    driveTransferredCache.set(sourceKey, { status: 'saved', entry: compact });
+    WKApp.mittBus.emit('wk:drive-transferred-changed', { sourceKey, entry: compact });
+  } else {
+    driveTransferredCache.set(sourceKey, { status: 'notfound' });
+  }
+}
 
 // NOTE: the share (`/drive/s/:token`) and invite (`/drive/invite/:token`)
 // landing pages are intercepted by the host Layout (apps/web) as standalone
@@ -135,6 +203,28 @@ export default class DriveModule implements IModule {
         if (message.contentType !== MessageContentTypeConst.file) return null;
         if (!isDriveTransferSupportedChannel(message.channel.channelType)) return null;
         if (!message.messageID) return null; // unsent / send-ack pending
+        // Two-state menu: mirror the icon. If the cache says the file is
+        // already saved somewhere the caller can reach, offer "在云盘中查看"
+        // that jumps to the winner. Otherwise (notfound / unknown) offer
+        // the picker. Unknown is treated as "may not be saved" — safer
+        // default: never hide the save entry when we don't know.
+        const known = WKApp.getDriveTransferred?.({
+          im_group_no: message.channel.channelID,
+          im_channel_type: message.channel.channelType,
+          im_msg_id: message.messageID,
+        });
+        if (known) {
+          return {
+            title: translate('drive.contextMenus.viewInDrive'),
+            onClick: () => {
+              WKApp.openDriveFile?.({
+                space_id: known.space_id,
+                file_id: known.file_id,
+                parent_id: known.parent_id,
+              });
+            },
+          };
+        }
         return {
           title: translate('drive.contextMenus.saveToDrive'),
           onClick: () => {
@@ -154,7 +244,7 @@ export default class DriveModule implements IModule {
           },
         };
       },
-      1500,
+      100000, // put the entry LAST — dmworkbase uses up to 99999
     );
 
     // Bridge for the chat file card's "save to Drive" action. Backend accepts
@@ -166,24 +256,37 @@ export default class DriveModule implements IModule {
     // Callers hand raw `message.channel.channelID`; this is the single
     // normalisation point for the drive-transfer path (see bridge/types).
     WKApp.saveMessageToDrive = async ({ im_group_no, im_channel_type, im_msg_id }: { im_group_no: string; im_channel_type: number; im_msg_id: string }) => {
+      const normalised = normaliseImChannelID(im_channel_type, im_group_no);
       const result = await transferFromIm({
-        im_group_no: normaliseImChannelID(im_channel_type, im_group_no),
+        im_group_no: normalised,
         im_channel_type,
         im_msg_id,
         target_space_id: '',
         target_parent_id: 0,
       });
-      return { file_id: result.id, space_id: result.space_id, parent_id: result.parent_id };
+      const entry = { file_id: result.id, space_id: result.space_id, parent_id: result.parent_id };
+      // Fan out to the cache + mittBus so the message's own FileCell icon
+      // and any other subscribers (e.g. the right-click menu factory next
+      // time it opens) all see the saved state without a round-trip.
+      const sourceKey = imTransferredSourceKey({
+        im_channel_type,
+        im_group_no: normalised,
+        im_msg_id,
+      });
+      markDriveSaved(sourceKey, entry);
+      return entry;
     };
 
     // Save-with-picker: same trigger, but the caller wants to choose target
     // space + folder rather than the default personal-space-root fallback.
-    // Opens SaveToDriveModal via the global-modal singleton so it renders
-    // outside the message list (WKBase.showGlobalModal is the shared modal
-    // slot used by summary-share preview + confirmation flows). Resolves
-    // when the user confirms and the transfer POST returns, or rejects if
-    // they cancel. The returned shape matches saveMessageToDrive so both
-    // callers can reuse the same "flip icon + open drive" post-processing.
+    // Renders SaveToDriveModal into its own detached DOM node so its inner
+    // Semi `<Modal>` is the ONLY modal in the tree — do NOT use
+    // WKBase.showGlobalModal here: that helper wraps `body` in another
+    // Semi `<Modal>`, and stacking our own Modal inside it produced the
+    // "two boxes stacked" bug the owner reported. The picker is a full
+    // modal already, so it gets its own portal mount and cleans up on
+    // resolve/reject/cancel. Resolves when the user confirms and the
+    // transfer POST returns, rejects on cancel or backend failure.
     WKApp.saveMessageToDriveAt = ({ im_group_no, im_channel_type, im_msg_id }: { im_group_no: string; im_channel_type: number; im_msg_id: string }) => {
       return new Promise<{ file_id: number; space_id: string; parent_id: number }>((resolve, reject) => {
         // Ensure vm.spaces is loaded before the picker opens — the modal
@@ -191,58 +294,97 @@ export default class DriveModule implements IModule {
         // picker also gates rank on viewer_role, which only exists on the
         // list response; a stale vm.spaces would gate wrong.
         vm.ensureLoaded();
-        const close = (): void => WKApp.shared.baseContext.hideGlobalModal();
+        const host = document.createElement('div');
+        host.setAttribute('data-role', 'drive-save-modal-host');
+        document.body.appendChild(host);
         let settled = false;
-        WKApp.shared.baseContext.showGlobalModal({
-          width: '480px',
-          closable: false,
-          footer: null,
-          onCancel: () => {
-            if (settled) return;
-            settled = true;
-            close();
-            reject(new Error('save-to-drive cancelled'));
-          },
-          body: (
-            <SaveToDriveModal
-              visible
-              spaces={vm.spaces}
-              defaultSpaceId={vm.activeSpaceId}
-              onClose={() => {
-                if (settled) return;
-                settled = true;
-                close();
-                reject(new Error('save-to-drive cancelled'));
-              }}
-              onConfirm={async (targetSpaceId, targetParentId) => {
-                try {
-                  const result = await transferFromIm({
-                    im_group_no: normaliseImChannelID(im_channel_type, im_group_no),
-                    im_channel_type,
-                    im_msg_id,
-                    target_space_id: targetSpaceId,
-                    target_parent_id: targetParentId,
-                  });
-                  settled = true;
-                  resolve({
-                    file_id: result.id,
-                    space_id: result.space_id,
-                    parent_id: result.parent_id,
-                  });
-                  return true;
-                } catch (err) {
-                  // Leave the modal open so the user can retry / choose a
-                  // different target — a 403 here means they picked a space
-                  // the backend refused (rank changed between listSpaces and
-                  // the POST); the picker still shows the same list.
-                  reject(err);
-                  return false;
-                }
-              }}
-            />
-          ),
+        const cleanup = (): void => {
+          try {
+            ReactDOM.unmountComponentAtNode(host);
+          } catch {
+            // ignore — component may have already unmounted
+          }
+          host.remove();
+        };
+        const done = (fn: () => void): void => {
+          if (settled) return;
+          settled = true;
+          fn();
+          cleanup();
+        };
+        const normalised = normaliseImChannelID(im_channel_type, im_group_no);
+        const sourceKey = imTransferredSourceKey({
+          im_channel_type,
+          im_group_no: normalised,
+          im_msg_id,
         });
+        // Race guard: if the file was saved via ANOTHER path (icon quick-save
+        // in a different tab, or a batch-lookup that just resolved) while
+        // this picker was open, don't fire a second transfer. Skip
+        // straight to resolve with the cached entry so the caller's happy-
+        // path (icon flip + open-drive jump) still runs.
+        const cached = readDriveCache(sourceKey);
+        if (cached.status === 'saved') {
+          done(() => resolve(cached.entry));
+          return;
+        }
+        ReactDOM.render(
+          <SaveToDriveModal
+            visible
+            spaces={vm.spaces}
+            defaultSpaceId={vm.activeSpaceId}
+            onClose={() => done(() => reject(new Error('save-to-drive cancelled')))}
+            onConfirm={async (targetSpaceId, targetParentId) => {
+              // Second race check — the picker was open long enough for
+              // another path to win. Behaves like the pre-open guard: use
+              // the cached entry, close the modal, don't POST.
+              const now = readDriveCache(sourceKey);
+              if (now.status === 'saved') {
+                done(() => resolve(now.entry));
+                return true;
+              }
+              try {
+                const result = await transferFromIm({
+                  im_group_no: normalised,
+                  im_channel_type,
+                  im_msg_id,
+                  target_space_id: targetSpaceId,
+                  target_parent_id: targetParentId,
+                });
+                const entry = { file_id: result.id, space_id: result.space_id, parent_id: result.parent_id };
+                markDriveSaved(sourceKey, entry);
+                done(() => resolve(entry));
+                return true;
+              } catch (err) {
+                // Leave the modal open so the user can retry / choose a
+                // different target — a 403 here means they picked a space
+                // the backend refused (rank changed between listSpaces and
+                // the POST); the picker still shows the same list. The
+                // caller's outer .catch swallows the reject, so surfacing
+                // it here doesn't spam the console.
+                reject(err);
+                return false;
+              }
+            }}
+          />,
+          host,
+        );
       });
+    };
+
+    // Synchronous cache probe — see WKApp.getDriveTransferred JSDoc. Right-
+    // click menu factory needs a "known-so-far" answer at menu-open time.
+    WKApp.getDriveTransferred = ({ im_group_no, im_channel_type, im_msg_id }) => {
+      if (!im_group_no || !im_msg_id) return undefined;
+      const sourceKey = imTransferredSourceKey({
+        im_channel_type,
+        im_group_no: normaliseImChannelID(im_channel_type, im_group_no),
+        im_msg_id,
+      });
+      const state = readDriveCache(sourceKey);
+      if (state.status === 'saved') return state.entry;
+      if (state.status === 'notfound') return null;
+      return undefined;
     };
 
     // Chat file card mount-time check: has this IM file already been transferred?
@@ -273,6 +415,10 @@ export default class DriveModule implements IModule {
         .then((results) => {
           for (const [key, entry] of batch) {
             const found = results[key] ?? null;
+            // Fill the module-level cache BEFORE resolving waiters: FileCell
+            // resolvers will call readDriveCache to decide setState, so the
+            // seed must land first. Emits on 'saved' via seedDriveCache.
+            seedDriveCache(key, found);
             for (const w of entry.waiters) w.resolve(found);
           }
         })
@@ -304,8 +450,22 @@ export default class DriveModule implements IModule {
           im_channel_type: msg.im_channel_type,
           im_msg_id: msg.im_msg_id,
         };
-        if (!pendingBatch) pendingBatch = new Map();
         const sourceKey = imTransferredSourceKey(item);
+        // Cache short-circuit: an earlier batch/save already gave us the
+        // answer. Re-resolve synchronously (well, next microtask via the
+        // Promise) without hitting the backend or enqueueing. This is what
+        // keeps FileCell re-mounts (scroll-out → scroll-in) from spending a
+        // round-trip per re-appearance.
+        const cached = readDriveCache(sourceKey);
+        if (cached.status === 'saved') {
+          resolve({ ...cached.entry } as ImTransferredEntry);
+          return;
+        }
+        if (cached.status === 'notfound') {
+          resolve(null);
+          return;
+        }
+        if (!pendingBatch) pendingBatch = new Map();
         const existing = pendingBatch.get(sourceKey);
         if (existing) {
           existing.waiters.push({ resolve, reject });

--- a/packages/dmworkdrive/src/module.tsx
+++ b/packages/dmworkdrive/src/module.tsx
@@ -451,20 +451,14 @@ export default class DriveModule implements IModule {
           im_msg_id: msg.im_msg_id,
         };
         const sourceKey = imTransferredSourceKey(item);
-        // Cache short-circuit: an earlier batch/save already gave us the
-        // answer. Re-resolve synchronously (well, next microtask via the
-        // Promise) without hitting the backend or enqueueing. This is what
-        // keeps FileCell re-mounts (scroll-out → scroll-in) from spending a
-        // round-trip per re-appearance.
-        const cached = readDriveCache(sourceKey);
-        if (cached.status === 'saved') {
-          resolve({ ...cached.entry } as ImTransferredEntry);
-          return;
-        }
-        if (cached.status === 'notfound') {
-          resolve(null);
-          return;
-        }
+        // Deliberately NO cache short-circuit here — every FileCell mount
+        // must hit the backend so a drive-side delete (or any other tab's
+        // save/delete) is reflected on the next entry into a chat window.
+        // The cache is a WRITE-THROUGH sink for cross-component broadcast
+        // (mittBus + right-click menu's synchronous read), not a read-side
+        // freshness gate. Batch coalescing (queueMicrotask below) still
+        // dedupes concurrent same-key checks so a screen of messages
+        // resolves in one HTTP round-trip.
         if (!pendingBatch) pendingBatch = new Map();
         const existing = pendingBatch.get(sourceKey);
         if (existing) {

--- a/packages/dmworkdrive/src/module.tsx
+++ b/packages/dmworkdrive/src/module.tsx
@@ -10,7 +10,7 @@ import type { IModule } from '@octo/base';
 import DriveSidebar from './pages/DriveSidebar';
 import DriveContent from './pages/DriveContent';
 import { DriveVM } from './pages/DriveVM';
-import { transferFromIm, checkImTransferredBatch } from './api/driveApi';
+import { transferFromIm, checkImTransferredBatch, getAncestors } from './api/driveApi';
 import type { ImTransferredEntry } from './api/driveApi';
 import { imTransferredSourceKey, normaliseImChannelID } from './bridge/types';
 
@@ -208,12 +208,15 @@ export default class DriveModule implements IModule {
     // mount the RIGHT file view and let the VM focus/flash the target file.
     // switchToMenuById intentionally does not popToRoot (shared left stack),
     // and only syncs the route — it does not mount contentRight, so we still
-    // call mountDriveContent explicitly. IM-transfer callers only produce files
-    // at the personal-space root, so no parent_id is threaded through.
-    WKApp.openDriveFile = ({ space_id, file_id }: { space_id: string; file_id: number }) => {
+    // call mountDriveContent explicitly. When the file lives in a nested
+    // folder (any space, including a shared one — cross-space save-to-drive
+    // saves the file at any depth), pass parent_id so DriveVM.focusFile can
+    // pull the ancestor chain and rebuild the breadcrumb; parent_id=0/undefined
+    // = space root (the personal-space-root case that always worked).
+    WKApp.openDriveFile = ({ space_id, file_id, parent_id }: { space_id: string; file_id: number; parent_id?: number }) => {
       WKApp.switchToMenuById?.('drive');
       mountDriveContent();
-      vm.focusFile(space_id, file_id);
+      void vm.focusFile(space_id, file_id, parent_id);
     };
 
     // `/drive` renders the space rail into contentLeft. hostShell keeps

--- a/packages/dmworkdrive/src/module.tsx
+++ b/packages/dmworkdrive/src/module.tsx
@@ -12,11 +12,12 @@ import {
 import type { IModule } from '@octo/base';
 import DriveSidebar from './pages/DriveSidebar';
 import DriveContent from './pages/DriveContent';
-import { DriveVM } from './pages/DriveVM';
+import { DriveVM, useDriveVM } from './pages/DriveVM';
 import { transferFromIm, checkImTransferredBatch, getAncestors } from './api/driveApi';
 import type { ImTransferredEntry } from './api/driveApi';
 import { imTransferredSourceKey, normaliseImChannelID } from './bridge/types';
 import SaveToDriveModal from './ui/SaveToDriveModal';
+import { Toast } from './utils/toast';
 
 import enUS from './i18n/en-US.json';
 import zhCN from './i18n/zh-CN.json';
@@ -25,6 +26,12 @@ import zhCN from './i18n/zh-CN.json';
 let _initialized = false;
 /** `space-changed` subscription, kept for HMR teardown. */
 let _spaceChangedHandler: (() => void) | null = null;
+/** `wk:auth-state-changed` subscription, kept for HMR teardown. Bound alongside
+ *  `space-changed` so both flush the drive-transferred cache on tenant/user
+ *  swaps (see review PR #1322 non-blocking finding: the cache used to survive
+ *  identity changes and could feed stale synchronous state to the right-click
+ *  menu until the next backend batch overwrote it). */
+let _authStateChangedHandler: (() => void) | null = null;
 /** remoteConfig (drive_on) listeners, kept so a repeat init drops them before rebinding. */
 let _configUnsubscribers: Array<() => void> = [];
 
@@ -34,6 +41,10 @@ if (import.meta.hot) {
     if (_spaceChangedHandler) {
       WKApp.mittBus.off('space-changed', _spaceChangedHandler);
       _spaceChangedHandler = null;
+    }
+    if (_authStateChangedHandler) {
+      WKApp.mittBus.off('wk:auth-state-changed', _authStateChangedHandler);
+      _authStateChangedHandler = null;
     }
     for (const unsub of _configUnsubscribers) unsub();
     _configUnsubscribers = [];
@@ -110,6 +121,63 @@ function seedDriveCache(sourceKey: string, entry: ImTransferredEntry | null): vo
   } else {
     driveTransferredCache.set(sourceKey, { status: 'notfound' });
   }
+}
+
+// ---------------------------------------------------------------------------
+// SaveToDriveModalHost — subscribes to DriveVM so the picker survives cold
+// start (user never opened Drive this session → vm.spaces starts empty and
+// arrives asynchronously after `loadSpaces()` resolves). Without this
+// wrapper the one-shot ReactDOM.render used to snapshot vm.spaces at portal-
+// creation time, and post-load list updates never re-rendered the picker —
+// the space dropdown stayed empty and Confirm stayed disabled forever
+// (Jerry-Xin review 2026-08-10 blocking finding on PR #1322).
+//
+// Behaviour:
+//   - `useDriveVM(vm)` triggers `vm.ensureLoaded()` on mount AND re-renders
+//     the host whenever the VM notifies.
+//   - Before spaces have arrived, render a small centred spinner in a
+//     `<Modal>` shell so the user can still cancel; do NOT render the real
+//     picker yet — its Confirm button would be disabled with no explanation.
+//   - Once spaces are present, render the real picker with the current
+//     activeSpaceId as default (matches vm.ensureLoaded's post-load state).
+//
+// The host receives the callbacks unchanged from saveMessageToDriveAt; it
+// does not know about the race guard, the cache, or the transfer POST.
+// ---------------------------------------------------------------------------
+interface SaveToDriveModalHostProps {
+  vm: DriveVM;
+  onClose: () => void;
+  onConfirm: (targetSpaceId: string, targetParentId: number) => Promise<boolean>;
+}
+function SaveToDriveModalHost({ vm, onClose, onConfirm }: SaveToDriveModalHostProps): JSX.Element {
+  const live = useDriveVM(vm);
+  if (live.spaces.length === 0) {
+    // Loading state: use the SAME modal shell (visible + onClose) so the
+    // user can cancel out of the picker while spaces are still loading.
+    // Empty spaces + our own loading marker keeps SaveToDriveModal's
+    // existing "waiting" branch (Confirm disabled) from ever being shown
+    // — that branch is only reachable via tests that mock spaces=[] AND
+    // don't wire the VM, which the wrapper now prevents in prod.
+    return (
+      <SaveToDriveModal
+        visible
+        spaces={[]}
+        defaultSpaceId={null}
+        spacesLoading
+        onClose={onClose}
+        onConfirm={onConfirm}
+      />
+    );
+  }
+  return (
+    <SaveToDriveModal
+      visible
+      spaces={live.spaces}
+      defaultSpaceId={live.activeSpaceId}
+      onClose={onClose}
+      onConfirm={onConfirm}
+    />
+  );
 }
 
 // NOTE: the share (`/drive/s/:token`) and invite (`/drive/invite/:token`)
@@ -289,11 +357,7 @@ export default class DriveModule implements IModule {
     // transfer POST returns, rejects on cancel or backend failure.
     WKApp.saveMessageToDriveAt = ({ im_group_no, im_channel_type, im_msg_id }: { im_group_no: string; im_channel_type: number; im_msg_id: string }) => {
       return new Promise<{ file_id: number; space_id: string; parent_id: number }>((resolve, reject) => {
-        // Ensure vm.spaces is loaded before the picker opens — the modal
-        // takes the space list as a prop and expects it non-empty. The
-        // picker also gates rank on viewer_role, which only exists on the
-        // list response; a stale vm.spaces would gate wrong.
-        vm.ensureLoaded();
+        // The host wrapper does its own ensureLoaded via useDriveVM.
         const host = document.createElement('div');
         host.setAttribute('data-role', 'drive-save-modal-host');
         document.body.appendChild(host);
@@ -329,10 +393,8 @@ export default class DriveModule implements IModule {
           return;
         }
         ReactDOM.render(
-          <SaveToDriveModal
-            visible
-            spaces={vm.spaces}
-            defaultSpaceId={vm.activeSpaceId}
+          <SaveToDriveModalHost
+            vm={vm}
             onClose={() => done(() => reject(new Error('save-to-drive cancelled')))}
             onConfirm={async (targetSpaceId, targetParentId) => {
               // Second race check — the picker was open long enough for
@@ -356,13 +418,16 @@ export default class DriveModule implements IModule {
                 done(() => resolve(entry));
                 return true;
               } catch (err) {
-                // Leave the modal open so the user can retry / choose a
-                // different target — a 403 here means they picked a space
-                // the backend refused (rank changed between listSpaces and
-                // the POST); the picker still shows the same list. The
-                // caller's outer .catch swallows the reject, so surfacing
-                // it here doesn't spam the console.
-                reject(err);
+                // Deliberately do NOT reject the outer promise here — the
+                // modal stays open for the user to retry (a 403 typically
+                // means the picked space's rank changed between listSpaces
+                // and the POST). If we rejected, a later successful retry
+                // could not fulfil an already-settled promise. Only cancel
+                // (onClose above) rejects. Surface the failure inline via
+                // toast so the click isn't silent (Jerry-Xin review non-
+                // blocking finding on PR #1322).
+                const msg = (err as Error)?.message || translate('drive.toast.opFailed');
+                Toast.error(msg);
                 return false;
               }
             }}
@@ -535,8 +600,26 @@ export default class DriveModule implements IModule {
     // showing the previous tenant's spaces/breadcrumb while requests already
     // carry the new X-Space-Id. Reset + reload the shared VM. Mirrors the
     // sister modules' `space-changed` subscription (dmworksummary/module.tsx).
-    _spaceChangedHandler = () => vm.reset();
+    // Also flush the drive-transferred cache — the right-click menu factory
+    // reads this synchronously; leaving stale entries survives a tenant
+    // swap and can show "在云盘中查看" for a file the new identity does not
+    // own. Backend batches will refill on the next FileCell mount.
+    // (Jerry-Xin review 2026-08-10 non-blocking finding on PR #1322.)
+    _spaceChangedHandler = () => {
+      driveTransferredCache.clear();
+      vm.reset();
+    };
     WKApp.mittBus.on('space-changed', _spaceChangedHandler);
+
+    // Same cache-flush contract, tighter trigger: login/logout/account
+    // replacement (`wk:auth-state-changed`). This runs alongside the
+    // space-changed handler because the events don't fully overlap — a
+    // pure re-auth on the same tenant fires wk:auth-state-changed without
+    // space-changed, and we still need a clean cache.
+    _authStateChangedHandler = () => {
+      driveTransferredCache.clear();
+    };
+    WKApp.mittBus.on('wk:auth-state-changed', _authStateChangedHandler);
 
     // appconfig is fetched asynchronously, so at init() driveOn is usually still
     // the default false. Refresh the NavRail whenever drive_on resolves/changes

--- a/packages/dmworkdrive/src/pages/DriveVM.ts
+++ b/packages/dmworkdrive/src/pages/DriveVM.ts
@@ -45,6 +45,15 @@ export class DriveVM extends ProviderListener {
    */
   private loadSeq = 0;
 
+  /**
+   * Monotonic focus generation, same rationale as `loadSeq`: two quick
+   * "view in drive" clicks race across `getAncestors`, and the slower
+   * request MUST NOT overwrite state the newer click already committed.
+   * Every focusFile call claims the next value and every state write
+   * checks it's still the newest before touching the VM.
+   */
+  private focusSeq = 0;
+
   get personalSpace(): Space | null {
     return this.spaces.find((s) => s.type === 'personal') ?? null;
   }
@@ -87,6 +96,19 @@ export class DriveVM extends ProviderListener {
    */
   reset(): void {
     if (!this.loadStarted) return;
+    // Bump both generation counters so any in-flight loadSpaces AND any
+    // in-flight focusFile that started under the previous tenant will fail
+    // their post-await guards and refuse to commit to the freshly-reset
+    // VM. Without the focusSeq bump, a "view in drive" jump that was
+    // awaiting getAncestors when a host tenant switch fires reset() will
+    // still pass its `seq === this.focusSeq` check and write the previous
+    // tenant's activeSpaceId/path/highlight into the new tenant's VM,
+    // leaving a dangling activeSpaceId that DriveContent then browses
+    // under the wrong X-Space-Id. Reviewer Jerry-Xin / yujiawei / Octo-Q
+    // round-4 P1 on PR #1322: focusSeq alone serializes focus-vs-focus
+    // but does NOT cover focus-vs-reset.
+    this.loadSeq++;
+    this.focusSeq++;
     this.spaces = [];
     this.spacesError = null;
     this.activeSpaceId = null;
@@ -175,39 +197,71 @@ export class DriveVM extends ProviderListener {
    *  space even if the intermediate folders didn't paint.
    */
   async focusFile(spaceId: string, fileId: number, parentId?: number): Promise<void> {
-    this.ensureLoaded();
+    // Claim the newest focus generation. Any await point below re-checks this
+    // before touching state: two quick "view in drive" clicks (from a
+    // stack of message cards, or a click-into-drive followed by another
+    // click before ancestors resolve) must not see the slower resolution
+    // overwrite the newer one. Same discipline as loadSeq in loadSpaces.
+    const seq = ++this.focusSeq;
+
+    // Kick the first-time load if it hasn't started yet, then AWAIT its
+    // outcome — the previous version called both ensureLoaded (fire-and-
+    // forget) AND await loadSpaces (a fresh load) whenever the space
+    // wasn't found, so the cold path always paid for two listSpaces
+    // round-trips. Now: if loadStarted is false we ensure + await the
+    // already-in-flight load; if loadStarted is true we don't re-fetch
+    // unless we still don't know about the space.
+    if (!this.loadStarted) {
+      this.ensureLoaded();
+    }
+    if (this.spacesLoading) {
+      // Wait for the current load to settle via a listener-driven yield.
+      await new Promise<void>((resolve) => {
+        const off = this.addListener(() => {
+          if (!this.spacesLoading) {
+            off();
+            resolve();
+          }
+        });
+      });
+    }
+    if (seq !== this.focusSeq) return;
     let space = this.spaces.find((s) => s.id === spaceId);
-    // If the caller triggered focusFile before the first-time load
-    // resolved, `spaces` may still be empty here — retry once after a
-    // notifyListener tick would happen (loadSpaces is fire-and-forget).
-    // The simpler cover: rely on the caller's expectation that a saved-
-    // hit space is one the caller currently belongs to (the batch
-    // transferred-state lookup gates on membership), so the space either
-    // is in the list at focus time, or won't be after a load either.
     if (!space) {
-      // Reload once — the space may have been added between last
+      // Reload once — the space may have been added between the last
       // loadSpaces and this click (shared-space invite acceptance, etc.).
       await this.loadSpaces();
+      if (seq !== this.focusSeq) return;
       space = this.spaces.find((s) => s.id === spaceId);
     }
     if (!space) {
       Toast.error(t('drive.toast.spaceNotFound'));
       return;
     }
-    this.activeSpaceId = spaceId;
-    const rootCrumb: Crumb = { id: 0, name: spaceDisplayName(space, t) };
-    if (!parentId || parentId === 0) {
-      this.path = [rootCrumb];
-    } else {
-      let ancestors: Array<{ id: number; name: string }> = [];
+    // Resolve ancestors FIRST, then commit activeSpaceId / path /
+    // highlightFileId / notifyListener in one atomic block. The earlier
+    // version split the transition across the await: activeSpaceId
+    // updated synchronously → DriveContent's useFileList observed the
+    // new space with the previous space's path (currentParentId was a
+    // folder id from another space) → issued a cross-space
+    // `browse({space_id: <new>, parent_id: <old space's folder>})` that
+    // 404/403'd during the ancestors round-trip. Reviewer flagged this
+    // as the deep-jump race (Jerry-Xin / yujiawei / Octo-Q PR #1322).
+    let ancestors: Array<{ id: number; name: string }> = [];
+    if (parentId && parentId !== 0) {
       try {
         ancestors = await api.getAncestors(fileId);
       } catch {
         // Best-effort — leave ancestors empty and land on the space root.
         ancestors = [];
       }
-      this.path = [rootCrumb, ...ancestors.map((a) => ({ id: a.id, name: a.name }))];
+      if (seq !== this.focusSeq) return;
     }
+    const rootCrumb: Crumb = { id: 0, name: spaceDisplayName(space, t) };
+    this.activeSpaceId = spaceId;
+    this.path = ancestors.length === 0
+      ? [rootCrumb]
+      : [rootCrumb, ...ancestors.map((a) => ({ id: a.id, name: a.name }))];
     this.highlightFileId = fileId;
     this.notifyListener();
   }

--- a/packages/dmworkdrive/src/pages/DriveVM.ts
+++ b/packages/dmworkdrive/src/pages/DriveVM.ts
@@ -152,13 +152,62 @@ export class DriveVM extends ProviderListener {
     this.notifyListener();
   }
 
-  /** Jump to a file in a space and mark it for flash highlight. IM-transfer
-   *  callers only produce files at the personal-space root, so we reset the
-   *  path to root unconditionally. */
-  focusFile(spaceId: string, fileId: number): void {
-    const space = this.spaces.find((s) => s.id === spaceId);
+  /** Jump to a file in a space, opening the correct breadcrumb path and
+   *  marking the file for flash highlight. When parentId is 0 / undefined
+   *  the target lives at the space root — set path to just the space
+   *  root crumb (the personal-space-root case that always worked).
+   *  For a parentId > 0 (target buried in nested folders — the common case
+   *  once save-to-drive can pick any target folder in any space) we fetch
+   *  the ancestor chain from the backend and rebuild the breadcrumb, so
+   *  the left sidebar shows the correct hierarchy and each ancestor is
+   *  navigable back up.
+   *
+   *  Safety net: `ensureLoaded()` is called first so a caller who has
+   *  never opened drive still has a `spaces` list to look up the target
+   *  in. If the target space is not in the loaded list (caller was
+   *  removed from a shared space between save and this click), toast and
+   *  skip — do NOT switch to a nonexistent space (would render a dangling
+   *  activeSpaceId with an empty toolbar).
+   *
+   *  Ancestor fetch is best-effort: a 4xx / network hiccup falls back to
+   *  the space-root breadcrumb rather than blocking the jump. The file
+   *  itself is still highlighted; the user can see it lives in this
+   *  space even if the intermediate folders didn't paint.
+   */
+  async focusFile(spaceId: string, fileId: number, parentId?: number): Promise<void> {
+    this.ensureLoaded();
+    let space = this.spaces.find((s) => s.id === spaceId);
+    // If the caller triggered focusFile before the first-time load
+    // resolved, `spaces` may still be empty here — retry once after a
+    // notifyListener tick would happen (loadSpaces is fire-and-forget).
+    // The simpler cover: rely on the caller's expectation that a saved-
+    // hit space is one the caller currently belongs to (the batch
+    // transferred-state lookup gates on membership), so the space either
+    // is in the list at focus time, or won't be after a load either.
+    if (!space) {
+      // Reload once — the space may have been added between last
+      // loadSpaces and this click (shared-space invite acceptance, etc.).
+      await this.loadSpaces();
+      space = this.spaces.find((s) => s.id === spaceId);
+    }
+    if (!space) {
+      Toast.error(t('drive.toast.spaceNotFound'));
+      return;
+    }
     this.activeSpaceId = spaceId;
-    this.path = [{ id: 0, name: space ? spaceDisplayName(space, t) : t('drive.file.root') }];
+    const rootCrumb: Crumb = { id: 0, name: spaceDisplayName(space, t) };
+    if (!parentId || parentId === 0) {
+      this.path = [rootCrumb];
+    } else {
+      let ancestors: Array<{ id: number; name: string }> = [];
+      try {
+        ancestors = await api.getAncestors(fileId);
+      } catch {
+        // Best-effort — leave ancestors empty and land on the space root.
+        ancestors = [];
+      }
+      this.path = [rootCrumb, ...ancestors.map((a) => ({ id: a.id, name: a.name }))];
+    }
     this.highlightFileId = fileId;
     this.notifyListener();
   }

--- a/packages/dmworkdrive/src/pages/__tests__/DriveVM.test.ts
+++ b/packages/dmworkdrive/src/pages/__tests__/DriveVM.test.ts
@@ -6,6 +6,7 @@ vi.mock('../../api/driveApi', () => ({
   listSpaces: vi.fn(),
   ensurePersonalSpace: vi.fn(),
   createSharedSpace: vi.fn(),
+  getAncestors: vi.fn(),
 }));
 vi.mock('../../utils/toast', () => ({ Toast: { success: vi.fn(), error: vi.fn() } }));
 
@@ -115,5 +116,70 @@ describe('DriveVM tenant isolation (PR#1146 review B1)', () => {
     await waitFor(() => expect(vm.spaces.length).toBe(2));
     expect(vm.spaces.map((s) => s.id)).toEqual(['p2', 'b']);
     expect(api.listSpaces).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('DriveVM.focusFile', () => {
+  it('root file jump keeps path at just the space root', async () => {
+    vi.mocked(api.listSpaces).mockResolvedValue([space('p', 'personal'), space('s', 'shared')]);
+    const vm = new DriveVM();
+    vm.ensureLoaded();
+    await waitFor(() => expect(vm.spaces.length).toBe(2));
+
+    await vm.focusFile('s', 42);
+    expect(vm.activeSpaceId).toBe('s');
+    expect(vm.path.length).toBe(1);
+    expect(vm.path[0].id).toBe(0);
+    expect(vm.highlightFileId).toBe(42);
+    // no ancestors fetch for root files
+    expect(api.getAncestors).not.toHaveBeenCalled();
+  });
+
+  it('deep file jump fetches ancestors and expands the breadcrumb root-first', async () => {
+    vi.mocked(api.listSpaces).mockResolvedValue([space('p', 'personal'), space('s', 'shared')]);
+    vi.mocked(api.getAncestors).mockResolvedValueOnce([
+      { id: 10, name: 'A' },
+      { id: 20, name: 'B' },
+      { id: 30, name: 'C' },
+    ]);
+    const vm = new DriveVM();
+    vm.ensureLoaded();
+    await waitFor(() => expect(vm.spaces.length).toBe(2));
+
+    await vm.focusFile('s', 999, 30);
+    expect(vm.activeSpaceId).toBe('s');
+    // root crumb + 3 ancestors
+    expect(vm.path.map((c) => c.id)).toEqual([0, 10, 20, 30]);
+    expect(vm.path.map((c) => c.name).slice(1)).toEqual(['A', 'B', 'C']);
+    expect(vm.highlightFileId).toBe(999);
+    expect(api.getAncestors).toHaveBeenCalledWith(999);
+  });
+
+  it('unknown target space toasts and does not switch', async () => {
+    vi.mocked(api.listSpaces).mockResolvedValue([space('p', 'personal')]);
+    const vm = new DriveVM();
+    vm.ensureLoaded();
+    await waitFor(() => expect(vm.spaces.length).toBe(1));
+    const before = vm.activeSpaceId;
+
+    // Caller was removed from shared-space 'gone' between save and click.
+    await vm.focusFile('gone', 5);
+    expect(vm.activeSpaceId).toBe(before); // no switch
+    expect(vm.highlightFileId).toBeNull(); // no highlight
+    // Second loadSpaces was invoked by focusFile's retry.
+    expect(api.listSpaces).toHaveBeenCalledTimes(2);
+  });
+
+  it('getAncestors failure falls back to the space root breadcrumb', async () => {
+    vi.mocked(api.listSpaces).mockResolvedValue([space('p', 'personal'), space('s', 'shared')]);
+    vi.mocked(api.getAncestors).mockRejectedValueOnce(new Error('boom'));
+    const vm = new DriveVM();
+    vm.ensureLoaded();
+    await waitFor(() => expect(vm.spaces.length).toBe(2));
+
+    await vm.focusFile('s', 777, 30);
+    expect(vm.activeSpaceId).toBe('s');
+    expect(vm.path.length).toBe(1); // no ancestors landed, root only
+    expect(vm.highlightFileId).toBe(777); // still highlight the file
   });
 });

--- a/packages/dmworkdrive/src/pages/__tests__/DriveVM.test.ts
+++ b/packages/dmworkdrive/src/pages/__tests__/DriveVM.test.ts
@@ -182,4 +182,119 @@ describe('DriveVM.focusFile', () => {
     expect(vm.path.length).toBe(1); // no ancestors landed, root only
     expect(vm.highlightFileId).toBe(777); // still highlight the file
   });
+
+  // Reviewer P1-1 round 2 (Jerry-Xin / yujiawei / Octo-Q): focusFile used to
+  // split its state transition across the getAncestors await, committing
+  // activeSpaceId synchronously and path/highlight after. DriveContent
+  // subscribes to (activeSpaceId, currentParentId) and issued a
+  // cross-space browse during the RTT with the previous space's parent_id.
+  // The fix (focusSeq guard + resolve-then-commit) pins ALL three writes
+  // to happen after the ancestor RTT, and a second concurrent focusFile
+  // that lands first must not be clobbered by the first's late resolution.
+  it('deep-jump commits activeSpaceId / path / highlight atomically after ancestors resolve', async () => {
+    vi.mocked(api.listSpaces).mockResolvedValue([space('a', 'personal'), space('b', 'shared')]);
+    // Ancestors takes a controllable amount of time — first call is slow.
+    let releaseFirst: (v: Array<{ id: number; name: string }>) => void = () => {};
+    vi.mocked(api.getAncestors).mockImplementationOnce(
+      () => new Promise((r) => { releaseFirst = r; }),
+    );
+    const vm = new DriveVM();
+    vm.ensureLoaded();
+    await waitFor(() => expect(vm.spaces.length).toBe(2));
+
+    // Seed a stale state: pretend the user already had space 'a' open at
+    // folder id 300 before the deep-jump click.
+    vm.selectSpace('a');
+    vm.enterFolder(300, 'folder-300');
+    expect(vm.activeSpaceId).toBe('a');
+    expect(vm.currentParentId).toBe(300);
+
+    // Fire focusFile('b', 999, 501) — should NOT commit activeSpaceId='b'
+    // synchronously (that would leave currentParentId=300 pointing at a
+    // folder from space 'a' → cross-space browse). All three writes
+    // (activeSpaceId, path, highlightFileId) must land together after
+    // the ancestors resolve.
+    const jump = vm.focusFile('b', 999, 501);
+    // Micro-tick: nothing should have moved yet — the await ancestors is
+    // still pending, and pre-commit state must still show the old space.
+    await Promise.resolve();
+    expect(vm.activeSpaceId).toBe('a'); // still the old space
+    expect(vm.currentParentId).toBe(300); // still the old folder
+
+    releaseFirst([{ id: 501, name: 'target-parent' }]);
+    await jump;
+    expect(vm.activeSpaceId).toBe('b');
+    expect(vm.path.map((c) => c.id)).toEqual([0, 501]);
+    expect(vm.highlightFileId).toBe(999);
+  });
+
+  it('a newer focusFile wins over a slower older jump (out-of-order ancestors)', async () => {
+    vi.mocked(api.listSpaces).mockResolvedValue([space('s1', 'personal'), space('s2', 'shared')]);
+    // First call slow, second call fast.
+    let releaseSlow: (v: Array<{ id: number; name: string }>) => void = () => {};
+    vi.mocked(api.getAncestors)
+      .mockImplementationOnce(() => new Promise((r) => { releaseSlow = r; }))
+      .mockImplementationOnce(() => Promise.resolve([{ id: 201, name: 'p2' }]));
+    const vm = new DriveVM();
+    vm.ensureLoaded();
+    await waitFor(() => expect(vm.spaces.length).toBe(2));
+
+    const slow = vm.focusFile('s1', 111, 101);
+    // Second click while the first's ancestors are still in flight.
+    await vm.focusFile('s2', 222, 201);
+    // Fast one has committed to s2 already.
+    expect(vm.activeSpaceId).toBe('s2');
+    expect(vm.highlightFileId).toBe(222);
+    // Now let the slow first call resolve. It MUST NOT overwrite the
+    // s2 state — the focusSeq guard drops it.
+    releaseSlow([{ id: 101, name: 'p1' }]);
+    await slow;
+    expect(vm.activeSpaceId).toBe('s2');
+    expect(vm.highlightFileId).toBe(222);
+    expect(vm.path.map((c) => c.id)).toEqual([0, 201]);
+  });
+
+  // Round-4 P1 (Jerry-Xin / yujiawei / Octo-Q): a focusFile continuation
+  // awaiting getAncestors when a host tenant switch fires reset() used
+  // to still pass its focusSeq guard and commit the OLD tenant's state
+  // into the freshly-reset VM. The self-heal path (activeSpaceId being
+  // null after reset so loadSpaces re-selects personal) was accidentally
+  // removed in round-2's atomicity fix. reset() must invalidate every
+  // in-flight focus so its continuation refuses to write.
+  it('reset() during a focusFile await invalidates the continuation (focus-vs-reset)', async () => {
+    // Two "tenants": t1 has an initial listSpaces answer, t2 has the
+    // fresh answer post-reset.
+    vi.mocked(api.listSpaces)
+      .mockResolvedValueOnce([space('t1-shared', 'shared'), space('t1-personal', 'personal')])
+      .mockResolvedValueOnce([space('t2-personal', 'personal')]);
+    let releaseAncestors: (v: Array<{ id: number; name: string }>) => void = () => {};
+    vi.mocked(api.getAncestors).mockImplementationOnce(
+      () => new Promise((r) => { releaseAncestors = r; }),
+    );
+    const vm = new DriveVM();
+    vm.ensureLoaded();
+    await waitFor(() => expect(vm.spaces.length).toBe(2));
+
+    // Kick a deep-jump under t1; ancestors is pending.
+    const jump = vm.focusFile('t1-shared', 999, 77);
+    await Promise.resolve();
+    // Simulate a host tenant switch mid-flight: reset() bumps loadSeq +
+    // focusSeq, clears state, and kicks a fresh loadSpaces.
+    vm.reset();
+    // Fresh tenant's listSpaces resolves.
+    await waitFor(() => expect(vm.spaces.length).toBe(1));
+    expect(vm.spaces[0].id).toBe('t2-personal');
+    // t2's loadSpaces auto-selected the personal space.
+    expect(vm.activeSpaceId).toBe('t2-personal');
+
+    // Now release the stale ancestors. The continuation must NOT
+    // clobber activeSpaceId / path / highlight with t1's data.
+    releaseAncestors([{ id: 77, name: 'stale-parent' }]);
+    await jump;
+
+    expect(vm.activeSpaceId).toBe('t2-personal'); // NOT 't1-shared'
+    expect(vm.highlightFileId).toBeNull(); // reset cleared it, continuation didn't write
+    // Breadcrumb belongs to the new tenant, not the old one's [0, 77].
+    expect(vm.path.map((c) => c.id)).not.toContain(77);
+  });
 });

--- a/packages/dmworkdrive/src/ui/SaveToDriveModal/__tests__/SaveToDriveModal.test.tsx
+++ b/packages/dmworkdrive/src/ui/SaveToDriveModal/__tests__/SaveToDriveModal.test.tsx
@@ -211,4 +211,42 @@ describe('SaveToDriveModal', () => {
     q<HTMLButtonElement>(container, '[data-testid="cancel"]').click();
     expect(onClose).toHaveBeenCalled();
   });
+
+  // Regression: PR #1322 round-3 (Jerry-Xin). Switching space in the
+  // dropdown used to leave a one-tick desync window where `spaceId` was
+  // updated but `path` still held the previous space's folder ids —
+  // making a fast Confirm mis-file into the wrong folder, and firing a
+  // cross-space browse with a foreign parent_id. handleSpaceChange now
+  // batches both setState calls so the (spaceId, path) pair is
+  // atomically consistent from the very next render.
+  it('changing space atomically resets path to the new space root (no cross-space parent leak)', async () => {
+    // Two spaces the caller can upload to. Start on 'a', descend to a
+    // folder in 'a', then switch to 'b': path must collapse to b's root.
+    const spaces = [space('a', 'personal', 'super_admin'), space('b', 'shared', 'editor')];
+    const onConfirm = vi.fn().mockResolvedValue(true);
+    // Give api.browse a stub so the picker's folder effect doesn't blow up.
+    const api = await import('../../../api/driveApi');
+    vi.spyOn(api, 'browse').mockResolvedValue({ entries: [], page: {} } as any);
+    const { container } = render(
+      <SaveToDriveModal visible spaces={spaces} onConfirm={onConfirm} onClose={vi.fn()} />,
+    );
+    // Sanity: 'a' is the default selection.
+    const select = q<HTMLSelectElement>(container, '[data-testid="space-select"]');
+    expect(select.value).toBe('a');
+    // Switch to 'b' — the atomic change resets path in the same commit.
+    await act(async () => {
+      select.value = 'b';
+      select.dispatchEvent(new Event('change', { bubbles: true }));
+      await Promise.resolve();
+    });
+    // Fast Confirm right after the change. Must fire with (b, root=0),
+    // NOT (b, <a-folder-id>). If path were still a's folders this would
+    // be a mis-file bug.
+    await act(async () => {
+      q<HTMLButtonElement>(container, '[data-testid="ok"]').click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(onConfirm).toHaveBeenCalledWith('b', 0);
+  });
 });

--- a/packages/dmworkdrive/src/ui/SaveToDriveModal/__tests__/SaveToDriveModal.test.tsx
+++ b/packages/dmworkdrive/src/ui/SaveToDriveModal/__tests__/SaveToDriveModal.test.tsx
@@ -1,0 +1,183 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, act } from '../../../__tests__/harness';
+
+// Mock Semi UI: the same jsdom-hostile barrel avoidance MoveModal / FileList
+// tests use. We only exercise SaveToDriveModal's own logic (space-list
+// filtering by viewer_role, folder navigation, onConfirm shape) — Semi is
+// just a rendering shell here.
+vi.mock('@douyinfe/semi-ui', async () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const r: any = await vi.importActual('react');
+  const Modal = ({ visible, title, children, onOk, onCancel, okText, cancelText, okButtonProps }: any) => {
+    if (!visible) return null;
+    return r.createElement(
+      'div',
+      { 'data-testid': 'modal', 'aria-label': title },
+      children,
+      r.createElement(
+        'button',
+        {
+          'data-testid': 'ok',
+          onClick: onOk,
+          disabled: okButtonProps?.disabled,
+        },
+        okText,
+      ),
+      r.createElement('button', { 'data-testid': 'cancel', onClick: onCancel }, cancelText),
+    );
+  };
+  const Spin = () => r.createElement('div', { 'data-testid': 'spin' });
+  const Select = ({ value, onChange, optionList }: any) =>
+    r.createElement(
+      'select',
+      {
+        'data-testid': 'space-select',
+        value: value ?? '',
+        onChange: (e: any) => onChange(e.target.value),
+      },
+      (optionList ?? []).map((opt: any) =>
+        r.createElement(
+          'option',
+          {
+            key: opt.value,
+            value: opt.value,
+            disabled: opt.disabled,
+          },
+          opt.label,
+        ),
+      ),
+    );
+  return { Modal, Spin, Select };
+});
+
+// Mock the browse API — folder tree fetches go through this.
+vi.mock('../../../api/driveApi', () => ({
+  browse: vi.fn(),
+}));
+
+// Mock Toast — we don't need to observe it, but the module imports it.
+vi.mock('../../../utils/toast', () => ({ Toast: { error: vi.fn(), success: vi.fn() } }));
+
+import * as api from '../../../api/driveApi';
+import SaveToDriveModal from '../index';
+import type { Space } from '../../../bridge/types';
+
+function space(id: string, type: 'personal' | 'shared', role?: string): Space {
+  return {
+    id,
+    type,
+    name: id,
+    super_admin_uid: 'sa',
+    created_at: '2026-08-10T00:00:00.000Z',
+    updated_at: '2026-08-10T00:00:00.000Z',
+    viewer_role: role as any,
+  };
+}
+
+function q<T extends HTMLElement = HTMLElement>(container: HTMLElement, sel: string): T {
+  const el = container.querySelector<T>(sel);
+  if (!el) throw new Error(`selector "${sel}" not found`);
+  return el;
+}
+
+beforeEach(() => {
+  vi.mocked(api.browse).mockReset();
+  vi.mocked(api.browse).mockResolvedValue({ entries: [], filter: { type: 'all', source: 'all' }, total: 0 } as any);
+});
+
+describe('SaveToDriveModal', () => {
+  it('disables spaces below uploader_downloader rank', async () => {
+    const spaces = [
+      space('p', 'personal', 'super_admin'),
+      space('s-editor', 'shared', 'editor'),
+      space('s-downloader', 'shared', 'downloader'),
+      space('s-preview', 'shared', 'preview_only'),
+      space('s-unknown', 'shared', ''),
+    ];
+    const { container } = render(
+      <SaveToDriveModal
+        visible
+        spaces={spaces}
+        onConfirm={vi.fn().mockResolvedValue(true)}
+        onClose={vi.fn()}
+      />,
+    );
+    const select = q<HTMLSelectElement>(container, '[data-testid="space-select"]');
+    const options = Array.from(select.querySelectorAll('option'));
+    const disabledMap = new Map(options.map((o) => [o.value, o.disabled]));
+    expect(disabledMap.get('p')).toBe(false); // super_admin (rank 100) OK
+    expect(disabledMap.get('s-editor')).toBe(false); // editor (60) OK
+    expect(disabledMap.get('s-downloader')).toBe(true); // downloader (30) < 40
+    expect(disabledMap.get('s-preview')).toBe(true); // preview_only (20) < 40
+    expect(disabledMap.get('s-unknown')).toBe(false); // unknown role → permissive
+  });
+
+  it('confirms with the selected space and root parent when no folder is entered', async () => {
+    const spaces = [space('p', 'personal', 'super_admin')];
+    const onConfirm = vi.fn().mockResolvedValue(true);
+    const { container } = render(
+      <SaveToDriveModal visible spaces={spaces} onConfirm={onConfirm} onClose={vi.fn()} />,
+    );
+    await act(async () => {
+      q<HTMLButtonElement>(container, '[data-testid="ok"]').click();
+      // Two microtasks so the async onConfirm chain settles inside the click.
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(onConfirm).toHaveBeenCalledWith('p', 0);
+  });
+
+  it('pre-selects the personal space when defaultSpaceId is not uploadable', async () => {
+    const spaces = [
+      space('p', 'personal', 'super_admin'),
+      space('s-downloader', 'shared', 'downloader'),
+    ];
+    const onConfirm = vi.fn().mockResolvedValue(true);
+    const { container } = render(
+      <SaveToDriveModal
+        visible
+        spaces={spaces}
+        defaultSpaceId="s-downloader"
+        onConfirm={onConfirm}
+        onClose={vi.fn()}
+      />,
+    );
+    await act(async () => {
+      q<HTMLButtonElement>(container, '[data-testid="ok"]').click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    // Fell back to the personal space, not the disabled downloader default.
+    expect(onConfirm).toHaveBeenCalledWith('p', 0);
+  });
+
+  it('OK button is disabled while there is no uploadable space at all', () => {
+    const spaces = [space('s-downloader', 'shared', 'downloader')];
+    const { container } = render(
+      <SaveToDriveModal
+        visible
+        spaces={spaces}
+        onConfirm={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    const ok = q<HTMLButtonElement>(container, '[data-testid="ok"]');
+    expect(ok.disabled).toBe(true);
+  });
+
+  it('cancel calls onClose', () => {
+    const spaces = [space('p', 'personal', 'super_admin')];
+    const onClose = vi.fn();
+    const { container } = render(
+      <SaveToDriveModal
+        visible
+        spaces={spaces}
+        onConfirm={vi.fn()}
+        onClose={onClose}
+      />,
+    );
+    q<HTMLButtonElement>(container, '[data-testid="cancel"]').click();
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/packages/dmworkdrive/src/ui/SaveToDriveModal/__tests__/SaveToDriveModal.test.tsx
+++ b/packages/dmworkdrive/src/ui/SaveToDriveModal/__tests__/SaveToDriveModal.test.tsx
@@ -180,4 +180,35 @@ describe('SaveToDriveModal', () => {
     q<HTMLButtonElement>(container, '[data-testid="cancel"]').click();
     expect(onClose).toHaveBeenCalled();
   });
+
+  // Regression: cold-start right-click "存到云盘…" before the user has opened
+  // Drive this session. `saveMessageToDriveAt` renders the modal with
+  // spacesLoading=true while it waits for vm.spaces to arrive; the modal must
+  // (a) render (visible), (b) keep Cancel clickable, (c) keep Confirm
+  // disabled, (d) NOT render the space Select — that would look like a broken
+  // dropdown when spaces=[]. See Jerry-Xin review PR #1322 blocking finding.
+  it('renders a loading shell (spacesLoading=true) with Cancel enabled and Confirm disabled', () => {
+    const onClose = vi.fn();
+    const { container } = render(
+      <SaveToDriveModal
+        visible
+        spaces={[]}
+        spacesLoading
+        onConfirm={vi.fn()}
+        onClose={onClose}
+      />,
+    );
+    // Modal itself is rendered.
+    expect(container.querySelector('[data-testid="modal"]')).not.toBeNull();
+    // Space Select is NOT rendered in the loading shell.
+    expect(container.querySelector('[data-testid="space-select"]')).toBeNull();
+    // Spinner is rendered.
+    expect(container.querySelector('[data-testid="spin"]')).not.toBeNull();
+    // Confirm disabled.
+    const ok = q<HTMLButtonElement>(container, '[data-testid="ok"]');
+    expect(ok.disabled).toBe(true);
+    // Cancel still fires onClose.
+    q<HTMLButtonElement>(container, '[data-testid="cancel"]').click();
+    expect(onClose).toHaveBeenCalled();
+  });
 });

--- a/packages/dmworkdrive/src/ui/SaveToDriveModal/index.css
+++ b/packages/dmworkdrive/src/ui/SaveToDriveModal/index.css
@@ -1,33 +1,37 @@
 .drive-save {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: var(--wk-sp-3);
+}
+
+.drive-save--loading {
+  min-height: 200px;
 }
 
 .drive-save__space {
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: var(--wk-sp-1-5);
 }
 
 .drive-save__label {
-  font-size: 13px;
-  color: var(--semi-color-text-1, #4e5969);
+  font-size: var(--wk-text-size-base);
+  color: var(--semi-color-text-1);
 }
 
 .drive-save__folder {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--wk-sp-2);
 }
 
 .drive-save__list {
   min-height: 200px;
   max-height: 320px;
   overflow-y: auto;
-  border: 1px solid var(--semi-color-border, #e5e6eb);
-  border-radius: 6px;
-  padding: 4px;
+  border: 1px solid var(--semi-color-border);
+  border-radius: var(--wk-r-sm);
+  padding: var(--wk-sp-1);
 }
 
 .drive-save__center {
@@ -38,30 +42,30 @@
 }
 
 .drive-save__empty {
-  color: var(--semi-color-text-2, #86909c);
-  font-size: 13px;
+  color: var(--semi-color-text-2);
+  font-size: var(--wk-text-size-base);
 }
 
 .drive-save__item {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--wk-sp-2);
   width: 100%;
-  padding: 8px 10px;
+  padding: var(--wk-sp-2) var(--wk-sp-3);
   border: none;
-  border-radius: 4px;
+  border-radius: var(--wk-r-xs);
   background: transparent;
   cursor: pointer;
-  font-size: 14px;
+  font-size: var(--wk-text-size-md);
   text-align: left;
 }
 
 .drive-save__item:hover {
-  background: var(--semi-color-fill-0, #f2f3f5);
+  background: var(--semi-color-fill-0);
 }
 
 .drive-save__item-icon {
-  color: var(--wk-brand-primary, #1c1c23);
+  color: var(--wk-brand-primary);
   flex-shrink: 0;
 }
 
@@ -73,6 +77,6 @@
 }
 
 .drive-save__item-arrow {
-  color: var(--semi-color-text-2, #c9cdd4);
+  color: var(--semi-color-text-2);
   flex-shrink: 0;
 }

--- a/packages/dmworkdrive/src/ui/SaveToDriveModal/index.css
+++ b/packages/dmworkdrive/src/ui/SaveToDriveModal/index.css
@@ -80,3 +80,9 @@
   color: var(--semi-color-text-2);
   flex-shrink: 0;
 }
+
+.drive-save__truncated {
+  font-size: var(--wk-text-size-sm);
+  color: var(--semi-color-text-2);
+  padding: var(--wk-sp-1) var(--wk-sp-1);
+}

--- a/packages/dmworkdrive/src/ui/SaveToDriveModal/index.css
+++ b/packages/dmworkdrive/src/ui/SaveToDriveModal/index.css
@@ -1,0 +1,78 @@
+.drive-save {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.drive-save__space {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.drive-save__label {
+  font-size: 13px;
+  color: var(--semi-color-text-1, #4e5969);
+}
+
+.drive-save__folder {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.drive-save__list {
+  min-height: 200px;
+  max-height: 320px;
+  overflow-y: auto;
+  border: 1px solid var(--semi-color-border, #e5e6eb);
+  border-radius: 6px;
+  padding: 4px;
+}
+
+.drive-save__center {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 200px;
+}
+
+.drive-save__empty {
+  color: var(--semi-color-text-2, #86909c);
+  font-size: 13px;
+}
+
+.drive-save__item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 8px 10px;
+  border: none;
+  border-radius: 4px;
+  background: transparent;
+  cursor: pointer;
+  font-size: 14px;
+  text-align: left;
+}
+
+.drive-save__item:hover {
+  background: var(--semi-color-fill-0, #f2f3f5);
+}
+
+.drive-save__item-icon {
+  color: var(--wk-brand-primary, #1c1c23);
+  flex-shrink: 0;
+}
+
+.drive-save__item-name {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.drive-save__item-arrow {
+  color: var(--semi-color-text-2, #c9cdd4);
+  flex-shrink: 0;
+}

--- a/packages/dmworkdrive/src/ui/SaveToDriveModal/index.tsx
+++ b/packages/dmworkdrive/src/ui/SaveToDriveModal/index.tsx
@@ -29,6 +29,13 @@ export interface SaveToDriveModalProps {
   /** Return true on success to close the modal; false leaves it open. */
   onConfirm: (targetSpaceId: string, targetParentId: number) => Promise<boolean>;
   onClose: () => void;
+  /** When true, the picker is being kept open while the caller resolves its
+   *  data prerequisites (spaces list, viewer_role, etc.). Body renders a
+   *  loading placeholder in the modal shell instead of the picker controls
+   *  so the user sees progress and can still Cancel. Confirm is disabled.
+   *  Set by SaveToDriveModalHost in module.tsx during cold-start (user has
+   *  never opened Drive this session and vm.spaces has not arrived yet). */
+  spacesLoading?: boolean;
 }
 
 /**
@@ -52,6 +59,7 @@ export default function SaveToDriveModal({
   defaultSpaceId,
   onConfirm,
   onClose,
+  spacesLoading = false,
 }: SaveToDriveModalProps) {
   const { t: ti } = useI18n();
 
@@ -138,7 +146,7 @@ export default function SaveToDriveModal({
     return (ROLE_RANK[s.viewer_role as keyof typeof ROLE_RANK] ?? 0) >= UPLOADER_RANK;
   };
 
-  const okDisabled = !spaceId || (activeSpace ? !spaceUploadable(activeSpace) : true);
+  const okDisabled = spacesLoading || !spaceId || (activeSpace ? !spaceUploadable(activeSpace) : true);
 
   return (
     <Modal
@@ -152,7 +160,18 @@ export default function SaveToDriveModal({
       okButtonProps={{ disabled: okDisabled }}
       maskClosable={false}
     >
-      <div className="drive-save">
+      {spacesLoading ? (
+        // Cold-start body: user right-clicked without having opened Drive
+        // this session. Show a compact centred spinner so the click is
+        // acknowledged and Cancel stays clickable; the host wrapper flips
+        // this off the moment vm.spaces arrives.
+        <div className="drive-save drive-save--loading">
+          <div className="drive-save__center">
+            <Spin size="middle" />
+          </div>
+        </div>
+      ) : (
+        <div className="drive-save">
         <div className="drive-save__space">
           <label className="drive-save__label">{ti('drive.saveModal.selectSpace')}</label>
           <Select
@@ -195,7 +214,8 @@ export default function SaveToDriveModal({
             )}
           </div>
         </div>
-      </div>
+        </div>
+      )}
     </Modal>
   );
 }

--- a/packages/dmworkdrive/src/ui/SaveToDriveModal/index.tsx
+++ b/packages/dmworkdrive/src/ui/SaveToDriveModal/index.tsx
@@ -16,6 +16,29 @@ import './index.css';
  *  in the dropdown so the user can't pick them and hit a 403. */
 const UPLOADER_RANK = ROLE_RANK.uploader_downloader; // = 40
 
+// Client-side upload gate for a Space: transparency layer only — the drive
+// backend's `assertUploader` is the final authority (see
+// `internal/modules/imtransfer/service.go`), so this predicate is deliberately
+// permissive at the edges:
+//
+//   - `viewer_role` absent → server didn't say (legacy or downgraded response).
+//     Show the space as selectable; if the caller can't upload the POST
+//     returns 403 and we keep the modal open for retry.
+//   - `custom` role → `ROLE_RANK.custom = 10`, well below the uploader floor,
+//     but the rank is a UI hint, not a permission decision. A `custom` role
+//     may or may not carry upload rights; the backend knows and will 403 if
+//     not. Reviewer Jerry-Xin P2-8: unconditionally disabling `custom` locks
+//     legitimate users out with no way to proceed.
+//
+// Everything else gates on rank ≥ UPLOADER_RANK. This is enough to disable
+// obviously non-uploader roles (`downloader`, `preview_only`) so users don't
+// hit an easily-avoidable 403.
+function spaceUploadable(s: Space): boolean {
+  if (!s.viewer_role) return true;
+  if (s.viewer_role === 'custom') return true;
+  return (ROLE_RANK[s.viewer_role as keyof typeof ROLE_RANK] ?? 0) >= UPLOADER_RANK;
+}
+
 export interface SaveToDriveModalProps {
   visible: boolean;
   /** Spaces the caller currently belongs to (from DriveVM.spaces). Callers pass
@@ -36,6 +59,16 @@ export interface SaveToDriveModalProps {
    *  Set by SaveToDriveModalHost in module.tsx during cold-start (user has
    *  never opened Drive this session and vm.spaces has not arrived yet). */
   spacesLoading?: boolean;
+  /** When set, the caller's initial space-list fetch failed. The modal body
+   *  renders an error card with a Retry button (wired to `onRetry`) instead
+   *  of the picker or the loading shell — otherwise the shell spins
+   *  forever with only a toast to signal the problem (Octo-Q round-2 P2 on
+   *  PR #1322). Confirm is disabled while this is set. */
+  spacesError?: string | null;
+  /** Callback for the retry button rendered alongside `spacesError`.
+   *  Typically re-issues the underlying `listSpaces` request. When absent
+   *  no retry affordance is shown. */
+  onRetry?: () => void;
 }
 
 /**
@@ -60,6 +93,8 @@ export default function SaveToDriveModal({
   onConfirm,
   onClose,
   spacesLoading = false,
+  spacesError = null,
+  onRetry,
 }: SaveToDriveModalProps) {
   const { t: ti } = useI18n();
 
@@ -68,17 +103,13 @@ export default function SaveToDriveModal({
   // (would land in a "disabled" option). Otherwise pick the personal space,
   // otherwise the first uploader-eligible space, otherwise the first space.
   const initialSpaceId = useMemo(() => {
-    const canUpload = (s: Space): boolean => {
-      if (!s.viewer_role) return true; // unknown role → don't pre-gate
-      return (ROLE_RANK[s.viewer_role as keyof typeof ROLE_RANK] ?? 0) >= UPLOADER_RANK;
-    };
     if (defaultSpaceId) {
       const sp = spaces.find((s) => s.id === defaultSpaceId);
-      if (sp && canUpload(sp)) return sp.id;
+      if (sp && spaceUploadable(sp)) return sp.id;
     }
-    const personal = spaces.find((s) => s.type === 'personal' && canUpload(s));
+    const personal = spaces.find((s) => s.type === 'personal' && spaceUploadable(s));
     if (personal) return personal.id;
-    const anyUploadable = spaces.find(canUpload);
+    const anyUploadable = spaces.find(spaceUploadable);
     if (anyUploadable) return anyUploadable.id;
     return spaces[0]?.id ?? null;
   }, [defaultSpaceId, spaces]);
@@ -86,14 +117,31 @@ export default function SaveToDriveModal({
   const [spaceId, setSpaceId] = useState<string | null>(initialSpaceId);
   const [path, setPath] = useState<Crumb[]>([]);
   const [folders, setFolders] = useState<DriveEntry[]>([]);
+  const [truncated, setTruncated] = useState(false);
   const [loading, setLoading] = useState(false);
   const [submitting, setSubmitting] = useState(false);
+  // React 17 has no built-in mounted flag; setState after unmount logs a
+  // dev warning (Octo-Q / yujiawei P2-3: on the success path onConfirm
+  // → done()→ReactDOM.unmountComponentAtNode(host) runs before handleOk's
+  // finally, so `setSubmitting(false)` used to hit an unmounted tree).
+  const mountedRef = React.useRef(true);
+  React.useEffect(
+    () => () => {
+      mountedRef.current = false;
+    },
+    [],
+  );
 
   const activeSpace = spaces.find((s) => s.id === spaceId) ?? null;
   const rootName = activeSpace ? spaceDisplayName(activeSpace, t) : ti('drive.file.root');
 
   // Reset picker state whenever the modal opens or the selected space
-  // changes: breadcrumb collapses to the space root; folder list re-fetches.
+  // changes: breadcrumb collapses to the space root. Fires a folder
+  // browse of the root once path is at the root — the effect on `path`
+  // below owns fetching so a spaceId change collapses path FIRST and
+  // then the browse observes the fresh (spaceId, root) pair; this fixes
+  // yujiawei P2-1 (space change used to fire a browse with the previous
+  // space's parent_id because the two effects both keyed on `spaceId`).
   useEffect(() => {
     if (!visible) return;
     setSpaceId(initialSpaceId);
@@ -105,17 +153,32 @@ export default function SaveToDriveModal({
   }, [visible, spaceId, rootName]);
 
   const currentId = path.length ? path[path.length - 1].id : 0;
-
+  // Browse keyed on (spaceId, path-last-id): the reset above collapses
+  // path first, so the two effects sequence rather than race. `alive`
+  // guards against out-of-order responses if the user descends fast.
   useEffect(() => {
     if (!visible || !spaceId) return;
+    // Additional guard: don't fire a browse if `path` is empty. That
+    // happens for a single render tick between the spaceId change and
+    // the reset effect below observing it — otherwise the parent_id
+    // would be `0` combined with a still-inconsistent spaceId. Empty
+    // path means "reset is in flight; wait one commit."
+    if (path.length === 0) return;
     let alive = true;
     setLoading(true);
     api
       .browse({ space_id: spaceId, parent_id: currentId, type: 'folder', page_size: 200 })
       .then((res) => {
-        if (alive) {
-          setFolders((res.entries ?? []).filter((e) => e.type === 'folder'));
-        }
+        if (!alive) return;
+        const list = (res.entries ?? []).filter((e) => e.type === 'folder');
+        setFolders(list);
+        // Surface the 200-entry cap. `list.length === 200` isn't a
+        // guaranteed signal (could be exactly 200 with no next page),
+        // but `res.page?.next_cursor` / `res.total > list.length` is
+        // the authoritative check. Fall back to length-based when the
+        // backend doesn't return totals. Reviewer Jerry-Xin P2-7.
+        const total = (res.page as unknown as { total?: number })?.total;
+        setTruncated(typeof total === 'number' ? total > list.length : list.length >= 200);
       })
       .catch(() => {
         if (alive) Toast.error(t('drive.toast.loadFailed'));
@@ -126,7 +189,7 @@ export default function SaveToDriveModal({
     return () => {
       alive = false;
     };
-  }, [visible, spaceId, currentId]);
+  }, [visible, spaceId, currentId, path.length]);
 
   const handleOk = async (): Promise<void> => {
     if (submitting || !spaceId) return;
@@ -135,18 +198,30 @@ export default function SaveToDriveModal({
       const ok = await onConfirm(spaceId, currentId);
       if (ok) onClose();
     } finally {
-      setSubmitting(false);
+      // onConfirm's success path may synchronously unmount this modal
+      // (via ReactDOM.unmountComponentAtNode on the portal host); guard
+      // the setState so React 17 doesn't warn.
+      if (mountedRef.current) setSubmitting(false);
     }
   };
 
-  // Space is uploadable if viewer_role is unknown (be permissive; backend
-  // is the final gate) or its rank meets the uploader floor.
-  const spaceUploadable = (s: Space): boolean => {
-    if (!s.viewer_role) return true;
-    return (ROLE_RANK[s.viewer_role as keyof typeof ROLE_RANK] ?? 0) >= UPLOADER_RANK;
+  // Atomic space change: set spaceId AND collapse path to the new space's
+  // root in the SAME handler, so there is no render tick during which
+  // `spaceId=B` while `path` still holds A's folder ids. The earlier
+  // passive-effect version left a one-tick desync window where a fast
+  // Confirm click would call onConfirm(B, A_folderId) — filing the save
+  // into the wrong folder (Jerry-Xin round-3 blocking on PR #1322).
+  // React 17 auto-batches state updates dispatched inside an event
+  // handler, so these two setState calls commit together; Confirm and
+  // the browse effect both observe the consistent (B, [B_root]) pair.
+  const handleSpaceChange = (nextSpaceId: string): void => {
+    const nextSpace = spaces.find((s) => s.id === nextSpaceId) ?? null;
+    const nextRootName = nextSpace ? spaceDisplayName(nextSpace, t) : ti('drive.file.root');
+    setSpaceId(nextSpaceId);
+    setPath([{ id: 0, name: nextRootName }]);
   };
 
-  const okDisabled = spacesLoading || !spaceId || (activeSpace ? !spaceUploadable(activeSpace) : true);
+  const okDisabled = spacesLoading || !!spacesError || !spaceId || (activeSpace ? !spaceUploadable(activeSpace) : true);
 
   return (
     <Modal
@@ -160,7 +235,29 @@ export default function SaveToDriveModal({
       okButtonProps={{ disabled: okDisabled }}
       maskClosable={false}
     >
-      {spacesLoading ? (
+      {spacesError ? (
+        // Failure state: give the user something they can act on. Retry
+        // triggers the caller's onRetry (typically vm.loadSpaces); Cancel
+        // dismisses the picker via the modal's own footer. Confirm stays
+        // disabled via okDisabled above.
+        <div className="drive-save drive-save--loading">
+          <div className="drive-save__center drive-save__empty" role="alert">
+            {spacesError}
+          </div>
+          {onRetry && (
+            <div className="drive-save__center">
+              <button
+                type="button"
+                className="drive-save__item"
+                onClick={onRetry}
+                style={{ width: 'auto' }}
+              >
+                {ti('drive.common.retry')}
+              </button>
+            </div>
+          )}
+        </div>
+      ) : spacesLoading ? (
         // Cold-start body: user right-clicked without having opened Drive
         // this session. Show a compact centred spinner so the click is
         // acknowledged and Cancel stays clickable; the host wrapper flips
@@ -176,7 +273,7 @@ export default function SaveToDriveModal({
           <label className="drive-save__label">{ti('drive.saveModal.selectSpace')}</label>
           <Select
             value={spaceId ?? undefined}
-            onChange={(v) => setSpaceId(String(v))}
+            onChange={(v) => handleSpaceChange(String(v))}
             style={{ width: '100%' }}
             optionList={spaces.map((s) => ({
               value: s.id,
@@ -213,6 +310,20 @@ export default function SaveToDriveModal({
               ))
             )}
           </div>
+          {/*
+            Surface the folder-list page cap so users don't wonder why a
+            folder they expect to see is absent. The reviewer flagged
+            silent truncation past 200 subfolders (Jerry-Xin P2-7) —
+            uncommon but not impossible in a big shared space. Since the
+            picker is a single-page browse (matches MoveModal today),
+            direct users to descend into a subfolder to see more, or use
+            the drive app for exhaustive navigation.
+          */}
+          {truncated && (
+            <div className="drive-save__truncated" role="status">
+              {ti('drive.saveModal.folderTruncated')}
+            </div>
+          )}
         </div>
         </div>
       )}

--- a/packages/dmworkdrive/src/ui/SaveToDriveModal/index.tsx
+++ b/packages/dmworkdrive/src/ui/SaveToDriveModal/index.tsx
@@ -1,0 +1,201 @@
+import React, { useState, useEffect, useMemo } from 'react';
+import { useI18n, t } from '@octo/base';
+import { Modal, Spin, Select } from '@douyinfe/semi-ui';
+import { Folder, ChevronRight } from 'lucide-react';
+import * as api from '../../api/driveApi';
+import type { DriveEntry, Space } from '../../bridge/types';
+import { Toast } from '../../utils/toast';
+import { ROLE_RANK } from '../../utils/roleLabel';
+import { spaceDisplayName } from '../../utils/spaceName';
+import Breadcrumb, { Crumb } from '../Breadcrumb';
+import './index.css';
+
+/** Rank floor for save targets — mirrors backend imtransfer.assertUploader
+ *  (uploader_downloader+). Spaces where the caller's role sits below this
+ *  are still listed (transparency: "you are a member here"), but disabled
+ *  in the dropdown so the user can't pick them and hit a 403. */
+const UPLOADER_RANK = ROLE_RANK.uploader_downloader; // = 40
+
+export interface SaveToDriveModalProps {
+  visible: boolean;
+  /** Spaces the caller currently belongs to (from DriveVM.spaces). Callers pass
+   *  the shared VM's list so the modal reflects any recently added shared
+   *  spaces without a second listSpaces round-trip. */
+  spaces: Space[];
+  /** Default selection — usually the current active-space id, so users who
+   *  already had a space open see it pre-selected. Falls back to the caller's
+   *  personal space when the default's rank is below uploader_downloader. */
+  defaultSpaceId?: string | null;
+  /** Return true on success to close the modal; false leaves it open. */
+  onConfirm: (targetSpaceId: string, targetParentId: number) => Promise<boolean>;
+  onClose: () => void;
+}
+
+/**
+ * Save-to-drive target picker. Two levels:
+ *   1. Space dropdown — caller's own spaces; entries below
+ *      uploader_downloader are visible but disabled (transparency without
+ *      letting the user pick a 403).
+ *   2. Folder tree — browse `type=folder` in the selected space, with
+ *      breadcrumb back-navigation. The current folder is the destination.
+ *
+ * Visual language mirrors MoveModal so the two pickers feel like one
+ * primitive; the two are DELIBERATELY separate components: MoveModal's
+ * semantics ("move/copy an existing DriveEntry within a space", with a
+ * `sameAsOrigin` no-op guard) do not fit "save a chat message into any
+ * folder in any space" — trying to overload MoveModal would poison its
+ * types and its guard logic.
+ */
+export default function SaveToDriveModal({
+  visible,
+  spaces,
+  defaultSpaceId,
+  onConfirm,
+  onClose,
+}: SaveToDriveModalProps) {
+  const { t: ti } = useI18n();
+
+  // Compute the pre-selected space when the modal opens. Prefer the caller-
+  // supplied default, but drop it if the caller lacks upload rank there
+  // (would land in a "disabled" option). Otherwise pick the personal space,
+  // otherwise the first uploader-eligible space, otherwise the first space.
+  const initialSpaceId = useMemo(() => {
+    const canUpload = (s: Space): boolean => {
+      if (!s.viewer_role) return true; // unknown role → don't pre-gate
+      return (ROLE_RANK[s.viewer_role as keyof typeof ROLE_RANK] ?? 0) >= UPLOADER_RANK;
+    };
+    if (defaultSpaceId) {
+      const sp = spaces.find((s) => s.id === defaultSpaceId);
+      if (sp && canUpload(sp)) return sp.id;
+    }
+    const personal = spaces.find((s) => s.type === 'personal' && canUpload(s));
+    if (personal) return personal.id;
+    const anyUploadable = spaces.find(canUpload);
+    if (anyUploadable) return anyUploadable.id;
+    return spaces[0]?.id ?? null;
+  }, [defaultSpaceId, spaces]);
+
+  const [spaceId, setSpaceId] = useState<string | null>(initialSpaceId);
+  const [path, setPath] = useState<Crumb[]>([]);
+  const [folders, setFolders] = useState<DriveEntry[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+
+  const activeSpace = spaces.find((s) => s.id === spaceId) ?? null;
+  const rootName = activeSpace ? spaceDisplayName(activeSpace, t) : ti('drive.file.root');
+
+  // Reset picker state whenever the modal opens or the selected space
+  // changes: breadcrumb collapses to the space root; folder list re-fetches.
+  useEffect(() => {
+    if (!visible) return;
+    setSpaceId(initialSpaceId);
+  }, [visible, initialSpaceId]);
+
+  useEffect(() => {
+    if (!visible) return;
+    setPath([{ id: 0, name: rootName }]);
+  }, [visible, spaceId, rootName]);
+
+  const currentId = path.length ? path[path.length - 1].id : 0;
+
+  useEffect(() => {
+    if (!visible || !spaceId) return;
+    let alive = true;
+    setLoading(true);
+    api
+      .browse({ space_id: spaceId, parent_id: currentId, type: 'folder', page_size: 200 })
+      .then((res) => {
+        if (alive) {
+          setFolders((res.entries ?? []).filter((e) => e.type === 'folder'));
+        }
+      })
+      .catch(() => {
+        if (alive) Toast.error(t('drive.toast.loadFailed'));
+      })
+      .finally(() => {
+        if (alive) setLoading(false);
+      });
+    return () => {
+      alive = false;
+    };
+  }, [visible, spaceId, currentId]);
+
+  const handleOk = async (): Promise<void> => {
+    if (submitting || !spaceId) return;
+    setSubmitting(true);
+    try {
+      const ok = await onConfirm(spaceId, currentId);
+      if (ok) onClose();
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  // Space is uploadable if viewer_role is unknown (be permissive; backend
+  // is the final gate) or its rank meets the uploader floor.
+  const spaceUploadable = (s: Space): boolean => {
+    if (!s.viewer_role) return true;
+    return (ROLE_RANK[s.viewer_role as keyof typeof ROLE_RANK] ?? 0) >= UPLOADER_RANK;
+  };
+
+  const okDisabled = !spaceId || (activeSpace ? !spaceUploadable(activeSpace) : true);
+
+  return (
+    <Modal
+      title={ti('drive.saveModal.title')}
+      visible={visible}
+      onOk={handleOk}
+      onCancel={onClose}
+      confirmLoading={submitting}
+      okText={ti('drive.common.confirm')}
+      cancelText={ti('drive.common.cancel')}
+      okButtonProps={{ disabled: okDisabled }}
+      maskClosable={false}
+    >
+      <div className="drive-save">
+        <div className="drive-save__space">
+          <label className="drive-save__label">{ti('drive.saveModal.selectSpace')}</label>
+          <Select
+            value={spaceId ?? undefined}
+            onChange={(v) => setSpaceId(String(v))}
+            style={{ width: '100%' }}
+            optionList={spaces.map((s) => ({
+              value: s.id,
+              label: spaceDisplayName(s, t),
+              disabled: !spaceUploadable(s),
+            }))}
+          />
+        </div>
+        <div className="drive-save__folder">
+          <Breadcrumb path={path} onNavigate={(i) => setPath((p) => p.slice(0, i + 1))} />
+          <div className="drive-save__list">
+            {loading ? (
+              <div className="drive-save__center">
+                <Spin size="small" />
+              </div>
+            ) : folders.length === 0 ? (
+              <div className="drive-save__center drive-save__empty">
+                {ti('drive.saveModal.noSubfolder')}
+              </div>
+            ) : (
+              folders.map((f) => (
+                <button
+                  key={f.id}
+                  type="button"
+                  className="drive-save__item"
+                  onClick={() => setPath((p) => [...p, { id: f.id, name: f.name }])}
+                >
+                  <Folder size={16} className="drive-save__item-icon" />
+                  <span className="drive-save__item-name" title={f.name}>
+                    {f.name}
+                  </span>
+                  <ChevronRight size={14} className="drive-save__item-arrow" />
+                </button>
+              ))
+            )}
+          </div>
+        </div>
+      </div>
+    </Modal>
+  );
+}


### PR DESCRIPTION
## Summary

Adds the "save chat file to any drive space / folder" flow via a right-click menu + target picker, unifies the icon and menu into a single saved-state per chat file (any save path flips both), and lands "view in drive" on the exact folder when the file lives in a nested location. Fixes #1321.

## Related Issue

Fixes #1321

## Changes

- **feat(drive) 30fc4e40** — cross-space + deep-folder "view in drive" jump. `DriveVM.focusFile` becomes async and takes an optional `parentId`; when > 0 it fetches ancestors from the new `GET /v1/drive/files/:id/ancestors` endpoint and rebuilds the breadcrumb. `driveApi.getAncestors` + wire type `DriveAncestor` added. `Space` gains `viewer_role`.
- **feat(drive) 11d095a2** — right-click "存到云盘…" opens a new `SaveToDriveModal` (space dropdown with rank-based disabled options + folder tree). `WKApp.saveMessageToDriveAt` hook returns a Promise resolved after the transfer POST returns. Portal-mounted so its inner `<Modal>` is the only modal in the tree.
- **fix(drive) 83c08ea9** — module-scope `driveTransferredCache` + mittBus `wk:drive-transferred-changed`. Every save path (icon quick-save, picker save, batch lookup) writes the cache; FileCell subscribes and setState()s on a matching source_key so the icon flips no matter which entry point saved the file. Right-click menu factory reads the cache synchronously to choose between "存到云盘…" and "在云盘中查看". Reverts an earlier `X-Space-Id` override design that 403'd (drive space uuids belong in the body, not the tenant-space header).
- **fix(drive) c1f3071d** — drop the "saved" cache short-circuit in `checkDriveTransferred`. Every `FileCell` mount must hit the backend so drive-side deletes are reflected on the next entry into a chat window. The cache stays a write-through fan-out sink, not a read-side freshness gate.

Wire-shape summary (all additive):
- `GET /v1/drive/spaces` DTO: adds `viewer_role: string` (empty on legacy rows).
- `POST /v1/drive/blobs/im-transferred/batch`: response shape unchanged; semantic scope widens from personal-only to any space the caller belongs to (tie-break: personal > freshest shared).
- New `GET /v1/drive/files/:id/ancestors` → `{ancestors: [{id, name}, ...]}` root-first, member+ permission.

## Architecture / Module Boundary

- Affected module(s): `packages/dmworkdrive` (drive plugin) + `packages/dmworkbase` (chat file cell + `WKApp` static hooks + `MittEvents` type).
- New or changed user-visible entry point: yes — right-click "存到云盘…" on chat file messages (sort `100000` so it lands last, mirroring the icon's gate: `driveOn` + File contentType + supported channel type + persisted messageID).
- Shared layer touched: `Messages/File/index.tsx` gains a mittBus subscription + one source_key helper; `App.tsx` gains a `MittEvents` entry + two `WKApp` static hook slots (`saveMessageToDriveAt`, `getDriveTransferred`).
- If shared code changed, impact scope: FileCell change is additive on the existing icon behaviour (subscribes to a new event; unaffected callers see no diff). `App.tsx` changes are new optional fields; no existing consumer breaks.
- Duplicate entry point checked: yes — the icon still owns quick-save to personal root; right-click menu owns the "pick target" path. Once saved, both entry points show "view in drive" (single path). No overlap.

## Testing

- `pnpm test` in `packages/dmworkdrive` — **249 tests pass, 24 files, 0 failures**. New coverage: `SaveToDriveModal` (5 cases: rank gating, defaults, confirm shape, disabled ok, cancel), `DriveVM.focusFile` (4 cases: root file, deep chain, unknown space, ancestors failure), `driveApi` (3 new cases: `getAncestors` GET+unwrap, empty ancestors, transferFromIm body-only target_space_id).
- `pnpm test` in `packages/dmworkbase` — **2632 tests pass, 292 files, 0 failures**. No regressions from adding the FileCell mittBus subscription.
- Manually verified end-to-end against a docker-compose stack backed by the matching octo-drive branch:
  - Right-click "存到云盘…" on a group chat File message → target picker opens (single modal), pick any space + any folder → transfer POST succeeds → toast + icon flips to "在云盘中查看" → right-click menu now shows "在云盘中查看" → click either entry point jumps into drive, lands on the correct folder with the file highlighted.
  - Save to a subfolder → verify DriveVM breadcrumb shows the ancestor chain, not just the space root.
  - Delete the saved file inside drive → switch back to the chat window → icon flips back to "存到云盘".
- Bundle marker verification post-build (tier-1 i18n keys + tier-2 runtime symbols survive minification): `drive.contextMenus.viewInDrive`, `drive.contextMenus.saveToDrive`, `saveModal.title`, `drive-save-modal-host`, `unmountComponentAtNode`, `wk:drive-transferred-changed`, `driveTransferredCache`, `getDriveTransferred`, `markDriveSaved` all present in the deployed `index-*.js`.

- [x] Unit tests added/updated
- [x] Manually verified

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation (JSDoc + inline comments; no separate doc file needed)
- [x] Ran `pnpm i18n:check` or confirmed the change does not affect UI copy — new keys added under `drive.saveModal.*` and `drive.contextMenus.*` in both `zh-CN.json` and `en-US.json`
- [x] Confirmed the change follows module ownership and does not add duplicate user-visible entry points (see Architecture section)
- [x] Described impact scope when shared components, messages, bridge, or services are changed
- [x] Followed commit message conventions (Conventional Commits)

## Dependencies

This PR ships the frontend only. It depends on three matching commits landing in [Mininglamp-OSS/octo-drive](https://github.com/Mininglamp-OSS/octo-drive) first:

- `feat(space): expose caller's role on space list DTO` (adds `viewer_role`)
- `feat(imtransfer): batch-lookup transferred state across all my spaces`
- `feat(file): add GET /v1/drive/files/:id/ancestors for deep breadcrumb`

The frontend degrades gracefully if the backend is behind — deep-folder jump falls back to the space-root breadcrumb, and the cross-space lookup returns the same shape as before with tie-break still yielding a valid winner.
