### PR TITLE
fix(forward-modal): 选人过多时授权区顶掉转发按钮

### DIFF
--- a/packages/dmworkbase/src/Components/ForwardModal/ForwardModal.css
+++ b/packages/dmworkbase/src/Components/ForwardModal/ForwardModal.css
@@ -35,6 +35,9 @@
 .wk-fm-content {
   display: flex;
   flex: 1;
+  /* 授权区（Bot 列表）内容再多也不能把两列列表压成 0 高度：保底 240px，
+     配合 .wk-fm-grant 的 max-height 上限，三段（内容 / 授权 / Footer）总高不超过弹窗。 */
+  min-height: 240px;
   overflow: hidden;
 }
 
@@ -412,6 +415,11 @@
   gap: var(--wk-sp-1, 4px);
   padding: var(--wk-sp-2, 8px) var(--wk-sp-3, 12px);
   border-top: 1px solid var(--wk-border-color, #ebedf0);
+  /* 选中人数多时授权区曾无限增高 → 顶掉 Footer 的转发按钮并压塌两列列表。
+     固定不被压缩 + 总高上限 + 自身滚动，保证 Footer 永远可见。 */
+  flex-shrink: 0;
+  max-height: 200px;
+  overflow-y: auto;
 }
 
 .wk-fm-grant-row {
@@ -455,6 +463,43 @@
   flex-direction: column;
   gap: var(--wk-sp-1, 4px);
   margin-top: var(--wk-sp-2, 8px);
+  min-height: 0;
+}
+
+.wk-fm-grant-bots-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--wk-sp-2, 8px);
+}
+
+/* 逐人 Bot 列表：默认折叠；展开后限高自滚，不再撑爆授权区。 */
+.wk-fm-grant-bot-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--wk-sp-1, 4px);
+  max-height: 112px;
+  overflow-y: auto;
+}
+
+.wk-fm-grant-bots-toggle {
+  flex-shrink: 0;
+  border: 0;
+  background: transparent;
+  padding: var(--wk-sp-1, 4px) var(--wk-sp-2, 8px);
+  border-radius: var(--wk-r-xs, 4px);
+  color: var(--wk-brand-primary, #1c1c23);
+  cursor: pointer;
+  font-size: var(--wk-text-size-tiny, 12px);
+}
+
+.wk-fm-grant-bots-toggle:hover {
+  background: var(--wk-brand-alpha-06, rgba(28, 28, 35, 0.06));
+}
+
+.wk-fm-grant-bots-toggle:focus-visible {
+  outline: 2px solid var(--wk-brand-alpha-20, rgba(28, 28, 35, 0.2));
+  outline-offset: 1px;
 }
 
 .wk-fm-grant-bots-summary {

--- a/packages/dmworkbase/src/Components/ForwardModal/ui/GrantArea.tsx
+++ b/packages/dmworkbase/src/Components/ForwardModal/ui/GrantArea.tsx
@@ -10,10 +10,14 @@ import type { ForwardGrantConfig } from "../grant"
  *
  * Bot 展开器（feature: user+Bot grants）：授权开关开启且选中人员创建过 Bot 时，渲染
  * 「N 人 / M Bot」汇总 + 每个人可展开、逐个取消其 Bot 的列表；默认全选。无 Bot 时不渲染该区块。
+ *
+ * 逐人那一层列表默认整体折叠（只留一行「查看 N 人的 M 个 Bot」）：以前选几个人就长几行，
+ * 人多时授权区会顶掉 Footer 的转发按钮、压塌两列列表（转发弹窗固定 560px + overflow:hidden）。
  */
 export function GrantArea({ grant }: { grant: ForwardGrantConfig }) {
   const { t } = useI18n()
   const [expanded, setExpanded] = React.useState<Set<string>>(() => new Set())
+  const [listOpen, setListOpen] = React.useState(false)
   if (!grant.canGrant) {
     return (
       <div className="wk-fm-grant wk-fm-grant--disabled">
@@ -61,51 +65,70 @@ export function GrantArea({ grant }: { grant: ForwardGrantConfig }) {
       )}
       {grant.enabled && bots?.ready && bots.groups.length > 0 && (
         <div className="wk-fm-grant-bots">
-          <div className="wk-fm-grant-bots-summary">
-            {t("base.forwardModal.grant.botSummary", {
-              values: { people: bots.peopleCount, bots: bots.botCount },
-            })}
+          <div className="wk-fm-grant-bots-header">
+            <span className="wk-fm-grant-bots-summary">
+              {t("base.forwardModal.grant.botSummary", {
+                values: { people: bots.peopleCount, bots: bots.botCount },
+              })}
+            </span>
+            <button
+              type="button"
+              className="wk-fm-grant-bots-toggle"
+              aria-expanded={listOpen}
+              onClick={() => setListOpen((prev) => !prev)}
+            >
+              {t(
+                listOpen
+                  ? "base.forwardModal.grant.botListCollapse"
+                  : "base.forwardModal.grant.botListExpand",
+                { values: { people: bots.peopleCount, bots: bots.botCount } },
+              )}
+            </button>
           </div>
-          {bots.groups.map((group) => {
-            const isExpanded = expanded.has(group.uid)
-            return (
-              <div className="wk-fm-grant-bot-group" key={group.uid}>
-                <button
-                  type="button"
-                  className="wk-fm-grant-bot-expand"
-                  aria-expanded={isExpanded}
-                  onClick={() =>
-                    setExpanded((prev: Set<string>) => {
-                      const next = new Set(prev)
-                      if (next.has(group.uid)) next.delete(group.uid)
-                      else next.add(group.uid)
-                      return next
-                    })
-                  }
-                >
-                  {t(isExpanded ? "base.forwardModal.grant.hideBots" : "base.forwardModal.grant.showBots", {
-                    values: { name: group.name, count: group.bots.length },
-                  })}
-                </button>
-                {isExpanded &&
-                  group.bots.map((bot) => (
-                    <label className="wk-fm-grant-bot" key={bot.uid}>
-                      <Checkbox
-                        checked={bot.selected}
-                        onCheck={() => bots.toggleBot(bot.uid)}
-                        ariaLabel={t(
-                          bot.selected
-                            ? "base.forwardModal.grant.botCheckedFor"
-                            : "base.forwardModal.grant.botUncheckedFor",
-                          { values: { bot: bot.name, person: group.name } },
-                        )}
-                      />
-                      <span className="wk-fm-grant-bot-name">{bot.name}</span>
-                    </label>
-                  ))}
-              </div>
-            )
-          })}
+          {listOpen && (
+            <div className="wk-fm-grant-bot-list">
+              {bots.groups.map((group) => {
+                const isExpanded = expanded.has(group.uid)
+                return (
+                  <div className="wk-fm-grant-bot-group" key={group.uid}>
+                    <button
+                      type="button"
+                      className="wk-fm-grant-bot-expand"
+                      aria-expanded={isExpanded}
+                      onClick={() =>
+                        setExpanded((prev: Set<string>) => {
+                          const next = new Set(prev)
+                          if (next.has(group.uid)) next.delete(group.uid)
+                          else next.add(group.uid)
+                          return next
+                        })
+                      }
+                    >
+                      {t(isExpanded ? "base.forwardModal.grant.hideBots" : "base.forwardModal.grant.showBots", {
+                        values: { name: group.name, count: group.bots.length },
+                      })}
+                    </button>
+                    {isExpanded &&
+                      group.bots.map((bot) => (
+                        <label className="wk-fm-grant-bot" key={bot.uid}>
+                          <Checkbox
+                            checked={bot.selected}
+                            onCheck={() => bots.toggleBot(bot.uid)}
+                            ariaLabel={t(
+                              bot.selected
+                                ? "base.forwardModal.grant.botCheckedFor"
+                                : "base.forwardModal.grant.botUncheckedFor",
+                              { values: { bot: bot.name, person: group.name } },
+                            )}
+                          />
+                          <span className="wk-fm-grant-bot-name">{bot.name}</span>
+                        </label>
+                      ))}
+                  </div>
+                )
+              })}
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/packages/dmworkbase/src/Components/ForwardModal/ui/__tests__/GrantArea.test.tsx
+++ b/packages/dmworkbase/src/Components/ForwardModal/ui/__tests__/GrantArea.test.tsx
@@ -1,0 +1,165 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import React from "react";
+import ReactDOM from "react-dom";
+import { act } from "react-dom/test-utils";
+
+vi.mock("lucide-react", () => ({
+  Lock: () => <span data-testid="lock-icon" />,
+}));
+vi.mock("../../../../i18n", () => ({
+  useI18n: () => ({
+    t: (key: string, opts?: { values?: Record<string, unknown> }) =>
+      opts?.values ? `${key}:${JSON.stringify(opts.values)}` : key,
+  }),
+}));
+vi.mock("../../../Checkbox", () => ({
+  default: ({
+    checked,
+    onCheck,
+    ariaLabel,
+  }: {
+    checked?: boolean;
+    onCheck?: () => void;
+    ariaLabel?: string;
+  }) => (
+    <div
+      role="checkbox"
+      aria-checked={!!checked}
+      aria-label={ariaLabel}
+      onClick={() => onCheck?.()}
+    />
+  ),
+}));
+
+import { GrantArea } from "../GrantArea";
+import type { ForwardGrantConfig } from "../../grant";
+
+/** Many creators, mirroring the reported bug (grant area grew one row per selected person). */
+function manyGroups(count: number) {
+  return Array.from({ length: count }, (_, i) => ({
+    uid: `u_${i}`,
+    name: `Person ${i}`,
+    bots: [{ uid: `b_${i}`, name: `Bot ${i}`, selected: true }],
+  }));
+}
+
+function config(
+  overrides: Partial<ForwardGrantConfig> = {}
+): ForwardGrantConfig {
+  return {
+    canGrant: true,
+    enabled: true,
+    role: "reader",
+    onEnabledChange: vi.fn(),
+    onRoleChange: vi.fn(),
+    bots: {
+      ready: true,
+      peopleCount: 21,
+      botCount: 178,
+      groups: manyGroups(21),
+      toggleBot: vi.fn(),
+    },
+    ...overrides,
+  };
+}
+
+describe("GrantArea Bot list is collapsed by default (forward button overflow fix)", () => {
+  let container: HTMLDivElement;
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+  });
+  afterEach(() => {
+    act(() => {
+      ReactDOM.unmountComponentAtNode(container);
+    });
+    container.remove();
+  });
+
+  function render(grant: ForwardGrantConfig) {
+    act(() => {
+      ReactDOM.render(<GrantArea grant={grant} />, container);
+    });
+  }
+
+  it("keeps the summary visible but renders no per-person rows until expanded", () => {
+    render(config());
+    expect(
+      container.querySelector(".wk-fm-grant-bots-summary")?.textContent
+    ).toContain("base.forwardModal.grant.botSummary");
+    // The tall per-person list is what used to push the Footer out of the fixed-height modal.
+    expect(container.querySelector(".wk-fm-grant-bot-list")).toBeNull();
+    expect(container.querySelectorAll(".wk-fm-grant-bot-group").length).toBe(0);
+    const toggle = container.querySelector(".wk-fm-grant-bots-toggle");
+    expect(toggle).not.toBeNull();
+    expect(toggle?.getAttribute("aria-expanded")).toBe("false");
+  });
+
+  it("expands to a bounded scroll list on demand and collapses again", () => {
+    render(config());
+    const toggle = container.querySelector(
+      ".wk-fm-grant-bots-toggle"
+    ) as HTMLButtonElement;
+    act(() => {
+      toggle.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    expect(container.querySelector(".wk-fm-grant-bot-list")).not.toBeNull();
+    expect(container.querySelectorAll(".wk-fm-grant-bot-group").length).toBe(
+      21
+    );
+    expect(
+      (
+        container.querySelector(".wk-fm-grant-bots-toggle") as HTMLButtonElement
+      ).getAttribute("aria-expanded")
+    ).toBe("true");
+
+    act(() => {
+      (
+        container.querySelector(".wk-fm-grant-bots-toggle") as HTMLButtonElement
+      ).dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    expect(container.querySelector(".wk-fm-grant-bot-list")).toBeNull();
+  });
+
+  it("still lets an individual Bot be unchecked after expanding both levels", () => {
+    const toggleBot = vi.fn();
+    const grant = config();
+    grant.bots!.toggleBot = toggleBot;
+    render(grant);
+    act(() => {
+      (
+        container.querySelector(".wk-fm-grant-bots-toggle") as HTMLButtonElement
+      ).dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    act(() => {
+      (
+        container.querySelector(".wk-fm-grant-bot-expand") as HTMLButtonElement
+      ).dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    const box = container.querySelector(
+      ".wk-fm-grant-bot [role=checkbox]"
+    ) as HTMLElement;
+    expect(box).not.toBeNull();
+    act(() => {
+      box.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    expect(toggleBot).toHaveBeenCalledWith("b_0");
+  });
+
+  it("renders no Bot block when there are no Bots (zero-Bot compatible)", () => {
+    render(
+      config({
+        bots: {
+          ready: true,
+          peopleCount: 3,
+          botCount: 0,
+          groups: [],
+          toggleBot: vi.fn(),
+        },
+      })
+    );
+    expect(container.querySelector(".wk-fm-grant-bots")).toBeNull();
+    expect(container.querySelector(".wk-fm-grant-bots-toggle")).toBeNull();
+  });
+});

--- a/packages/dmworkbase/src/i18n/locales/en-US.json
+++ b/packages/dmworkbase/src/i18n/locales/en-US.json
@@ -870,6 +870,8 @@
   "forwardModal.grant.roleWriter": "Can edit",
   "forwardModal.grant.targetMembers": "Will grant access to the group's current {{count}} member(s)",
   "forwardModal.grant.botSummary": "{{people}} people / {{bots}} Bots",
+  "forwardModal.grant.botListExpand": "Review {{bots}} Bots from {{people}} people",
+  "forwardModal.grant.botListCollapse": "Hide Bot list",
   "forwardModal.grant.botLoading": "Loading Bots…",
   "forwardModal.grant.botError": "Could not load Bots. Try again before forwarding.",
   "forwardModal.grant.botRetry": "Retry",

--- a/packages/dmworkbase/src/i18n/locales/zh-CN.json
+++ b/packages/dmworkbase/src/i18n/locales/zh-CN.json
@@ -870,6 +870,8 @@
   "forwardModal.grant.roleWriter": "可编辑",
   "forwardModal.grant.targetMembers": "将授权给群当前 {{count}} 名成员",
   "forwardModal.grant.botSummary": "共 {{people}} 人 / {{bots}} Bot",
+  "forwardModal.grant.botListExpand": "查看 {{people}} 人的 {{bots}} 个 Bot",
+  "forwardModal.grant.botListCollapse": "收起 Bot 列表",
   "forwardModal.grant.botLoading": "正在加载 Bot…",
   "forwardModal.grant.botError": "Bot 加载失败，请重试后再转发。",
   "forwardModal.grant.botRetry": "重试",


### PR DESCRIPTION
## 问题

「转发到聊天 + 转发时授权」场景下，选中的人一多，授权区把底部的**转发 / 取消按钮整个顶出弹窗**，左右两列列表也一起消失，用户无法完成转发（截图为 21 人 / 178 Bot 的实际状态）。

## 根因

`ForwardModal` 是固定 `height: 560px` + `overflow: hidden` 的纵向 flex 容器（Header 56 / 内容区 flex:1 / 授权区 / Footer 60）。

- `.wk-fm-grant`（授权区）既没有 `flex-shrink: 0`，也没有 `max-height`；
- `GrantArea` 为**每一个被选中的人**渲染一行「X 的 N 个 Bot」展开按钮，选 21 人就是 21 行（约 650px）。

于是授权区的 auto 高度不可压缩 → `.wk-fm-content` 被压成 0 高度（自身 `overflow:hidden`，最小内容尺寸为 0）→ `.wk-fm-footer` 被挤出 560px 边界并被 `overflow:hidden` 裁掉。约 8～10 行起开始吃到按钮，人多时必然复现。

## 改动（纯布局 / 交互，不动授权逻辑与数据流）

1. `.wk-fm-grant`：`flex-shrink: 0` + `max-height: 200px` + `overflow-y: auto` —— 授权区自己滚，Footer 永远可见。
2. `.wk-fm-content`：`min-height: 240px` —— 两列列表（搜索 / Tab / 候选列表 / 已选列表）不再被压塌。
3. 逐人 Bot 列表**默认整体折叠**，只保留一行「查看 N 人的 M 个 Bot」按钮；展开后 `.wk-fm-grant-bot-list` 限高 112px 自滚。汇总行「共 N 人 / M Bot」与授权开关 + 角色下拉始终可见。
4. 新增 i18n key（zh-CN / en-US）：`forwardModal.grant.botListExpand` / `botListCollapse`。

**行为不变**：Bot 默认全选、逐个取消勾选、`toggleBot` 语义、加载中 / 失败 + 重试提示、未 ready 时阻塞确认、无 Bot 时不渲染该区块 —— 全部保持原样。既有转发路径（Conversation / Chat / Summary）不传 `grant`，零回归。

## 效果对比

修复前：授权区吞掉两列列表和底部按钮。
修复后：三段结构稳定（内容 / 授权 / Footer），转发按钮常驻可见；Bot 列表折叠态下左列可见约 6 行，展开态在授权区内部滚动。

## 验证

- `@octo/base` 全量单测：**293 files / 2636 tests passed**（含新增 `ui/__tests__/GrantArea.test.tsx` 4 项：默认折叠不渲染逐人行、展开/收起、展开两层后仍能取消单个 Bot、无 Bot 时不渲染区块）。
- `ForwardModal` 目录聚焦单测：19 files / 149 tests passed。
- `pnpm i18n:check`：passed（0 candidates within baseline; locale keys healthy）。
- `stylelint --config stylelint.ci.config.mjs`：0 errors（新增规则均使用 `var(--wk-*)` token，未引入硬编码颜色）。

## 部署前提 / 必配环境变量

**无。** 纯前端 CSS + 组件渲染改动，不新增/不依赖任何环境变量，不涉及后端接口与 DB。构建部署按现有 web 流程即可。
