### PR TITLE
fix(message): stop single-tilde ranges rendering as strikethrough

### DIFF
--- a/packages/dmworkbase/src/Messages/Text/MarkdownContent.tsx
+++ b/packages/dmworkbase/src/Messages/Text/MarkdownContent.tsx
@@ -18,10 +18,7 @@ import { copyToClipboard } from "../../Utils/clipboard";
 import { t } from "../../i18n";
 import { ImagePreviewLightbox } from "../Image/ImagePreview";
 import { getMentionRenderState } from "./mentionRenderState";
-import {
-  isForwardDocCard,
-  type ParagraphChildKind,
-} from "./forwardClamp";
+import { isForwardDocCard, type ParagraphChildKind } from "./forwardClamp";
 
 export interface MentionInfo {
   name: string; // "@张三"（含@符号）
@@ -144,6 +141,8 @@ const baseRehypePlugins: any[] = [
   [rehypeSanitize, sanitizeSchema],
 ];
 
+const remarkGfmOptions = { singleTilde: false };
+
 /** 含 KaTeX 的 rehype 插件 */
 const mathRehypePlugins: any[] = [
   [rehypeHighlight, { aliases: { json5: "json" }, ignoreMissing: true }],
@@ -154,14 +153,14 @@ const mathRehypePlugins: any[] = [
 /** 基础 remark 插件（不含 math） */
 const baseRemarkPlugins: any[] = [
   rawHtmlAsTextPlugin,
-  remarkGfm,
+  [remarkGfm, remarkGfmOptions],
   remarkBreaks,
 ];
 
 /** 含 math 的 remark 插件 */
 const mathRemarkPlugins: any[] = [
   rawHtmlAsTextPlugin,
-  remarkGfm,
+  [remarkGfm, remarkGfmOptions],
   remarkBreaks,
   remarkMath,
 ];
@@ -371,7 +370,8 @@ const baseComponents: any = {
       </a>
     );
   },
-  p: ({ node: _node, children, ...props }: any) => renderParagraph(children, props),
+  p: ({ node: _node, children, ...props }: any) =>
+    renderParagraph(children, props),
   pre: ({ children, ...props }: any) => (
     <MarkdownCodeBlock preProps={props}>{children}</MarkdownCodeBlock>
   ),
@@ -407,7 +407,10 @@ function plainText(children: React.ReactNode): string {
  * message's bold text is affected. The full title lives in the `title` attribute so PC hover /
  * mobile tap still reveals it in full while the visible text is clamped to 2 lines.
  */
-function renderParagraph(children: React.ReactNode, props: any): React.ReactElement {
+function renderParagraph(
+  children: React.ReactNode,
+  props: any
+): React.ReactElement {
   const arr = React.Children.toArray(children);
   const kinds: ParagraphChildKind[] = arr.map((c) => {
     if (typeof c === "string") return { text: c };
@@ -416,9 +419,11 @@ function renderParagraph(children: React.ReactNode, props: any): React.ReactElem
       const cprops = (c.props ?? {}) as any;
       // Carry the visible text of bold/link runs so the detector can require the link label to
       // equal the bold title (the forward card duplicates the title as its anchor text).
-      if (type === "strong" || type === "b") return { isStrong: true, content: plainText(cprops.children) };
+      if (type === "strong" || type === "b")
+        return { isStrong: true, content: plainText(cprops.children) };
       if (type === "br") return { isBreak: true };
-      if (cprops.href != null || type === baseComponents.a) return { isLink: true, content: plainText(cprops.children) };
+      if (cprops.href != null || type === baseComponents.a)
+        return { isLink: true, content: plainText(cprops.children) };
     }
     return {};
   });
@@ -427,7 +432,10 @@ function renderParagraph(children: React.ReactNode, props: any): React.ReactElem
   }
   // Clone the leading <strong> to carry the full-title tooltip + clamp class.
   const clamped = arr.map((c, i) => {
-    if (React.isValidElement(c) && ((c.type as any) === "strong" || (c.type as any) === "b")) {
+    if (
+      React.isValidElement(c) &&
+      ((c.type as any) === "strong" || (c.type as any) === "b")
+    ) {
       const cprops = c.props as any;
       // Read the title text array-safely: react-markdown 8.x always hands `strong` an ARRAY of
       // children (e.g. ["Quarterly plan"]), never a bare string, so the old
@@ -438,14 +446,19 @@ function renderParagraph(children: React.ReactNode, props: any): React.ReactElem
       const full = plainText(cprops?.children) || undefined;
       return React.cloneElement(c as React.ReactElement<any>, {
         key: i,
-        className: `${cprops?.className ?? ""} wk-markdown-forward-title`.trim(),
+        className: `${
+          cprops?.className ?? ""
+        } wk-markdown-forward-title`.trim(),
         title: full,
       });
     }
     return c;
   });
   return (
-    <p {...props} className={`${props?.className ?? ""} wk-markdown-forward-card`.trim()}>
+    <p
+      {...props}
+      className={`${props?.className ?? ""} wk-markdown-forward-card`.trim()}
+    >
       {clamped}
     </p>
   );
@@ -617,7 +630,15 @@ const MarkdownContent: React.FC<MarkdownContentProps> = ({
       );
     const wrap =
       (Tag: string) =>
-      ({ node, children, ordered, checked, index, siblingCount, ...props }: any) =>
+      ({
+        node,
+        children,
+        ordered,
+        checked,
+        index,
+        siblingCount,
+        ...props
+      }: any) =>
         React.createElement(Tag, props, process(children));
     return {
       ...activeBaseComponents,

--- a/packages/dmworkbase/src/Messages/Text/__tests__/MarkdownContentStrikethrough.test.tsx
+++ b/packages/dmworkbase/src/Messages/Text/__tests__/MarkdownContentStrikethrough.test.tsx
@@ -1,0 +1,83 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import ReactDOM from "react-dom";
+import { act } from "react-dom/test-utils";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../../App", () => ({
+  default: {
+    dataSource: { commonDataSource: { getImageURL: (src: string) => src } },
+  },
+}));
+
+vi.mock("../../../i18n", () => ({
+  t: (key: string) => key,
+  useI18n: () => ({ t: (key: string) => key }),
+}));
+
+import MarkdownContent from "../MarkdownContent";
+
+let container: HTMLDivElement | null = null;
+
+afterEach(() => {
+  if (!container) return;
+  ReactDOM.unmountComponentAtNode(container);
+  container.remove();
+  container = null;
+});
+
+function renderContent(content: string, enableMath = false) {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  act(() => {
+    ReactDOM.render(
+      <MarkdownContent content={content} enableMath={enableMath} />,
+      container
+    );
+  });
+  return container;
+}
+
+function expectPlainText(root: HTMLElement, text: string) {
+  expect(root.querySelector("del")).toBeNull();
+  expect(root.textContent).toBe(text);
+}
+
+describe("MarkdownContent — GFM strikethrough", () => {
+  it("keeps hyphenated month ranges as plain text", () => {
+    expectPlainText(
+      renderContent("1-3月的合计，以及4-12月的预测"),
+      "1-3月的合计，以及4-12月的预测"
+    );
+  });
+
+  it("keeps single-tilde numeric ranges as plain text", () => {
+    expectPlainText(renderContent("25~30, 31~35"), "25~30, 31~35");
+  });
+
+  it("keeps single-tilde emphasis-like text as plain text", () => {
+    expectPlainText(renderContent("~重要~"), "~重要~");
+  });
+
+  it("still renders standard double-tilde strikethrough", () => {
+    const root = renderContent("~~已删除~~");
+    const deleted = root.querySelector("del");
+    expect(deleted).not.toBeNull();
+    expect(deleted?.textContent).toBe("已删除");
+  });
+
+  it("keeps inline code and code block range text literal", () => {
+    const root = renderContent(
+      "`1-3月` `25~30` `~重要~`\n\n```\n1-3月\n25~30\n~重要~\n```"
+    );
+    expect(root.querySelector("del")).toBeNull();
+    expect(
+      Array.from(root.querySelectorAll("code")).map((code) => code.textContent)
+    ).toEqual(["1-3月", "25~30", "~重要~", "1-3月\n25~30\n~重要~\n"]);
+  });
+
+  it("uses the same single-tilde rule when math rendering is enabled", () => {
+    expectPlainText(renderContent("25~30, 31~35", true), "25~30, 31~35");
+  });
+});


### PR DESCRIPTION
## Summary
- Configure shared `MarkdownContent` message Markdown `remark-gfm` usage with `singleTilde: false` so single `~...~` ranges/plain text do not render as strikethrough.
- Keep standard `~~...~~` strikethrough support unchanged.
- Add regression coverage for hyphen ranges, tilde ranges, single-tilde text, code/code-block preservation, and the math-enabled render path.

## Test plan
- `cd packages/dmworkbase && ../../node_modules/.bin/vitest run --config vitest.config.ts src/Messages/Text/__tests__/MarkdownContentStrikethrough.test.tsx src/Messages/Text/__tests__/MarkdownContentMention.test.tsx src/Messages/Text/__tests__/MarkdownContentForwardClamp.test.tsx`
- `cd packages/dmworkbase && ../../node_modules/.bin/prettier --check src/Messages/Text/MarkdownContent.tsx src/Messages/Text/__tests__/MarkdownContentStrikethrough.test.tsx`
- `cd packages/dmworkbase && git diff --check`

## Risks
- The reported `1-3月` hyphen case does not parse as GFM strikethrough in either old or new `remark-gfm` config; if still reproducible online, it likely comes from another parser/conversion path and should be tracked separately.
- Summary/skill-market/changelog Markdown entry points still use default `remark-gfm`; this PR intentionally keeps the code change to the shared `MarkdownContent` renderer rather than changing every repository Markdown surface. Existing non-message consumers of `MarkdownContent` (for example Markdown preview surfaces) will also get the stricter double-tilde-only behavior.

Multica Issue: OCT-9