### PR TITLE
fix(drive): resolve DM peer uid before saving to drive to prevent 400 peer_uid

### DIFF
--- a/packages/dmworkbase/src/Messages/File/index.tsx
+++ b/packages/dmworkbase/src/Messages/File/index.tsx
@@ -13,7 +13,9 @@ import MessageRow from "../../ui/message/MessageRow";
 import { getFileMessageUI } from "../../bridge/message/useFileMessageUI";
 import { isMessageSelectable } from "../../Service/messageSelection";
 import { isSafeUrl } from "../../Utils/security";
-import { isDriveTransferSupportedChannel, imDriveTransferSourceKey } from "../../Service/SpacePrefix";
+import { isDriveTransferSupportedChannel, imDriveTransferSourceKey, stripSpacePrefix } from "../../Service/SpacePrefix";
+import { resolveCardActionChannelId } from "../InteractiveCard/cardAction";
+import { ChannelTypePerson } from "wukongimjssdk";
 import { I18nContext } from "../../i18n";
 
 export { FileContent } from "./FileContent";
@@ -460,6 +462,51 @@ export class FileCell extends MessageCell<any, FileCellState> {
     WKApp.mittBus.on("wk:drive-transferred-changed", this._driveTransferredListener);
   }
 
+  // Resolve the DM peer uid for the drive-transfer wire.
+  //
+  // In a person-DM the octo-server 'get message by (peer_uid, msg_id)' probe
+  // that drive uses to authorise the transfer takes the PEER's uid — NOT the
+  // caller's own uid — as the peer parameter. In normal 1v1 DMs
+  // `message.channel.channelID` is already the peer's uid so passing it
+  // through works fine. But some WuKongIM system-bot DMs (notification,
+  // fileHelper, and any bot that pushes system messages) deliver recv packets
+  // whose `channel.channelID` COLLAPSES to the receiver's own uid — the
+  // "receiver as container" storage layout that InteractiveCard hit as bug
+  // in #1261 review round 7. If we forward channelID=self as im_group_no,
+  // drive → octo-server GET /v1/messages/person/<self>/<msg-id> returns
+  // 400 `peer_uid` (can't query my own DM with myself) and the save
+  // silently fails with "invalid IM message reference".
+  //
+  // Same tie-break rule as InteractiveCard's `resolveCardActionChannelId`:
+  // when person + channelID === selfUID, fall back to `message.fromUID`
+  // (the WKSDK-canonical peer for a received message). Groups / topics and
+  // any DM whose channelID is already the peer pass through unchanged.
+  //
+  // The result of THIS helper is what upstream (dmworkdrive backend) sees.
+  //
+  // Space-prefix stripping IS applied here (only on Person channels), because
+  // the self-collapse comparison `bareChannelID === selfUID` has to be done
+  // in the same namespace: in a Space deployment the recv-packet channelID
+  // is `s<32hex>_<uid>` while `WKApp.loginInfo.uid` is the bare uid, so
+  // without the strip the equality check silently misses the collapse case
+  // and the caller still forwards `s<32hex>_<self>`. `stripSpacePrefix`
+  // is idempotent (no prefix → passthrough) so this is safe on non-Space
+  // deployments too; the downstream `imDriveTransferSourceKey` /
+  // `normaliseImDriveChannelID` will just no-op on the already-bare id.
+  private resolvedImChannelID(): string {
+    const { message } = this.props;
+    const bareChannelID =
+      message.channel.channelType === ChannelTypePerson
+        ? stripSpacePrefix(message.channel.channelID)
+        : message.channel.channelID;
+    return resolveCardActionChannelId({
+      channelType: message.channel.channelType,
+      channelID: bareChannelID,
+      fromUID: message.fromUID,
+      selfUID: WKApp.loginInfo?.uid,
+    });
+  }
+
   // sourceKey is derived by @octo/base's `imDriveTransferSourceKey` — the
   // SAME implementation dmworkdrive uses to construct the wire source_key
   // and to key the mittBus 'wk:drive-transferred-changed' fan-out. Hosting
@@ -467,11 +514,14 @@ export class FileCell extends MessageCell<any, FileCellState> {
   // subscriber-side key to drift from the emitter-side key (Octo-Q /
   // yujiawei review PR #1322 P2-6 — the earlier local inline version was
   // an obvious silent-drift trap).
+  //
+  // Uses the DM-peer-resolved channel id (not the raw one) so a system-bot
+  // DM's source_key matches what the module.tsx save/check handlers emit.
   private driveSourceKey(): string {
     const { message } = this.props;
     return imDriveTransferSourceKey(
       message.channel.channelType,
-      message.channel.channelID,
+      this.resolvedImChannelID(),
       message.messageID,
     );
   }
@@ -516,7 +566,7 @@ export class FileCell extends MessageCell<any, FileCellState> {
 
     this._checkInFlight = true;
     check({
-      im_group_no: message.channel.channelID,
+      im_group_no: this.resolvedImChannelID(),
       im_channel_type: message.channel.channelType,
       im_msg_id: message.messageID,
     })
@@ -617,7 +667,7 @@ export class FileCell extends MessageCell<any, FileCellState> {
     if (!save) return;
     try {
       const result = await save({
-        im_group_no: message.channel.channelID,
+        im_group_no: this.resolvedImChannelID(),
         im_channel_type: message.channel.channelType,
         im_msg_id: message.messageID,
       });

--- a/packages/dmworkbase/src/Messages/InteractiveCard/__tests__/cardAction.test.ts
+++ b/packages/dmworkbase/src/Messages/InteractiveCard/__tests__/cardAction.test.ts
@@ -124,6 +124,31 @@ describe("resolveCardActionChannelId — person DM 对端塌缩兜底", () => {
       })
     ).toBe("peer-uid");
   });
+
+  // Regression: octo-web fix/dm-peer-uid-fallback — File-cell drive save flow.
+  // In a Space deployment, recv-packet channelID for a Person DM arrives
+  // Space-prefixed (`s<32hex>_<uid>`) while `WKApp.loginInfo.uid` is bare.
+  // The FileCell / module.tsx call sites strip the prefix on Person channels
+  // BEFORE handing the id to `resolveCardActionChannelId`, so that the
+  // self-collapse comparison happens in the same namespace and a collapsed
+  // channelID (bare or prefixed) correctly falls back to `fromUID`. Anchor
+  // the two-step behaviour end-to-end here so a future refactor that keeps
+  // one step but drops the other regresses one of these cases.
+  it("Space deployment: prefixed channelID === selfUID 塌缩 → strip 前缀后回退到 fromUID", () => {
+    // stripSpacePrefix("s<32hex>_<self>") === "<self>" is done inline by the
+    // call sites (see FileCell.resolvedImChannelID and module.tsx). This
+    // test locks the equivalent explicit two-step contract.
+    const bare = "s6ac237f6137a4c6dac0c7cc88883a32f_" + SELF;
+    const strippedBare = bare.substring(bare.indexOf("_") + 1); // "<self>"
+    expect(
+      resolveCardActionChannelId({
+        channelType: 1,
+        channelID: strippedBare,
+        fromUID: "notification",
+        selfUID: SELF,
+      })
+    ).toBe("notification");
+  });
 });
 
 describe("isRetryableCardActionError — 409/5xx 可重试；400/403 终态", () => {

--- a/packages/dmworkbase/src/index.tsx
+++ b/packages/dmworkbase/src/index.tsx
@@ -158,3 +158,4 @@ export { Channel, ChannelTypePerson } from 'wukongimjssdk'
 // dmworkbase (FileCell) and dmworkdrive (module.tsx). Single source of truth
 // for the channel-normalisation contract (#1261 review round 6).
 export { hasSpacePrefix, stripSpacePrefix, isDriveTransferSupportedChannel, normaliseImDriveChannelID, imDriveTransferSourceKey } from './Service/SpacePrefix'
+export { resolveCardActionChannelId } from './Messages/InteractiveCard/cardAction'

--- a/packages/dmworkdrive/src/__mocks__/dmworkBase.ts
+++ b/packages/dmworkdrive/src/__mocks__/dmworkBase.ts
@@ -85,6 +85,22 @@ export const imDriveTransferSourceKey = (
   msgID: string,
 ): string => `${channelType}#${normaliseImDriveChannelID(channelType, channelID)}#${msgID}`;
 
+// Mirror @octo/base's resolveCardActionChannelId — person DM self-collapse
+// fallback to fromUID. Kept trivial and value-equivalent so any test that
+// asserts on the source_key wire format still exercises the same branch.
+export const resolveCardActionChannelId = (params: {
+  channelType: number;
+  channelID: string;
+  fromUID?: string;
+  selfUID?: string;
+}): string => {
+  const { channelType, channelID, fromUID, selfUID } = params;
+  if (channelType === 1 && !!selfUID && channelID === selfUID && !!fromUID) {
+    return fromUID;
+  }
+  return channelID;
+};
+
 export class Menus {
   constructor(
     public id: string,

--- a/packages/dmworkdrive/src/module.tsx
+++ b/packages/dmworkdrive/src/module.tsx
@@ -8,6 +8,8 @@ import {
   t as translate,
   MessageContentTypeConst,
   isDriveTransferSupportedChannel,
+  resolveCardActionChannelId,
+  stripSpacePrefix,
 } from '@octo/base';
 import type { IModule } from '@octo/base';
 import DriveSidebar from './pages/DriveSidebar';
@@ -353,13 +355,42 @@ export default class DriveModule implements IModule {
         // and adding a runtime import here breaks the isolated web build
         // Rolldown pass ("failed to resolve import 'wukongimjssdk'").
         if (message.status !== 1) return null;
+        // DM peer-uid resolution: system-bot DMs (notification / fileHelper)
+        // deliver recv packets whose channel.channelID collapses to the
+        // receiver's own uid instead of the peer's — see the corresponding
+        // `resolvedImChannelID` helper in dmworkbase/Messages/File/index.tsx
+        // for the full rationale. Both the cache read AND the save path
+        // below must forward the RESOLVED peer, otherwise:
+        //   (a) getDriveTransferred keys on a source_key that never matches
+        //       what the batch-check emitter side stored → menu stays on
+        //       "存到云盘…" for an already-saved file, and
+        //   (b) saveMessageToDriveAt POSTs im_group_no=self → drive fires
+        //       octo-server GET /v1/messages/person/<self>/<msg-id> which
+        //       fails with 400 `peer_uid` and the picker Toasts an
+        //       "invalid IM message reference" error.
+        //
+        // Strip the Space prefix (`s<32hex>_`) before the self-collapse
+        // comparison: in Space deployments the recv-packet channelID
+        // arrives prefixed while `WKApp.loginInfo.uid` is bare, so a
+        // plain `channelID === selfUID` misses the collapse case.
+        // `stripSpacePrefix` is idempotent on unprefixed ids.
+        const bareChannelID =
+          message.channel.channelType === 1
+            ? stripSpacePrefix(message.channel.channelID)
+            : message.channel.channelID;
+        const resolvedGroupNo = resolveCardActionChannelId({
+          channelType: message.channel.channelType,
+          channelID: bareChannelID,
+          fromUID: message.fromUID,
+          selfUID: WKApp.loginInfo?.uid,
+        });
         // Two-state menu: mirror the icon. If the cache says the file is
         // already saved somewhere the caller can reach, offer "在云盘中查看"
         // that jumps to the winner. Otherwise (notfound / unknown) offer
         // the picker. Unknown is treated as "may not be saved" — safer
         // default: never hide the save entry when we don't know.
         const known = WKApp.getDriveTransferred?.({
-          im_group_no: message.channel.channelID,
+          im_group_no: resolvedGroupNo,
           im_channel_type: message.channel.channelType,
           im_msg_id: message.messageID,
         });
@@ -381,7 +412,7 @@ export default class DriveModule implements IModule {
             const save = WKApp.saveMessageToDriveAt;
             if (!save) return;
             void save({
-              im_group_no: message.channel.channelID,
+              im_group_no: resolvedGroupNo,
               im_channel_type: message.channel.channelType,
               im_msg_id: message.messageID,
             }).catch(() => {


### PR DESCRIPTION
## Summary

Save-to-drive on a chat file fails with 400 `invalid IM message reference` when the message's `channel.channelID` has collapsed to the receiver's own uid — the WuKongIM "receiver as container" delivery shape used by system-bot DMs (`notification`, `fileHelper`, `botfather`, and any bot pushing system messages).

Closes #1335.

Same class of bug as `Messages/InteractiveCard/cardAction.ts` `resolveCardActionChannelId` (fixed on PR #1261 round-7); this PR applies the same self→fromUID fallback to the drive save flow's five call sites.

## Root cause

FileCell (`packages/dmworkbase/src/Messages/File/index.tsx`) and the drive right-click menu factory (`packages/dmworkdrive/src/module.tsx`) forward `message.channel.channelID` verbatim as `im_group_no` on:

- FileCell: `driveSourceKey()`, `runTransferredCheck()`, `handleSaveToDrive()`.
- module.tsx menu factory: `WKApp.getDriveTransferred(...)`, `WKApp.saveMessageToDriveAt(...)`.

When `channelID === self`, drive fires `GET /v1/messages/person/<self>/<msg-id>` at octo-server, which enforces `peer_uid != loginUID` and returns 400. drive's transfer envelope surfaces that as `invalid IM message reference`.

## The change

A new private helper `resolvedImChannelID()` on FileCell, and an equivalent inline resolution in the module.tsx menu factory, apply a **two-step** normalisation:

1. **Strip Space prefix** on Person channels (`stripSpacePrefix(channelID)`). Necessary because in Space deployments the recv-packet channelID arrives as `s<32hex>_<uid>` while `WKApp.loginInfo.uid` is bare; without the strip the equality comparison in step 2 silently misses the collapse case. `stripSpacePrefix` is idempotent on unprefixed ids (safe on non-Space deployments).
2. **Self-collapse fallback** via `resolveCardActionChannelId({channelType, channelID, fromUID, selfUID})` — the same helper InteractiveCard uses. When Person + `channelID === selfUID` + `fromUID` non-empty, returns `fromUID` (the WKSDK-canonical peer for a received message); otherwise passes through.

Both steps apply only on Person channels. Group / thread channels pass through unchanged (their `channelID` never collapses to self, and Space prefix is not their concern).

All five call sites in `packages/dmworkbase/src/Messages/File/index.tsx` and `packages/dmworkdrive/src/module.tsx` now forward the resolved id in place of the raw channelID.

## Files touched

- `packages/dmworkbase/src/index.tsx` — export `resolveCardActionChannelId` from `@octo/base` (previously only imported inside dmworkbase; dmworkdrive needs it too).
- `packages/dmworkbase/src/Messages/File/index.tsx` — new private `resolvedImChannelID()` helper, applied to the three FileCell call sites listed above.
- `packages/dmworkdrive/src/module.tsx` — two-step resolution inline in the right-click factory, applied to `WKApp.getDriveTransferred` (cache read that decides the menu label) and `WKApp.saveMessageToDriveAt` (picker-driven save).
- `packages/dmworkdrive/src/__mocks__/dmworkBase.ts` — mirror `resolveCardActionChannelId` so the vitest alias for `@octo/base` keeps working.
- `packages/dmworkbase/src/Messages/InteractiveCard/__tests__/cardAction.test.ts` — added a Space-deployment regression test that pins the explicit two-step contract (stripSpacePrefix of prefixed-self + resolveCardActionChannelId === fromUID).

## Testing

- `packages/dmworkbase` — **2637/2637 pass**.
- `packages/dmworkdrive` — **254/254 pass**.
- Deployed on the local VM and marker-verified: bundle hash rolled forward (`index-BPE-C2kS.js` → `index-D5s_RfrV.js`), tier-1 i18n keys (`saveToDriveSuccess`, `viewInDrive`) still present in the new bundle, http `/` = 200.

## Why not fix in drive or octo-server

- **drive** has no `fromUID` in the transfer request (wire is `im_group_no + im_channel_type + im_msg_id`), so a backend fallback would need an extra octo-server round-trip just to look up `fromUID`. `fromUID` also only makes sense on a *received* message, not on a transfer intent — the right layer to normalise is the client that owns the `Message` object.
- **octo-server** has no `fromUID` on the URL parameter either (`GET /messages/person/:peer_uid/:message_id`), and can't guess.
- **InteractiveCard** already picked the web-layer fix (`cardAction.ts` round-7 on #1261); this PR stays consistent with that precedent.

## Not in scope

- iOS / Android / Desktop clients likely need the equivalent fallback; that's a separate track. A defensive check at the drive backend (400 `self_collapse_detected` when `IMChannelType == Person && IMGroupNo == actor.UID`) would give those clients a clearer error, but is deferred to keep this PR web-only.

## COMPREHENSION

- **What load-bearing paths does this touch?** Only client-side normalisation on the five save-to-drive call sites. No wire-shape or endpoint change. Group / thread channels are byte-identical after the resolution (both steps are no-ops on non-Person channels).
- **What could break?** Nothing beyond the tests exercised above. The fallback branch only fires when Person + `bareChannelID === selfUID` + `fromUID` non-empty — the exact combo that was already broken. Every other DM shape (peer intact, unprefixed / prefixed, bot / real-user, group / thread) goes through the passthrough branch.
- **How is it proven?** Two Space-deployment regression tests + 2637 + 254 test suite runs + local-VM deploy showing the previously failing repro now succeeds.