### PR TITLE
fix(card): align toggle target node counting

### DIFF
--- a/packages/dmworkbase/src/Messages/InteractiveCard/__tests__/validateCardForOcto.test.ts
+++ b/packages/dmworkbase/src/Messages/InteractiveCard/__tests__/validateCardForOcto.test.ts
@@ -534,6 +534,29 @@ describe("validateCardForOcto — 真实预算上限（MAX_NODES=200 / MAX_DEPTH
       ).ok
     ).toBe(true);
   });
+  it("ToggleVisibility action 自身仍计 1 个节点（200 个元素 + 1 个 action）", () => {
+    const targetIds = Array.from(
+      { length: 200 },
+      (_, index) => `section-${index}`
+    );
+    const body = targetIds.map((id) => ({
+      type: "Container",
+      id,
+      items: [],
+    }));
+    expect(
+      validateCardForOcto(
+        AC(body, {
+          actions: [
+            {
+              type: "Action.ToggleVisibility",
+              targetElements: targetIds,
+            },
+          ],
+        })
+      ).ok
+    ).toBe(false);
+  });
   it("嵌套深度 17 层 → 越界降级", () => {
     let node: Record<string, unknown> = { type: "TextBlock", text: "deep" };
     for (let i = 0; i < 17; i++) node = { type: "Container", items: [node] };

--- a/packages/dmworkbase/src/Messages/InteractiveCard/__tests__/validateCardForOcto.test.ts
+++ b/packages/dmworkbase/src/Messages/InteractiveCard/__tests__/validateCardForOcto.test.ts
@@ -511,6 +511,29 @@ describe("validateCardForOcto — 真实预算上限（MAX_NODES=200 / MAX_DEPTH
     }));
     expect(validateCardForOcto(AC(many)).ok).toBe(true);
   });
+  it("targetElements 是引用，不计入节点预算（199 个元素 + 1 个 action）", () => {
+    const targetIds = Array.from(
+      { length: 199 },
+      (_, index) => `section-${index}`
+    );
+    const body = targetIds.map((id) => ({
+      type: "Container",
+      id,
+      items: [],
+    }));
+    expect(
+      validateCardForOcto(
+        AC(body, {
+          actions: [
+            {
+              type: "Action.ToggleVisibility",
+              targetElements: targetIds,
+            },
+          ],
+        })
+      ).ok
+    ).toBe(true);
+  });
   it("嵌套深度 17 层 → 越界降级", () => {
     let node: Record<string, unknown> = { type: "TextBlock", text: "deep" };
     for (let i = 0; i < 17; i++) node = { type: "Container", items: [node] };

--- a/packages/dmworkbase/src/Messages/InteractiveCard/validateCardForOcto.ts
+++ b/packages/dmworkbase/src/Messages/InteractiveCard/validateCardForOcto.ts
@@ -134,8 +134,9 @@ function validateToggleVisibilityAction(
     throw new OctoInvalidCard("ToggleVisibility targetElements required");
   }
   for (const target of targets) {
-    // targetElements 是对已存在元素的引用，不是卡片树节点。服务端 walker
-    // 仅将其收集为 targetRefs 并校验存在性，只对 action 本身计一个节点。
+    // targetElements 是对已存在元素的引用，不是卡片树节点。服务端权威：
+    // octo-server/pkg/cardmsg/validate.go 的 walker.action() 只对 action bump，
+    // walker.toggleVisibility() 仅收集 targetRefs，由 resolveTargetRefs() 校验存在性。
     validateToggleTargetElement(target, ctx);
   }
 }

--- a/packages/dmworkbase/src/Messages/InteractiveCard/validateCardForOcto.ts
+++ b/packages/dmworkbase/src/Messages/InteractiveCard/validateCardForOcto.ts
@@ -134,9 +134,8 @@ function validateToggleVisibilityAction(
     throw new OctoInvalidCard("ToggleVisibility targetElements required");
   }
   for (const target of targets) {
-    // 每个 target 计入节点预算（与 facts / actions / columns / choices / images 一致），
-    // 对齐服务端 walker MAX_NODES 计数口径，防止巨量 target 数组绕过预算。
-    if (!ctx.budget.consume()) throw new OctoInvalidCard("node count exceeded");
+    // targetElements 是对已存在元素的引用，不是卡片树节点。服务端 walker
+    // 仅将其收集为 targetRefs 并校验存在性，只对 action 本身计一个节点。
     validateToggleTargetElement(target, ctx);
   }
 }


### PR DESCRIPTION
## Summary

Align InteractiveCard node-budget validation with the authoritative server walker so Action.ToggleVisibility targetElements references do not make otherwise valid edited cards fall back to plain text.

## Related Issue

N/A

## Changes

- Stop counting targetElements references as rendered card-tree nodes while retaining their shape and existence validation.
- Keep Action.ToggleVisibility itself in the 200-node budget.
- Add boundary coverage for 199 elements plus one action (valid) and 200 elements plus one action (invalid).
- Anchor the cross-repository counting rule to the matching octo-server walker functions.

## Architecture / Module Boundary

- Affected module(s): @octo/base InteractiveCard rendering
- New or changed user-visible entry point: no
- Shared layer touched: Messages
- If shared code changed, impact scope: InteractiveCard pre-render validation and whole-card fallback decisions in web clients
- Duplicate entry point checked: not applicable

## Testing

- [x] Unit tests added/updated
- [ ] Manually verified

Commands run:

- pnpm --filter @octo/base exec vitest run src/Messages/InteractiveCard — 25 files / 314 tests passed
- pnpm exec prettier --check packages/dmworkbase/src/Messages/InteractiveCard/validateCardForOcto.ts packages/dmworkbase/src/Messages/InteractiveCard/__tests__/validateCardForOcto.test.ts — passed
- Mutation check: removing root-action budget consumption makes the new upper-bound test fail as intended

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated inline contract documentation
- [x] Confirmed the change does not affect UI copy; i18n validation is not required
- [x] Confirmed the change follows module ownership and does not add duplicate user-visible entry points
- [x] Described impact scope when shared components, messages, bridge, or services are changed
- [x] Followed commit message conventions (Conventional Commits)