### PR TITLE
fix(message-input): clear composer as soon as a send is enqueued (#1280)

### DIFF
--- a/packages/dmworkbase/src/Components/Conversation/index.tsx
+++ b/packages/dmworkbase/src/Components/Conversation/index.tsx
@@ -633,6 +633,11 @@ export class Conversation
    * 发送媒体消息并等待上传完成 + 服务端 ack 后才返回。
    * 保证多条消息严格顺序发送，且本地回显排序正确（每条消息的 messageSeq 确定后再发下一条）。
    * 超时 30s 自动 resolve（避免网络断开时永久阻塞）。
+   *
+   * 返回值语义 (octo-web#1280)：**是否已入队**（本地气泡已出现在消息列表），
+   * 不是「服务端已确认」。等待 ack 只为排序；ack 失败/超时的消息会带失败标记与
+   * 重发入口（Messages/Base + MediaMessageUploadTask.restart），若把它当失败上报，
+   * MessageInput 会把已经可见的内容塞回输入框（#1280 的主要投诉）。
    */
   private async sendMediaAndWait(
     content: MessageContent,
@@ -721,13 +726,18 @@ export class Conversation
     WKSDK.shared().chatManager.addMessageStatusListener(ackListener);
 
     // 发送消息（内部会 addTask → task.start()，所有 listener 已就绪）
+    let enqueued = false;
     let message: Message;
     try {
       message = await this.sendMessage(content, channel);
     } catch (err) {
+      // 未入队：调用方据此保留草稿供重试。
       done(false);
       throw err;
     }
+    // 已入队：本地气泡已经出现在消息列表里，之后无论上传/ack 成功与否，
+    // 用户都能在气泡上重发，输入框不应再把这条内容拿回来 (octo-web#1280)。
+    enqueued = true;
     clientSeq = message.clientSeq;
 
     // sendMessage 返回后主动检查
@@ -777,7 +787,14 @@ export class Conversation
       }
     }
 
-    return promise;
+    // 等 upload+ack 结果（或超时）只为保证发送顺序；对外只告知「是否已入队」。
+    const delivered = await promise;
+    if (!delivered) {
+      console.warn(
+        "[Conversation] media message not confirmed (upload/ack failed or timed out); the bubble keeps its failure state and can be resent"
+      );
+    }
+    return enqueued;
   }
 
   /**
@@ -785,6 +802,9 @@ export class Conversation
    * 用于连续发送多条消息时保证本地回显顺序与服务端一致：
    * 每条消息拿到 messageSeq 后 order 被正确设置，再发下一条时 fillOrder 不会乱。
    * 超时 10s 自动 resolve（文本消息不需要上传，ack 应该很快回来）。
+   *
+   * 返回值语义同 sendMediaAndWait (octo-web#1280)：**是否已入队**。ack 超时
+   * （慢网/丢 ack）不再上报失败，否则已经发出去的文字会被塞回输入框。
    */
   private async sendTextAndWaitAck(
     content: MessageContent,
@@ -829,13 +849,17 @@ export class Conversation
     };
     WKSDK.shared().chatManager.addMessageStatusListener(statusListener);
 
+    let enqueued = false;
     let message: Message;
     try {
       message = await this.sendMessage(content, channel);
     } catch (err) {
+      // 未入队（例如发送前编码抛错）→ 调用方保留草稿供重试。
       done(false);
       throw err;
     }
+    // 已入队：气泡已在消息列表，ack 结果只影响气泡状态，不影响输入框 (#1280)。
+    enqueued = true;
     clientSeq = message.clientSeq;
 
     // fallback：检查暂存的 ack 或已处理的 status
@@ -856,7 +880,14 @@ export class Conversation
       }
     }
 
-    return promise;
+    // 等 ack（或超时）只为保证发送顺序；对外只告知「是否已入队」。
+    const delivered = await promise;
+    if (!delivered) {
+      console.warn(
+        "[Conversation] text message not acked (failed or timed out); the bubble keeps its failure state and can be resent"
+      );
+    }
+    return enqueued;
   }
 
   /**
@@ -2922,14 +2953,19 @@ export class Conversation
                         topFiles?: { id: string; file: File }[],
                         editorBlocks?: EditorContentBlock[]
                       ): Promise<boolean | SendResultDetail> => {
-                        // 返回值告诉 MessageInput 是否清空编辑器/附件：
-                        //   true  → 发送成功(或已消费)，清空草稿+附件；
-                        //   false → 发送失败，保留编辑器内容+图片引用供重试。
-                        // 关键：混排 (text+image) 上传失败时必须返回 false，否则
-                        // 用户整条消息会被同步清空丢失 (octo-web#227 Jerry-Xin P1)。
+                        // 返回值告诉 MessageInput「已消费的 compose 是否保持消费」：
+                        //   true  → 消息已入队（本地气泡已在列表），输入框保持清空；
+                        //   false → 未入队，把内容还给输入框供重试。
+                        // 关键：混排 (text+image) 在入队前上传失败时必须返回 false，
+                        // 否则整条消息会丢 (octo-web#227)；反之，**已入队但 ack 失败/
+                        // 超时绝不能返回 false**，否则已经可见的内容会被塞回输入框
+                        // (octo-web#1280)。
                         const sendDraftGeneration = this.draftSaveGeneration;
                         const remoteDraftAtSend =
                           this.vm.currentConversation?.remoteExtra?.draft || "";
+                        // #1280 起编辑器在进入这里之前已被同步消费（清空），所以这里
+                        // 取到的是空串；它与 liveDraft 的比对语义因此变成「等待期间用户
+                        // 是否写了新草稿」——写了就不清远端草稿，恰好是需要的保护。
                         const draftAtSend =
                           this.messageInputContext()?.text() || "";
                         VoiceFeedback.shared()?.submitAll(text);
@@ -3275,13 +3311,12 @@ export class Conversation
                                 draftAtSend
                               );
                             }
-                            // 返回 snapshot-aware 结果 (octo-web#227 Jerry-Xin
-                            // 第二轮)：
-                            //   • editorConsumed=mixedSent：混排失败时保留编辑器
-                            //     文本+图片，用户可整条重试；
+                            // 返回部分结果 (octo-web#227 → #1280)：
+                            //   • editorConsumed=mixedSent：混排未入队时把文本+图片
+                            //     还给编辑器，用户可整条重试；
                             //   • consumedTopIds：本次已发出的顶部附件 id。即使
-                            //     混排失败，这些文件也已发出，让 MessageInput 只
-                            //     清掉它们、不随编辑器草稿一起保留，避免重试重复。
+                            //     混排失败，这些文件也已发出，MessageInput 不会把
+                            //     它们放回附件区，避免重试重复发送。
                             return finishRichTextMixedSend(
                               anyMessageSent,
                               mixedSent,

--- a/packages/dmworkbase/src/Components/Conversation/index.tsx
+++ b/packages/dmworkbase/src/Components/Conversation/index.tsx
@@ -52,7 +52,14 @@ import MessageInput, {
   MessageInputContext,
   EditorContentBlock,
 } from "../MessageInput";
-import { SendResultDetail } from "../MessageInput/sendFlow";
+import {
+  SendResultDetail,
+  SendTargetSnapshot,
+} from "../MessageInput/sendFlow";
+import {
+  captureSendTarget,
+  type CapturedSendTarget,
+} from "./sendTarget";
 import {
   tryConsumeInitialCompose,
   type ComposeHost,
@@ -108,7 +115,10 @@ import { downloadFile } from "../../Utils/download";
 import Lightbox from "yet-another-react-lightbox";
 import Download from "yet-another-react-lightbox/plugins/download";
 import { buildChatContext, ChatContextChannelInfo } from "./chatContext";
-import { shouldClearDraftAfterSend } from "../../Utils/draftLifecycle";
+import {
+  resolveDraftToPersist,
+  shouldClearDraftAfterSend,
+} from "../../Utils/draftLifecycle";
 import {
   isSuccessfulSendAck,
   messageStatusWaitResult,
@@ -1391,8 +1401,11 @@ export class Conversation
     // 辅助 Thread 不覆盖主会话的全局附件守卫；否则开关侧栏会让主会话
     // 的待发送附件失去离开确认，或被侧栏草稿反向阻塞。
     if (!this.props.isAuxiliary) {
+      // in-flight 发送也算「有待发送内容」(octo-web#1280 review)：compose 已被
+      // 清出输入框、气泡还没出现，这时切走会让内容彻底消失，必须先弹确认。
       WKApp.shared.pendingAttachmentGuard = () =>
-        this.getPendingAttachments().length === 0;
+        this.getPendingAttachments().length === 0 &&
+        this.pendingSendCount() === 0;
       WKApp.shared.pendingAttachmentGuardId = this._guardId;
     }
 
@@ -1555,11 +1568,26 @@ export class Conversation
     this.vm.releaseOpenConversationOwnership();
   }
 
+  /** Composes consumed by the composer but not yet enqueued (octo-web#1280). */
+  private pendingSendCount(): number {
+    return this.messageInputContext()?.pendingSendCount?.() ?? 0;
+  }
+
+  private pendingSendText(): string {
+    return this.messageInputContext()?.pendingSendText?.() ?? "";
+  }
+
   markConversationExtra() {
-    let draft = this.messageInputContext()?.text();
+    // 不要用空草稿覆盖「已消费但还没入队」的内容 (octo-web#1280 review)：
+    // 输入框在发送开始时就被清空，离开会话时这里读到的是空串。
+    const draft = resolveDraftToPersist({
+      liveDraft: this.messageInputContext()?.text() || "",
+      pendingSendText: this.pendingSendText(),
+      existingDraft: this.vm.currentConversation?.remoteExtra?.draft || "",
+    });
     this.draftSaveGeneration += 1;
-    this.latestSavedDraft = draft || "";
-    void this.updateConversationExtra(draft || "");
+    this.latestSavedDraft = draft;
+    void this.updateConversationExtra(draft);
   }
 
   updateConversationExtra(draft: string) {
@@ -2946,12 +2974,27 @@ export class Conversation
                           },
                         });
                       }}
+                      onCaptureSendTarget={() =>
+                        // 与 compose 同步取走 reply/edit 目标并收起横幅
+                        // (octo-web#1280)：排队发送不能再实时读 vm 上的状态。
+                        captureSendTarget<Message>({
+                          getReplyMessage: () => vm.currentReplyMessage,
+                          setReplyMessage: (m) => {
+                            vm.currentReplyMessage = m;
+                          },
+                          getHandlerType: () => vm.currentHandlerType,
+                          setHandlerType: (h) => {
+                            vm.currentHandlerType = h;
+                          },
+                        })
+                      }
                       onSend={async (
                         text: string,
                         mention?: MentionModel,
                         _attachments?: { id: string; file: File }[],
                         topFiles?: { id: string; file: File }[],
-                        editorBlocks?: EditorContentBlock[]
+                        editorBlocks?: EditorContentBlock[],
+                        sendTarget?: SendTargetSnapshot
                       ): Promise<boolean | SendResultDetail> => {
                         // 返回值告诉 MessageInput「已消费的 compose 是否保持消费」：
                         //   true  → 消息已入队（本地气泡已在列表），输入框保持清空；
@@ -2963,48 +3006,68 @@ export class Conversation
                         const sendDraftGeneration = this.draftSaveGeneration;
                         const remoteDraftAtSend =
                           this.vm.currentConversation?.remoteExtra?.draft || "";
-                        // #1280 起编辑器在进入这里之前已被同步消费（清空），所以这里
-                        // 取到的是空串；它与 liveDraft 的比对语义因此变成「等待期间用户
-                        // 是否写了新草稿」——写了就不清远端草稿，恰好是需要的保护。
+                        // #1280 起编辑器在 send 开始时就被同步消费，而 onSend 可能被
+                        // 排队后才执行，所以这里读到的**不一定**是空串：
+                        //   • 立即执行的发送 → 空串；
+                        //   • 排队后执行的发送 → 用户这期间已经写的新内容。
+                        // 两种情况下语义都收敛为「交给本次发送之后，输入框是否已经
+                        // 往前走了」——走了就不清远端草稿（新草稿权威），没走才清。
+                        // 已发出的内容在任何情况下都不再是草稿。详见
+                        // Utils/draftLifecycle.ts 的 shouldClearDraftAfterSend。
                         const draftAtSend =
                           this.messageInputContext()?.text() || "";
                         VoiceFeedback.shared()?.submitAll(text);
 
                         // ── 回复/编辑处理 ──────────────
+                        // ⚠️ 必须用按键时同步取走的 sendTarget 快照，**绝不能**在这里
+                        // 实时读 vm.currentReplyMessage / currentHandlerType：发送被
+                        // 排队后这里可能晚几秒才执行，用户可能已经改了回复目标、甚至
+                        // 切到「编辑消息」——实时读会回复错消息或覆盖无关消息
+                        // (octo-web#1280 review)。
+                        // 兼容：老调用方没有传 sendTarget 时退回实时读取。
+                        const target =
+                          (sendTarget as CapturedSendTarget<Message> | undefined) ??
+                          captureSendTarget<Message>({
+                            getReplyMessage: () => vm.currentReplyMessage,
+                            setReplyMessage: (m) => {
+                              vm.currentReplyMessage = m;
+                            },
+                            getHandlerType: () => vm.currentHandlerType,
+                            setHandlerType: (h) => {
+                              vm.currentHandlerType = h;
+                            },
+                          });
+                        const targetMessage = target.replyMessage;
                         let reply: Reply | undefined;
-                        if (vm.currentReplyMessage) {
-                          if (vm.currentHandlerType === 2) {
-                            // 编辑消息
+                        if (targetMessage) {
+                          if (target.handlerType === 2) {
+                            // 编辑消息。失败时抛出，让 MessageInput 把 compose 与
+                            // 编辑目标一起还原，用户重试仍是「编辑」而不是发新消息。
                             const editContent = new MessageText(text);
                             let json = editContent.encodeJSON();
                             json["type"] = MessageContentType.text;
                             await vm.editMessage(
-                              vm.currentReplyMessage.messageID,
-                              vm.currentReplyMessage.messageSeq,
-                              vm.currentReplyMessage.channel.channelID,
-                              vm.currentReplyMessage.channel.channelType,
+                              targetMessage.messageID,
+                              targetMessage.messageSeq,
+                              targetMessage.channel.channelID,
+                              targetMessage.channel.channelType,
                               JSON.stringify(json)
                             );
-                            vm.currentReplyMessage = undefined;
                             // 编辑消息已提交，编辑器应清空。
                             return true;
                           }
                           reply = new Reply();
-                          reply.messageID = vm.currentReplyMessage.messageID;
-                          reply.messageSeq = vm.currentReplyMessage.messageSeq;
-                          reply.fromUID = vm.currentReplyMessage.fromUID;
+                          reply.messageID = targetMessage.messageID;
+                          reply.messageSeq = targetMessage.messageSeq;
+                          reply.fromUID = targetMessage.fromUID;
                           const channelInfo = getImChannelInfo(
                             WKSDK.shared(),
-                            new Channel(
-                              vm.currentReplyMessage.fromUID,
-                              ChannelTypePerson
-                            )
+                            new Channel(targetMessage.fromUID, ChannelTypePerson)
                           );
                           if (channelInfo) {
                             reply.fromName = channelInfo.title;
                           }
-                          reply.content = vm.currentReplyMessage.content;
-                          vm.currentReplyMessage = undefined;
+                          reply.content = targetMessage.content;
                         }
 
                         // ── 辅助：发送单张图片（读取预览+宽高） ──────────────
@@ -3192,6 +3255,10 @@ export class Conversation
                         // 清掉这些已发文件、保留编辑器草稿，重试不会重复发送
                         // (octo-web#227 Jerry-Xin non-blocking)。
                         const consumedTopIds: string[] = [];
+                        // 编辑器内粘贴附件中「未入队」的 id：整条 compose 已被
+                        // MessageInput 同步消费，只有精确回报这些 id 才能把它们放回
+                        // 编辑器，而不是连同已发出的内容一起丢掉 (octo-web#1280 review)。
+                        const unsentEditorAttachmentIds: string[] = [];
                         const topFilesToSend = topFiles || [];
                         const mixedCandidate = buildRichTextMixedCandidate(
                           topFilesToSend,
@@ -3344,10 +3411,17 @@ export class Conversation
                               } else if (block.type === "image") {
                                 if (await sendImageFile(block.file)) {
                                   anyMessageSent = true;
+                                } else {
+                                  // 预检拒绝等未入队情形：记下 id，让 MessageInput
+                                  // 只把这张图放回编辑器，其余已发内容保持消费
+                                  // (octo-web#1280 review)。
+                                  unsentEditorAttachmentIds.push(block.id);
                                 }
                               } else if (block.type === "file") {
                                 if (await sendFileAttachment(block.file)) {
                                   anyMessageSent = true;
+                                } else {
+                                  unsentEditorAttachmentIds.push(block.id);
                                 }
                               }
                             } catch (err) {
@@ -3355,6 +3429,9 @@ export class Conversation
                                 "[Conversation] editorBlock send failed:",
                                 err
                               );
+                              if (block.type !== "text") {
+                                unsentEditorAttachmentIds.push(block.id);
+                              }
                               Toast.error(
                                 t("base.conversation.message.sendFailed")
                               );
@@ -3393,10 +3470,19 @@ export class Conversation
                           );
                         }
                         if (anyMessageSent) this.props.onMessageSent?.();
-                        // 与 clearDraftAfterSend 同口径：只有确实发出消息时才让
-                        // MessageInput 清空编辑器；全部失败/被预检拒绝时返回 false
-                        // 保留草稿可重试。
-                        return anyMessageSent;
+                        // 返回真实的部分结果，而不是裸 boolean (octo-web#1280 review)：
+                        //   • editorConsumed=anyMessageSent：一条都没入队时整条 compose
+                        //     还给输入框可重试；
+                        //   • consumedTopIds：只有真正发出的顶部附件保持消费，被预检
+                        //     拒绝的会回到附件区（裸 true 会被当成「全部已消费」而丢掉）；
+                        //   • unsentEditorAttachmentIds：编辑器内被拒的粘贴附件单独回到
+                        //     编辑器。文本块失败无法单独回滚（失败即整条 send 抛错，
+                        //     anyMessageSent 保持 false 走整体还原）。
+                        return {
+                          editorConsumed: anyMessageSent,
+                          consumedTopIds,
+                          unsentEditorAttachmentIds,
+                        };
                       }}
                     ></MessageInput>
                       </>

--- a/packages/dmworkbase/src/Components/Conversation/index.tsx
+++ b/packages/dmworkbase/src/Components/Conversation/index.tsx
@@ -1402,7 +1402,8 @@ export class Conversation
     // 的待发送附件失去离开确认，或被侧栏草稿反向阻塞。
     if (!this.props.isAuxiliary) {
       // in-flight 发送也算「有待发送内容」(octo-web#1280 review)：compose 已被
-      // 清出输入框、气泡还没出现，这时切走会让内容彻底消失，必须先弹确认。
+      // 清出输入框，未入队时切走会让内容彻底消失；已入队但还在上传/等 ack 的也
+      // 一并保护（拆掉会话期间没人能还原失败内容），因此这里取整个 onSend 窗口。
       WKApp.shared.pendingAttachmentGuard = () =>
         this.getPendingAttachments().length === 0 &&
         this.pendingSendCount() === 0;
@@ -1568,7 +1569,7 @@ export class Conversation
     this.vm.releaseOpenConversationOwnership();
   }
 
-  /** Composes consumed by the composer but not yet enqueued (octo-web#1280). */
+  /** Composes handed to a send that has not settled yet (octo-web#1280). */
   private pendingSendCount(): number {
     return this.messageInputContext()?.pendingSendCount?.() ?? 0;
   }

--- a/packages/dmworkbase/src/Components/Conversation/index.tsx
+++ b/packages/dmworkbase/src/Components/Conversation/index.tsx
@@ -55,6 +55,7 @@ import MessageInput, {
 import {
   SendResultDetail,
   SendTargetSnapshot,
+  UnsentEditorBlock,
 } from "../MessageInput/sendFlow";
 import {
   captureSendTarget,
@@ -3256,10 +3257,13 @@ export class Conversation
                         // 清掉这些已发文件、保留编辑器草稿，重试不会重复发送
                         // (octo-web#227 Jerry-Xin non-blocking)。
                         const consumedTopIds: string[] = [];
-                        // 编辑器内粘贴附件中「未入队」的 id：整条 compose 已被
-                        // MessageInput 同步消费，只有精确回报这些 id 才能把它们放回
+                        // 编辑器 compose 里「未入队」的块（按文档顺序）：整条 compose
+                        // 已被 MessageInput 同步消费，只有精确回报这些块才能把它们放回
                         // 编辑器，而不是连同已发出的内容一起丢掉 (octo-web#1280 review)。
-                        const unsentEditorAttachmentIds: string[] = [];
+                        // 文本块也必须登记：sendTextAndWaitAck 在入队前失败会抛错，
+                        // 若此前已有块发出（anyMessageSent=true），异常被 per-block
+                        // catch 吞掉后这段文字既没发出、也不会被整体还原。
+                        const unsentEditorBlocks: UnsentEditorBlock[] = [];
                         const topFilesToSend = topFiles || [];
                         const mixedCandidate = buildRichTextMixedCandidate(
                           topFilesToSend,
@@ -3408,21 +3412,32 @@ export class Conversation
                                 isFirstTextBlock = false;
                                 if (await this.sendTextAndWaitAck(msgContent)) {
                                   anyMessageSent = true;
+                                } else {
+                                  unsentEditorBlocks.push({
+                                    type: "text",
+                                    text: block.text,
+                                  });
                                 }
                               } else if (block.type === "image") {
                                 if (await sendImageFile(block.file)) {
                                   anyMessageSent = true;
                                 } else {
-                                  // 预检拒绝等未入队情形：记下 id，让 MessageInput
-                                  // 只把这张图放回编辑器，其余已发内容保持消费
+                                  // 预检拒绝等未入队情形：记下这一块，让 MessageInput
+                                  // 只把它放回编辑器，其余已发内容保持消费
                                   // (octo-web#1280 review)。
-                                  unsentEditorAttachmentIds.push(block.id);
+                                  unsentEditorBlocks.push({
+                                    type: "attachment",
+                                    id: block.id,
+                                  });
                                 }
                               } else if (block.type === "file") {
                                 if (await sendFileAttachment(block.file)) {
                                   anyMessageSent = true;
                                 } else {
-                                  unsentEditorAttachmentIds.push(block.id);
+                                  unsentEditorBlocks.push({
+                                    type: "attachment",
+                                    id: block.id,
+                                  });
                                 }
                               }
                             } catch (err) {
@@ -3430,9 +3445,13 @@ export class Conversation
                                 "[Conversation] editorBlock send failed:",
                                 err
                               );
-                              if (block.type !== "text") {
-                                unsentEditorAttachmentIds.push(block.id);
-                              }
+                              // 入队前抛错（解散守卫 / sendMessage 失败等）：文本块
+                              // 也要登记，否则它既没发出又不会被还原，内容直接消失。
+                              unsentEditorBlocks.push(
+                                block.type === "text"
+                                  ? { type: "text", text: block.text }
+                                  : { type: "attachment", id: block.id }
+                              );
                               Toast.error(
                                 t("base.conversation.message.sendFailed")
                               );
@@ -3476,13 +3495,13 @@ export class Conversation
                         //     还给输入框可重试；
                         //   • consumedTopIds：只有真正发出的顶部附件保持消费，被预检
                         //     拒绝的会回到附件区（裸 true 会被当成「全部已消费」而丢掉）；
-                        //   • unsentEditorAttachmentIds：编辑器内被拒的粘贴附件单独回到
-                        //     编辑器。文本块失败无法单独回滚（失败即整条 send 抛错，
-                        //     anyMessageSent 保持 false 走整体还原）。
+                        //   • unsentEditorBlocks：编辑器内未入队的块（被拒的粘贴附件、
+                        //     入队前抛错的文本）按原顺序单独回到编辑器；已发出的块保持
+                        //     消费，所以重试不会重复发送。
                         return {
                           editorConsumed: anyMessageSent,
                           consumedTopIds,
-                          unsentEditorAttachmentIds,
+                          unsentEditorBlocks,
                         };
                       }}
                     ></MessageInput>

--- a/packages/dmworkbase/src/Components/Conversation/index.tsx
+++ b/packages/dmworkbase/src/Components/Conversation/index.tsx
@@ -118,8 +118,9 @@ import Lightbox from "yet-another-react-lightbox";
 import Download from "yet-another-react-lightbox/plugins/download";
 import { buildChatContext, ChatContextChannelInfo } from "./chatContext";
 import {
+  DraftPersistenceSource,
+  resolveDraftAfterSend,
   resolveDraftToPersist,
-  shouldClearDraftAfterSend,
 } from "../../Utils/draftLifecycle";
 import {
   isSuccessfulSendAck,
@@ -362,6 +363,7 @@ export class Conversation
   private _unsubscribeChannelInfoListener?: () => void;
   private draftSaveGeneration = 0;
   private latestSavedDraft = "";
+  private latestSavedDraftSource: DraftPersistenceSource = "empty";
   private _addAttachmentFn?: (
     files: File[],
     source?: "paste" | "upload"
@@ -1580,16 +1582,20 @@ export class Conversation
     return this.messageInputContext()?.pendingSendText?.() ?? "";
   }
 
+  private pendingSendDrafts(): string[] {
+    return this.messageInputContext()?.pendingSendDrafts?.() ?? [];
+  }
+
   markConversationExtra() {
     // 不要用空草稿覆盖「已消费但还没入队」的内容 (octo-web#1280 review)：
     // 输入框在发送开始时就被清空，离开会话时这里读到的是空串。
-    const draft = resolveDraftToPersist({
+    const { draft, source } = resolveDraftToPersist({
       liveDraft: this.messageInputContext()?.text() || "",
       pendingSendText: this.pendingSendText(),
-      existingDraft: this.vm.currentConversation?.remoteExtra?.draft || "",
     });
     this.draftSaveGeneration += 1;
     this.latestSavedDraft = draft;
+    this.latestSavedDraftSource = source;
     void this.updateConversationExtra(draft);
   }
 
@@ -1642,26 +1648,29 @@ export class Conversation
 
   async clearDraftAfterSend(
     sendDraftGeneration: number,
-    remoteDraftAtSend: string
+    remoteDraftAtSend: string,
+    sentDraft: string
   ) {
     const remoteExtra = this.vm.currentConversation?.remoteExtra;
-    if (
-      !shouldClearDraftAfterSend({
-        liveDraft: this.messageInputContext()?.text() || "",
-        remoteDraft: remoteExtra?.draft || "",
-        remoteDraftAtSend,
-        draftSavedAfterSend: this.draftSaveGeneration !== sendDraftGeneration,
-        latestSavedDraft: this.latestSavedDraft,
-      })
-    ) {
+    const pendingDrafts = this.pendingSendDrafts();
+    const nextDraft = resolveDraftAfterSend({
+      liveDraft: this.messageInputContext()?.text() || "",
+      remoteDraft: remoteExtra?.draft || "",
+      remoteDraftAtSend,
+      draftSavedAfterSend: this.draftSaveGeneration !== sendDraftGeneration,
+      latestSavedDraft: this.latestSavedDraft,
+      latestSavedDraftSource: this.latestSavedDraftSource,
+      sentDraft,
+      pendingDrafts: pendingDrafts.length > 0 ? pendingDrafts : [sentDraft],
+    });
+    if (nextDraft === undefined) {
       return;
     }
 
-    if (remoteExtra) {
-      remoteExtra.draft = "";
-    }
+    this.latestSavedDraft = nextDraft;
+    this.latestSavedDraftSource = nextDraft ? "pending" : "empty";
     try {
-      await this.updateConversationExtra("");
+      await this.updateConversationExtra(nextDraft);
     } catch (err) {
       console.warn("[Conversation] clear draft after send failed", err);
     }
@@ -3299,7 +3308,8 @@ export class Conversation
                           if (mixedSent) {
                             await this.clearDraftAfterSend(
                               sendDraftGeneration,
-                              remoteDraftAtSend
+                              remoteDraftAtSend,
+                              sendDraft?.text ?? text
                             );
                           }
                           return finishRichTextMixedSend(
@@ -3379,7 +3389,8 @@ export class Conversation
                             if (mixedSent) {
                               await this.clearDraftAfterSend(
                                 sendDraftGeneration,
-                                remoteDraftAtSend
+                                remoteDraftAtSend,
+                                sendDraft?.text ?? text
                               );
                             }
                             // 返回部分结果 (octo-web#227 → #1280)：
@@ -3514,7 +3525,8 @@ export class Conversation
                         if (anyMessageSent) {
                           await this.clearDraftAfterSend(
                             sendDraftGeneration,
-                            remoteDraftAtSend
+                            remoteDraftAtSend,
+                            sendDraft?.text ?? text
                           );
                         }
                         if (anyMessageSent) this.props.onMessageSent?.();

--- a/packages/dmworkbase/src/Components/Conversation/index.tsx
+++ b/packages/dmworkbase/src/Components/Conversation/index.tsx
@@ -54,6 +54,7 @@ import MessageInput, {
 } from "../MessageInput";
 import {
   SendResultDetail,
+  SendDraftSnapshot,
   SendTargetSnapshot,
   UnsentEditorBlock,
 } from "../MessageInput/sendFlow";
@@ -1641,14 +1642,12 @@ export class Conversation
 
   async clearDraftAfterSend(
     sendDraftGeneration: number,
-    remoteDraftAtSend: string,
-    draftAtSend: string
+    remoteDraftAtSend: string
   ) {
     const remoteExtra = this.vm.currentConversation?.remoteExtra;
     if (
       !shouldClearDraftAfterSend({
         liveDraft: this.messageInputContext()?.text() || "",
-        draftAtSend,
         remoteDraft: remoteExtra?.draft || "",
         remoteDraftAtSend,
         draftSavedAfterSend: this.draftSaveGeneration !== sendDraftGeneration,
@@ -2990,13 +2989,19 @@ export class Conversation
                           },
                         })
                       }
+                      onCaptureSendDraft={() => ({
+                        generation: this.draftSaveGeneration,
+                        remoteDraft:
+                          this.vm.currentConversation?.remoteExtra?.draft || "",
+                      })}
                       onSend={async (
                         text: string,
                         mention?: MentionModel,
                         _attachments?: { id: string; file: File }[],
                         topFiles?: { id: string; file: File }[],
                         editorBlocks?: EditorContentBlock[],
-                        sendTarget?: SendTargetSnapshot
+                        sendTarget?: SendTargetSnapshot,
+                        sendDraft?: SendDraftSnapshot
                       ): Promise<boolean | SendResultDetail> => {
                         // 返回值告诉 MessageInput「已消费的 compose 是否保持消费」：
                         //   true  → 消息已入队（本地气泡已在列表），输入框保持清空；
@@ -3005,19 +3010,14 @@ export class Conversation
                         // 否则整条消息会丢 (octo-web#227)；反之，**已入队但 ack 失败/
                         // 超时绝不能返回 false**，否则已经可见的内容会被塞回输入框
                         // (octo-web#1280)。
-                        const sendDraftGeneration = this.draftSaveGeneration;
+                        // This callback may run after waiting in the send queue,
+                        // so use the draft snapshot captured with the compose.
+                        const sendDraftGeneration =
+                          sendDraft?.generation ?? this.draftSaveGeneration;
                         const remoteDraftAtSend =
-                          this.vm.currentConversation?.remoteExtra?.draft || "";
-                        // #1280 起编辑器在 send 开始时就被同步消费，而 onSend 可能被
-                        // 排队后才执行，所以这里读到的**不一定**是空串：
-                        //   • 立即执行的发送 → 空串；
-                        //   • 排队后执行的发送 → 用户这期间已经写的新内容。
-                        // 两种情况下语义都收敛为「交给本次发送之后，输入框是否已经
-                        // 往前走了」——走了就不清远端草稿（新草稿权威），没走才清。
-                        // 已发出的内容在任何情况下都不再是草稿。详见
-                        // Utils/draftLifecycle.ts 的 shouldClearDraftAfterSend。
-                        const draftAtSend =
-                          this.messageInputContext()?.text() || "";
+                          sendDraft?.remoteDraft ??
+                          this.vm.currentConversation?.remoteExtra?.draft ??
+                          "";
                         VoiceFeedback.shared()?.submitAll(text);
 
                         // ── 回复/编辑处理 ──────────────
@@ -3299,8 +3299,7 @@ export class Conversation
                           if (mixedSent) {
                             await this.clearDraftAfterSend(
                               sendDraftGeneration,
-                              remoteDraftAtSend,
-                              draftAtSend
+                              remoteDraftAtSend
                             );
                           }
                           return finishRichTextMixedSend(
@@ -3333,6 +3332,7 @@ export class Conversation
                         }
 
                         // ── 第二阶段：按编辑器文档顺序发送内容块（文本段和粘贴图片交替） ──
+                        let restoreReplyTarget = false;
                         if (editorBlocks && editorBlocks.length > 0) {
                           // 图文混排：同时含文本和图片、且无非图片文件块时，聚合成单条
                           // RichText(=14) 消息（而非拆成多条独立消息）。含 file 块或
@@ -3379,8 +3379,7 @@ export class Conversation
                             if (mixedSent) {
                               await this.clearDraftAfterSend(
                                 sendDraftGeneration,
-                                remoteDraftAtSend,
-                                draftAtSend
+                                remoteDraftAtSend
                               );
                             }
                             // 返回部分结果 (octo-web#227 → #1280)：
@@ -3398,6 +3397,7 @@ export class Conversation
                           }
                           let isFirstTextBlock = true;
                           for (const block of editorBlocks) {
+                            let carriesReply = false;
                             try {
                               if (block.type === "text") {
                                 const msgContent = buildTextContent(
@@ -3407,16 +3407,18 @@ export class Conversation
                                 // 第一个文本块携带 reply 信息
                                 if (reply && isFirstTextBlock) {
                                   msgContent.reply = reply;
-                                  reply = undefined;
+                                  carriesReply = true;
                                 }
                                 isFirstTextBlock = false;
                                 if (await this.sendTextAndWaitAck(msgContent)) {
                                   anyMessageSent = true;
+                                  if (carriesReply) reply = undefined;
                                 } else {
                                   unsentEditorBlocks.push({
                                     type: "text",
-                                    text: block.text,
+                                    text: block.restoreText,
                                   });
+                                  if (carriesReply) restoreReplyTarget = true;
                                 }
                               } else if (block.type === "image") {
                                 if (await sendImageFile(block.file)) {
@@ -3449,9 +3451,10 @@ export class Conversation
                               // 也要登记，否则它既没发出又不会被还原，内容直接消失。
                               unsentEditorBlocks.push(
                                 block.type === "text"
-                                  ? { type: "text", text: block.text }
+                                  ? { type: "text", text: block.restoreText }
                                   : { type: "attachment", id: block.id }
                               );
+                              if (carriesReply) restoreReplyTarget = true;
                               Toast.error(
                                 t("base.conversation.message.sendFailed")
                               );
@@ -3460,10 +3463,23 @@ export class Conversation
                           // 如果 reply 还没被消费（没有文本块），附加到一条空白消息;
                           // 但仅当本次确实发出了别的消息时,否则用户的所有附件都被
                           // 预检拒绝、却仍收到一条孤立的空回复气泡 (#119 Jerry-Xin)。
-                          if (reply && anyMessageSent) {
+                          if (reply && anyMessageSent && !restoreReplyTarget) {
                             const emptyContent = new MessageText("");
                             emptyContent.reply = reply;
-                            await this.sendTextAndWaitAck(emptyContent);
+                            try {
+                              if (await this.sendTextAndWaitAck(emptyContent)) {
+                                reply = undefined;
+                              }
+                            } catch (err) {
+                              console.error(
+                                "[Conversation] empty reply send failed:",
+                                err
+                              );
+                              restoreReplyTarget = true;
+                              Toast.error(
+                                t("base.conversation.message.sendFailed")
+                              );
+                            }
                           }
                         } else {
                           // fallback：无 editorBlocks 时走旧逻辑（纯文本）
@@ -3479,14 +3495,26 @@ export class Conversation
                             // 同上: 顶部附件全部被预检拒绝时不要补空回复
                             const emptyContent = new MessageText("");
                             emptyContent.reply = reply;
-                            await this.sendTextAndWaitAck(emptyContent);
+                            try {
+                              if (await this.sendTextAndWaitAck(emptyContent)) {
+                                reply = undefined;
+                              }
+                            } catch (err) {
+                              console.error(
+                                "[Conversation] empty reply send failed:",
+                                err
+                              );
+                              restoreReplyTarget = true;
+                              Toast.error(
+                                t("base.conversation.message.sendFailed")
+                              );
+                            }
                           }
                         }
                         if (anyMessageSent) {
                           await this.clearDraftAfterSend(
                             sendDraftGeneration,
-                            remoteDraftAtSend,
-                            draftAtSend
+                            remoteDraftAtSend
                           );
                         }
                         if (anyMessageSent) this.props.onMessageSent?.();
@@ -3502,6 +3530,7 @@ export class Conversation
                           editorConsumed: anyMessageSent,
                           consumedTopIds,
                           unsentEditorBlocks,
+                          restoreSendTarget: restoreReplyTarget,
                         };
                       }}
                     ></MessageInput>

--- a/packages/dmworkbase/src/Components/Conversation/sendTarget.ts
+++ b/packages/dmworkbase/src/Components/Conversation/sendTarget.ts
@@ -1,0 +1,65 @@
+/**
+ * Reply / edit target capture for the send path (octo-web#1280).
+ *
+ * `Conversation.onSend` used to read `vm.currentReplyMessage` /
+ * `vm.currentHandlerType` at the moment it ran. Once sends are queued that read
+ * can happen seconds later, after the user picked another reply target or
+ * switched to "edit message" — a queued send could then reply to the wrong
+ * message or, worse, overwrite an unrelated one via `editMessage`.
+ *
+ * The target is therefore taken out of the view model synchronously when the
+ * composer consumes its compose (which also hides the reply/edit banner, so the
+ * UI stops inviting a change that can no longer apply), travels with that
+ * compose, and is put back if the send never got enqueued so a retry still
+ * edits/replies to the original message.
+ */
+
+/** The reply/edit slice of the conversation view model. */
+export interface SendTargetHost<M> {
+  getReplyMessage: () => M | undefined;
+  setReplyMessage: (message: M | undefined) => void;
+  getHandlerType: () => number;
+  setHandlerType: (handlerType: number) => void;
+}
+
+export interface CapturedSendTarget<M> {
+  /** The reply/edit target as it was when the user pressed send. */
+  replyMessage?: M;
+  /** 2 = edit an existing message, otherwise reply. Mirrors vm.currentHandlerType. */
+  handlerType: number;
+  /** Put the captured target back (used when the send was not enqueued). */
+  restore: () => void;
+}
+
+/**
+ * Read and clear the reply/edit target.
+ *
+ * `restore()` is deliberately conservative: if the user already selected a new
+ * reply/edit target while the send was in flight, the newer selection wins and
+ * the captured one is dropped — restoring would silently retarget the user's
+ * current intent, which is the class of bug this whole capture exists to avoid.
+ */
+export function captureSendTarget<M>(
+  host: SendTargetHost<M>,
+): CapturedSendTarget<M> {
+  const replyMessage = host.getReplyMessage();
+  const handlerType = host.getHandlerType();
+
+  if (replyMessage) {
+    host.setReplyMessage(undefined);
+  }
+
+  let restored = false;
+  return {
+    replyMessage,
+    handlerType,
+    restore: () => {
+      if (restored) return;
+      restored = true;
+      if (!replyMessage) return;
+      if (host.getReplyMessage()) return; // newer selection wins
+      host.setReplyMessage(replyMessage);
+      host.setHandlerType(handlerType);
+    },
+  };
+}

--- a/packages/dmworkbase/src/Components/MessageInput/__tests__/composeConsume.test.ts
+++ b/packages/dmworkbase/src/Components/MessageInput/__tests__/composeConsume.test.ts
@@ -36,6 +36,7 @@ import {
   type SendResult,
 } from "../sendFlow";
 import { captureSendTarget } from "../../Conversation/sendTarget";
+import { parseConsumedTextToContent } from "../mentionSendParse";
 
 const TestAttachment = Node.create({
   name: "attachment",
@@ -54,6 +55,22 @@ const TestAttachment = Node.create({
   },
   renderHTML() {
     return ["span", { "data-attachment": "" }];
+  },
+});
+
+const TestMention = Node.create({
+  name: "mention",
+  group: "inline",
+  inline: true,
+  atom: true,
+  addAttributes() {
+    return { id: { default: null }, label: { default: "" } };
+  },
+  renderText({ node }) {
+    return `@${node.attrs.label}`;
+  },
+  renderHTML({ node }) {
+    return ["span", { "data-mention": node.attrs.id }, `@${node.attrs.label}`];
   },
 });
 
@@ -77,6 +94,7 @@ function makeEditor(content?: unknown): Editor {
         link: false,
       }),
       TestAttachment,
+      TestMention,
     ],
     content: content as never,
   });
@@ -116,6 +134,7 @@ interface Harness {
   revoked: string[];
   errors: Array<{ step: string; err: unknown }>;
   restoredCompose: number;
+  restoredSendTarget: number;
   /** Mirrors MessageInput's restore-offset ref (reset on every consume). */
   offsets: { blocks: number; topAttachments: number };
 }
@@ -128,6 +147,7 @@ function harness(content?: unknown, top: TopAttachmentLike[] = []): Harness {
     revoked: [],
     errors: [],
     restoredCompose: 0,
+    restoredSendTarget: 0,
     offsets: { blocks: 0, topAttachments: 0 },
   };
 }
@@ -144,6 +164,8 @@ function consume(h: Harness) {
       h.top = items;
     },
     revokeObjectURL: (url) => h.revoked.push(url),
+    parseTextToNodes: (value) =>
+      parseConsumedTextToContent(value).content as ComposeDoc["content"] as never,
     getRestoreOffsets: () => h.offsets,
     onRestored: ({ blocks, topAttachments }) => {
       h.offsets = {
@@ -153,6 +175,9 @@ function consume(h: Harness) {
     },
     onRestoreCompose: () => {
       h.restoredCompose += 1;
+    },
+    onRestoreSendTarget: () => {
+      h.restoredSendTarget += 1;
     },
     onRestoreError: (err, step) => h.errors.push({ step, err }),
   });
@@ -534,6 +559,40 @@ describe("consumeCompose — text that failed before enqueue comes back (#1333 r
     expect(h.top).toEqual([]);
     expect(h.revoked).toEqual(["blob:t1"]);
     expect(h.errors).toEqual([]);
+  });
+
+  it("restores a reply target and structured member mention on partial failure", async () => {
+    const h = harness(doc(para(text("placeholder"))), [
+      { id: "t1", previewUrl: "blob:t1" },
+    ]);
+    const handle = consume(h);
+
+    await runSendWithConsumedCompose(
+      () => ({
+        editorConsumed: true,
+        consumedTopIds: ["t1"],
+        unsentEditorBlocks: [
+          { type: "text" as const, text: "@[u-alice:Alice] please retry" },
+        ],
+        restoreSendTarget: true,
+      }),
+      handle.ids,
+      handle.compose,
+    );
+
+    expect(h.restoredSendTarget).toBe(1);
+    expect(h.editor.getJSON()).toEqual({
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            { type: "mention", attrs: { id: "u-alice", label: "Alice" } },
+            { type: "text", text: " please retry" },
+          ],
+        },
+      ],
+    });
   });
 
   it("restores mixed unsent text and attachments in document order", async () => {

--- a/packages/dmworkbase/src/Components/MessageInput/__tests__/composeConsume.test.ts
+++ b/packages/dmworkbase/src/Components/MessageInput/__tests__/composeConsume.test.ts
@@ -286,7 +286,7 @@ describe("consumeCompose — partial pasted-attachment failure", () => {
       () => ({
         editorConsumed: true,
         consumedTopIds: [],
-        unsentEditorAttachmentIds: ["img-2"],
+        unsentEditorBlocks: [{ type: "attachment" as const, id: "img-2" }],
       }),
       handle.ids,
       handle.compose,
@@ -502,5 +502,90 @@ describe("consumeCompose — two queued sends that both fail keep their order", 
       "t2",
       "t3-added-later",
     ]);
+  });
+});
+
+describe("consumeCompose — text that failed before enqueue comes back (#1333 review)", () => {
+  it("restores the unsent text while the block that was sent stays consumed", async () => {
+    // Repro shape: a top attachment enqueues (anyMessageSent = true), then the
+    // text block's send throws before enqueue. Reporting only
+    // `editorConsumed: true` used to drop that text: the editor was already
+    // cleared, so it existed nowhere.
+    const h = harness(doc(para(text("this text must survive"))), [
+      { id: "t1", previewUrl: "blob:t1" },
+    ]);
+    const handle = consume(h);
+
+    const ok = await runSendWithConsumedCompose(
+      () => ({
+        editorConsumed: true,
+        consumedTopIds: ["t1"],
+        unsentEditorBlocks: [
+          { type: "text" as const, text: "this text must survive" },
+        ],
+      }),
+      handle.ids,
+      handle.compose,
+    );
+
+    expect(ok).toBe(true);
+    expect(h.editor.getText()).toBe("this text must survive");
+    // The attachment that did go out is not restored → retry cannot duplicate it.
+    expect(h.top).toEqual([]);
+    expect(h.revoked).toEqual(["blob:t1"]);
+    expect(h.errors).toEqual([]);
+  });
+
+  it("restores mixed unsent text and attachments in document order", async () => {
+    const h = harness(
+      doc(
+        para(text("caption")),
+        para(attachment("img-1", "blob:1"), attachment("img-2", "blob:2")),
+        para(text("tail")),
+      ),
+    );
+    h.files.set("img-1", new File(["1"], "img-1.png", { type: "image/png" }));
+    h.files.set("img-2", new File(["2"], "img-2.png", { type: "image/png" }));
+    const handle = consume(h);
+
+    // img-1 went out; the caption, img-2 and the tail did not.
+    await runSendWithConsumedCompose(
+      () => ({
+        editorConsumed: true,
+        unsentEditorBlocks: [
+          { type: "text" as const, text: "caption" },
+          { type: "attachment" as const, id: "img-2" },
+          { type: "text" as const, text: "tail" },
+        ],
+      }),
+      handle.ids,
+      handle.compose,
+    );
+
+    const value = h.editor.getText();
+    expect(value).toContain("caption");
+    expect(value).toContain("tail");
+    expect(value.indexOf("caption")).toBeLessThan(value.indexOf("tail"));
+    const json = JSON.stringify(h.editor.getJSON());
+    expect(json).toContain("img-2");
+    expect(json).not.toContain("img-1");
+    expect(h.files.has("img-2")).toBe(true);
+    expect(h.files.has("img-1")).toBe(false);
+  });
+
+  it("does not restore empty text blocks", async () => {
+    const h = harness(doc(para(text("x"))));
+    const handle = consume(h);
+
+    await runSendWithConsumedCompose(
+      () => ({
+        editorConsumed: true,
+        unsentEditorBlocks: [{ type: "text" as const, text: "   " }],
+      }),
+      handle.ids,
+      handle.compose,
+    );
+
+    expect(h.editor.getText()).toBe("");
   });
 });

--- a/packages/dmworkbase/src/Components/MessageInput/__tests__/composeConsume.test.ts
+++ b/packages/dmworkbase/src/Components/MessageInput/__tests__/composeConsume.test.ts
@@ -21,9 +21,7 @@
 
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { Editor, Node } from "@tiptap/core";
-import Document from "@tiptap/extension-document";
-import Paragraph from "@tiptap/extension-paragraph";
-import Text from "@tiptap/extension-text";
+import StarterKit from "@tiptap/starter-kit";
 import {
   composeSnapshotText,
   consumeCompose,
@@ -63,7 +61,23 @@ const editors: Editor[] = [];
 
 function makeEditor(content?: unknown): Editor {
   const editor = new Editor({
-    extensions: [Document, Paragraph, Text, TestAttachment],
+    // Mirrors the composer's own extension set (StarterKit, rich formatting
+    // disabled) and uses only dependencies `@octo/base` declares, so the suite
+    // also resolves under a strict pnpm install.
+    extensions: [
+      StarterKit.configure({
+        bold: false,
+        italic: false,
+        code: false,
+        heading: false,
+        blockquote: false,
+        horizontalRule: false,
+        codeBlock: false,
+        strike: false,
+        link: false,
+      }),
+      TestAttachment,
+    ],
     content: content as never,
   });
   editors.push(editor);

--- a/packages/dmworkbase/src/Components/MessageInput/__tests__/composeConsume.test.ts
+++ b/packages/dmworkbase/src/Components/MessageInput/__tests__/composeConsume.test.ts
@@ -1,0 +1,492 @@
+/**
+ * Integration coverage for the consume-first compose flow (octo-web#1280).
+ *
+ * The first round of this fix was reviewed as "the tests don't reach the code
+ * that carries the risk": every scenario was asserted against `vi.fn()` spies, so
+ * no test ever mutated a document. These tests drive a **real Tiptap editor**
+ * through `consumeCompose` + `runSendWithConsumedCompose`, which is where the
+ * dangerous cases live:
+ *   - the user keeps typing while the send is in flight;
+ *   - a send that never got enqueued must give the content back — before the new
+ *     draft, never overwriting it;
+ *   - one of several pasted images is rejected and must come back alone;
+ *   - the editor was destroyed meanwhile (channel switch) → the content cannot be
+ *     restored, which must be reported instead of vanishing silently;
+ *   - queued sends stay ordered and each carries its own reply/edit target.
+ *
+ * The attachment node here mirrors the production schema (inline atom named
+ * "attachment" carrying id/previewUrl) without the React node view: these tests
+ * are about document manipulation, not rendering.
+ */
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { Editor, Node } from "@tiptap/core";
+import Document from "@tiptap/extension-document";
+import Paragraph from "@tiptap/extension-paragraph";
+import Text from "@tiptap/extension-text";
+import {
+  composeSnapshotText,
+  consumeCompose,
+  ComposeRestoreUnavailableError,
+  type ComposeDoc,
+  type ComposeEditorPort,
+  type TopAttachmentLike,
+} from "../composeConsume";
+import {
+  createSendQueue,
+  runSendWithConsumedCompose,
+  type SendResult,
+} from "../sendFlow";
+import { captureSendTarget } from "../../Conversation/sendTarget";
+
+const TestAttachment = Node.create({
+  name: "attachment",
+  group: "inline",
+  inline: true,
+  atom: true,
+  addAttributes() {
+    return {
+      id: { default: null },
+      name: { default: "" },
+      previewUrl: { default: undefined },
+    };
+  },
+  parseHTML() {
+    return [{ tag: "span[data-attachment]" }];
+  },
+  renderHTML() {
+    return ["span", { "data-attachment": "" }];
+  },
+});
+
+const editors: Editor[] = [];
+
+function makeEditor(content?: unknown): Editor {
+  const editor = new Editor({
+    extensions: [Document, Paragraph, Text, TestAttachment],
+    content: content as never,
+  });
+  editors.push(editor);
+  return editor;
+}
+
+afterEach(() => {
+  editors.splice(0).forEach((editor) => {
+    if (!editor.isDestroyed) editor.destroy();
+  });
+});
+
+function port(editor: Editor): ComposeEditorPort {
+  return {
+    getJSON: () => editor.getJSON() as ComposeDoc,
+    isEmpty: () => editor.isEmpty,
+    isDestroyed: () => editor.isDestroyed,
+    clearContent: () => editor.commands.clearContent(),
+    setContent: (doc) => editor.commands.setContent(doc as never),
+    insertContentAtBlock: (blockOffset, nodes) => {
+      const docNode = editor.state.doc;
+      const limit = Math.min(blockOffset, docNode.childCount);
+      let pos = 0;
+      for (let i = 0; i < limit; i++) pos += docNode.child(i).nodeSize;
+      editor.commands.insertContentAt(pos, nodes as never);
+    },
+    appendContent: (nodes) => editor.commands.insertContent(nodes as never),
+    focusEnd: () => editor.commands.focus("end"),
+  };
+}
+
+interface Harness {
+  editor: Editor;
+  files: Map<string, File>;
+  top: TopAttachmentLike[];
+  revoked: string[];
+  errors: Array<{ step: string; err: unknown }>;
+  restoredCompose: number;
+  /** Mirrors MessageInput's restore-offset ref (reset on every consume). */
+  offsets: { blocks: number; topAttachments: number };
+}
+
+function harness(content?: unknown, top: TopAttachmentLike[] = []): Harness {
+  return {
+    editor: makeEditor(content),
+    files: new Map<string, File>(),
+    top: [...top],
+    revoked: [],
+    errors: [],
+    restoredCompose: 0,
+    offsets: { blocks: 0, topAttachments: 0 },
+  };
+}
+
+function consume(h: Harness) {
+  // The component resets the offsets on every consume, because consuming clears
+  // the editor and removes this send's attachments.
+  h.offsets = { blocks: 0, topAttachments: 0 };
+  return consumeCompose({
+    editor: port(h.editor),
+    attachmentFiles: h.files,
+    getTopAttachments: () => h.top,
+    setTopAttachments: (items) => {
+      h.top = items;
+    },
+    revokeObjectURL: (url) => h.revoked.push(url),
+    getRestoreOffsets: () => h.offsets,
+    onRestored: ({ blocks, topAttachments }) => {
+      h.offsets = {
+        blocks: h.offsets.blocks + blocks,
+        topAttachments: h.offsets.topAttachments + topAttachments,
+      };
+    },
+    onRestoreCompose: () => {
+      h.restoredCompose += 1;
+    },
+    onRestoreError: (err, step) => h.errors.push({ step, err }),
+  });
+}
+
+const attachment = (id: string, previewUrl?: string) => ({
+  type: "attachment",
+  attrs: { id, name: `${id}.png`, previewUrl },
+});
+
+const doc = (...content: unknown[]) => ({ type: "doc", content });
+const para = (...content: unknown[]) => ({ type: "paragraph", content });
+const text = (value: string) => ({ type: "text", text: value });
+
+describe("consumeCompose — the composer is emptied synchronously", () => {
+  it("clears the editor and removes this send's top attachments before any await", () => {
+    const h = harness(doc(para(text("hello"))), [
+      { id: "t1", previewUrl: "blob:t1" },
+    ]);
+
+    const handle = consume(h);
+
+    expect(h.editor.getText()).toBe("");
+    expect(h.top).toEqual([]);
+    expect(handle.ids.topIds).toEqual(["t1"]);
+    expect(composeSnapshotText(handle.snapshot)).toBe("hello");
+  });
+
+  it("captures pasted attachment ids in document order", () => {
+    const h = harness(
+      doc(
+        para(text("a"), attachment("img-1", "blob:1")),
+        para(attachment("img-2", "blob:2"), text("b")),
+      ),
+    );
+
+    const handle = consume(h);
+
+    expect(handle.ids.editorAttachmentIds).toEqual(["img-1", "img-2"]);
+  });
+});
+
+describe("consumeCompose — a send that was never enqueued gives the content back", () => {
+  it("restores the original document when the composer is still empty", async () => {
+    const h = harness(doc(para(text("retry me"))));
+    const handle = consume(h);
+
+    await runSendWithConsumedCompose(
+      () => false as SendResult,
+      handle.ids,
+      handle.compose,
+    );
+
+    expect(h.editor.getText()).toBe("retry me");
+    expect(h.restoredCompose).toBe(1);
+    expect(h.errors).toEqual([]);
+  });
+
+  it("inserts the failed content BEFORE a draft typed during the await (no overwrite)", async () => {
+    const h = harness(doc(para(text("first message"))));
+    const handle = consume(h);
+
+    // The user starts the next message while the send is still pending.
+    h.editor.commands.insertContent("next draft");
+
+    await runSendWithConsumedCompose(
+      () => false as SendResult,
+      handle.ids,
+      handle.compose,
+    );
+
+    const value = h.editor.getText();
+    expect(value).toContain("first message");
+    expect(value).toContain("next draft");
+    expect(value.indexOf("first message")).toBeLessThan(
+      value.indexOf("next draft"),
+    );
+  });
+
+  it("keeps pasted-image File refs and preview URLs alive for the retry", async () => {
+    const h = harness(doc(para(text("cap"), attachment("img-1", "blob:1"))));
+    h.files.set("img-1", new File(["x"], "img-1.png", { type: "image/png" }));
+    const handle = consume(h);
+
+    await runSendWithConsumedCompose(
+      () => false as SendResult,
+      handle.ids,
+      handle.compose,
+    );
+
+    expect(h.editor.getJSON()).toEqual(
+      expect.objectContaining({ type: "doc" }),
+    );
+    expect(JSON.stringify(h.editor.getJSON())).toContain("img-1");
+    expect(h.files.has("img-1")).toBe(true);
+    expect(h.revoked).toEqual([]);
+  });
+
+  it("restores unsent top attachments while keeping ones queued during the await", async () => {
+    const h = harness(doc(para(text("x"))), [
+      { id: "t1", previewUrl: "blob:t1" },
+      { id: "t2", previewUrl: "blob:t2" },
+    ]);
+    const handle = consume(h);
+
+    // The user adds another file while the send is pending.
+    h.top = [...h.top, { id: "t3", previewUrl: "blob:t3" }];
+
+    // t1 was actually sent, t2 was rejected by the pre-check.
+    await runSendWithConsumedCompose(
+      () => ({ editorConsumed: true, consumedTopIds: ["t1"] }),
+      handle.ids,
+      handle.compose,
+    );
+
+    expect(h.top.map((item) => item.id)).toEqual(["t2", "t3"]);
+    expect(h.revoked).toEqual(["blob:t1"]);
+  });
+});
+
+describe("consumeCompose — partial pasted-attachment failure", () => {
+  it("brings back only the rejected image and disposes the sent one", async () => {
+    const h = harness(
+      doc(para(text("two pics"), attachment("img-1", "blob:1"), attachment("img-2", "blob:2"))),
+    );
+    h.files.set("img-1", new File(["1"], "img-1.png", { type: "image/png" }));
+    h.files.set("img-2", new File(["2"], "img-2.png", { type: "image/png" }));
+    const handle = consume(h);
+
+    await runSendWithConsumedCompose(
+      () => ({
+        editorConsumed: true,
+        consumedTopIds: [],
+        unsentEditorAttachmentIds: ["img-2"],
+      }),
+      handle.ids,
+      handle.compose,
+    );
+
+    const json = JSON.stringify(h.editor.getJSON());
+    expect(json).toContain("img-2");
+    expect(json).not.toContain("img-1");
+    // The sent image is released; the rejected one stays retryable.
+    expect(h.files.has("img-1")).toBe(false);
+    expect(h.files.has("img-2")).toBe(true);
+    expect(h.revoked).toEqual(["blob:1"]);
+    // Sent text is NOT re-inserted — only the rejected attachment comes back.
+    expect(h.editor.getText()).not.toContain("two pics");
+  });
+});
+
+describe("consumeCompose — the editor is gone (channel switch mid-flight)", () => {
+  it("reports an unrestorable compose instead of silently dropping it", async () => {
+    const h = harness(doc(para(text("lost?"))), [
+      { id: "t1", previewUrl: "blob:t1" },
+    ]);
+    const handle = consume(h);
+
+    h.editor.destroy(); // switching conversation unmounts MessageInput
+
+    const ok = await runSendWithConsumedCompose(
+      () => false as SendResult,
+      handle.ids,
+      handle.compose,
+    );
+
+    expect(ok).toBe(false);
+    // The user is told (MessageInput turns this into a notification)…
+    expect(h.errors).toHaveLength(1);
+    expect(h.errors[0].step).toBe("restoreEditor");
+    expect(h.errors[0].err).toBeInstanceOf(ComposeRestoreUnavailableError);
+    // …the unsent top attachments were still put back first…
+    expect(h.top.map((item) => item.id)).toEqual(["t1"]);
+    // …and the compose-level side effects (reply/edit target, expanded state)
+    // ran even though the document could not be restored.
+    expect(h.restoredCompose).toBe(1);
+  });
+});
+
+describe("send queue — consecutive sends keep their own target and order", () => {
+  it("runs queued composes in order, each with the reply target captured at press time", async () => {
+    const vm: { reply?: string; handlerType: number } = {
+      reply: "message-X",
+      handlerType: 1,
+    };
+    const host = {
+      getReplyMessage: () => vm.reply,
+      setReplyMessage: (m: string | undefined) => {
+        vm.reply = m;
+      },
+      getHandlerType: () => vm.handlerType,
+      setHandlerType: (h: number) => {
+        vm.handlerType = h;
+      },
+    };
+    const queue = createSendQueue();
+    const seen: Array<string | undefined> = [];
+    const gates: Array<() => void> = [];
+
+    const send = (target: { replyMessage?: string }) =>
+      queue.enqueue(
+        () =>
+          new Promise<void>((resolve) => {
+            seen.push(target.replyMessage);
+            gates.push(resolve);
+          }),
+      );
+
+    // A: replying to message-X. The target is taken synchronously…
+    const first = send(captureSendTarget(host));
+    expect(vm.reply).toBeUndefined(); // …so the banner is already gone.
+
+    // While A is pending the user switches to "edit" on an unrelated message.
+    vm.reply = "message-Y";
+    vm.handlerType = 2;
+    const second = send(captureSendTarget(host));
+
+    await Promise.resolve();
+    // B must not start before A finished (ordering), and A must not see Y.
+    expect(seen).toEqual(["message-X"]);
+    gates[0]();
+    await first;
+    await Promise.resolve();
+    gates[1]();
+    await second;
+
+    expect(seen).toEqual(["message-X", "message-Y"]);
+    expect(queue.pending).toBe(0);
+  });
+
+  it("restores the captured target when the send was not enqueued, unless a newer one exists", () => {
+    const vm: { reply?: string; handlerType: number } = {
+      reply: "message-X",
+      handlerType: 2,
+    };
+    const host = {
+      getReplyMessage: () => vm.reply,
+      setReplyMessage: (m: string | undefined) => {
+        vm.reply = m;
+      },
+      getHandlerType: () => vm.handlerType,
+      setHandlerType: (h: number) => {
+        vm.handlerType = h;
+      },
+    };
+
+    const captured = captureSendTarget(host);
+    expect(vm.reply).toBeUndefined();
+
+    captured.restore();
+    // Edit mode is back, so a retry still edits message-X instead of sending new.
+    expect(vm.reply).toBe("message-X");
+    expect(vm.handlerType).toBe(2);
+
+    // A newer selection always wins over a late restore.
+    const second = captureSendTarget(host);
+    vm.reply = "message-Z";
+    second.restore();
+    expect(vm.reply).toBe("message-Z");
+  });
+});
+
+describe("composeSnapshotText", () => {
+  it("flattens text, mentions and line breaks for draft persistence", () => {
+    const snapshot = doc(
+      para(text("hi "), { type: "attachment", attrs: { id: "a" } }),
+      para(text("bye")),
+    ) as ComposeDoc;
+    expect(composeSnapshotText(snapshot)).toBe("hi \nbye");
+  });
+
+  it("returns an empty string for an empty compose", () => {
+    expect(composeSnapshotText(undefined)).toBe("");
+    expect(composeSnapshotText({ type: "doc", content: [] })).toBe("");
+  });
+});
+
+describe("consumeCompose — success leaves the composer alone", () => {
+  it("does not touch a draft typed during the await", async () => {
+    const h = harness(doc(para(text("sent text"))));
+    const handle = consume(h);
+    h.editor.commands.insertContent("brand new draft");
+
+    const ok = await runSendWithConsumedCompose(
+      () => true as SendResult,
+      handle.ids,
+      handle.compose,
+    );
+
+    expect(ok).toBe(true);
+    // The classic #1280 symptom would leave "sent text" behind here.
+    expect(h.editor.getText()).toBe("brand new draft");
+    expect(vi.isMockFunction(h.editor.commands.setContent)).toBe(false);
+  });
+});
+
+describe("consumeCompose — two queued sends that both fail keep their order", () => {
+  it("restores as A, B, <live draft> instead of stacking up reversed", async () => {
+    const h = harness(doc(para(text("AAA"))));
+    const handleA = consume(h);
+
+    // The user immediately types and sends the next message; both are queued.
+    h.editor.commands.insertContent("BBB");
+    const handleB = consume(h);
+
+    // ...and then starts a third draft while both sends are in flight.
+    h.editor.commands.insertContent("live draft");
+
+    // Both fail before enqueue (e.g. upload credentials rejected).
+    await runSendWithConsumedCompose(
+      () => false as SendResult,
+      handleA.ids,
+      handleA.compose,
+    );
+    await runSendWithConsumedCompose(
+      () => false as SendResult,
+      handleB.ids,
+      handleB.compose,
+    );
+
+    const value = h.editor.getText();
+    expect(value.indexOf("AAA")).toBeGreaterThanOrEqual(0);
+    expect(value.indexOf("AAA")).toBeLessThan(value.indexOf("BBB"));
+    expect(value.indexOf("BBB")).toBeLessThan(value.indexOf("live draft"));
+  });
+
+  it("keeps restored top attachments in send order too", async () => {
+    const h = harness(doc(para(text("a"))), [{ id: "t1" }]);
+    const handleA = consume(h);
+    h.top = [{ id: "t2" }];
+    const handleB = consume(h);
+    h.top = [{ id: "t3-added-later" }];
+
+    await runSendWithConsumedCompose(
+      () => false as SendResult,
+      handleA.ids,
+      handleA.compose,
+    );
+    await runSendWithConsumedCompose(
+      () => false as SendResult,
+      handleB.ids,
+      handleB.compose,
+    );
+
+    expect(h.top.map((item) => item.id)).toEqual([
+      "t1",
+      "t2",
+      "t3-added-later",
+    ]);
+  });
+});

--- a/packages/dmworkbase/src/Components/MessageInput/__tests__/mentionSendParse.test.ts
+++ b/packages/dmworkbase/src/Components/MessageInput/__tests__/mentionSendParse.test.ts
@@ -22,6 +22,7 @@ import {
   serializeMentionMarker,
   stripTrustMark,
   parseDraftToContent,
+  parseConsumedTextToContent,
 } from "../mentionSendParse";
 import type { SendParseMember } from "../mentionSendParse";
 import {
@@ -289,6 +290,25 @@ describe("draft round-trip — forged broadcast cannot be laundered (Finding 1)"
     const nodes = doc.content.flatMap((p) => p.content);
     const mentionNode = nodes.find((n) => n.type === "mention");
     expect(mentionNode?.attrs).toEqual({ id: "u-alice", label: "Alice" });
+  });
+});
+
+describe("consumed-compose partial restore", () => {
+  it("restores a trust-marked broadcast node without relaxing draft parsing", () => {
+    const restored = parseConsumedTextToContent(
+      trusted(MENTION_UID_HUMANS, "所有人")
+    );
+    expect(restored.content[0].content).toEqual([
+      {
+        type: "mention",
+        attrs: { id: MENTION_UID_HUMANS, label: "所有人" },
+      },
+    ]);
+
+    expect(
+      parseDraftToContent(trusted(MENTION_UID_HUMANS, "所有人")).content[0]
+        .content
+    ).toEqual([{ type: "text", text: "@所有人" }]);
   });
 });
 

--- a/packages/dmworkbase/src/Components/MessageInput/__tests__/sendFlow.test.ts
+++ b/packages/dmworkbase/src/Components/MessageInput/__tests__/sendFlow.test.ts
@@ -1,38 +1,42 @@
 /**
- * Regression tests for the two send-side data-loss bugs (octo-web#227).
+ * Regression tests for the send-side compose bugs (octo-web#227 → #1280).
  *
- * Round 1 — mixed text+image send failure wiped the draft:
+ * Round 1 (#227) — mixed text+image send failure wiped the draft:
  *   MessageInput cleared the editor / deleted pasted-image File refs / revoked
  *   preview URLs synchronously, BEFORE the awaited async send (mixed RichText)
  *   could report failure. A failed image upload therefore destroyed the user's
  *   whole text+image compose with no message and nothing to retry.
  *
- * Round 2 — await-cleanup race wiped the NEXT draft (Jerry-Xin P1):
- *   Once the send was awaited, the editor stayed editable during the wait. If
- *   the user finished one message and started typing the next while upload/ack
- *   was still pending, the older send's success cleared the live (newer) editor
- *   and top-attachment list. The cleanup must be snapshot-aware: clear the
- *   editor only if it still holds exactly what was sent, and remove only the
- *   top attachments that were actually consumed.
+ * Round 2 (#227) — await-cleanup race wiped the NEXT draft:
+ *   The editor stayed editable during the wait, so the older send's success
+ *   cleared the live (newer) editor and top-attachment list.
  *
- * The contract these tests lock in:
- *   - send resolves false  → editor preserved; no top attachment removed.
- *   - send throws          → same as false.
- *   - send resolves true / void → success; consumed top ids = all; editor
- *     cleared IFF unchanged.
- *   - send resolves a detail object → partial: editor cleared per
- *     editorConsumed, top attachments removed per consumedTopIds.
- *   - editor changed during await → editor NEVER cleared (round-2 fix), even on
- *     success; consumed top attachments are still removed by id.
- *   - cleanup never runs before the send settles (ordering guarantee).
+ * Round 3 (#1280) — the round-2 "snapshot-aware" cleanup was all-or-nothing:
+ *   whenever the document changed mid-flight the ALREADY SENT content stayed in
+ *   the composer (visible in history + still in the input box, re-sendable by a
+ *   second Enter). Consecutive image/text sends hit this constantly.
+ *
+ * Current contract (consume-first / restore-on-failure) locked in below:
+ *   - the caller consumes the compose synchronously before calling;
+ *   - send resolves true / void → consumed stays consumed; File refs + preview
+ *     URLs are disposed; nothing is restored (so no leftovers, no duplicates);
+ *   - send resolves false / throws → the compose is restored (editor content
+ *     re-inserted, top attachments re-added) and nothing is disposed;
+ *   - detail result → editor restored per editorConsumed, only the top ids NOT
+ *     in consumedTopIds are restored (already-sent files never come back);
+ *   - restore/dispose never run before the send settles (ordering guarantee);
+ *   - createSendQueue serializes sends instead of dropping them.
  */
 
 import { describe, it, expect, vi } from "vitest";
 import {
   announceContextAfterSendReady,
+  createSendQueue,
   invokeReadySend,
-  runSendWithCleanup,
-  SendCleanup,
+  restoreComposeSnapshot,
+  runSendWithConsumedCompose,
+  ConsumedCompose,
+  ComposeRestoreTarget,
 } from "../sendFlow";
 
 describe("announceContextAfterSendReady", () => {
@@ -62,219 +66,265 @@ describe("invokeReadySend", () => {
   });
 });
 
-interface RecordingCleanup extends SendCleanup {
+interface RecordingCompose extends ConsumedCompose {
   calls: string[];
-  removedIds: string[];
-  editorUnchanged: boolean;
+  restoredTopIds: string[];
+  disposedTopIds: string[];
 }
 
-function makeCleanup(opts?: { editorUnchanged?: boolean }): RecordingCleanup {
+function makeCompose(): RecordingCompose {
   const calls: string[] = [];
-  const removedIds: string[] = [];
+  const restoredTopIds: string[] = [];
+  const disposedTopIds: string[] = [];
   const state = {
     calls,
-    removedIds,
-    editorUnchanged: opts?.editorUnchanged ?? true,
-    isEditorUnchanged: vi.fn(() => state.editorUnchanged),
-    deleteEditorAttachmentRefs: vi.fn(() => calls.push("deleteEditorAttachmentRefs")),
-    revokeEditorPreviewUrls: vi.fn(() => calls.push("revokeEditorPreviewUrls")),
-    clearEditor: vi.fn(() => calls.push("clearEditor")),
-    removeTopAttachments: vi.fn((ids: string[]) => {
-      calls.push("removeTopAttachments");
-      removedIds.push(...ids);
+    restoredTopIds,
+    disposedTopIds,
+    restoreEditor: vi.fn(() => calls.push("restoreEditor")),
+    disposeEditorAttachments: vi.fn(() => calls.push("disposeEditorAttachments")),
+    disposeTopAttachments: vi.fn((ids: string[]) => {
+      calls.push("disposeTopAttachments");
+      disposedTopIds.push(...ids);
     }),
-    collapseExpanded: vi.fn(() => calls.push("collapseExpanded")),
+    restoreTopAttachments: vi.fn((ids: string[]) => {
+      calls.push("restoreTopAttachments");
+      restoredTopIds.push(...ids);
+    }),
   };
-  return state as unknown as RecordingCleanup;
+  return state as unknown as RecordingCompose;
 }
 
-describe("runSendWithCleanup — round 1: mixed send failure preserves draft", () => {
-  it("does NOT clear editor / refs / urls and removes no top attachment when send resolves false", async () => {
-    const cleanup = makeCleanup();
-    const send = vi.fn().mockResolvedValue(false);
-
-    const ok = await runSendWithCleanup(send, ["t1", "t2"], cleanup);
-
-    expect(ok).toBe(false);
-    expect(cleanup.clearEditor).not.toHaveBeenCalled();
-    expect(cleanup.deleteEditorAttachmentRefs).not.toHaveBeenCalled();
-    expect(cleanup.revokeEditorPreviewUrls).not.toHaveBeenCalled();
-    expect(cleanup.removeTopAttachments).not.toHaveBeenCalled();
-    expect(cleanup.collapseExpanded).not.toHaveBeenCalled();
-    expect(cleanup.calls).toEqual([]);
-  });
-
-  it("preserves draft when send throws (image prepare/upload error)", async () => {
-    const cleanup = makeCleanup();
-    const send = vi.fn().mockRejectedValue(new Error("upload failed"));
-
-    const ok = await runSendWithCleanup(send, ["t1"], cleanup);
-
-    expect(ok).toBe(false);
-    expect(cleanup.calls).toEqual([]);
-  });
-
-  it("clears compose state and removes all top attachments when send resolves true", async () => {
-    const cleanup = makeCleanup();
+describe("runSendWithConsumedCompose — success keeps the composer empty (#1280)", () => {
+  it("disposes refs/urls and restores nothing when the send succeeds", async () => {
+    const compose = makeCompose();
     const send = vi.fn().mockResolvedValue(true);
 
-    const ok = await runSendWithCleanup(send, ["t1", "t2"], cleanup);
+    const ok = await runSendWithConsumedCompose(send, ["t1", "t2"], compose);
 
     expect(ok).toBe(true);
-    expect(cleanup.removeTopAttachments).toHaveBeenCalledTimes(1);
-    expect(cleanup.removedIds).toEqual(["t1", "t2"]);
-    expect(cleanup.deleteEditorAttachmentRefs).toHaveBeenCalledTimes(1);
-    expect(cleanup.revokeEditorPreviewUrls).toHaveBeenCalledTimes(1);
-    expect(cleanup.clearEditor).toHaveBeenCalledTimes(1);
-    expect(cleanup.collapseExpanded).toHaveBeenCalledTimes(1);
+    expect(compose.restoreEditor).not.toHaveBeenCalled();
+    expect(compose.restoreTopAttachments).not.toHaveBeenCalled();
+    expect(compose.disposeEditorAttachments).toHaveBeenCalledTimes(1);
+    expect(compose.disposedTopIds).toEqual(["t1", "t2"]);
   });
 
   it("treats void/undefined return as success (back-compat with legacy onSend)", async () => {
-    const cleanup = makeCleanup();
-    const send = vi.fn().mockResolvedValue(undefined);
+    const compose = makeCompose();
 
-    const ok = await runSendWithCleanup(send, ["t1"], cleanup);
+    const ok = await runSendWithConsumedCompose(
+      vi.fn().mockResolvedValue(undefined),
+      ["t1"],
+      compose,
+    );
 
     expect(ok).toBe(true);
-    expect(cleanup.clearEditor).toHaveBeenCalledTimes(1);
-    expect(cleanup.removedIds).toEqual(["t1"]);
+    expect(compose.restoreEditor).not.toHaveBeenCalled();
+    expect(compose.disposedTopIds).toEqual(["t1"]);
   });
 
   it("treats a synchronous void return as success", async () => {
-    const cleanup = makeCleanup();
+    const compose = makeCompose();
     const send = vi.fn(() => {
       /* legacy void onSend */
     });
 
-    const ok = await runSendWithCleanup(send, [], cleanup);
+    const ok = await runSendWithConsumedCompose(send, [], compose);
 
     expect(ok).toBe(true);
-    expect(cleanup.clearEditor).toHaveBeenCalledTimes(1);
+    expect(compose.restoreEditor).not.toHaveBeenCalled();
+    expect(compose.disposeEditorAttachments).toHaveBeenCalledTimes(1);
   });
 
-  it("never runs cleanup before the async send settles (ordering guarantee)", async () => {
-    const cleanup = makeCleanup();
+  it("does NOT restore already-sent content even when the user typed during the await", async () => {
+    // The #1280 bug: a mid-flight document change used to leave the sent content
+    // in the composer. Consume-first makes it structurally impossible — success
+    // simply never touches the live document.
+    const compose = makeCompose();
     let resolveSend!: (v: boolean) => void;
-    const send = vi.fn(
-      () =>
-        new Promise<boolean>((res) => {
-          resolveSend = res;
-        }),
-    );
+    const send = vi.fn(() => new Promise<boolean>((res) => (resolveSend = res)));
 
-    const p = runSendWithCleanup(send, ["t1"], cleanup);
+    const p = runSendWithConsumedCompose(send, ["t1"], compose);
+    // ...user pastes another image / types the next line here...
+    resolveSend(true);
+
+    await expect(p).resolves.toBe(true);
+    expect(compose.restoreEditor).not.toHaveBeenCalled();
+    expect(compose.restoreTopAttachments).not.toHaveBeenCalled();
+  });
+});
+
+describe("runSendWithConsumedCompose — round 1: failure restores the whole draft", () => {
+  it("restores editor + top attachments when the send resolves false", async () => {
+    const compose = makeCompose();
+    const send = vi.fn().mockResolvedValue(false);
+
+    const ok = await runSendWithConsumedCompose(send, ["t1", "t2"], compose);
+
+    expect(ok).toBe(false);
+    expect(compose.restoreEditor).toHaveBeenCalledTimes(1);
+    expect(compose.restoredTopIds).toEqual(["t1", "t2"]);
+    // Nothing disposed → the restored pasted images still resolve to their File.
+    expect(compose.disposeEditorAttachments).not.toHaveBeenCalled();
+    expect(compose.disposeTopAttachments).not.toHaveBeenCalled();
+  });
+
+  it("restores the draft when the send throws (image prepare/upload error)", async () => {
+    const compose = makeCompose();
+    const send = vi.fn().mockRejectedValue(new Error("upload failed"));
+
+    const ok = await runSendWithConsumedCompose(send, ["t1"], compose);
+
+    expect(ok).toBe(false);
+    expect(compose.restoreEditor).toHaveBeenCalledTimes(1);
+    expect(compose.restoredTopIds).toEqual(["t1"]);
+    expect(compose.disposeEditorAttachments).not.toHaveBeenCalled();
+  });
+
+  it("never restores or disposes before the async send settles (ordering guarantee)", async () => {
+    const compose = makeCompose();
+    let resolveSend!: (v: boolean) => void;
+    const send = vi.fn(() => new Promise<boolean>((res) => (resolveSend = res)));
+
+    const p = runSendWithConsumedCompose(send, ["t1"], compose);
 
     await Promise.resolve();
-    expect(cleanup.clearEditor).not.toHaveBeenCalled();
-    expect(cleanup.deleteEditorAttachmentRefs).not.toHaveBeenCalled();
-    expect(cleanup.removeTopAttachments).not.toHaveBeenCalled();
+    expect(compose.calls).toEqual([]);
 
-    resolveSend(true);
+    resolveSend(false);
     await p;
 
-    expect(cleanup.clearEditor).toHaveBeenCalledTimes(1);
-    expect(cleanup.removeTopAttachments).toHaveBeenCalledTimes(1);
+    expect(compose.restoreEditor).toHaveBeenCalledTimes(1);
   });
 });
 
-describe("runSendWithCleanup — round 2: snapshot-aware cleanup preserves the NEXT draft", () => {
-  it("does NOT clear the editor when the user started a new draft during the await, even on success", async () => {
-    // editor changed during the await → isEditorUnchanged() returns false.
-    const cleanup = makeCleanup({ editorUnchanged: false });
-    const send = vi.fn().mockResolvedValue(true);
-
-    const ok = await runSendWithCleanup(send, [], cleanup);
-
-    // Send still reported success...
-    expect(ok).toBe(true);
-    // ...but the live (newer) editor draft must survive untouched.
-    expect(cleanup.clearEditor).not.toHaveBeenCalled();
-    expect(cleanup.deleteEditorAttachmentRefs).not.toHaveBeenCalled();
-    expect(cleanup.revokeEditorPreviewUrls).not.toHaveBeenCalled();
-    expect(cleanup.collapseExpanded).not.toHaveBeenCalled();
-  });
-
-  it("still removes consumed top attachments by id even when the editor changed mid-flight", async () => {
-    const cleanup = makeCleanup({ editorUnchanged: false });
-    const send = vi.fn().mockResolvedValue(true);
-
-    await runSendWithCleanup(send, ["t1", "t2"], cleanup);
-
-    // Consumed top attachments are id-scoped, so removing them never touches a
-    // newly queued attachment — safe regardless of editor changes.
-    expect(cleanup.removeTopAttachments).toHaveBeenCalledTimes(1);
-    expect(cleanup.removedIds).toEqual(["t1", "t2"]);
-    // Editor itself preserved.
-    expect(cleanup.clearEditor).not.toHaveBeenCalled();
-  });
-
-  it("clears the editor on success when it still holds exactly what was sent", async () => {
-    const cleanup = makeCleanup({ editorUnchanged: true });
-    const send = vi.fn().mockResolvedValue(true);
-
-    await runSendWithCleanup(send, [], cleanup);
-
-    expect(cleanup.clearEditor).toHaveBeenCalledTimes(1);
-  });
-
-  it("pure-text send: a new draft typed during ack wait is not wiped by the old send", async () => {
-    // Pure text now also awaits sendTextAndWaitAck; simulate ack landing after
-    // the user started a new line.
-    const cleanup = makeCleanup({ editorUnchanged: false });
-    let resolveSend!: (v: boolean) => void;
-    const send = vi.fn(
-      () => new Promise<boolean>((res) => (resolveSend = res)),
-    );
-
-    const p = runSendWithCleanup(send, [], cleanup);
-    // user types the next message while ack is pending → editor now differs.
-    resolveSend(true);
-    const ok = await p;
-
-    expect(ok).toBe(true);
-    expect(cleanup.clearEditor).not.toHaveBeenCalled();
-  });
-});
-
-describe("runSendWithCleanup — partial result (top attachments sent, editor failed)", () => {
-  it("preserves the editor but drops only the consumed top attachments (no retry duplication)", async () => {
-    const cleanup = makeCleanup({ editorUnchanged: true });
+describe("runSendWithConsumedCompose — partial result (top attachments sent, editor failed)", () => {
+  it("restores the editor but keeps the already-sent top attachments consumed", async () => {
+    const compose = makeCompose();
     // Top attachments t1,t2 were sent first; the mixed editor send then failed.
     const send = vi
       .fn()
       .mockResolvedValue({ editorConsumed: false, consumedTopIds: ["t1", "t2"] });
 
-    const ok = await runSendWithCleanup(send, ["t1", "t2"], cleanup);
+    const ok = await runSendWithConsumedCompose(send, ["t1", "t2"], compose);
 
-    // editorConsumed=false → return false so MessageInput keeps the editor.
     expect(ok).toBe(false);
-    expect(cleanup.clearEditor).not.toHaveBeenCalled();
-    expect(cleanup.deleteEditorAttachmentRefs).not.toHaveBeenCalled();
-    // But the already-sent top attachments are removed so retry won't resend.
-    expect(cleanup.removeTopAttachments).toHaveBeenCalledTimes(1);
-    expect(cleanup.removedIds).toEqual(["t1", "t2"]);
+    expect(compose.restoreEditor).toHaveBeenCalledTimes(1);
+    // Already-sent files must NOT come back, otherwise a retry duplicates them.
+    expect(compose.restoreTopAttachments).not.toHaveBeenCalled();
+    expect(compose.disposedTopIds).toEqual(["t1", "t2"]);
   });
 
-  it("detail with editorConsumed=true clears editor and removes the listed top ids", async () => {
-    const cleanup = makeCleanup({ editorUnchanged: true });
+  it("restores only the top attachments that were not sent", async () => {
+    const compose = makeCompose();
     const send = vi
       .fn()
       .mockResolvedValue({ editorConsumed: true, consumedTopIds: ["t1"] });
 
-    const ok = await runSendWithCleanup(send, ["t1", "t2"], cleanup);
+    const ok = await runSendWithConsumedCompose(send, ["t1", "t2"], compose);
 
     expect(ok).toBe(true);
-    expect(cleanup.clearEditor).toHaveBeenCalledTimes(1);
-    // Only the explicitly-consumed id is removed, not the whole allTopIds list.
-    expect(cleanup.removedIds).toEqual(["t1"]);
+    expect(compose.disposedTopIds).toEqual(["t1"]);
+    expect(compose.restoredTopIds).toEqual(["t2"]);
   });
 
   it("detail editorConsumed=true with no consumedTopIds falls back to all top ids", async () => {
-    const cleanup = makeCleanup({ editorUnchanged: true });
-    const send = vi.fn().mockResolvedValue({ editorConsumed: true });
+    const compose = makeCompose();
 
-    await runSendWithCleanup(send, ["t1", "t2"], cleanup);
+    await runSendWithConsumedCompose(
+      vi.fn().mockResolvedValue({ editorConsumed: true }),
+      ["t1", "t2"],
+      compose,
+    );
 
-    expect(cleanup.removedIds).toEqual(["t1", "t2"]);
+    expect(compose.disposedTopIds).toEqual(["t1", "t2"]);
+    expect(compose.restoreTopAttachments).not.toHaveBeenCalled();
+  });
+});
+
+describe("createSendQueue — consecutive sends are serialized, never dropped (#1280)", () => {
+  it("runs queued sends in order instead of rejecting them while one is pending", async () => {
+    const queue = createSendQueue();
+    const order: string[] = [];
+    const resolvers: Array<() => void> = [];
+    const task = (name: string) => () =>
+      new Promise<string>((res) => {
+        order.push(`start:${name}`);
+        resolvers.push(() => {
+          order.push(`end:${name}`);
+          res(name);
+        });
+      });
+
+    const first = queue.enqueue(task("a"));
+    const second = queue.enqueue(task("b"));
+
+    await Promise.resolve();
+    // b must not start before a finished (message ordering).
+    expect(order).toEqual(["start:a"]);
+    expect(queue.pending).toBe(2);
+
+    resolvers[0]();
+    await expect(first).resolves.toBe("a");
+    await Promise.resolve();
+    resolvers[1]();
+    await expect(second).resolves.toBe("b");
+
+    expect(order).toEqual(["start:a", "end:a", "start:b", "end:b"]);
+    expect(queue.pending).toBe(0);
+  });
+
+  it("keeps draining after a failed send", async () => {
+    const queue = createSendQueue();
+    const failing = queue.enqueue(() => Promise.reject(new Error("boom")));
+    const following = queue.enqueue(() => Promise.resolve("ok"));
+
+    await expect(failing).rejects.toThrow("boom");
+    await expect(following).resolves.toBe("ok");
+    expect(queue.pending).toBe(0);
+  });
+});
+
+describe("restoreComposeSnapshot — a failed send never loses or overwrites content", () => {
+  function makeTarget(isEmpty: boolean, throwOnStart = false) {
+    const calls: string[] = [];
+    const target: ComposeRestoreTarget = {
+      isEmpty: () => isEmpty,
+      setContent: () => calls.push("setContent"),
+      focusEnd: () => calls.push("focusEnd"),
+      insertContentAtStart: () => {
+        calls.push("insertContentAtStart");
+        if (throwOnStart) throw new Error("bad position");
+      },
+      appendContent: () => calls.push("appendContent"),
+    };
+    return { target, calls };
+  }
+
+  const snapshot = { content: [{ type: "paragraph" }] };
+
+  it("restores the snapshot as-is when the composer is still empty", () => {
+    const { target, calls } = makeTarget(true);
+    restoreComposeSnapshot(snapshot, target);
+    expect(calls).toEqual(["setContent", "focusEnd"]);
+  });
+
+  it("prepends the failed content before a draft typed during the await", () => {
+    const { target, calls } = makeTarget(false);
+    restoreComposeSnapshot(snapshot, target);
+    // Never setContent here — that was the #227 round-2 data loss.
+    expect(calls).toEqual(["insertContentAtStart"]);
+  });
+
+  it("falls back to appending when the start position is rejected", () => {
+    const { target, calls } = makeTarget(false, true);
+    restoreComposeSnapshot(snapshot, target);
+    expect(calls).toEqual(["insertContentAtStart", "appendContent"]);
+  });
+
+  it("does nothing for an empty snapshot", () => {
+    const { target, calls } = makeTarget(true);
+    restoreComposeSnapshot({ content: [] }, target);
+    restoreComposeSnapshot(undefined, target);
+    expect(calls).toEqual([]);
   });
 });

--- a/packages/dmworkbase/src/Components/MessageInput/__tests__/sendFlow.test.ts
+++ b/packages/dmworkbase/src/Components/MessageInput/__tests__/sendFlow.test.ts
@@ -70,41 +70,77 @@ interface RecordingCompose extends ConsumedCompose {
   calls: string[];
   restoredTopIds: string[];
   disposedTopIds: string[];
+  restoredEditorIds: string[];
+  disposedEditorIds: string[];
+  restoreErrors: Array<{ step: string; err: unknown }>;
 }
 
-function makeCompose(): RecordingCompose {
+function makeCompose(
+  opts: { throwOn?: string } = {},
+): RecordingCompose {
   const calls: string[] = [];
   const restoredTopIds: string[] = [];
   const disposedTopIds: string[] = [];
+  const restoredEditorIds: string[] = [];
+  const disposedEditorIds: string[] = [];
+  const restoreErrors: Array<{ step: string; err: unknown }> = [];
+  const record = (name: string) => {
+    calls.push(name);
+    if (opts.throwOn === name) throw new Error(`${name} exploded`);
+  };
   const state = {
     calls,
     restoredTopIds,
     disposedTopIds,
-    restoreEditor: vi.fn(() => calls.push("restoreEditor")),
-    disposeEditorAttachments: vi.fn(() => calls.push("disposeEditorAttachments")),
+    restoredEditorIds,
+    disposedEditorIds,
+    restoreErrors,
+    restoreEditor: vi.fn(() => record("restoreEditor")),
+    restoreEditorAttachments: vi.fn((ids: string[]) => {
+      restoredEditorIds.push(...ids);
+      record("restoreEditorAttachments");
+    }),
+    disposeEditorAttachments: vi.fn((ids: string[]) => {
+      disposedEditorIds.push(...ids);
+      record("disposeEditorAttachments");
+    }),
     disposeTopAttachments: vi.fn((ids: string[]) => {
-      calls.push("disposeTopAttachments");
       disposedTopIds.push(...ids);
+      record("disposeTopAttachments");
     }),
     restoreTopAttachments: vi.fn((ids: string[]) => {
-      calls.push("restoreTopAttachments");
       restoredTopIds.push(...ids);
+      record("restoreTopAttachments");
+    }),
+    onRestoreError: vi.fn((err: unknown, step: string) => {
+      restoreErrors.push({ step, err });
     }),
   };
   return state as unknown as RecordingCompose;
 }
+
+/** Ids helper: `runSendWithConsumedCompose` now takes both id families. */
+const ids = (topIds: string[], editorAttachmentIds: string[] = []) => ({
+  topIds,
+  editorAttachmentIds,
+});
 
 describe("runSendWithConsumedCompose — success keeps the composer empty (#1280)", () => {
   it("disposes refs/urls and restores nothing when the send succeeds", async () => {
     const compose = makeCompose();
     const send = vi.fn().mockResolvedValue(true);
 
-    const ok = await runSendWithConsumedCompose(send, ["t1", "t2"], compose);
+    const ok = await runSendWithConsumedCompose(
+      send,
+      ids(["t1", "t2"], ["e1"]),
+      compose,
+    );
 
     expect(ok).toBe(true);
     expect(compose.restoreEditor).not.toHaveBeenCalled();
     expect(compose.restoreTopAttachments).not.toHaveBeenCalled();
-    expect(compose.disposeEditorAttachments).toHaveBeenCalledTimes(1);
+    expect(compose.restoreEditorAttachments).not.toHaveBeenCalled();
+    expect(compose.disposedEditorIds).toEqual(["e1"]);
     expect(compose.disposedTopIds).toEqual(["t1", "t2"]);
   });
 
@@ -113,7 +149,7 @@ describe("runSendWithConsumedCompose — success keeps the composer empty (#1280
 
     const ok = await runSendWithConsumedCompose(
       vi.fn().mockResolvedValue(undefined),
-      ["t1"],
+      ids(["t1"]),
       compose,
     );
 
@@ -128,11 +164,11 @@ describe("runSendWithConsumedCompose — success keeps the composer empty (#1280
       /* legacy void onSend */
     });
 
-    const ok = await runSendWithConsumedCompose(send, [], compose);
+    const ok = await runSendWithConsumedCompose(send, ids([], ["e1"]), compose);
 
     expect(ok).toBe(true);
     expect(compose.restoreEditor).not.toHaveBeenCalled();
-    expect(compose.disposeEditorAttachments).toHaveBeenCalledTimes(1);
+    expect(compose.disposedEditorIds).toEqual(["e1"]);
   });
 
   it("does NOT restore already-sent content even when the user typed during the await", async () => {
@@ -143,7 +179,7 @@ describe("runSendWithConsumedCompose — success keeps the composer empty (#1280
     let resolveSend!: (v: boolean) => void;
     const send = vi.fn(() => new Promise<boolean>((res) => (resolveSend = res)));
 
-    const p = runSendWithConsumedCompose(send, ["t1"], compose);
+    const p = runSendWithConsumedCompose(send, ids(["t1"]), compose);
     // ...user pastes another image / types the next line here...
     resolveSend(true);
 
@@ -158,7 +194,7 @@ describe("runSendWithConsumedCompose — round 1: failure restores the whole dra
     const compose = makeCompose();
     const send = vi.fn().mockResolvedValue(false);
 
-    const ok = await runSendWithConsumedCompose(send, ["t1", "t2"], compose);
+    const ok = await runSendWithConsumedCompose(send, ids(["t1", "t2"]), compose);
 
     expect(ok).toBe(false);
     expect(compose.restoreEditor).toHaveBeenCalledTimes(1);
@@ -172,7 +208,7 @@ describe("runSendWithConsumedCompose — round 1: failure restores the whole dra
     const compose = makeCompose();
     const send = vi.fn().mockRejectedValue(new Error("upload failed"));
 
-    const ok = await runSendWithConsumedCompose(send, ["t1"], compose);
+    const ok = await runSendWithConsumedCompose(send, ids(["t1"]), compose);
 
     expect(ok).toBe(false);
     expect(compose.restoreEditor).toHaveBeenCalledTimes(1);
@@ -185,7 +221,7 @@ describe("runSendWithConsumedCompose — round 1: failure restores the whole dra
     let resolveSend!: (v: boolean) => void;
     const send = vi.fn(() => new Promise<boolean>((res) => (resolveSend = res)));
 
-    const p = runSendWithConsumedCompose(send, ["t1"], compose);
+    const p = runSendWithConsumedCompose(send, ids(["t1"]), compose);
 
     await Promise.resolve();
     expect(compose.calls).toEqual([]);
@@ -205,7 +241,7 @@ describe("runSendWithConsumedCompose — partial result (top attachments sent, e
       .fn()
       .mockResolvedValue({ editorConsumed: false, consumedTopIds: ["t1", "t2"] });
 
-    const ok = await runSendWithConsumedCompose(send, ["t1", "t2"], compose);
+    const ok = await runSendWithConsumedCompose(send, ids(["t1", "t2"]), compose);
 
     expect(ok).toBe(false);
     expect(compose.restoreEditor).toHaveBeenCalledTimes(1);
@@ -220,7 +256,7 @@ describe("runSendWithConsumedCompose — partial result (top attachments sent, e
       .fn()
       .mockResolvedValue({ editorConsumed: true, consumedTopIds: ["t1"] });
 
-    const ok = await runSendWithConsumedCompose(send, ["t1", "t2"], compose);
+    const ok = await runSendWithConsumedCompose(send, ids(["t1", "t2"]), compose);
 
     expect(ok).toBe(true);
     expect(compose.disposedTopIds).toEqual(["t1"]);
@@ -232,7 +268,7 @@ describe("runSendWithConsumedCompose — partial result (top attachments sent, e
 
     await runSendWithConsumedCompose(
       vi.fn().mockResolvedValue({ editorConsumed: true }),
-      ["t1", "t2"],
+      ids(["t1", "t2"]),
       compose,
     );
 
@@ -287,17 +323,19 @@ describe("createSendQueue — consecutive sends are serialized, never dropped (#
 describe("restoreComposeSnapshot — a failed send never loses or overwrites content", () => {
   function makeTarget(isEmpty: boolean, throwOnStart = false) {
     const calls: string[] = [];
+    const offsets: number[] = [];
     const target: ComposeRestoreTarget = {
       isEmpty: () => isEmpty,
       setContent: () => calls.push("setContent"),
       focusEnd: () => calls.push("focusEnd"),
-      insertContentAtStart: () => {
-        calls.push("insertContentAtStart");
+      insertContentAtBlock: (blockOffset: number) => {
+        calls.push("insertContentAtBlock");
+        offsets.push(blockOffset);
         if (throwOnStart) throw new Error("bad position");
       },
       appendContent: () => calls.push("appendContent"),
     };
-    return { target, calls };
+    return { target, calls, offsets };
   }
 
   const snapshot = { content: [{ type: "paragraph" }] };
@@ -309,16 +347,24 @@ describe("restoreComposeSnapshot — a failed send never loses or overwrites con
   });
 
   it("prepends the failed content before a draft typed during the await", () => {
-    const { target, calls } = makeTarget(false);
-    restoreComposeSnapshot(snapshot, target);
+    const { target, calls, offsets } = makeTarget(false);
+    expect(restoreComposeSnapshot(snapshot, target)).toBe(1);
     // Never setContent here — that was the #227 round-2 data loss.
-    expect(calls).toEqual(["insertContentAtStart"]);
+    expect(calls).toEqual(["insertContentAtBlock"]);
+    expect(offsets).toEqual([0]);
   });
 
-  it("falls back to appending when the start position is rejected", () => {
+  it("inserts after content an earlier failed send already restored", () => {
+    const { target, offsets } = makeTarget(false);
+    restoreComposeSnapshot(snapshot, target, 2);
+    // Two blocks already belong to an earlier restore → keep A, B order.
+    expect(offsets).toEqual([2]);
+  });
+
+  it("falls back to appending when the insert position is rejected", () => {
     const { target, calls } = makeTarget(false, true);
     restoreComposeSnapshot(snapshot, target);
-    expect(calls).toEqual(["insertContentAtStart", "appendContent"]);
+    expect(calls).toEqual(["insertContentAtBlock", "appendContent"]);
   });
 
   it("does nothing for an empty snapshot", () => {
@@ -326,5 +372,106 @@ describe("restoreComposeSnapshot — a failed send never loses or overwrites con
     restoreComposeSnapshot({ content: [] }, target);
     restoreComposeSnapshot(undefined, target);
     expect(calls).toEqual([]);
+  });
+});
+
+describe("runSendWithConsumedCompose — partial editor attachments (#1280 review)", () => {
+  it("restores only the pasted attachments that were rejected, disposing the sent ones", async () => {
+    const compose = makeCompose();
+    // Two pasted images: img-1 enqueued, img-2 rejected by the upload pre-check.
+    const send = vi.fn().mockResolvedValue({
+      editorConsumed: true,
+      consumedTopIds: [],
+      unsentEditorAttachmentIds: ["img-2"],
+    });
+
+    const ok = await runSendWithConsumedCompose(
+      send,
+      ids([], ["img-1", "img-2"]),
+      compose,
+    );
+
+    expect(ok).toBe(true);
+    // The sent image's File ref/URL can go; the rejected one must stay alive…
+    expect(compose.disposedEditorIds).toEqual(["img-1"]);
+    // …and its node comes back so the user can retry just that image.
+    expect(compose.restoredEditorIds).toEqual(["img-2"]);
+  });
+
+  it("restores every pasted attachment when nothing was enqueued", async () => {
+    const compose = makeCompose();
+
+    await runSendWithConsumedCompose(
+      vi.fn().mockResolvedValue(false),
+      ids([], ["img-1", "img-2"]),
+      compose,
+    );
+
+    // Whole compose restored → no per-attachment restore, nothing disposed.
+    expect(compose.restoreEditor).toHaveBeenCalledTimes(1);
+    expect(compose.restoreEditorAttachments).not.toHaveBeenCalled();
+    expect(compose.disposeEditorAttachments).not.toHaveBeenCalled();
+  });
+
+  it("ignores unsentEditorAttachmentIds when the editor compose was not consumed", async () => {
+    const compose = makeCompose();
+
+    await runSendWithConsumedCompose(
+      vi.fn().mockResolvedValue({
+        editorConsumed: false,
+        unsentEditorAttachmentIds: ["img-1"],
+      }),
+      ids([], ["img-1", "img-2"]),
+      compose,
+    );
+
+    expect(compose.restoreEditor).toHaveBeenCalledTimes(1);
+    expect(compose.restoreEditorAttachments).not.toHaveBeenCalled();
+  });
+});
+
+describe("runSendWithConsumedCompose — step isolation (#1280 review)", () => {
+  it("settles top attachments BEFORE the editor so an editor throw cannot skip them", async () => {
+    const compose = makeCompose({ throwOn: "restoreEditor" });
+
+    const ok = await runSendWithConsumedCompose(
+      vi.fn().mockResolvedValue(false),
+      ids(["t1"], ["e1"]),
+      compose,
+    );
+
+    expect(ok).toBe(false);
+    // Attachments were restored first, so the editor failure cannot swallow them.
+    expect(compose.calls).toEqual(["restoreTopAttachments", "restoreEditor"]);
+    expect(compose.restoredTopIds).toEqual(["t1"]);
+    // The failure is reported instead of vanishing silently.
+    expect(compose.restoreErrors.map((e) => e.step)).toEqual(["restoreEditor"]);
+  });
+
+  it("keeps going when a dispose step throws", async () => {
+    const compose = makeCompose({ throwOn: "disposeTopAttachments" });
+
+    const ok = await runSendWithConsumedCompose(
+      vi.fn().mockResolvedValue(true),
+      ids(["t1"], ["e1"]),
+      compose,
+    );
+
+    expect(ok).toBe(true);
+    expect(compose.disposedEditorIds).toEqual(["e1"]);
+    expect(compose.restoreErrors.map((e) => e.step)).toEqual([
+      "disposeTopAttachments",
+    ]);
+  });
+
+  it("never rejects, so the fire-and-forget Enter path cannot produce an unhandled rejection", async () => {
+    const compose = makeCompose({ throwOn: "restoreEditor" });
+    await expect(
+      runSendWithConsumedCompose(
+        vi.fn().mockRejectedValue(new Error("network down")),
+        ids([], []),
+        compose,
+      ),
+    ).resolves.toBe(false);
   });
 });

--- a/packages/dmworkbase/src/Components/MessageInput/__tests__/sendFlow.test.ts
+++ b/packages/dmworkbase/src/Components/MessageInput/__tests__/sendFlow.test.ts
@@ -100,6 +100,7 @@ function makeCompose(
       restoredEditorBlocks.push(...blocks);
       record("restoreEditorBlocks");
     }),
+    restoreSendTarget: vi.fn(() => record("restoreSendTarget")),
     disposeEditorAttachments: vi.fn((ids: string[]) => {
       disposedEditorIds.push(...ids);
       record("disposeEditorAttachments");
@@ -419,6 +420,46 @@ describe("runSendWithConsumedCompose — partial editor blocks (#1280 review)", 
     ]);
     // The attachment that did go out stays consumed → no duplicate on retry.
     expect(compose.disposedTopIds).toEqual(["t1"]);
+  });
+
+  it("restores the captured reply target before partial editor content", async () => {
+    const compose = makeCompose();
+
+    await runSendWithConsumedCompose(
+      vi.fn().mockResolvedValue({
+        editorConsumed: true,
+        consumedTopIds: ["t1"],
+        unsentEditorBlocks: [{ type: "text", text: "@[u1:Alice] retry" }],
+        restoreSendTarget: true,
+      }),
+      ids(["t1"]),
+      compose,
+    );
+
+    expect(compose.calls).toEqual([
+      "disposeTopAttachments",
+      "restoreSendTarget",
+      "restoreEditorBlocks",
+    ]);
+  });
+
+  it("restores the reply target when an attachment-only reply fails pre-enqueue", async () => {
+    const compose = makeCompose();
+
+    await runSendWithConsumedCompose(
+      vi.fn().mockResolvedValue({
+        editorConsumed: true,
+        consumedTopIds: ["t1"],
+        restoreSendTarget: true,
+      }),
+      ids(["t1"]),
+      compose,
+    );
+
+    expect(compose.calls).toEqual([
+      "disposeTopAttachments",
+      "restoreSendTarget",
+    ]);
   });
 
   it("keeps document order when both text and an attachment are unsent", async () => {

--- a/packages/dmworkbase/src/Components/MessageInput/__tests__/sendFlow.test.ts
+++ b/packages/dmworkbase/src/Components/MessageInput/__tests__/sendFlow.test.ts
@@ -70,7 +70,7 @@ interface RecordingCompose extends ConsumedCompose {
   calls: string[];
   restoredTopIds: string[];
   disposedTopIds: string[];
-  restoredEditorIds: string[];
+  restoredEditorBlocks: unknown[];
   disposedEditorIds: string[];
   restoreErrors: Array<{ step: string; err: unknown }>;
 }
@@ -81,7 +81,7 @@ function makeCompose(
   const calls: string[] = [];
   const restoredTopIds: string[] = [];
   const disposedTopIds: string[] = [];
-  const restoredEditorIds: string[] = [];
+  const restoredEditorBlocks: unknown[] = [];
   const disposedEditorIds: string[] = [];
   const restoreErrors: Array<{ step: string; err: unknown }> = [];
   const record = (name: string) => {
@@ -92,13 +92,13 @@ function makeCompose(
     calls,
     restoredTopIds,
     disposedTopIds,
-    restoredEditorIds,
+    restoredEditorBlocks,
     disposedEditorIds,
     restoreErrors,
     restoreEditor: vi.fn(() => record("restoreEditor")),
-    restoreEditorAttachments: vi.fn((ids: string[]) => {
-      restoredEditorIds.push(...ids);
-      record("restoreEditorAttachments");
+    restoreEditorBlocks: vi.fn((blocks: unknown[]) => {
+      restoredEditorBlocks.push(...blocks);
+      record("restoreEditorBlocks");
     }),
     disposeEditorAttachments: vi.fn((ids: string[]) => {
       disposedEditorIds.push(...ids);
@@ -139,7 +139,7 @@ describe("runSendWithConsumedCompose — success keeps the composer empty (#1280
     expect(ok).toBe(true);
     expect(compose.restoreEditor).not.toHaveBeenCalled();
     expect(compose.restoreTopAttachments).not.toHaveBeenCalled();
-    expect(compose.restoreEditorAttachments).not.toHaveBeenCalled();
+    expect(compose.restoreEditorBlocks).not.toHaveBeenCalled();
     expect(compose.disposedEditorIds).toEqual(["e1"]);
     expect(compose.disposedTopIds).toEqual(["t1", "t2"]);
   });
@@ -375,14 +375,14 @@ describe("restoreComposeSnapshot — a failed send never loses or overwrites con
   });
 });
 
-describe("runSendWithConsumedCompose — partial editor attachments (#1280 review)", () => {
+describe("runSendWithConsumedCompose — partial editor blocks (#1280 review)", () => {
   it("restores only the pasted attachments that were rejected, disposing the sent ones", async () => {
     const compose = makeCompose();
     // Two pasted images: img-1 enqueued, img-2 rejected by the upload pre-check.
     const send = vi.fn().mockResolvedValue({
       editorConsumed: true,
       consumedTopIds: [],
-      unsentEditorAttachmentIds: ["img-2"],
+      unsentEditorBlocks: [{ type: "attachment", id: "img-2" }],
     });
 
     const ok = await runSendWithConsumedCompose(
@@ -395,7 +395,51 @@ describe("runSendWithConsumedCompose — partial editor attachments (#1280 revie
     // The sent image's File ref/URL can go; the rejected one must stay alive…
     expect(compose.disposedEditorIds).toEqual(["img-1"]);
     // …and its node comes back so the user can retry just that image.
-    expect(compose.restoredEditorIds).toEqual(["img-2"]);
+    expect(compose.restoredEditorBlocks).toEqual([
+      { type: "attachment", id: "img-2" },
+    ]);
+  });
+
+  it("restores text that failed before enqueue after an earlier block was sent", async () => {
+    const compose = makeCompose();
+    // A top attachment went out, then the text block's send threw pre-enqueue
+    // (disbanded-group guard / sendMessage failure). Reporting only
+    // `editorConsumed: true` used to discard that text for good (#1333 review).
+    const send = vi.fn().mockResolvedValue({
+      editorConsumed: true,
+      consumedTopIds: ["t1"],
+      unsentEditorBlocks: [{ type: "text", text: "please keep me" }],
+    });
+
+    const ok = await runSendWithConsumedCompose(send, ids(["t1"], []), compose);
+
+    expect(ok).toBe(true);
+    expect(compose.restoredEditorBlocks).toEqual([
+      { type: "text", text: "please keep me" },
+    ]);
+    // The attachment that did go out stays consumed → no duplicate on retry.
+    expect(compose.disposedTopIds).toEqual(["t1"]);
+  });
+
+  it("keeps document order when both text and an attachment are unsent", async () => {
+    const compose = makeCompose();
+    const send = vi.fn().mockResolvedValue({
+      editorConsumed: true,
+      unsentEditorBlocks: [
+        { type: "text", text: "before" },
+        { type: "attachment", id: "img-2" },
+        { type: "text", text: "after" },
+      ],
+    });
+
+    await runSendWithConsumedCompose(send, ids([], ["img-1", "img-2"]), compose);
+
+    expect(compose.restoredEditorBlocks).toEqual([
+      { type: "text", text: "before" },
+      { type: "attachment", id: "img-2" },
+      { type: "text", text: "after" },
+    ]);
+    expect(compose.disposedEditorIds).toEqual(["img-1"]);
   });
 
   it("restores every pasted attachment when nothing was enqueued", async () => {
@@ -409,24 +453,24 @@ describe("runSendWithConsumedCompose — partial editor attachments (#1280 revie
 
     // Whole compose restored → no per-attachment restore, nothing disposed.
     expect(compose.restoreEditor).toHaveBeenCalledTimes(1);
-    expect(compose.restoreEditorAttachments).not.toHaveBeenCalled();
+    expect(compose.restoreEditorBlocks).not.toHaveBeenCalled();
     expect(compose.disposeEditorAttachments).not.toHaveBeenCalled();
   });
 
-  it("ignores unsentEditorAttachmentIds when the editor compose was not consumed", async () => {
+  it("ignores unsentEditorBlocks when the editor compose was not consumed", async () => {
     const compose = makeCompose();
 
     await runSendWithConsumedCompose(
       vi.fn().mockResolvedValue({
         editorConsumed: false,
-        unsentEditorAttachmentIds: ["img-1"],
+        unsentEditorBlocks: [{ type: "attachment", id: "img-1" }],
       }),
       ids([], ["img-1", "img-2"]),
       compose,
     );
 
     expect(compose.restoreEditor).toHaveBeenCalledTimes(1);
-    expect(compose.restoreEditorAttachments).not.toHaveBeenCalled();
+    expect(compose.restoreEditorBlocks).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/dmworkbase/src/Components/MessageInput/composeConsume.ts
+++ b/packages/dmworkbase/src/Components/MessageInput/composeConsume.ts
@@ -78,6 +78,8 @@ export interface ConsumeComposeOptions {
   parseTextToNodes?: (text: string) => ComposeNode[];
   /** Extra side effects to undo when the whole compose is restored. */
   onRestoreCompose?: () => void;
+  /** Restore only the captured reply/edit target after a partial send. */
+  onRestoreSendTarget?: () => void;
   /**
    * Restore ordering across consecutive failures (#1280 review). Two queued
    * sends that both fail must come back as `A, B, <live draft>`, not `B, A`, so
@@ -231,6 +233,7 @@ export function consumeCompose(
       if (content.length === 0) return;
       restoreDoc({ type: "doc", content });
     },
+    restoreSendTarget: () => opts.onRestoreSendTarget?.(),
     disposeEditorAttachments: (ids: string[]) => {
       ids.forEach((id) => {
         attachmentFiles.delete(id);

--- a/packages/dmworkbase/src/Components/MessageInput/composeConsume.ts
+++ b/packages/dmworkbase/src/Components/MessageInput/composeConsume.ts
@@ -1,0 +1,269 @@
+/**
+ * Synchronous compose consumption for `MessageInput.send()` (octo-web#1280).
+ *
+ * The composer is emptied the moment a send starts and only restored if the send
+ * never got enqueued (see `sendFlow.ts` for the whole model). All of that logic
+ * lives here rather than inline in the component so it can be unit-tested
+ * against a **real** Tiptap editor: mid-flight typing, partial attachment
+ * failures and a destroyed editor are exactly the cases that used to be covered
+ * only by `vi.fn()` spies (#1280 review).
+ *
+ * Nothing in this module touches React.
+ */
+
+import type { ConsumedCompose, ConsumedComposeIds } from "./sendFlow";
+import { restoreComposeSnapshot } from "./sendFlow";
+
+/** Minimal document node shape we need from the editor JSON. */
+export interface ComposeNode {
+  type?: string;
+  attrs?: { id?: string; previewUrl?: string; [key: string]: unknown };
+  content?: ComposeNode[];
+  [key: string]: unknown;
+}
+
+export interface ComposeDoc extends ComposeNode {
+  content?: ComposeNode[];
+}
+
+/** The editor operations the consume/restore flow needs. */
+export interface ComposeEditorPort {
+  getJSON: () => ComposeDoc;
+  isEmpty: () => boolean;
+  /** True once the editor instance is gone (unmount / channel switch). */
+  isDestroyed: () => boolean;
+  clearContent: () => void;
+  setContent: (doc: ComposeDoc) => void;
+  /** Insert nodes after `blockOffset` leading top-level blocks. */
+  insertContentAtBlock: (blockOffset: number, nodes: ComposeNode[]) => void;
+  appendContent: (nodes: ComposeNode[]) => void;
+  focusEnd: () => void;
+}
+
+export interface TopAttachmentLike {
+  id: string;
+  previewUrl?: string;
+}
+
+/**
+ * Thrown when a compose cannot be given back because the editor no longer
+ * exists (the user switched conversation while the send was in flight). The
+ * caller is expected to surface this — silently dropping content that is in
+ * neither the composer nor the message list is the failure mode #1280 is about.
+ */
+export class ComposeRestoreUnavailableError extends Error {
+  constructor(message = "editor is destroyed, compose cannot be restored") {
+    super(message);
+    this.name = "ComposeRestoreUnavailableError";
+  }
+}
+
+export interface ConsumeComposeOptions {
+  editor: ComposeEditorPort;
+  /** In-memory pasted-image files, keyed by attachment node id. */
+  attachmentFiles: Map<string, File>;
+  /** Live top-attachment list accessor/mutator (kept outside this module). */
+  getTopAttachments: () => TopAttachmentLike[];
+  setTopAttachments: (items: TopAttachmentLike[]) => void;
+  /** Injectable for tests / non-browser environments. */
+  revokeObjectURL?: (url: string) => void;
+  /** Extra side effects to undo when the whole compose is restored. */
+  onRestoreCompose?: () => void;
+  /**
+   * Restore ordering across consecutive failures (#1280 review). Two queued
+   * sends that both fail must come back as `A, B, <live draft>`, not `B, A`, so
+   * each restore starts after the blocks/attachments earlier restores put back.
+   */
+  getRestoreOffsets?: () => { blocks: number; topAttachments: number };
+  onRestored?: (restored: { blocks: number; topAttachments: number }) => void;
+  /** Reported when a restore/dispose step throws (see ConsumedCompose). */
+  onRestoreError?: (err: unknown, step: string) => void;
+}
+
+export interface ConsumedComposeHandle {
+  ids: ConsumedComposeIds;
+  compose: ConsumedCompose;
+  /** The document that was taken out of the editor (for draft persistence). */
+  snapshot: ComposeDoc;
+}
+
+/** Collect attachment nodes (inline atoms) from a document snapshot, in order. */
+function collectAttachmentNodes(doc: ComposeDoc): ComposeNode[] {
+  const found: ComposeNode[] = [];
+  const walk = (node: ComposeNode | undefined) => {
+    if (!node) return;
+    if (node.type === "attachment" && node.attrs?.id) {
+      found.push(node);
+      return;
+    }
+    node.content?.forEach(walk);
+  };
+  doc.content?.forEach(walk);
+  return found;
+}
+
+/**
+ * Take the current compose out of the composer and return the hooks
+ * `runSendWithConsumedCompose` needs.
+ *
+ * Consumption is synchronous and unconditional: the editor is cleared and the
+ * top attachments handed to this send are removed before any await, so a send
+ * that resolves later can never fight with what the user typed meanwhile.
+ */
+export function consumeCompose(
+  opts: ConsumeComposeOptions,
+): ConsumedComposeHandle {
+  const {
+    editor,
+    attachmentFiles,
+    getTopAttachments,
+    setTopAttachments,
+    onRestoreCompose,
+    onRestoreError,
+  } = opts;
+  const revokeObjectURL =
+    opts.revokeObjectURL ??
+    ((url: string) => {
+      if (typeof URL !== "undefined" && URL.revokeObjectURL) {
+        URL.revokeObjectURL(url);
+      }
+    });
+
+  const snapshot = editor.getJSON();
+  const attachmentNodes = collectAttachmentNodes(snapshot);
+  const editorAttachmentIds = attachmentNodes
+    .map((node) => node.attrs?.id)
+    .filter((id): id is string => typeof id === "string");
+  const previewUrlById = new Map<string, string | undefined>();
+  attachmentNodes.forEach((node) => {
+    if (node.attrs?.id) {
+      previewUrlById.set(node.attrs.id, node.attrs.previewUrl);
+    }
+  });
+
+  const topItemsAtSend = getTopAttachments().slice();
+  const topIds = topItemsAtSend.map((item) => item.id);
+
+  // ── consume ──────────────────────────────────────────────────────────────
+  editor.clearContent();
+  if (topIds.length > 0) {
+    const consumed = new Set(topIds);
+    setTopAttachments(getTopAttachments().filter((a) => !consumed.has(a.id)));
+  }
+
+  const assertRestorable = () => {
+    if (editor.isDestroyed()) {
+      throw new ComposeRestoreUnavailableError();
+    }
+  };
+
+  const restoreTarget = {
+    isEmpty: () => editor.isEmpty(),
+    setContent: (doc: unknown) => editor.setContent(doc as ComposeDoc),
+    focusEnd: () => editor.focusEnd(),
+    insertContentAtBlock: (blockOffset: number, nodes: unknown[]) =>
+      editor.insertContentAtBlock(blockOffset, nodes as ComposeNode[]),
+    appendContent: (nodes: unknown[]) =>
+      editor.appendContent(nodes as ComposeNode[]),
+  };
+
+  const offsets = () =>
+    opts.getRestoreOffsets?.() ?? { blocks: 0, topAttachments: 0 };
+  const restoreDoc = (snapshotToRestore: ComposeDoc) => {
+    const inserted = restoreComposeSnapshot(
+      snapshotToRestore,
+      restoreTarget,
+      offsets().blocks,
+    );
+    opts.onRestored?.({ blocks: inserted, topAttachments: 0 });
+  };
+
+  const compose: ConsumedCompose = {
+    restoreEditor: () => {
+      // Side effects that belong to "the whole compose came back" (reply/edit
+      // target, expanded state) run FIRST, so a document restore that throws
+      // cannot skip them (#1280 review).
+      onRestoreCompose?.();
+      assertRestorable();
+      restoreDoc(snapshot);
+    },
+    restoreEditorAttachments: (ids: string[]) => {
+      assertRestorable();
+      const wanted = new Set(ids);
+      const nodes = attachmentNodes.filter(
+        (node) => node.attrs?.id && wanted.has(node.attrs.id),
+      );
+      if (nodes.length === 0) return;
+      // Attachment nodes are inline atoms, so they need a block wrapper.
+      restoreDoc({
+        type: "doc",
+        content: [{ type: "paragraph", content: nodes }],
+      });
+    },
+    disposeEditorAttachments: (ids: string[]) => {
+      ids.forEach((id) => {
+        attachmentFiles.delete(id);
+        const previewUrl = previewUrlById.get(id);
+        if (previewUrl) revokeObjectURL(previewUrl);
+      });
+    },
+    disposeTopAttachments: (ids: string[]) => {
+      const wanted = new Set(ids);
+      topItemsAtSend.forEach((item) => {
+        if (wanted.has(item.id) && item.previewUrl) {
+          revokeObjectURL(item.previewUrl);
+        }
+      });
+    },
+    restoreTopAttachments: (ids: string[]) => {
+      const wanted = new Set(ids);
+      const restored = topItemsAtSend.filter((item) => wanted.has(item.id));
+      if (restored.length === 0) return;
+      const live = getTopAttachments();
+      const liveIds = new Set(live.map((item) => item.id));
+      const fresh = restored.filter((item) => !liveIds.has(item.id));
+      if (fresh.length === 0) return;
+      // Keep the original relative order of the restored items, insert them
+      // after items an earlier failed send already restored, and never duplicate
+      // an item the user re-added during the await.
+      const offset = Math.min(offsets().topAttachments, live.length);
+      setTopAttachments([
+        ...live.slice(0, offset),
+        ...fresh,
+        ...live.slice(offset),
+      ]);
+      opts.onRestored?.({ blocks: 0, topAttachments: fresh.length });
+    },
+    onRestoreError,
+  };
+
+  return { ids: { topIds, editorAttachmentIds }, compose, snapshot };
+}
+
+/** Plain text of a compose snapshot — used for draft persistence / previews. */
+export function composeSnapshotText(doc: ComposeDoc | undefined): string {
+  if (!doc?.content) return "";
+  const parts: string[] = [];
+  const walk = (node: ComposeNode | undefined) => {
+    if (!node) return;
+    if (node.type === "text" && typeof node.text === "string") {
+      parts.push(node.text);
+      return;
+    }
+    if (node.type === "mention") {
+      const label = node.attrs?.label;
+      if (typeof label === "string") parts.push(`@${label}`);
+      return;
+    }
+    if (node.type === "hardBreak") {
+      parts.push("\n");
+      return;
+    }
+    node.content?.forEach(walk);
+  };
+  doc.content.forEach((node, index) => {
+    if (index > 0) parts.push("\n");
+    walk(node);
+  });
+  return parts.join("").trim();
+}

--- a/packages/dmworkbase/src/Components/MessageInput/composeConsume.ts
+++ b/packages/dmworkbase/src/Components/MessageInput/composeConsume.ts
@@ -11,7 +11,11 @@
  * Nothing in this module touches React.
  */
 
-import type { ConsumedCompose, ConsumedComposeIds } from "./sendFlow";
+import type {
+  ConsumedCompose,
+  ConsumedComposeIds,
+  UnsentEditorBlock,
+} from "./sendFlow";
 import { restoreComposeSnapshot } from "./sendFlow";
 
 /** Minimal document node shape we need from the editor JSON. */
@@ -67,6 +71,11 @@ export interface ConsumeComposeOptions {
   setTopAttachments: (items: TopAttachmentLike[]) => void;
   /** Injectable for tests / non-browser environments. */
   revokeObjectURL?: (url: string) => void;
+  /**
+   * Turn a send-format text block back into document nodes when only part of the
+   * compose is restored (mentions come back as nodes). Defaults to plain text.
+   */
+  parseTextToNodes?: (text: string) => ComposeNode[];
   /** Extra side effects to undo when the whole compose is restored. */
   onRestoreCompose?: () => void;
   /**
@@ -121,6 +130,11 @@ export function consumeCompose(
     onRestoreCompose,
     onRestoreError,
   } = opts;
+  const parseTextToNodes =
+    opts.parseTextToNodes ??
+    ((value: string) => [
+      { type: "paragraph", content: [{ type: "text", text: value }] },
+    ]);
   const revokeObjectURL =
     opts.revokeObjectURL ??
     ((url: string) => {
@@ -187,18 +201,35 @@ export function consumeCompose(
       assertRestorable();
       restoreDoc(snapshot);
     },
-    restoreEditorAttachments: (ids: string[]) => {
+    restoreEditorBlocks: (blocks: UnsentEditorBlock[]) => {
       assertRestorable();
-      const wanted = new Set(ids);
-      const nodes = attachmentNodes.filter(
-        (node) => node.attrs?.id && wanted.has(node.attrs.id),
-      );
-      if (nodes.length === 0) return;
-      // Attachment nodes are inline atoms, so they need a block wrapper.
-      restoreDoc({
-        type: "doc",
-        content: [{ type: "paragraph", content: nodes }],
+      const nodeById = new Map<string, ComposeNode>();
+      attachmentNodes.forEach((node) => {
+        if (node.attrs?.id) nodeById.set(node.attrs.id, node);
       });
+
+      const content: ComposeNode[] = [];
+      let inline: ComposeNode[] = [];
+      const flushInline = () => {
+        if (inline.length === 0) return;
+        // Attachment nodes are inline atoms, so they need a block wrapper.
+        content.push({ type: "paragraph", content: inline });
+        inline = [];
+      };
+      blocks.forEach((block) => {
+        if (block.type === "attachment") {
+          const node = nodeById.get(block.id);
+          if (node) inline.push(node);
+          return;
+        }
+        if (block.text.trim() === "") return;
+        flushInline();
+        content.push(...parseTextToNodes(block.text));
+      });
+      flushInline();
+
+      if (content.length === 0) return;
+      restoreDoc({ type: "doc", content });
     },
     disposeEditorAttachments: (ids: string[]) => {
       ids.forEach((id) => {

--- a/packages/dmworkbase/src/Components/MessageInput/index.css
+++ b/packages/dmworkbase/src/Components/MessageInput/index.css
@@ -685,3 +685,17 @@
   object-fit: cover;
   border-radius: var(--wk-r-sm);
 }
+
+/* ============================================
+   发送中提示（octo-web#1280）
+   compose 在发送开始时就被清出输入框，气泡出现前用这条提示告诉用户
+   「消息还在发送中」，避免误以为没发出去。
+   ============================================ */
+
+.wk-messageinput-sending {
+  width: 100%;
+  padding: 0 var(--wk-sp-1);
+  margin-bottom: var(--wk-sp-1);
+  font-size: var(--wk-text-size-xs);
+  color: var(--wk-text-tertiary);
+}

--- a/packages/dmworkbase/src/Components/MessageInput/index.tsx
+++ b/packages/dmworkbase/src/Components/MessageInput/index.tsx
@@ -47,6 +47,7 @@ import {
   runSendWithConsumedCompose,
   SendQueue,
   SendResultDetail,
+  SendDraftSnapshot,
   SendTargetSnapshot,
 } from "./sendFlow";
 import {
@@ -111,7 +112,7 @@ function extractAttachmentsFromEditor(
  * 用于按顺序发送编辑器中穿插的文本和媒体。
  */
 export type EditorContentBlock =
-  | { type: "text"; text: string; mention?: MentionModel }
+  | { type: "text"; text: string; restoreText: string; mention?: MentionModel }
   | { type: "image"; id: string; file: File }
   | { type: "file"; id: string; file: File };
 
@@ -137,7 +138,7 @@ function extractOrderedBlocks(
     const joined = stripInvisibleChars(pendingTextParts.join(""));
     if (joined.trim() !== "") {
       const { content, mention } = formatMentionTextV2(joined);
-      blocks.push({ type: "text", text: content, mention });
+      blocks.push({ type: "text", text: content, restoreText: joined, mention });
     }
     pendingTextParts = [];
   }
@@ -259,13 +260,16 @@ interface MessageInputProps {
      * 发送被排队时 vm 上的 reply/edit 状态可能已被用户改掉，onSend 必须用这个
      * 快照而不是实时读取，否则可能回复错的消息、甚至编辑到无关消息。
      */
-    sendTarget?: SendTargetSnapshot
+    sendTarget?: SendTargetSnapshot,
+    sendDraft?: SendDraftSnapshot
   ) => void | boolean | SendResultDetail | Promise<void | boolean | SendResultDetail>;
   /**
    * 同步取走并清除 reply/edit 目标（横幅同时收起），返回的快照会被透传给
    * onSend；发送未入队时 MessageInput 调 `restore()` 复位 (octo-web#1280)。
    */
   onCaptureSendTarget?: () => SendTargetSnapshot | undefined;
+  /** Capture draft state before this send enters the serial queue. */
+  onCaptureSendDraft?: () => SendDraftSnapshot;
   members?: Array<Subscriber>;
   onInputRef?: any;
   onInsertText?: (fnc: OnInsertFnc) => void;
@@ -330,6 +334,7 @@ import {
   serializeMentionMarker,
   stripTrustMark,
   parseDraftToContent,
+  parseConsumedTextToContent,
 } from "./mentionSendParse";
 import type { SendParseMember } from "./mentionSendParse";
 
@@ -1067,6 +1072,7 @@ const MessageInput: React.FC<MessageInputProps> = (props) => {
     // 结果编排在 sendFlow.ts 的 runSendWithConsumedCompose。
     // reply/edit 目标必须与 compose 同步取走（见 SendTargetSnapshot 注释）。
     const sendTarget = props.onCaptureSendTarget?.();
+    const sendDraft = props.onCaptureSendDraft?.();
     // 本次消费会清空编辑器与本次附件，之前失败还原留下的偏移随之失效。
     restoreOffsetsRef.current = { blocks: 0, topAttachments: 0 };
     const expandedAtSend = expanded;
@@ -1094,7 +1100,7 @@ const MessageInput: React.FC<MessageInputProps> = (props) => {
       attachmentFiles: attachmentFilesRef.current,
       // 部分还原时把 @[uid:label] 还原成 mention 节点（与草稿恢复同一套解析）。
       parseTextToNodes: (value) =>
-        (parseDraftToContent(value).content ?? []) as ComposeDoc["content"] as never,
+        (parseConsumedTextToContent(value).content ?? []) as ComposeDoc["content"] as never,
       getTopAttachments: () => topAttachmentsRef.current,
       setTopAttachments: (items) => {
         topAttachmentsRef.current = items as TopAttachmentItem[];
@@ -1118,6 +1124,7 @@ const MessageInput: React.FC<MessageInputProps> = (props) => {
           props.onExpandChange?.(true);
         }
       },
+      onRestoreSendTarget: () => sendTarget?.restore(),
       onRestoreError: (err, step) => {
         // 内容既不在输入框也不在消息列表时必须让用户知道，不能静默丢失
         // （典型触发：还原时会话已被切走、editor 已 destroy）。
@@ -1156,7 +1163,8 @@ const MessageInput: React.FC<MessageInputProps> = (props) => {
               allAttachments.length > 0 ? allAttachments : undefined,
               topAttachmentFiles.length > 0 ? topAttachmentFiles : undefined,
               orderedBlocks.length > 0 ? orderedBlocks : undefined,
-              sendTarget
+              sendTarget,
+              sendDraft
             ),
           handle.ids,
           handle.compose
@@ -1168,6 +1176,7 @@ const MessageInput: React.FC<MessageInputProps> = (props) => {
     expanded,
     props.onSend,
     props.onCaptureSendTarget,
+    props.onCaptureSendDraft,
     props.onExpandChange,
     getSendQueue,
     registerPendingSend,

--- a/packages/dmworkbase/src/Components/MessageInput/index.tsx
+++ b/packages/dmworkbase/src/Components/MessageInput/index.tsx
@@ -1092,6 +1092,9 @@ const MessageInput: React.FC<MessageInputProps> = (props) => {
         focusEnd: () => editor.commands.focus("end"),
       },
       attachmentFiles: attachmentFilesRef.current,
+      // 部分还原时把 @[uid:label] 还原成 mention 节点（与草稿恢复同一套解析）。
+      parseTextToNodes: (value) =>
+        (parseDraftToContent(value).content ?? []) as ComposeDoc["content"] as never,
       getTopAttachments: () => topAttachmentsRef.current,
       setTopAttachments: (items) => {
         topAttachmentsRef.current = items as TopAttachmentItem[];

--- a/packages/dmworkbase/src/Components/MessageInput/index.tsx
+++ b/packages/dmworkbase/src/Components/MessageInput/index.tsx
@@ -381,14 +381,19 @@ export interface MessageInputContext {
   /** Clear editor content without sending */
   clear: () => void;
   /**
-   * Number of composes that are consumed but not yet enqueued/settled
-   * (octo-web#1280). During that window the content lives in neither the
-   * composer nor the message list, so callers that used to rely on
-   * "composer holds the content" must consult this too — e.g. the pending
-   * attachment guard before switching channel, and draft persistence.
+   * Number of composes that were handed to `onSend` and have not settled yet
+   * (octo-web#1280).
+   *
+   * Scope, deliberately conservative: this covers the whole `onSend` lifetime —
+   * "consumed but no bubble yet" (mixed compose still uploading, so the content
+   * exists nowhere visible) AND "bubble created, still uploading / waiting for
+   * ack". The first part is the data-loss window; the second is kept in because
+   * callers use this to decide whether it is safe to tear the conversation down,
+   * and a message that is still ordering is still work in progress. Splitting the
+   * two states is a possible refinement (#1333 review, non-blocking).
    */
   pendingSendCount: () => number;
-  /** Plain text of every in-flight compose, newest last. */
+  /** Plain text of every unsettled compose, newest last. */
   pendingSendText: () => string;
 }
 
@@ -1131,8 +1136,11 @@ const MessageInput: React.FC<MessageInputProps> = (props) => {
 
     // 串行队列取代旧的重入保护：pending 期间的 Enter 不再被静默丢弃（#1280 的
     // 「连点没反应」），而是排在前一条之后执行，消息顺序仍由 Conversation 等 ack
-    // 保证。in-flight 期间把 compose 文本登记到 pendingSendsRef，供切会话守卫、
-    // 草稿保存和「发送中」提示使用——这段时间内容不在输入框也还没有气泡。
+    // 保证。onSend 未 settle 前把 compose 文本登记到 pendingSendsRef，供切会话
+    // 守卫、草稿保存和「发送中」提示使用。登记覆盖整个 onSend 生命周期：既包含
+    // 「已消费但还没有气泡」（混排上传中，内容此刻不在任何可见位置——这是真正的
+    // 丢失窗口），也包含「气泡已出现但仍在上传/等 ack」。后者保留是有意的：这些
+    // 调用方要判断此刻能否安全拆掉会话，仍在排序的消息也算未完成的活。
     const pendingId = ++pendingSendSeqRef.current;
     registerPendingSend(pendingId, composeSnapshotText(handle.snapshot));
     return getSendQueue()
@@ -1344,8 +1352,9 @@ const MessageInput: React.FC<MessageInputProps> = (props) => {
         {/* 引用/编辑条在卡片内部 */}
         {topView && <div className="wk-messageinput-topview">{topView}</div>}
 
-        {/* 发送中提示 (octo-web#1280)：compose 已被消费但气泡还没出现的窗口内，
-            给用户一个「还在发」的信号，避免以为没发出去而重复操作。 */}
+        {/* 发送中提示 (octo-web#1280)：输入框在发送开始时就被清空，这里给用户一个
+            「还在发」的信号，避免以为没发出去而重复操作。覆盖到 onSend settle
+            （上传 + ack 结束）为止，与 pendingSendCount 同口径。 */}
         {pendingSendCount > 0 && (
           <div className="wk-messageinput-sending" aria-live="polite">
             {t("base.message.sending")}

--- a/packages/dmworkbase/src/Components/MessageInput/index.tsx
+++ b/packages/dmworkbase/src/Components/MessageInput/index.tsx
@@ -44,10 +44,17 @@ import {
   announceContextAfterSendReady,
   createSendQueue,
   invokeReadySend,
-  restoreComposeSnapshot,
   runSendWithConsumedCompose,
+  SendQueue,
   SendResultDetail,
+  SendTargetSnapshot,
 } from "./sendFlow";
+import {
+  composeSnapshotText,
+  consumeCompose,
+  ComposeDoc,
+  ComposeRestoreUnavailableError,
+} from "./composeConsume";
 import { extractOctoRichTextClipboardPayloadFromHtml } from "../../Utils/richTextClipboard";
 import {
   imageBlockToPasteFile,
@@ -246,8 +253,19 @@ interface MessageInputProps {
     /** 顶部附件区文件（通过上传按钮添加），优先于编辑器内容发送 */
     topFiles?: AttachmentFile[],
     /** 编辑器中按文档顺序排列的内容块（文本段和粘贴图片交替） */
-    editorBlocks?: EditorContentBlock[]
+    editorBlocks?: EditorContentBlock[],
+    /**
+     * 本次发送的 reply/edit 目标，按下发送键时同步取走 (octo-web#1280)。
+     * 发送被排队时 vm 上的 reply/edit 状态可能已被用户改掉，onSend 必须用这个
+     * 快照而不是实时读取，否则可能回复错的消息、甚至编辑到无关消息。
+     */
+    sendTarget?: SendTargetSnapshot
   ) => void | boolean | SendResultDetail | Promise<void | boolean | SendResultDetail>;
+  /**
+   * 同步取走并清除 reply/edit 目标（横幅同时收起），返回的快照会被透传给
+   * onSend；发送未入队时 MessageInput 调 `restore()` 复位 (octo-web#1280)。
+   */
+  onCaptureSendTarget?: () => SendTargetSnapshot | undefined;
   members?: Array<Subscriber>;
   onInputRef?: any;
   onInsertText?: (fnc: OnInsertFnc) => void;
@@ -362,6 +380,16 @@ export interface MessageInputContext {
   send: () => void | Promise<boolean | void> | undefined;
   /** Clear editor content without sending */
   clear: () => void;
+  /**
+   * Number of composes that are consumed but not yet enqueued/settled
+   * (octo-web#1280). During that window the content lives in neither the
+   * composer nor the message list, so callers that used to rely on
+   * "composer holds the content" must consult this too — e.g. the pending
+   * attachment guard before switching channel, and draft persistence.
+   */
+  pendingSendCount: () => number;
+  /** Plain text of every in-flight compose, newest last. */
+  pendingSendText: () => string;
 }
 
 // MemberInfo / buildMentionRegex / parseMentionMarkers / buildMemberInfos live
@@ -493,9 +521,46 @@ const MessageInput: React.FC<MessageInputProps> = (props) => {
     props.context.channel().channelType === ChannelTypePerson,
   );
   const sendRef = useRef<(() => Promise<boolean>) | null>(null);
+  // 键盘/Enter 是 fire-and-forget 调用：send() 的同步阶段（快照/清空/取 target）
+  // 若抛错会变成 unhandled rejection，这里统一兜住并提示 (#1280 review)。
+  const fireAndForgetSend = useCallback(() => {
+    try {
+      const result = sendRef.current?.();
+      if (result && typeof result.catch === "function") {
+        result.catch((err: unknown) => {
+          console.error("[MessageInput] send rejected", err);
+        });
+      }
+    } catch (err) {
+      console.error("[MessageInput] send threw synchronously", err);
+    }
+  }, []);
   // 串行发送队列 (octo-web#1280)：compose 在 send 开始时就被同步消费，因此
   // pending 期间的新发送不再被丢弃，只需排在前一条之后执行以保持消息顺序。
-  const sendQueueRef = useRef(createSendQueue());
+  // 惰性创建，避免每次渲染都构造一个用不上的队列。
+  const sendQueueRef = useRef<SendQueue | null>(null);
+  const getSendQueue = useCallback((): SendQueue => {
+    if (!sendQueueRef.current) {
+      sendQueueRef.current = createSendQueue();
+    }
+    return sendQueueRef.current;
+  }, []);
+  // in-flight compose 登记表：这段时间内容既不在输入框、也还没有消息气泡，
+  // 切会话守卫 / 草稿保存 / 「发送中」提示都要能看到它 (octo-web#1280 review)。
+  const pendingSendsRef = useRef<Map<number, string>>(new Map());
+  const pendingSendSeqRef = useRef(0);
+  // 连续失败还原时的插入位置：已被更早的失败 send 放回的块数 / 附件数，
+  // 保证 A、B 依次失败后顺序仍是 A、B、<新草稿> 而不是倒过来 (#1280 review)。
+  const restoreOffsetsRef = useRef({ blocks: 0, topAttachments: 0 });
+  const [pendingSendCount, setPendingSendCount] = useState(0);
+  const registerPendingSend = useCallback((id: number, text: string) => {
+    pendingSendsRef.current.set(id, text);
+    setPendingSendCount(pendingSendsRef.current.size);
+  }, []);
+  const releasePendingSend = useCallback((id: number) => {
+    pendingSendsRef.current.delete(id);
+    setPendingSendCount(pendingSendsRef.current.size);
+  }, []);
   const mentionActiveRef = useRef(false);
   // 表情前缀联想下拉激活标志，激活时 Enter 用于选中而非发送
   const emojiSuggestionActiveRef = useRef(false);
@@ -987,98 +1052,117 @@ const MessageInput: React.FC<MessageInputProps> = (props) => {
     // 再按一次 Enter 还会重复发送）。
     //
     // 本轮改为：发送开始时就**同步消费** compose（拍快照 → 清空编辑器 → 移除
-    // 本次顶部附件），await 之后不再对「当前文档」做任何判定：
-    //   • 成功 → UI 无需再动，只回收 File 引用与预览 URL；
+    // 本次顶部附件 → 同步取走 reply/edit 目标），await 之后不再对「当前文档」做
+    // 任何判定：
+    //   • 成功 → UI 无需再动，只回收已发出部分的 File 引用与预览 URL；
     //   • 失败（预检拒绝 / 混排上传失败等未入队情形）→ 把快照插回文档最前面、
-    //     未发出的顶部附件放回附件区，round-1 的「失败不丢草稿」保护仍然成立；
-    //     用户在等待期间新写的草稿天然完整保留（round-2 保护）。
-    // 编排逻辑在纯函数 runSendWithConsumedCompose，便于单测覆盖各竞态场景。
-    const editorSnapshot = editor.getJSON() as JSONContent;
-    const consumedAttachmentAttrs = attachmentAttrs;
-    const topItemsAtSend = topAttachmentsRef.current;
-    const allTopIds = topItemsAtSend.map((item) => item.id);
+    //     未发出的顶部附件放回附件区、reply/edit 目标复位，round-1 的「失败不丢
+    //     草稿」保护仍然成立；用户在等待期间新写的草稿天然完整保留（round-2）。
+    // 同步消费与还原的实现在 composeConsume.ts（可用真实 Tiptap editor 单测），
+    // 结果编排在 sendFlow.ts 的 runSendWithConsumedCompose。
+    // reply/edit 目标必须与 compose 同步取走（见 SendTargetSnapshot 注释）。
+    const sendTarget = props.onCaptureSendTarget?.();
+    // 本次消费会清空编辑器与本次附件，之前失败还原留下的偏移随之失效。
+    restoreOffsetsRef.current = { blocks: 0, topAttachments: 0 };
+    const expandedAtSend = expanded;
+    const handle = consumeCompose({
+      editor: {
+        getJSON: () => editor.getJSON() as ComposeDoc,
+        isEmpty: () => editor.isEmpty,
+        isDestroyed: () => editor.isDestroyed,
+        clearContent: () => editor.commands.clearContent(),
+        setContent: (doc) => editor.commands.setContent(doc as JSONContent),
+        insertContentAtBlock: (blockOffset, nodes) => {
+          // 把「第 n 个顶层块之前」换算成 ProseMirror 位置。
+          const docNode = editor.state.doc;
+          const limit = Math.min(blockOffset, docNode.childCount);
+          let pos = 0;
+          for (let i = 0; i < limit; i++) {
+            pos += docNode.child(i).nodeSize;
+          }
+          editor.commands.insertContentAt(pos, nodes as JSONContent[]);
+        },
+        appendContent: (nodes) =>
+          editor.commands.insertContent(nodes as JSONContent[]),
+        focusEnd: () => editor.commands.focus("end"),
+      },
+      attachmentFiles: attachmentFilesRef.current,
+      getTopAttachments: () => topAttachmentsRef.current,
+      setTopAttachments: (items) => {
+        topAttachmentsRef.current = items as TopAttachmentItem[];
+        setTopAttachments(topAttachmentsRef.current);
+      },
+      getRestoreOffsets: () => restoreOffsetsRef.current,
+      onRestored: ({ blocks, topAttachments }) => {
+        restoreOffsetsRef.current = {
+          blocks: restoreOffsetsRef.current.blocks + blocks,
+          topAttachments:
+            restoreOffsetsRef.current.topAttachments + topAttachments,
+        };
+      },
+      onRestoreCompose: () => {
+        // 整条 compose 回到输入框时，把 reply/edit 目标和展开态也一起复位，
+        // 否则「编辑消息」失败后重试会变成发一条新消息、大段草稿被挤在收起态里
+        // (#1280 review)。restore() 自身幂等，且用户已选新目标时不会覆盖。
+        sendTarget?.restore();
+        if (expandedAtSend) {
+          setExpanded(true);
+          props.onExpandChange?.(true);
+        }
+      },
+      onRestoreError: (err, step) => {
+        // 内容既不在输入框也不在消息列表时必须让用户知道，不能静默丢失
+        // （典型触发：还原时会话已被切走、editor 已 destroy）。
+        console.error(`[MessageInput] compose ${step} failed`, err);
+        Notification.error({
+          className: "wk-octo-notification",
+          content:
+            err instanceof ComposeRestoreUnavailableError
+              ? t("base.messageInput.send.restoreFailed")
+              : t("base.conversation.message.sendFailed"),
+        });
+      },
+    });
 
-    // ── 同步消费：编辑器 + 本次顶部附件 ──────────────
-    editor.commands.clearContent();
-    if (allTopIds.length > 0) {
-      const consumedIds = new Set(allTopIds);
-      topAttachmentsRef.current = topAttachmentsRef.current.filter(
-        (a: TopAttachmentItem) => !consumedIds.has(a.id)
-      );
-      setTopAttachments(topAttachmentsRef.current);
-    }
     if (expanded) {
       setExpanded(false);
       props.onExpandChange?.(false);
     }
 
-    /** 失败回滚：把本次发送的内容插回编辑器，新草稿排在其后（策略见 sendFlow）。 */
-    const restoreEditorSnapshot = () =>
-      restoreComposeSnapshot(editorSnapshot, {
-        isEmpty: () => editor.isEmpty,
-        setContent: (snapshot) => editor.commands.setContent(snapshot as JSONContent),
-        focusEnd: () => editor.commands.focus("end"),
-        insertContentAtStart: (blocks) =>
-          editor.commands.insertContentAt(0, blocks as JSONContent[]),
-        appendContent: (blocks) =>
-          editor.commands.insertContent(blocks as JSONContent[]),
-      });
-
-    /** 失败回滚：把未真正发出的顶部附件放回附件区（预览 URL 未被 revoke）。 */
-    const restoreTopItems = (ids: string[]) => {
-      const idSet = new Set(ids);
-      const restored = topItemsAtSend.filter((item: TopAttachmentItem) =>
-        idSet.has(item.id)
-      );
-      if (restored.length === 0) return;
-      const live = new Set(
-        topAttachmentsRef.current.map((a: TopAttachmentItem) => a.id)
-      );
-      topAttachmentsRef.current = [
-        ...restored.filter((item: TopAttachmentItem) => !live.has(item.id)),
-        ...topAttachmentsRef.current,
-      ];
-      setTopAttachments(topAttachmentsRef.current);
-    };
-
     // 串行队列取代旧的重入保护：pending 期间的 Enter 不再被静默丢弃（#1280 的
     // 「连点没反应」），而是排在前一条之后执行，消息顺序仍由 Conversation 等 ack
-    // 保证。返回真实结果供 initialCompose 编排器区分 sent / failed；
-    // 键盘/Enter 路径忽略返回值，行为不变。
-    return sendQueueRef.current.enqueue(() =>
-      runSendWithConsumedCompose(
-        () =>
-          props.onSend!(
-            content,
-            mention,
-            allAttachments.length > 0 ? allAttachments : undefined,
-            topAttachmentFiles.length > 0 ? topAttachmentFiles : undefined,
-            orderedBlocks.length > 0 ? orderedBlocks : undefined
-          ),
-        allTopIds,
-        {
-          restoreEditor: restoreEditorSnapshot,
-          restoreTopAttachments: restoreTopItems,
-          disposeEditorAttachments: () => {
-            consumedAttachmentAttrs.forEach((attr) => {
-              attachmentFilesRef.current.delete(attr.id);
-              if (attr.previewUrl) {
-                URL.revokeObjectURL(attr.previewUrl);
-              }
-            });
-          },
-          disposeTopAttachments: (ids: string[]) => {
-            const idSet = new Set(ids);
-            topItemsAtSend.forEach((item: TopAttachmentItem) => {
-              if (idSet.has(item.id) && item.previewUrl) {
-                URL.revokeObjectURL(item.previewUrl);
-              }
-            });
-          },
-        }
+    // 保证。in-flight 期间把 compose 文本登记到 pendingSendsRef，供切会话守卫、
+    // 草稿保存和「发送中」提示使用——这段时间内容不在输入框也还没有气泡。
+    const pendingId = ++pendingSendSeqRef.current;
+    registerPendingSend(pendingId, composeSnapshotText(handle.snapshot));
+    return getSendQueue()
+      .enqueue(() =>
+        runSendWithConsumedCompose(
+          () =>
+            props.onSend!(
+              content,
+              mention,
+              allAttachments.length > 0 ? allAttachments : undefined,
+              topAttachmentFiles.length > 0 ? topAttachmentFiles : undefined,
+              orderedBlocks.length > 0 ? orderedBlocks : undefined,
+              sendTarget
+            ),
+          handle.ids,
+          handle.compose
+        )
       )
-    );
-  }, [editor, expanded, props.onSend, props.onExpandChange, t]);
+      .finally(() => releasePendingSend(pendingId));
+  }, [
+    editor,
+    expanded,
+    props.onSend,
+    props.onCaptureSendTarget,
+    props.onExpandChange,
+    getSendQueue,
+    registerPendingSend,
+    releasePendingSend,
+    t,
+  ]);
 
   // 先接好 sendRef，再导出 context。Conversation 会在 onContext 回调里同步消费
   // initialCompose；两步必须处于同一 effect，避免首次无附件自动发送撞上空 sendRef。
@@ -1097,6 +1181,11 @@ const MessageInput: React.FC<MessageInputProps> = (props) => {
         text: () => (editor ? extractMentionsFromEditor(editor) : undefined),
         focus: () => editor?.commands.focus(),
         send: () => invokeReadySend(sendRef.current),
+        pendingSendCount: () => pendingSendsRef.current.size,
+        pendingSendText: () =>
+          Array.from(pendingSendsRef.current.values())
+            .filter((text) => text.trim() !== "")
+            .join("\n"),
         clear: () => {
           editor?.commands.clearContent(true);
           topAttachmentsRef.current.forEach((item) => {
@@ -1183,7 +1272,7 @@ const MessageInput: React.FC<MessageInputProps> = (props) => {
             handleSlashSelect(filtered[slashActiveIndex]);
           } else {
             setSlashMenuVisible(false);
-            sendRef.current?.();
+            fireAndForgetSend();
           }
           return true;
         }
@@ -1199,7 +1288,7 @@ const MessageInput: React.FC<MessageInputProps> = (props) => {
       if (event.key === "Enter" && !event.shiftKey) {
         if (mentionActiveRef.current) return false;
         if (emojiSuggestionActiveRef.current) return false;
-        sendRef.current?.();
+        fireAndForgetSend();
         return true;
       }
 
@@ -1210,6 +1299,7 @@ const MessageInput: React.FC<MessageInputProps> = (props) => {
     slashActiveIndex,
     getFilteredSlashCommands,
     handleSlashSelect,
+    fireAndForgetSend,
   ]);
 
   const toggleExpand = useCallback(() => {
@@ -1253,6 +1343,15 @@ const MessageInput: React.FC<MessageInputProps> = (props) => {
       >
         {/* 引用/编辑条在卡片内部 */}
         {topView && <div className="wk-messageinput-topview">{topView}</div>}
+
+        {/* 发送中提示 (octo-web#1280)：compose 已被消费但气泡还没出现的窗口内，
+            给用户一个「还在发」的信号，避免以为没发出去而重复操作。 */}
+        {pendingSendCount > 0 && (
+          <div className="wk-messageinput-sending" aria-live="polite">
+            {t("base.message.sending")}
+            {pendingSendCount > 1 ? ` (${pendingSendCount})` : ""}
+          </div>
+        )}
 
         {/* 顶部附件区（非图片文件 + 上传的图片） */}
         {topAttachments.length > 0 && (

--- a/packages/dmworkbase/src/Components/MessageInput/index.tsx
+++ b/packages/dmworkbase/src/Components/MessageInput/index.tsx
@@ -42,8 +42,10 @@ import {
 import { t as translate, useI18n } from "../../i18n";
 import {
   announceContextAfterSendReady,
+  createSendQueue,
   invokeReadySend,
-  runSendWithCleanup,
+  restoreComposeSnapshot,
+  runSendWithConsumedCompose,
   SendResultDetail,
 } from "./sendFlow";
 import { extractOctoRichTextClipboardPayloadFromHtml } from "../../Utils/richTextClipboard";
@@ -222,17 +224,20 @@ export interface AttachmentFile {
 interface MessageInputProps {
   context: ConversationContext;
   /**
-   * 发送回调。返回值决定是否清空编辑器/附件：
-   *   - resolve `true`（或 `undefined`/`void`，向后兼容）→ 发送成功，清空编辑器
-   *     草稿与全部本次附件；
-   *   - resolve `false` → 发送失败/未发送，保留编辑器内容、附件引用与预览 URL；
+   * 发送回调。返回值决定「已消费的 compose 是否保持消费」：
+   *   - resolve `true`（或 `undefined`/`void`，向后兼容）→ 已入队，编辑器保持清空；
+   *   - resolve `false` → 未入队（预检拒绝 / 混排上传失败等），把 compose 还原
+   *     回编辑器与顶部附件区，供用户重试；
    *   - resolve `{ editorConsumed, consumedTopIds }` → 部分成功：可表达「顶部
-   *     附件已发出但编辑器混排失败需保留」，仅清掉已消费的 top 附件，避免重试
+   *     附件已发出但编辑器混排失败需还原」，只还原未发出的 top 附件，避免重试
    *     重复发送 (octo-web#227 Jerry-Xin non-blocking)。
-   * 必须在 send 内被 `await`，否则同步清理会先于异步发送结果丢掉混排草稿。
-   * 注意 (第二轮 octo-web#227)：清理是 snapshot-aware 的——onSend 返回成功后，
-   * 仅当编辑器内容仍等于发送时的快照才会清空；用户在 await 期间输入的新草稿
-   * 不会被旧 send 误删。
+   *
+   * 语义约定 (octo-web#1280)：`true` = **消息已入队并出现在消息列表**，不是
+   * 「服务端已 ack」。已入队但 ack 失败/超时的消息会带失败标记 + 重发入口，因此
+   * 绝不能返回 `false`——否则已经可见的内容会被塞回输入框（#1280 的现象之一）。
+   *
+   * compose 在 send 开始时就被同步消费（清空编辑器 + 移除本次顶部附件），失败
+   * 才还原，所以 await 期间用户新输入的草稿不会被旧 send 干扰。
    */
   onSend?: (
     text: string,
@@ -488,8 +493,9 @@ const MessageInput: React.FC<MessageInputProps> = (props) => {
     props.context.channel().channelType === ChannelTypePerson,
   );
   const sendRef = useRef<(() => Promise<boolean>) | null>(null);
-  // 发送进行中标志：onSend 现在被 await，发送窗口内防止重复触发 (octo-web#227)。
-  const sendingRef = useRef(false);
+  // 串行发送队列 (octo-web#1280)：compose 在 send 开始时就被同步消费，因此
+  // pending 期间的新发送不再被丢弃，只需排在前一条之后执行以保持消息顺序。
+  const sendQueueRef = useRef(createSendQueue());
   const mentionActiveRef = useRef(false);
   // 表情前缀联想下拉激活标志，激活时 Enter 用于选中而非发送
   const emojiSuggestionActiveRef = useRef(false);
@@ -924,9 +930,6 @@ const MessageInput: React.FC<MessageInputProps> = (props) => {
 
   const send = useCallback(async (): Promise<boolean> => {
     if (!editor) return false;
-    // 重入保护：onSend 现在被 await，发送期间可能再次触发 Enter/快捷键，
-    // 避免同一份草稿被发送两次 (octo-web#227)。
-    if (sendingRef.current) return false;
 
     const text = editor.getText();
     if (text.length > MAX_MESSAGE_LENGTH) {
@@ -975,28 +978,75 @@ const MessageInput: React.FC<MessageInputProps> = (props) => {
     // 提取编辑器中有序内容块（文本段和粘贴图片按文档顺序交替）
     const orderedBlocks = extractOrderedBlocks(editor, attachmentFilesRef.current);
 
-    // ⚠️ 关键修复 (octo-web#227, Jerry-Xin P1 第二轮)：
-    // round 1 已把同步清理改成「await onSend、仅成功才清」，避免混排上传失败
-    // 丢整条草稿。但 await 期间编辑器仍可编辑，onSend 可能耗时数秒（上传图片 +
-    // 等 ack），用户趁发送 pending 时打的下一条草稿，会被上一条 send 成功后的
-    // 清理误删。本轮改为 snapshot-aware：
-    //   • 发送前对编辑器文档拍 JSON 快照 (editorSnapshot)；成功回来时只有当
-    //     编辑器内容仍 === 快照（用户没开始新草稿）才 clearContent，否则保留。
-    //   • 顶部附件按本次实际消费的 id 精确移除，绝不 setTopAttachments([])
-    //     全清，等待期间新加的附件因此不丢。
-    //   • onSend 可返回 { editorConsumed, consumedTopIds } 表达「顶部附件已发、
-    //     但编辑器混排失败」，让已发文件不被重试重复 (Jerry-Xin non-blocking)。
-    // 编排逻辑在纯函数 runSendWithCleanup，便于单测覆盖各竞态场景。
-    const editorSnapshot = JSON.stringify(editor.getJSON());
+    // ⚠️ 关键修复 (octo-web#1280，承接 #227 两轮)：consume-first / restore-on-failure。
+    //
+    // #227 round 1 把同步清理改成「await onSend、仅成功才清」；round 2 再加
+    // snapshot 判定，避免旧 send 清掉用户在等待期间写的新草稿。但 round 2 是
+    // 「全清或全不清」：只要 await 期间文档变了，**已经发出去的内容也留在输入框**
+    // ——这正是 #1280 报的现象（消息已在聊天记录里，输入框还挂着缩略图/文字，
+    // 再按一次 Enter 还会重复发送）。
+    //
+    // 本轮改为：发送开始时就**同步消费** compose（拍快照 → 清空编辑器 → 移除
+    // 本次顶部附件），await 之后不再对「当前文档」做任何判定：
+    //   • 成功 → UI 无需再动，只回收 File 引用与预览 URL；
+    //   • 失败（预检拒绝 / 混排上传失败等未入队情形）→ 把快照插回文档最前面、
+    //     未发出的顶部附件放回附件区，round-1 的「失败不丢草稿」保护仍然成立；
+    //     用户在等待期间新写的草稿天然完整保留（round-2 保护）。
+    // 编排逻辑在纯函数 runSendWithConsumedCompose，便于单测覆盖各竞态场景。
+    const editorSnapshot = editor.getJSON() as JSONContent;
     const consumedAttachmentAttrs = attachmentAttrs;
     const topItemsAtSend = topAttachmentsRef.current;
     const allTopIds = topItemsAtSend.map((item) => item.id);
-    sendingRef.current = true;
-    try {
-      // runSendWithCleanup 返回 editor 是否被消费（true=发送成功，false=保留草稿/发送失败）。
-      // 把真实结果 return 出去，供 initialCompose 编排器区分 sent / failed；
-      // 键盘/Enter 发送路径忽略返回值，行为不变。
-      const editorConsumed = await runSendWithCleanup(
+
+    // ── 同步消费：编辑器 + 本次顶部附件 ──────────────
+    editor.commands.clearContent();
+    if (allTopIds.length > 0) {
+      const consumedIds = new Set(allTopIds);
+      topAttachmentsRef.current = topAttachmentsRef.current.filter(
+        (a: TopAttachmentItem) => !consumedIds.has(a.id)
+      );
+      setTopAttachments(topAttachmentsRef.current);
+    }
+    if (expanded) {
+      setExpanded(false);
+      props.onExpandChange?.(false);
+    }
+
+    /** 失败回滚：把本次发送的内容插回编辑器，新草稿排在其后（策略见 sendFlow）。 */
+    const restoreEditorSnapshot = () =>
+      restoreComposeSnapshot(editorSnapshot, {
+        isEmpty: () => editor.isEmpty,
+        setContent: (snapshot) => editor.commands.setContent(snapshot as JSONContent),
+        focusEnd: () => editor.commands.focus("end"),
+        insertContentAtStart: (blocks) =>
+          editor.commands.insertContentAt(0, blocks as JSONContent[]),
+        appendContent: (blocks) =>
+          editor.commands.insertContent(blocks as JSONContent[]),
+      });
+
+    /** 失败回滚：把未真正发出的顶部附件放回附件区（预览 URL 未被 revoke）。 */
+    const restoreTopItems = (ids: string[]) => {
+      const idSet = new Set(ids);
+      const restored = topItemsAtSend.filter((item: TopAttachmentItem) =>
+        idSet.has(item.id)
+      );
+      if (restored.length === 0) return;
+      const live = new Set(
+        topAttachmentsRef.current.map((a: TopAttachmentItem) => a.id)
+      );
+      topAttachmentsRef.current = [
+        ...restored.filter((item: TopAttachmentItem) => !live.has(item.id)),
+        ...topAttachmentsRef.current,
+      ];
+      setTopAttachments(topAttachmentsRef.current);
+    };
+
+    // 串行队列取代旧的重入保护：pending 期间的 Enter 不再被静默丢弃（#1280 的
+    // 「连点没反应」），而是排在前一条之后执行，消息顺序仍由 Conversation 等 ack
+    // 保证。返回真实结果供 initialCompose 编排器区分 sent / failed；
+    // 键盘/Enter 路径忽略返回值，行为不变。
+    return sendQueueRef.current.enqueue(() =>
+      runSendWithConsumedCompose(
         () =>
           props.onSend!(
             content,
@@ -1007,47 +1057,27 @@ const MessageInput: React.FC<MessageInputProps> = (props) => {
           ),
         allTopIds,
         {
-          isEditorUnchanged: () =>
-            JSON.stringify(editor.getJSON()) === editorSnapshot,
-          deleteEditorAttachmentRefs: () => {
+          restoreEditor: restoreEditorSnapshot,
+          restoreTopAttachments: restoreTopItems,
+          disposeEditorAttachments: () => {
             consumedAttachmentAttrs.forEach((attr) => {
               attachmentFilesRef.current.delete(attr.id);
-            });
-          },
-          revokeEditorPreviewUrls: () => {
-            consumedAttachmentAttrs.forEach((attr) => {
               if (attr.previewUrl) {
                 URL.revokeObjectURL(attr.previewUrl);
               }
             });
           },
-          clearEditor: () => editor.commands.clearContent(),
-          removeTopAttachments: (ids: string[]) => {
+          disposeTopAttachments: (ids: string[]) => {
             const idSet = new Set(ids);
-            // 先 revoke 被消费项的预览 URL（避免内存泄漏），用拍快照时的列表
-            // 取 previewUrl，再按 id 过滤当前 state——保留等待期间新加的附件。
             topItemsAtSend.forEach((item: TopAttachmentItem) => {
               if (idSet.has(item.id) && item.previewUrl) {
                 URL.revokeObjectURL(item.previewUrl);
               }
             });
-            topAttachmentsRef.current = topAttachmentsRef.current.filter(
-              (a: TopAttachmentItem) => !idSet.has(a.id)
-            );
-            setTopAttachments(topAttachmentsRef.current);
-          },
-          collapseExpanded: () => {
-            if (expanded) {
-              setExpanded(false);
-              props.onExpandChange?.(false);
-            }
           },
         }
-      );
-      return editorConsumed;
-    } finally {
-      sendingRef.current = false;
-    }
+      )
+    );
   }, [editor, expanded, props.onSend, props.onExpandChange, t]);
 
   // 先接好 sendRef，再导出 context。Conversation 会在 onContext 回调里同步消费

--- a/packages/dmworkbase/src/Components/MessageInput/index.tsx
+++ b/packages/dmworkbase/src/Components/MessageInput/index.tsx
@@ -269,7 +269,7 @@ interface MessageInputProps {
    */
   onCaptureSendTarget?: () => SendTargetSnapshot | undefined;
   /** Capture draft state before this send enters the serial queue. */
-  onCaptureSendDraft?: () => SendDraftSnapshot;
+  onCaptureSendDraft?: () => Omit<SendDraftSnapshot, "text">;
   members?: Array<Subscriber>;
   onInputRef?: any;
   onInsertText?: (fnc: OnInsertFnc) => void;
@@ -398,6 +398,8 @@ export interface MessageInputContext {
    * two states is a possible refinement (#1333 review, non-blocking).
    */
   pendingSendCount: () => number;
+  /** Plain text of unsettled composes in consumption order, including empties. */
+  pendingSendDrafts: () => string[];
   /** Plain text of every unsettled compose, newest last. */
   pendingSendText: () => string;
 }
@@ -1072,7 +1074,7 @@ const MessageInput: React.FC<MessageInputProps> = (props) => {
     // 结果编排在 sendFlow.ts 的 runSendWithConsumedCompose。
     // reply/edit 目标必须与 compose 同步取走（见 SendTargetSnapshot 注释）。
     const sendTarget = props.onCaptureSendTarget?.();
-    const sendDraft = props.onCaptureSendDraft?.();
+    const sendDraftBaseline = props.onCaptureSendDraft?.();
     // 本次消费会清空编辑器与本次附件，之前失败还原留下的偏移随之失效。
     restoreOffsetsRef.current = { blocks: 0, topAttachments: 0 };
     const expandedAtSend = expanded;
@@ -1138,6 +1140,10 @@ const MessageInput: React.FC<MessageInputProps> = (props) => {
         });
       },
     });
+    const composeText = composeSnapshotText(handle.snapshot);
+    const sendDraft = sendDraftBaseline
+      ? { ...sendDraftBaseline, text: composeText }
+      : undefined;
 
     if (expanded) {
       setExpanded(false);
@@ -1152,7 +1158,7 @@ const MessageInput: React.FC<MessageInputProps> = (props) => {
     // 丢失窗口），也包含「气泡已出现但仍在上传/等 ack」。后者保留是有意的：这些
     // 调用方要判断此刻能否安全拆掉会话，仍在排序的消息也算未完成的活。
     const pendingId = ++pendingSendSeqRef.current;
-    registerPendingSend(pendingId, composeSnapshotText(handle.snapshot));
+    registerPendingSend(pendingId, composeText);
     return getSendQueue()
       .enqueue(() =>
         runSendWithConsumedCompose(
@@ -1202,6 +1208,7 @@ const MessageInput: React.FC<MessageInputProps> = (props) => {
         focus: () => editor?.commands.focus(),
         send: () => invokeReadySend(sendRef.current),
         pendingSendCount: () => pendingSendsRef.current.size,
+        pendingSendDrafts: () => Array.from(pendingSendsRef.current.values()),
         pendingSendText: () =>
           Array.from(pendingSendsRef.current.values())
             .filter((text) => text.trim() !== "")

--- a/packages/dmworkbase/src/Components/MessageInput/mentionSendParse.ts
+++ b/packages/dmworkbase/src/Components/MessageInput/mentionSendParse.ts
@@ -270,7 +270,10 @@ export interface DraftDoc {
  * and restored also degrades to inert text — a fail-closed UX nick, not a
  * security loss. The plain typed-@ → send path (no draft) is unaffected.
  */
-export function parseDraftToContent(text: string): DraftDoc {
+function parseTextToContent(
+  text: string,
+  restoreTrustedBroadcast: boolean,
+): DraftDoc {
   const lines = text.split("\n");
   const paragraphs = lines.map((line) => {
     const nodes: DraftDocNode[] = [];
@@ -281,7 +284,8 @@ export function parseDraftToContent(text: string): DraftDoc {
     let match: RegExpExecArray | null;
 
     while ((match = regex.exec(line)) !== null) {
-      const uid = stripTrustMark(match[1]);
+      const rawUid = match[1];
+      const uid = stripTrustMark(rawUid);
       const label = match[2];
       const matchStart = match.index;
 
@@ -289,7 +293,10 @@ export function parseDraftToContent(text: string): DraftDoc {
         nodes.push({ type: "text", text: line.slice(lastIndex, matchStart) });
       }
 
-      if (isBroadcastSentinelUid(uid)) {
+      if (
+        isBroadcastSentinelUid(uid) &&
+        !(restoreTrustedBroadcast && rawUid.startsWith(MENTION_TRUST_MARK))
+      ) {
         // Fail closed: never rebuild a broadcast sentinel as a node from
         // untrusted draft text — emit inert `@label` text instead.
         nodes.push({ type: "text", text: `@${label}` });
@@ -308,4 +315,13 @@ export function parseDraftToContent(text: string): DraftDoc {
   });
 
   return { type: "doc", content: paragraphs };
+}
+
+export function parseDraftToContent(text: string): DraftDoc {
+  return parseTextToContent(text, false);
+}
+
+/** Restore text serialized directly from consumed editor nodes. */
+export function parseConsumedTextToContent(text: string): DraftDoc {
+  return parseTextToContent(text, true);
 }

--- a/packages/dmworkbase/src/Components/MessageInput/sendFlow.ts
+++ b/packages/dmworkbase/src/Components/MessageInput/sendFlow.ts
@@ -77,14 +77,24 @@ export interface SendResultDetail {
    *  the rest are restored. Omit to derive from `editorConsumed`. */
   consumedTopIds?: string[];
   /**
-   * Ids of pasted (in-editor) attachments that were NOT sent even though other
-   * blocks of the same compose were — e.g. one of two pasted images is rejected
-   * by the upload pre-check. Only these attachment nodes are restored into the
-   * editor; their `File` refs and preview URLs are kept alive so the user can
-   * retry just that image instead of silently losing it (#1280 review).
+   * The parts of the editor compose that were NOT sent even though other parts
+   * were — e.g. one of two pasted images rejected by the upload pre-check, or a
+   * text block whose send threw before enqueue after an earlier block had already
+   * gone out. Listed in document order; only these are restored into the editor,
+   * and the `File` refs / preview URLs of the listed attachments are kept alive so
+   * the user can retry exactly what did not make it (#1280 review).
    */
-  unsentEditorAttachmentIds?: string[];
+  unsentEditorBlocks?: UnsentEditorBlock[];
 }
+
+/**
+ * A piece of the editor compose that did not make it out. Attachments are
+ * addressed by node id; text carries its send-format string (with `@[uid:label]`
+ * markers) because text blocks have no stable id.
+ */
+export type UnsentEditorBlock =
+  | { type: "attachment"; id: string }
+  | { type: "text"; text: string };
 
 export type SendResult = void | boolean | SendResultDetail;
 
@@ -178,11 +188,10 @@ export interface ConsumedCompose {
    */
   restoreEditor: () => void;
   /**
-   * Put back only these pasted-attachment nodes (the rest of the compose *was*
-   * sent). Used for `unsentEditorAttachmentIds`, e.g. one of two pasted images
-   * rejected by the upload pre-check.
+   * Put back only these parts of the compose, in document order (the rest *was*
+   * sent). Used for `unsentEditorBlocks`.
    */
-  restoreEditorAttachments: (ids: string[]) => void;
+  restoreEditorBlocks: (blocks: UnsentEditorBlock[]) => void;
   /** Drop in-memory `File` refs + revoke preview URLs of these pasted images. */
   disposeEditorAttachments: (ids: string[]) => void;
   /** Revoke preview URLs of top attachments that stay consumed. */
@@ -271,7 +280,7 @@ export function restoreComposeSnapshot(
 interface SendDecision {
   editorConsumed: boolean;
   consumedTopIds: string[];
-  unsentEditorAttachmentIds: string[];
+  unsentEditorBlocks: UnsentEditorBlock[];
 }
 
 /** Normalize the loose `SendResult` union into an explicit decision. */
@@ -280,28 +289,25 @@ function normalizeResult(
   ids: ConsumedComposeIds,
 ): SendDecision {
   if (result === false) {
-    return {
-      editorConsumed: false,
-      consumedTopIds: [],
-      unsentEditorAttachmentIds: ids.editorAttachmentIds,
-    };
+    return { editorConsumed: false, consumedTopIds: [], unsentEditorBlocks: [] };
   }
   if (result === true || result == null) {
     // void / undefined / true → full success.
     return {
       editorConsumed: true,
       consumedTopIds: ids.topIds,
-      unsentEditorAttachmentIds: [],
+      unsentEditorBlocks: [],
     };
   }
-  // Detailed partial result.
+  // Detailed partial result. When the editor compose was not consumed the whole
+  // snapshot is restored, so a per-block list would be redundant.
   return {
     editorConsumed: result.editorConsumed,
     consumedTopIds:
       result.consumedTopIds ?? (result.editorConsumed ? ids.topIds : []),
-    unsentEditorAttachmentIds: result.editorConsumed
-      ? result.unsentEditorAttachmentIds ?? []
-      : ids.editorAttachmentIds,
+    unsentEditorBlocks: result.editorConsumed
+      ? result.unsentEditorBlocks ?? []
+      : [],
   };
 }
 
@@ -333,11 +339,7 @@ export async function runSendWithConsumedCompose(
   } catch (err) {
     // onSend should surface its own error toast; we just restore the draft.
     console.error("[MessageInput] send failed, restoring draft", err);
-    decision = {
-      editorConsumed: false,
-      consumedTopIds: [],
-      unsentEditorAttachmentIds: ids.editorAttachmentIds,
-    };
+    decision = { editorConsumed: false, consumedTopIds: [], unsentEditorBlocks: [] };
   }
 
   const step = (label: string, run: () => void) => {
@@ -371,20 +373,26 @@ export async function runSendWithConsumedCompose(
     return false;
   }
 
-  // The editor compose was sent, but individual pasted attachments may have been
-  // rejected before enqueue — keep those alive and put just them back.
-  const unsent = new Set(decision.unsentEditorAttachmentIds);
+  // The editor compose went out, but individual blocks may have failed before
+  // enqueue (a rejected pasted image, or a text block whose send threw after an
+  // earlier block had already been sent). Keep those alive and put just them back
+  // — everything else stays consumed so nothing is sent twice.
+  const unsentAttachmentIds = new Set(
+    decision.unsentEditorBlocks
+      .filter((block) => block.type === "attachment")
+      .map((block) => (block as { id: string }).id),
+  );
   const disposableEditorIds = ids.editorAttachmentIds.filter(
-    (id) => !unsent.has(id),
+    (id) => !unsentAttachmentIds.has(id),
   );
   if (disposableEditorIds.length > 0) {
     step("disposeEditorAttachments", () =>
       compose.disposeEditorAttachments(disposableEditorIds),
     );
   }
-  if (unsent.size > 0) {
-    step("restoreEditorAttachments", () =>
-      compose.restoreEditorAttachments(Array.from(unsent)),
+  if (decision.unsentEditorBlocks.length > 0) {
+    step("restoreEditorBlocks", () =>
+      compose.restoreEditorBlocks(decision.unsentEditorBlocks),
     );
   }
 

--- a/packages/dmworkbase/src/Components/MessageInput/sendFlow.ts
+++ b/packages/dmworkbase/src/Components/MessageInput/sendFlow.ts
@@ -119,6 +119,8 @@ export interface SendTargetSnapshot {
 export interface SendDraftSnapshot {
   generation: number;
   remoteDraft: string;
+  /** Plain text synchronously consumed by this send. */
+  text: string;
 }
 
 /**

--- a/packages/dmworkbase/src/Components/MessageInput/sendFlow.ts
+++ b/packages/dmworkbase/src/Components/MessageInput/sendFlow.ts
@@ -85,6 +85,8 @@ export interface SendResultDetail {
    * the user can retry exactly what did not make it (#1280 review).
    */
   unsentEditorBlocks?: UnsentEditorBlock[];
+  /** Restore the captured reply/edit target alongside a partial editor restore. */
+  restoreSendTarget?: boolean;
 }
 
 /**
@@ -111,6 +113,12 @@ export type SendResult = void | boolean | SendResultDetail;
  */
 export interface SendTargetSnapshot {
   restore: () => void;
+}
+
+/** Draft state captured synchronously when the compose is consumed. */
+export interface SendDraftSnapshot {
+  generation: number;
+  remoteDraft: string;
 }
 
 /**
@@ -192,6 +200,8 @@ export interface ConsumedCompose {
    * sent). Used for `unsentEditorBlocks`.
    */
   restoreEditorBlocks: (blocks: UnsentEditorBlock[]) => void;
+  /** Put back only the captured reply/edit target after a partial send failure. */
+  restoreSendTarget: () => void;
   /** Drop in-memory `File` refs + revoke preview URLs of these pasted images. */
   disposeEditorAttachments: (ids: string[]) => void;
   /** Revoke preview URLs of top attachments that stay consumed. */
@@ -281,6 +291,7 @@ interface SendDecision {
   editorConsumed: boolean;
   consumedTopIds: string[];
   unsentEditorBlocks: UnsentEditorBlock[];
+  restoreSendTarget: boolean;
 }
 
 /** Normalize the loose `SendResult` union into an explicit decision. */
@@ -289,7 +300,12 @@ function normalizeResult(
   ids: ConsumedComposeIds,
 ): SendDecision {
   if (result === false) {
-    return { editorConsumed: false, consumedTopIds: [], unsentEditorBlocks: [] };
+    return {
+      editorConsumed: false,
+      consumedTopIds: [],
+      unsentEditorBlocks: [],
+      restoreSendTarget: false,
+    };
   }
   if (result === true || result == null) {
     // void / undefined / true → full success.
@@ -297,6 +313,7 @@ function normalizeResult(
       editorConsumed: true,
       consumedTopIds: ids.topIds,
       unsentEditorBlocks: [],
+      restoreSendTarget: false,
     };
   }
   // Detailed partial result. When the editor compose was not consumed the whole
@@ -308,6 +325,9 @@ function normalizeResult(
     unsentEditorBlocks: result.editorConsumed
       ? result.unsentEditorBlocks ?? []
       : [],
+    restoreSendTarget: result.editorConsumed
+      ? result.restoreSendTarget === true
+      : false,
   };
 }
 
@@ -339,7 +359,12 @@ export async function runSendWithConsumedCompose(
   } catch (err) {
     // onSend should surface its own error toast; we just restore the draft.
     console.error("[MessageInput] send failed, restoring draft", err);
-    decision = { editorConsumed: false, consumedTopIds: [], unsentEditorBlocks: [] };
+    decision = {
+      editorConsumed: false,
+      consumedTopIds: [],
+      unsentEditorBlocks: [],
+      restoreSendTarget: false,
+    };
   }
 
   const step = (label: string, run: () => void) => {
@@ -391,9 +416,14 @@ export async function runSendWithConsumedCompose(
     );
   }
   if (decision.unsentEditorBlocks.length > 0) {
+    if (decision.restoreSendTarget) {
+      step("restoreSendTarget", () => compose.restoreSendTarget());
+    }
     step("restoreEditorBlocks", () =>
       compose.restoreEditorBlocks(decision.unsentEditorBlocks),
     );
+  } else if (decision.restoreSendTarget) {
+    step("restoreSendTarget", () => compose.restoreSendTarget());
   }
 
   return true;

--- a/packages/dmworkbase/src/Components/MessageInput/sendFlow.ts
+++ b/packages/dmworkbase/src/Components/MessageInput/sendFlow.ts
@@ -76,9 +76,32 @@ export interface SendResultDetail {
   /** Ids of top attachments that were actually sent. Only these stay consumed;
    *  the rest are restored. Omit to derive from `editorConsumed`. */
   consumedTopIds?: string[];
+  /**
+   * Ids of pasted (in-editor) attachments that were NOT sent even though other
+   * blocks of the same compose were — e.g. one of two pasted images is rejected
+   * by the upload pre-check. Only these attachment nodes are restored into the
+   * editor; their `File` refs and preview URLs are kept alive so the user can
+   * retry just that image instead of silently losing it (#1280 review).
+   */
+  unsentEditorAttachmentIds?: string[];
 }
 
 export type SendResult = void | boolean | SendResultDetail;
+
+/**
+ * Per-send target (reply / edit) captured synchronously with the compose.
+ *
+ * #1280: `Conversation.onSend` used to read `vm.currentReplyMessage` /
+ * `vm.currentHandlerType` when it ran. With sends queued, that read happens
+ * *after* the user may have picked a different reply target — or switched to
+ * "edit message" — so a queued send could reply to the wrong message or
+ * overwrite an unrelated one. The target is therefore taken (and its banner
+ * cleared) at key-press time, travels with the compose, and is put back by
+ * `restore()` when the send is not enqueued so a retry still edits/replies.
+ */
+export interface SendTargetSnapshot {
+  restore: () => void;
+}
 
 /**
  * Publish a composer context only after its imperative send callback is wired.
@@ -125,8 +148,9 @@ export function createSendQueue(): SendQueue {
     enqueue<T>(task: () => Promise<T>): Promise<T> {
       pending += 1;
       const run = () => task();
-      // Run after the previous task settles, regardless of its outcome.
-      const result = tail.then(run, run);
+      // `tail` is always a promise that cannot reject (see below), so a single
+      // fulfilment handler is enough — and states that invariant honestly.
+      const result = tail.then(run);
       tail = result.then(
         () => undefined,
         () => undefined,
@@ -147,17 +171,40 @@ export function createSendQueue(): SendQueue {
  */
 export interface ConsumedCompose {
   /**
-   * Put the consumed editor compose back (failure path). Implementations must
-   * re-insert it *before* any draft the user typed during the await, and must
-   * keep the pasted-image node ids so their `File` refs still resolve.
+   * Put the whole consumed editor compose back (nothing was sent).
+   * Implementations must re-insert it *before* any draft the user typed during
+   * the await, and must keep the pasted-image node ids so their `File` refs
+   * still resolve.
    */
   restoreEditor: () => void;
-  /** Drop in-memory pasted-image `File` refs + revoke their preview URLs. */
-  disposeEditorAttachments: () => void;
+  /**
+   * Put back only these pasted-attachment nodes (the rest of the compose *was*
+   * sent). Used for `unsentEditorAttachmentIds`, e.g. one of two pasted images
+   * rejected by the upload pre-check.
+   */
+  restoreEditorAttachments: (ids: string[]) => void;
+  /** Drop in-memory `File` refs + revoke preview URLs of these pasted images. */
+  disposeEditorAttachments: (ids: string[]) => void;
   /** Revoke preview URLs of top attachments that stay consumed. */
   disposeTopAttachments: (ids: string[]) => void;
-  /** Put back the top attachments that were not actually sent (failure path). */
+  /** Put back the top attachments that were not actually sent. */
   restoreTopAttachments: (ids: string[]) => void;
+  /**
+   * Called when one restore/dispose step throws. Every step is isolated so a
+   * failure in one can never skip the others (#1280 review: an editor restore
+   * throwing used to swallow the attachment restore as well). Implementations
+   * should surface this to the user — content that is in neither the composer
+   * nor the message list must not disappear silently.
+   */
+  onRestoreError?: (err: unknown, step: string) => void;
+}
+
+/** Everything this send attempt consumed, used to expand loose send results. */
+export interface ConsumedComposeIds {
+  /** Ids of every top attachment handed to this send attempt. */
+  topIds: string[];
+  /** Ids of every pasted (in-editor) attachment handed to this send attempt. */
+  editorAttachmentIds: string[];
 }
 
 /**
@@ -171,8 +218,13 @@ export interface ComposeRestoreTarget {
   setContent: (snapshot: unknown) => void;
   /** Put the caret at the end of the document. */
   focusEnd: () => void;
-  /** Insert the snapshot blocks BEFORE the live content. */
-  insertContentAtStart: (blocks: unknown[]) => void;
+  /**
+   * Insert the snapshot blocks before the live content, after `blockOffset`
+   * leading blocks. The offset is how many leading blocks already belong to
+   * earlier restores, so consecutive failed sends keep their original order
+   * instead of stacking up reversed (#1280 review).
+   */
+  insertContentAtBlock: (blockOffset: number, blocks: unknown[]) => void;
   /** Fallback: append the snapshot blocks at the end. */
   appendContent: (blocks: unknown[]) => void;
 }
@@ -185,92 +237,156 @@ export interface ComposeRestoreTarget {
  *   there";
  * - non-empty document (the user already started the next message) → the failed
  *   content is inserted BEFORE the new draft, so nothing is overwritten (this is
- *   what #227 round 2 protected, now without leaving sent content behind);
+ *   what #227 round 2 protected, now without leaving sent content behind), and
+ *   AFTER content restored by earlier failed sends so their order survives;
  * - a position error never loses content: fall back to appending.
+ *
+ * @returns how many blocks were inserted, so the caller can advance the offset
+ *   for a following restore.
  */
 export function restoreComposeSnapshot(
-  snapshot: { content?: unknown[] } | undefined,
+  snapshot: { type?: string; content?: unknown[] } | undefined,
   target: ComposeRestoreTarget,
-): void {
+  blockOffset = 0,
+): number {
   const blocks = snapshot?.content;
-  if (!blocks || blocks.length === 0) return;
+  if (!blocks || blocks.length === 0) return 0;
   if (target.isEmpty()) {
     target.setContent(snapshot);
     target.focusEnd();
-    return;
+    return blocks.length;
   }
   try {
-    target.insertContentAtStart(blocks);
+    target.insertContentAtBlock(blockOffset, blocks);
   } catch (err) {
     console.error(
-      "[MessageInput] restoring the draft at the document start failed, appending instead",
+      "[MessageInput] restoring the draft in place failed, appending instead",
       err,
     );
     target.appendContent(blocks);
   }
+  return blocks.length;
+}
+
+interface SendDecision {
+  editorConsumed: boolean;
+  consumedTopIds: string[];
+  unsentEditorAttachmentIds: string[];
 }
 
 /** Normalize the loose `SendResult` union into an explicit decision. */
 function normalizeResult(
   result: SendResult,
-  allTopIds: string[],
-): { editorConsumed: boolean; consumedTopIds: string[] } {
+  ids: ConsumedComposeIds,
+): SendDecision {
   if (result === false) {
-    return { editorConsumed: false, consumedTopIds: [] };
+    return {
+      editorConsumed: false,
+      consumedTopIds: [],
+      unsentEditorAttachmentIds: ids.editorAttachmentIds,
+    };
   }
   if (result === true || result == null) {
     // void / undefined / true → full success.
-    return { editorConsumed: true, consumedTopIds: allTopIds };
+    return {
+      editorConsumed: true,
+      consumedTopIds: ids.topIds,
+      unsentEditorAttachmentIds: [],
+    };
   }
   // Detailed partial result.
   return {
     editorConsumed: result.editorConsumed,
     consumedTopIds:
-      result.consumedTopIds ?? (result.editorConsumed ? allTopIds : []),
+      result.consumedTopIds ?? (result.editorConsumed ? ids.topIds : []),
+    unsentEditorAttachmentIds: result.editorConsumed
+      ? result.unsentEditorAttachmentIds ?? []
+      : ids.editorAttachmentIds,
   };
 }
 
 /**
  * Await `send()` for a compose the caller already consumed, then either dispose
- * the consumed resources (success) or restore the compose (failure).
+ * the consumed resources or restore what was not sent.
  *
- * @param allTopIds Ids of every top attachment handed to this send attempt;
- *   used to expand a `true`/`void` result into "all consumed" and to compute
- *   which ones must be restored on a partial result.
+ * Ordering and isolation matter here (#1280 review):
+ *   - top attachments are settled BEFORE the editor, so an editor restore that
+ *     throws (e.g. the editor was destroyed by a channel switch) can never skip
+ *     putting the unsent files back;
+ *   - every step runs in its own try/catch and reports through
+ *     `compose.onRestoreError`, so one failure never cascades into losing the
+ *     rest of the compose, and the caller can surface it to the user.
+ *
+ * @param ids Everything this attempt consumed; used to expand `true`/`void`
+ *   into "all consumed" and to compute what must be restored.
  * @returns `true` if the editor compose was consumed; `false` if it was
  *   restored for retry.
  */
 export async function runSendWithConsumedCompose(
   send: () => SendResult | Promise<SendResult>,
-  allTopIds: string[],
+  ids: ConsumedComposeIds,
   compose: ConsumedCompose,
 ): Promise<boolean> {
-  let decision: { editorConsumed: boolean; consumedTopIds: string[] };
+  let decision: SendDecision;
   try {
-    decision = normalizeResult(await send(), allTopIds);
+    decision = normalizeResult(await send(), ids);
   } catch (err) {
     // onSend should surface its own error toast; we just restore the draft.
     console.error("[MessageInput] send failed, restoring draft", err);
-    decision = { editorConsumed: false, consumedTopIds: [] };
+    decision = {
+      editorConsumed: false,
+      consumedTopIds: [],
+      unsentEditorAttachmentIds: ids.editorAttachmentIds,
+    };
   }
 
-  if (decision.editorConsumed) {
-    compose.disposeEditorAttachments();
-  } else {
+  const step = (label: string, run: () => void) => {
+    try {
+      run();
+    } catch (err) {
+      console.error(`[MessageInput] compose ${label} failed`, err);
+      compose.onRestoreError?.(err, label);
+    }
+  };
+
+  // ── Top attachments first: never skippable by an editor-side failure ──
+  const consumedTop = new Set(decision.consumedTopIds);
+  const restoredTopIds = ids.topIds.filter((id) => !consumedTop.has(id));
+  if (decision.consumedTopIds.length > 0) {
+    step("disposeTopAttachments", () =>
+      compose.disposeTopAttachments(decision.consumedTopIds),
+    );
+  }
+  if (restoredTopIds.length > 0) {
+    step("restoreTopAttachments", () =>
+      compose.restoreTopAttachments(restoredTopIds),
+    );
+  }
+
+  if (!decision.editorConsumed) {
     // Nothing was sent (or the mixed compose failed before enqueue) → give the
     // content back. Refs/URLs are intentionally NOT disposed here so the
     // restored pasted images still resolve to their `File` objects.
-    compose.restoreEditor();
+    step("restoreEditor", () => compose.restoreEditor());
+    return false;
   }
 
-  const consumed = new Set(decision.consumedTopIds);
-  const restoredTopIds = allTopIds.filter((id) => !consumed.has(id));
-  if (decision.consumedTopIds.length > 0) {
-    compose.disposeTopAttachments(decision.consumedTopIds);
+  // The editor compose was sent, but individual pasted attachments may have been
+  // rejected before enqueue — keep those alive and put just them back.
+  const unsent = new Set(decision.unsentEditorAttachmentIds);
+  const disposableEditorIds = ids.editorAttachmentIds.filter(
+    (id) => !unsent.has(id),
+  );
+  if (disposableEditorIds.length > 0) {
+    step("disposeEditorAttachments", () =>
+      compose.disposeEditorAttachments(disposableEditorIds),
+    );
   }
-  if (restoredTopIds.length > 0) {
-    compose.restoreTopAttachments(restoredTopIds);
+  if (unsent.size > 0) {
+    step("restoreEditorAttachments", () =>
+      compose.restoreEditorAttachments(Array.from(unsent)),
+    );
   }
 
-  return decision.editorConsumed;
+  return true;
 }

--- a/packages/dmworkbase/src/Components/MessageInput/sendFlow.ts
+++ b/packages/dmworkbase/src/Components/MessageInput/sendFlow.ts
@@ -1,55 +1,80 @@
 /**
- * Send-flow orchestration helper (octo-web#227, Jerry-Xin P1).
+ * Send-flow orchestration helper (octo-web#227 → octo-web#1280).
  *
- * Background — two data-loss bugs this guards against:
+ * ## History — three rounds of send-side bugs
  *
- * 1. (round 1) `MessageInput.send()` used to call `props.onSend(...)` (typed
+ * 1. (#227 round 1) `MessageInput.send()` called `props.onSend(...)` (typed
  *    `=> void`, never awaited) and then, in the *same synchronous frame*,
  *    unconditionally cleared the editor, deleted pasted-image `File` refs,
  *    revoked preview URLs and cleared the top-attachment area. For the mixed
- *    text+image RichText path `onSend` is async and only fails after an upload,
- *    so the compose state was destroyed before the failure was known — one
- *    failed upload wiped the whole draft with nothing to retry.
- *    Fix: make the contract awaitable and clean up ONLY after a successful send.
+ *    text+image path `onSend` is async and only fails after an upload, so the
+ *    compose state was destroyed before the failure was known — one failed
+ *    upload wiped the whole draft with nothing to retry.
+ *    Fix: make the contract awaitable and clean up only after the send settles.
  *
- * 2. (round 2 — this file's reason for being snapshot-aware) Once the send was
- *    awaited, the editor stayed editable during the wait. `Conversation.onSend`
- *    can take seconds (image upload + message ack). If the user finished one
- *    message and started typing the next while the first was still pending, the
- *    successful completion of the *older* send cleared the *current* (newer)
- *    editor document and top-attachment list — wiping the new draft. Pure text
- *    is affected too, because the callback now awaits `sendTextAndWaitAck`.
- *    Fix: cleanup is snapshot-aware. The editor is only cleared if it still
- *    holds exactly the content that was sent (`isEditorUnchanged`); otherwise
- *    the user's newer draft is left untouched. Top attachments are removed by
- *    the specific ids that were consumed, never with a blanket reset, so items
- *    queued during the wait survive.
- *    Residual follow-up: when the editor changed mid-flight we leave the live
- *    doc untouched, so the already-sent snapshot blocks stay alongside the new
- *    draft and could be re-sent on the next send (duplicate). Accepted over the
- *    worse "draft wiped" failure; a precise per-range removal is deferred — see
- *    the `!isEditorUnchanged()` branch below.
+ * 2. (#227 round 2) Awaiting the send left the editor editable during the wait.
+ *    `Conversation.onSend` can take seconds (upload + ack). If the user started
+ *    the next message while the first was pending, the older send's success
+ *    cleared the *current* (newer) editor — wiping the new draft.
+ *    Fix at the time: snapshot-aware cleanup — clear the editor only when it
+ *    still held exactly what was sent, otherwise leave everything alone.
  *
- * `onSend` return-value contract (back-compatible):
- *   - `undefined` / `void` → success: editor consumed, all consumed top
- *     attachments cleared (legacy void-returning callers keep working);
+ * 3. (#1280 — this round) The round-2 fix was all-or-nothing, and its own
+ *    "known residual edge case" became the top user complaint: when the user
+ *    keeps typing / pasting while a send is in flight (the normal "send several
+ *    images in a row" flow), the *already sent* content is left in the composer
+ *    forever. The message is visible in the history, so the composer looks
+ *    broken ("nothing was sent"), and pressing send again re-sends it.
+ *    Two other defects piled onto the same symptom:
+ *      • `MessageInput` had a re-entrancy guard that silently dropped any send
+ *        issued while another was pending — the 2nd/3rd Enter did nothing;
+ *      • `Conversation` reported an ack timeout as *failure*, so a slow network
+ *        pushed already-delivered content back into the composer.
+ *
+ * ## Current model: consume-first, restore-on-failure
+ *
+ * The composer is consumed **synchronously** when the send starts (editor
+ * cleared, consumed top attachments removed) and the compose payload is
+ * captured. Nothing about the composer is decided after the await, so the whole
+ * "did the document change while we waited?" race disappears:
+ *
+ *   - success → nothing to clean in the UI; only in-memory `File` refs and
+ *     preview object URLs of the consumed compose are disposed;
+ *   - failure → the captured compose is restored (editor content re-inserted
+ *     *before* whatever the user typed meanwhile, top attachments re-added), so
+ *     the round-1 "failed upload wiped the draft" protection is preserved and
+ *     the round-2 "newer draft wiped" protection holds by construction.
+ *
+ * Sends are serialized through {@link createSendQueue} instead of being dropped:
+ * each send captures its payload immediately and runs after the previous one, so
+ * message ordering (which `Conversation` guarantees by awaiting ack) is kept
+ * while rapid consecutive sends all go out.
+ *
+ * `onSend` return-value contract (unchanged, back-compatible):
+ *   - `undefined` / `void` → success: compose consumed;
  *   - `true`               → success: same as void;
- *   - `false`              → failure / nothing sent: PRESERVE everything so the
+ *   - `false`              → failure / nothing sent: RESTORE everything so the
  *     user can retry;
- *   - `{ editorConsumed, consumedTopIds }` → partial result. Lets a caller say
- *     "the editor compose failed and must be preserved, but these top
- *     attachments were already sent — drop just those so a retry does not
- *     duplicate them" (octo-web#227 non-blocking note by Jerry-Xin);
- *   - throws               → treated as failure → preserve everything.
+ *   - `{ editorConsumed, consumedTopIds }` → partial result: "the editor compose
+ *     failed and must be restored, but these top attachments were already sent —
+ *     keep them consumed so a retry does not duplicate them";
+ *   - throws               → treated as failure → restore everything.
+ *
+ * NOTE for `onSend` implementors: "consumed" means *the message was enqueued and
+ * is visible in the message list* — not "the server acked it". A message that is
+ * enqueued and later fails renders a failure marker with resend, so it must NOT
+ * be reported as `false`; reporting `false` would push already-visible content
+ * back into the composer (defect 3c above).
  */
 
 /** Partial send outcome — see contract above. */
 export interface SendResultDetail {
   /** Whether the editor compose (text + pasted images / ordered blocks) was
-   *  sent. `true` → the editor may be cleared; `false` → preserve it. */
+   *  sent. `true` → the consumed editor content stays consumed; `false` → it is
+   *  restored into the live editor. */
   editorConsumed: boolean;
-  /** Ids of top attachments that were actually sent. Only these are removed
-   *  from the top-attachment area. Omit to derive from `editorConsumed`. */
+  /** Ids of top attachments that were actually sent. Only these stay consumed;
+   *  the rest are restored. Omit to derive from `editorConsumed`. */
   consumedTopIds?: string[];
 }
 
@@ -76,28 +101,113 @@ export async function invokeReadySend(
   return send ? send() : false;
 }
 
-/** Snapshot-aware cleanup steps, run after the send settles. */
-export interface SendCleanup {
+/**
+ * Serial task queue for sends.
+ *
+ * Rapid consecutive sends used to be dropped by a re-entrancy guard (#1280):
+ * while one send awaited upload+ack, every following Enter returned `false`
+ * without feedback. Since the compose is now captured synchronously, a pending
+ * send no longer has to block the next one — it only has to run *before* it, so
+ * the messages keep their order.
+ *
+ * Failures never break the chain: a rejected task still lets the queue continue.
+ */
+export interface SendQueue {
+  enqueue<T>(task: () => Promise<T>): Promise<T>;
+  /** Number of tasks queued or running. Exposed for a "sending" UI state/tests. */
+  readonly pending: number;
+}
+
+export function createSendQueue(): SendQueue {
+  let tail: Promise<unknown> = Promise.resolve();
+  let pending = 0;
+  return {
+    enqueue<T>(task: () => Promise<T>): Promise<T> {
+      pending += 1;
+      const run = () => task();
+      // Run after the previous task settles, regardless of its outcome.
+      const result = tail.then(run, run);
+      tail = result.then(
+        () => undefined,
+        () => undefined,
+      );
+      return result.finally(() => {
+        pending -= 1;
+      });
+    },
+    get pending() {
+      return pending;
+    },
+  };
+}
+
+/**
+ * Restore / dispose hooks for a compose that was already consumed synchronously
+ * by the caller before the send started.
+ */
+export interface ConsumedCompose {
   /**
-   * True iff the editor still holds exactly the document that was sent, i.e. the
-   * user has NOT started a new draft during the await. Editor-scoped cleanup is
-   * skipped when this returns false so a newer draft is never wiped by an older
-   * send.
+   * Put the consumed editor compose back (failure path). Implementations must
+   * re-insert it *before* any draft the user typed during the await, and must
+   * keep the pasted-image node ids so their `File` refs still resolve.
    */
-  isEditorUnchanged: () => boolean;
-  /** Delete in-memory pasted-image File refs consumed by this send. */
-  deleteEditorAttachmentRefs: () => void;
-  /** Revoke object URLs for the editor's pasted-image previews. */
-  revokeEditorPreviewUrls: () => void;
-  /** Clear the editor document. */
-  clearEditor: () => void;
-  /**
-   * Remove the given top attachments (by id) and revoke their preview URLs.
-   * Id-scoped so attachments queued during the await are preserved.
-   */
-  removeTopAttachments: (ids: string[]) => void;
-  /** Optional: collapse the expanded composer (only when the editor is cleared). */
-  collapseExpanded?: () => void;
+  restoreEditor: () => void;
+  /** Drop in-memory pasted-image `File` refs + revoke their preview URLs. */
+  disposeEditorAttachments: () => void;
+  /** Revoke preview URLs of top attachments that stay consumed. */
+  disposeTopAttachments: (ids: string[]) => void;
+  /** Put back the top attachments that were not actually sent (failure path). */
+  restoreTopAttachments: (ids: string[]) => void;
+}
+
+/**
+ * Editor operations needed to put a consumed compose back after a failed send.
+ * Structural so the restore policy can be unit-tested without a real editor.
+ */
+export interface ComposeRestoreTarget {
+  /** Whether the live document is currently empty. */
+  isEmpty: () => boolean;
+  /** Replace the whole document with the snapshot (empty-document case). */
+  setContent: (snapshot: unknown) => void;
+  /** Put the caret at the end of the document. */
+  focusEnd: () => void;
+  /** Insert the snapshot blocks BEFORE the live content. */
+  insertContentAtStart: (blocks: unknown[]) => void;
+  /** Fallback: append the snapshot blocks at the end. */
+  appendContent: (blocks: unknown[]) => void;
+}
+
+/**
+ * Restore policy for a failed send (#1280 consume-first model).
+ *
+ * - empty document (nothing typed during the await) → the snapshot is restored
+ *   as-is and the caret goes to the end, i.e. "your failed message is still
+ *   there";
+ * - non-empty document (the user already started the next message) → the failed
+ *   content is inserted BEFORE the new draft, so nothing is overwritten (this is
+ *   what #227 round 2 protected, now without leaving sent content behind);
+ * - a position error never loses content: fall back to appending.
+ */
+export function restoreComposeSnapshot(
+  snapshot: { content?: unknown[] } | undefined,
+  target: ComposeRestoreTarget,
+): void {
+  const blocks = snapshot?.content;
+  if (!blocks || blocks.length === 0) return;
+  if (target.isEmpty()) {
+    target.setContent(snapshot);
+    target.focusEnd();
+    return;
+  }
+  try {
+    target.insertContentAtStart(blocks);
+  } catch (err) {
+    console.error(
+      "[MessageInput] restoring the draft at the document start failed, appending instead",
+      err,
+    );
+    target.appendContent(blocks);
+  }
 }
 
 /** Normalize the loose `SendResult` union into an explicit decision. */
@@ -121,67 +231,46 @@ function normalizeResult(
 }
 
 /**
- * Await `send()` and apply snapshot-aware compose cleanup.
- *
- * - Consumed top attachments are removed by id (safe even if the user queued
- *   more during the wait).
- * - The editor is cleared only if its compose was consumed AND it still holds
- *   exactly what was sent; if the user typed a new draft meanwhile it is left
- *   intact.
+ * Await `send()` for a compose the caller already consumed, then either dispose
+ * the consumed resources (success) or restore the compose (failure).
  *
  * @param allTopIds Ids of every top attachment handed to this send attempt;
- *   used to expand a `true`/`void` result into "all consumed".
- * @returns `true` if the editor compose was consumed (and cleanup considered
- *   clearing it); `false` if the editor compose was preserved for retry.
+ *   used to expand a `true`/`void` result into "all consumed" and to compute
+ *   which ones must be restored on a partial result.
+ * @returns `true` if the editor compose was consumed; `false` if it was
+ *   restored for retry.
  */
-export async function runSendWithCleanup(
+export async function runSendWithConsumedCompose(
   send: () => SendResult | Promise<SendResult>,
   allTopIds: string[],
-  cleanup: SendCleanup,
+  compose: ConsumedCompose,
 ): Promise<boolean> {
   let decision: { editorConsumed: boolean; consumedTopIds: string[] };
   try {
     decision = normalizeResult(await send(), allTopIds);
   } catch (err) {
-    // onSend should surface its own error toast; we just preserve the draft.
-    console.error("[MessageInput] send failed, preserving draft", err);
+    // onSend should surface its own error toast; we just restore the draft.
+    console.error("[MessageInput] send failed, restoring draft", err);
     decision = { editorConsumed: false, consumedTopIds: [] };
   }
 
-  // Top attachments: drop only the ones actually sent. Always safe — id-scoped,
-  // so anything queued during the await stays. This runs even when the editor
-  // compose failed, so a retry of the editor does not re-send these files
-  // (octo-web#227 non-blocking note).
+  if (decision.editorConsumed) {
+    compose.disposeEditorAttachments();
+  } else {
+    // Nothing was sent (or the mixed compose failed before enqueue) → give the
+    // content back. Refs/URLs are intentionally NOT disposed here so the
+    // restored pasted images still resolve to their `File` objects.
+    compose.restoreEditor();
+  }
+
+  const consumed = new Set(decision.consumedTopIds);
+  const restoredTopIds = allTopIds.filter((id) => !consumed.has(id));
   if (decision.consumedTopIds.length > 0) {
-    cleanup.removeTopAttachments(decision.consumedTopIds);
+    compose.disposeTopAttachments(decision.consumedTopIds);
+  }
+  if (restoredTopIds.length > 0) {
+    compose.restoreTopAttachments(restoredTopIds);
   }
 
-  if (!decision.editorConsumed) {
-    // Editor compose not sent → keep its content, refs and preview URLs.
-    return false;
-  }
-
-  if (!cleanup.isEditorUnchanged()) {
-    // The user started a new draft while the older send was in flight. We must
-    // NOT clear the editor — doing so would wipe the newly typed draft (the
-    // round-2 data-loss bug). We deliberately leave the live document as-is.
-    //
-    // Known residual edge case (octo-web#227, tracked as a follow-up): the live
-    // editor now holds [already-sent snapshot blocks] + [new draft]. The
-    // already-sent blocks are NOT auto-removed here, so if the user presses send
-    // again those blocks are re-sent → a duplicate of the previous message. The
-    // message was delivered and the leftover content is visible to the user, so
-    // per the team's severity call this is accepted for now over the worse
-    // "draft wiped" failure. A precise fix (remove only the submitted snapshot
-    // range from the live doc, mirroring the by-id removeTopAttachments path)
-    // is deferred to a dedicated PR with its own ProseMirror-position tests.
-    return true;
-  }
-
-  // Editor still holds exactly what was sent → safe to clear it.
-  cleanup.deleteEditorAttachmentRefs();
-  cleanup.revokeEditorPreviewUrls();
-  cleanup.clearEditor();
-  cleanup.collapseExpanded?.();
-  return true;
+  return decision.editorConsumed;
 }

--- a/packages/dmworkbase/src/Utils/__tests__/draftLifecycle.test.ts
+++ b/packages/dmworkbase/src/Utils/__tests__/draftLifecycle.test.ts
@@ -4,7 +4,6 @@ import { resolveDraftToPersist, shouldClearDraftAfterSend } from "../draftLifecy
 describe("shouldClearDraftAfterSend", () => {
     it("clears the draft snapshot that belonged to the sent message", () => {
         expect(shouldClearDraftAfterSend({
-            draftAtSend: "hello",
             remoteDraft: "hello",
             remoteDraftAtSend: "hello",
             draftSavedAfterSend: false,
@@ -14,26 +13,23 @@ describe("shouldClearDraftAfterSend", () => {
     it("does not clear a live draft typed while the send is pending", () => {
         expect(shouldClearDraftAfterSend({
             liveDraft: "new draft",
-            draftAtSend: "hello",
             remoteDraft: "hello",
             remoteDraftAtSend: "hello",
             draftSavedAfterSend: false,
         })).toBe(false)
     })
 
-    it("clears a restored draft while the sent snapshot is still in the editor", () => {
+    it("does not clear non-empty live input even when it equals the sent text", () => {
         expect(shouldClearDraftAfterSend({
             liveDraft: "hello",
-            draftAtSend: "hello",
             remoteDraft: "hello",
             remoteDraftAtSend: "hello",
             draftSavedAfterSend: false,
-        })).toBe(true)
+        })).toBe(false)
     })
 
     it("does not clear a newer draft saved while the send is pending", () => {
         expect(shouldClearDraftAfterSend({
-            draftAtSend: "hello",
             remoteDraft: "hello",
             remoteDraftAtSend: "hello",
             draftSavedAfterSend: true,
@@ -41,20 +37,18 @@ describe("shouldClearDraftAfterSend", () => {
         })).toBe(false)
     })
 
-    it("allows the clear when a later save still contains only the sent snapshot", () => {
+    it("does not clear a non-empty draft saved after compose consumption", () => {
         expect(shouldClearDraftAfterSend({
             liveDraft: "hello",
-            draftAtSend: "hello",
             remoteDraft: "hello",
             remoteDraftAtSend: "hello",
             draftSavedAfterSend: true,
             latestSavedDraft: "hello",
-        })).toBe(true)
+        })).toBe(false)
     })
 
     it("allows the clear when the only later save is an empty editor", () => {
         expect(shouldClearDraftAfterSend({
-            draftAtSend: "hello",
             remoteDraft: "hello",
             remoteDraftAtSend: "hello",
             draftSavedAfterSend: true,
@@ -62,23 +56,31 @@ describe("shouldClearDraftAfterSend", () => {
         })).toBe(true)
     })
 
-    it("clears an edited restored draft after it is sent", () => {
+    it("does not clear edited live input after compose consumption", () => {
         expect(shouldClearDraftAfterSend({
-            draftAtSend: "hello edited",
             remoteDraft: "hello",
             remoteDraftAtSend: "hello",
             liveDraft: "hello edited",
             draftSavedAfterSend: false,
-        })).toBe(true)
+        })).toBe(false)
     })
 
     it("does not clear a remote draft updated while the send is pending", () => {
         expect(shouldClearDraftAfterSend({
-            draftAtSend: "hello",
             remoteDraft: "remote new draft",
             remoteDraftAtSend: "hello",
             liveDraft: "",
             draftSavedAfterSend: false,
+        })).toBe(false)
+    })
+
+    it("does not let queued send B erase C saved while send A was pending", () => {
+        expect(shouldClearDraftAfterSend({
+            liveDraft: "",
+            remoteDraft: "C",
+            remoteDraftAtSend: "C",
+            draftSavedAfterSend: true,
+            latestSavedDraft: "C",
         })).toBe(false)
     })
 })

--- a/packages/dmworkbase/src/Utils/__tests__/draftLifecycle.test.ts
+++ b/packages/dmworkbase/src/Utils/__tests__/draftLifecycle.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { shouldClearDraftAfterSend } from "../draftLifecycle"
+import { resolveDraftToPersist, shouldClearDraftAfterSend } from "../draftLifecycle"
 
 describe("shouldClearDraftAfterSend", () => {
     it("clears the draft snapshot that belonged to the sent message", () => {
@@ -80,5 +80,41 @@ describe("shouldClearDraftAfterSend", () => {
             liveDraft: "",
             draftSavedAfterSend: false,
         })).toBe(false)
+    })
+})
+
+describe("resolveDraftToPersist (octo-web#1280)", () => {
+    it("persists what the composer currently holds", () => {
+        expect(resolveDraftToPersist({
+            liveDraft: "typing this",
+            pendingSendText: "",
+            existingDraft: "old",
+        })).toBe("typing this")
+    })
+
+    it("does not clear the stored draft while a consumed compose is still in flight", () => {
+        // Leaving the conversation mid-send used to persist "" over content that
+        // had no bubble yet — composer, draft and message list all empty at once.
+        expect(resolveDraftToPersist({
+            liveDraft: "",
+            pendingSendText: "message being sent",
+            existingDraft: "older draft",
+        })).toBe("older draft")
+    })
+
+    it("still lets the live composer win over an in-flight compose", () => {
+        expect(resolveDraftToPersist({
+            liveDraft: "next message",
+            pendingSendText: "message being sent",
+            existingDraft: "older draft",
+        })).toBe("next message")
+    })
+
+    it("clears the draft normally when nothing is in flight", () => {
+        expect(resolveDraftToPersist({
+            liveDraft: "",
+            pendingSendText: "",
+            existingDraft: "older draft",
+        })).toBe("")
     })
 })

--- a/packages/dmworkbase/src/Utils/__tests__/draftLifecycle.test.ts
+++ b/packages/dmworkbase/src/Utils/__tests__/draftLifecycle.test.ts
@@ -1,122 +1,158 @@
 import { describe, expect, it } from "vitest"
-import { resolveDraftToPersist, shouldClearDraftAfterSend } from "../draftLifecycle"
+import { resolveDraftAfterSend, resolveDraftToPersist } from "../draftLifecycle"
 
-describe("shouldClearDraftAfterSend", () => {
-    it("clears the draft snapshot that belonged to the sent message", () => {
-        expect(shouldClearDraftAfterSend({
+describe("resolveDraftAfterSend", () => {
+    it("clears the unchanged remote draft after a successful send", () => {
+        expect(resolveDraftAfterSend({
             remoteDraft: "hello",
             remoteDraftAtSend: "hello",
             draftSavedAfterSend: false,
-        })).toBe(true)
+            sentDraft: "hello",
+            pendingDrafts: ["hello"],
+        })).toBe("")
     })
 
-    it("does not clear a live draft typed while the send is pending", () => {
-        expect(shouldClearDraftAfterSend({
-            liveDraft: "new draft",
-            remoteDraft: "hello",
-            remoteDraftAtSend: "hello",
-            draftSavedAfterSend: false,
-        })).toBe(false)
-    })
-
-    it("does not clear non-empty live input even when it equals the sent text", () => {
-        expect(shouldClearDraftAfterSend({
+    it("does not touch live input typed after compose consumption", () => {
+        expect(resolveDraftAfterSend({
             liveDraft: "hello",
             remoteDraft: "hello",
             remoteDraftAtSend: "hello",
             draftSavedAfterSend: false,
-        })).toBe(false)
+            sentDraft: "hello",
+            pendingDrafts: ["hello"],
+        })).toBeUndefined()
     })
 
-    it("does not clear a newer draft saved while the send is pending", () => {
-        expect(shouldClearDraftAfterSend({
-            remoteDraft: "hello",
-            remoteDraftAtSend: "hello",
-            draftSavedAfterSend: true,
-            latestSavedDraft: "new draft",
-        })).toBe(false)
-    })
-
-    it("does not clear a non-empty draft saved after compose consumption", () => {
-        expect(shouldClearDraftAfterSend({
-            liveDraft: "hello",
-            remoteDraft: "hello",
-            remoteDraftAtSend: "hello",
-            draftSavedAfterSend: true,
-            latestSavedDraft: "hello",
-        })).toBe(false)
-    })
-
-    it("allows the clear when the only later save is an empty editor", () => {
-        expect(shouldClearDraftAfterSend({
-            remoteDraft: "hello",
-            remoteDraftAtSend: "hello",
-            draftSavedAfterSend: true,
-            latestSavedDraft: "",
-        })).toBe(true)
-    })
-
-    it("does not clear edited live input after compose consumption", () => {
-        expect(shouldClearDraftAfterSend({
-            remoteDraft: "hello",
-            remoteDraftAtSend: "hello",
-            liveDraft: "hello edited",
+    it("does not clear a newer live draft even when its text equals the sent text", () => {
+        expect(resolveDraftAfterSend({
+            liveDraft: "same text",
+            remoteDraft: "",
+            remoteDraftAtSend: "",
             draftSavedAfterSend: false,
-        })).toBe(false)
+            sentDraft: "same text",
+            pendingDrafts: ["same text"],
+        })).toBeUndefined()
     })
 
-    it("does not clear a remote draft updated while the send is pending", () => {
-        expect(shouldClearDraftAfterSend({
-            remoteDraft: "remote new draft",
-            remoteDraftAtSend: "hello",
-            liveDraft: "",
-            draftSavedAfterSend: false,
-        })).toBe(false)
+    it("clears the provisional draft written for this send", () => {
+        expect(resolveDraftAfterSend({
+            remoteDraft: "A",
+            remoteDraftAtSend: "A",
+            draftSavedAfterSend: true,
+            latestSavedDraft: "A",
+            latestSavedDraftSource: "pending",
+            sentDraft: "A",
+            pendingDrafts: ["A"],
+        })).toBe("")
     })
 
-    it("does not let queued send B erase C saved while send A was pending", () => {
-        expect(shouldClearDraftAfterSend({
-            liveDraft: "",
+    it("reduces queued provisional drafts as each send succeeds", () => {
+        expect(resolveDraftAfterSend({
+            remoteDraft: "A\nB",
+            remoteDraftAtSend: "",
+            draftSavedAfterSend: true,
+            latestSavedDraft: "A\nB",
+            latestSavedDraftSource: "pending",
+            sentDraft: "A",
+            pendingDrafts: ["A", "B"],
+        })).toBe("B")
+
+        expect(resolveDraftAfterSend({
+            remoteDraft: "B",
+            remoteDraftAtSend: "",
+            draftSavedAfterSend: true,
+            latestSavedDraft: "B",
+            latestSavedDraftSource: "pending",
+            sentDraft: "B",
+            pendingDrafts: ["B"],
+        })).toBe("")
+    })
+
+    it("does not erase a later live draft saved while the send was pending", () => {
+        expect(resolveDraftAfterSend({
             remoteDraft: "C",
-            remoteDraftAtSend: "C",
+            remoteDraftAtSend: "",
             draftSavedAfterSend: true,
             latestSavedDraft: "C",
-        })).toBe(false)
+            latestSavedDraftSource: "live",
+            sentDraft: "B",
+            pendingDrafts: ["B"],
+        })).toBeUndefined()
+    })
+
+    it("does not mistake same-text live input for a provisional send draft", () => {
+        expect(resolveDraftAfterSend({
+            remoteDraft: "A",
+            remoteDraftAtSend: "",
+            draftSavedAfterSend: true,
+            latestSavedDraft: "A",
+            latestSavedDraftSource: "live",
+            sentDraft: "A",
+            pendingDrafts: ["A"],
+        })).toBeUndefined()
+    })
+
+    it("does not clear when the executing send does not own the first pending slot", () => {
+        expect(resolveDraftAfterSend({
+            remoteDraft: "A\nB",
+            remoteDraftAtSend: "",
+            draftSavedAfterSend: true,
+            latestSavedDraft: "A\nB",
+            latestSavedDraftSource: "pending",
+            sentDraft: "B",
+            pendingDrafts: ["A", "B"],
+        })).toBeUndefined()
+    })
+
+    it("does not let an attachment-only send consume the next text draft", () => {
+        expect(resolveDraftAfterSend({
+            remoteDraft: "B",
+            remoteDraftAtSend: "",
+            draftSavedAfterSend: true,
+            latestSavedDraft: "B",
+            latestSavedDraftSource: "pending",
+            sentDraft: "B",
+            pendingDrafts: ["", "B"],
+        })).toBeUndefined()
+    })
+
+    it("does not clear a remote draft changed outside this send", () => {
+        expect(resolveDraftAfterSend({
+            remoteDraft: "remote update",
+            remoteDraftAtSend: "A",
+            draftSavedAfterSend: false,
+            sentDraft: "A",
+            pendingDrafts: ["A"],
+        })).toBeUndefined()
     })
 })
 
 describe("resolveDraftToPersist (octo-web#1280)", () => {
-    it("persists what the composer currently holds", () => {
+    it("persists live input with live ownership", () => {
         expect(resolveDraftToPersist({
             liveDraft: "typing this",
             pendingSendText: "",
-            existingDraft: "old",
-        })).toBe("typing this")
+        })).toEqual({ draft: "typing this", source: "live" })
     })
 
-    it("does not clear the stored draft while a consumed compose is still in flight", () => {
-        // Leaving the conversation mid-send used to persist "" over content that
-        // had no bubble yet — composer, draft and message list all empty at once.
+    it("persists an in-flight compose as a provisional draft", () => {
         expect(resolveDraftToPersist({
             liveDraft: "",
             pendingSendText: "message being sent",
-            existingDraft: "older draft",
-        })).toBe("older draft")
+        })).toEqual({ draft: "message being sent", source: "pending" })
     })
 
-    it("still lets the live composer win over an in-flight compose", () => {
+    it("still lets live input win over an in-flight compose", () => {
         expect(resolveDraftToPersist({
             liveDraft: "next message",
             pendingSendText: "message being sent",
-            existingDraft: "older draft",
-        })).toBe("next message")
+        })).toEqual({ draft: "next message", source: "live" })
     })
 
-    it("clears the draft normally when nothing is in flight", () => {
+    it("persists an empty draft when nothing is live or pending", () => {
         expect(resolveDraftToPersist({
             liveDraft: "",
             pendingSendText: "",
-            existingDraft: "older draft",
-        })).toBe("")
+        })).toEqual({ draft: "", source: "empty" })
     })
 })

--- a/packages/dmworkbase/src/Utils/draftLifecycle.ts
+++ b/packages/dmworkbase/src/Utils/draftLifecycle.ts
@@ -7,6 +7,16 @@ export interface ShouldClearDraftAfterSendOptions {
     latestSavedDraft?: string
 }
 
+/**
+ * Decide whether the remote draft may be cleared after a send.
+ *
+ * Since octo-web#1280 the composer is consumed synchronously when the send
+ * starts, so `draftAtSend` (read inside `onSend`) is the empty string for an
+ * immediate send and, for a queued one, whatever the user has typed since. The
+ * comparison below therefore reads as "has the composer moved on since this send
+ * was handed over?" — if it has, the newer draft is authoritative and must not be
+ * cleared; the sent content is no longer a draft in either case.
+ */
 export function shouldClearDraftAfterSend({
     liveDraft,
     draftAtSend,
@@ -15,8 +25,8 @@ export function shouldClearDraftAfterSend({
     draftSavedAfterSend,
     latestSavedDraft,
 }: ShouldClearDraftAfterSendOptions): boolean {
-    // MessageInput clears the editor only after onSend resolves, so the sent
-    // snapshot can still be live here. Only a different value is a newer draft.
+    // Only a value that differs from what was handed to this send counts as a
+    // newer draft (see the note above about consume-first).
     if (liveDraft && liveDraft !== draftAtSend) return false
     if (
         draftSavedAfterSend &&
@@ -26,4 +36,39 @@ export function shouldClearDraftAfterSend({
     if ((remoteDraft || "") !== (remoteDraftAtSend || "")) return false
 
     return true
+}
+
+export interface ResolveDraftToPersistOptions {
+    /** What the composer currently holds. */
+    liveDraft: string
+    /** Plain text of composes that are consumed but not yet enqueued/settled. */
+    pendingSendText: string
+    /** The draft currently stored for this conversation. */
+    existingDraft: string
+}
+
+/**
+ * Decide what to persist as the conversation draft (octo-web#1280).
+ *
+ * The composer is emptied the moment a send starts, so a draft save that happens
+ * during an in-flight send (leaving the conversation is the common trigger) used
+ * to write an EMPTY draft over content that had not been enqueued yet — the
+ * composer, the draft and the message list were then all empty at once.
+ *
+ * Rules:
+ *   - the live composer content always wins (the user's newest intent);
+ *   - while a send is in flight and the composer is empty, keep the stored draft
+ *     as-is instead of clearing it — the in-flight content is not a draft (it is
+ *     about to become a message, and its bubble owns retry from then on), but it
+ *     must not destroy an older draft either;
+ *   - otherwise persist the (possibly empty) live value as before.
+ */
+export function resolveDraftToPersist({
+    liveDraft,
+    pendingSendText,
+    existingDraft,
+}: ResolveDraftToPersistOptions): string {
+    if (liveDraft.trim() !== "") return liveDraft
+    if (pendingSendText.trim() !== "") return existingDraft
+    return liveDraft
 }

--- a/packages/dmworkbase/src/Utils/draftLifecycle.ts
+++ b/packages/dmworkbase/src/Utils/draftLifecycle.ts
@@ -41,7 +41,7 @@ export function shouldClearDraftAfterSend({
 export interface ResolveDraftToPersistOptions {
     /** What the composer currently holds. */
     liveDraft: string
-    /** Plain text of composes that are consumed but not yet enqueued/settled. */
+    /** Plain text of composes handed to a send that has not settled yet. */
     pendingSendText: string
     /** The draft currently stored for this conversation. */
     existingDraft: string

--- a/packages/dmworkbase/src/Utils/draftLifecycle.ts
+++ b/packages/dmworkbase/src/Utils/draftLifecycle.ts
@@ -1,6 +1,5 @@
 export interface ShouldClearDraftAfterSendOptions {
     liveDraft?: string
-    draftAtSend: string
     remoteDraft?: string
     remoteDraftAtSend?: string
     draftSavedAfterSend: boolean
@@ -10,29 +9,20 @@ export interface ShouldClearDraftAfterSendOptions {
 /**
  * Decide whether the remote draft may be cleared after a send.
  *
- * Since octo-web#1280 the composer is consumed synchronously when the send
- * starts, so `draftAtSend` (read inside `onSend`) is the empty string for an
- * immediate send and, for a queued one, whatever the user has typed since. The
- * comparison below therefore reads as "has the composer moved on since this send
- * was handed over?" — if it has, the newer draft is authoritative and must not be
- * cleared; the sent content is no longer a draft in either case.
+ * Since octo-web#1280 the composer is consumed synchronously. Any non-empty live
+ * draft after that point is newer input, even if it happens to equal the sent
+ * text. The generation and remote snapshot must be captured at consume time so a
+ * queued send cannot mistake a draft saved while it waited for its own snapshot.
  */
 export function shouldClearDraftAfterSend({
     liveDraft,
-    draftAtSend,
     remoteDraft,
     remoteDraftAtSend,
     draftSavedAfterSend,
     latestSavedDraft,
 }: ShouldClearDraftAfterSendOptions): boolean {
-    // Only a value that differs from what was handed to this send counts as a
-    // newer draft (see the note above about consume-first).
-    if (liveDraft && liveDraft !== draftAtSend) return false
-    if (
-        draftSavedAfterSend &&
-        latestSavedDraft &&
-        latestSavedDraft !== draftAtSend
-    ) return false
+    if (liveDraft) return false
+    if (draftSavedAfterSend && latestSavedDraft) return false
     if ((remoteDraft || "") !== (remoteDraftAtSend || "")) return false
 
     return true

--- a/packages/dmworkbase/src/Utils/draftLifecycle.ts
+++ b/packages/dmworkbase/src/Utils/draftLifecycle.ts
@@ -1,31 +1,57 @@
-export interface ShouldClearDraftAfterSendOptions {
+export type DraftPersistenceSource = "live" | "pending" | "empty"
+
+export interface ResolveDraftAfterSendOptions {
     liveDraft?: string
     remoteDraft?: string
     remoteDraftAtSend?: string
     draftSavedAfterSend: boolean
     latestSavedDraft?: string
+    latestSavedDraftSource?: DraftPersistenceSource
+    sentDraft: string
+    pendingDrafts: string[]
 }
 
 /**
- * Decide whether the remote draft may be cleared after a send.
+ * Decide whether a successful send owns the persisted draft and, if it does,
+ * what should remain after that send settles.
  *
- * Since octo-web#1280 the composer is consumed synchronously. Any non-empty live
- * draft after that point is newer input, even if it happens to equal the sent
- * text. The generation and remote snapshot must be captured at consume time so a
- * queued send cannot mistake a draft saved while it waited for its own snapshot.
+ * `pendingDrafts` is ordered by send consumption. The currently executing send
+ * is first; later queued sends remain behind it. A persisted pending draft is
+ * therefore reduced from `A\nB` to `B` when A succeeds, then cleared when B
+ * succeeds. A live draft is never owned by the send, even when its text happens
+ * to be identical.
  */
-export function shouldClearDraftAfterSend({
+export function resolveDraftAfterSend({
     liveDraft,
     remoteDraft,
     remoteDraftAtSend,
     draftSavedAfterSend,
     latestSavedDraft,
-}: ShouldClearDraftAfterSendOptions): boolean {
-    if (liveDraft) return false
-    if (draftSavedAfterSend && latestSavedDraft) return false
-    if ((remoteDraft || "") !== (remoteDraftAtSend || "")) return false
+    latestSavedDraftSource,
+    sentDraft,
+    pendingDrafts,
+}: ResolveDraftAfterSendOptions): string | undefined {
+    if (liveDraft) return undefined
 
-    return true
+    const [currentPending = "", ...remainingPending] = pendingDrafts
+    if (currentPending !== sentDraft) return undefined
+
+    const pendingDraft = pendingDrafts.filter((draft) => draft.trim() !== "").join("\n")
+    const remainingDraft = remainingPending
+        .filter((draft) => draft.trim() !== "")
+        .join("\n")
+
+    if (draftSavedAfterSend) {
+        const ownsPersistedPendingDraft =
+            latestSavedDraftSource === "pending" &&
+            (latestSavedDraft || "") === pendingDraft &&
+            (remoteDraft || "") === pendingDraft
+        return ownsPersistedPendingDraft ? remainingDraft : undefined
+    }
+
+    if ((remoteDraft || "") !== (remoteDraftAtSend || "")) return undefined
+
+    return ""
 }
 
 export interface ResolveDraftToPersistOptions {
@@ -33,8 +59,11 @@ export interface ResolveDraftToPersistOptions {
     liveDraft: string
     /** Plain text of composes handed to a send that has not settled yet. */
     pendingSendText: string
-    /** The draft currently stored for this conversation. */
-    existingDraft: string
+}
+
+export interface ResolvedDraftPersistence {
+    draft: string
+    source: DraftPersistenceSource
 }
 
 /**
@@ -47,18 +76,17 @@ export interface ResolveDraftToPersistOptions {
  *
  * Rules:
  *   - the live composer content always wins (the user's newest intent);
- *   - while a send is in flight and the composer is empty, keep the stored draft
- *     as-is instead of clearing it — the in-flight content is not a draft (it is
- *     about to become a message, and its bubble owns retry from then on), but it
- *     must not destroy an older draft either;
+ *   - while a send is in flight and the composer is empty, persist its text as a
+ *     provisional draft so a pre-enqueue failure can survive editor teardown;
  *   - otherwise persist the (possibly empty) live value as before.
  */
 export function resolveDraftToPersist({
     liveDraft,
     pendingSendText,
-    existingDraft,
-}: ResolveDraftToPersistOptions): string {
-    if (liveDraft.trim() !== "") return liveDraft
-    if (pendingSendText.trim() !== "") return existingDraft
-    return liveDraft
+}: ResolveDraftToPersistOptions): ResolvedDraftPersistence {
+    if (liveDraft.trim() !== "") return { draft: liveDraft, source: "live" }
+    if (pendingSendText.trim() !== "") {
+        return { draft: pendingSendText, source: "pending" }
+    }
+    return { draft: liveDraft, source: "empty" }
 }

--- a/packages/dmworkbase/src/i18n/locales/en-US.json
+++ b/packages/dmworkbase/src/i18n/locales/en-US.json
@@ -1235,6 +1235,7 @@
   "messageInput.placeholder.reply": "Type a message...  {{shortcut}}+↵ to create a task",
   "messageInput.placeholder.replyWithName": "Reply in {{name}}...  {{shortcut}}+↵ to create a task",
   "messageInput.slashCommand": "Slash commands",
+  "messageInput.send.restoreFailed": "The message was not sent and its content could not be restored",
   "messageInput.validation.maxLength": "Message cannot exceed {{max}} characters.",
   "mentionList.noMembers": "No members found",
   "qrCodeMy.scanToAdd": "Scan this QR code to add me on {{appName}}",

--- a/packages/dmworkbase/src/i18n/locales/zh-CN.json
+++ b/packages/dmworkbase/src/i18n/locales/zh-CN.json
@@ -1235,6 +1235,7 @@
   "messageInput.placeholder.reply": "输入消息...  {{shortcut}}+↵ 创建任务",
   "messageInput.placeholder.replyWithName": "在 {{name}} 中回复...  {{shortcut}}+↵ 创建任务",
   "messageInput.slashCommand": "斜杠命令",
+  "messageInput.send.restoreFailed": "消息未发出，且内容已无法恢复",
   "messageInput.validation.maxLength": "输入内容长度不能大于{{max}}字符！",
   "mentionList.noMembers": "没有找到成员",
   "qrCodeMy.scanToAdd": "扫一扫上面的二维码图案，加我{{appName}}",


### PR DESCRIPTION
## Summary

Consecutive sends left the composer holding content that had already been sent: the images/text appear in the conversation, but the input box still shows the thumbnails and the text. Users read that as a failed send and retry, and a second Enter re-sends the same content.

The root cause is *when* the composer is cleared. Three defects stack into the same symptom:

1. **All-or-nothing snapshot cleanup.** The snapshot-aware cleanup added in #227 round 2 only clears the editor when the document still equals what was sent. As soon as the user pastes/types the next message during the await — the normal "send several images in a row" flow — the *already sent* content is left behind too. `sendFlow.ts` documented this as an accepted residual edge case; #1280 is that follow-up.
2. **Silently dropped sends.** `MessageInput` had a re-entrancy guard that returned `false` while a send was pending, so the 2nd/3rd Enter did nothing with no feedback, reinforcing the "nothing was sent" impression.
3. **Ack timeout treated as failure.** `Conversation` reported an ack timeout (10s text / 30s media) as a send failure, so on a slow network already-delivered content was pushed back into the composer.

The fix makes composer consumption a synchronous, decided-up-front operation (**consume-first / restore-on-failure**), so the "did the document change while we waited?" race is gone by construction rather than patched again.

Because the composer no longer holds content while a send is in flight, everything that relied on that invariant is updated in the same PR: the reply/edit target, partial send results, the pending-attachment guard, draft persistence, and the restore path itself.

## Related Issue

Fixes #1280

## Changes

**Consume-first core**

- `MessageInput/sendFlow.ts`: `runSendWithConsumedCompose` replaces the post-await snapshot decision. Top attachments are settled *before* the editor, every restore/dispose step is isolated and reported through `onRestoreError`, and the loose `SendResult` union now also carries `unsentEditorAttachmentIds`. `createSendQueue` serializes sends instead of dropping them; `restoreComposeSnapshot` owns the restore placement policy.
- `MessageInput/composeConsume.ts` (new): the synchronous consume + restore/dispose implementation behind a small editor port, so it can be driven by a real Tiptap editor in tests instead of spies.
- `MessageInput/index.tsx`: `send()` captures the compose, clears the editor, removes this send's top attachments, collapses the composer and takes the reply/edit target — all synchronously — then runs `onSend` through the serial queue. The re-entrancy guard is gone; Enter no longer leaks promise rejections.

**Reply/edit target travels with the compose**

- `Conversation/sendTarget.ts` (new): `captureSendTarget` reads and clears `currentReplyMessage` / `currentHandlerType` at key-press time (which also hides the banner) and restores them if the send was not enqueued, so a failed *edit* retries as an edit. A newer user selection always wins over a late restore.
- `Conversation.onSend` uses that snapshot instead of reading the view model when it runs.

**Partial results are representable**

- The non-mixed path returns a real `SendResultDetail` (`editorConsumed` + `consumedTopIds` + `unsentEditorAttachmentIds`) instead of a bare boolean, so a pre-flight-rejected top attachment is restored, and a rejected pasted image comes back on its own while the blocks that did enqueue stay consumed.

**The in-flight window is visible and protected**

- `pendingSendCount()` / `pendingSendText()` on the composer context; the pending-attachment guard blocks a channel switch while a send is in flight, `markConversationExtra` no longer writes an empty draft over content that has no bubble yet (`resolveDraftToPersist`), and the composer shows a "sending" hint (reuses `base.message.sending`).
- A restore into a destroyed editor raises `ComposeRestoreUnavailableError` and is surfaced as a notification (one new i18n key in `zh-CN` + `en-US`) instead of disappearing silently.

**Enqueued ≠ acked**

- `sendTextAndWaitAck` / `sendMediaAndWait` still await upload + ack for ordering, but report "enqueued": an ack failure/timeout is not a send failure (the bubble carries a failure marker and resend), and `false` is returned only when the message never got enqueued.

Behaviour preserved by construction:

- #227 round 1 — a send that fails before enqueue returns the full compose (text + pasted images + attachments + reply/edit target + expanded state) for retry.
- #227 round 2 — a draft typed during the await is never overwritten; restored content is inserted before it, and after content restored by earlier failed sends so `A, B, <draft>` order survives.

## Architecture / Module Boundary

- Affected module(s): `packages/dmworkbase/src/Components/MessageInput`, `packages/dmworkbase/src/Components/Conversation`, `packages/dmworkbase/src/Utils/draftLifecycle.ts`
- New or changed user-visible entry point: no new entry point. The only new UI is a "sending" hint inside the existing composer.
- Shared layer touched: Components (composer + conversation send orchestration), Utils (draft lifecycle), i18n locales
- If shared code changed, impact scope: every chat send path through `MessageInput` — plain text, pasted images, top-attachment uploads, mixed text+image RichText, reply, edit-message, and the `initialCompose` auto-send orchestrator (its `send()` result semantics are unchanged). `MessageInputContext` gains two read-only accessors; `onSend` gains an optional trailing `sendTarget` argument and `Conversation` falls back to the previous live read when it is absent, so external callers keep working.
- Duplicate entry point checked: yes

## Testing

Automated:

- `MessageInput/__tests__/composeConsume.test.ts` (new, 15 cases) drives a **real Tiptap editor**: consume empties the composer synchronously; a not-enqueued send restores the document, and inserts it *before* a draft typed during the await; pasted-image `File` refs and preview URLs survive a failure; one of two pasted images rejected comes back alone while the sent one is disposed; a destroyed editor reports `ComposeRestoreUnavailableError` after the top attachments were already restored; two queued sends stay ordered and each keeps the reply target captured at press time (including the "user switches to edit mode mid-flight" repro); two consecutive failures restore as `A, B, <draft>`; `composeSnapshotText`.
- `MessageInput/__tests__/sendFlow.test.ts` (25 cases): success/failure/partial contracts, `unsentEditorAttachmentIds`, step isolation and ordering (an editor-restore throw cannot skip the attachment restore), never rejecting, and queue serialization/draining.
- `Utils/__tests__/draftLifecycle.test.ts`: `resolveDraftToPersist` — an in-flight compose must not be overwritten by an empty draft, while the live composer still wins.
- `cd packages/dmworkbase && npx vitest run` → 295 files / 2671 tests pass.
- `cd apps/web && npx vitest run` → failure set identical to `main` (52 files / 36 tests, all pre-existing).
- `npx tsc --noEmit -p packages/dmworkbase/tsconfig.json` → diagnostics for the touched files identical to `main`.
- `pnpm i18n:check` → passes. `pnpm lint:css` → no new problems. `npx vite build` in `apps/web` → succeeds.

Manual (dev server against a real IM backend):

- Group chat: paste and send 3 images back to back → the composer clears every time, all 3 land in history in order, no leftover thumbnails, no duplicate on a further Enter.
- Type and send several text messages rapidly, including while a previous send is still pending → the new draft survives, the sent text does not come back.
- Reply to message X, send, then switch to "edit" on another message while the first send is pending → the first message keeps its reply to X, and the edit applies to the message the user actually picked.
- Blocked upload credentials on a mixed text+image compose → error toast and the whole compose (text, image, reply target, expanded state) is restored for retry.
- Oversized top attachment plus a valid pasted image → the valid part is sent, only the rejected file returns to the attachment area.
- Two pasted images where one is rejected → only the rejected image returns to the editor.
- Offline text send → composer clears, bubble shows the failure marker, resend from the bubble works.
- Switch conversation while a send is in flight → the switch confirmation dialog appears, and the existing draft is not overwritten.

- [x] Unit tests added/updated
- [x] Manually verified

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes
- [ ] Updated documentation — not applicable; the rationale lives in the `sendFlow.ts` / `composeConsume.ts` / `sendTarget.ts` module docblocks
- [x] Ran `pnpm i18n:check` (passes; one new key added to `zh-CN` and `en-US`)
- [x] Confirmed the change follows module ownership and does not add duplicate user-visible entry points
- [x] Described impact scope when shared components, messages, bridge, or services are changed
- [x] Followed commit message conventions (Conventional Commits)

## Notes for reviewers

- **Why the guard + draft protection instead of pre-upload bubbles.** Of the three options suggested for closing the in-flight window, this PR takes "include queue depth in `pendingAttachmentGuard`" plus "stop draft persistence from clearing content", and adds a visible sending hint and a notification when a restore is impossible. Creating the local bubble before the RichText-mixed upload means enqueueing a placeholder message and reconciling it after upload — a change to the wire path that deserves its own PR. Persisting queued composes as drafts was rejected on purpose: `clearDraftAfterSend` cannot clear a draft it did not write, so a successful send would leave the sent text sitting in the composer as a stale draft — the same family of bug from the other side.
- **Head-of-line blocking** is unchanged: the queue still waits for the previous send's ack (10s/30s worst case) because ordering relies on `messageSeq`. The sequence-token idea from the review is the right long-term fix and is not attempted here.
- **Text-block partial failure** is still all-or-nothing: a text block only fails when `sendMessage` throws (e.g. the disbanded-group guard), which fails the whole compose, so `anyMessageSent` stays `false` and everything is restored. Only attachments needed per-block granularity.
