### PR TITLE
fix(docs): let users collapse a query-expanded bot list in MemberPicker

### DIFF
--- a/packages/docs/src/members/MemberPicker.test.tsx
+++ b/packages/docs/src/members/MemberPicker.test.tsx
@@ -817,3 +817,72 @@ describe('MemberPicker selection reachability across rerenders (yujiawei P1)', (
     expect(submittedUids).not.toContain('u_grace')
   })
 })
+
+// Collapse-override semantics (intentional — not a bug). A review P1 argued that a manual expand
+// that the user later collapses (while a query is active) is "silently destroyed" on query clear,
+// and proposed keeping the uid in `expanded` on collapse (only recording collapsedByUser). We
+// reject that: the LAST EXPLICIT user action wins, so an explicit collapse must survive the query
+// clearing. The proposed change would also introduce a real "ghost EXPAND" (test (b)): a later
+// query — even one that does not hit this Bot — clears collapsedByUser and re-opens a list the user
+// closed. These two tests pin that contract. NOTE: if someone "fixes" per the review by removing
+// `expanded.delete(m.uid)` from the collapse branch of the expander onClick, test (b) fails.
+describe('MemberPicker collapse-override semantics (review P1 rejected)', () => {
+  function botResponder(bots: Array<{ uid: string; name: string; creator_uid?: string }>) {
+    return (method: string, url: string) =>
+      method === 'get' && url.startsWith('/robot/space_bots')
+        ? { data: bots, status: 200 }
+        : { data: [], status: 200 }
+  }
+
+  // (a) An explicit collapse survives clearing the search: manual expand (no query) → type a query
+  // that hits the Bot → collapse → clear the query. The list stays CLOSED because the user's last
+  // explicit action was "collapse" (last-explicit-action-wins). This is deliberate, not a bug.
+  it('keeps an explicit collapse closed after the search is cleared', async () => {
+    wk.apiClient.responder = botResponder([
+      { uid: 'b_1', name: 'Writer Bot', creator_uid: 'u_ada' },
+    ])
+    render(<MemberPicker space="s_1" existingUids={new Set()} onAdd={() => {}} />)
+    await waitFor(() => expect(screen.getByText('Ada Lovelace')).toBeTruthy())
+    const search = screen.getByPlaceholderText('docs.member.pickPlaceholder')
+    // Manual expand with NO query active.
+    fireEvent.click(screen.getByText('docs.member.showBots'))
+    expect(screen.getByText('Writer Bot')).toBeTruthy()
+    // Type a query that hits the Bot (list stays open).
+    fireEvent.change(search, { target: { value: 'Writer Bot' } })
+    expect(screen.getByText('docs.member.hideBots')).toBeTruthy()
+    // Explicit collapse.
+    fireEvent.click(screen.getByText('docs.member.hideBots'))
+    expect(screen.queryByText('Writer Bot')).toBeNull()
+    // Clear the query — the list stays CLOSED (last explicit action = collapse wins).
+    fireEvent.change(search, { target: { value: '' } })
+    expect(screen.queryByText('Writer Bot')).toBeNull()
+    expect(screen.getByText('docs.member.showBots')).toBeTruthy()
+  })
+
+  // (b) Guardrail against the review's proposed change: a list closed by the user must NOT re-open
+  // itself when a later query merely matches the PERSON (not the Bot). Manual expand (no query) →
+  // collapse (still no query) → search the human's name "Ada" (matches Ada, NOT "Writer Bot"). The
+  // Bot list must stay CLOSED. If collapse kept the uid in `expanded` (the review's suggestion),
+  // the [query] effect would clear collapsedByUser and the still-`expanded` uid would pop open — a
+  // real ghost-expand. This test FAILS if `expanded.delete(m.uid)` is removed from the collapse
+  // branch of the expander onClick.
+  it('does not self-expand a user-collapsed list when a later query matches only the person', async () => {
+    wk.apiClient.responder = botResponder([
+      { uid: 'b_1', name: 'Writer Bot', creator_uid: 'u_ada' },
+    ])
+    render(<MemberPicker space="s_1" existingUids={new Set()} onAdd={() => {}} />)
+    await waitFor(() => expect(screen.getByText('Ada Lovelace')).toBeTruthy())
+    const search = screen.getByPlaceholderText('docs.member.pickPlaceholder')
+    // Manual expand then collapse, all with NO query active.
+    fireEvent.click(screen.getByText('docs.member.showBots'))
+    expect(screen.getByText('Writer Bot')).toBeTruthy()
+    fireEvent.click(screen.getByText('docs.member.hideBots'))
+    expect(screen.queryByText('Writer Bot')).toBeNull()
+    // Search by the PERSON's name "Ada" — matches Ada, does NOT hit "Writer Bot".
+    fireEvent.change(search, { target: { value: 'Ada' } })
+    expect(screen.getByText('Ada Lovelace')).toBeTruthy()
+    // The user-closed Bot list must stay CLOSED (no ghost-expand).
+    expect(screen.queryByText('Writer Bot')).toBeNull()
+    expect(screen.getByText('docs.member.showBots')).toBeTruthy()
+  })
+})

--- a/packages/docs/src/members/MemberPicker.test.tsx
+++ b/packages/docs/src/members/MemberPicker.test.tsx
@@ -691,6 +691,63 @@ describe('MemberPicker Bot expander UX (task #3)', () => {
     ).toBe(true)
     expect(onAdd).not.toHaveBeenCalled()
   })
+
+  // Bug (task): a query hit auto-expands a creator's Bot list. The user must be able to collapse
+  // that query-expanded list and have it STAY collapsed for the current term; a new term restores
+  // the "hit ⇒ default open" convenience; and manual collapse→expand must still work (no dead click).
+  it('lets the user collapse a query-expanded Bot list (stays collapsed under the same query)', async () => {
+    wk.apiClient.responder = botResponder([
+      { uid: 'b_1', name: 'Writer Bot', creator_uid: 'u_ada' },
+    ])
+    render(<MemberPicker space="s_1" existingUids={new Set()} onAdd={() => {}} />)
+    await waitFor(() => expect(screen.getByText('Ada Lovelace')).toBeTruthy())
+    // Query hits the Bot → its list defaults open (protects the current convenience).
+    fireEvent.change(screen.getByPlaceholderText('docs.member.pickPlaceholder'), {
+      target: { value: 'Writer Bot' },
+    })
+    expect(screen.getByText('Writer Bot')).toBeTruthy()
+    // The expander reads as expanded (label = hideBots).
+    expect(screen.getByText('docs.member.hideBots')).toBeTruthy()
+    // Click “collapse” → the Bot row disappears and the label flips back to showBots (FAILS before fix).
+    fireEvent.click(screen.getByText('docs.member.hideBots'))
+    expect(screen.queryByText('Writer Bot')).toBeNull()
+    expect(screen.getByText('docs.member.showBots')).toBeTruthy()
+  })
+
+  it('restores the default-open on a new query term after a manual collapse', async () => {
+    wk.apiClient.responder = botResponder([
+      { uid: 'b_1', name: 'Writer Bot', creator_uid: 'u_ada' },
+    ])
+    render(<MemberPicker space="s_1" existingUids={new Set()} onAdd={() => {}} />)
+    await waitFor(() => expect(screen.getByText('Ada Lovelace')).toBeTruthy())
+    const search = screen.getByPlaceholderText('docs.member.pickPlaceholder')
+    fireEvent.change(search, { target: { value: 'Writer' } })
+    // Manually collapse the query-expanded list.
+    fireEvent.click(screen.getByText('docs.member.hideBots'))
+    expect(screen.queryByText('Writer Bot')).toBeNull()
+    // A different term that still hits the Bot clears the override → defaults open again.
+    fireEvent.change(search, { target: { value: 'Bot' } })
+    expect(screen.getByText('Writer Bot')).toBeTruthy()
+    expect(screen.getByText('docs.member.hideBots')).toBeTruthy()
+  })
+
+  it('allows manual collapse then manual re-expand (direction toggle never dead-locks)', async () => {
+    wk.apiClient.responder = botResponder([
+      { uid: 'b_1', name: 'Writer Bot', creator_uid: 'u_ada' },
+    ])
+    render(<MemberPicker space="s_1" existingUids={new Set()} onAdd={() => {}} />)
+    await waitFor(() => expect(screen.getByText('Ada Lovelace')).toBeTruthy())
+    fireEvent.change(screen.getByPlaceholderText('docs.member.pickPlaceholder'), {
+      target: { value: 'Writer Bot' },
+    })
+    // collapse …
+    fireEvent.click(screen.getByText('docs.member.hideBots'))
+    expect(screen.queryByText('Writer Bot')).toBeNull()
+    // … then re-expand on the very next click (a single click must flip it back open).
+    fireEvent.click(screen.getByText('docs.member.showBots'))
+    expect(screen.getByText('Writer Bot')).toBeTruthy()
+    expect(screen.getByText('docs.member.hideBots')).toBeTruthy()
+  })
 })
 
 // Latest blocking P1 (yujiawei): selection reachability across live rerenders. A selected human

--- a/packages/docs/src/members/MemberPicker.tsx
+++ b/packages/docs/src/members/MemberPicker.tsx
@@ -106,6 +106,11 @@ export function MemberPicker({
   const [selected, setSelected] = useState<Set<string>>(new Set())
   const [selectedBots, setSelectedBots] = useState<Set<string>>(new Set())
   const [expanded, setExpanded] = useState<Set<string>>(new Set())
+  // uids the user EXPLICITLY collapsed under the current query. A query-hit auto-expands a
+  // creator's Bot list (convenience), but the user must be able to collapse it and have it stay
+  // collapsed — this override wins over both `expanded` and the query hit. It is scoped to the
+  // current search term: changing `query` clears it so a new term restores "hit ⇒ default open".
+  const [collapsedByUser, setCollapsedByUser] = useState<Set<string>>(new Set())
   // Default to 'writer' when offered (keeps rich-doc's prior initial), else the sole/first role
   // so a single-role dropdown ('reader' for HTML) is selected without an empty state.
   const [role, setRole] = useState<Role>(
@@ -127,6 +132,12 @@ export function MemberPicker({
       return effectiveRoles.includes('writer') ? 'writer' : effectiveRoles[0]
     })
   }, [roles, defaultRole])
+
+  // A new search term drops every manual-collapse override so the fresh term recovers the
+  // "query hits a Bot ⇒ its list defaults open" convenience (behaviour #3).
+  useEffect(() => {
+    setCollapsedByUser((prev) => (prev.size === 0 ? prev : new Set()))
+  }, [query])
 
   useEffect(() => {
     let active = true
@@ -396,7 +407,11 @@ export function MemberPicker({
           const queryHitsBot =
             !!q && bots.some((b) => b.name.toLowerCase().includes(q) || b.uid.toLowerCase().includes(q))
           const showBots = bots.length > 0
-          const isExpanded = expanded.has(m.uid) || queryHitsBot
+          // A user's explicit collapse (scoped to this query) wins over both the click-expand set
+          // and the query auto-expand; otherwise a click-expand or a query hit opens the list.
+          const isExpanded = collapsedByUser.has(m.uid)
+            ? false
+            : expanded.has(m.uid) || queryHitsBot
           return (
             <div key={m.uid} className="octo-member-picker-group" role="presentation">
             <button
@@ -446,7 +461,19 @@ export function MemberPicker({
                 {/* Expander is its own control: clicking it toggles the Bot list, never the human
                     row's selection (UX #3). Chevron is decorative; state is on aria-expanded. */}
                 <button type="button" className="octo-member-picker-expand" aria-expanded={isExpanded}
-                  onClick={() => setExpanded((prev) => { const next = new Set(prev); if (next.has(m.uid)) next.delete(m.uid); else next.add(m.uid); return next })}>
+                  onClick={() => {
+                    // Toggle from the ACTUAL rendered state (isExpanded), not just `expanded`, so a
+                    // query-auto-expanded list collapses on the first click. Keep both sets coherent:
+                    // collapsing records the override + clears the click-expand; expanding clears the
+                    // override + records the click-expand.
+                    if (isExpanded) {
+                      setCollapsedByUser((prev) => { const next = new Set(prev); next.add(m.uid); return next })
+                      setExpanded((prev) => { if (!prev.has(m.uid)) return prev; const next = new Set(prev); next.delete(m.uid); return next })
+                    } else {
+                      setCollapsedByUser((prev) => { if (!prev.has(m.uid)) return prev; const next = new Set(prev); next.delete(m.uid); return next })
+                      setExpanded((prev) => { const next = new Set(prev); next.add(m.uid); return next })
+                    }
+                  }}>
                   <span className="octo-member-picker-chevron" aria-hidden="true" />
                   {t(isExpanded ? 'docs.member.hideBots' : 'docs.member.showBots', { values: { count: bots.length } })}
                 </button>

--- a/packages/docs/src/members/MemberPicker.tsx
+++ b/packages/docs/src/members/MemberPicker.tsx
@@ -110,6 +110,10 @@ export function MemberPicker({
   // creator's Bot list (convenience), but the user must be able to collapse it and have it stay
   // collapsed — this override wins over both `expanded` and the query hit. It is scoped to the
   // current search term: changing `query` clears it so a new term restores "hit ⇒ default open".
+  // Semantics (intentional): collapsing ALSO drops the uid from `expanded` (see the expander
+  // onClick) so the last EXPLICIT user action wins. Keeping it in `expanded` instead would let a
+  // later query (even one not hitting this Bot) clear the override and re-open a list the user
+  // closed ("ghost expand"); collapse must stay collapse until the user reopens it.
   const [collapsedByUser, setCollapsedByUser] = useState<Set<string>>(new Set())
   // Default to 'writer' when offered (keeps rich-doc's prior initial), else the sole/first role
   // so a single-role dropdown ('reader' for HTML) is selected without an empty state.


### PR DESCRIPTION
## Summary

搜索时若关键字命中某人名下的 Bot，该人的 Bot 下拉会**固定在展开状态、点不合上**。本 PR 保留"命中即默认展开"的便利，同时让用户可以真正点收起。

**根因**（`MemberPicker.tsx`）：展开态由「用户点击态 `expanded`」与「搜索命中态 `queryHitsBot`」用 `||` 合成：

```ts
const isExpanded = expanded.has(m.uid) || queryHitsBot
```

只要搜索词仍命中该人名下的 Bot，`queryHitsBot` 恒为 `true`；用户点"收起"只修改了 `expanded`，`isExpanded` 依旧为 `true` → 列表永远合不上，按钮文案也停在 `hideBots`。

**修法**：新增用户显式折叠覆盖态 `collapsedByUser: Set<uid>`，它同时压过 `expanded` 与 `queryHitsBot`：

```ts
const isExpanded = collapsedByUser.has(m.uid) ? false : expanded.has(m.uid) || queryHitsBot
```

- 展开器 `onClick` 改为**基于实际渲染态 `isExpanded`** 决定方向（否则被 query 自动展开的列表第一次点击会"没反应"），并保持两个 set 自洽：收起 → 记入 `collapsedByUser` + 从 `expanded` 移除；展开 → 反之。
- 覆盖态**作用域为当前搜索词**：`query` 变化时清空 `collapsedByUser`，新搜索词恢复"命中即默认展开"。
- `aria-expanded` 与按钮文案(`showBots`/`hideBots`)均由同一个 `isExpanded` 推导，状态与渲染永不脱节。

**行为契约（刻意设计，第二个 commit 已用测试钉死）**：收起时同时清 `expanded`，即**最后一次显式用户操作胜出**——显式收起会挺过"清空搜索词"。反向做法（收起只记 `collapsedByUser`、保留 `expanded`）会引入真实的 **ghost expand**：用户手动关掉某人列表后，只要再输入一个匹配到该人、**却完全不命中其 Bot** 的搜索词（如按人名搜 `Ada`），`[query]` effect 清空覆盖态 → 仍在 `expanded` 中的 uid 会**自己弹开**。

## Linked Spec

无独立 spec 文档；需求来自成员面板可用性反馈（搜索命中 Bot 后下拉无法收起）。行为契约固化在
`MemberPicker.test.tsx` 的 `describe('MemberPicker collapse-override semantics ...')` 注释与断言中。

## How verified

- `npx vitest run src/members` → **84 passed (6 files)**（基线 82 → 新增 5 条：3 条修复用 + 2 条语义护栏）。
- **Positive control（逐条反向验证）**：把 `MemberPicker.tsx` 还原为基线实现、测试留在本 PR 版本 → 新增的 3 条修复测试**精确失败**（`Writer Bot` 仍可见 / 文案仍为 `hideBots`），还原实现后全绿；非重言式、非假 fail-before。
- 护栏测试 (b) 的有效性亦经反向验证：若按"收起不清 `expanded`"改动，该条失败并暴露 ghost expand。
- `tsc --noEmit -p tsconfig.typecheck.json` → 无新增错误（仅基线既有的 `../dmworkbase/src/i18n/format.ts`、`src/board/octoNativeShapes.contract.test.ts` 两处无关报错）。
- 独立复审：一轮 CHANGES-REQUESTED（P1 "ghost collapse"）经实测后判定不成立（见上方行为契约），实现保持不变、改以回归测试固化语义；其余检查项 APPROVE，无 P0/P2。

## COMPREHENSION

**(a) 对承载路径做了什么（before/after）**

承载路径 = `MemberPicker` 的 Bot 展开态推导（`isExpanded`）与展开器点击语义。

- Before：`isExpanded = expanded.has(uid) || queryHitsBot`；`onClick` 仅 toggle `expanded`。搜索命中 Bot 时用户丧失收起能力。
- After：新增 `collapsedByUser` 覆盖态，`isExpanded = collapsedByUser.has(uid) ? false : (expanded.has(uid) || queryHitsBot)`；`onClick` 依据实际 `isExpanded` 双向维护两个 set；`query` 变化清空覆盖态。

**未触碰**选择/提交路径：`selected` / `selectedBots` / `submittable` / `add()` 及其 prune effect 逐字节未变。折叠仅停止渲染 Bot 行，已选中的 Bot 仍在提交 payload 中（既有测试 `preserves Bot selection across collapse/expand` 继续覆盖）。

**(b) 可能坏什么（依赖方 + 失效模式）**

- 依赖方：仅 `packages/docs` 内的 `MemberPanel.tsx`（rich/sheet/board）与 `HtmlMemberPanel.tsx`。两者只传 props，从不触碰展开态；`collapsedByUser` 完全内部，**无 prop/API 变更**。`dmworkcontacts/GroupMemberPicker` 是无关组件，不引用本组件。
- 失效模式 1：若 `onClick` 仍按 `expanded` 而非 `isExpanded` 判方向 → 被自动展开的列表首次点击"死点"。已由 `allows manual collapse then manual re-expand` 覆盖。
- 失效模式 2：若收起时保留 `expanded` → ghost expand（见 Summary）。已由 `does not self-expand a user-collapsed list when a later query matches only the person` 覆盖。
- 失效模式 3：覆盖态若不随 `query` 清空 → 换搜索词后丧失"命中即默认展开"。已由 `restores the default-open on a new query term after a manual collapse` 覆盖。
- 键选择：`collapsedByUser` 以 **creator 行 uid** 为键（与 `expanded` 一致），同一 Bot 挂多个 creator 时各行状态互不串扰。

**(c) 怎么知道它可用**

Positive control 逐条反向验证（还原实现 → 3 条精确失败；移除 `expanded.delete` → 护栏条失败），`src/members` 84 条全绿，typecheck 无新增错误。

## 部署前提 / 必配环境变量

**无。** 纯前端组件内部状态改动：不新增/不修改任何环境变量、不改后端契约、不加接口、不新增 i18n key（复用既有 `docs.member.showBots` / `docs.member.hideBots`）、不改 CSS。
