### PR TITLE
refactor(docs): share the current-members list between rich and html panels

### DIFF
--- a/packages/docs/src/html/HtmlMemberPanel.test.tsx
+++ b/packages/docs/src/html/HtmlMemberPanel.test.tsx
@@ -207,17 +207,22 @@ describe('HtmlMemberPanel — shared current-members list (author gate)', () => 
     await waitFor(() => expect(screen.getByText('docs.member.errorRole')).toBeTruthy())
   })
 
-  it('locks the creator/owner row: no remove button, role select disabled', async () => {
+  it('locks the creator/owner row: no remove button, no editable role select', async () => {
     listGrants.mockResolvedValue([{ uid: 'u_reader', role: 'reader', source: 'direct' }])
     render(<HtmlMemberPanel slug="s1" docId="d1" role="reader" isAuthor={true} creatorUid="u_owner" />)
     await waitFor(() => expect(screen.getByText('docs.member.ownerBadge')).toBeTruthy())
     // Exactly one removable member (u_reader) → one remove button; the owner row has none.
     expect(screen.getAllByText('docs.member.remove')).toHaveLength(1)
+    // The owner row carries NO role select on the html surface (its 'author' role is not
+    // grantable here, so it renders name + badge only — never a reader-looking select).
+    const ownerRow = screen
+      .getByText('docs.member.ownerBadge')
+      .closest('.octo-member-row') as HTMLElement
+    expect(ownerRow.querySelector('select')).toBeNull()
+    // The one member row (u_reader) still has an enabled select.
     const selects = Array.from(
       document.querySelectorAll('.octo-member-section select'),
     ) as HTMLSelectElement[]
-    // Owner row select is disabled (locked); the member row select is enabled.
-    expect(selects.some((s) => s.disabled)).toBe(true)
     expect(selects.some((s) => !s.disabled)).toBe(true)
   })
 
@@ -234,5 +239,40 @@ describe('HtmlMemberPanel — shared current-members list (author gate)', () => 
       'writer',
     ])
     expect(Array.from(memberSelect.options).map((o) => o.value)).not.toContain('admin')
+  })
+
+  // The owner's synthetic role ('author', mapped to 'admin' for ranking) is NOT in the html
+  // grantable set (reader/commenter/writer). Rendering a select there left React with no matching
+  // <option>, snapping selectedIndex to 0 → the doc AUTHOR was shown as "reader" (misleading UI).
+  // The owner row must carry the owner badge + name only, with NO role select and NO role text.
+  it('owner row shows no role select and is not mislabeled as reader (P1)', async () => {
+    listGrants.mockResolvedValue([{ uid: 'u_reader', role: 'reader', source: 'direct' }])
+    render(<HtmlMemberPanel slug="s1" docId="d1" role="reader" isAuthor={true} creatorUid="u_owner" />)
+    await waitFor(() => expect(screen.getByText('docs.member.ownerBadge')).toBeTruthy())
+    const ownerRow = screen
+      .getByText('docs.member.ownerBadge')
+      .closest('.octo-member-row') as HTMLElement
+    // No editable/inert role select on the owner row at all.
+    expect(ownerRow.querySelector('select')).toBeNull()
+    // And crucially it is NOT displayed as reader (the fail-before symptom) or any role text.
+    expect(ownerRow.textContent).not.toContain('docs.role.reader')
+    expect(ownerRow.textContent).not.toContain('docs.role.commenter')
+    expect(ownerRow.textContent).not.toContain('docs.role.writer')
+  })
+
+  // Safety: a historical `admin` grant returned by the backend is NOT grantable on the html surface
+  // (reader/commenter/writer). Previously it rendered a select with no admin option → shown as
+  // reader, and a single change would have silently downgraded a real admin. It must render as
+  // static `docs.role.admin` text with no editable select.
+  it('renders a non-grantable admin grant as static text, never a downgradeable select (safety)', async () => {
+    listGrants.mockResolvedValue([{ uid: 'u_admin', role: 'admin', source: 'direct' }])
+    render(<HtmlMemberPanel slug="s1" docId="d1" role="reader" isAuthor={true} creatorUid="u_owner" />)
+    await waitFor(() => expect(screen.getByText(/u_admin/)).toBeTruthy())
+    const adminRow = screen.getByText(/u_admin/).closest('.octo-member-row') as HTMLElement
+    // No editable select for a role this surface can't grant → cannot be silently downgraded.
+    expect(adminRow.querySelector('select')).toBeNull()
+    // The real role is shown as static text, not misrepresented as reader.
+    expect(adminRow.textContent).toContain('docs.role.admin')
+    expect(adminRow.textContent).not.toContain('docs.role.reader')
   })
 })

--- a/packages/docs/src/html/HtmlMemberPanel.test.tsx
+++ b/packages/docs/src/html/HtmlMemberPanel.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { render, screen, waitFor, cleanup } from '@testing-library/react'
+import { render, screen, waitFor, cleanup, fireEvent } from '@testing-library/react'
 import { setWKApp } from '../octoweb/index.ts'
 import { createMockWKApp } from '../octoweb/mock.ts'
 
@@ -42,6 +42,7 @@ vi.mock('../members/MemberPicker.tsx', () => ({
 }))
 
 import { HtmlMemberPanel } from './HtmlMemberPanel.tsx'
+import * as htmlGrantsApi from './htmlGrantsApi.ts'
 
 // Ordered heading text (h3 + h4), so we can compare against the rich-doc MemberPanel section
 // order literally. Explicit sequence beats a snapshot: i18n text may shift, but the ordering
@@ -139,5 +140,99 @@ describe('HtmlMemberPanel — section order (OCT-195)', () => {
     expect(screen.queryByTestId('pending-requests-stub')).toBeNull()
     expect(screen.queryByText('docs.member.addMember')).toBeNull()
     expect(screen.queryByText('docs.member.currentMembers')).toBeNull()
+  })
+})
+
+// Current-members list is now the shared CurrentMembersList (rich/html parity). These tests exercise
+// the real list behavior: role ordering, role-change → PUT /grants + refresh, error path, the
+// locked owner/creator row, and the reader/commenter/writer role surface (admin never grantable).
+describe('HtmlMemberPanel — shared current-members list (author gate)', () => {
+  const listGrants = vi.mocked(htmlGrantsApi.listGrants)
+  const addGrant = vi.mocked(htmlGrantsApi.addGrant)
+
+  beforeEach(() => {
+    listGrants.mockReset()
+    addGrant.mockReset().mockResolvedValue(undefined)
+  })
+
+  function memberRowUids(): string[] {
+    return Array.from(
+      document.querySelectorAll('.octo-member-section .octo-member-row .octo-uid'),
+    ).map((el) => el.textContent ?? '')
+  }
+
+  it('orders members by role: owner pinned, admin before reader (sort.ts parity)', async () => {
+    // Backend returns rows out of role order; the shared list must re-sort them. admin appears here
+    // only to prove ordering (a stray admin grant); owner/creator is pinned above all.
+    listGrants.mockResolvedValue([
+      { uid: 'u_reader', role: 'reader', source: 'direct' },
+      { uid: 'u_admin', role: 'admin', source: 'direct' },
+      { uid: 'u_writer', role: 'writer', source: 'direct' },
+    ])
+    render(<HtmlMemberPanel slug="s1" docId="d1" role="reader" isAuthor={true} creatorUid="u_owner" />)
+    await waitFor(() => expect(screen.getByText('docs.member.ownerBadge')).toBeTruthy())
+    const rows = memberRowUids()
+    const idx = (u: string) => rows.findIndex((r) => r.includes(u))
+    expect(idx('u_owner')).toBe(0) // owner/creator pinned first
+    expect(idx('u_admin')).toBeLessThan(idx('u_writer'))
+    expect(idx('u_writer')).toBeLessThan(idx('u_reader')) // admin < writer < reader
+  })
+
+  it('changing a member role issues PUT /grants with the new role and refreshes', async () => {
+    listGrants
+      .mockResolvedValueOnce([{ uid: 'u_reader', role: 'reader', source: 'direct' }])
+      // refresh after the change: reflect the upsert so the list is consistent.
+      .mockResolvedValueOnce([{ uid: 'u_reader', role: 'writer', source: 'direct' }])
+    render(<HtmlMemberPanel slug="s1" docId="d1" role="reader" isAuthor={true} creatorUid="u_owner" />)
+    await waitFor(() => expect(screen.getByText(/u_reader/)).toBeTruthy())
+    const selects = Array.from(
+      document.querySelectorAll('.octo-member-section select'),
+    ) as HTMLSelectElement[]
+    const memberSelect = selects.find((s) => !s.disabled)!
+    fireEvent.change(memberSelect, { target: { value: 'writer' } })
+    await waitFor(() => expect(addGrant).toHaveBeenCalledWith('s1', 'u_reader', 'writer'))
+    // refresh() called again after the change → listGrants hit a second time.
+    await waitFor(() => expect(listGrants).toHaveBeenCalledTimes(2))
+  })
+
+  it('shows the role error text when the role change PUT fails', async () => {
+    listGrants.mockResolvedValue([{ uid: 'u_reader', role: 'reader', source: 'direct' }])
+    addGrant.mockRejectedValue(new Error('boom'))
+    render(<HtmlMemberPanel slug="s1" docId="d1" role="reader" isAuthor={true} creatorUid="u_owner" />)
+    await waitFor(() => expect(screen.getByText(/u_reader/)).toBeTruthy())
+    const memberSelect = (Array.from(
+      document.querySelectorAll('.octo-member-section select'),
+    ) as HTMLSelectElement[]).find((s) => !s.disabled)!
+    fireEvent.change(memberSelect, { target: { value: 'commenter' } })
+    await waitFor(() => expect(screen.getByText('docs.member.errorRole')).toBeTruthy())
+  })
+
+  it('locks the creator/owner row: no remove button, role select disabled', async () => {
+    listGrants.mockResolvedValue([{ uid: 'u_reader', role: 'reader', source: 'direct' }])
+    render(<HtmlMemberPanel slug="s1" docId="d1" role="reader" isAuthor={true} creatorUid="u_owner" />)
+    await waitFor(() => expect(screen.getByText('docs.member.ownerBadge')).toBeTruthy())
+    // Exactly one removable member (u_reader) → one remove button; the owner row has none.
+    expect(screen.getAllByText('docs.member.remove')).toHaveLength(1)
+    const selects = Array.from(
+      document.querySelectorAll('.octo-member-section select'),
+    ) as HTMLSelectElement[]
+    // Owner row select is disabled (locked); the member row select is enabled.
+    expect(selects.some((s) => s.disabled)).toBe(true)
+    expect(selects.some((s) => !s.disabled)).toBe(true)
+  })
+
+  it('offers only reader/commenter/writer on member rows — admin is never grantable', async () => {
+    listGrants.mockResolvedValue([{ uid: 'u_reader', role: 'reader', source: 'direct' }])
+    render(<HtmlMemberPanel slug="s1" docId="d1" role="reader" isAuthor={true} creatorUid="u_owner" />)
+    await waitFor(() => expect(screen.getByText(/u_reader/)).toBeTruthy())
+    const memberSelect = (Array.from(
+      document.querySelectorAll('.octo-member-section select'),
+    ) as HTMLSelectElement[]).find((s) => !s.disabled)!
+    expect(Array.from(memberSelect.options).map((o) => o.value)).toEqual([
+      'reader',
+      'commenter',
+      'writer',
+    ])
+    expect(Array.from(memberSelect.options).map((o) => o.value)).not.toContain('admin')
   })
 })

--- a/packages/docs/src/html/HtmlMemberPanel.tsx
+++ b/packages/docs/src/html/HtmlMemberPanel.tsx
@@ -3,6 +3,7 @@ import type { Role } from '../auth/roles.ts'
 import { canManage } from '../auth/roles.ts'
 import { t } from '../octoweb/index.ts'
 import { MemberPicker } from '../members/MemberPicker.tsx'
+import { CurrentMembersList } from '../members/CurrentMembersList.tsx'
 import { useMemberNames } from '../members/useMemberNames.ts'
 import { listGrants, addGrant, removeGrant, type HtmlGrant, type HtmlGrantRole } from './htmlGrantsApi.ts'
 import { ShareScopePanel } from '../share/ShareScopePanel.tsx'
@@ -141,6 +142,20 @@ export function HtmlMemberPanel({
     }
   }
 
+  // Change a grant's role. PUT /grants is an upsert, so we reuse addGrant. admin is never grantable
+  // here (backend AddGrant refuses it — admin identity is owned by creator_uid); guard defensively
+  // like onAdd. creator/owner rows never reach here (their select is disabled + role-locked).
+  async function onChangeRole(uid: string, role: Role) {
+    if (role === 'admin') return
+    setError(null)
+    try {
+      await addGrant(slug, uid, role)
+      await refresh()
+    } catch {
+      setError(t('docs.member.errorRole'))
+    }
+  }
+
   // Existing uids (for the picker's "already added" pins): every granted uid plus
   // the creator. The creator is never a candidate (hidden) and never removable.
   const existingUids = new Set<string>(grants.map((g) => g.uid))
@@ -228,39 +243,19 @@ export function HtmlMemberPanel({
         />
       )}
 
-      {/* Slot 5: Current Members (author gate). */}
+      {/* Slot 5: Current Members (author gate). Shared with the rich-doc panel: owner/creator row
+          is locked (disabled select, no remove); non-owner rows get a reader/commenter/writer
+          select (admin never grantable). */}
       {canManageAuthorGrants && (
-        <div className="octo-member-section">
-          <h4 className="octo-member-subtitle">{t('docs.member.currentMembers')}</h4>
-          {loading && <p className="octo-loading">{t('docs.member.loading')}</p>}
-          {!loading && rows.length === 0 && (
-            <p className="octo-member-empty">{t('docs.member.empty')}</p>
-          )}
-          {rows.map((m) => {
-            const isOwner = m.source === 'owner'
-            // Non-owner rows render their actual granted role label (reader/commenter/writer);
-            // the owner row uses the fixed owner badge and carries the 'author' sentinel role.
-            const roleLabel = m.role !== 'author' ? t(`docs.role.${m.role}`) : ''
-            return (
-              <div className="octo-member-row" key={m.uid}>
-                <span className="octo-uid">
-                  {names.get(m.uid) || m.uid}{' '}
-                  {isOwner && <span className="octo-owner-badge">{t('docs.member.ownerBadge')}</span>}
-                  {!isOwner && <small style={{ color: 'var(--octo-muted)' }}> · {roleLabel}</small>}
-                </span>
-                {!isOwner && (
-                  <button
-                    type="button"
-                    className="octo-tb-btn"
-                    onClick={() => onRemove(m.uid)}
-                  >
-                    {t('docs.member.remove')}
-                  </button>
-                )}
-              </div>
-            )
-          })}
-        </div>
+        <CurrentMembersList
+          rows={rows}
+          ownerUid={creatorUid}
+          roles={['reader', 'commenter', 'writer']}
+          displayName={(uid) => names.get(uid) || uid}
+          loading={loading}
+          onChangeRole={onChangeRole}
+          onRemove={onRemove}
+        />
       )}
     </section>
   )

--- a/packages/docs/src/members/CurrentMembersList.tsx
+++ b/packages/docs/src/members/CurrentMembersList.tsx
@@ -14,6 +14,13 @@ import type { Member } from './api.ts'
  * fixed owner badge, a disabled role select, and no remove button. Non-owner rows show ` · source`
  * and an editable role select limited to `roles` (the caller narrows the surface — html omits admin
  * so it can never be minted through /grants).
+ *
+ * Any row whose effective role has no matching option in `roles` (e.g. the html owner's `'author'`
+ * sentinel, or a historical `admin` grant surfaced on the html reader/commenter/writer surface)
+ * renders the role as STATIC text instead of a select. Rendering a select there would leave React
+ * with no matching <option>, silently snapping the shown value to option 0 (reader) — which both
+ * misrepresents the row's real role and, on change, would downgrade it. Fail closed: no editable
+ * control for a role this surface can't grant. This is one uniform rule, not a caller branch.
  */
 
 /** A row's role may be a real Role or the owner sentinel `'author'` (never a doc_member role). */
@@ -77,6 +84,11 @@ export function CurrentMembersList({
         // the sort member (its uid is all the owner row renders beyond the badge).
         const row = byUid.get(sm.uid) ?? { uid: sm.uid, role: sm.role, source: sm.source }
         const removable = !isOwner && (canRemove ? canRemove(row) : true)
+        // The row's effective (display) role is `row.role` — the owner sentinel `'author'` for the
+        // html owner, or the real/mapped role otherwise. Editable only when that role has a matching
+        // option in `roles`; otherwise show static text (see the file header for why).
+        const effectiveRole = row.role
+        const roleGrantable = roles.includes(effectiveRole as Role)
         return (
           <div className="octo-member-row" key={sm.uid}>
             <span className="octo-uid">
@@ -86,19 +98,26 @@ export function CurrentMembersList({
                 <small style={{ color: 'var(--octo-muted)' }}> · {t(`docs.member.source.${row.source}`)}</small>
               )}
             </span>
-            <select
-              // Owner is disabled; use the ranking role (admin) as its shown value so it maps to a
-              // real option where admin is grantable (rich) and stays inert otherwise (html).
-              value={isOwner ? (sm.role as Role) : (row.role as Role)}
-              disabled={isOwner}
-              onChange={(e) => onChangeRole(sm.uid, e.target.value as Role)}
-            >
-              {roles.map((r) => (
-                <option key={r} value={r}>
-                  {t(`docs.role.${r}`)}
-                </option>
-              ))}
-            </select>
+            {roleGrantable ? (
+              <select
+                // The effective role has a matching option; the owner row is inert (disabled) but
+                // still shows its real role (admin where admin is grantable, i.e. rich).
+                value={effectiveRole as Role}
+                disabled={isOwner}
+                onChange={(e) => onChangeRole(sm.uid, e.target.value as Role)}
+              >
+                {roles.map((r) => (
+                  <option key={r} value={r}>
+                    {t(`docs.role.${r}`)}
+                  </option>
+                ))}
+              </select>
+            ) : (
+              // Role not in this surface's grantable set: render it read-only (no select) so we
+              // neither misrepresent it as reader nor allow a silent downgrade on change. The html
+              // owner ('author') has no docs.role.* text — it's already covered by the owner badge.
+              !isOwner && <span>{t(`docs.role.${effectiveRole}`)}</span>
+            )}
             {/* The owner row is synthetic (owner lives outside doc_member) — not a removable grant,
                 so it shows no remove button. */}
             {!isOwner && (

--- a/packages/docs/src/members/CurrentMembersList.tsx
+++ b/packages/docs/src/members/CurrentMembersList.tsx
@@ -1,0 +1,119 @@
+import type { Role } from '../auth/roles.ts'
+import { t } from '../octoweb/index.ts'
+import { sortMembersForDisplay, withSyntheticOwner } from './sort.ts'
+import type { Member } from './api.ts'
+
+/**
+ * Shared "current members" list for the rich-doc (MemberPanel) and HTML (HtmlMemberPanel) panels.
+ *
+ * Pure presentation + callbacks — no network. Both panels feed it their own `rows` and mutation
+ * callbacks; the ordering (owner pinned → admin → writer → commenter → reader, stable within a
+ * tier) is applied here via sort.ts so the two surfaces stay byte-identical.
+ *
+ * The owner is a synthetic row (owner identity lives outside the grant table): it carries the
+ * fixed owner badge, a disabled role select, and no remove button. Non-owner rows show ` · source`
+ * and an editable role select limited to `roles` (the caller narrows the surface — html omits admin
+ * so it can never be minted through /grants).
+ */
+
+/** A row's role may be a real Role or the owner sentinel `'author'` (never a doc_member role). */
+export interface CurrentMemberRow {
+  uid: string
+  role: Role | 'author'
+  source: 'direct' | 'invite' | 'owner'
+}
+
+/**
+ * Adapt a display row to the rich-doc `Member` shape sort.ts consumes. The owner sentinel role
+ * `'author'` is mapped to `'admin'` purely for ranking — the synthetic owner is pinned first by
+ * `ownerUid` anyway, so the mapped role never affects placement, and this keeps sort.ts's public
+ * `Member` signature untouched (no widening of the Role union).
+ */
+function toSortMember(row: CurrentMemberRow): Member {
+  return {
+    uid: row.uid,
+    role: row.role === 'author' ? 'admin' : row.role,
+    source: row.source,
+    grantedBy: '',
+  }
+}
+
+export function CurrentMembersList({
+  rows,
+  ownerUid,
+  roles,
+  displayName,
+  loading,
+  onChangeRole,
+  onRemove,
+  canRemove,
+}: {
+  rows: CurrentMemberRow[]
+  ownerUid?: string
+  /** Grantable role set for the row selects (rich: 4 roles; html: reader/commenter/writer). */
+  roles: Role[]
+  displayName: (uid: string) => string
+  loading?: boolean
+  onChangeRole: (uid: string, role: Role) => void | Promise<void>
+  onRemove: (uid: string) => void | Promise<void>
+  /** Whether a (non-owner) row may be removed. Default: any non-owner row is removable. */
+  canRemove?: (row: CurrentMemberRow) => boolean
+}) {
+  // Order via sort.ts on the adapted Member[]; keep the original display rows keyed by uid so the
+  // owner sentinel role survives (the adapter only exists for ranking, not rendering).
+  const byUid = new Map(rows.map((r) => [r.uid, r]))
+  const sorted = sortMembersForDisplay(withSyntheticOwner(rows.map(toSortMember), ownerUid), ownerUid)
+
+  return (
+    <div className="octo-member-section">
+      <h4 className="octo-member-subtitle">{t('docs.member.currentMembers')}</h4>
+      {loading && <p className="octo-loading">{t('docs.member.loading')}</p>}
+      {!loading && sorted.length === 0 && (
+        <p className="octo-member-empty">{t('docs.member.empty')}</p>
+      )}
+      {sorted.map((sm) => {
+        const isOwner = ownerUid != null && sm.uid === ownerUid
+        // Resolve back to the display row; the synthetic owner has no display row, so fall back to
+        // the sort member (its uid is all the owner row renders beyond the badge).
+        const row = byUid.get(sm.uid) ?? { uid: sm.uid, role: sm.role, source: sm.source }
+        const removable = !isOwner && (canRemove ? canRemove(row) : true)
+        return (
+          <div className="octo-member-row" key={sm.uid}>
+            <span className="octo-uid">
+              {displayName(sm.uid)}{' '}
+              {isOwner && <span className="octo-owner-badge">{t('docs.member.ownerBadge')}</span>}
+              {!isOwner && (
+                <small style={{ color: 'var(--octo-muted)' }}> · {t(`docs.member.source.${row.source}`)}</small>
+              )}
+            </span>
+            <select
+              // Owner is disabled; use the ranking role (admin) as its shown value so it maps to a
+              // real option where admin is grantable (rich) and stays inert otherwise (html).
+              value={isOwner ? (sm.role as Role) : (row.role as Role)}
+              disabled={isOwner}
+              onChange={(e) => onChangeRole(sm.uid, e.target.value as Role)}
+            >
+              {roles.map((r) => (
+                <option key={r} value={r}>
+                  {t(`docs.role.${r}`)}
+                </option>
+              ))}
+            </select>
+            {/* The owner row is synthetic (owner lives outside doc_member) — not a removable grant,
+                so it shows no remove button. */}
+            {!isOwner && (
+              <button
+                type="button"
+                className="octo-tb-btn"
+                disabled={!removable}
+                onClick={() => onRemove(sm.uid)}
+              >
+                {t('docs.member.remove')}
+              </button>
+            )}
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/packages/docs/src/members/MemberPanel.test.tsx
+++ b/packages/docs/src/members/MemberPanel.test.tsx
@@ -89,6 +89,24 @@ describe('MemberPanel — display names (#7)', () => {
     expect(selects.some((s) => s.disabled)).toBe(true)
   })
 
+  it('keeps the owner row rendering a disabled admin select on the rich surface (zero change)', async () => {
+    // Guards rich-side parity after the locked-row fix: on rich the grantable set is the full
+    // ROLES (incl. admin), so the owner's synthetic 'admin' role DOES have a matching option and
+    // must still render as a disabled select whose value is 'admin' (unlike html, which drops it).
+    render(<MemberPanel docId="d_1" role="admin" space="s_1" ownerId="u_named" />)
+    await waitFor(() => expect(screen.getByText('docs.member.ownerBadge')).toBeTruthy())
+    const ownerRow = screen
+      .getByText('docs.member.ownerBadge')
+      .closest('.octo-member-row') as HTMLElement
+    const ownerSelect = ownerRow.querySelector('select') as HTMLSelectElement
+    expect(ownerSelect).toBeTruthy()
+    expect(ownerSelect.disabled).toBe(true)
+    // On rich the owner's effective role ('writer' here — a real grant; 'admin' when synthesized)
+    // is in the grantable ROLES set, so it renders a disabled select showing that real role
+    // (rich behavior is unchanged by the html locked-row fix).
+    expect(ownerSelect.value).toBe('writer')
+  })
+
   it('synthesizes a pinned owner row when the owner is absent from the members API (#A1/#A3)', async () => {
     // Backend members API excludes the owner (owner lives in doc_meta, not doc_member). With an
     // ownerId that is NOT in the returned members, the panel still shows an owner row + badge.

--- a/packages/docs/src/members/MemberPanel.test.tsx
+++ b/packages/docs/src/members/MemberPanel.test.tsx
@@ -130,6 +130,43 @@ describe('MemberPanel — display names (#7)', () => {
     )
     expect(requestSelect).toBeTruthy()
   })
+  it('still sorts the current-members list by role after migrating to the shared component (#A3)', async () => {
+    // Members arrive in a deliberately unsorted order; the shared CurrentMembersList must still
+    // apply sort.ts ordering (owner pinned → admin → writer → commenter → reader). This locks the
+    // post-migration ordering contract: fail-before if the shared list dropped the sort call.
+    wk.apiClient.responder = (method, url) => {
+      if (method === 'get' && url.endsWith('/members')) {
+        return {
+          data: {
+            items: [
+              { uid: 'u_reader', role: 'reader', source: 'direct', grantedBy: 'u_admin' },
+              { uid: 'u_writer', role: 'writer', source: 'direct', grantedBy: 'u_admin' },
+              { uid: 'u_commenter', role: 'commenter', source: 'direct', grantedBy: 'u_admin' },
+            ],
+          },
+          status: 200,
+        }
+      }
+      if (method === 'get' && url.endsWith('/invites')) return { data: { items: [] }, status: 200 }
+      return { data: {}, status: 200 }
+    }
+    render(<MemberPanel docId="d_1" role="admin" space="s_1" ownerId="u_owner" />)
+    await waitFor(() => expect(screen.getByText('docs.member.ownerBadge')).toBeTruthy())
+    // Scope to the Current Members section (the one carrying the owner badge); other sections
+    // (the picker roster) also render `.octo-uid` rows and would pollute the ordering read.
+    const currentSection = screen.getByText('docs.member.ownerBadge').closest('.octo-member-section')!
+    const rows = Array.from(
+      currentSection.querySelectorAll('.octo-member-row .octo-uid'),
+    ).map((el) => el.textContent ?? '')
+    // owner first (synthetic), then writer → commenter → reader.
+    const idxOwner = rows.findIndex((r) => r.includes('u_owner'))
+    const idxWriter = rows.findIndex((r) => r.includes('u_writer'))
+    const idxCommenter = rows.findIndex((r) => r.includes('u_commenter'))
+    const idxReader = rows.findIndex((r) => r.includes('u_reader'))
+    expect(idxOwner).toBe(0)
+    expect(idxWriter).toBeLessThan(idxCommenter)
+    expect(idxCommenter).toBeLessThan(idxReader)
+  })
 })
 
 describe('MemberPanel add: partial-failure detail survives a refresh failure (task #5)', () => {

--- a/packages/docs/src/members/MemberPanel.tsx
+++ b/packages/docs/src/members/MemberPanel.tsx
@@ -12,7 +12,7 @@ import {
 } from './api.ts'
 import { useMemberNames } from './useMemberNames.ts'
 import { MemberPicker } from './MemberPicker.tsx'
-import { sortMembersForDisplay, withSyntheticOwner } from './sort.ts'
+import { CurrentMembersList } from './CurrentMembersList.tsx'
 import { settleWithConcurrency } from './batchGrant.ts'
 import { InvitePanel } from '../invite/InvitePanel.tsx'
 import { useAccessRequests, type UseAccessRequestsResult } from '../access-request/useAccessRequests.ts'
@@ -211,51 +211,16 @@ export function MemberPanel({
         displayName={displayName}
       />
 
-      <div className="octo-member-section">
-        <h4 className="octo-member-subtitle">{t('docs.member.currentMembers')}</h4>
-        {loading && <p className="octo-loading">{t('docs.member.loading')}</p>}
-        {!loading && members.length === 0 && (
-          <p className="octo-member-empty">{t('docs.member.empty')}</p>
-        )}
-        {sortMembersForDisplay(withSyntheticOwner(members, resolvedOwner), resolvedOwner).map((m) => {
-          const isOwner = resolvedOwner != null && m.uid === resolvedOwner
-          const removable = !isOwner && (resolvedOwner ? canRemoveMember(m, resolvedOwner) : true)
-          return (
-            <div className="octo-member-row" key={m.uid}>
-              <span className="octo-uid">
-                {displayName(m.uid)}{' '}
-                {isOwner && <span className="octo-owner-badge">{t('docs.member.ownerBadge')}</span>}
-                {!isOwner && (
-                  <small style={{ color: 'var(--octo-muted)' }}> · {t(`docs.member.source.${m.source}`)}</small>
-                )}
-              </span>
-              <select
-                value={m.role}
-                disabled={isOwner}
-                onChange={(e) => onChangeRole(m.uid, e.target.value as Role)}
-              >
-                {ROLES.map((r) => (
-                  <option key={r} value={r}>
-                    {t(`docs.role.${r}`)}
-                  </option>
-                ))}
-              </select>
-              {/* The owner row is synthetic (owner lives in doc_meta, not doc_member) — it is not
-                  a removable member grant, so it shows no remove button. */}
-              {!isOwner && (
-                <button
-                  type="button"
-                  className="octo-tb-btn"
-                  disabled={!removable}
-                  onClick={() => onRemove(m.uid)}
-                >
-                  {t('docs.member.remove')}
-                </button>
-              )}
-            </div>
-          )
-        })}
-      </div>
+      <CurrentMembersList
+        rows={members}
+        ownerUid={resolvedOwner}
+        roles={ROLES}
+        displayName={displayName}
+        loading={loading}
+        onChangeRole={onChangeRole}
+        onRemove={onRemove}
+        canRemove={(m) => (resolvedOwner ? canRemoveMember({ ...m, grantedBy: '' } as Member, resolvedOwner) : true)}
+      />
     </section>
   )
 }


### PR DESCRIPTION
## Summary

HTML 文档成员面板最下方的「当前成员」原本是**另写的一套**，与富文本/表格/白板的当前成员在四个维度上不一致。本 PR 把该列表抽成共享组件 `CurrentMembersList`，两侧共用，**从结构上消除"改一处漏一处"**，并为 HTML 侧补齐改角色能力。

对齐前后差异（HTML 侧）：

| 维度 | rich / sheet / board（基准） | HTML（before） | HTML（after） |
|---|---|---|---|
| 排序 | `withSyntheticOwner` + `sortMembersForDisplay`：owner 置顶 → admin → writer → commenter → reader，同档稳定 | creator 置顶 + 后端原序，无角色排序 | 同基准 |
| 角色 | `<select>` 可改（4 角色） | 只读文本，不能改 | `<select>` 可改（reader/commenter/writer，**admin 不可授**） |
| 副标签 | ` · 来源`（direct/invite/owner） | ` · 角色名` | ` · 来源` |
| 移除 | `canRemoveMember` 控 disabled，owner 行无按钮 | 一律可点，无规则 | owner 行无按钮 |

**改角色不新增接口**：复用既有 `addGrant(slug, uid, role)`（`PUT /grants` 本身是 upsert）；`role === 'admin'` 防御性 `return`（后端 `AddGrant` 拒绝 admin，admin 身份归 `creator_uid`）；成功 `refresh()`，失败 `setError(t('docs.member.errorRole'))`。

### 第二个 commit：修复本次重构引入的 P1（作者被显示成"只读"）

抽取过程中，共享组件对 owner 行也渲染了 disabled `<select>`，其 value 取自排序用的映射角色 `admin`；而 HTML 侧 `roles = ['reader','commenter','writer']` **没有 admin option** → React 无匹配项，`selectedIndex` 回落到 0。

实测探针（`creatorUid=u_owner`）：

```
{"value":"reader","selectedIndex":0,"options":["reader","commenter","writer"]}
```

即**文档作者在 HTML 成员列表里显示为"只读"**。324 条测试全绿未能发现，因为断言只检查了 `disabled` 真假、未检查显示的角色文字。

更危险的同源变体：后端返回一条历史 `admin` grant 时，该行同样被显示成 reader，**用户一改就静默降权**。

修法（一条统一规则，非调用方分支）：**行的有效角色在 `roles` 中无匹配 option 时不渲染可编辑 select** ——
- owner 哨兵 `'author'` 不在 `roles` 中 → owner 行不渲染 select（回到本 PR 前的 HTML 行为：仅名字 + owner 徽标）；
- rich 侧 owner 合成角色 `admin` ∈ `ROLES` → 照旧渲染 disabled 的 admin select，**rich 侧行为零变化**；
- 非 owner 行角色不在 `roles` 中（如历史 admin grant）→ 渲染静态 `docs.role.admin` 文字，fail closed，不给可降权的控件。

修复后实测（同一探针）：owner 行 `u_owner + ownerBadge`、无 select；历史 admin 行显示静态 `docs.role.admin`、无 select；普通成员行 select 可改。

## Linked Spec

延续 OCT-195（HTML 文档成员面板补齐）的对齐目标；无独立 spec 文档。排序契约的单一来源是 `packages/docs/src/members/sort.ts`。

## How verified

- `npx vitest run src/members src/html` → **327 passed (21 files)**（重构后 324 → P1 修复再 +3）。
- **rich 侧行为零变化**：`MemberPanel.test.tsx` 现有断言**一字未改**（diff 仅在文件末尾新增 `it`），全部通过。
- **HTML 侧新测试逐条 mutation 验证 fail-before**：排序退化为 `withSyntheticOwner` → 2 失败；`onChangeRole` 改 no-op → 2 失败；移除 `!isOwner` 守卫 → 1 失败；`roles` 加入 admin → 1 失败。
- **P1 由 orchestrator 独立探针实测确认**（非静态推断），修复后再次探针复核 DOM 形状（见上方输出）。
- `tsc --noEmit -p tsconfig.typecheck.json` → 本 PR 触及文件零错误（仅基线既有的 `../dmworkbase/src/i18n/format.ts`、`src/board/octoNativeShapes.contract.test.ts` 无关报错）。

## COMPREHENSION

**(a) 对承载路径做了什么（before/after）**

承载路径 = 文档成员列表的**展示与角色变更入口**（授权面 UI）。

- Before：rich 与 HTML 各写一套渲染；HTML 无角色排序、角色只读、移除无 disabled 规则。
- After：唯一渲染入口 `CurrentMembersList`（纯展示 + 回调，无网络）；排序统一走 `sort.ts`；HTML 获得改角色能力（复用 upsert，admin 双重不可授：`roles` 不含 + `onChangeRole` 守卫）；**角色与可授集合不匹配的行一律降级为静态文字**，杜绝"显示 reader、一改就降权"。

`sort.ts` 公共签名、`Member` 类型、`htmlGrantsApi.ts` 导出签名均未改动；owner 哨兵 `'author'` 仅在组件内局部适配（`toSortMember`，映射仅用于排名，不用于渲染）。

**(b) 可能坏什么（依赖方 + 失效模式）**

- 依赖方：`MemberPanel.tsx`（rich/sheet/board 共用）与 `HtmlMemberPanel.tsx`。rich 侧为纯渲染容器替换，靠"现有断言一字不改且全过"守住零变化。
- 失效模式 1（已发生并修复）：owner/历史 admin 行角色与 `roles` 不匹配 → 误显示为 reader + 可静默降权。已由 owner 行无 select、历史 admin 行静态文字两条测试覆盖。
- 失效模式 2：HTML 侧若把 admin 放进 `roles` 或去掉 `onChangeRole` 的 admin 守卫 → 可能尝试铸造 admin（后端会拒，但 UI 误导）。已由「admin 不在可选角色」测试覆盖。
- 失效模式 3：creator 行若可移除 → 后端返 409。owner 行不渲染移除按钮，已由测试覆盖。
- 权限门未变：`canManageAuthorGrants`（octo-doc author，管 grants 区）与 `canManageBackend`（docs-backend role，管 Share/Invite/Requests）语义逐字未动。

**(c) 怎么知道它可用**

327 条测试全绿；rich 侧断言未改动即通过；HTML 侧每条新测试均经反向 mutation 证明可失败；P1 前后各一次真实 DOM 探针实测；typecheck 无新增错误。

## 部署前提 / 必配环境变量

**无。** 纯前端改动：不新增/不修改任何环境变量、不改后端契约、不新增接口（改角色复用既有 `PUT /grants` upsert）、不增加请求次数、不新增 i18n key（复用 `docs.member.currentMembers` / `loading` / `empty` / `ownerBadge` / `remove` / `source.*` / `role.*` / `errorRole`）、不新建或修改 CSS。
