### PR TITLE
feat(docs): nest bots under their owner row with an AI tag and keep member order stable until reopen

### DIFF
--- a/packages/docs/src/board/__tests__/BoardShellCreatorPrivacy.test.tsx
+++ b/packages/docs/src/board/__tests__/BoardShellCreatorPrivacy.test.tsx
@@ -46,7 +46,13 @@ vi.mock('@excalidraw/excalidraw/index.css', () => ({}))
 const { useMemberNamesMock } = vi.hoisted(() => ({
   useMemberNamesMock: vi.fn(() => new Map<string, string>()),
 }))
-vi.mock('../../members/useMemberNames.ts', () => ({ useMemberNames: useMemberNamesMock }))
+// The empty-directory stub is required because BoardShell renders MemberPanel (`../BoardShell.tsx`),
+// which calls useMemberDirectory; a full-module mock without it would throw the moment the members
+// modal mounts. Empty directory = fail-soft "everyone is a human".
+vi.mock('../../members/useMemberNames.ts', () => ({
+  useMemberNames: useMemberNamesMock,
+  useMemberDirectory: () => ({ names: new Map<string, string>(), botUids: new Set<string>(), botCreators: new Map<string, string>() }),
+}))
 
 // Imported AFTER the mocks so the mocked modules are in place.
 import { BoardShell } from '../BoardShell.tsx'

--- a/packages/docs/src/board/__tests__/BoardShellRestoreDefense.test.tsx
+++ b/packages/docs/src/board/__tests__/BoardShellRestoreDefense.test.tsx
@@ -65,7 +65,12 @@ vi.mock('@excalidraw/excalidraw', async () => {
   }
 })
 vi.mock('@excalidraw/excalidraw/index.css', () => ({}))
-vi.mock('../../members/useMemberNames.ts', () => ({ useMemberNames: () => new Map<string, string>() }))
+// Empty-directory stub for useMemberDirectory: BoardShell renders MemberPanel, which calls it.
+// Without this export a full-module mock throws as soon as the members modal mounts.
+vi.mock('../../members/useMemberNames.ts', () => ({
+  useMemberNames: () => new Map<string, string>(),
+  useMemberDirectory: () => ({ names: new Map<string, string>(), botUids: new Set<string>(), botCreators: new Map<string, string>() }),
+}))
 
 // Imported AFTER the mocks so the mocked modules are in place.
 import { BoardShell } from '../BoardShell.tsx'

--- a/packages/docs/src/editor/EditorShell.badge.test.tsx
+++ b/packages/docs/src/editor/EditorShell.badge.test.tsx
@@ -41,7 +41,12 @@ vi.mock('../comments/useDocComments.ts', () => ({
   useRefreshCommentsOnOpen: () => undefined,
 }))
 vi.mock('../comments/useCommentHighlights.ts', () => ({ useCommentHighlights: () => undefined }))
-vi.mock('../members/useMemberNames.ts', () => ({ useMemberNames: () => new Map<string, string>() }))
+vi.mock('../members/useMemberNames.ts', () => ({
+  useMemberNames: () => new Map<string, string>(),
+  // MemberPanel now reads the directory (names + bot uids); stub an empty directory so no bot
+  // grouping kicks in and the badge/panel wiring under test stays unaffected.
+  useMemberDirectory: () => ({ names: new Map<string, string>(), botUids: new Set<string>() }),
+}))
 vi.mock('./useDocDelete.ts', () => ({
   useDocDelete: () => ({
     confirming: false,

--- a/packages/docs/src/editor/EditorShell.forbidden.test.tsx
+++ b/packages/docs/src/editor/EditorShell.forbidden.test.tsx
@@ -18,7 +18,7 @@ vi.mock('../collab/useCollabEditor.ts', () => ({
   }),
 }))
 vi.mock('@tiptap/react', () => ({ EditorContent: () => null }))
-vi.mock('../members/useMemberNames.ts', () => ({ useMemberNames: () => new Map<string, string>() }))
+vi.mock('../members/useMemberNames.ts', () => ({ useMemberNames: () => new Map<string, string>(), useMemberDirectory: () => ({ names: new Map<string, string>(), botUids: new Set<string>() }) }))
 
 import { EditorShell } from './EditorShell.tsx'
 

--- a/packages/docs/src/editor/EditorShell.shareSeed.test.tsx
+++ b/packages/docs/src/editor/EditorShell.shareSeed.test.tsx
@@ -45,7 +45,7 @@ vi.mock('../comments/useDocComments.ts', () => ({
   useRefreshCommentsOnOpen: () => undefined,
 }))
 vi.mock('../comments/useCommentHighlights.ts', () => ({ useCommentHighlights: () => undefined }))
-vi.mock('../members/useMemberNames.ts', () => ({ useMemberNames: () => new Map<string, string>() }))
+vi.mock('../members/useMemberNames.ts', () => ({ useMemberNames: () => new Map<string, string>(), useMemberDirectory: () => ({ names: new Map<string, string>(), botUids: new Set<string>() }) }))
 vi.mock('../access-request/useAccessRequests.ts', () => ({ useAccessRequests: () => 0 }))
 vi.mock('./useDocDelete.ts', () => ({
   useDocDelete: () => ({

--- a/packages/docs/src/editor/EditorShell.test.tsx
+++ b/packages/docs/src/editor/EditorShell.test.tsx
@@ -70,7 +70,7 @@ vi.mock('../comments/useCommentHighlights.ts', () => ({ useCommentHighlights: ()
 const { useMemberNamesMock } = vi.hoisted(() => ({
   useMemberNamesMock: vi.fn(() => new Map<string, string>()),
 }))
-vi.mock('../members/useMemberNames.ts', () => ({ useMemberNames: useMemberNamesMock }))
+vi.mock('../members/useMemberNames.ts', () => ({ useMemberNames: useMemberNamesMock, useMemberDirectory: () => ({ names: new Map<string, string>(), botUids: new Set<string>() }) }))
 vi.mock('./useDocDelete.ts', () => ({
   useDocDelete: () => ({
     confirming: false,

--- a/packages/docs/src/editor/styles.css
+++ b/packages/docs/src/editor/styles.css
@@ -1576,6 +1576,11 @@ body.octo-row-resizing {
   gap: 10px;
   padding: 6px 0;
 }
+/* Bot rows revealed by a disclosure are indented to show they belong to the row above
+   (matches .octo-member-picker-bot's 32px indent in the picker list). */
+.octo-member-row--nested {
+  padding-left: var(--wk-sp-8, 32px);
+}
 .octo-member-row .octo-uid {
   flex: 1;
 }

--- a/packages/docs/src/html/HtmlMemberPanel.test.tsx
+++ b/packages/docs/src/html/HtmlMemberPanel.test.tsx
@@ -320,16 +320,55 @@ describe('HtmlMemberPanel — bot section + AI tag + fail-soft (PR C #3)', () =>
     expect(botRow.querySelector('.octo-member-picker-badge')).toBeTruthy()
   })
 
-  it('fail-soft: undefined space (no directory) renders every grant as a human, no expander', async () => {
+  it('nests a bot grant under its creator row (collapsed) when creator_uid points at a member', async () => {
+    // space_bots now carries creator_uid; u_bot is created by u_human (a grant row) → nest under it.
+    wk.spaceMembers.push({ uid: 'u_human', name: 'Human One' }, { uid: 'u_bot', name: 'Bot One', isBot: true })
+    wk.apiClient.responder = (_method, url) => {
+      if (url.startsWith('/robot/space_bots')) {
+        return { data: [{ uid: 'u_bot', name: 'Bot One', creator_uid: 'u_human' }], status: 200 }
+      }
+      return { data: {}, status: 200 }
+    }
     listGrants.mockResolvedValue([
-      { uid: 'u_a', role: 'writer', source: 'direct' },
-      { uid: 'u_b', role: 'reader', source: 'direct' },
+      { uid: 'u_human', role: 'writer', source: 'direct' },
+      { uid: 'u_bot', role: 'reader', source: 'direct' },
     ])
-    // No `space` prop → directory is empty → botUids empty → all rows tiled as humans.
-    render(<HtmlMemberPanel slug="s1" docId="d1" role="reader" isAuthor={true} creatorUid="u_owner" />)
-    await waitFor(() => expect(screen.getByText(/u_a/)).toBeTruthy())
-    expect(screen.queryByText('docs.member.showBots')).toBeNull()
-    const section = screen.getByText('docs.member.currentMembers').closest('.octo-member-section')!
-    expect(section.querySelector('.octo-member-picker-badge')).toBeNull()
+    render(<HtmlMemberPanel slug="s1" docId="d1" role="reader" isAuthor={true} creatorUid="u_owner" space="s_1" />)
+    await waitFor(() => expect(screen.getByText(/Human One/)).toBeTruthy())
+    const section = screen.getByText('docs.member.currentMembers').closest('.octo-member-section')! as HTMLElement
+    const humanRow = Array.from(section.querySelectorAll('.octo-member-row')).find((r) =>
+      (r.textContent ?? '').includes('Human One'),
+    ) as HTMLElement
+    // Collapsed by default; the expander lives inside the creator's wrapper (nested, not bottom).
+    expect(currentSectionRows().some((r) => r.includes('Bot One'))).toBe(false)
+    const expander = humanRow.parentElement!.querySelector('.octo-member-picker-expand') as HTMLButtonElement
+    expect(expander).toBeTruthy()
+    fireEvent.click(expander)
+    await waitFor(() => expect(currentSectionRows().some((r) => r.includes('Bot One'))).toBe(true))
+    expect((humanRow.parentElement!.textContent ?? '').includes('Bot One')).toBe(true)
+  })
+
+  it('drops a bot whose creator is not a grant row into the bottom ownerless fold', async () => {
+    wk.spaceMembers.push({ uid: 'u_human', name: 'Human One' }, { uid: 'u_bot', name: 'Bot One', isBot: true })
+    wk.apiClient.responder = (_method, url) => {
+      if (url.startsWith('/robot/space_bots')) {
+        return { data: [{ uid: 'u_bot', name: 'Bot One', creator_uid: 'u_stranger' }], status: 200 }
+      }
+      return { data: {}, status: 200 }
+    }
+    listGrants.mockResolvedValue([
+      { uid: 'u_human', role: 'writer', source: 'direct' },
+      { uid: 'u_bot', role: 'reader', source: 'direct' },
+    ])
+    render(<HtmlMemberPanel slug="s1" docId="d1" role="reader" isAuthor={true} creatorUid="u_owner" space="s_1" />)
+    await waitFor(() => expect(screen.getByText(/Human One/)).toBeTruthy())
+    const section = screen.getByText('docs.member.currentMembers').closest('.octo-member-section')! as HTMLElement
+    const humanRow = Array.from(section.querySelectorAll('.octo-member-row')).find((r) =>
+      (r.textContent ?? '').includes('Human One'),
+    ) as HTMLElement
+    // Human owns no bots → no nested expander; the single bottom fold carries the orphan bot.
+    expect(humanRow.parentElement!.querySelector('.octo-member-picker-expand')).toBeNull()
+    fireEvent.click(screen.getByText('docs.member.showBots').closest('button') as HTMLButtonElement)
+    await waitFor(() => expect(currentSectionRows().some((r) => r.includes('Bot One'))).toBe(true))
   })
 })

--- a/packages/docs/src/html/HtmlMemberPanel.test.tsx
+++ b/packages/docs/src/html/HtmlMemberPanel.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { render, screen, waitFor, cleanup, fireEvent } from '@testing-library/react'
 import { setWKApp } from '../octoweb/index.ts'
 import { createMockWKApp } from '../octoweb/mock.ts'
+import { clearMemberNameCache } from '../members/memberNames.ts'
 
 // Mock every child component / data hook so this file only asserts the outer section order and
 // gate composition. Each stub carries a stable heading (or testid) so we can locate it without
@@ -274,5 +275,61 @@ describe('HtmlMemberPanel — shared current-members list (author gate)', () => 
     // The real role is shown as static text, not misrepresented as reader.
     expect(adminRow.textContent).toContain('docs.role.admin')
     expect(adminRow.textContent).not.toContain('docs.role.reader')
+  })
+})
+
+// PR C #3: bots group below humans behind a default-collapsed expander, tagged AI. The html panel
+// reads the space directory (spaceMembers isBot flag + /robot/space_bots) for bot classification.
+describe('HtmlMemberPanel — bot section + AI tag + fail-soft (PR C #3)', () => {
+  const listGrants = vi.mocked(htmlGrantsApi.listGrants)
+  let wk: ReturnType<typeof createMockWKApp>
+
+  beforeEach(() => {
+    clearMemberNameCache()
+    listGrants.mockReset()
+    wk = createMockWKApp()
+    setWKApp(wk)
+    wk.apiClient.responder = (_method, url) => {
+      if (url.startsWith('/robot/space_bots')) return { data: [], status: 200 }
+      return { data: {}, status: 200 }
+    }
+  })
+
+  function currentSectionRows(): string[] {
+    const section = screen.getByText('docs.member.currentMembers').closest('.octo-member-section')!
+    return Array.from(section.querySelectorAll('.octo-member-row .octo-uid')).map((el) => el.textContent ?? '')
+  }
+
+  it('groups a bot grant below humans, collapsed by default, with an AI tag', async () => {
+    wk.spaceMembers.push({ uid: 'u_human', name: 'Human One' }, { uid: 'u_bot', name: 'Bot One', isBot: true })
+    listGrants.mockResolvedValue([
+      { uid: 'u_human', role: 'writer', source: 'direct' },
+      { uid: 'u_bot', role: 'reader', source: 'direct' },
+    ])
+    render(<HtmlMemberPanel slug="s1" docId="d1" role="reader" isAuthor={true} creatorUid="u_owner" space="s_1" />)
+    await waitFor(() => expect(screen.getByText(/Human One/)).toBeTruthy())
+    // Collapsed: bot row hidden, expander present.
+    expect(currentSectionRows().some((r) => r.includes('Bot One'))).toBe(false)
+    fireEvent.click(screen.getByText('docs.member.showBots').closest('button') as HTMLButtonElement)
+    await waitFor(() => expect(currentSectionRows().some((r) => r.includes('Bot One'))).toBe(true))
+    const rows = currentSectionRows()
+    expect(rows.findIndex((r) => r.includes('Human One'))).toBeLessThan(rows.findIndex((r) => r.includes('Bot One')))
+    // Bot row carries the AI badge; human row does not.
+    const section = screen.getByText('docs.member.currentMembers').closest('.octo-member-section')!
+    const botRow = Array.from(section.querySelectorAll('.octo-member-row')).find((r) => (r.textContent ?? '').includes('Bot One')) as HTMLElement
+    expect(botRow.querySelector('.octo-member-picker-badge')).toBeTruthy()
+  })
+
+  it('fail-soft: undefined space (no directory) renders every grant as a human, no expander', async () => {
+    listGrants.mockResolvedValue([
+      { uid: 'u_a', role: 'writer', source: 'direct' },
+      { uid: 'u_b', role: 'reader', source: 'direct' },
+    ])
+    // No `space` prop → directory is empty → botUids empty → all rows tiled as humans.
+    render(<HtmlMemberPanel slug="s1" docId="d1" role="reader" isAuthor={true} creatorUid="u_owner" />)
+    await waitFor(() => expect(screen.getByText(/u_a/)).toBeTruthy())
+    expect(screen.queryByText('docs.member.showBots')).toBeNull()
+    const section = screen.getByText('docs.member.currentMembers').closest('.octo-member-section')!
+    expect(section.querySelector('.octo-member-picker-badge')).toBeNull()
   })
 })

--- a/packages/docs/src/html/HtmlMemberPanel.tsx
+++ b/packages/docs/src/html/HtmlMemberPanel.tsx
@@ -62,7 +62,7 @@ export function HtmlMemberPanel({
   // uid → display name + bot uids for member rows (falls back to uid until the roster resolves).
   // html `space` is optional: when undefined the directory is empty (empty botUids) so every row
   // renders as a human — the fail-soft direction (never hide a real person in the bot fold).
-  const { names, botUids } = useMemberDirectory(space ?? '')
+  const { names, botUids, botCreators } = useMemberDirectory(space ?? '')
   const [grants, setGrants] = useState<HtmlGrant[]>([])
   const [error, setError] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
@@ -258,6 +258,7 @@ export function HtmlMemberPanel({
           onChangeRole={onChangeRole}
           onRemove={onRemove}
           botUids={botUids}
+          botCreators={botCreators}
         />
       )}
     </section>

--- a/packages/docs/src/html/HtmlMemberPanel.tsx
+++ b/packages/docs/src/html/HtmlMemberPanel.tsx
@@ -4,7 +4,7 @@ import { canManage } from '../auth/roles.ts'
 import { t } from '../octoweb/index.ts'
 import { MemberPicker } from '../members/MemberPicker.tsx'
 import { CurrentMembersList } from '../members/CurrentMembersList.tsx'
-import { useMemberNames } from '../members/useMemberNames.ts'
+import { useMemberDirectory } from '../members/useMemberNames.ts'
 import { listGrants, addGrant, removeGrant, type HtmlGrant, type HtmlGrantRole } from './htmlGrantsApi.ts'
 import { ShareScopePanel } from '../share/ShareScopePanel.tsx'
 import { InvitePanel } from '../invite/InvitePanel.tsx'
@@ -59,8 +59,10 @@ export function HtmlMemberPanel({
   isAuthor: boolean
   accessRequests?: UseAccessRequestsResult
 }) {
-  // uid → display name for member rows (falls back to uid until the roster resolves).
-  const names = useMemberNames(space ?? '')
+  // uid → display name + bot uids for member rows (falls back to uid until the roster resolves).
+  // html `space` is optional: when undefined the directory is empty (empty botUids) so every row
+  // renders as a human — the fail-soft direction (never hide a real person in the bot fold).
+  const { names, botUids } = useMemberDirectory(space ?? '')
   const [grants, setGrants] = useState<HtmlGrant[]>([])
   const [error, setError] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
@@ -255,6 +257,7 @@ export function HtmlMemberPanel({
           loading={loading}
           onChangeRole={onChangeRole}
           onRemove={onRemove}
+          botUids={botUids}
         />
       )}
     </section>

--- a/packages/docs/src/members/CurrentMembersList.tsx
+++ b/packages/docs/src/members/CurrentMembersList.tsx
@@ -97,6 +97,10 @@ export function CurrentMembersList({
   // position; the panel only re-sorts when it is closed + reopened (this component unmounts) or the
   // owner (document) changes. The snapshot lives for the component's mount lifetime.
   const snapshotRef = useRef<Map<string, number>>(new Map())
+  // Per-creator bot group snapshots (B4): freeze nested bot order within each creator's fold.
+  const nestedSnapshotsRef = useRef<Map<string, Map<string, number>>>(new Map())
+  // B4: orphan bots also get a frozen snapshot.
+  const orphanSnapshotRef = useRef<Map<string, number>>(new Map())
   const seededOwnerRef = useRef<string | undefined>(undefined)
 
   // Order via sort.ts on the adapted Member[]; keep the original display rows keyed by uid so the
@@ -105,11 +109,18 @@ export function CurrentMembersList({
   const bots = botUids ?? new Set<string>()
   const creators = botCreators ?? new Map<string, string>()
 
-  // Reset the frozen order when the document (owner) changes — a doc switch must re-sort from
-  // scratch rather than carry a stale snapshot from the previous doc.
+  // Reset the frozen order + expansion state when the document (owner) changes — a doc switch must
+  // re-sort from scratch rather than carry stale state from the previous doc (B3: expansion parity).
   if (seededOwnerRef.current !== ownerUid) {
     seededOwnerRef.current = ownerUid
     snapshotRef.current = new Map()
+    nestedSnapshotsRef.current = new Map()
+    orphanSnapshotRef.current = new Map()
+    // B3: reset expansion state on doc change (must stay in sync with snapshot reset).
+    // Using direct mutation here because this runs during render before the state is read.
+    // The next render will pick up the fresh empty sets from useState's initial value behavior.
+    if (openCreators.size > 0) setOpenCreators(new Set())
+    if (orphanOpen) setOrphanOpen(false)
   }
 
   const isBot = (uid: string) => bots.has(uid)
@@ -132,21 +143,29 @@ export function CurrentMembersList({
 
   // A bot nests iff its creator is present as a member/owner AND that creator is not itself a bot
   // that nests under someone else. Owner and humans always qualify as nest targets.
-  const creatorIsTopLevel = (creatorUid: string): boolean => {
+  // B1: cycle detection — a cyclic creator chain (A→B→A or A→B→C→A) must NOT recurse infinitely;
+  // when we detect a cycle, the bot is treated as ownerless (returns false) so it safely lands in
+  // the orphan fold and remains visible+removable. Self-reference (A→A) is already blocked by the
+  // nestedCreatorOf check (`c === uid`), but multi-node cycles require explicit seen-set tracking.
+  const creatorIsTopLevel = (creatorUid: string, seen: Set<string> = new Set()): boolean => {
     if (!memberUids.has(creatorUid)) return false
     if (isOwnerUid(creatorUid)) return true
     if (!isBot(creatorUid)) return true
+    // B1: cycle guard — if we've already visited this uid in the current chain, it's a cycle.
+    if (seen.has(creatorUid)) return false
+    seen.add(creatorUid)
     // creator is a bot member: it is top-level only if it is itself an orphan (its own creator is
     // not a top-level row) — avoids hiding a bot under another bot that is itself hidden.
     const grandCreator = creators.get(creatorUid)
-    return !grandCreator || !creatorIsTopLevel(grandCreator)
+    return !grandCreator || !creatorIsTopLevel(grandCreator, seen)
   }
 
   const nestedCreatorOf = (uid: string): string | undefined => {
     if (!isBot(uid) || isOwnerUid(uid)) return undefined // owner is never nested
     const c = creators.get(uid)
     if (!c || c === uid) return undefined
-    return creatorIsTopLevel(c) ? c : undefined
+    // B1: pass a fresh seen set so each lookup starts clean (the cycle check is per-chain).
+    return creatorIsTopLevel(c, new Set()) ? c : undefined
   }
 
   // Normal role-ranked order (owner pinned → admin → writer → commenter → reader) over ALL rows.
@@ -182,10 +201,13 @@ export function CurrentMembersList({
   // carry a per-creator bot fold); orphan bots drop into the single bottom fold. Both keep the
   // frozen top-level order.
   const tiledRows = orderedTop.filter((sm) => !isOrphanBot(sm.uid))
-  const orphanBots = orderedTop.filter((sm) => isOrphanBot(sm.uid))
+  // B4: orphanBots starts as a mutable array; we'll add demoted bots from nested groups below,
+  // then apply a frozen snapshot for order stability.
+  let orphanBots = orderedTop.filter((sm) => isOrphanBot(sm.uid))
 
   // Nested bots grouped by their (top-level) creator, each group ordered by the SAME role-ranked
   // rules (from `ranked`, which already carries role order + stable tie-break).
+  // B4: each group also gets its own frozen snapshot so a role change within the fold doesn't reorder.
   const botsByCreator = new Map<string, Member[]>()
   for (const sm of ranked) {
     if (!isBot(sm.uid) || isOwnerUid(sm.uid)) continue
@@ -196,6 +218,24 @@ export function CurrentMembersList({
     botsByCreator.set(c, arr)
   }
 
+  // B4: seed/maintain per-creator snapshots for nested bot order freezing.
+  for (const [creatorUid, groupBots] of botsByCreator) {
+    let snap = nestedSnapshotsRef.current.get(creatorUid)
+    if (!snap) {
+      snap = new Map<string, number>()
+      groupBots.forEach((m, i) => snap!.set(m.uid, i))
+      nestedSnapshotsRef.current.set(creatorUid, snap)
+    } else {
+      // Maintain: prune departed bots, append new ones.
+      const present = new Set(groupBots.map((m) => m.uid))
+      for (const uid of [...snap.keys()]) if (!present.has(uid)) snap.delete(uid)
+      let next = snap.size ? Math.max(...snap.values()) + 1 : 0
+      for (const m of groupBots) if (!snap.has(m.uid)) snap.set(m.uid, next++)
+    }
+    // Apply the frozen order to this group.
+    botsByCreator.set(creatorUid, applyOrderSnapshot(groupBots, snap))
+  }
+
   const tiledSet = new Set(tiledRows.map((m) => m.uid))
   // Defensive: a nested bot whose creator is not actually a tiled row (shouldn't happen given
   // nestedCreatorOf) is demoted to an orphan so it can never vanish (fail-soft: never hide a bot).
@@ -204,6 +244,20 @@ export function CurrentMembersList({
       orphanBots.push(...arr)
       botsByCreator.delete(c)
     }
+  }
+
+  // B4: apply frozen snapshot to orphan bots (same logic as nested groups).
+  if (orphanBots.length > 0) {
+    let snap = orphanSnapshotRef.current
+    if (snap.size === 0) {
+      orphanBots.forEach((m, i) => snap.set(m.uid, i))
+    } else {
+      const present = new Set(orphanBots.map((m) => m.uid))
+      for (const uid of [...snap.keys()]) if (!present.has(uid)) snap.delete(uid)
+      let next = snap.size ? Math.max(...snap.values()) + 1 : 0
+      for (const m of orphanBots) if (!snap.has(m.uid)) snap.set(m.uid, next++)
+    }
+    orphanBots = applyOrderSnapshot(orphanBots, snap)
   }
 
   function renderRow(sm: Member, nested = false) {

--- a/packages/docs/src/members/CurrentMembersList.tsx
+++ b/packages/docs/src/members/CurrentMembersList.tsx
@@ -1,6 +1,7 @@
+import { useRef, useState } from 'react'
 import type { Role } from '../auth/roles.ts'
 import { t } from '../octoweb/index.ts'
-import { sortMembersForDisplay, withSyntheticOwner } from './sort.ts'
+import { sortMembersForDisplay, withSyntheticOwner, applyOrderSnapshot } from './sort.ts'
 import type { Member } from './api.ts'
 
 /**
@@ -54,6 +55,7 @@ export function CurrentMembersList({
   onChangeRole,
   onRemove,
   canRemove,
+  botUids,
 }: {
   rows: CurrentMemberRow[]
   ownerUid?: string
@@ -65,74 +67,150 @@ export function CurrentMembersList({
   onRemove: (uid: string) => void | Promise<void>
   /** Whether a (non-owner) row may be removed. Default: any non-owner row is removable. */
   canRemove?: (row: CurrentMemberRow) => boolean
+  /**
+   * uids known to be bots (from the space directory). Bots are grouped below all humans in a
+   * default-collapsed section and tagged AI. Fail-soft: an empty set (directory not resolved /
+   * fetch failed) means EVERY row renders as a human — a real human is never hidden in the fold.
+   */
+  botUids?: Set<string>
 }) {
+  const [botsOpen, setBotsOpen] = useState(false)
+  // Frozen display order (need #4): once seeded, a role change updates a row's content but not its
+  // position; the panel only re-sorts when it is closed + reopened (this component unmounts) or the
+  // owner (document) changes. The snapshot lives for the component's mount lifetime.
+  const snapshotRef = useRef<Map<string, number>>(new Map())
+  const seededOwnerRef = useRef<string | undefined>(undefined)
+
   // Order via sort.ts on the adapted Member[]; keep the original display rows keyed by uid so the
   // owner sentinel role survives (the adapter only exists for ranking, not rendering).
   const byUid = new Map(rows.map((r) => [r.uid, r]))
-  const sorted = sortMembersForDisplay(withSyntheticOwner(rows.map(toSortMember), ownerUid), ownerUid)
+  const bots = botUids ?? new Set<string>()
+
+  // Reset the frozen order when the document (owner) changes — a doc switch must re-sort from
+  // scratch rather than carry a stale snapshot from the previous doc.
+  if (seededOwnerRef.current !== ownerUid) {
+    seededOwnerRef.current = ownerUid
+    snapshotRef.current = new Map()
+  }
+
+  // Normal role-ranked order (owner pinned → admin → writer → commenter → reader).
+  const ranked = sortMembersForDisplay(withSyntheticOwner(rows.map(toSortMember), ownerUid), ownerUid)
+
+  // Seed the snapshot the FIRST time we have non-empty rows (skip the empty first paint so an
+  // initial [] never freezes the order to empty). After seeding, freeze order via the snapshot;
+  // append brand-new uids to its tail and drop vanished uids so it can't grow unbounded.
+  if (ranked.length > 0) {
+    if (snapshotRef.current.size === 0) {
+      const seeded = new Map<string, number>()
+      ranked.forEach((m, i) => seeded.set(m.uid, i))
+      snapshotRef.current = seeded
+    } else {
+      const snap = snapshotRef.current
+      const present = new Set(ranked.map((m) => m.uid))
+      // Drop uids no longer present (removed members) so the snapshot stays bounded.
+      for (const uid of [...snap.keys()]) if (!present.has(uid)) snap.delete(uid)
+      // Append any new uid after the current max index, preserving arrival order.
+      let next = snap.size ? Math.max(...snap.values()) + 1 : 0
+      for (const m of ranked) if (!snap.has(m.uid)) snap.set(m.uid, next++)
+    }
+  }
+
+  // Apply the frozen order to the ranked rows (a no-op before seeding / when empty).
+  const ordered = snapshotRef.current.size > 0 ? applyOrderSnapshot(ranked, snapshotRef.current) : ranked
+
+  // Partition into owner / humans / bots. Partition FIRST, then the snapshot only reorders WITHIN
+  // the full list — a role change never moves a row across a partition, so changing a permission
+  // can't make a human jump into the bot fold.
+  const ownerRows = ordered.filter((sm) => ownerUid != null && sm.uid === ownerUid)
+  const humanRows = ordered.filter((sm) => (ownerUid == null || sm.uid !== ownerUid) && !bots.has(sm.uid))
+  const botRows = ordered.filter((sm) => (ownerUid == null || sm.uid !== ownerUid) && bots.has(sm.uid))
+
+  function renderRow(sm: Member) {
+    const isOwner = ownerUid != null && sm.uid === ownerUid
+    const isBotRow = !isOwner && bots.has(sm.uid)
+    // Resolve back to the display row; the synthetic owner has no display row, so fall back to
+    // the sort member (its uid is all the owner row renders beyond the badge).
+    const row = byUid.get(sm.uid) ?? { uid: sm.uid, role: sm.role, source: sm.source }
+    const removable = !isOwner && (canRemove ? canRemove(row) : true)
+    // The row's effective (display) role is `row.role` — the owner sentinel `'author'` for the
+    // html owner, or the real/mapped role otherwise. Editable only when that role has a matching
+    // option in `roles`; otherwise show static text (see the file header for why).
+    const effectiveRole = row.role
+    const roleGrantable = roles.includes(effectiveRole as Role)
+    return (
+      <div className="octo-member-row" key={sm.uid}>
+        <span className="octo-uid">
+          {displayName(sm.uid)}{' '}
+          {isBotRow && <span className="octo-member-picker-badge">{t('docs.member.aiTag')}</span>}
+          {isOwner && <span className="octo-owner-badge">{t('docs.member.ownerBadge')}</span>}
+          {!isOwner && (
+            <small style={{ color: 'var(--octo-muted)' }}> · {t(`docs.member.source.${row.source}`)}</small>
+          )}
+        </span>
+        {roleGrantable ? (
+          <select
+            // The effective role has a matching option; the owner row is inert (disabled) but
+            // still shows its real role (admin where admin is grantable, i.e. rich).
+            value={effectiveRole as Role}
+            disabled={isOwner}
+            onChange={(e) => onChangeRole(sm.uid, e.target.value as Role)}
+          >
+            {roles.map((r) => (
+              <option key={r} value={r}>
+                {t(`docs.role.${r}`)}
+              </option>
+            ))}
+          </select>
+        ) : (
+          // Role not in this surface's grantable set: render it read-only (no select) so we
+          // neither misrepresent it as reader nor allow a silent downgrade on change. The html
+          // owner ('author') has no docs.role.* text — it's already covered by the owner badge.
+          !isOwner && <span>{t(`docs.role.${effectiveRole}`)}</span>
+        )}
+        {/* The owner row is synthetic (owner lives outside doc_member) — not a removable grant,
+            so it shows no remove button. */}
+        {!isOwner && (
+          <button
+            type="button"
+            className="octo-tb-btn"
+            disabled={!removable}
+            onClick={() => onRemove(sm.uid)}
+          >
+            {t('docs.member.remove')}
+          </button>
+        )}
+      </div>
+    )
+  }
 
   return (
     <div className="octo-member-section">
       <h4 className="octo-member-subtitle">{t('docs.member.currentMembers')}</h4>
       {loading && <p className="octo-loading">{t('docs.member.loading')}</p>}
-      {!loading && sorted.length === 0 && (
+      {!loading && ordered.length === 0 && (
         <p className="octo-member-empty">{t('docs.member.empty')}</p>
       )}
-      {sorted.map((sm) => {
-        const isOwner = ownerUid != null && sm.uid === ownerUid
-        // Resolve back to the display row; the synthetic owner has no display row, so fall back to
-        // the sort member (its uid is all the owner row renders beyond the badge).
-        const row = byUid.get(sm.uid) ?? { uid: sm.uid, role: sm.role, source: sm.source }
-        const removable = !isOwner && (canRemove ? canRemove(row) : true)
-        // The row's effective (display) role is `row.role` — the owner sentinel `'author'` for the
-        // html owner, or the real/mapped role otherwise. Editable only when that role has a matching
-        // option in `roles`; otherwise show static text (see the file header for why).
-        const effectiveRole = row.role
-        const roleGrantable = roles.includes(effectiveRole as Role)
-        return (
-          <div className="octo-member-row" key={sm.uid}>
-            <span className="octo-uid">
-              {displayName(sm.uid)}{' '}
-              {isOwner && <span className="octo-owner-badge">{t('docs.member.ownerBadge')}</span>}
-              {!isOwner && (
-                <small style={{ color: 'var(--octo-muted)' }}> · {t(`docs.member.source.${row.source}`)}</small>
-              )}
-            </span>
-            {roleGrantable ? (
-              <select
-                // The effective role has a matching option; the owner row is inert (disabled) but
-                // still shows its real role (admin where admin is grantable, i.e. rich).
-                value={effectiveRole as Role}
-                disabled={isOwner}
-                onChange={(e) => onChangeRole(sm.uid, e.target.value as Role)}
-              >
-                {roles.map((r) => (
-                  <option key={r} value={r}>
-                    {t(`docs.role.${r}`)}
-                  </option>
-                ))}
-              </select>
-            ) : (
-              // Role not in this surface's grantable set: render it read-only (no select) so we
-              // neither misrepresent it as reader nor allow a silent downgrade on change. The html
-              // owner ('author') has no docs.role.* text — it's already covered by the owner badge.
-              !isOwner && <span>{t(`docs.role.${effectiveRole}`)}</span>
-            )}
-            {/* The owner row is synthetic (owner lives outside doc_member) — not a removable grant,
-                so it shows no remove button. */}
-            {!isOwner && (
-              <button
-                type="button"
-                className="octo-tb-btn"
-                disabled={!removable}
-                onClick={() => onRemove(sm.uid)}
-              >
-                {t('docs.member.remove')}
-              </button>
-            )}
-          </div>
-        )
-      })}
+      {/* Owner pinned first (even a bot owner), then humans — unchanged tiled behavior. */}
+      {ownerRows.map(renderRow)}
+      {humanRows.map(renderRow)}
+      {/* Bots grouped below all humans behind a default-collapsed expander. Not rendered at all
+          when there are no bots (no empty "Show 0 Bots" affordance). */}
+      {botRows.length > 0 && (
+        <>
+          <button
+            type="button"
+            className="octo-member-picker-expand"
+            aria-expanded={botsOpen}
+            onClick={() => setBotsOpen((v) => !v)}
+          >
+            <span className="octo-member-picker-chevron" aria-hidden="true" />
+            {t(botsOpen ? 'docs.member.hideBots' : 'docs.member.showBots', {
+              values: { count: botRows.length },
+            })}
+          </button>
+          {botsOpen && botRows.map(renderRow)}
+        </>
+      )}
     </div>
   )
 }

--- a/packages/docs/src/members/CurrentMembersList.tsx
+++ b/packages/docs/src/members/CurrentMembersList.tsx
@@ -117,8 +117,12 @@ export function CurrentMembersList({
     nestedSnapshotsRef.current = new Map()
     orphanSnapshotRef.current = new Map()
     // B3: reset expansion state on doc change (must stay in sync with snapshot reset).
-    // Using direct mutation here because this runs during render before the state is read.
-    // The next render will pick up the fresh empty sets from useState's initial value behavior.
+    // This is React's sanctioned "adjust state when a prop changes" pattern: calling setState during
+    // render makes React discard this render's output and immediately re-render this component with
+    // the new state BEFORE committing, so the previous doc's expansion state is never painted.
+    // (useState initializers run only at mount and play no part here.) Do NOT move this into a
+    // useEffect: that runs after commit and would reintroduce exactly the stale frame this avoids.
+    // The `size > 0` / truthiness guards are what bound the re-render to a single extra pass.
     if (openCreators.size > 0) setOpenCreators(new Set())
     if (orphanOpen) setOrphanOpen(false)
   }

--- a/packages/docs/src/members/CurrentMembersList.tsx
+++ b/packages/docs/src/members/CurrentMembersList.tsx
@@ -206,7 +206,7 @@ export function CurrentMembersList({
     }
   }
 
-  function renderRow(sm: Member) {
+  function renderRow(sm: Member, nested = false) {
     const isOwner = ownerUid != null && sm.uid === ownerUid
     const isBotRow = !isOwner && bots.has(sm.uid)
     // Resolve back to the display row; the synthetic owner has no display row, so fall back to
@@ -219,7 +219,7 @@ export function CurrentMembersList({
     const effectiveRole = row.role
     const roleGrantable = roles.includes(effectiveRole as Role)
     return (
-      <div className="octo-member-row" key={sm.uid}>
+      <div className={'octo-member-row' + (nested ? ' octo-member-row--nested' : '')} key={sm.uid}>
         <span className="octo-uid">
           {displayName(sm.uid)}{' '}
           {isBotRow && <span className="octo-member-picker-badge">{t('docs.member.aiTag')}</span>}
@@ -300,7 +300,7 @@ export function CurrentMembersList({
                     values: { count: ownBots.length },
                   })}
                 </button>
-                {open && ownBots.map(renderRow)}
+                {open && ownBots.map((b) => renderRow(b, true))}
               </>
             )}
           </div>
@@ -321,7 +321,7 @@ export function CurrentMembersList({
               values: { count: orphanBots.length },
             })}
           </button>
-          {orphanOpen && orphanBots.map(renderRow)}
+          {orphanOpen && orphanBots.map((b) => renderRow(b, true))}
         </>
       )}
     </div>

--- a/packages/docs/src/members/CurrentMembersList.tsx
+++ b/packages/docs/src/members/CurrentMembersList.tsx
@@ -11,6 +11,12 @@ import type { Member } from './api.ts'
  * callbacks; the ordering (owner pinned → admin → writer → commenter → reader, stable within a
  * tier) is applied here via sort.ts so the two surfaces stay byte-identical.
  *
+ * Bots are AI-tagged and NEST under their creator: each top-level row (owner + humans + ownerless
+ * bots) carries its own default-collapsed expander for the bots it owns; bots whose creator is
+ * unknown or not a top-level row fall into one default-collapsed "ownerless bots" fold at the
+ * bottom. The order freeze applies to TOP-LEVEL rows only — nested bots ride along with their
+ * creator. Fail-soft: an empty `botUids` set makes every row a human (never hide a real person).
+ *
  * The owner is a synthetic row (owner identity lives outside the grant table): it carries the
  * fixed owner badge, a disabled role select, and no remove button. Non-owner rows show ` · source`
  * and an editable role select limited to `roles` (the caller narrows the surface — html omits admin
@@ -56,6 +62,7 @@ export function CurrentMembersList({
   onRemove,
   canRemove,
   botUids,
+  botCreators,
 }: {
   rows: CurrentMemberRow[]
   ownerUid?: string
@@ -68,13 +75,24 @@ export function CurrentMembersList({
   /** Whether a (non-owner) row may be removed. Default: any non-owner row is removable. */
   canRemove?: (row: CurrentMemberRow) => boolean
   /**
-   * uids known to be bots (from the space directory). Bots are grouped below all humans in a
-   * default-collapsed section and tagged AI. Fail-soft: an empty set (directory not resolved /
-   * fetch failed) means EVERY row renders as a human — a real human is never hidden in the fold.
+   * uids known to be bots (from the space directory). Bots are tagged AI and nested under their
+   * creator's row (default-collapsed per creator); bots whose creator is unknown or not a top-level
+   * row fall into a single default-collapsed "ownerless bots" fold at the bottom. Fail-soft: an
+   * empty set (directory not resolved / fetch failed) means EVERY row renders as a human — a real
+   * human is never hidden in the fold.
    */
   botUids?: Set<string>
+  /**
+   * botUid → creatorUid (from `/robot/space_bots`). A bot whose creator is itself a top-level row is
+   * nested beneath that creator; anything else (creator unknown, or not a top-level row) is an
+   * "ownerless" bot in the bottom fold. Empty map + non-empty `botUids` ⇒ every bot is ownerless
+   * (never hide a bot just because its owner is unknown).
+   */
+  botCreators?: Map<string, string>
 }) {
-  const [botsOpen, setBotsOpen] = useState(false)
+  // Per-creator expansion (need: each owner's bots collapse independently) + the ownerless fold.
+  const [openCreators, setOpenCreators] = useState<Set<string>>(() => new Set())
+  const [orphanOpen, setOrphanOpen] = useState(false)
   // Frozen display order (need #4): once seeded, a role change updates a row's content but not its
   // position; the panel only re-sorts when it is closed + reopened (this component unmounts) or the
   // owner (document) changes. The snapshot lives for the component's mount lifetime.
@@ -85,6 +103,7 @@ export function CurrentMembersList({
   // owner sentinel role survives (the adapter only exists for ranking, not rendering).
   const byUid = new Map(rows.map((r) => [r.uid, r]))
   const bots = botUids ?? new Set<string>()
+  const creators = botCreators ?? new Map<string, string>()
 
   // Reset the frozen order when the document (owner) changes — a doc switch must re-sort from
   // scratch rather than carry a stale snapshot from the previous doc.
@@ -93,37 +112,99 @@ export function CurrentMembersList({
     snapshotRef.current = new Map()
   }
 
-  // Normal role-ranked order (owner pinned → admin → writer → commenter → reader).
+  const isBot = (uid: string) => bots.has(uid)
+  const isOwnerUid = (uid: string) => ownerUid != null && uid === ownerUid
+
+  // TOP-LEVEL rows = owner + humans + ORPHAN bots (a bot whose creator is unknown, or whose creator
+  // is itself not a top-level row). A NESTED bot is a bot whose creator IS a top-level row and gets
+  // rendered under that creator. We compute this in the required order: first the top-level SET,
+  // then the snapshot over top-level rows, then per-creator bot ordering. A role change can never
+  // move a row across these groups (partition is by identity, not role).
+  //
+  // A bot's creator qualifies as a top-level row iff it is the owner OR a human (non-bot) member
+  // present in `rows`, OR a bot member that itself has no resolvable top-level creator (an orphan
+  // bot can still own bots). To keep it simple + robust: a creator is a top-level row iff it is
+  // NOT a nested bot. We resolve nesting with a single pass since nesting is only one level deep in
+  // practice (a bot's creator is a person/owner). Guard against a creator chain / self-reference by
+  // treating a creator that is itself a bot-with-a-known-top-level-creator as non-top-level.
+  const memberUids = new Set(rows.map((r) => r.uid))
+  if (ownerUid != null) memberUids.add(ownerUid)
+
+  // A bot nests iff its creator is present as a member/owner AND that creator is not itself a bot
+  // that nests under someone else. Owner and humans always qualify as nest targets.
+  const creatorIsTopLevel = (creatorUid: string): boolean => {
+    if (!memberUids.has(creatorUid)) return false
+    if (isOwnerUid(creatorUid)) return true
+    if (!isBot(creatorUid)) return true
+    // creator is a bot member: it is top-level only if it is itself an orphan (its own creator is
+    // not a top-level row) — avoids hiding a bot under another bot that is itself hidden.
+    const grandCreator = creators.get(creatorUid)
+    return !grandCreator || !creatorIsTopLevel(grandCreator)
+  }
+
+  const nestedCreatorOf = (uid: string): string | undefined => {
+    if (!isBot(uid) || isOwnerUid(uid)) return undefined // owner is never nested
+    const c = creators.get(uid)
+    if (!c || c === uid) return undefined
+    return creatorIsTopLevel(c) ? c : undefined
+  }
+
+  // Normal role-ranked order (owner pinned → admin → writer → commenter → reader) over ALL rows.
   const ranked = sortMembersForDisplay(withSyntheticOwner(rows.map(toSortMember), ownerUid), ownerUid)
 
-  // Seed the snapshot the FIRST time we have non-empty rows (skip the empty first paint so an
-  // initial [] never freezes the order to empty). After seeding, freeze order via the snapshot;
-  // append brand-new uids to its tail and drop vanished uids so it can't grow unbounded.
-  if (ranked.length > 0) {
+  const isOrphanBot = (uid: string) => isBot(uid) && !isOwnerUid(uid) && nestedCreatorOf(uid) === undefined
+
+  // TOP-LEVEL = everything that is NOT a nested bot: owner + humans + orphan bots. The order freeze
+  // (snapshot) applies to this whole set so a role change can't reorder it; we then SPLIT it for
+  // rendering (owner/humans tiled at top, orphan bots into the bottom fold) — nested bots ride with
+  // their creator and never enter the snapshot.
+  const topRanked = ranked.filter((sm) => nestedCreatorOf(sm.uid) === undefined)
+
+  // Seed / maintain the frozen order snapshot over TOP-LEVEL rows only.
+  if (topRanked.length > 0) {
     if (snapshotRef.current.size === 0) {
       const seeded = new Map<string, number>()
-      ranked.forEach((m, i) => seeded.set(m.uid, i))
+      topRanked.forEach((m, i) => seeded.set(m.uid, i))
       snapshotRef.current = seeded
     } else {
       const snap = snapshotRef.current
-      const present = new Set(ranked.map((m) => m.uid))
-      // Drop uids no longer present (removed members) so the snapshot stays bounded.
+      const present = new Set(topRanked.map((m) => m.uid))
       for (const uid of [...snap.keys()]) if (!present.has(uid)) snap.delete(uid)
-      // Append any new uid after the current max index, preserving arrival order.
       let next = snap.size ? Math.max(...snap.values()) + 1 : 0
-      for (const m of ranked) if (!snap.has(m.uid)) snap.set(m.uid, next++)
+      for (const m of topRanked) if (!snap.has(m.uid)) snap.set(m.uid, next++)
     }
   }
 
-  // Apply the frozen order to the ranked rows (a no-op before seeding / when empty).
-  const ordered = snapshotRef.current.size > 0 ? applyOrderSnapshot(ranked, snapshotRef.current) : ranked
+  // Apply the frozen order to the top-level rows (a no-op before seeding / when empty).
+  const orderedTop = snapshotRef.current.size > 0 ? applyOrderSnapshot(topRanked, snapshotRef.current) : topRanked
 
-  // Partition into owner / humans / bots. Partition FIRST, then the snapshot only reorders WITHIN
-  // the full list — a role change never moves a row across a partition, so changing a permission
-  // can't make a human jump into the bot fold.
-  const ownerRows = ordered.filter((sm) => ownerUid != null && sm.uid === ownerUid)
-  const humanRows = ordered.filter((sm) => (ownerUid == null || sm.uid !== ownerUid) && !bots.has(sm.uid))
-  const botRows = ordered.filter((sm) => (ownerUid == null || sm.uid !== ownerUid) && bots.has(sm.uid))
+  // Split the ordered top-level rows for rendering: owner + humans are tiled directly (each may
+  // carry a per-creator bot fold); orphan bots drop into the single bottom fold. Both keep the
+  // frozen top-level order.
+  const tiledRows = orderedTop.filter((sm) => !isOrphanBot(sm.uid))
+  const orphanBots = orderedTop.filter((sm) => isOrphanBot(sm.uid))
+
+  // Nested bots grouped by their (top-level) creator, each group ordered by the SAME role-ranked
+  // rules (from `ranked`, which already carries role order + stable tie-break).
+  const botsByCreator = new Map<string, Member[]>()
+  for (const sm of ranked) {
+    if (!isBot(sm.uid) || isOwnerUid(sm.uid)) continue
+    const c = nestedCreatorOf(sm.uid)
+    if (c === undefined) continue
+    const arr = botsByCreator.get(c) ?? []
+    arr.push(sm)
+    botsByCreator.set(c, arr)
+  }
+
+  const tiledSet = new Set(tiledRows.map((m) => m.uid))
+  // Defensive: a nested bot whose creator is not actually a tiled row (shouldn't happen given
+  // nestedCreatorOf) is demoted to an orphan so it can never vanish (fail-soft: never hide a bot).
+  for (const [c, arr] of [...botsByCreator.entries()]) {
+    if (!tiledSet.has(c)) {
+      orphanBots.push(...arr)
+      botsByCreator.delete(c)
+    }
+  }
 
   function renderRow(sm: Member) {
     const isOwner = ownerUid != null && sm.uid === ownerUid
@@ -183,32 +264,64 @@ export function CurrentMembersList({
     )
   }
 
+  const noRows = tiledRows.length === 0 && orphanBots.length === 0
   return (
     <div className="octo-member-section">
       <h4 className="octo-member-subtitle">{t('docs.member.currentMembers')}</h4>
       {loading && <p className="octo-loading">{t('docs.member.loading')}</p>}
-      {!loading && ordered.length === 0 && (
+      {!loading && noRows && (
         <p className="octo-member-empty">{t('docs.member.empty')}</p>
       )}
-      {/* Owner pinned first (even a bot owner), then humans — unchanged tiled behavior. */}
-      {ownerRows.map(renderRow)}
-      {humanRows.map(renderRow)}
-      {/* Bots grouped below all humans behind a default-collapsed expander. Not rendered at all
-          when there are no bots (no empty "Show 0 Bots" affordance). */}
-      {botRows.length > 0 && (
+      {/* Each tiled row (owner pinned first, then humans, in frozen order), with its own bots nested
+          directly beneath it behind a per-creator, default-collapsed expander. */}
+      {tiledRows.map((sm) => {
+        const ownBots = botsByCreator.get(sm.uid) ?? []
+        const open = openCreators.has(sm.uid)
+        return (
+          <div key={sm.uid}>
+            {renderRow(sm)}
+            {ownBots.length > 0 && (
+              <>
+                <button
+                  type="button"
+                  className="octo-member-picker-expand"
+                  aria-expanded={open}
+                  onClick={() =>
+                    setOpenCreators((prev) => {
+                      const next = new Set(prev)
+                      if (next.has(sm.uid)) next.delete(sm.uid)
+                      else next.add(sm.uid)
+                      return next
+                    })
+                  }
+                >
+                  <span className="octo-member-picker-chevron" aria-hidden="true" />
+                  {t(open ? 'docs.member.hideBots' : 'docs.member.showBots', {
+                    values: { count: ownBots.length },
+                  })}
+                </button>
+                {open && ownBots.map(renderRow)}
+              </>
+            )}
+          </div>
+        )
+      })}
+      {/* Ownerless bots (creator unknown or not a top-level row) grouped in one default-collapsed
+          fold at the bottom. Not rendered at all when there are none (no empty "Show 0 Bots"). */}
+      {orphanBots.length > 0 && (
         <>
           <button
             type="button"
             className="octo-member-picker-expand"
-            aria-expanded={botsOpen}
-            onClick={() => setBotsOpen((v) => !v)}
+            aria-expanded={orphanOpen}
+            onClick={() => setOrphanOpen((v) => !v)}
           >
             <span className="octo-member-picker-chevron" aria-hidden="true" />
-            {t(botsOpen ? 'docs.member.hideBots' : 'docs.member.showBots', {
-              values: { count: botRows.length },
+            {t(orphanOpen ? 'docs.member.hideBots' : 'docs.member.showBots', {
+              values: { count: orphanBots.length },
             })}
           </button>
-          {botsOpen && botRows.map(renderRow)}
+          {orphanOpen && orphanBots.map(renderRow)}
         </>
       )}
     </div>

--- a/packages/docs/src/members/MemberPanel.test.tsx
+++ b/packages/docs/src/members/MemberPanel.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
-import { render, screen, waitFor, cleanup, fireEvent } from '@testing-library/react'
+import { render, screen, waitFor, cleanup, fireEvent, within } from '@testing-library/react'
 import { setWKApp } from '../octoweb/index.ts'
 import { createMockWKApp } from '../octoweb/mock.ts'
 import { clearMemberNameCache } from './memberNames.ts'
@@ -184,6 +184,213 @@ describe('MemberPanel — display names (#7)', () => {
     expect(idxOwner).toBe(0)
     expect(idxWriter).toBeLessThan(idxCommenter)
     expect(idxCommenter).toBeLessThan(idxReader)
+  })
+})
+
+describe('MemberPanel — bot section + AI tag + frozen order (PR C #3/#4)', () => {
+  // Members list (grants) comes from the /members API; bot classification comes from the space
+  // directory (spaceMembers isBot flag + /robot/space_bots). Helper to wire both together.
+  function wireMembers(members: Array<{ uid: string; role: string; source?: string }>): void {
+    wk.apiClient.responder = (method, url) => {
+      if (method === 'get' && url.endsWith('/members')) {
+        return {
+          data: {
+            items: members.map((m) => ({
+              uid: m.uid,
+              role: m.role,
+              source: m.source ?? 'direct',
+              grantedBy: 'u_admin',
+            })),
+          },
+          status: 200,
+        }
+      }
+      if (method === 'get' && url.endsWith('/invites')) return { data: { items: [] }, status: 200 }
+      if (url.startsWith('/robot/space_bots')) return { data: [], status: 200 }
+      return { data: {}, status: 200 }
+    }
+  }
+
+  function currentSection(): HTMLElement {
+    return screen.getByText('docs.member.currentMembers').closest('.octo-member-section')! as HTMLElement
+  }
+  function currentSectionRows(): string[] {
+    return Array.from(currentSection().querySelectorAll('.octo-member-row .octo-uid')).map((el) => el.textContent ?? '')
+  }
+
+  it('groups bots below all humans, default-collapsed (hidden until expanded)', async () => {
+    // u_bot is a bot (space-member isBot flag); u_human is a person.
+    wk.spaceMembers.push({ uid: 'u_human', name: 'Human One' }, { uid: 'u_bot', name: 'Bot One', isBot: true })
+    wireMembers([
+      { uid: 'u_human', role: 'writer' },
+      { uid: 'u_bot', role: 'writer' },
+    ])
+    render(<MemberPanel docId="d_1" role="admin" space="s_1" ownerId="u_owner" />)
+    await waitFor(() => expect(screen.getByText('docs.member.ownerBadge')).toBeTruthy())
+    await waitFor(() => expect(currentSectionRows().some((r) => r.includes('Human One'))).toBe(true))
+    // Collapsed by default: the bot row is NOT rendered, and the expander (showBots) is present.
+    expect(currentSectionRows().some((r) => r.includes('Bot One'))).toBe(false)
+    const toggle = within(currentSection()).getByText('docs.member.showBots').closest('button') as HTMLButtonElement
+    expect(toggle).toBeTruthy()
+    expect(toggle.getAttribute('aria-expanded')).toBe('false')
+    // Expand → bot row appears, and it sits AFTER the human row.
+    fireEvent.click(toggle)
+    await waitFor(() => expect(currentSectionRows().some((r) => r.includes('Bot One'))).toBe(true))
+    const rows = currentSectionRows()
+    expect(rows.findIndex((r) => r.includes('Human One'))).toBeLessThan(
+      rows.findIndex((r) => r.includes('Bot One')),
+    )
+    // aria-expanded flips to true after expanding.
+    expect(within(currentSection()).getByText('docs.member.hideBots').closest('button')!.getAttribute('aria-expanded')).toBe('true')
+  })
+
+  it('tags bot rows with the AI badge; human rows have none', async () => {
+    wk.spaceMembers.push({ uid: 'u_human', name: 'Human One' }, { uid: 'u_bot', name: 'Bot One', isBot: true })
+    wireMembers([
+      { uid: 'u_human', role: 'writer' },
+      { uid: 'u_bot', role: 'writer' },
+    ])
+    render(<MemberPanel docId="d_1" role="admin" space="s_1" ownerId="u_owner" />)
+    await waitFor(() => expect(currentSectionRows().some((r) => r.includes('Human One'))).toBe(true))
+    fireEvent.click(within(currentSection()).getByText('docs.member.showBots').closest('button') as HTMLButtonElement)
+    await waitFor(() => expect(currentSectionRows().some((r) => r.includes('Bot One'))).toBe(true))
+    const section = currentSection()
+    const botRow = Array.from(section.querySelectorAll('.octo-member-row')).find((r) =>
+      (r.textContent ?? '').includes('Bot One'),
+    ) as HTMLElement
+    const humanRow = Array.from(section.querySelectorAll('.octo-member-row')).find((r) =>
+      (r.textContent ?? '').includes('Human One'),
+    ) as HTMLElement
+    expect(botRow.querySelector('.octo-member-picker-badge')).toBeTruthy()
+    expect(botRow.textContent).toContain('docs.member.aiTag')
+    expect(humanRow.querySelector('.octo-member-picker-badge')).toBeNull()
+  })
+
+  it('pins a bot OWNER at the top and never folds it into the bot section', async () => {
+    // The owner itself is a bot; it must still be pinned first and stay out of the fold.
+    wk.spaceMembers.push({ uid: 'u_owner', name: 'Bot Owner', isBot: true }, { uid: 'u_human', name: 'Human One' })
+    wireMembers([{ uid: 'u_human', role: 'writer' }])
+    render(<MemberPanel docId="d_1" role="admin" space="s_1" ownerId="u_owner" />)
+    await waitFor(() => expect(screen.getByText('docs.member.ownerBadge')).toBeTruthy())
+    const section = currentSection()
+    const ownerRow = screen.getByText('docs.member.ownerBadge').closest('.octo-member-row') as HTMLElement
+    // Owner row is the FIRST row in the section.
+    const firstRow = section.querySelector('.octo-member-row')
+    expect(firstRow).toBe(ownerRow)
+    // A single (bot) owner + one human, zero foldable bots → no expander at all.
+    expect(within(section).queryByText('docs.member.showBots')).toBeNull()
+  })
+
+  it('fail-soft: empty bot directory renders every row tiled, no AI tag, no expander', async () => {
+    // No isBot flags, no space_bots rows → botUids empty → all rows are humans.
+    wk.spaceMembers.push({ uid: 'u_a', name: 'Aaa' }, { uid: 'u_b', name: 'Bbb' })
+    wireMembers([
+      { uid: 'u_a', role: 'writer' },
+      { uid: 'u_b', role: 'reader' },
+    ])
+    render(<MemberPanel docId="d_1" role="admin" space="s_1" ownerId="u_owner" />)
+    await waitFor(() => expect(currentSectionRows().some((r) => r.includes('Aaa'))).toBe(true))
+    const section = currentSection()
+    expect(within(section).queryByText('docs.member.showBots')).toBeNull()
+    expect(within(section).queryByText('docs.member.hideBots')).toBeNull()
+    expect(section.querySelector('.octo-member-picker-badge')).toBeNull()
+  })
+
+  it('does not render a bot expander when there are zero bots', async () => {
+    wk.spaceMembers.push({ uid: 'u_a', name: 'Aaa' })
+    wireMembers([{ uid: 'u_a', role: 'writer' }])
+    render(<MemberPanel docId="d_1" role="admin" space="s_1" ownerId="u_owner" />)
+    await waitFor(() => expect(currentSectionRows().some((r) => r.includes('Aaa'))).toBe(true))
+    expect(within(currentSection()).queryByText('docs.member.showBots')).toBeNull()
+  })
+
+  it('freezes member order across a role change until the panel is reopened (need #4)', async () => {
+    // u_a starts as commenter, u_z as reader → u_a sorts ABOVE u_z. We then promote u_z to admin;
+    // a raw re-sort would jump u_z to the TOP (admin rank), so the frozen snapshot is the only
+    // thing that can keep u_a above u_z (fail-before: without the snapshot u_z leads).
+    let zRole = 'reader'
+    wk.apiClient.responder = (method, url) => {
+      if (method === 'get' && url.endsWith('/members')) {
+        return {
+          data: {
+            items: [
+              { uid: 'u_a', role: 'commenter', source: 'direct', grantedBy: 'u_admin' },
+              { uid: 'u_z', role: zRole, source: 'direct', grantedBy: 'u_admin' },
+            ],
+          },
+          status: 200,
+        }
+      }
+      if (method === 'get' && url.endsWith('/invites')) return { data: { items: [] }, status: 200 }
+      if (method === 'put' && url.endsWith('/members')) {
+        zRole = 'admin' // upsert reflected on the next refresh — would out-rank u_a under raw sort
+        return { data: {}, status: 200 }
+      }
+      if (url.startsWith('/robot/space_bots')) return { data: [], status: 200 }
+      return { data: {}, status: 200 }
+    }
+    const { unmount } = render(<MemberPanel docId="d_1" role="admin" space="s_1" ownerId="u_owner" />)
+    await waitFor(() => expect(currentSectionRows().some((r) => r.includes('u_z'))).toBe(true))
+    // Initial frozen order: u_a (commenter) before u_z (reader).
+    let rows = currentSectionRows()
+    expect(rows.findIndex((r) => r.includes('u_a'))).toBeLessThan(rows.findIndex((r) => r.includes('u_z')))
+    // Promote u_z reader → admin via its row select (scoped to the current section).
+    const zRow = Array.from(currentSection().querySelectorAll('.octo-member-row')).find((r) =>
+      (r.textContent ?? '').includes('u_z'),
+    ) as HTMLElement
+    fireEvent.change(zRow.querySelector('select') as HTMLSelectElement, { target: { value: 'admin' } })
+    // After the refresh u_z's role updates to admin, but its POSITION is frozen (still after u_a).
+    await waitFor(() => {
+      const s = (Array.from(currentSection().querySelectorAll('.octo-member-row')).find((r) =>
+        (r.textContent ?? '').includes('u_z'),
+      ) as HTMLElement).querySelector('select') as HTMLSelectElement
+      expect(s.value).toBe('admin')
+    })
+    rows = currentSectionRows()
+    expect(rows.findIndex((r) => r.includes('u_a'))).toBeLessThan(rows.findIndex((r) => r.includes('u_z')))
+
+    // Reopen (unmount + remount): the fresh mount re-seeds the snapshot from the NEW roles — u_z is
+    // now admin, so it out-ranks u_a and leads. This proves reopen recomputes order from scratch.
+    unmount()
+    render(<MemberPanel docId="d_1" role="admin" space="s_1" ownerId="u_owner" />)
+    await waitFor(() => expect(currentSectionRows().some((r) => r.includes('u_z'))).toBe(true))
+    const reopened = currentSectionRows()
+    expect(reopened.findIndex((r) => r.includes('u_z'))).toBeLessThan(reopened.findIndex((r) => r.includes('u_a')))
+  })
+
+  it('appends a newly added member to the end of the frozen order (need #4)', async () => {
+    let includeNew = false
+    wk.apiClient.responder = (method, url) => {
+      if (method === 'get' && url.endsWith('/members')) {
+        const items = [
+          { uid: 'u_a', role: 'writer', source: 'direct', grantedBy: 'u_admin' },
+          { uid: 'u_b', role: 'reader', source: 'direct', grantedBy: 'u_admin' },
+        ]
+        // A new admin member arrives on refresh; by raw sort it would jump to the TOP (admin rank),
+        // but the frozen snapshot must append it at the END.
+        if (includeNew) items.push({ uid: 'u_new', role: 'admin', source: 'direct', grantedBy: 'u_admin' })
+        return { data: { items }, status: 200 }
+      }
+      if (method === 'get' && url.endsWith('/invites')) return { data: { items: [] }, status: 200 }
+      if (method === 'put' && url.endsWith('/members')) {
+        includeNew = true
+        return { data: {}, status: 200 }
+      }
+      if (url.startsWith('/robot/space_bots')) return { data: [], status: 200 }
+      return { data: {}, status: 200 }
+    }
+    render(<MemberPanel docId="d_1" role="admin" space="s_1" ownerId="u_owner" />)
+    await waitFor(() => expect(currentSectionRows().some((r) => r.includes('u_b'))).toBe(true))
+    // Trigger a refresh that surfaces the new admin member (change u_b's role to force the PUT+refresh).
+    const bRow = Array.from(currentSection().querySelectorAll('.octo-member-row')).find((r) =>
+      (r.textContent ?? '').includes('u_b'),
+    ) as HTMLElement
+    fireEvent.change(bRow.querySelector('select') as HTMLSelectElement, { target: { value: 'commenter' } })
+    await waitFor(() => expect(currentSectionRows().some((r) => r.includes('u_new'))).toBe(true))
+    const rows = currentSectionRows()
+    // Despite being an admin (top rank), the new member is appended LAST (after u_a and u_b).
+    expect(rows.findIndex((r) => r.includes('u_new'))).toBeGreaterThan(rows.findIndex((r) => r.includes('u_a')))
+    expect(rows.findIndex((r) => r.includes('u_new'))).toBeGreaterThan(rows.findIndex((r) => r.includes('u_b')))
   })
 })
 

--- a/packages/docs/src/members/MemberPanel.test.tsx
+++ b/packages/docs/src/members/MemberPanel.test.tsx
@@ -394,6 +394,198 @@ describe('MemberPanel — bot section + AI tag + frozen order (PR C #3/#4)', () 
   })
 })
 
+describe('MemberPanel — bots nested under their creator (PR C bot-nesting change)', () => {
+  // space_bots now carries creator_uid; the panel nests each bot under its creator row (per-creator
+  // default-collapsed expander) and drops ownerless bots into a single bottom fold.
+  function wireMembers(
+    members: Array<{ uid: string; role: string; source?: string }>,
+    bots: Array<{ uid: string; name?: string; creator_uid?: string }>,
+  ): void {
+    // The list only renders actual doc-member grants; a bot must therefore be BOTH a grant row AND
+    // a space_bots entry (its creator_uid) to show. Auto-grant each bot as a member (reader).
+    const memberItems = [
+      ...members.map((m) => ({ uid: m.uid, role: m.role, source: m.source ?? 'direct', grantedBy: 'u_admin' })),
+      ...bots.map((b) => ({ uid: b.uid, role: 'reader', source: 'direct', grantedBy: 'u_admin' })),
+    ]
+    wk.apiClient.responder = (method, url) => {
+      if (method === 'get' && url.endsWith('/members')) {
+        return { data: { items: memberItems }, status: 200 }
+      }
+      if (method === 'get' && url.endsWith('/invites')) return { data: { items: [] }, status: 200 }
+      if (url.startsWith('/robot/space_bots')) return { data: bots, status: 200 }
+      return { data: {}, status: 200 }
+    }
+  }
+  function currentSection(): HTMLElement {
+    return screen.getByText('docs.member.currentMembers').closest('.octo-member-section')! as HTMLElement
+  }
+  function rowFor(text: string): HTMLElement {
+    return Array.from(currentSection().querySelectorAll('.octo-member-row')).find((r) =>
+      (r.textContent ?? '').includes(text),
+    ) as HTMLElement
+  }
+  function visibleUids(): string[] {
+    return Array.from(currentSection().querySelectorAll('.octo-member-row .octo-uid')).map((el) => el.textContent ?? '')
+  }
+
+  it('renders a bot directly below its creator row, collapsed by default (new #1/#2)', async () => {
+    // u_human owns Bot One (creator_uid = u_human). Bot must nest under u_human, hidden until the
+    // creator's own expander is clicked.
+    wk.spaceMembers.push({ uid: 'u_human', name: 'Human One' })
+    wireMembers(
+      [{ uid: 'u_human', role: 'writer' }],
+      [{ uid: 'b_1', name: 'Bot One', creator_uid: 'u_human' }],
+    )
+    render(<MemberPanel docId="d_1" role="admin" space="s_1" ownerId="u_owner" />)
+    await waitFor(() => expect(visibleUids().some((r) => r.includes('Human One'))).toBe(true))
+    // Collapsed by default: Bot One not visible; a per-creator expander sits right after the human.
+    expect(visibleUids().some((r) => r.includes('Bot One'))).toBe(false)
+    const humanRow = rowFor('Human One')
+    const expander = humanRow.parentElement!.querySelector('.octo-member-picker-expand') as HTMLButtonElement
+    expect(expander).toBeTruthy()
+    expect(expander.getAttribute('aria-expanded')).toBe('false')
+    fireEvent.click(expander)
+    await waitFor(() => expect(visibleUids().some((r) => r.includes('Bot One'))).toBe(true))
+    // The bot renders inside the SAME wrapper as its creator (nested, not the bottom fold).
+    expect((humanRow.parentElement!.textContent ?? '').includes('Bot One')).toBe(true)
+  })
+
+  it('gives each creator an INDEPENDENT expander (expanding A leaves B collapsed)', async () => {
+    wk.spaceMembers.push({ uid: 'u_a', name: 'Alpha' }, { uid: 'u_b', name: 'Beta' })
+    wireMembers(
+      [
+        { uid: 'u_a', role: 'writer' },
+        { uid: 'u_b', role: 'writer' },
+      ],
+      [
+        { uid: 'b_a', name: 'BotA', creator_uid: 'u_a' },
+        { uid: 'b_b', name: 'BotB', creator_uid: 'u_b' },
+      ],
+    )
+    render(<MemberPanel docId="d_1" role="admin" space="s_1" ownerId="u_owner" />)
+    await waitFor(() => expect(visibleUids().some((r) => r.includes('Alpha'))).toBe(true))
+    const expanders = Array.from(currentSection().querySelectorAll('.octo-member-picker-expand')) as HTMLButtonElement[]
+    expect(expanders.length).toBe(2)
+    const alphaExpander = rowFor('Alpha').parentElement!.querySelector('.octo-member-picker-expand') as HTMLButtonElement
+    fireEvent.click(alphaExpander)
+    await waitFor(() => expect(visibleUids().some((r) => r.includes('BotA'))).toBe(true))
+    // Beta's bot is STILL hidden — independent expansion state.
+    expect(visibleUids().some((r) => r.includes('BotB'))).toBe(false)
+  })
+
+  it('drops a bot whose creator is not a member into the bottom ownerless fold (new #3)', async () => {
+    wk.spaceMembers.push({ uid: 'u_human', name: 'Human One' })
+    wireMembers(
+      [{ uid: 'u_human', role: 'writer' }],
+      [{ uid: 'b_orphan', name: 'Orphan Bot', creator_uid: 'u_stranger' }],
+    )
+    render(<MemberPanel docId="d_1" role="admin" space="s_1" ownerId="u_owner" />)
+    await waitFor(() => expect(visibleUids().some((r) => r.includes('Human One'))).toBe(true))
+    // The human has no bots → no expander in its wrapper.
+    expect(rowFor('Human One').parentElement!.querySelector('.octo-member-picker-expand')).toBeNull()
+    const expander = within(currentSection()).getByText('docs.member.showBots').closest('button') as HTMLButtonElement
+    fireEvent.click(expander)
+    await waitFor(() => expect(visibleUids().some((r) => r.includes('Orphan Bot'))).toBe(true))
+  })
+
+  it('does not render the bottom ownerless fold when there are zero orphan bots (new #4)', async () => {
+    wk.spaceMembers.push({ uid: 'u_human', name: 'Human One' })
+    wireMembers(
+      [{ uid: 'u_human', role: 'writer' }],
+      [{ uid: 'b_1', name: 'Bot One', creator_uid: 'u_human' }],
+    )
+    render(<MemberPanel docId="d_1" role="admin" space="s_1" ownerId="u_owner" />)
+    await waitFor(() => expect(visibleUids().some((r) => r.includes('Human One'))).toBe(true))
+    const expanders = Array.from(currentSection().querySelectorAll('.octo-member-picker-expand')) as HTMLButtonElement[]
+    expect(expanders.length).toBe(1)
+    // That single expander lives inside the creator's wrapper (nested), not a bottom sibling.
+    expect(rowFor('Human One').parentElement!.contains(expanders[0])).toBe(true)
+  })
+
+  it('renders no expander for a creator that owns zero bots (new #5)', async () => {
+    wk.spaceMembers.push({ uid: 'u_a', name: 'Alpha' }, { uid: 'u_b', name: 'Beta' })
+    wireMembers(
+      [
+        { uid: 'u_a', role: 'writer' },
+        { uid: 'u_b', role: 'writer' },
+      ],
+      [{ uid: 'b_a', name: 'BotA', creator_uid: 'u_a' }],
+    )
+    render(<MemberPanel docId="d_1" role="admin" space="s_1" ownerId="u_owner" />)
+    await waitFor(() => expect(visibleUids().some((r) => r.includes('Beta'))).toBe(true))
+    expect(rowFor('Alpha').parentElement!.querySelector('.octo-member-picker-expand')).toBeTruthy()
+    expect(rowFor('Beta').parentElement!.querySelector('.octo-member-picker-expand')).toBeNull()
+  })
+
+  it('lets the OWNER be a bot creator (owner keeps pinned + carries its dropdown) (new #6)', async () => {
+    wk.spaceMembers.push({ uid: 'u_owner', name: 'Owner Person' }, { uid: 'u_human', name: 'Human One' })
+    wireMembers(
+      [{ uid: 'u_human', role: 'writer' }],
+      [{ uid: 'b_owned', name: 'Owner Bot', creator_uid: 'u_owner' }],
+    )
+    render(<MemberPanel docId="d_1" role="admin" space="s_1" ownerId="u_owner" />)
+    await waitFor(() => expect(screen.getByText('docs.member.ownerBadge')).toBeTruthy())
+    const ownerRow = screen.getByText('docs.member.ownerBadge').closest('.octo-member-row') as HTMLElement
+    // Owner is the FIRST row.
+    expect(currentSection().querySelector('.octo-member-row')).toBe(ownerRow)
+    const ownerExpander = ownerRow.parentElement!.querySelector('.octo-member-picker-expand') as HTMLButtonElement
+    expect(ownerExpander).toBeTruthy()
+    fireEvent.click(ownerExpander)
+    await waitFor(() => expect(visibleUids().some((r) => r.includes('Owner Bot'))).toBe(true))
+  })
+
+  it('tags EVERY bot row (nested + orphan) with the AI badge; humans have none (new #7)', async () => {
+    wk.spaceMembers.push({ uid: 'u_human', name: 'Human One' })
+    wireMembers(
+      [{ uid: 'u_human', role: 'writer' }],
+      [
+        { uid: 'b_nested', name: 'Nested Bot', creator_uid: 'u_human' },
+        { uid: 'b_orphan', name: 'Orphan Bot', creator_uid: 'u_stranger' },
+      ],
+    )
+    render(<MemberPanel docId="d_1" role="admin" space="s_1" ownerId="u_owner" />)
+    await waitFor(() => expect(visibleUids().some((r) => r.includes('Human One'))).toBe(true))
+    fireEvent.click(rowFor('Human One').parentElement!.querySelector('.octo-member-picker-expand') as HTMLButtonElement)
+    fireEvent.click(within(currentSection()).getByText('docs.member.showBots').closest('button') as HTMLButtonElement)
+    await waitFor(() => expect(visibleUids().some((r) => r.includes('Orphan Bot'))).toBe(true))
+    expect(rowFor('Nested Bot').querySelector('.octo-member-picker-badge')).toBeTruthy()
+    expect(rowFor('Orphan Bot').querySelector('.octo-member-picker-badge')).toBeTruthy()
+    expect(rowFor('Human One').querySelector('.octo-member-picker-badge')).toBeNull()
+  })
+
+  it('fail-soft: no bot directory → all rows tiled, no AI tag, no expander (new #8)', async () => {
+    wk.spaceMembers.push({ uid: 'u_a', name: 'Aaa' }, { uid: 'u_b', name: 'Bbb' })
+    wireMembers(
+      [
+        { uid: 'u_a', role: 'writer' },
+        { uid: 'u_b', role: 'reader' },
+      ],
+      [],
+    )
+    render(<MemberPanel docId="d_1" role="admin" space="s_1" ownerId="u_owner" />)
+    await waitFor(() => expect(visibleUids().some((r) => r.includes('Aaa'))).toBe(true))
+    expect(currentSection().querySelector('.octo-member-picker-expand')).toBeNull()
+    expect(currentSection().querySelector('.octo-member-picker-badge')).toBeNull()
+  })
+
+  it('empty botCreators (bots but no creator_uid) → all bots land in the bottom fold (new #9)', async () => {
+    wk.spaceMembers.push({ uid: 'u_human', name: 'Human One' })
+    wireMembers(
+      [{ uid: 'u_human', role: 'writer' }],
+      [
+        { uid: 'b_1', name: 'Bot One' },
+        { uid: 'b_2', name: 'Bot Two' },
+      ],
+    )
+    render(<MemberPanel docId="d_1" role="admin" space="s_1" ownerId="u_owner" />)
+    await waitFor(() => expect(visibleUids().some((r) => r.includes('Human One'))).toBe(true))
+    expect(rowFor('Human One').parentElement!.querySelector('.octo-member-picker-expand')).toBeNull()
+    fireEvent.click(within(currentSection()).getByText('docs.member.showBots').closest('button') as HTMLButtonElement)
+    await waitFor(() => expect(visibleUids().some((r) => r.includes('Bot One'))).toBe(true))
+    expect(visibleUids().some((r) => r.includes('Bot Two'))).toBe(true)
+  })
+})
+
 describe('MemberPanel add: partial-failure detail survives a refresh failure (task #5)', () => {
   it('keeps the partial-failure message when the post-add refresh also fails', async () => {
     wk.spaceMembers.push({ uid: 'u_ada', name: 'Ada Lovelace' })

--- a/packages/docs/src/members/MemberPanel.test.tsx
+++ b/packages/docs/src/members/MemberPanel.test.tsx
@@ -666,3 +666,239 @@ describe('MemberPanel add: partial-failure detail survives a refresh failure (ta
     expect(screen.queryByText('docs.member.errorAddSnapshot')).toBeNull()
   })
 })
+
+describe('MemberPanel — cyclic bot creator chain resilience (B1)', () => {
+  // B1: a cyclic creator_uid chain (A→B→A or A→B→C→A) must NOT cause a stack overflow; the
+  // panel must render the involved bots in the orphan fold (visible + removable, not hidden).
+  function wireMembers(
+    members: Array<{ uid: string; role: string; source?: string }>,
+    bots: Array<{ uid: string; name?: string; creator_uid?: string }>,
+  ): void {
+    const memberItems = [
+      ...members.map((m) => ({ uid: m.uid, role: m.role, source: m.source ?? 'direct', grantedBy: 'u_admin' })),
+      ...bots.map((b) => ({ uid: b.uid, role: 'reader', source: 'direct', grantedBy: 'u_admin' })),
+    ]
+    wk.apiClient.responder = (method, url) => {
+      if (method === 'get' && url.endsWith('/members')) {
+        return { data: { items: memberItems }, status: 200 }
+      }
+      if (method === 'get' && url.endsWith('/invites')) return { data: { items: [] }, status: 200 }
+      if (url.startsWith('/robot/space_bots')) return { data: bots, status: 200 }
+      return { data: {}, status: 200 }
+    }
+  }
+  function currentSection(): HTMLElement {
+    return screen.getByText('docs.member.currentMembers').closest('.octo-member-section')! as HTMLElement
+  }
+  function visibleUids(): string[] {
+    return Array.from(currentSection().querySelectorAll('.octo-member-row .octo-uid')).map((el) => el.textContent ?? '')
+  }
+
+  it('handles a two-node cycle (A→B→A) without crashing, placing both in the orphan fold', async () => {
+    // bot_x -> bot_y, bot_y -> bot_x (both are bots and members)
+    wireMembers(
+      [],
+      [
+        { uid: 'bot_x', name: 'Bot X', creator_uid: 'bot_y' },
+        { uid: 'bot_y', name: 'Bot Y', creator_uid: 'bot_x' },
+      ],
+    )
+    // Should NOT throw RangeError; both bots should land in orphan fold.
+    render(<MemberPanel docId="d_1" role="admin" space="s_1" ownerId="u_owner" />)
+    await waitFor(() => expect(screen.getByText('docs.member.ownerBadge')).toBeTruthy())
+    // Expand the orphan fold.
+    const expander = within(currentSection()).getByText('docs.member.showBots').closest('button') as HTMLButtonElement
+    fireEvent.click(expander)
+    await waitFor(() => expect(visibleUids().some((r) => r.includes('Bot X'))).toBe(true))
+    expect(visibleUids().some((r) => r.includes('Bot Y'))).toBe(true)
+    // Both have AI badges (they are bots).
+    expect(currentSection().querySelectorAll('.octo-member-picker-badge').length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('handles a three-node cycle (A→B→C→A) without crashing, placing all in the orphan fold', async () => {
+    wireMembers(
+      [],
+      [
+        { uid: 'bot_a', name: 'Bot A', creator_uid: 'bot_c' },
+        { uid: 'bot_b', name: 'Bot B', creator_uid: 'bot_a' },
+        { uid: 'bot_c', name: 'Bot C', creator_uid: 'bot_b' },
+      ],
+    )
+    render(<MemberPanel docId="d_1" role="admin" space="s_1" ownerId="u_owner" />)
+    await waitFor(() => expect(screen.getByText('docs.member.ownerBadge')).toBeTruthy())
+    const expander = within(currentSection()).getByText('docs.member.showBots').closest('button') as HTMLButtonElement
+    fireEvent.click(expander)
+    await waitFor(() => expect(visibleUids().some((r) => r.includes('Bot A'))).toBe(true))
+    expect(visibleUids().some((r) => r.includes('Bot B'))).toBe(true)
+    expect(visibleUids().some((r) => r.includes('Bot C'))).toBe(true)
+  })
+
+  it('handles a self-reference (A→A) without crashing, placing the bot in the orphan fold', async () => {
+    wireMembers(
+      [],
+      [{ uid: 'bot_s', name: 'Self Bot', creator_uid: 'bot_s' }],
+    )
+    render(<MemberPanel docId="d_1" role="admin" space="s_1" ownerId="u_owner" />)
+    await waitFor(() => expect(screen.getByText('docs.member.ownerBadge')).toBeTruthy())
+    const expander = within(currentSection()).getByText('docs.member.showBots').closest('button') as HTMLButtonElement
+    fireEvent.click(expander)
+    await waitFor(() => expect(visibleUids().some((r) => r.includes('Self Bot'))).toBe(true))
+  })
+})
+
+describe('MemberPanel — expansion state reset on ownerUid change (B3)', () => {
+  function wireMembers(
+    members: Array<{ uid: string; role: string; source?: string }>,
+    bots: Array<{ uid: string; name?: string; creator_uid?: string }>,
+  ): void {
+    const memberItems = [
+      ...members.map((m) => ({ uid: m.uid, role: m.role, source: m.source ?? 'direct', grantedBy: 'u_admin' })),
+      ...bots.map((b) => ({ uid: b.uid, role: 'reader', source: 'direct', grantedBy: 'u_admin' })),
+    ]
+    wk.apiClient.responder = (method, url) => {
+      if (method === 'get' && url.endsWith('/members')) {
+        return { data: { items: memberItems }, status: 200 }
+      }
+      if (method === 'get' && url.endsWith('/invites')) return { data: { items: [] }, status: 200 }
+      if (url.startsWith('/robot/space_bots')) return { data: bots, status: 200 }
+      return { data: {}, status: 200 }
+    }
+  }
+  function currentSection(): HTMLElement {
+    return screen.getByText('docs.member.currentMembers').closest('.octo-member-section')! as HTMLElement
+  }
+  function visibleUids(): string[] {
+    return Array.from(currentSection().querySelectorAll('.octo-member-row .octo-uid')).map((el) => el.textContent ?? '')
+  }
+
+  it('resets expansion state when ownerUid changes (doc switch)', async () => {
+    wk.spaceMembers.push({ uid: 'u_human', name: 'Human One' })
+    wireMembers(
+      [{ uid: 'u_human', role: 'writer' }],
+      [{ uid: 'b_1', name: 'Bot One', creator_uid: 'u_human' }],
+    )
+    const { rerender } = render(<MemberPanel docId="d_1" role="admin" space="s_1" ownerId="u_owner_a" />)
+    await waitFor(() => expect(visibleUids().some((r) => r.includes('Human One'))).toBe(true))
+    // Expand the bot fold.
+    const expander = currentSection().querySelector('.octo-member-picker-expand') as HTMLButtonElement
+    fireEvent.click(expander)
+    await waitFor(() => expect(visibleUids().some((r) => r.includes('Bot One'))).toBe(true))
+    // Now switch doc (owner changes).
+    rerender(<MemberPanel docId="d_2" role="admin" space="s_1" ownerId="u_owner_b" />)
+    await waitFor(() => expect(screen.getByText('docs.member.ownerBadge')).toBeTruthy())
+    // The expansion state should have reset — the bot should NOT be visible until re-expanded.
+    expect(visibleUids().some((r) => r.includes('Bot One'))).toBe(false)
+    expect(currentSection().querySelector('.octo-member-picker-expand')!.getAttribute('aria-expanded')).toBe('false')
+  })
+})
+
+describe('MemberPanel — nested bot order freezing (B4)', () => {
+  function currentSection(): HTMLElement {
+    return screen.getByText('docs.member.currentMembers').closest('.octo-member-section')! as HTMLElement
+  }
+  function visibleUids(): string[] {
+    return Array.from(currentSection().querySelectorAll('.octo-member-row .octo-uid')).map((el) => el.textContent ?? '')
+  }
+  function rowFor(text: string): HTMLElement {
+    return Array.from(currentSection().querySelectorAll('.octo-member-row')).find((r) =>
+      (r.textContent ?? '').includes(text),
+    ) as HTMLElement
+  }
+
+  it('freezes nested bot order within a creator fold across role changes (B4)', async () => {
+    // Two bots under the same creator: bot_z starts as reader, bot_a as commenter.
+    // Initial order: bot_a (commenter) before bot_z (reader).
+    // After promoting bot_z to admin, it should NOT jump ahead of bot_a (frozen order).
+    let zRole = 'reader'
+    wk.spaceMembers.push({ uid: 'u_human', name: 'Human One' })
+    wk.apiClient.responder = (method, url) => {
+      if (method === 'get' && url.endsWith('/members')) {
+        return {
+          data: {
+            items: [
+              { uid: 'u_human', role: 'writer', source: 'direct', grantedBy: 'u_admin' },
+              { uid: 'bot_a', role: 'commenter', source: 'direct', grantedBy: 'u_admin' },
+              { uid: 'bot_z', role: zRole, source: 'direct', grantedBy: 'u_admin' },
+            ],
+          },
+          status: 200,
+        }
+      }
+      if (method === 'get' && url.endsWith('/invites')) return { data: { items: [] }, status: 200 }
+      if (url.startsWith('/robot/space_bots')) {
+        return {
+          data: [
+            { uid: 'bot_a', name: 'Bot A', creator_uid: 'u_human' },
+            { uid: 'bot_z', name: 'Bot Z', creator_uid: 'u_human' },
+          ],
+          status: 200,
+        }
+      }
+      if (method === 'put' && url.endsWith('/members')) {
+        zRole = 'admin'
+        return { data: {}, status: 200 }
+      }
+      return { data: {}, status: 200 }
+    }
+    render(<MemberPanel docId="d_1" role="admin" space="s_1" ownerId="u_owner" />)
+    await waitFor(() => expect(visibleUids().some((r) => r.includes('Human One'))).toBe(true))
+    // Expand the creator's bot fold.
+    const expander = rowFor('Human One').parentElement!.querySelector('.octo-member-picker-expand') as HTMLButtonElement
+    fireEvent.click(expander)
+    await waitFor(() => expect(visibleUids().some((r) => r.includes('Bot A'))).toBe(true))
+    // Initial order: bot_a before bot_z.
+    let rows = visibleUids()
+    expect(rows.findIndex((r) => r.includes('Bot A'))).toBeLessThan(rows.findIndex((r) => r.includes('Bot Z')))
+    // Promote bot_z from reader to admin.
+    const zRow = rowFor('Bot Z')
+    fireEvent.change(zRow.querySelector('select') as HTMLSelectElement, { target: { value: 'admin' } })
+    await waitFor(() => {
+      const s = rowFor('Bot Z').querySelector('select') as HTMLSelectElement
+      expect(s.value).toBe('admin')
+    })
+    // Frozen order: bot_a should STILL be before bot_z.
+    rows = visibleUids()
+    expect(rows.findIndex((r) => r.includes('Bot A'))).toBeLessThan(rows.findIndex((r) => r.includes('Bot Z')))
+  })
+
+  it('reorders nested bots after unmount + remount (fresh snapshot)', async () => {
+    // Same setup, but unmount and remount to prove the frozen order resets.
+    let zRole = 'admin' // bot_z is already admin after the previous test's promotion
+    wk.spaceMembers.push({ uid: 'u_human', name: 'Human One' })
+    wk.apiClient.responder = (method, url) => {
+      if (method === 'get' && url.endsWith('/members')) {
+        return {
+          data: {
+            items: [
+              { uid: 'u_human', role: 'writer', source: 'direct', grantedBy: 'u_admin' },
+              { uid: 'bot_a', role: 'commenter', source: 'direct', grantedBy: 'u_admin' },
+              { uid: 'bot_z', role: zRole, source: 'direct', grantedBy: 'u_admin' },
+            ],
+          },
+          status: 200,
+        }
+      }
+      if (method === 'get' && url.endsWith('/invites')) return { data: { items: [] }, status: 200 }
+      if (url.startsWith('/robot/space_bots')) {
+        return {
+          data: [
+            { uid: 'bot_a', name: 'Bot A', creator_uid: 'u_human' },
+            { uid: 'bot_z', name: 'Bot Z', creator_uid: 'u_human' },
+          ],
+          status: 200,
+        }
+      }
+      return { data: {}, status: 200 }
+    }
+    const { unmount } = render(<MemberPanel docId="d_1" role="admin" space="s_1" ownerId="u_owner" />)
+    await waitFor(() => expect(visibleUids().some((r) => r.includes('Human One'))).toBe(true))
+    const expander = rowFor('Human One').parentElement!.querySelector('.octo-member-picker-expand') as HTMLButtonElement
+    fireEvent.click(expander)
+    await waitFor(() => expect(visibleUids().some((r) => r.includes('Bot A'))).toBe(true))
+    // With bot_z as admin, on a fresh mount it should sort BEFORE bot_a (commenter).
+    // (This proves the snapshot is fresh on remount.)
+    const rows = visibleUids()
+    expect(rows.findIndex((r) => r.includes('Bot Z'))).toBeLessThan(rows.findIndex((r) => r.includes('Bot A')))
+    unmount()
+  })
+})

--- a/packages/docs/src/members/MemberPanel.test.tsx
+++ b/packages/docs/src/members/MemberPanel.test.tsx
@@ -584,6 +584,37 @@ describe('MemberPanel — bots nested under their creator (PR C bot-nesting chan
     await waitFor(() => expect(visibleUids().some((r) => r.includes('Bot One'))).toBe(true))
     expect(visibleUids().some((r) => r.includes('Bot Two'))).toBe(true)
   })
+
+  it('indents a bot revealed under its creator (octo-member-row--nested); creator + owner are not indented', async () => {
+    wk.spaceMembers.push({ uid: 'u_owner', name: 'Owner Person' }, { uid: 'u_human', name: 'Human One' })
+    wireMembers(
+      [{ uid: 'u_human', role: 'writer' }],
+      [{ uid: 'b_1', name: 'Bot One', creator_uid: 'u_human' }],
+    )
+    render(<MemberPanel docId="d_1" role="admin" space="s_1" ownerId="u_owner" />)
+    await waitFor(() => expect(visibleUids().some((r) => r.includes('Human One'))).toBe(true))
+    fireEvent.click(rowFor('Human One').parentElement!.querySelector('.octo-member-picker-expand') as HTMLButtonElement)
+    await waitFor(() => expect(visibleUids().some((r) => r.includes('Bot One'))).toBe(true))
+    // The revealed bot row carries the nested modifier (indented under its creator)…
+    expect(rowFor('Bot One').classList.contains('octo-member-row--nested')).toBe(true)
+    // …while the creator row and the owner row (both top-level) do NOT.
+    expect(rowFor('Human One').classList.contains('octo-member-row--nested')).toBe(false)
+    const ownerRow = screen.getByText('docs.member.ownerBadge').closest('.octo-member-row') as HTMLElement
+    expect(ownerRow.classList.contains('octo-member-row--nested')).toBe(false)
+  })
+
+  it('indents orphan bots revealed in the bottom fold (octo-member-row--nested)', async () => {
+    wk.spaceMembers.push({ uid: 'u_human', name: 'Human One' })
+    wireMembers(
+      [{ uid: 'u_human', role: 'writer' }],
+      [{ uid: 'b_orphan', name: 'Orphan Bot', creator_uid: 'u_stranger' }],
+    )
+    render(<MemberPanel docId="d_1" role="admin" space="s_1" ownerId="u_owner" />)
+    await waitFor(() => expect(visibleUids().some((r) => r.includes('Human One'))).toBe(true))
+    fireEvent.click(within(currentSection()).getByText('docs.member.showBots').closest('button') as HTMLButtonElement)
+    await waitFor(() => expect(visibleUids().some((r) => r.includes('Orphan Bot'))).toBe(true))
+    expect(rowFor('Orphan Bot').classList.contains('octo-member-row--nested')).toBe(true)
+  })
 })
 
 describe('MemberPanel add: partial-failure detail survives a refresh failure (task #5)', () => {

--- a/packages/docs/src/members/MemberPanel.tsx
+++ b/packages/docs/src/members/MemberPanel.tsx
@@ -10,7 +10,7 @@ import {
   UserNotFoundError,
   type Member,
 } from './api.ts'
-import { useMemberNames } from './useMemberNames.ts'
+import { useMemberDirectory } from './useMemberNames.ts'
 import { MemberPicker } from './MemberPicker.tsx'
 import { CurrentMembersList } from './CurrentMembersList.tsx'
 import { settleWithConcurrency } from './batchGrant.ts'
@@ -68,7 +68,7 @@ export function MemberPanel({
   const [error, setError] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
   const [adding, setAdding] = useState(false)
-  const names = useMemberNames(space ?? '')
+  const { names, botUids } = useMemberDirectory(space ?? '')
   // Screen 4c admin side: prefer the shared instance from EditorShell so the toolbar badge and this
   // panel read/mutate the SAME pending-request state; only fall back to a local hook when rendered
   // standalone (no shared instance passed). The fallback is kept INERT (enabled=false) whenever a
@@ -219,6 +219,7 @@ export function MemberPanel({
         loading={loading}
         onChangeRole={onChangeRole}
         onRemove={onRemove}
+        botUids={botUids}
         canRemove={(m) => (resolvedOwner ? canRemoveMember({ ...m, grantedBy: '' } as Member, resolvedOwner) : true)}
       />
     </section>

--- a/packages/docs/src/members/MemberPanel.tsx
+++ b/packages/docs/src/members/MemberPanel.tsx
@@ -68,7 +68,7 @@ export function MemberPanel({
   const [error, setError] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
   const [adding, setAdding] = useState(false)
-  const { names, botUids } = useMemberDirectory(space ?? '')
+  const { names, botUids, botCreators } = useMemberDirectory(space ?? '')
   // Screen 4c admin side: prefer the shared instance from EditorShell so the toolbar badge and this
   // panel read/mutate the SAME pending-request state; only fall back to a local hook when rendered
   // standalone (no shared instance passed). The fallback is kept INERT (enabled=false) whenever a
@@ -220,6 +220,7 @@ export function MemberPanel({
         onChangeRole={onChangeRole}
         onRemove={onRemove}
         botUids={botUids}
+        botCreators={botCreators}
         canRemove={(m) => (resolvedOwner ? canRemoveMember({ ...m, grantedBy: '' } as Member, resolvedOwner) : true)}
       />
     </section>

--- a/packages/docs/src/members/memberNames.test.ts
+++ b/packages/docs/src/members/memberNames.test.ts
@@ -161,3 +161,46 @@ describe('getSpaceMemberDirectory — bot uid set (PR C need #3)', () => {
     await first
   })
 })
+
+describe('getSpaceMemberDirectory — botCreators from /robot/space_bots creator_uid (PR C nesting)', () => {
+  let wk: ReturnType<typeof createMockWKApp>
+
+  beforeEach(() => {
+    clearMemberNameCache()
+    wk = createMockWKApp()
+    setWKApp(wk)
+  })
+
+  function respondBots(bots: unknown): void {
+    wk.apiClient.responder = (_method, url) => {
+      if (url.startsWith('/robot/space_bots')) return { data: bots, status: 200 }
+      return { data: {}, status: 200 }
+    }
+  }
+
+  it('maps botUid → creatorUid straight from the endpoint creator_uid', async () => {
+    respondBots([
+      { uid: 'bot1', name: 'Bot One', creator_uid: 'u_human' },
+      { uid: 'bot2', name: 'Bot Two', creator_uid: 'u_owner' },
+    ])
+    const dir = await getSpaceMemberDirectory('s_1')
+    expect(dir.botCreators.get('bot1')).toBe('u_human')
+    expect(dir.botCreators.get('bot2')).toBe('u_owner')
+    // Both bots are still in the bot set + name map (no behavior lost).
+    expect(dir.botUids.has('bot1')).toBe(true)
+    expect(dir.names.get('bot1')).toBe('Bot One')
+  })
+
+  it('leaves a bot with NO creator_uid out of botCreators (still a bot, just ownerless)', async () => {
+    respondBots([{ uid: 'bot1', name: 'Bot One' }])
+    const dir = await getSpaceMemberDirectory('s_1')
+    expect(dir.botCreators.has('bot1')).toBe(false)
+    // It is still classified as a bot (space_bots endpoint returns bots only).
+    expect(dir.botUids.has('bot1')).toBe(true)
+  })
+
+  it('fail-soft: blank space / empty directory yields an empty botCreators map', async () => {
+    const dir = await getSpaceMemberDirectory('')
+    expect(dir.botCreators.size).toBe(0)
+  })
+})

--- a/packages/docs/src/members/memberNames.test.ts
+++ b/packages/docs/src/members/memberNames.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import { setWKApp } from '../octoweb/index.ts'
 import { createMockWKApp } from '../octoweb/mock.ts'
-import { getSpaceMemberNames, clearMemberNameCache } from './memberNames.ts'
+import { getSpaceMemberNames, getSpaceMemberDirectory, clearMemberNameCache } from './memberNames.ts'
 
 describe('getSpaceMemberNames — uid → display name resolution', () => {
   let wk: ReturnType<typeof createMockWKApp>
@@ -95,5 +95,69 @@ describe('getSpaceMemberNames — bot name backfill via /robot/space_bots (#60)'
     respondBots({ unexpected: true })
     const map = await getSpaceMemberNames('s_1')
     expect(map.get('u1')).toBe('Alice')
+  })
+})
+
+describe('getSpaceMemberDirectory — bot uid set (PR C need #3)', () => {
+  let wk: ReturnType<typeof createMockWKApp>
+
+  beforeEach(() => {
+    clearMemberNameCache()
+    wk = createMockWKApp()
+    setWKApp(wk)
+  })
+
+  function respondBots(bots: unknown, opts: { fail?: boolean } = {}): void {
+    wk.apiClient.responder = (_method, url) => {
+      if (url.startsWith('/robot/space_bots')) {
+        if (opts.fail) return Promise.reject(new Error('space_bots down'))
+        return { data: bots, status: 200 }
+      }
+      return { data: {}, status: 200 }
+    }
+  }
+
+  it('marks space-member entries flagged isBot as bots, humans stay out of the set', async () => {
+    wk.spaceMembers.push(
+      { uid: 'u_human', name: 'Alice' },
+      { uid: 'u_bot', name: 'Helper', isBot: true },
+    )
+    respondBots([])
+    const dir = await getSpaceMemberDirectory('s_1')
+    expect(dir.botUids.has('u_bot')).toBe(true)
+    expect(dir.botUids.has('u_human')).toBe(false)
+  })
+
+  it('adds every /robot/space_bots uid to the bot set (that endpoint returns bots only)', async () => {
+    wk.spaceMembers.push({ uid: 'u_human', name: 'Alice' })
+    respondBots([{ uid: 'bot1', name: 'Bot One' }])
+    const dir = await getSpaceMemberDirectory('s_1')
+    expect(dir.botUids.has('bot1')).toBe(true)
+    expect(dir.botUids.has('u_human')).toBe(false)
+    // Names still resolve for both.
+    expect(dir.names.get('bot1')).toBe('Bot One')
+    expect(dir.names.get('u_human')).toBe('Alice')
+  })
+
+  it('fail-soft: an empty space yields an empty bot set (unknown ⇒ human)', async () => {
+    const dir = await getSpaceMemberDirectory('')
+    expect(dir.botUids.size).toBe(0)
+    expect(dir.names.size).toBe(0)
+  })
+
+  it('fail-soft: a missing isBot flag is treated as human, never as a bot', async () => {
+    // No isBot on the member and no space_bots rows → nothing is classified as a bot.
+    wk.spaceMembers.push({ uid: 'u_maybe', name: 'Maybe' })
+    respondBots([])
+    const dir = await getSpaceMemberDirectory('s_1')
+    expect(dir.botUids.size).toBe(0)
+  })
+
+  it('getSpaceMemberNames stays identity-stable (single fetch) alongside the directory', async () => {
+    wk.spaceMembers.push({ uid: 'u1', name: 'Alice' })
+    const first = getSpaceMemberNames('s_1')
+    const second = getSpaceMemberNames('s_1')
+    expect(first).toBe(second)
+    await first
   })
 })

--- a/packages/docs/src/members/memberNames.test.ts
+++ b/packages/docs/src/members/memberNames.test.ts
@@ -204,3 +204,54 @@ describe('getSpaceMemberDirectory — botCreators from /robot/space_bots creator
     expect(dir.botCreators.size).toBe(0)
   })
 })
+
+describe('useMemberDirectory — space switch returns EMPTY_DIRECTORY until new space resolves (B2)', () => {
+  // B2: when spaceId changes, useMemberDirectory must NOT return the old space's directory;
+  // it must return EMPTY_DIRECTORY (fail-soft: everyone is a human) until the new space resolves.
+  // This prevents a real person in space B from being misclassified as a bot (and hidden) because
+  // space A's botUids contained that uid.
+  //
+  // Testing hooks in isolation is tricky; we use a minimal component + renderHook from @testing-library/react.
+  let wk: ReturnType<typeof createMockWKApp>
+
+  beforeEach(() => {
+    clearMemberNameCache()
+    wk = createMockWKApp()
+    setWKApp(wk)
+  })
+
+  it('returns empty directory immediately after spaceId changes (before new space resolves)', async () => {
+    // Import the hook dynamically to avoid hoisting issues.
+    const { useMemberDirectory } = await import('./useMemberNames.ts')
+    const { renderHook, waitFor } = await import('@testing-library/react')
+
+    // Space A has a bot.
+    wk.spaceMembers.push({ uid: 'u_bot_a', name: 'Bot A', isBot: true })
+    wk.apiClient.responder = (_method, url) => {
+      if (url.startsWith('/robot/space_bots')) return { data: [{ uid: 'u_bot_a', name: 'Bot A' }], status: 200 }
+      return { data: {}, status: 200 }
+    }
+
+    const { result, rerender } = renderHook(({ space }) => useMemberDirectory(space), {
+      initialProps: { space: 's_a' },
+    })
+
+    // Wait for space A's directory to resolve.
+    await waitFor(() => expect(result.current.botUids.has('u_bot_a')).toBe(true))
+
+    // Now switch to space B. Before B resolves, the hook should return EMPTY_DIRECTORY.
+    clearMemberNameCache() // Clear so B is a fresh fetch.
+    wk.spaceMembers.length = 0 // B has no bots.
+    wk.apiClient.responder = (_method, url) => {
+      if (url.startsWith('/robot/space_bots')) return { data: [], status: 200 }
+      return { data: {}, status: 200 }
+    }
+
+    rerender({ space: 's_b' })
+
+    // IMMEDIATELY after rerender (before the async fetch completes), the directory should be EMPTY.
+    // This is the critical assertion: we must NOT still have u_bot_a in botUids.
+    expect(result.current.botUids.has('u_bot_a')).toBe(false)
+    expect(result.current.botUids.size).toBe(0)
+  })
+})

--- a/packages/docs/src/members/memberNames.ts
+++ b/packages/docs/src/members/memberNames.ts
@@ -34,6 +34,12 @@ import { fetchAllSpaceMembers, fetchSpaceBotNames } from '../octoweb/index.ts'
 export interface SpaceMemberDirectory {
   names: Map<string, string>
   botUids: Set<string>
+  /**
+   * botUid → creatorUid, populated ONLY from `/robot/space_bots` rows that carried a `creator_uid`.
+   * The panel nests each bot beneath its creator's row; a bot with no known creator (absent here)
+   * falls into the shared "ownerless bots" fold. No extra request — same Promise.all as `botUids`.
+   */
+  botCreators: Map<string, string>
 }
 
 const cache = new Map<string, Promise<SpaceMemberDirectory>>()
@@ -48,7 +54,7 @@ const namesProjection = new WeakMap<Promise<SpaceMemberDirectory>, Promise<Map<s
  * from data we already fetch, not a new call.
  */
 export function getSpaceMemberDirectory(spaceId: string): Promise<SpaceMemberDirectory> {
-  if (!spaceId) return Promise.resolve({ names: new Map<string, string>(), botUids: new Set<string>() })
+  if (!spaceId) return Promise.resolve({ names: new Map<string, string>(), botUids: new Set<string>(), botCreators: new Map<string, string>() })
   const cached = cache.get(spaceId)
   if (cached) return cached
   const pending = Promise.all([
@@ -66,6 +72,7 @@ export function getSpaceMemberDirectory(spaceId: string): Promise<SpaceMemberDir
     if (members === null) cache.delete(spaceId)
     const map = new Map<string, string>()
     const botUids = new Set<string>()
+    const botCreators = new Map<string, string>()
     for (const m of members ?? []) {
       if (!m.uid) continue
       map.set(m.uid, m.name || m.uid)
@@ -78,10 +85,13 @@ export function getSpaceMemberDirectory(spaceId: string): Promise<SpaceMemberDir
     for (const b of bots) {
       if (!b.uid) continue
       botUids.add(b.uid)
+      // Nest under the creator only when the endpoint carried one; a bot with no creator_uid stays
+      // out of this map and lands in the ownerless fold.
+      if (b.creatorUid) botCreators.set(b.uid, b.creatorUid)
       const existing = map.get(b.uid)
       if (!existing || existing === b.uid) map.set(b.uid, b.name || b.uid)
     }
-    return { names: map, botUids }
+    return { names: map, botUids, botCreators }
   })
   cache.set(spaceId, pending)
   return pending

--- a/packages/docs/src/members/memberNames.ts
+++ b/packages/docs/src/members/memberNames.ts
@@ -19,14 +19,36 @@
 
 import { fetchAllSpaceMembers, fetchSpaceBotNames } from '../octoweb/index.ts'
 
-const cache = new Map<string, Promise<Map<string, string>>>()
+/**
+ * Resolved directory for a space: uid → display name PLUS the set of uids known to be bots.
+ *
+ * The member row data (rich `Member` / html `HtmlGrant`) only carries uid/role/source, so it can't
+ * tell a bot from a human. We already fetch two bot-aware sources here in the SAME Promise.all, so
+ * we surface a `botUids` set alongside the names — no extra request. `botUids` is the union of:
+ *   - space-member entries flagged `isBot` (host `robot === 1`), and
+ *   - every uid returned by `/robot/space_bots` (that endpoint returns bots exclusively).
+ *
+ * fail-soft direction is "unknown ⇒ human": on empty/failed/unresolved data `botUids` is empty, so
+ * every row renders as a person (never hide a real human in a bot fold). The panel relies on this.
+ */
+export interface SpaceMemberDirectory {
+  names: Map<string, string>
+  botUids: Set<string>
+}
+
+const cache = new Map<string, Promise<SpaceMemberDirectory>>()
+// Memoized names-only projection, keyed by the directory promise, so getSpaceMemberNames returns a
+// STABLE promise for a given space (same-identity as before) and never triggers a second fetch.
+const namesProjection = new WeakMap<Promise<SpaceMemberDirectory>, Promise<Map<string, string>>>()
 
 /**
- * Resolve the uid → display-name map for a space (cached per spaceId). Always resolves; on a
- * fetch error it yields an empty map and drops the cache entry so the next call can retry.
+ * Resolve the uid → display-name + bot directory for a space (cached per spaceId). Always
+ * resolves; on a fetch error it yields an empty directory and drops the cache entry so the next
+ * call can retry. Still exactly ONE Promise.all (two requests) per space — the bot set is derived
+ * from data we already fetch, not a new call.
  */
-export function getSpaceMemberNames(spaceId: string): Promise<Map<string, string>> {
-  if (!spaceId) return Promise.resolve(new Map<string, string>())
+export function getSpaceMemberDirectory(spaceId: string): Promise<SpaceMemberDirectory> {
+  if (!spaceId) return Promise.resolve({ names: new Map<string, string>(), botUids: new Set<string>() })
   const cached = cache.get(spaceId)
   if (cached) return cached
   const pending = Promise.all([
@@ -43,20 +65,40 @@ export function getSpaceMemberNames(spaceId: string): Promise<Map<string, string
     // caching "no names". We still merge whatever bot names we got for this render.
     if (members === null) cache.delete(spaceId)
     const map = new Map<string, string>()
+    const botUids = new Set<string>()
     for (const m of members ?? []) {
-      if (m.uid) map.set(m.uid, m.name || m.uid)
+      if (!m.uid) continue
+      map.set(m.uid, m.name || m.uid)
+      // Only a POSITIVE isBot flag marks a bot; missing/false stays human (fail-soft direction).
+      if (m.isBot === true) botUids.add(m.uid)
     }
     // Backfill ONLY uids that are absent or still resolve to their raw uid — never overwrite a
     // real human/member name (bots filtered out of queryMembers are exactly the missing ones).
+    // Every space_bots row is a bot by definition → its uid joins botUids.
     for (const b of bots) {
       if (!b.uid) continue
+      botUids.add(b.uid)
       const existing = map.get(b.uid)
       if (!existing || existing === b.uid) map.set(b.uid, b.name || b.uid)
     }
-    return map
+    return { names: map, botUids }
   })
   cache.set(spaceId, pending)
   return pending
+}
+
+/**
+ * Backward-compatible names-only accessor (unchanged signature/behavior). Kept so every existing
+ * caller (EditorShell caret label, panels, tests) keeps working without a change; it simply
+ * projects the directory down to its `names` map.
+ */
+export function getSpaceMemberNames(spaceId: string): Promise<Map<string, string>> {
+  const dir = getSpaceMemberDirectory(spaceId)
+  const existing = namesProjection.get(dir)
+  if (existing) return existing
+  const names = dir.then((d) => d.names)
+  namesProjection.set(dir, names)
+  return names
 }
 
 /** Test/util hook: drop all cached maps (e.g. between tests or after a space switch). */

--- a/packages/docs/src/members/sort.test.ts
+++ b/packages/docs/src/members/sort.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { sortMembersForDisplay, sortPickerMembers, withSyntheticOwner } from './sort.ts'
+import { sortMembersForDisplay, sortPickerMembers, withSyntheticOwner, applyOrderSnapshot } from './sort.ts'
 import type { Member } from './api.ts'
 import type { SpaceMemberLite } from '../octoweb/index.ts'
 
@@ -58,5 +58,35 @@ describe('sortPickerMembers (#A3)', () => {
     ]
     const sorted = sortPickerMembers(roster, new Set(['b', 'd'])).map((m) => m.uid)
     expect(sorted).toEqual(['b', 'd', 'a', 'c'])
+  })
+})
+
+describe('applyOrderSnapshot (need #4 — frozen order)', () => {
+  const row = (uid: string) => ({ uid })
+
+  it('orders rows by their snapshot index, ignoring incoming order (in-snapshot case)', () => {
+    // Snapshot froze the order [a, b, c]; rows arrive shuffled (e.g. a re-rank after a role change).
+    const snapshot = new Map([['a', 0], ['b', 1], ['c', 2]])
+    const rows = [row('c'), row('a'), row('b')]
+    expect(applyOrderSnapshot(rows, snapshot).map((r) => r.uid)).toEqual(['a', 'b', 'c'])
+  })
+
+  it('appends uids absent from the snapshot after all snapshot rows, keeping their relative order (out-of-snapshot case)', () => {
+    const snapshot = new Map([['a', 0], ['b', 1]])
+    // x and y are new (not snapshotted) and arrive interleaved; they must land AFTER a,b in arrival order.
+    const rows = [row('y'), row('a'), row('x'), row('b')]
+    expect(applyOrderSnapshot(rows, snapshot).map((r) => r.uid)).toEqual(['a', 'b', 'y', 'x'])
+  })
+
+  it('simply omits snapshot uids that have disappeared from rows (removed case)', () => {
+    const snapshot = new Map([['a', 0], ['b', 1], ['c', 2]])
+    // b was removed; the remaining rows keep their frozen relative order.
+    const rows = [row('c'), row('a')]
+    expect(applyOrderSnapshot(rows, snapshot).map((r) => r.uid)).toEqual(['a', 'c'])
+  })
+
+  it('is a stable pass-through when the snapshot is empty (all rows treated as new)', () => {
+    const rows = [row('a'), row('b'), row('c')]
+    expect(applyOrderSnapshot(rows, new Map()).map((r) => r.uid)).toEqual(['a', 'b', 'c'])
   })
 })

--- a/packages/docs/src/members/sort.ts
+++ b/packages/docs/src/members/sort.ts
@@ -47,6 +47,40 @@ export function sortMembersForDisplay(members: Member[], ownerId?: string): Memb
 }
 
 /**
+ * Apply a frozen order snapshot to a set of rows (need #4). Given `snapshot` mapping uid → a fixed
+ * index, rows are ordered by that index so a role change (which would otherwise re-rank a row via
+ * sortMembersForDisplay) does NOT move the row. Behavior:
+ *   - a uid present in the snapshot keeps its snapshot index (stable regardless of its new role);
+ *   - a uid absent from the snapshot (newly added since the snapshot was taken) is appended AFTER
+ *     all snapshot rows, preserving the relative order in which such new uids arrive in `rows`;
+ *   - a uid that has disappeared from `rows` simply does not appear (nothing to place).
+ *
+ * Pure + side-effect free (independent of sortMembersForDisplay / withSyntheticOwner). Callers seed
+ * the snapshot once from the normal sorted order, then keep using this so the visible order is
+ * frozen until the snapshot is discarded (panel reopen / doc switch).
+ */
+export function applyOrderSnapshot<T extends { uid: string }>(
+  rows: T[],
+  snapshot: Map<string, number>,
+): T[] {
+  return rows
+    .map((row, i) => [row, i] as const)
+    .sort((a, b) => {
+      const ai = snapshot.get(a[0].uid)
+      const bi = snapshot.get(b[0].uid)
+      const aKnown = ai !== undefined
+      const bKnown = bi !== undefined
+      // Snapshot rows come before any brand-new (unsnapshotted) rows.
+      if (aKnown !== bKnown) return aKnown ? -1 : 1
+      // Both in the snapshot: order by the frozen index.
+      if (aKnown && bKnown) return ai - bi
+      // Both new: keep their incoming relative order (stable append).
+      return a[1] - b[1]
+    })
+    .map(([row]) => row)
+}
+
+/**
  * Order the picker roster (#A3): members already on the document are pinned at the top (they are
  * shown disabled/marked) so the admin can see who is already in, with the original order preserved
  * within each group.

--- a/packages/docs/src/members/useMemberNames.ts
+++ b/packages/docs/src/members/useMemberNames.ts
@@ -23,22 +23,35 @@ export function useMemberNames(spaceId: string): Map<string, string> {
 
 const EMPTY_DIRECTORY: SpaceMemberDirectory = { names: new Map(), botUids: new Set(), botCreators: new Map() }
 
+/** State shape for useMemberDirectory: directory keyed by spaceId to detect stale data on switch. */
+interface KeyedDirectory {
+  key: string
+  dir: SpaceMemberDirectory
+}
+
 /**
  * Subscribe a component to the space's full directory (names + bot uids). Shares the SAME cached
  * fetch as useMemberNames (one Promise.all per space), so adding this hook next to useMemberNames
  * costs no extra request. Returns an empty directory (empty names, empty botUids) until it
  * resolves — the panel treats an empty `botUids` as "everyone is a human" (fail-soft).
+ *
+ * B2 fix: the directory is keyed by spaceId. When the spaceId changes, the hook returns
+ * EMPTY_DIRECTORY until the new space's directory resolves — this prevents a brief window where
+ * the OLD space's botUids could misclassify a real person as a bot (hiding them in a fold).
+ * Fail-soft direction: unknown → human.
  */
 export function useMemberDirectory(spaceId: string): SpaceMemberDirectory {
-  const [directory, setDirectory] = useState<SpaceMemberDirectory>(() => EMPTY_DIRECTORY)
+  const [stored, setStored] = useState<KeyedDirectory | null>(null)
   useEffect(() => {
     let active = true
     void getSpaceMemberDirectory(spaceId).then((d) => {
-      if (active) setDirectory(d)
+      if (active) setStored({ key: spaceId, dir: d })
     })
     return () => {
       active = false
     }
   }, [spaceId])
-  return directory
+  // B2: only return the stored directory if its key matches the current spaceId; otherwise
+  // return EMPTY_DIRECTORY so stale data from a previous space can never misclassify rows.
+  return stored && stored.key === spaceId ? stored.dir : EMPTY_DIRECTORY
 }

--- a/packages/docs/src/members/useMemberNames.ts
+++ b/packages/docs/src/members/useMemberNames.ts
@@ -21,7 +21,7 @@ export function useMemberNames(spaceId: string): Map<string, string> {
   return names
 }
 
-const EMPTY_DIRECTORY: SpaceMemberDirectory = { names: new Map(), botUids: new Set() }
+const EMPTY_DIRECTORY: SpaceMemberDirectory = { names: new Map(), botUids: new Set(), botCreators: new Map() }
 
 /**
  * Subscribe a component to the space's full directory (names + bot uids). Shares the SAME cached

--- a/packages/docs/src/members/useMemberNames.ts
+++ b/packages/docs/src/members/useMemberNames.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { getSpaceMemberNames } from './memberNames.ts'
+import { getSpaceMemberNames, getSpaceMemberDirectory, type SpaceMemberDirectory } from './memberNames.ts'
 
 /**
  * Subscribe a component to the space's uid → display-name map (features #7 / #8). Returns an
@@ -19,4 +19,26 @@ export function useMemberNames(spaceId: string): Map<string, string> {
     }
   }, [spaceId])
   return names
+}
+
+const EMPTY_DIRECTORY: SpaceMemberDirectory = { names: new Map(), botUids: new Set() }
+
+/**
+ * Subscribe a component to the space's full directory (names + bot uids). Shares the SAME cached
+ * fetch as useMemberNames (one Promise.all per space), so adding this hook next to useMemberNames
+ * costs no extra request. Returns an empty directory (empty names, empty botUids) until it
+ * resolves — the panel treats an empty `botUids` as "everyone is a human" (fail-soft).
+ */
+export function useMemberDirectory(spaceId: string): SpaceMemberDirectory {
+  const [directory, setDirectory] = useState<SpaceMemberDirectory>(() => EMPTY_DIRECTORY)
+  useEffect(() => {
+    let active = true
+    void getSpaceMemberDirectory(spaceId).then((d) => {
+      if (active) setDirectory(d)
+    })
+    return () => {
+      active = false
+    }
+  }, [spaceId])
+  return directory
 }

--- a/packages/docs/src/octoweb/index.ts
+++ b/packages/docs/src/octoweb/index.ts
@@ -241,16 +241,23 @@ async function getSpaceBots(spaceId: string): Promise<HostSpaceBot[]> {
  * so one request per space backfills those names with no per-uid fanout and no extra permission.
  *
  * Returns `{ uid, name }` pairs (name falls back to the uid so a bot with no display name is never
- * blank). Name backfill is COSMETIC, so a malformed (non-array) 200 degrades to an EMPTY list here
- * and the uid fallback stands — unlike the grant-critical snapshot path, which fails closed. Request
- * failures still reject; callers wrap them so the human-member name path never breaks.
+ * blank), plus `creatorUid` when the endpoint carried one — the member panel nests each bot under
+ * its creator row. Same source/request as before (no extra fetch); the signature/return type are
+ * unchanged (`creatorUid` is an already-existing optional field on SpaceMemberLite). Name backfill
+ * is COSMETIC, so a malformed (non-array) 200 degrades to an EMPTY list here and the uid fallback
+ * stands — unlike the grant-critical snapshot path, which fails closed. Request failures still
+ * reject; callers wrap them so the human-member name path never breaks.
  */
 export async function fetchSpaceBotNames(spaceId: string): Promise<SpaceMemberLite[]> {
   const bots = await getSpaceBots(spaceId).catch((e: unknown) => {
     if (e instanceof MalformedSpaceBotsError) return [] as HostSpaceBot[]
     throw e
   })
-  return bots.map((b) => ({ uid: b.uid, name: b.name || b.uid }))
+  return bots.map((b) => ({
+    uid: b.uid,
+    name: b.name || b.uid,
+    ...(b.creator_uid ? { creatorUid: b.creator_uid } : {}),
+  }))
 }
 
 /**

--- a/packages/docs/src/octoweb/spaceMembers.test.ts
+++ b/packages/docs/src/octoweb/spaceMembers.test.ts
@@ -145,13 +145,20 @@ describe('octoweb fetchSpaceBotSnapshots seam', () => {
     expect(calls[0].url).toBe('/robot/space_bots?space_id=s_1')
   })
 
-  it('does NOT alter the name-only fetchSpaceBotNames contract', async () => {
+  it('carries creatorUid on fetchSpaceBotNames but keeps it isBot-free (name-backfill contract)', async () => {
     wk.apiClient.responder = () => ({
-      data: [{ uid: 'b_1', name: 'Writer', creator_uid: 'u_ada' }],
+      data: [
+        { uid: 'b_1', name: 'Writer', creator_uid: 'u_ada' },
+        { uid: 'b_2', name: 'Nameless creator' },
+      ],
       status: 200,
     })
-    // Same source, but the name-only accessor still returns bare { uid, name } pairs.
-    expect(await fetchSpaceBotNames('s_1')).toEqual([{ uid: 'b_1', name: 'Writer' }])
+    // Same source as the snapshot path; the name-only accessor now surfaces creatorUid (used to
+    // nest a bot under its creator) but still omits isBot — a bot with no creator_uid stays bare.
+    expect(await fetchSpaceBotNames('s_1')).toEqual([
+      { uid: 'b_1', name: 'Writer', creatorUid: 'u_ada' },
+      { uid: 'b_2', name: 'Nameless creator' },
+    ])
   })
 
   it('falls back to the uid and skips entries without a uid', async () => {

--- a/packages/docs/src/pages/StandaloneDocPage.test.tsx
+++ b/packages/docs/src/pages/StandaloneDocPage.test.tsx
@@ -65,6 +65,7 @@ vi.mock('../board/BoardSession.tsx', () => ({
 // focused on the preflight gate and chrome.
 vi.mock('../members/useMemberNames.ts', () => ({
   useMemberNames: () => new Map<string, string>(),
+  useMemberDirectory: () => ({ names: new Map<string, string>(), botUids: new Set<string>() }),
 }))
 
 // Replace the collaborative spreadsheet host (Univer + Yjs + Hocuspocus) with a marker so a

--- a/packages/docs/src/sheet/ProtectionUserPart.test.tsx
+++ b/packages/docs/src/sheet/ProtectionUserPart.test.tsx
@@ -37,6 +37,7 @@ vi.mock('../members/useMemberNames.ts', () => ({
   // Real shape: Map<uid, name>. Empty here — displayName() falls back to the uid, which is exactly
   // the "names have not arrived" state this test is about.
   useMemberNames: () => new Map<string, string>(),
+  useMemberDirectory: () => ({ names: new Map<string, string>(), botUids: new Set<string>() }),
 }))
 
 vi.mock('../octoweb/index.ts', () => ({ t: (k: string) => k }))


### PR DESCRIPTION
## Summary

> #1347 已合并进 main，本 PR 已 rebase 到最新 main，diff 现在只含本 PR 自身的三个 commit：
> `9a90b137`（Bot 分区 + AI 标 + 顺序冻结）→ `d717d18f`（**按需求变更**改为按主人嵌套）→ `f9c798fb`（Bot 行缩进）。
> rebase 前后已用 patch 逐行比对（1479 行完全一致），确认未夹带任何 main 侧改动。

一次性覆盖全部文档格式（rich / sheet / board / html），因为两侧已在 #1347 收敛到同一个 `CurrentMembersList`。

### 需求 3：Bot 挂在**它主人**行的下面 + 可折叠 + 标注 AI

> 需求原话：「看 bot 是谁的，就在谁的下边加个下拉。然后如果 bot 的主人没有的话就单独列。」

- **归属 Bot** → 渲染在**它主人那一行的正下方**，由**该主人行自己的下拉**控制显隐，**默认折叠**。每个主人**独立展开态**（`Set<creatorUid>`，不是全局 boolean）——展开 A 不会连带展开 B。
- **孤儿 Bot**（`creator_uid` 缺失，或主人不是本文档成员）→ 归到**列表最底部单独一个折叠区**。孤儿数为 0 时该区完全不渲染。
- 某主人名下 Bot 数为 0 时，该行**不渲染**下拉按钮（不留"展开 0 个 Bot"）。
- **owner 行也可以是主人**、同样能挂下拉；**owner 自己永远置顶、永不被折叠进任何区**（即使 owner 本身是 Bot）。
- 所有 Bot 行（归属 + 孤儿）名字后带 AI 徽标；**被下拉展开出来的 Bot 行向右缩进** `var(--wk-sp-8, 32px)`，与成员搜索列表 `.octo-member-picker-bot` 的缩进量一致（复用同一 token，未硬编码数值）。

**数据来源（零新增请求）**：成员行（rich `Member` / html `HtmlGrant`）只有 `uid/role/source`，判不出是不是 Bot、更不知道主人是谁。而 `memberNames.ts` 原本已在**同一个 `Promise.all`** 里拉了两份 Bot-aware 数据 —— `fetchAllSpaceMembers`（带 `isBot`，host `robot === 1`）与 `fetchSpaceBotNames`（`/robot/space_bots`，返回的全是 Bot，**且响应本就带 `creator_uid`**，此前被丢弃）。故将解析结果升级为 `SpaceMemberDirectory { names, botUids, botCreators }`：

- `botUids` = 上述两源的并集；`botCreators: Map<botUid, creatorUid>` 仅在 `creator_uid` 存在时写入。
- `fetchSpaceBotNames` 只多填一个**已存在的可选字段** `creatorUid`（`SpaceMemberLite.creatorUid`），签名与 fail 策略均不变（畸形 200 仍降级空数组）；`getSpaceBots` / `fetchSpaceBotSnapshots` 未动（后者仍 fail-closed）。
- `getSpaceMemberNames` **签名与行为完全不变**，改为对 directory 的 identity-memoized（`WeakMap`）投影，保证同一 space 返回**同一 promise 身份**（既有测试依赖此不变式），且不触发第二次 fetch。新增 `getSpaceMemberDirectory` / `useMemberDirectory` 供面板使用。

**fail-soft 方向 = 「判不出来当人 / 判不出主人也不藏」**（安全相关）：仅 `isBot === true` 或命中 `/robot/space_bots` 才算 Bot。
- `botUids` 为空集（directory 未 resolve / 请求失败 / html `space` 为 `undefined`）→ **所有行按人平铺、不标 AI、不渲染任何折叠区**。绝不能反向——外部分享页 `/d/:docId` 常拿不到 roster，判不出就当 Bot 会把**真人藏进折叠区**。
- `botCreators` 为空但有 Bot → 全部落底部孤儿区（**不会因为不知道主人就让 Bot 消失**）。
- 防御：creator 指向自身、或 creator 本身是个被嵌套的 Bot（Bot 嵌 Bot 的多级链）→ 降级为孤儿。**只做一层嵌套**，避免把 Bot 藏在一个同样折叠着的 Bot 里面。

### 需求 4：改权限后顺序保持稳定，退出面板再进入才重排

**Before**：`onChangeRole → addOrUpdateMember → refresh → listMembers → sortMembersForDisplay` 按角色档位重排 → 被改的那行**当场跳走**，用户丢失视觉锚点。

**After**：`sort.ts` 新增纯函数 `applyOrderSnapshot<T extends { uid: string }>(rows, snapshot)`：快照内的 uid 按冻结 index 排、快照外的新 uid 追加尾部并保持到达顺序、快照中已消失的 uid 自然不出现。`sortMembersForDisplay` / `withSyntheticOwner` 签名未动。

`CurrentMembersList` 用 `useRef` 持有快照：**首次拿到非空 rows** 时按正常角色排序 seed 一次（跳过空首帧，否则顺序会被锁成空）；之后 rows 变化只更新行内容、顺序走快照；新 uid 追加尾部，消失的 uid 从快照删除（避免无界增长）。

**"退出再进入才重排"靠 unmount 自然实现**：三个挂载点（`EditorShell` / `BoardShell` / `HtmlDocView`）的成员弹窗都是条件渲染，关闭即 unmount → 快照随之销毁 → 重新打开按新角色重排。未额外加"打开时手动 reset"逻辑。另加保险：`ownerUid`（切文档）变化时清空快照。

**分组与快照的关系**：实现顺序严格为「先算顶层行集合 + 分组 → 顶层套快照 → 组内 Bot 单独排序」。快照只管**顶层行**（owner + 人 + 孤儿 Bot），归属 Bot 跟着主人走、不参与顶层快照 → 改权限**永远不会让一行跨组**（人不会跳进 Bot 区、归属 Bot 不会跳成孤儿）。

## Linked Spec

无独立 spec 文档；需求来自成员面板可用性反馈（需求 3 / 需求 4，含一次需求变更：从"全部 Bot 置底"改为"按主人嵌套"）。排序契约的单一来源是 `packages/docs/src/members/sort.ts`。

## How verified

- `npx vitest run src/members src/html` → **360 passed (21 files)**（#1347 基线 327 → 需求变更后 358 → 缩进 +2）。
- 全量 `npx vitest run src` → **2724 passed / 23 failed**；23 条全部落在 `board/excalidrawToolbarPatch.contract.test.ts`、`board/octoNativeShapes.contract.test.ts`、`editor/TableReorderInterrupt.test.ts`。**已在本 PR 之外的干净基线上单独复跑这三个文件，得到完全相同的 3 files / 23 failed**，确认为既有基线问题、与本 PR 无关（`useMemberNames` / `fetchSpaceBotNames` 改动零回归）。
- **Positive control（orchestrator 独立执行，非读取 fixer 报告）**：
  - 还原 `CurrentMembersList.tsx` + `sort.ts` 至 `9543f452^` → **精确 9 条失败**（bot 分区 3 / 顺序冻结与尾部追加 2 / `applyOrderSnapshot` 纯函数 4），装回全绿。
  - 还原 `CurrentMembersList.tsx` + `memberNames.ts` + `octoweb/index.ts` 至 `499f4f0b^` → **精确 10 条失败**（嵌套结构 / 独立展开 / 孤儿区 / `botCreators` 解析），装回 **395 passed** 全绿。
- **DOM 探针实测（orchestrator 独立执行）**，`ownerUid` 为主人 + 2 人 + 2 归属 Bot + 1 孤儿 Bot：
  - 折叠态：仅 3 行（owner、human_a、human_b），owner 与 human_a 各自带一个 `showBots`（`aria-expanded=false`），底部另有孤儿区按钮；
  - 点开 human_a：**仅其名下 2 个 Bot 出现在该行正下方**（带 `aiTag`），owner 的下拉**仍为收起**（证明 per-creator 独立）；
  - 点开底部孤儿区：主人不在成员列表的 Bot 单独列出；
  - 缩进：展开后归属 Bot 与孤儿 Bot 均带 `octo-member-row--nested`，owner 行与人行**不带**；
  - fail-soft（`botUids` 缺省）：全部平铺、无 AI 标、无任何折叠按钮；`botCreators` 缺省但有 Bot → 全落底部孤儿区。
- **构建/运行时自证**：`turbo run build --filter=@octo/web` 通过；构建产物与运行容器内均确认 `octo-member-row--nested{padding-left:var(--wk-sp-8,32px)}` 存在（非仅本地源码）。
- `tsc --noEmit -p tsconfig.typecheck.json` → 本 PR 触及文件零错误（仅基线既有的 `../dmworkbase/src/i18n/format.ts`、`src/board/octoNativeShapes.contract.test.ts` 无关报错）。
- 改写的既有断言仅一处：`octoweb/spaceMembers.test.ts` 原「`fetchSpaceBotNames` 返回 bare `{uid,name}`」——这正是本次要改的行为，改写为「带 `creatorUid` 但仍不带 `isBot`」。PR B 的角色 / owner / 移除 / 快照相关断言**一律未动**。

## COMPREHENSION

**(a) 对承载路径做了什么（before/after）**

两条承载路径：① 空间成员目录解析（`memberNames` 缓存，被 caret label / 成员面板 / 多个 shell 共用）；② 成员列表的分组与展示顺序。

- ①：Before `Map<uid,name>`；After `SpaceMemberDirectory{names, botUids, botCreators}`，**同一次 Promise.all、同样两个请求**；`getSpaceMemberNames` 以 identity-memoized 投影保持旧签名与 promise 身份不变。
- ②：Before 单一 `sortMembersForDisplay` 平铺、改角色即重排；After 「顶层行（owner/人/孤儿 Bot）+ 每主人嵌套 Bot 折叠区 + 底部孤儿折叠区」，顶层顺序在挂载期内冻结，Bot 行缩进并标 AI。

**(b) 可能坏什么（依赖方 + 失效模式）**

- 依赖方：`useMemberNames` 的所有调用点（`EditorShell` caret label、`BoardShell`、`StandaloneDocPage`、`ProtectionUserPart` 等）。风险是改 `memberNames` 返回形状打破它们 → 已用**全量 `vitest run src`** 覆盖验证（并为 6 处既有 `vi.mock('../members/useMemberNames.ts')` 补齐 `useMemberDirectory` stub，否则读 directory 的面板在这些 mock 下无法渲染）。
- 失效模式 1（安全）：fail-soft 反向（判不出当 Bot）→ 真人被藏进折叠区，外部分享页尤甚。已由「`botUids` 为空集则全部平铺」测试锁定。
- 失效模式 2（安全）：不知主人就丢弃 Bot → 授权行凭空消失、无法撤销。已由「`botCreators` 为空 → 全落底部孤儿区」与「creator 非成员 → 孤儿区」测试锁定。
- 失效模式 3：owner 被折叠 → 文档所有者从列表消失。已由「owner 即使是 Bot 也置顶、不入任何折叠区」测试锁定。
- 失效模式 4：展开态若用全局 boolean → 展开一个主人会连带露出其他主人的 Bot。已由「两个主人独立展开」测试锁定（该条在旧实现下硬失败）。
- 失效模式 5：若先套快照再分组、或让快照跨组生效 → 改权限可能把人挪进 Bot 区。实现为「分组优先」，并由分组 + 快照测试共同覆盖。
- 失效模式 6：空首帧 seed 快照 → 顺序锁成空、列表永远为空。已由 seed 条件（`ranked.length > 0`）与顺序冻结测试覆盖。
- 失效模式 7：快照只增不减 → 长会话内存增长。每次 rows 变化删除消失的 uid。
- 失效模式 8：Bot 嵌 Bot 的多级链 → Bot 被藏在同样折叠的 Bot 内、不可达。已降级为孤儿（只做一层嵌套）。
- PR B 的角色安全契约未破：归属 / 孤儿 Bot 与人行共用同一 `renderRow`，`select` / 移除 / `canRemove` / 「角色不在 `roles` 里则渲染静态文字」完全一致。
- 请求量：**未新增任何 HTTP 请求**。HTML 两道 gate（`canManageAuthorGrants` / `canManageBackend`）语义逐字未动。

**(c) 怎么知道它可用**

360 条测试全绿；两轮 positive control（还原实现分别精确 9 / 10 条失败）；多组独立 DOM 探针实测（嵌套 / 独立展开 / 孤儿区 / owner-Bot / 缩进 class / 两种 fail-soft）；构建产物与运行容器内均自证缩进规则已生效；全量测试套件比对确认 23 条失败为既有基线问题；typecheck 无新增错误。

## 部署前提 / 必配环境变量

**无。** 纯前端改动：不新增/不修改任何环境变量、不改后端契约、不新增接口、**不增加任何 HTTP 请求次数**、不新增 i18n key（复用 `docs.member.showBots` / `hideBots` / `aiTag`）、未修改任何既有 CSS 规则（仅新增一条 `.octo-member-row--nested`，间距取 `var(--wk-sp-8, 32px)` token，无硬编码数值、无 `!important`）。

---

## 评审修复轮（`71d0faa0` / `d4ee3024`）

三位评审提出 2 项 blocking + 2 项非阻塞，**全部已修**，且每项均由 orchestrator 独立探针实测复核（非读取 fixer 报告）。

### 🔴 B1（P0）环形 `creator_uid` 导致栈溢出崩溃 — 已修
`/robot/space_bots` 的 `creator_uid` 是外部数据，此前 `creatorIsTopLevel` 无环检测：`bot_x → bot_y → bot_x` 直接 `RangeError: Maximum call stack size exceeded`，**整个成员面板崩溃**（orchestrator 探针已复现，非静态推断）。

修法：递归携带 `seen: Set<string>`，重复访问即判定该 creator **非 top-level** → 该链上的 Bot 降级为孤儿、落底部孤儿区。选择"降级为孤儿"而非 `return true`：环意味着数据不可信，孤儿区是安全落点 —— **Bot 仍然可见可撤销，且不隐藏任何行**；`return true` 会把 Bot 嵌进一个同样折叠的 Bot 里面。

修复后实测（三种畸形输入全部不崩，且都可达）：
```
两节点环 bot_x⇄bot_y     → no throw；孤儿区展开后可见 [bot_x, bot_y]，2 个 AI 徽标
三节点环 b1→b2→b3→b1     → no throw；孤儿区展开后可见 [b1, b2, b3]
自引用   bot_s→bot_s      → no throw；孤儿区展开后可见 [bot_s]
```

### 🔴 B2（P1）space 切换后沿用旧空间 `botUids`，可能隐藏真人 — 已修
`useMemberDirectory` 的 state 只初始化一次，`spaceId` 变化时 effect cleanup 仅翻 `active` 标志、不重置已暴露的 directory。A→B 切换窗口内用 **A 的 botUids** 分类 B 的成员：某 uid 在 A 是 Bot、在 B 是真人 → 该真人被塞进默认折叠区**被隐藏**，与本 PR 声明的「unknown ⇒ human」方向相反。

修法：state 改为 `{ key: spaceId, dir }`，读取时 `stored.key === spaceId ? stored.dir : EMPTY_DIRECTORY` —— key 不匹配一律返回空 directory（全部行 fail-soft 成人）。**不用** effect 里 `setState(EMPTY)`（会多一次渲染且仍有一帧旧值）。`useMemberNames`（names-only）签名与行为**未动**：短暂旧名字只是显示问题，不涉及隐藏真人。请求次数不变。

修复后实测（hook 探针）：
```
space A resolved:              space=s_A bots=[u_shared] names=1
切到 space B（B 的请求未 resolve）: space=s_B bots=[]        names=0   ← 不再沿用 A 的分类
```

### 🟡 B3（非阻塞）`ownerUid` 变化时展开态未重置 — 已修
顺序快照已在 `ownerUid`（切文档）变化时清空，但 `openCreators` / `orphanOpen` 未清，两者语义不一致。改为在同一判定点一起重置（未新增 effect）。实测：`aria-expanded` 由 `true` → 切 `ownerUid` 后 `false`。

### 🟡 B4（非阻塞）折叠区内 Bot 因改角色重排 — 已修
顶层行有顺序冻结，但**组内 Bot 没有** —— `bot_z` reader→admin 会跳到 `bot_a` 前面，与需求 4 语义不一致。修法：每个 creator 的 Bot 组 + 孤儿区各自也套一份顺序快照（复用纯函数 `applyOrderSnapshot`，签名未改），生命周期与顶层快照一致。实测：
```
展开后 [bot_a, bot_z] → bot_z reader→admin → 仍 [bot_a, bot_z]（位置冻结）
unmount 重挂 → [bot_z, bot_a]（按新角色重排，符合"退出再进入才重排"）
```

### 本轮验证
- `npx vitest run src/members src/html` → **372 passed (21 files)**（修复前 365 + 新增 7）。
- **Positive control（orchestrator 独立执行）**：把 `CurrentMembersList.tsx` + `useMemberNames.ts` 还原至 `f9c798fb` → **精确 5 条失败**（space 切换 1 / 两节点环 1 / 三节点环 1 / 展开态重置 1 / 组内顺序冻结 1），装回后 372 全绿。
- 全量 `npx vitest run src` → 2770 passed / 23 failed，23 条仍全部落在既有无关文件（`board/excalidrawToolbarPatch.contract.test.ts`、`board/octoNativeShapes.contract.test.ts`、`editor/TableReorderInterrupt.test.ts`）。
- typecheck：本 PR 触及文件零错误。
- 构建 + 运行容器自证通过（`turbo run build --filter=@octo/web` 成功，容器 200）。
