### PR TITLE
fix(message-input): preserve Shift+Enter with active suggestions

### DIFF
--- a/packages/dmworkbase/src/Components/MessageInput/EmojiSuggestionList.tsx
+++ b/packages/dmworkbase/src/Components/MessageInput/EmojiSuggestionList.tsx
@@ -64,7 +64,7 @@ export default forwardRef((props: EmojiSuggestionListProps, ref) => {
         moveSelection('next')
         return true
       }
-      if (event.key === 'Enter') {
+      if (event.key === 'Enter' && !event.shiftKey) {
         selectItem(selectedIndexRef.current)
         return true
       }

--- a/packages/dmworkbase/src/Components/MessageInput/MentionList.tsx
+++ b/packages/dmworkbase/src/Components/MessageInput/MentionList.tsx
@@ -218,7 +218,7 @@ export default forwardRef((props: MentionListProps, ref) => {
         return true
       }
 
-      if (event.key === 'Enter') {
+      if (event.key === 'Enter' && !event.shiftKey) {
         enterHandler()
         return true
       }

--- a/packages/dmworkbase/src/Components/MessageInput/__tests__/EmojiSuggestionList.test.tsx
+++ b/packages/dmworkbase/src/Components/MessageInput/__tests__/EmojiSuggestionList.test.tsx
@@ -1,0 +1,92 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import React from "react";
+import ReactDOM from "react-dom";
+import { act } from "react-dom/test-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import EmojiSuggestionList from "../EmojiSuggestionList";
+
+const items = [
+  {
+    key: "[使命必达]",
+    label: "使命必达",
+    image: "emoji://mission",
+  },
+];
+
+let container: HTMLDivElement;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  container = document.createElement("div");
+  document.body.appendChild(container);
+});
+
+afterEach(() => {
+  act(() => {
+    ReactDOM.unmountComponentAtNode(container);
+  });
+  container.remove();
+});
+
+function renderEmojiSuggestionList(command = vi.fn(), nextItems = items) {
+  const ref = React.createRef<any>();
+
+  act(() => {
+    ReactDOM.render(
+      <EmojiSuggestionList ref={ref} items={nextItems} command={command} />,
+      container
+    );
+  });
+
+  return { command, ref };
+}
+
+describe("EmojiSuggestionList keyboard handling", () => {
+  it("keeps plain Enter selecting the active emoji", () => {
+    const command = vi.fn();
+    const { ref } = renderEmojiSuggestionList(command);
+
+    let handled: boolean | undefined;
+    act(() => {
+      handled = ref.current.onKeyDown({
+        event: { key: "Enter", shiftKey: false },
+      });
+    });
+
+    expect(handled).toBe(true);
+    expect(command).toHaveBeenCalledWith(items[0]);
+  });
+
+  it("lets Shift+Enter fall through without selecting an emoji", () => {
+    const command = vi.fn();
+    const { ref } = renderEmojiSuggestionList(command);
+
+    let handled: boolean | undefined;
+    act(() => {
+      handled = ref.current.onKeyDown({
+        event: { key: "Enter", shiftKey: true },
+      });
+    });
+
+    expect(handled).toBe(false);
+    expect(command).not.toHaveBeenCalled();
+  });
+
+  it("lets Shift+Enter fall through when no emoji result is visible", () => {
+    const command = vi.fn();
+    const { ref } = renderEmojiSuggestionList(command, []);
+
+    let handled: boolean | undefined;
+    act(() => {
+      handled = ref.current.onKeyDown({
+        event: { key: "Enter", shiftKey: true },
+      });
+    });
+
+    expect(handled).toBe(false);
+    expect(command).not.toHaveBeenCalled();
+  });
+});

--- a/packages/dmworkbase/src/Components/MessageInput/__tests__/MentionList.test.tsx
+++ b/packages/dmworkbase/src/Components/MessageInput/__tests__/MentionList.test.tsx
@@ -303,6 +303,36 @@ describe("MentionList interaction mode", () => {
     expect(command).toHaveBeenCalledWith({ id: "uid-1", label: "Alice" });
   });
 
+  it("lets Shift+Enter fall through without selecting a mention", () => {
+    const command = vi.fn();
+    const { ref } = renderMentionList(command);
+
+    let handled: boolean | undefined;
+    act(() => {
+      handled = ref.current.onKeyDown({
+        event: { key: "Enter", shiftKey: true },
+      });
+    });
+
+    expect(handled).toBe(false);
+    expect(command).not.toHaveBeenCalled();
+  });
+
+  it("lets Shift+Enter fall through when no mention result is visible", () => {
+    const command = vi.fn();
+    const { ref } = renderMentionList(command, []);
+
+    let handled: boolean | undefined;
+    act(() => {
+      handled = ref.current.onKeyDown({
+        event: { key: "Enter", shiftKey: true },
+      });
+    });
+
+    expect(handled).toBe(false);
+    expect(command).not.toHaveBeenCalled();
+  });
+
   it("returns to the first keyboard item after the pointer leaves the list", () => {
     const command = vi.fn();
     const { ref } = renderMentionList(command);

--- a/packages/dmworkbase/src/Components/MessageInput/__tests__/suggestionShiftEnter.test.tsx
+++ b/packages/dmworkbase/src/Components/MessageInput/__tests__/suggestionShiftEnter.test.tsx
@@ -1,0 +1,177 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { Editor } from "@tiptap/core";
+import TiptapMention from "@tiptap/extension-mention";
+import { EditorContent } from "@tiptap/react";
+import StarterKit from "@tiptap/starter-kit";
+import React from "react";
+import ReactDOM from "react-dom";
+import { act } from "react-dom/test-utils";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  type Mock,
+  vi,
+} from "vitest";
+import { createMentionSuggestion } from "../mentionSuggestion";
+
+vi.mock("../../../i18n", () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("tippy.js", () => ({
+  default: () => [
+    {
+      destroy: vi.fn(),
+      hide: vi.fn(),
+      setProps: vi.fn(),
+      show: vi.fn(),
+    },
+  ],
+}));
+
+const mentionItems = [{ uid: "uid-1", name: "Alice", icon: "avatar://alice" }];
+const TestEditorContent = EditorContent as any;
+
+let container: HTMLDivElement;
+let editor: Editor;
+let mentionActiveChange: Mock<(active: boolean) => void>;
+let mentionCommand: Mock<(props: any) => void>;
+
+function countNodesOfType(node: any, type: string): number {
+  return (
+    (node.type === type ? 1 : 0) +
+    (node.content || []).reduce(
+      (count: number, child: any) => count + countNodesOfType(child, type),
+      0
+    )
+  );
+}
+
+function createEditor() {
+  const suggestion = {
+    ...createMentionSuggestion(
+      ({ query }) => (query === "a" ? mentionItems : []),
+      mentionActiveChange
+    ),
+    command: mentionCommand,
+  } as any;
+
+  editor = new Editor({
+    extensions: [
+      StarterKit.configure({
+        bold: false,
+        italic: false,
+        code: false,
+        heading: false,
+        blockquote: false,
+        horizontalRule: false,
+        codeBlock: false,
+        strike: false,
+        link: false,
+      }),
+      TiptapMention.configure({
+        suggestion,
+      }),
+    ],
+    content: "",
+  });
+
+  act(() => {
+    ReactDOM.render(<TestEditorContent editor={editor} />, container);
+  });
+}
+
+function pressEnter(shiftKey: boolean) {
+  const event = new KeyboardEvent("keydown", {
+    bubbles: true,
+    cancelable: true,
+    key: "Enter",
+    shiftKey,
+  });
+
+  act(() => {
+    editor.view.dom.dispatchEvent(event);
+  });
+
+  return event;
+}
+
+async function setLongMentionQuery(value: string) {
+  await act(async () => {
+    editor.commands.setContent(value);
+    editor.commands.setTextSelection(editor.state.doc.content.size);
+    await Promise.resolve();
+  });
+}
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  mentionActiveChange = vi.fn<(active: boolean) => void>();
+  mentionCommand = vi.fn<(props: any) => void>();
+  createEditor();
+});
+
+afterEach(() => {
+  act(() => {
+    ReactDOM.unmountComponentAtNode(container);
+  });
+  editor.destroy();
+  container.remove();
+});
+
+describe("MessageInput suggestion Shift+Enter", () => {
+  it("inserts a hard break in long text while a mention candidate is visible", async () => {
+    await setLongMentionQuery(`${"x".repeat(48)} @a`);
+
+    expect(mentionActiveChange).toHaveBeenCalledWith(true);
+    expect(editor.getText()).toHaveLength(51);
+
+    const event = pressEnter(true);
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(countNodesOfType(editor.getJSON(), "hardBreak")).toBe(1);
+    expect(countNodesOfType(editor.getJSON(), "mention")).toBe(0);
+    expect(mentionCommand).not.toHaveBeenCalled();
+  });
+
+  it("inserts a hard break after a long mention query hides all candidates", async () => {
+    await setLongMentionQuery(`${"x".repeat(47)} @a`);
+
+    await act(async () => {
+      editor.commands.insertContent("z");
+      await Promise.resolve();
+    });
+
+    expect(editor.getText()).toHaveLength(51);
+
+    const event = pressEnter(true);
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(countNodesOfType(editor.getJSON(), "hardBreak")).toBe(1);
+    expect(countNodesOfType(editor.getJSON(), "mention")).toBe(0);
+    expect(mentionCommand).not.toHaveBeenCalled();
+  });
+
+  it("keeps plain Enter selecting a visible mention candidate", async () => {
+    await setLongMentionQuery(`${"x".repeat(48)} @a`);
+
+    expect(mentionActiveChange).toHaveBeenCalledWith(true);
+
+    const event = pressEnter(false);
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(mentionCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        props: { id: "uid-1", label: "Alice" },
+      })
+    );
+    expect(countNodesOfType(editor.getJSON(), "hardBreak")).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

`Shift+Enter` could stop inserting a line break while a mention or emoji suggestion renderer was active. Both candidate lists treated every `Enter` as candidate selection, so modified Enter was consumed before Tiptap's `HardBreak` keymap. The failure was especially silent after a mention query hid the popup because it had no matches: candidate selection did nothing, but the key event was still reported as handled.

## Related Issue

Fixes #1344

## Changes

- Consume `Enter` in mention and emoji suggestion lists only when `Shift` is not pressed, allowing `Shift+Enter` to fall through to Tiptap `HardBreak`.
- Preserve plain Enter candidate-selection behavior.
- Add list-level regression coverage for visible and hidden/no-result suggestion states.
- Add a real Tiptap integration test covering 51-character composer content with both visible and newly hidden mention candidates.

## Architecture / Module Boundary

- Affected module(s): `packages/dmworkbase/src/Components/MessageInput`
- New or changed user-visible entry point: no
- Shared layer touched: `Components`
- If shared code changed, impact scope: chat composer keyboard handling while mention or emoji suggestions are active
- Duplicate entry point checked: not applicable

## Testing

- [x] Unit tests added/updated
- [ ] Manually verified
- `fnm exec --using 20.19.5 -- corepack pnpm --dir packages/dmworkbase exec vitest run src/Components/MessageInput/__tests__` — 9 files, 111 tests passed
- `VITE_API_URL=https://im.deepminer.com.cn fnm exec --using 20.19.5 -- corepack pnpm --dir apps/web build` — passed
- `git diff --check` — passed

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes
- [ ] Updated documentation — not applicable; this is a keyboard-event handling fix with regression tests
- [x] Ran `pnpm i18n:check` or confirmed the change does not affect UI copy — no UI copy changed
- [x] Confirmed the change follows module ownership and does not add duplicate user-visible entry points
- [x] Described impact scope when shared components, messages, bridge, or services are changed
- [x] Followed commit message conventions (Conventional Commits)
