### PR TITLE
feat(sum-20): open all summary types for Agent reference

### DIFF
--- a/apps/web/e2e-kit/case-specs/summary/agent/S10-summary-agent-reference-side-panel.md
+++ b/apps/web/e2e-kit/case-specs/summary/agent/S10-summary-agent-reference-side-panel.md
@@ -17,7 +17,7 @@
 - fixture: `fixtures-authed`，本地 mock 模式已预置登录态、Space `e2e-space-001` 和中文 locale。
 - baseline MSW handler 已覆盖 app shell / chat bootstrap 所需接口。
 - Per-case MSW handler: `e2e-kit/msw-handlers/s10-summary-agent-reference-side-panel.ts`
-  - `GET */summary/api/v1/summaries` — 普通列表入口返回空；引用选择器（page_size=50）返回已完成 Agent 总结 `S10 已有客户总结`。
+  - `GET */summary/api/v1/summaries` — 普通列表入口返回空；引用选择器（status=3=COMPLETED）返回已完成 Agent 总结 `S10 已有客户总结`。
   - `GET */summary/api/v1/summaries/10010` — 返回引用总结详情，包含正文 `历史风险需要继续跟进`。
   - `GET */summary/api/v1/summaries/10010/personal` — 兜底返回个人结果，供 side panel 在团队正文为空时 fallback。
   - `GET */summary/api/v1/summary-templates` — 返回空模板列表和 `custom_template_limit`，供创建页 mount。
@@ -59,8 +59,8 @@
 - `packages/dmworksummary/src/pages/SummaryCreatePage.tsx:1064`: Agent 模式渲染 `AgentChatPanel`。
 - `packages/dmworksummary/src/pages/SummaryCreatePage.tsx:1087`: 已选引用且 sidePanelOpen 时渲染 `SummaryReferenceSidePanel`。
 - `packages/dmworksummary/src/pages/SummaryCreatePage.tsx:1093`: 创建页挂载 `SummaryReferencePicker`。
-- `packages/dmworksummary/src/components/SummaryReferencePicker.tsx:62`: 引用选择器调用 `listSummaries()` 带 `status=COMPLETED`，兼容模式下带 `trigger_type=AGENT`。
-- `packages/dmworksummary/src/components/SummaryReferencePicker.tsx:80`: 引用选择器只保留可引用总结（`referenceable` 或 legacy `trigger_type === AGENT`）。
+- `packages/dmworksummary/src/components/SummaryReferencePicker.tsx:84`: 引用选择器调用 `listSummaries()` 带 `status=COMPLETED`，兼容模式下带 `trigger_type=AGENT`。
+- `packages/dmworksummary/src/components/SummaryReferencePicker.tsx:107`: 引用选择器只保留可引用总结（`referenceable` 或 legacy `trigger_type === AGENT`）。
 - `packages/dmworksummary/src/components/SummaryReferenceSidePanel.tsx:75`: 右侧对照面板加载 `getSummaryDetail()`。
 - `packages/dmworksummary/src/components/SummaryReferenceSidePanel.tsx:87`: 团队正文为空时 fallback 到 `getPersonalResult()`。
 - `packages/dmworksummary/src/i18n/zh-CN.json:607-618`: 引用选择器、引用卡片和预览提示实际中文文案。

--- a/apps/web/e2e-kit/case-specs/summary/agent/S10-summary-agent-reference-side-panel.md
+++ b/apps/web/e2e-kit/case-specs/summary/agent/S10-summary-agent-reference-side-panel.md
@@ -17,7 +17,7 @@
 - fixture: `fixtures-authed`，本地 mock 模式已预置登录态、Space `e2e-space-001` 和中文 locale。
 - baseline MSW handler 已覆盖 app shell / chat bootstrap 所需接口。
 - Per-case MSW handler: `e2e-kit/msw-handlers/s10-summary-agent-reference-side-panel.ts`
-  - `GET */summary/api/v1/summaries` — 普通列表入口返回空；引用选择器带 `trigger_type=3` 时返回已完成 Agent 总结 `S10 已有客户总结`。
+  - `GET */summary/api/v1/summaries` — 普通列表入口返回空；引用选择器（page_size=50）返回已完成 Agent 总结 `S10 已有客户总结`。
   - `GET */summary/api/v1/summaries/10010` — 返回引用总结详情，包含正文 `历史风险需要继续跟进`。
   - `GET */summary/api/v1/summaries/10010/personal` — 兜底返回个人结果，供 side panel 在团队正文为空时 fallback。
   - `GET */summary/api/v1/summary-templates` — 返回空模板列表和 `custom_template_limit`，供创建页 mount。
@@ -45,7 +45,7 @@
 
 ## 反例
 
-- 如果引用选择器没有按 `trigger_type=3` 获取可引用 Agent 总结，弹窗会显示「还没有可引用的总结」，case 应因找不到 `S10 已有客户总结` 失败。
+- 如果引用选择器未返回可引用总结，弹窗会显示「还没有可引用的总结」，case 应因找不到 `S10 已有客户总结` 失败。
 - 如果 SidePanel 漏 mock 详情接口，面板会显示「加载失败」或 sanityCheck 报 401，case 应失败。
 - 移除引用后不应继续显示 `S10 已有客户总结` 引用卡片；否则后续 Agent 问答会误带旧引用上下文。
 
@@ -59,8 +59,8 @@
 - `packages/dmworksummary/src/pages/SummaryCreatePage.tsx:1064`: Agent 模式渲染 `AgentChatPanel`。
 - `packages/dmworksummary/src/pages/SummaryCreatePage.tsx:1087`: 已选引用且 sidePanelOpen 时渲染 `SummaryReferenceSidePanel`。
 - `packages/dmworksummary/src/pages/SummaryCreatePage.tsx:1093`: 创建页挂载 `SummaryReferencePicker`。
-- `packages/dmworksummary/src/components/SummaryReferencePicker.tsx:60`: 引用选择器调用 `listSummaries()` 并带 `trigger_type: 3`。
-- `packages/dmworksummary/src/components/SummaryReferencePicker.tsx:73`: 引用选择器只保留已完成总结。
+- `packages/dmworksummary/src/components/SummaryReferencePicker.tsx:62`: 引用选择器调用 `listSummaries()` 带 `status=COMPLETED`，兼容模式下带 `trigger_type=AGENT`。
+- `packages/dmworksummary/src/components/SummaryReferencePicker.tsx:80`: 引用选择器只保留可引用总结（`referenceable` 或 legacy `trigger_type === AGENT`）。
 - `packages/dmworksummary/src/components/SummaryReferenceSidePanel.tsx:75`: 右侧对照面板加载 `getSummaryDetail()`。
 - `packages/dmworksummary/src/components/SummaryReferenceSidePanel.tsx:87`: 团队正文为空时 fallback 到 `getPersonalResult()`。
 - `packages/dmworksummary/src/i18n/zh-CN.json:607-618`: 引用选择器、引用卡片和预览提示实际中文文案。

--- a/apps/web/e2e-kit/case-specs/summary/agent/S10-summary-agent-reference-side-panel.md
+++ b/apps/web/e2e-kit/case-specs/summary/agent/S10-summary-agent-reference-side-panel.md
@@ -59,8 +59,8 @@
 - `packages/dmworksummary/src/pages/SummaryCreatePage.tsx:1064`: Agent 模式渲染 `AgentChatPanel`。
 - `packages/dmworksummary/src/pages/SummaryCreatePage.tsx:1087`: 已选引用且 sidePanelOpen 时渲染 `SummaryReferenceSidePanel`。
 - `packages/dmworksummary/src/pages/SummaryCreatePage.tsx:1093`: 创建页挂载 `SummaryReferencePicker`。
-- `packages/dmworksummary/src/components/SummaryReferencePicker.tsx:84`: 引用选择器调用 `listSummaries()` 带 `status=COMPLETED`，兼容模式下带 `trigger_type=AGENT`。
-- `packages/dmworksummary/src/components/SummaryReferencePicker.tsx:107`: 引用选择器只保留可引用总结（`referenceable` 或 legacy `trigger_type === AGENT`）。
+- `packages/dmworksummary/src/components/SummaryReferencePicker.tsx`（`fetchList`）: 引用选择器调用 `listSummaries()` 带 `status=COMPLETED`，兼容模式下带 `trigger_type=AGENT`；翻页收集可引用项。
+- `packages/dmworksummary/src/components/SummaryReferencePicker.tsx`（`isReferenceable`）: 引用选择器只保留可引用总结（`referenceable` 或 legacy `trigger_type === AGENT`）。
 - `packages/dmworksummary/src/components/SummaryReferenceSidePanel.tsx:75`: 右侧对照面板加载 `getSummaryDetail()`。
 - `packages/dmworksummary/src/components/SummaryReferenceSidePanel.tsx:87`: 团队正文为空时 fallback 到 `getPersonalResult()`。
 - `packages/dmworksummary/src/i18n/zh-CN.json:607-618`: 引用选择器、引用卡片和预览提示实际中文文案。

--- a/apps/web/e2e-kit/case-specs/summary/agent/S11-summary-agent-continue-refine.md
+++ b/apps/web/e2e-kit/case-specs/summary/agent/S11-summary-agent-continue-refine.md
@@ -17,7 +17,7 @@
 - fixture: `fixtures-authed`，本地 mock 模式已预置登录态、Space `e2e-space-001` 和中文 locale。
 - baseline MSW handler 已覆盖 app shell / chat bootstrap 所需接口。
 - Per-case MSW handler: `e2e-kit/msw-handlers/s11-summary-agent-continue-refine.ts`
-  - `GET */summary/api/v1/summaries` — 返回一条已完成 Agent 总结 `S11 Agent 原总结`。
+  - `GET */summary/api/v1/summaries` — 引用选择器（page_size=50）返回一条已完成 Agent 总结 `S11 Agent 原总结`。
   - `GET */summary/api/v1/summaries/11011` — 返回对应详情，`trigger_type=3` 且包含正文 `S11 原总结风险清单`。
   - `POST */summary/api/v1/summaries/11011/read`、`GET */summary/api/v1/summaries/11011/versions` — 详情页后续请求兜底。
   - `GET */summary/api/v1/summary-templates` — 返回空模板列表和 `custom_template_limit`，供继续优化打开创建页时 mount。

--- a/apps/web/e2e-kit/case-specs/summary/agent/S11-summary-agent-continue-refine.md
+++ b/apps/web/e2e-kit/case-specs/summary/agent/S11-summary-agent-continue-refine.md
@@ -17,7 +17,7 @@
 - fixture: `fixtures-authed`，本地 mock 模式已预置登录态、Space `e2e-space-001` 和中文 locale。
 - baseline MSW handler 已覆盖 app shell / chat bootstrap 所需接口。
 - Per-case MSW handler: `e2e-kit/msw-handlers/s11-summary-agent-continue-refine.ts`
-  - `GET */summary/api/v1/summaries` — 引用选择器（page_size=50）返回一条已完成 Agent 总结 `S11 Agent 原总结`。
+  - `GET */summary/api/v1/summaries` — 引用选择器（status=3=COMPLETED）返回一条已完成 Agent 总结 `S11 Agent 原总结`。
   - `GET */summary/api/v1/summaries/11011` — 返回对应详情，`trigger_type=3` 且包含正文 `S11 原总结风险清单`。
   - `POST */summary/api/v1/summaries/11011/read`、`GET */summary/api/v1/summaries/11011/versions` — 详情页后续请求兜底。
   - `GET */summary/api/v1/summary-templates` — 返回空模板列表和 `custom_template_limit`，供继续优化打开创建页时 mount。

--- a/apps/web/e2e-kit/case-specs/summary/agent/S11-summary-agent-continue-refine.md
+++ b/apps/web/e2e-kit/case-specs/summary/agent/S11-summary-agent-continue-refine.md
@@ -42,7 +42,7 @@
 
 ## 反例
 
-- 如果详情页 `trigger_type` 不是 Agent，页面不应显示「继续优化」；本 case 会因找不到按钮失败。
+- 如果详情页 `referenceable` 不为 `true`（且非兼容回退的 Agent 类型），页面不应显示「继续优化」；本 case 会因找不到按钮失败。
 - 如果继续优化没有把当前 task 作为 `derivedFromTask` 传给创建页，Agent 工作台不会显示「已引用」卡片，case 应失败。
 - 如果引用侧栏漏 mock 详情接口，右侧面板会显示「加载失败」或 sanityCheck 报 401。
 

--- a/apps/web/e2e-kit/case-specs/summary/agent/S13-summary-agent-new-session.md
+++ b/apps/web/e2e-kit/case-specs/summary/agent/S13-summary-agent-new-session.md
@@ -16,7 +16,7 @@
 
 - fixture: `fixtures-authed`，本地 mock 模式已预置登录态、Space `e2e-space-001` 和中文 locale。
 - Per-case MSW handler: `e2e-kit/msw-handlers/s13-summary-agent-new-session.ts`
-  - `GET */summary/api/v1/summaries` — 普通列表入口返回空；引用选择器（page_size=50）返回 `S13 可引用总结`。
+  - `GET */summary/api/v1/summaries` — 普通列表入口返回空；引用选择器（status=3=COMPLETED）返回 `S13 可引用总结`。
   - `GET */summary/api/v1/summaries/13013` — 返回引用 side panel 详情兜底。
   - `GET */summary/api/v1/summary-templates` — 返回空模板列表。
   - `GET */summary/api/v1/agent/chat/history` — 返回空历史。

--- a/apps/web/e2e-kit/case-specs/summary/agent/S13-summary-agent-new-session.md
+++ b/apps/web/e2e-kit/case-specs/summary/agent/S13-summary-agent-new-session.md
@@ -16,7 +16,7 @@
 
 - fixture: `fixtures-authed`，本地 mock 模式已预置登录态、Space `e2e-space-001` 和中文 locale。
 - Per-case MSW handler: `e2e-kit/msw-handlers/s13-summary-agent-new-session.ts`
-  - `GET */summary/api/v1/summaries` — 普通列表入口返回空；引用选择器带 `trigger_type=3` 时返回 `S13 可引用总结`。
+  - `GET */summary/api/v1/summaries` — 普通列表入口返回空；引用选择器（page_size=50）返回 `S13 可引用总结`。
   - `GET */summary/api/v1/summaries/13013` — 返回引用 side panel 详情兜底。
   - `GET */summary/api/v1/summary-templates` — 返回空模板列表。
   - `GET */summary/api/v1/agent/chat/history` — 返回空历史。

--- a/apps/web/e2e-kit/msw-handlers/s10-summary-agent-reference-side-panel.ts
+++ b/apps/web/e2e-kit/msw-handlers/s10-summary-agent-reference-side-panel.ts
@@ -80,12 +80,11 @@ export async function registerS10SummaryAgentReferenceSidePanel(page: Page): Pro
     worker.use(
       http.get("*/summary/api/v1/summaries", ({ request }: any) => {
         const url = new URL(request.url);
-        // 列表页传 status 参数；引用选择器不传 status（picker 传 status=COMPLETED 但以数值形式）。
-        // 用 page_size 或 status 的有无来区分：列表页 status 通常为 PENDING 等非 COMPLETED 值，
-        // picker 传 status=3（COMPLETED）且无 trigger_type。
-        // 更可靠的区分：列表页带 page_size=20，picker 带 page_size=50。
-        const pageSize = url.searchParams.get("page_size");
-        const isReferencePicker = pageSize === "50";
+        // Discriminate picker vs list-page requests:
+        // - Picker always sends status=3 (COMPLETED); list page sends other statuses or none.
+        // - We check status=3 as the picker signal (more robust than page_size).
+        const status = url.searchParams.get("status");
+        const isReferencePicker = status === "3";
         return env({
           items: isReferencePicker ? [listItem] : [],
           total: isReferencePicker ? 1 : 0,

--- a/apps/web/e2e-kit/msw-handlers/s10-summary-agent-reference-side-panel.ts
+++ b/apps/web/e2e-kit/msw-handlers/s10-summary-agent-reference-side-panel.ts
@@ -43,6 +43,7 @@ export async function registerS10SummaryAgentReferenceSidePanel(page: Page): Pro
       current_result_id: 100101,
       current_personal_version_id: null,
       activity_at: "2026-08-06T10:12:00Z",
+      referenceable: true,
     };
     const detail = {
       ...listItem,
@@ -77,12 +78,10 @@ export async function registerS10SummaryAgentReferenceSidePanel(page: Page): Pro
     };
 
     worker.use(
-      http.get("*/summary/api/v1/summaries", ({ request }: any) => {
-        const url = new URL(request.url);
-        const isReferencePicker = url.searchParams.get("trigger_type") === "3";
+      http.get("*/summary/api/v1/summaries", () => {
         return env({
-          items: isReferencePicker ? [listItem] : [],
-          total: isReferencePicker ? 1 : 0,
+          items: [listItem],
+          total: 1,
           attention_count: 0,
           unread_count: 0,
           pending_invitation_count: 0,

--- a/apps/web/e2e-kit/msw-handlers/s10-summary-agent-reference-side-panel.ts
+++ b/apps/web/e2e-kit/msw-handlers/s10-summary-agent-reference-side-panel.ts
@@ -78,10 +78,17 @@ export async function registerS10SummaryAgentReferenceSidePanel(page: Page): Pro
     };
 
     worker.use(
-      http.get("*/summary/api/v1/summaries", () => {
+      http.get("*/summary/api/v1/summaries", ({ request }: any) => {
+        const url = new URL(request.url);
+        // 列表页传 status 参数；引用选择器不传 status（picker 传 status=COMPLETED 但以数值形式）。
+        // 用 page_size 或 status 的有无来区分：列表页 status 通常为 PENDING 等非 COMPLETED 值，
+        // picker 传 status=3（COMPLETED）且无 trigger_type。
+        // 更可靠的区分：列表页带 page_size=20，picker 带 page_size=50。
+        const pageSize = url.searchParams.get("page_size");
+        const isReferencePicker = pageSize === "50";
         return env({
-          items: [listItem],
-          total: 1,
+          items: isReferencePicker ? [listItem] : [],
+          total: isReferencePicker ? 1 : 0,
           attention_count: 0,
           unread_count: 0,
           pending_invitation_count: 0,

--- a/apps/web/e2e-kit/msw-handlers/s11-summary-agent-continue-refine.ts
+++ b/apps/web/e2e-kit/msw-handlers/s11-summary-agent-continue-refine.ts
@@ -82,19 +82,9 @@ export async function registerS11SummaryAgentContinueRefine(page: Page): Promise
     };
 
     worker.use(
-      http.get("*/summary/api/v1/summaries", ({ request }: any) => {
-        const url = new URL(request.url);
-        // Discriminate picker vs list-page: picker sends status=3 (COMPLETED).
-        const status = url.searchParams.get("status");
-        const isReferencePicker = status === "3";
-        return env({
-          items: isReferencePicker ? [listItem] : [],
-          total: isReferencePicker ? 1 : 0,
-          attention_count: 0,
-          unread_count: isReferencePicker ? 1 : 0,
-          pending_invitation_count: 0,
-        });
-      }),
+      http.get("*/summary/api/v1/summaries", () =>
+        env({ items: [listItem], total: 1, attention_count: 0, unread_count: 1, pending_invitation_count: 0 })
+      ),
       http.get("*/summary/api/v1/summary-templates", () =>
         env({ templates: [], custom_template_limit: 30 })
       ),

--- a/apps/web/e2e-kit/msw-handlers/s11-summary-agent-continue-refine.ts
+++ b/apps/web/e2e-kit/msw-handlers/s11-summary-agent-continue-refine.ts
@@ -82,9 +82,18 @@ export async function registerS11SummaryAgentContinueRefine(page: Page): Promise
     };
 
     worker.use(
-      http.get("*/summary/api/v1/summaries", () =>
-        env({ items: [listItem], total: 1, attention_count: 0, unread_count: 1, pending_invitation_count: 0 })
-      ),
+      http.get("*/summary/api/v1/summaries", ({ request }: any) => {
+        const url = new URL(request.url);
+        const pageSize = url.searchParams.get("page_size");
+        const isReferencePicker = pageSize === "50";
+        return env({
+          items: isReferencePicker ? [listItem] : [],
+          total: isReferencePicker ? 1 : 0,
+          attention_count: 0,
+          unread_count: isReferencePicker ? 1 : 0,
+          pending_invitation_count: 0,
+        });
+      }),
       http.get("*/summary/api/v1/summary-templates", () =>
         env({ templates: [], custom_template_limit: 30 })
       ),

--- a/apps/web/e2e-kit/msw-handlers/s11-summary-agent-continue-refine.ts
+++ b/apps/web/e2e-kit/msw-handlers/s11-summary-agent-continue-refine.ts
@@ -84,8 +84,9 @@ export async function registerS11SummaryAgentContinueRefine(page: Page): Promise
     worker.use(
       http.get("*/summary/api/v1/summaries", ({ request }: any) => {
         const url = new URL(request.url);
-        const pageSize = url.searchParams.get("page_size");
-        const isReferencePicker = pageSize === "50";
+        // Discriminate picker vs list-page: picker sends status=3 (COMPLETED).
+        const status = url.searchParams.get("status");
+        const isReferencePicker = status === "3";
         return env({
           items: isReferencePicker ? [listItem] : [],
           total: isReferencePicker ? 1 : 0,

--- a/apps/web/e2e-kit/msw-handlers/s11-summary-agent-continue-refine.ts
+++ b/apps/web/e2e-kit/msw-handlers/s11-summary-agent-continue-refine.ts
@@ -47,6 +47,7 @@ export async function registerS11SummaryAgentContinueRefine(page: Page): Promise
       current_result_id: 11101,
       current_personal_version_id: null,
       activity_at: "2026-08-06T11:12:00Z",
+      referenceable: true,
     };
     const detail = {
       ...listItem,

--- a/apps/web/e2e-kit/msw-handlers/s13-summary-agent-new-session.ts
+++ b/apps/web/e2e-kit/msw-handlers/s13-summary-agent-new-session.ts
@@ -86,8 +86,9 @@ export async function registerS13SummaryAgentNewSession(page: Page): Promise<voi
     worker.use(
       http.get("*/summary/api/v1/summaries", ({ request }: any) => {
         const url = new URL(request.url);
-        const pageSize = url.searchParams.get("page_size");
-        const isReferencePicker = pageSize === "50";
+        // Discriminate picker vs list-page: picker sends status=3 (COMPLETED).
+        const status = url.searchParams.get("status");
+        const isReferencePicker = status === "3";
         return env({
           items: isReferencePicker ? [listItem] : [],
           total: isReferencePicker ? 1 : 0,

--- a/apps/web/e2e-kit/msw-handlers/s13-summary-agent-new-session.ts
+++ b/apps/web/e2e-kit/msw-handlers/s13-summary-agent-new-session.ts
@@ -49,6 +49,7 @@ export async function registerS13SummaryAgentNewSession(page: Page): Promise<voi
       current_result_id: 130131,
       current_personal_version_id: null,
       activity_at: "2026-08-06T13:12:00Z",
+      referenceable: true,
     };
     const detail = {
       ...listItem,
@@ -83,12 +84,10 @@ export async function registerS13SummaryAgentNewSession(page: Page): Promise<voi
     };
 
     worker.use(
-      http.get("*/summary/api/v1/summaries", ({ request }: any) => {
-        const url = new URL(request.url);
-        const isReferencePicker = url.searchParams.get("trigger_type") === "3";
+      http.get("*/summary/api/v1/summaries", () => {
         return env({
-          items: isReferencePicker ? [listItem] : [],
-          total: isReferencePicker ? 1 : 0,
+          items: [listItem],
+          total: 1,
           attention_count: 0,
           unread_count: 0,
           pending_invitation_count: 0,

--- a/apps/web/e2e-kit/msw-handlers/s13-summary-agent-new-session.ts
+++ b/apps/web/e2e-kit/msw-handlers/s13-summary-agent-new-session.ts
@@ -84,10 +84,13 @@ export async function registerS13SummaryAgentNewSession(page: Page): Promise<voi
     };
 
     worker.use(
-      http.get("*/summary/api/v1/summaries", () => {
+      http.get("*/summary/api/v1/summaries", ({ request }: any) => {
+        const url = new URL(request.url);
+        const pageSize = url.searchParams.get("page_size");
+        const isReferencePicker = pageSize === "50";
         return env({
-          items: [listItem],
-          total: 1,
+          items: isReferencePicker ? [listItem] : [],
+          total: isReferencePicker ? 1 : 0,
           attention_count: 0,
           unread_count: 0,
           pending_invitation_count: 0,

--- a/packages/dmworksummary/src/components/SummaryCard.tsx
+++ b/packages/dmworksummary/src/components/SummaryCard.tsx
@@ -6,6 +6,7 @@ import WKApp from "@octo/base/src/App";
 import type { SummaryListItem } from "../types/summary";
 import { ParticipantStatus, TaskStatus } from "../types/summary";
 import { getStatusLabel, getSummaryTypeLabel } from "../utils/summaryHelpers";
+import { TriggerType } from "../types/summary";
 import { deriveSummaryDisplayContent } from "../utils/templateResolver";
 import { summaryTestIds } from "../utils/testIds";
 
@@ -91,6 +92,7 @@ const SummaryCard: React.FC<SummaryCardProps> = ({ task, active, onClick, onDele
     const isGenerating = task.status === TaskStatus.PENDING || task.status === TaskStatus.PROCESSING;
     // Type label — shared with SummaryReferencePicker for consistency
     const typeLabel = getSummaryTypeLabel(t, task);
+    const isAgentType = task.trigger_type === TriggerType.AGENT;
     const sourceInfo = getSourceInfo(task, t);
     const relativeTime = formatRelativeTime(task.created_at, t);
     const isCreator = task.creator_id != null && task.creator_id === currentUid;

--- a/packages/dmworksummary/src/components/SummaryCard.tsx
+++ b/packages/dmworksummary/src/components/SummaryCard.tsx
@@ -4,8 +4,8 @@ import { MoreHorizontal, AlertTriangle, Bot, FileText, X } from "lucide-react";
 import { useI18n } from "@octo/base";
 import WKApp from "@octo/base/src/App";
 import type { SummaryListItem } from "../types/summary";
-import { ParticipantStatus, TaskStatus, TriggerType } from "../types/summary";
-import { getStatusLabel } from "../utils/summaryHelpers";
+import { ParticipantStatus, TaskStatus } from "../types/summary";
+import { getStatusLabel, getSummaryTypeLabel } from "../utils/summaryHelpers";
 import { deriveSummaryDisplayContent } from "../utils/templateResolver";
 import { summaryTestIds } from "../utils/testIds";
 
@@ -89,11 +89,8 @@ const SummaryCard: React.FC<SummaryCardProps> = ({ task, active, onClick, onDele
     const statusText = getStatusLabel(displayStatus);
 
     const isGenerating = task.status === TaskStatus.PENDING || task.status === TaskStatus.PROCESSING;
-    // Type icon: agent-conversation summaries vs the traditional workflow ("快速总结").
-    const isAgentType = task.trigger_type === TriggerType.AGENT;
-    const typeLabel = isAgentType
-        ? t("summary.summaryCard.agentType")
-        : t("summary.summaryCard.quickType");
+    // Type label — shared with SummaryReferencePicker for consistency
+    const typeLabel = getSummaryTypeLabel(t, task);
     const sourceInfo = getSourceInfo(task, t);
     const relativeTime = formatRelativeTime(task.created_at, t);
     const isCreator = task.creator_id != null && task.creator_id === currentUid;

--- a/packages/dmworksummary/src/components/SummaryCard.tsx
+++ b/packages/dmworksummary/src/components/SummaryCard.tsx
@@ -1,12 +1,10 @@
 import React, { useState } from "react";
 import { Dropdown, Modal, Tooltip } from "@douyinfe/semi-ui";
-import { MoreHorizontal, AlertTriangle, Bot, FileText, X } from "lucide-react";
+import { MoreHorizontal, AlertTriangle, Bot, Clock, FileText, UsersRound, X } from "lucide-react";
 import { useI18n } from "@octo/base";
 import WKApp from "@octo/base/src/App";
-import type { SummaryListItem } from "../types/summary";
-import { ParticipantStatus, TaskStatus } from "../types/summary";
-import { getStatusLabel, getSummaryTypeLabel } from "../utils/summaryHelpers";
-import { TriggerType } from "../types/summary";
+import { ParticipantStatus, TaskStatus, TriggerType, type SummaryListItem } from "../types/summary";
+import { getStatusLabel, getSummaryTypeKind, getSummaryTypeLabel } from "../utils/summaryHelpers";
 import { deriveSummaryDisplayContent } from "../utils/templateResolver";
 import { summaryTestIds } from "../utils/testIds";
 
@@ -90,9 +88,9 @@ const SummaryCard: React.FC<SummaryCardProps> = ({ task, active, onClick, onDele
     const statusText = getStatusLabel(displayStatus);
 
     const isGenerating = task.status === TaskStatus.PENDING || task.status === TaskStatus.PROCESSING;
-    // Type label — shared with SummaryReferencePicker for consistency
+    // 类型分类 — 单一 classifier 派生 label + icon + CSS class（R4 yj P2-2）。
+    const typeKind = getSummaryTypeKind(task);
     const typeLabel = getSummaryTypeLabel(t, task);
-    const isAgentType = task.trigger_type === TriggerType.AGENT;
     const sourceInfo = getSourceInfo(task, t);
     const relativeTime = formatRelativeTime(task.created_at, t);
     const isCreator = task.creator_id != null && task.creator_id === currentUid;
@@ -164,12 +162,15 @@ const SummaryCard: React.FC<SummaryCardProps> = ({ task, active, onClick, onDele
                 <div className="summary-card-title-row">
                     <Tooltip content={typeLabel} position="top">
                         <span
-                            className={`summary-card-type-icon summary-card-type-icon--${isAgentType ? "agent" : "quick"}`}
+                            className={`summary-card-type-icon summary-card-type-icon--${typeKind}`}
                             role="img"
                             aria-label={typeLabel}
                             tabIndex={0}
                         >
-                            {isAgentType ? <Bot size={14} /> : <FileText size={14} />}
+                            {typeKind === 'agent' ? <Bot size={14} />
+                                : typeKind === 'scheduled' ? <Clock size={14} />
+                                : typeKind === 'multi' ? <UsersRound size={14} />
+                                : <FileText size={14} />}
                         </span>
                     </Tooltip>
                     <div className="summary-card-title">{displayTitle}</div>

--- a/packages/dmworksummary/src/components/SummaryReferencePicker.css
+++ b/packages/dmworksummary/src/components/SummaryReferencePicker.css
@@ -36,6 +36,24 @@
     white-space: nowrap;
 }
 
+.summary-reference-picker-item-main {
+    width: 100%;
+}
+
+.summary-reference-picker-item-type {
+    display: inline-block;
+    padding: 1px 6px;
+    border-radius: 3px;
+    font-size: 11px;
+    background: var(--semi-color-fill-1);
+    color: var(--semi-color-text-1);
+}
+
+.summary-reference-picker-item-sep {
+    margin: 0 4px;
+    color: var(--semi-color-text-3);
+}
+
 .summary-reference-picker-item-meta {
     font-size: 12px;
     color: var(--semi-color-text-2);

--- a/packages/dmworksummary/src/components/SummaryReferencePicker.tsx
+++ b/packages/dmworksummary/src/components/SummaryReferencePicker.tsx
@@ -3,7 +3,7 @@ import { Modal, Input, List, Empty, Spin, Toast } from '@douyinfe/semi-ui';
 import { IconClose, IconLink } from '@douyinfe/semi-icons';
 import { listSummaries } from '../api/summaryApi';
 import type { SummaryListItem } from '../types/summary';
-import { TriggerType } from '../types/summary';
+import { TriggerType, SummaryMode } from '../types/summary';
 import { I18nContext, type I18nCtx } from '@octo/base';
 import { summaryTestIds } from '../utils/testIds';
 import './SummaryReferencePicker.css';
@@ -64,18 +64,24 @@ export default class SummaryReferencePicker extends Component<
         try {
             // 列出当前 space 所有总结（不再固定 trigger_type=3）。
             // 后端在列表项中返回 referenceable/reference_artifact_type/reference_unavailable_reason，
-            // 前端据此筛选可引用候选并展示类型标签/不可用原因。
+            // 前端据此筛选可引用候选并展示类型标签。
+            // 兼容：当后端尚未部署 referenceable 字段时，回退到 legacy
+            // trigger_type === AGENT 判定，保证现有功能不受影响。
+            //
+            // NOTE: 当前仅取首页 50 条并客户端过滤。若 space 中总结数量较多，
+            // 可引用项可能落在首页之外。后续应由后端支持 referenceable
+            // 服务端筛选或前端实现分页/懒加载来覆盖全部可引用项。
             const resp = await listSummaries({
                 page: 1,
                 page_size: 50,
                 keyword: keyword.trim() || undefined,
             });
-            // 只保留已完成且后端声明 referenceable=true 的项
+            // 只保留已完成且可引用的项（含 legacy 兼容）
             const items = (resp?.items || []).filter(
                 (t: SummaryListItem) =>
                     t.task_id != null && t.title != null &&
                     t.status === 3 &&
-                    t.referenceable === true,
+                    this.isReferenceable(t),
             );
             this.setState({ items, loading: false });
         } catch (err: any) {
@@ -99,15 +105,26 @@ export default class SummaryReferencePicker extends Component<
 
     private debounceTimer: number | null = null;
 
+    private isReferenceable = (t: SummaryListItem): boolean => {
+        // 当后端已部署 referenceable 字段时，以后端值为准。
+        // 字段缺失时（后端未部署或 mock 未提供），回退到 legacy 行为：
+        // 仅 trigger_type === AGENT 的总结可被引用，保证现有功能不受影响。
+        if (t.referenceable !== undefined) return t.referenceable === true;
+        return t.trigger_type === TriggerType.AGENT;
+    };
+
     private getTypeLabel = (item: SummaryListItem): string => {
         const { t } = this.context;
         switch (item.trigger_type) {
             case TriggerType.AGENT:
                 return t('summary.summaryCard.agentType');
             case TriggerType.SCHEDULED:
+                // 兼容 scheduled 类型：trigger_type 或 schedule_id 均可判定
                 return t('summary.summaryCard.scheduledType');
             case TriggerType.MANUAL:
-                return item.summary_mode === 2
+                // 多人总结通过 participants 数量判断，而非 summary_mode
+                // （summary_mode 是按群/按人的分组模式，不是参与人数）
+                return (item.participants?.length ?? 0) > 1
                     ? t('summary.summaryCard.multiPersonType')
                     : t('summary.summaryCard.quickType');
             default:
@@ -168,10 +185,17 @@ export default class SummaryReferencePicker extends Component<
                                             {item.title || t('summary.common.untitled')}
                                         </div>
                                         <div className="summary-reference-picker-item-meta">
-                                            <span className="summary-reference-picker-item-type">
-                                                {this.getTypeLabel(item)}
-                                            </span>
-                                            <span className="summary-reference-picker-item-sep">·</span>
+                                            {(() => {
+                                                const label = this.getTypeLabel(item);
+                                                return label ? (
+                                                    <>
+                                                        <span className="summary-reference-picker-item-type">
+                                                            {label}
+                                                        </span>
+                                                        <span className="summary-reference-picker-item-sep">·</span>
+                                                    </>
+                                                ) : null;
+                                            })()}
                                             <span>{item.task_no}</span>
                                             <span className="summary-reference-picker-item-sep">·</span>
                                             <span>{item.completed_at ? new Date(item.completed_at).toLocaleDateString() : t('summary.common.inProgress')}</span>

--- a/packages/dmworksummary/src/components/SummaryReferencePicker.tsx
+++ b/packages/dmworksummary/src/components/SummaryReferencePicker.tsx
@@ -3,9 +3,10 @@ import { Modal, Input, List, Empty, Spin, Toast } from '@douyinfe/semi-ui';
 import { IconClose, IconLink } from '@douyinfe/semi-icons';
 import { listSummaries } from '../api/summaryApi';
 import type { SummaryListItem } from '../types/summary';
-import { TriggerType, SummaryMode } from '../types/summary';
+import { TriggerType, TaskStatus } from '../types/summary';
 import { I18nContext, type I18nCtx } from '@octo/base';
 import { summaryTestIds } from '../utils/testIds';
+import { getSummaryTypeLabel, isReferenceable as isItemReferenceable } from '../utils/summaryHelpers';
 import './SummaryReferencePicker.css';
 
 /**
@@ -33,6 +34,8 @@ interface SummaryReferencePickerState {
     keyword: string;
     items: SummaryListItem[];
     error: string;
+    /** 后端未部署 referenceable 字段时为 true，请求带 trigger_type=AGENT 收窄 */
+    legacyMode: boolean;
 }
 
 export default class SummaryReferencePicker extends Component<
@@ -49,6 +52,7 @@ export default class SummaryReferencePicker extends Component<
             keyword: '',
             items: [],
             error: '',
+            legacyMode: false,
         };
     }
 
@@ -62,25 +66,40 @@ export default class SummaryReferencePicker extends Component<
     private fetchList = async (keyword: string) => {
         this.setState({ loading: true, error: '' });
         try {
-            // 列出当前 space 所有总结（不再固定 trigger_type=3）。
-            // 后端在列表项中返回 referenceable/reference_artifact_type/reference_unavailable_reason，
-            // 前端据此筛选可引用候选并展示类型标签。
-            // 兼容：当后端尚未部署 referenceable 字段时，回退到 legacy
-            // trigger_type === AGENT 判定，保证现有功能不受影响。
+            // 列出当前 space 可引用的总结。
             //
-            // NOTE: 当前仅取首页 50 条并客户端过滤。若 space 中总结数量较多，
-            // 可引用项可能落在首页之外。后续应由后端支持 referenceable
-            // 服务端筛选或前端实现分页/懒加载来覆盖全部可引用项。
+            // 兼容策略（与 isReferenceable 保持一致）：
+            // - 后端已部署 referenceable 字段时，不再传 trigger_type，由后端返回所有类型中
+            //   referenceable=true 的项；前端再按 status + referenceable 客户端复核。
+            // - 后端未部署 referenceable 时（字段缺失），仍传 trigger_type=AGENT 保持
+            //   与改动前等价的服务端收窄，避免在 >50 条总结的 space 中因全量拉取而
+            //   把原本可见的 Agent 总结挤出首页。
+            //
+            // 无论哪种模式，都传 status=COMPLETED 让服务端过滤未完成项，避免浪费配额。
+            //
+            // NOTE: 当前仅取首页 50 条。若 space 中总结数量较多且可引用项落在首页之外，
+            // 可引用项可能不显示。后续应由后端支持 referenceable 服务端筛选或前端实现
+            // 分页/懒加载来覆盖全部可引用项。
+            const useLegacyNarrowing = this.state.legacyMode;
             const resp = await listSummaries({
                 page: 1,
                 page_size: 50,
+                status: TaskStatus.COMPLETED,
+                trigger_type: useLegacyNarrowing ? TriggerType.AGENT : undefined,
                 keyword: keyword.trim() || undefined,
             });
+            // 检测后端是否已部署 referenceable 字段：如果返回的 items 中没有任何项
+            // 带 referenceable 字段，则进入 legacy 模式（后续请求继续带 trigger_type）。
+            const sampled = resp?.items || [];
+            const hasReferenceable = sampled.some(t => t.referenceable !== undefined);
+            if (!hasReferenceable && !this.state.legacyMode) {
+                this.setState({ legacyMode: true });
+            }
             // 只保留已完成且可引用的项（含 legacy 兼容）
-            const items = (resp?.items || []).filter(
+            const items = sampled.filter(
                 (t: SummaryListItem) =>
                     t.task_id != null && t.title != null &&
-                    t.status === 3 &&
+                    t.status === TaskStatus.COMPLETED &&
                     this.isReferenceable(t),
             );
             this.setState({ items, loading: false });
@@ -106,30 +125,11 @@ export default class SummaryReferencePicker extends Component<
     private debounceTimer: number | null = null;
 
     private isReferenceable = (t: SummaryListItem): boolean => {
-        // 当后端已部署 referenceable 字段时，以后端值为准。
-        // 字段缺失时（后端未部署或 mock 未提供），回退到 legacy 行为：
-        // 仅 trigger_type === AGENT 的总结可被引用，保证现有功能不受影响。
-        if (t.referenceable !== undefined) return t.referenceable === true;
-        return t.trigger_type === TriggerType.AGENT;
+        return isItemReferenceable(t);
     };
 
     private getTypeLabel = (item: SummaryListItem): string => {
-        const { t } = this.context;
-        switch (item.trigger_type) {
-            case TriggerType.AGENT:
-                return t('summary.summaryCard.agentType');
-            case TriggerType.SCHEDULED:
-                // 兼容 scheduled 类型：trigger_type 或 schedule_id 均可判定
-                return t('summary.summaryCard.scheduledType');
-            case TriggerType.MANUAL:
-                // 多人总结通过 participants 数量判断，而非 summary_mode
-                // （summary_mode 是按群/按人的分组模式，不是参与人数）
-                return (item.participants?.length ?? 0) > 1
-                    ? t('summary.summaryCard.multiPersonType')
-                    : t('summary.summaryCard.quickType');
-            default:
-                return '';
-        }
+        return getSummaryTypeLabel(this.context.t, item);
     };
 
     private handleSelect = (task: SummaryListItem) => {

--- a/packages/dmworksummary/src/components/SummaryReferencePicker.tsx
+++ b/packages/dmworksummary/src/components/SummaryReferencePicker.tsx
@@ -91,9 +91,20 @@ export default class SummaryReferencePicker extends Component<
             // 检测后端是否已部署 referenceable 字段：如果返回的 items 中没有任何项
             // 带 referenceable 字段，则进入 legacy 模式（后续请求继续带 trigger_type）。
             const sampled = resp?.items || [];
-            const hasReferenceable = sampled.some(t => t.referenceable !== undefined);
-            if (!hasReferenceable && !this.state.legacyMode) {
-                this.setState({ legacyMode: true });
+            // P1-2: Only infer legacy mode from non-empty responses: an empty list
+            // tells us nothing about whether the backend supports referenceable.
+            if (sampled.length > 0) {
+                const hasReferenceable = sampled.some(t => t.referenceable !== undefined);
+                if (!hasReferenceable && !this.state.legacyMode) {
+                    // P1-3: Re-fetch with legacy narrowing enabled so the user sees
+                    // Agent-type summaries immediately instead of an empty list.
+                    this.setState({ legacyMode: true }, () => this.fetchList(keyword));
+                    return;
+                }
+                // 后端已部署 referenceable 且之前在 legacy 模式，退出 legacy 模式。
+                if (hasReferenceable && this.state.legacyMode) {
+                    this.setState({ legacyMode: false });
+                }
             }
             // 只保留已完成且可引用的项（含 legacy 兼容）
             const items = sampled.filter(

--- a/packages/dmworksummary/src/components/SummaryReferencePicker.tsx
+++ b/packages/dmworksummary/src/components/SummaryReferencePicker.tsx
@@ -3,6 +3,7 @@ import { Modal, Input, List, Empty, Spin, Toast } from '@douyinfe/semi-ui';
 import { IconClose, IconLink } from '@douyinfe/semi-icons';
 import { listSummaries } from '../api/summaryApi';
 import type { SummaryListItem } from '../types/summary';
+import { TriggerType } from '../types/summary';
 import { I18nContext, type I18nCtx } from '@octo/base';
 import { summaryTestIds } from '../utils/testIds';
 import './SummaryReferencePicker.css';
@@ -61,21 +62,20 @@ export default class SummaryReferencePicker extends Component<
     private fetchList = async (keyword: string) => {
         this.setState({ loading: true, error: '' });
         try {
-            // listSummaries 返回按更新时间倒序的当前 space 总结列表
+            // 列出当前 space 所有总结（不再固定 trigger_type=3）。
+            // 后端在列表项中返回 referenceable/reference_artifact_type/reference_unavailable_reason，
+            // 前端据此筛选可引用候选并展示类型标签/不可用原因。
             const resp = await listSummaries({
                 page: 1,
                 page_size: 50,
                 keyword: keyword.trim() || undefined,
-                // 只列 agent 生成的总结:传统总结 refine 效果差(无 snapshot、无 tool_summary)
-                trigger_type: 3, // TriggerType.AGENT
             });
-            // 只保留有 origin_channel_id 的项(agent 保存流程需要 origin 才能落库)
-            // 老 agent 总结如 task_id=32 那种 origin 为空的直接过滤,避免用户选了却挂
+            // 只保留已完成且后端声明 referenceable=true 的项
             const items = (resp?.items || []).filter(
                 (t: SummaryListItem) =>
                     t.task_id != null && t.title != null &&
-                    // 状态必须是 COMPLETED(未完成的没内容可引用)
-                    t.status === 3,
+                    t.status === 3 &&
+                    t.referenceable === true,
             );
             this.setState({ items, loading: false });
         } catch (err: any) {
@@ -98,6 +98,22 @@ export default class SummaryReferencePicker extends Component<
     };
 
     private debounceTimer: number | null = null;
+
+    private getTypeLabel = (item: SummaryListItem): string => {
+        const { t } = this.context;
+        switch (item.trigger_type) {
+            case TriggerType.AGENT:
+                return t('summary.summaryCard.agentType');
+            case TriggerType.SCHEDULED:
+                return t('summary.summaryCard.scheduledType');
+            case TriggerType.MANUAL:
+                return item.summary_mode === 2
+                    ? t('summary.summaryCard.multiPersonType')
+                    : t('summary.summaryCard.quickType');
+            default:
+                return '';
+        }
+    };
 
     private handleSelect = (task: SummaryListItem) => {
         this.props.onSelect(task);
@@ -147,11 +163,19 @@ export default class SummaryReferencePicker extends Component<
                                     }`}
                                     onClick={() => this.handleSelect(item)}
                                 >
-                                    <div className="summary-reference-picker-item-title">
-                                        {item.title || t('summary.common.untitled')}
-                                    </div>
-                                    <div className="summary-reference-picker-item-meta">
-                                        {item.task_no} · {item.completed_at ? new Date(item.completed_at).toLocaleDateString() : t('summary.common.inProgress')}
+                                    <div className="summary-reference-picker-item-main">
+                                        <div className="summary-reference-picker-item-title">
+                                            {item.title || t('summary.common.untitled')}
+                                        </div>
+                                        <div className="summary-reference-picker-item-meta">
+                                            <span className="summary-reference-picker-item-type">
+                                                {this.getTypeLabel(item)}
+                                            </span>
+                                            <span className="summary-reference-picker-item-sep">·</span>
+                                            <span>{item.task_no}</span>
+                                            <span className="summary-reference-picker-item-sep">·</span>
+                                            <span>{item.completed_at ? new Date(item.completed_at).toLocaleDateString() : t('summary.common.inProgress')}</span>
+                                        </div>
                                     </div>
                                 </List.Item>
                             )}

--- a/packages/dmworksummary/src/components/SummaryReferencePicker.tsx
+++ b/packages/dmworksummary/src/components/SummaryReferencePicker.tsx
@@ -38,6 +38,18 @@ interface SummaryReferencePickerState {
     legacyMode: boolean;
 }
 
+/**
+ * Picker 翻页常量（R4 yj P1-1 / ms P1 / jx 🟡：50 行窗口回归）。
+ * 后端无 referenceable 服务端过滤（SUM-19 只加逐行字段），非 legacy 模式
+ * 必须翻页收集可引用项，否则繁忙 space 里可引用总结被挤出首页。
+ * - PICKER_PAGE_SIZE=100：后端 page_size 上限，减少请求数
+ * - PICKER_MAX_PAGES=5：硬上限，最多扫 500 条，防止异常数据下无限翻页
+ * - PICKER_TARGET_COUNT=50：收集满即停，与原首页配额对齐
+ */
+const PICKER_PAGE_SIZE = 100;
+const PICKER_MAX_PAGES = 5;
+const PICKER_TARGET_COUNT = 50;
+
 export default class SummaryReferencePicker extends Component<
     SummaryReferencePickerProps,
     SummaryReferencePickerState
@@ -63,58 +75,92 @@ export default class SummaryReferencePicker extends Component<
         }
     }
 
+    /**
+     * 单调请求序号（R4 yj P2-6 / ms P2：乱序响应守卫）。
+     * 打开弹窗、keyword debounce、legacy 翻转 re-fetch 三路都可能并发发起
+     * fetchList；每次进入递增 seq，异步续点发现 seq 过期即丢弃，过期响应
+     * 不会覆盖新结果。与 SummaryListPage 的 loadDataSeq 同一模式。
+     */
+    private fetchSeq = 0;
+
     private fetchList = async (keyword: string) => {
+        const seq = ++this.fetchSeq;
         this.setState({ loading: true, error: '' });
         try {
             // 列出当前 space 可引用的总结。
             //
             // 兼容策略（与 isReferenceable 保持一致）：
-            // - 后端已部署 referenceable 字段时，不再传 trigger_type，由后端返回所有类型中
-            //   referenceable=true 的项；前端再按 status + referenceable 客户端复核。
+            // - 后端已部署 referenceable 字段时，不再传 trigger_type，由后端返回所有类型，
+            //   前端按 status + referenceable 客户端复核。
             // - 后端未部署 referenceable 时（字段缺失），仍传 trigger_type=AGENT 保持
-            //   与改动前等价的服务端收窄，避免在 >50 条总结的 space 中因全量拉取而
-            //   把原本可见的 Agent 总结挤出首页。
+            //   与改动前等价的服务端收窄。
             //
             // 无论哪种模式，都传 status=COMPLETED 让服务端过滤未完成项，避免浪费配额。
             //
-            // NOTE: 当前仅取首页 50 条。若 space 中总结数量较多且可引用项落在首页之外，
-            // 可引用项可能不显示。后续应由后端支持 referenceable 服务端筛选或前端实现
-            // 分页/懒加载来覆盖全部可引用项。
+            // 翻页收集（R4 yj P1-1 / ms P1 / jx 🟡）：后端 ListSummaries 没有
+            // referenceable 服务端过滤，非 legacy 模式下不可引用项会占满首页，
+            // 把可引用项挤出 50 行窗口——繁忙 space 里原本可引用的总结从选择器
+            // 消失，严格差于改动前。因此翻页拉取直到收集满 PICKER_TARGET_COUNT
+            // 个可引用项、或遇到短页（最后一页）、或达到 PICKER_MAX_PAGES 硬上限。
+            // legacy 模式下服务端已按 AGENT 收窄，通常第一页即停，行为与改动前等价。
             const useLegacyNarrowing = this.state.legacyMode;
-            const resp = await listSummaries({
-                page: 1,
-                page_size: 50,
-                status: TaskStatus.COMPLETED,
-                trigger_type: useLegacyNarrowing ? TriggerType.AGENT : undefined,
-                keyword: keyword.trim() || undefined,
-            });
-            // 检测后端是否已部署 referenceable 字段：如果返回的 items 中没有任何项
-            // 带 referenceable 字段，则进入 legacy 模式（后续请求继续带 trigger_type）。
-            const sampled = resp?.items || [];
-            // P1-2: Only infer legacy mode from non-empty responses: an empty list
-            // tells us nothing about whether the backend supports referenceable.
-            if (sampled.length > 0) {
-                const hasReferenceable = sampled.some(t => t.referenceable !== undefined);
-                if (!hasReferenceable && !this.state.legacyMode) {
-                    // P1-3: Re-fetch with legacy narrowing enabled so the user sees
-                    // Agent-type summaries immediately instead of an empty list.
-                    this.setState({ legacyMode: true }, () => this.fetchList(keyword));
-                    return;
+            const collected: SummaryListItem[] = [];
+            const seenIds = new Set<number>();
+
+            for (let page = 1; page <= PICKER_MAX_PAGES; page++) {
+                if (seq !== this.fetchSeq) return; // 被更新的请求取代
+                const resp = await listSummaries({
+                    page,
+                    page_size: PICKER_PAGE_SIZE,
+                    status: TaskStatus.COMPLETED,
+                    trigger_type: useLegacyNarrowing ? TriggerType.AGENT : undefined,
+                    keyword: keyword.trim() || undefined,
+                });
+                if (seq !== this.fetchSeq) return; // 过期响应，丢弃
+                const sampled = resp?.items || [];
+
+                // 检测后端是否已部署 referenceable 字段：如果首页非空响应中没有任何项
+                // 带 referenceable 字段，则进入 legacy 模式（后续请求继续带 trigger_type）。
+                // P1-2: 只从非空响应推断 legacy —— 空列表无法说明后端是否支持该字段。
+                if (page === 1 && sampled.length > 0) {
+                    const hasReferenceable = sampled.some(t => t.referenceable !== undefined);
+                    if (!hasReferenceable && !this.state.legacyMode) {
+                        // P1-3: 翻转 legacy 并 re-fetch，让用户立刻看到 Agent 总结
+                        // 而不是空列表。re-fetch 会拿到新 seq，本页循环自动作废。
+                        this.setState({ legacyMode: true }, () => this.fetchList(keyword));
+                        return;
+                    }
+                    if (hasReferenceable && this.state.legacyMode) {
+                        // 后端已部署 referenceable 且之前在 legacy 模式：退出 legacy 并
+                        // re-fetch（R4 yj P2-7：与 true 分支对称，不再静默保留收窄窗口的旧数据）。
+                        this.setState({ legacyMode: false }, () => this.fetchList(keyword));
+                        return;
+                    }
                 }
-                // 后端已部署 referenceable 且之前在 legacy 模式，退出 legacy 模式。
-                if (hasReferenceable && this.state.legacyMode) {
-                    this.setState({ legacyMode: false });
+
+                // 收集本页中已完成且可引用的项（含 legacy 兼容），按 task_id 去重
+                // （后端分页窗口理论上不重叠，防御性去重防异常数据重复渲染）。
+                for (const t of sampled) {
+                    if (
+                        t.task_id != null && !seenIds.has(t.task_id) &&
+                        t.title != null &&
+                        t.status === TaskStatus.COMPLETED &&
+                        this.isReferenceable(t)
+                    ) {
+                        seenIds.add(t.task_id);
+                        collected.push(t);
+                    }
                 }
+
+                // 停止条件：收集满目标数量，或本页不满 page_size（最后一页）。
+                if (collected.length >= PICKER_TARGET_COUNT) break;
+                if (sampled.length < PICKER_PAGE_SIZE) break;
             }
-            // 只保留已完成且可引用的项（含 legacy 兼容）
-            const items = sampled.filter(
-                (t: SummaryListItem) =>
-                    t.task_id != null && t.title != null &&
-                    t.status === TaskStatus.COMPLETED &&
-                    this.isReferenceable(t),
-            );
-            this.setState({ items, loading: false });
+
+            if (seq !== this.fetchSeq) return;
+            this.setState({ items: collected, loading: false });
         } catch (err: any) {
+            if (seq !== this.fetchSeq) return; // 过期请求的错误不覆盖新状态
             console.error('[SummaryReferencePicker] fetchList failed', err);
             this.setState({
                 loading: false,
@@ -197,6 +243,9 @@ export default class SummaryReferencePicker extends Component<
                                         </div>
                                         <div className="summary-reference-picker-item-meta">
                                             {(() => {
+                                                // R4 yj P2-4: getSummaryTypeKind's default branch means
+                                                // label is never empty today; the guard is kept as
+                                                // defensive dead code in case a future kind yields no label.
                                                 const label = this.getTypeLabel(item);
                                                 return label ? (
                                                     <>

--- a/packages/dmworksummary/src/components/__tests__/SummaryReferencePicker.test.tsx
+++ b/packages/dmworksummary/src/components/__tests__/SummaryReferencePicker.test.tsx
@@ -1,0 +1,177 @@
+import React from 'react';
+import '@testing-library/jest-dom/vitest';
+import { render, screen, waitFor, cleanup, act } from '@testing-library/react';
+import { afterEach, describe, it, expect, vi } from 'vitest';
+import type { SummaryListItem } from '../../types/summary';
+import { TriggerType, TaskStatus, SummaryMode } from '../../types/summary';
+
+// Use vi.hoisted so the mock variable is available when vi.mock's factory runs
+const { mockListSummaries } = vi.hoisted(() => ({
+    mockListSummaries: vi.fn(),
+}));
+
+// Mock @octo/base — provide I18nContext with a real t function
+vi.mock('@octo/base', async () => {
+    const actual = await vi.importActual<typeof import('../../__mocks__/dmworkBase')>('../../__mocks__/dmworkBase');
+    return { ...actual };
+});
+
+// Mock semi-ui with minimal stubs
+vi.mock('@douyinfe/semi-ui', () => ({
+    Modal: ({ children, visible }: any) => visible ? <div data-testid="modal">{children}</div> : null,
+    Input: ({ value, onChange, prefix, ...rest }: any) => (
+        <input data-testid="summary-agent-ref-search-input" value={value || ''} onChange={(e) => onChange?.(e.target.value)} {...rest} />
+    ),
+    List: Object.assign(
+        ({ dataSource, renderItem }: any) => (
+            <div data-testid="list">
+                {(dataSource || []).map((item: any, idx: number) => (
+                    <div key={idx} data-testid="list-item">
+                        {renderItem(item)}
+                    </div>
+                ))}
+            </div>
+        ),
+        { Item: ({ children, onClick, className }: any) => (
+            <div data-testid="list-item-inner" className={className} onClick={onClick}>{children}</div>
+        ) },
+    ),
+    Empty: ({ description }: any) => <div data-testid="empty">{description}</div>,
+    Spin: () => <div data-testid="spin">Loading…</div>,
+    Toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+vi.mock('@douyinfe/semi-icons', () => ({
+    IconClose: () => <span>×</span>,
+    IconLink: () => <span>🔗</span>,
+}));
+
+// Mock summaryApi — the hoisted mockListSummaries is available here
+vi.mock('../../api/summaryApi', () => ({
+    listSummaries: (...args: any[]) => mockListSummaries(...args),
+}));
+
+// Import the component AFTER all mocks are set up
+import SummaryReferencePicker from '../SummaryReferencePicker';
+
+function makeItem(overrides: Partial<SummaryListItem> = {}): SummaryListItem {
+    return {
+        task_id: 1,
+        task_no: 'TASK-001',
+        title: '测试总结',
+        summary_mode: SummaryMode.BY_GROUP,
+        status: TaskStatus.COMPLETED,
+        trigger_type: TriggerType.AGENT,
+        time_range_start: '2026-08-05T00:00:00Z',
+        time_range_end: '2026-08-06T00:00:00Z',
+        sources: [],
+        participants: [{ user_id: 'u1', user_name: 'User1', status: 1 }],
+        total_msg_count: 10,
+        creator_name: 'Tester',
+        origin_channel_id: 'ch-1',
+        origin_channel_type: 1,
+        created_at: '2026-08-05T10:00:00Z',
+        completed_at: '2026-08-06T10:00:00Z',
+        is_unread: false,
+        has_pending_invitation: false,
+        has_pending_submission: false,
+        needs_attention: false,
+        activity_at: '2026-08-06T10:00:00Z',
+        ...overrides,
+    } as SummaryListItem;
+}
+
+/**
+ * Helper: render the picker with visible transitioning from false→true.
+ * The component fetches data in componentDidUpdate when visible flips to true.
+ */
+function renderPicker(props?: { item?: SummaryListItem; items?: SummaryListItem[] }) {
+    const items = props?.items ?? (props?.item ? [props.item] : []);
+    mockListSummaries.mockResolvedValue({ items, total: items.length });
+    const utils = render(<SummaryReferencePicker visible={false} onCancel={() => {}} onSelect={() => {}} />);
+    // Re-render with visible=true to trigger componentDidUpdate
+    utils.rerender(<SummaryReferencePicker visible={true} onCancel={() => {}} onSelect={() => {}} />);
+    return utils;
+}
+
+describe('SummaryReferencePicker', () => {
+    afterEach(() => {
+        cleanup();
+        vi.clearAllMocks();
+    });
+
+    describe('isReferenceable filter (compat bridge)', () => {
+        it('shows item when referenceable === true', async () => {
+            const item = makeItem({ referenceable: true });
+            renderPicker({ item });
+            await waitFor(() => expect(screen.getByText('测试总结')).toBeInTheDocument());
+        });
+
+        it('hides item when referenceable === false', async () => {
+            const item = makeItem({ referenceable: false });
+            renderPicker({ item });
+            await waitFor(() => expect(screen.getByTestId('empty')).toBeInTheDocument());
+            expect(screen.queryByText('测试总结')).not.toBeInTheDocument();
+        });
+
+        it('falls back to trigger_type === AGENT when referenceable is undefined', async () => {
+            const agentItem = makeItem({ referenceable: undefined, trigger_type: TriggerType.AGENT });
+            const manualItem = makeItem({ task_id: 2, title: '手动总结', referenceable: undefined, trigger_type: TriggerType.MANUAL });
+            renderPicker({ items: [agentItem, manualItem] });
+            await waitFor(() => expect(screen.getByText('测试总结')).toBeInTheDocument());
+            expect(screen.queryByText('手动总结')).not.toBeInTheDocument();
+        });
+
+        it('hides non-completed items even if referenceable === true', async () => {
+            const item = makeItem({ referenceable: true, status: TaskStatus.PROCESSING });
+            renderPicker({ item });
+            await waitFor(() => expect(screen.getByTestId('empty')).toBeInTheDocument());
+        });
+    });
+
+    describe('getTypeLabel', () => {
+        it('renders Agent type label for trigger_type AGENT', async () => {
+            const item = makeItem({ referenceable: true, trigger_type: TriggerType.AGENT });
+            renderPicker({ item });
+            await waitFor(() => expect(screen.getByText('Agent 总结')).toBeInTheDocument());
+        });
+
+        it('renders Scheduled type label for trigger_type SCHEDULED', async () => {
+            const item = makeItem({ referenceable: true, trigger_type: TriggerType.SCHEDULED });
+            renderPicker({ item });
+            await waitFor(() => expect(screen.getByText('定时总结')).toBeInTheDocument());
+        });
+
+        it('renders Multi-person label when participants > 1 for MANUAL type', async () => {
+            const item = makeItem({
+                referenceable: true,
+                trigger_type: TriggerType.MANUAL,
+                participants: [
+                    { user_id: 'u1', user_name: 'User1', status: 1 },
+                    { user_id: 'u2', user_name: 'User2', status: 1 },
+                ],
+            });
+            renderPicker({ item });
+            await waitFor(() => expect(screen.getByText('多人总结')).toBeInTheDocument());
+        });
+
+        it('renders Quick label when participants <= 1 for MANUAL type', async () => {
+            const item = makeItem({
+                referenceable: true,
+                trigger_type: TriggerType.MANUAL,
+                participants: [{ user_id: 'u1', user_name: 'User1', status: 1 }],
+            });
+            renderPicker({ item });
+            await waitFor(() => expect(screen.getByText('快速总结')).toBeInTheDocument());
+        });
+
+        it('renders no badge for unknown trigger_type', async () => {
+            const item = makeItem({ referenceable: true, trigger_type: 99 as any });
+            renderPicker({ item });
+            // Item should still appear, just without a type badge
+            await waitFor(() => expect(screen.getByText('测试总结')).toBeInTheDocument());
+            // The task_no should still render
+            expect(screen.getByText('TASK-001')).toBeInTheDocument();
+        });
+    });
+});

--- a/packages/dmworksummary/src/components/__tests__/SummaryReferencePicker.test.tsx
+++ b/packages/dmworksummary/src/components/__tests__/SummaryReferencePicker.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import '@testing-library/jest-dom/vitest';
-import { render, screen, waitFor, cleanup, act } from '@testing-library/react';
+import { render, screen, waitFor, cleanup, fireEvent } from '@testing-library/react';
 import { afterEach, describe, it, expect, vi } from 'vitest';
 import type { SummaryListItem } from '../../types/summary';
 import { TriggerType, TaskStatus, SummaryMode } from '../../types/summary';
@@ -172,6 +172,56 @@ describe('SummaryReferencePicker', () => {
             await waitFor(() => expect(screen.getByText('测试总结')).toBeInTheDocument());
             // The task_no should still render
             expect(screen.getByText('TASK-001')).toBeInTheDocument();
+        });
+
+        it('renders Scheduled label when schedule_id is present even if trigger_type is not SCHEDULED', async () => {
+            const item = makeItem({
+                referenceable: true,
+                trigger_type: TriggerType.MANUAL,
+                schedule_id: 42,
+            });
+            renderPicker({ item });
+            await waitFor(() => expect(screen.getByText('定时总结')).toBeInTheDocument());
+        });
+    });
+
+    describe('legacy mode (referenceable field missing)', () => {
+        it('first request omits trigger_type; second request sends AGENT after detecting missing referenceable', async () => {
+            const agentItem = makeItem({ referenceable: undefined, trigger_type: TriggerType.AGENT });
+            mockListSummaries.mockResolvedValue({ items: [agentItem], total: 1 });
+            const { rerender } = render(<SummaryReferencePicker visible={false} onCancel={() => {}} onSelect={() => {}} />);
+            rerender(<SummaryReferencePicker visible={true} onCancel={() => {}} onSelect={() => {}} />);
+
+            // First request: legacyMode=false, trigger_type should be undefined
+            await waitFor(() => {
+                expect(mockListSummaries).toHaveBeenCalledTimes(1);
+                const firstCallArg = mockListSummaries.mock.calls[0][0];
+                expect(firstCallArg.trigger_type).toBeUndefined();
+            });
+
+            // Trigger a second request by typing in search (debounced)
+            const input = screen.getByTestId('summary-agent-ref-search-input');
+            fireEvent.change(input, { target: { value: 'test' } });
+
+            // Wait for debounce + second call
+            await waitFor(() => {
+                expect(mockListSummaries).toHaveBeenCalledTimes(2);
+            }, { timeout: 2000 });
+
+            // Second request: legacyMode=true, trigger_type should be AGENT
+            const secondCallArg = mockListSummaries.mock.calls[1][0];
+            expect(secondCallArg.trigger_type).toBe(TriggerType.AGENT);
+        });
+
+        it('does not send trigger_type when referenceable field is present', async () => {
+            const item = makeItem({ referenceable: true, trigger_type: TriggerType.AGENT });
+            mockListSummaries.mockResolvedValue({ items: [item], total: 1 });
+            const { rerender } = render(<SummaryReferencePicker visible={false} onCancel={() => {}} onSelect={() => {}} />);
+            rerender(<SummaryReferencePicker visible={true} onCancel={() => {}} onSelect={() => {}} />);
+            await waitFor(() => {
+                const callArg = mockListSummaries.mock.calls[0][0];
+                expect(callArg.trigger_type).toBeUndefined();
+            });
         });
     });
 });

--- a/packages/dmworksummary/src/components/__tests__/SummaryReferencePicker.test.tsx
+++ b/packages/dmworksummary/src/components/__tests__/SummaryReferencePicker.test.tsx
@@ -165,11 +165,15 @@ describe('SummaryReferencePicker', () => {
             await waitFor(() => expect(screen.getByText('快速总结')).toBeInTheDocument());
         });
 
-        it('renders no badge for unknown trigger_type', async () => {
+        // R4 yj P2-4: renamed — unknown trigger_type falls back to the quick
+        // label (summaryHelpers.getSummaryTypeKind default branch), so a badge
+        // IS rendered. Assert the badge text to lock that behaviour.
+        it('falls back to the quick label for unknown trigger_type', async () => {
             const item = makeItem({ referenceable: true, trigger_type: 99 as any });
             renderPicker({ item });
-            // Item should still appear, just without a type badge
+            // Item should still appear, with the quick fallback badge
             await waitFor(() => expect(screen.getByText('测试总结')).toBeInTheDocument());
+            expect(screen.getByText('快速总结')).toBeInTheDocument();
             // The task_no should still render
             expect(screen.getByText('TASK-001')).toBeInTheDocument();
         });
@@ -182,6 +186,23 @@ describe('SummaryReferencePicker', () => {
             });
             renderPicker({ item });
             await waitFor(() => expect(screen.getByText('定时总结')).toBeInTheDocument());
+        });
+
+        // R4 yj P2-1: regression guard. `schedule_id: 0` means "no schedule"
+        // (the sentinel value the backend uses), so a MANUAL summary with
+        // schedule_id=0 must render 快速总结, NOT 定时总结. Without this case
+        // reverting summaryHelpers to the round-3 bug
+        // (`item.schedule_id != null`) leaves the suite green — verified by
+        // reviewer mutation testing.
+        it('renders Quick label when schedule_id is 0 (no-schedule sentinel)', async () => {
+            const item = makeItem({
+                referenceable: true,
+                trigger_type: TriggerType.MANUAL,
+                schedule_id: 0,
+            });
+            renderPicker({ item });
+            await waitFor(() => expect(screen.getByText('快速总结')).toBeInTheDocument());
+            expect(screen.queryByText('定时总结')).not.toBeInTheDocument();
         });
     });
 
@@ -239,6 +260,97 @@ describe('SummaryReferencePicker', () => {
                 const callArg = mockListSummaries.mock.calls[0][0];
                 expect(callArg.trigger_type).toBeUndefined();
             });
+        });
+    });
+
+    describe('pagination (R4 yj P1-1 / ms P1 / jx 🟡: referenceable items beyond page 1)', () => {
+        it('pages forward and surfaces a referenceable item sitting on page 2', async () => {
+            // Full first page of NON-referenceable items, referenceable one on page 2.
+            // This is the exact regression shape reviewers flagged: with a fixed
+            // page=1, page_size=50 window the referenceable item would be pushed out.
+            const bulkNonRef = Array.from({ length: 100 }, (_, i) => makeItem({
+                task_id: 1000 + i,
+                task_no: `TASK-${1000 + i}`,
+                title: `不可引用总结 ${i}`,
+                referenceable: false,
+            }));
+            const refItem = makeItem({ task_id: 9001, task_no: 'TASK-9001', title: '第二页可引用总结', referenceable: true });
+
+            mockListSummaries.mockImplementation((params: any) => {
+                if (params.page === 1) return Promise.resolve({ items: bulkNonRef, total: 101 });
+                if (params.page === 2) return Promise.resolve({ items: [refItem], total: 101 });
+                return Promise.resolve({ items: [], total: 101 });
+            });
+
+            const { rerender } = render(<SummaryReferencePicker visible={false} onCancel={() => {}} onSelect={() => {}} />);
+            rerender(<SummaryReferencePicker visible={true} onCancel={() => {}} onSelect={() => {}} />);
+
+            await waitFor(() => expect(screen.getByText('第二页可引用总结')).toBeInTheDocument());
+            // Page 1 full (100 == page_size) so it must have requested page 2
+            const pages = mockListSummaries.mock.calls.map((c) => c[0].page);
+            expect(pages).toContain(2);
+            // Non-referenceable bulk must not be rendered
+            expect(screen.queryByText('不可引用总结 0')).not.toBeInTheDocument();
+        });
+
+        it('stops on a short final page without over-paging', async () => {
+            const shortPage = Array.from({ length: 30 }, (_, i) => makeItem({
+                task_id: 2000 + i,
+                task_no: `TASK-${2000 + i}`,
+                title: `短页总结 ${i}`,
+                referenceable: false,
+            }));
+            mockListSummaries.mockImplementation((params: any) => {
+                if (params.page === 1) return Promise.resolve({ items: shortPage, total: 30 });
+                return Promise.resolve({ items: [], total: 30 });
+            });
+
+            const { rerender } = render(<SummaryReferencePicker visible={false} onCancel={() => {}} onSelect={() => {}} />);
+            rerender(<SummaryReferencePicker visible={true} onCancel={() => {}} onSelect={() => {}} />);
+
+            await waitFor(() => expect(screen.getByTestId('empty')).toBeInTheDocument());
+            // 30 < page_size=100 → short page → stop; must not request page 2
+            expect(mockListSummaries).toHaveBeenCalledTimes(1);
+            expect(mockListSummaries.mock.calls[0][0].page).toBe(1);
+        });
+
+        it('dedupes an item that appears on both pages', async () => {
+            // To actually reach page 2, page 1 must be FULL (100 items) and leave
+            // fewer than PICKER_TARGET_COUNT (50) referenceable items collected.
+            // page 1: 60 non-referenceable + 40 referenceable (one of them,
+            // task_id=555, is duplicated on page 2).
+            const page1: SummaryListItem[] = [
+                ...Array.from({ length: 60 }, (_, i) => makeItem({
+                    task_id: 3000 + i,
+                    task_no: `TASK-${3000 + i}`,
+                    title: `不可引用 ${i}`,
+                    referenceable: false,
+                })),
+                ...Array.from({ length: 39 }, (_, i) => makeItem({
+                    task_id: 4000 + i,
+                    task_no: `TASK-${4000 + i}`,
+                    title: `可引用 ${i}`,
+                    referenceable: true,
+                })),
+                makeItem({ task_id: 555, task_no: 'TASK-555', title: '重复总结', referenceable: true }),
+            ];
+            const page2 = [makeItem({ task_id: 555, task_no: 'TASK-555', title: '重复总结', referenceable: true })];
+
+            mockListSummaries.mockImplementation((params: any) => {
+                if (params.page === 1) return Promise.resolve({ items: page1, total: 101 });
+                if (params.page === 2) return Promise.resolve({ items: page2, total: 101 });
+                return Promise.resolve({ items: [], total: 101 });
+            });
+
+            const { rerender } = render(<SummaryReferencePicker visible={false} onCancel={() => {}} onSelect={() => {}} />);
+            rerender(<SummaryReferencePicker visible={true} onCancel={() => {}} onSelect={() => {}} />);
+
+            await waitFor(() => expect(screen.getByText('重复总结')).toBeInTheDocument());
+            // page 1 full (100) + only 40 referenceable (< 50 target) → page 2 requested
+            const pages = mockListSummaries.mock.calls.map((c) => c[0].page);
+            expect(pages).toContain(2);
+            // task_id=555 appears in both pages; must render exactly once
+            expect(screen.getAllByText('重复总结')).toHaveLength(1);
         });
     });
 });

--- a/packages/dmworksummary/src/components/__tests__/SummaryReferencePicker.test.tsx
+++ b/packages/dmworksummary/src/components/__tests__/SummaryReferencePicker.test.tsx
@@ -188,7 +188,11 @@ describe('SummaryReferencePicker', () => {
     describe('legacy mode (referenceable field missing)', () => {
         it('first request omits trigger_type; second request sends AGENT after detecting missing referenceable', async () => {
             const agentItem = makeItem({ referenceable: undefined, trigger_type: TriggerType.AGENT });
-            mockListSummaries.mockResolvedValue({ items: [agentItem], total: 1 });
+            // First call returns items without referenceable → triggers legacy flip + re-fetch.
+            // Second call (re-fetch) returns the same items with trigger_type=AGENT in the request.
+            mockListSummaries
+                .mockResolvedValueOnce({ items: [agentItem], total: 1 })
+                .mockResolvedValueOnce({ items: [agentItem], total: 1 });
             const { rerender } = render(<SummaryReferencePicker visible={false} onCancel={() => {}} onSelect={() => {}} />);
             rerender(<SummaryReferencePicker visible={true} onCancel={() => {}} onSelect={() => {}} />);
 
@@ -199,18 +203,31 @@ describe('SummaryReferencePicker', () => {
                 expect(firstCallArg.trigger_type).toBeUndefined();
             });
 
-            // Trigger a second request by typing in search (debounced)
-            const input = screen.getByTestId('summary-agent-ref-search-input');
-            fireEvent.change(input, { target: { value: 'test' } });
-
-            // Wait for debounce + second call
+            // Second request (re-fetch after legacy flip): legacyMode=true, trigger_type should be AGENT
             await waitFor(() => {
                 expect(mockListSummaries).toHaveBeenCalledTimes(2);
+                const secondCallArg = mockListSummaries.mock.calls[1][0];
+                expect(secondCallArg.trigger_type).toBe(TriggerType.AGENT);
             }, { timeout: 2000 });
 
-            // Second request: legacyMode=true, trigger_type should be AGENT
-            const secondCallArg = mockListSummaries.mock.calls[1][0];
-            expect(secondCallArg.trigger_type).toBe(TriggerType.AGENT);
+            // Item should still be visible after re-fetch
+            await waitFor(() => expect(screen.getByText('测试总结')).toBeInTheDocument());
+        });
+
+        it('does not enter legacy mode when response is empty (no items to infer from)', async () => {
+            // Empty response should NOT trigger legacy mode — we can't infer
+            // whether the backend supports referenceable from an empty list.
+            mockListSummaries.mockResolvedValue({ items: [], total: 0 });
+            const { rerender } = render(<SummaryReferencePicker visible={false} onCancel={() => {}} onSelect={() => {}} />);
+            rerender(<SummaryReferencePicker visible={true} onCancel={() => {}} onSelect={() => {}} />);
+
+            await waitFor(() => {
+                expect(mockListSummaries).toHaveBeenCalledTimes(1);
+            });
+            // Only one call — no re-fetch triggered because legacy mode is NOT flipped
+            // for empty responses.
+            expect(mockListSummaries).toHaveBeenCalledTimes(1);
+            expect(screen.getByTestId('empty')).toBeInTheDocument();
         });
 
         it('does not send trigger_type when referenceable field is present', async () => {

--- a/packages/dmworksummary/src/i18n/en-US.json
+++ b/packages/dmworksummary/src/i18n/en-US.json
@@ -565,7 +565,9 @@
         "confirmDeleteTitle": "Delete?",
         "confirmDeleteDesc": "This cannot be undone.",
         "confirmLeaveTitle": "Leave?",
-        "confirmLeaveDesc": "You will no longer participate in this summary."
+        "confirmLeaveDesc": "You will no longer participate in this summary.",
+        "scheduledType": "Scheduled summary",
+        "multiPersonType": "Multi-person summary"
     },
     "editor": {
         "saveSuccess": "Saved",

--- a/packages/dmworksummary/src/i18n/en-US.json
+++ b/packages/dmworksummary/src/i18n/en-US.json
@@ -202,7 +202,8 @@
         "saving": "Saving...",
         "noOutputToSave": "No summary content to save yet. Please chat with AI first to generate content.",
         "agentSummaryCreated": "AI summary saved",
-        "savedReferenceLostRetry": "Save failed: please re-select the referenced summary, or start a new session"
+        "savedReferenceLostRetry": "Save failed: please re-select the referenced summary, or start a new session",
+        "savedNoOriginRetry": "Save failed: the referenced summary has no source channel, and this session hasn't read any channel either. Pick a referenced summary with a source, or start a new session and let the AI read a channel first"
     },
     "chatSummary": {
         "panelTitle": "Summaries in this chat",

--- a/packages/dmworksummary/src/i18n/zh-CN.json
+++ b/packages/dmworksummary/src/i18n/zh-CN.json
@@ -565,7 +565,9 @@
         "confirmDeleteTitle": "确认删除？",
         "confirmDeleteDesc": "删除后无法恢复",
         "confirmLeaveTitle": "确认退出？",
-        "confirmLeaveDesc": "退出后将不再参与该总结"
+        "confirmLeaveDesc": "退出后将不再参与该总结",
+        "scheduledType": "定时总结",
+        "multiPersonType": "多人总结"
     },
     "editor": {
         "saveSuccess": "保存成功",

--- a/packages/dmworksummary/src/i18n/zh-CN.json
+++ b/packages/dmworksummary/src/i18n/zh-CN.json
@@ -202,7 +202,8 @@
         "saving": "保存中...",
         "noOutputToSave": "当前对话还没有可保存的总结，请先与 AI 对话产出内容",
         "agentSummaryCreated": "AI 总结已保存",
-        "savedReferenceLostRetry": "保存失败：请重新选择引用总结，或点「新会话」重来"
+        "savedReferenceLostRetry": "保存失败：请重新选择引用总结，或点「新会话」重来",
+        "savedNoOriginRetry": "保存失败：该引用总结缺少来源频道，本次会话也未读取过频道。请更换有来源的引用总结，或开始新会话让 AI 先读取频道"
     },
     "chatSummary": {
         "panelTitle": "聊天内的智能总结",

--- a/packages/dmworksummary/src/index.css
+++ b/packages/dmworksummary/src/index.css
@@ -515,6 +515,15 @@ body[theme-mode="dark"] .summary-list-status-trigger:hover {
     color: var(--wk-color-info);
     background: var(--wk-color-info-bg);
 }
+/* R4 yj P2-2: 四种类型各自 icon/class，与 getSummaryTypeKind classifier 一致 */
+.summary-card-type-icon--scheduled {
+    color: var(--wk-color-warning);
+    background: var(--wk-color-warning-bg);
+}
+.summary-card-type-icon--multi {
+    color: var(--wk-color-success);
+    background: var(--wk-color-success-bg);
+}
 .summary-card-type-icon:hover,
 .summary-card-type-icon:focus-visible {
     color: var(--wk-text-primary);

--- a/packages/dmworksummary/src/pages/SummaryCreatePage.tsx
+++ b/packages/dmworksummary/src/pages/SummaryCreatePage.tsx
@@ -1004,12 +1004,24 @@ export default class SummaryCreatePage extends Component<SummaryCreatePageProps,
                     Toast.error(t('summary.create.noOutputToSave'));
                     return false;
                 }
-                // 40001: origin_channel_id 反查失败(通常是引用总结退出重进后
-                // referencedTask 丢失,前端没发 referenced_task_ids,后端 fallback
-                // 借 origin 无路可走)。给友好文案指导用户下一步动作。
+                // 40001: origin_channel_id 反查失败。拆两个子因给不同文案
+                // （R4 ms P2-1）：
+                //   (a) referencedTask 还在：前端已把 referenced_task_ids 发过去，
+                //       后端继承兜底也失败 = 被引用总结本身没有 origin（老 agent
+                //       任务 / bot 创建的 owner-scoped 总结）。「重新选择 / 新会话」
+                //       文案对该子因无效——且前端不能显式传 origin：后端在
+                //       origin_channel_id 非 nil 时跳过 session trace 解析，会把
+                //       新总结归错频道（见 octo-smart-summary agent_summary.go
+                //       CreateAgentSummary 的 nil 分支优先级）。
+                //   (b) referencedTask 已丢（退出重进后前端没发 referenced_task_ids，
+                //       后端 fallback 无路可走）→ 沿用原「引用丢失」文案。
                 // 见 SUM-161 fast-follow · CHAT-REFERENCE-BASED-DESIGN-v1。
                 if (code === 40001) {
-                    Toast.error(t('summary.create.savedReferenceLostRetry'));
+                    if (this.state.referencedTask) {
+                        Toast.error(t('summary.create.savedNoOriginRetry'));
+                    } else {
+                        Toast.error(t('summary.create.savedReferenceLostRetry'));
+                    }
                     return false;
                 }
             }

--- a/packages/dmworksummary/src/pages/SummaryDetailPage.tsx
+++ b/packages/dmworksummary/src/pages/SummaryDetailPage.tsx
@@ -2192,7 +2192,7 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
      */
     handleContinueRefine = () => {
         const { detail } = this.state;
-        if (!detail || detail.trigger_type !== TriggerType.AGENT) return;
+        if (!detail || detail.referenceable !== true) return;
         const event = new CustomEvent('summary-open-chat-with-reference', {
             detail: {
                 task_id: detail.task_id,
@@ -3938,7 +3938,7 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
                     )}
                 </div>
                 <div className="summary-detail-header-actions">
-                    {detail && detail.status === TaskStatus.COMPLETED && detail.trigger_type === TriggerType.AGENT && (
+                    {detail && detail.status === TaskStatus.COMPLETED && detail.referenceable === true && (
                         <Button
                             data-testid={summaryTestIds.detailContinueRefineBtn}
                             theme="solid"

--- a/packages/dmworksummary/src/pages/SummaryDetailPage.tsx
+++ b/packages/dmworksummary/src/pages/SummaryDetailPage.tsx
@@ -56,6 +56,7 @@ import {
     scheduleToParams,
     formatScheduleSummary,
     shouldReactivateOnSave,
+    isReferenceable,
 } from "../utils/summaryHelpers";
 import { summaryTestIds } from "../utils/testIds";
 import CitationText from "../components/CitationText";
@@ -2179,6 +2180,16 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
     };
 
     /**
+     * 当前后端是否支持「继续优化」：兼容 referenceable 字段缺失的 legacy 路径。
+     * 抽取自原内联表达式（handleContinueRefine + render 按钮），统一调用点。
+     */
+    private canRefineCurrentDetail = (): boolean => {
+        const { detail } = this.state;
+        if (!detail) return false;
+        return isReferenceable(detail);
+    };
+
+    /**
      * 「继续优化」按钮 — 打开一个新的智能总结 chat session,预置引用当前总结。
      * 见 CHAT-REFERENCE-BASED-DESIGN-v1: 详情页入口和顶栏「新总结」入口的语义
      * 完全等价 — 都是新起一次 chat 生产工作台,唯一差别是这里预填了引用。
@@ -2192,13 +2203,8 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
      */
     handleContinueRefine = () => {
         const { detail } = this.state;
-        // 兼容：后端已部署 referenceable 时以后端值为准；
-        // 字段缺失时回退到 legacy trigger_type === AGENT 判定
         if (!detail) return;
-        const canRefine = detail.referenceable !== undefined
-            ? detail.referenceable === true
-            : detail.trigger_type === TriggerType.AGENT;
-        if (!canRefine) return;
+        if (!this.canRefineCurrentDetail()) return;
         const event = new CustomEvent('summary-open-chat-with-reference', {
             detail: {
                 task_id: detail.task_id,
@@ -3944,12 +3950,7 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
                     )}
                 </div>
                 <div className="summary-detail-header-actions">
-                    {detail && detail.status === TaskStatus.COMPLETED && (() => {
-                        const canRefine = detail.referenceable !== undefined
-                            ? detail.referenceable === true
-                            : detail.trigger_type === TriggerType.AGENT;
-                        return canRefine;
-                    })() && (
+                    {detail && detail.status === TaskStatus.COMPLETED && this.canRefineCurrentDetail() && (
                         <Button
                             data-testid={summaryTestIds.detailContinueRefineBtn}
                             theme="solid"

--- a/packages/dmworksummary/src/pages/SummaryDetailPage.tsx
+++ b/packages/dmworksummary/src/pages/SummaryDetailPage.tsx
@@ -2192,7 +2192,13 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
      */
     handleContinueRefine = () => {
         const { detail } = this.state;
-        if (!detail || detail.referenceable !== true) return;
+        // 兼容：后端已部署 referenceable 时以后端值为准；
+        // 字段缺失时回退到 legacy trigger_type === AGENT 判定
+        if (!detail) return;
+        const canRefine = detail.referenceable !== undefined
+            ? detail.referenceable === true
+            : detail.trigger_type === TriggerType.AGENT;
+        if (!canRefine) return;
         const event = new CustomEvent('summary-open-chat-with-reference', {
             detail: {
                 task_id: detail.task_id,
@@ -3938,7 +3944,12 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
                     )}
                 </div>
                 <div className="summary-detail-header-actions">
-                    {detail && detail.status === TaskStatus.COMPLETED && detail.referenceable === true && (
+                    {detail && detail.status === TaskStatus.COMPLETED && (() => {
+                        const canRefine = detail.referenceable !== undefined
+                            ? detail.referenceable === true
+                            : detail.trigger_type === TriggerType.AGENT;
+                        return canRefine;
+                    })() && (
                         <Button
                             data-testid={summaryTestIds.detailContinueRefineBtn}
                             theme="solid"

--- a/packages/dmworksummary/src/pages/__tests__/SummaryCreatePage.test.tsx
+++ b/packages/dmworksummary/src/pages/__tests__/SummaryCreatePage.test.tsx
@@ -17,6 +17,8 @@ vi.mock('@douyinfe/semi-ui', () => ({
     Modal: ({ children, visible, onOk, onCancel }: any) => visible ? <div data-testid="modal">{children}</div> : null,
     Typography: { Text: ({ children }: any) => <span>{children}</span> },
     Tag: ({ children }: any) => <span data-testid="tag">{children}</span>,
+    // Tooltip wraps several elements (SummaryCreatePage.tsx:1295); render children only.
+    Tooltip: ({ children }: any) => <>{children}</>,
     Avatar: ({ children }: any) => <span data-testid="avatar">{children}</span>,
     Modal: ({ children, visible }: any) => visible ? <div data-testid="modal">{children}</div> : null,
     SplitButtonGroup: ({ children, className }: any) => (
@@ -612,6 +614,49 @@ describe('SummaryCreatePage handleSubmit error handling', () => {
         expect(Toast.error).toHaveBeenCalled();
         const shown = (Toast.error as any).mock.calls[0]?.[0] ?? '';
         expect(shown).toBe('保存失败：请重新选择引用总结，或点「新会话」重来');
+        expect(result).toBe(false);
+    });
+
+    // R4 ms P2-1: when referencedTask IS still in state, the backend borrow
+    // fallback also failed — the referenced summary itself has no origin.
+    // The "re-select / new session" copy is useless for that sub-cause, so
+    // the toast must use the dedicated no-origin wording instead.
+    it('shows no-origin toast for 40001 when referencedTask is still selected', async () => {
+        const { Toast } = await import('@douyinfe/semi-ui');
+
+        const err = {
+            response: { data: { code: 40001, message: 'origin_channel_id 未传且无法从 session 反查(session 无 fetch_channel 调用),也无引用总结可继承 origin' } },
+        };
+        (api.createAgentSummary as any).mockRejectedValueOnce(err);
+
+        const ref = React.createRef<any>();
+        await act(async () => {
+            render(<SummaryCreatePage ref={ref} />);
+            await flushPromises();
+        });
+
+        const instance = ref.current as any;
+
+        await act(async () => {
+            instance.setState({
+                sessionId: 'session-abc',
+                mode: 'agent',
+                messages: [{ role: 'user', content: 'hi' }, { role: 'assistant', content: 'summary' }],
+                referencedTask: { task_id: 42, title: '老 Agent 总结', origin_channel_id: '', origin_channel_type: 1 },
+            });
+        });
+
+        (Toast.error as any).mockClear();
+
+        let result: boolean | undefined;
+        await act(async () => {
+            result = await instance.handleSaveAsSummary('a title');
+            await flushPromises();
+        });
+
+        expect(Toast.error).toHaveBeenCalled();
+        const shown = (Toast.error as any).mock.calls[0]?.[0] ?? '';
+        expect(shown).toBe('保存失败：该引用总结缺少来源频道，本次会话也未读取过频道。请更换有来源的引用总结，或开始新会话让 AI 先读取频道');
         expect(result).toBe(false);
     });
 });

--- a/packages/dmworksummary/src/types/summary.ts
+++ b/packages/dmworksummary/src/types/summary.ts
@@ -204,6 +204,12 @@ export interface SummaryListItem {
     current_result_id?: number | null;
     current_personal_version_id?: number | null;
     activity_at?: string | null;
+    /** 后端权威字段：该总结是否可被 Agent 引用 */
+    referenceable?: boolean;
+    /** 引用产物类型：team_result | personal_result | null */
+    reference_artifact_type?: string | null;
+    /** 不可引用原因（referenceable=false 时后端返回） */
+    reference_unavailable_reason?: string | null;
 }
 
 /** 详情 */
@@ -235,6 +241,12 @@ export interface SummaryDetail {
     result_id?: number;
     result_edited_at?: string | null;
     result_is_edited?: boolean;
+    /** 后端权威字段：该总结是否可被 Agent 引用 */
+    referenceable?: boolean;
+    /** 引用产物类型：team_result | personal_result | null */
+    reference_artifact_type?: string | null;
+    /** 不可引用原因（referenceable=false 时后端返回） */
+    reference_unavailable_reason?: string | null;
     permissions?: {
         /** 旧字段，语义已迁移到 can_edit_team；前端勿用。 */
         can_edit: boolean;

--- a/packages/dmworksummary/src/types/summary.ts
+++ b/packages/dmworksummary/src/types/summary.ts
@@ -206,7 +206,12 @@ export interface SummaryListItem {
     activity_at?: string | null;
     /** 后端权威字段：该总结是否可被 Agent 引用 */
     referenceable?: boolean;
-    /** 引用产物类型：team_result | personal_result | null */
+    /**
+     * 引用产物类型：team_result | personal_result | null。
+     * R4 yj P2-9: forward declarations for SUM-19; no reader in this
+     * package yet — the picker keeps only referenceable items, so there is
+     * no UI surface that could show a reason or artifact type.
+     */
     reference_artifact_type?: string | null;
     /** 不可引用原因（referenceable=false 时后端返回） */
     reference_unavailable_reason?: string | null;
@@ -243,9 +248,9 @@ export interface SummaryDetail {
     result_is_edited?: boolean;
     /** 后端权威字段：该总结是否可被 Agent 引用 */
     referenceable?: boolean;
-    /** 引用产物类型：team_result | personal_result | null */
+    /** 引用产物类型：team_result | personal_result | null（前向声明，当前无读取方，见 SummaryListItem 同名字段注释，R4 yj P2-9） */
     reference_artifact_type?: string | null;
-    /** 不可引用原因（referenceable=false 时后端返回） */
+    /** 不可引用原因（referenceable=false 时后端返回；前向声明，同上） */
     reference_unavailable_reason?: string | null;
     permissions?: {
         /** 旧字段，语义已迁移到 can_edit_team；前端勿用。 */

--- a/packages/dmworksummary/src/utils/summaryHelpers.ts
+++ b/packages/dmworksummary/src/utils/summaryHelpers.ts
@@ -3,11 +3,13 @@ import {
     TaskStatus,
     SourceType,
     ParticipantStatus,
+    TriggerType,
     type TaskStatusType,
     type SummaryModeType,
     type SourceTypeValue,
     type ScheduleConfig,
     type ScheduleItem,
+    type SummaryListItem,
 } from "../types/summary";
 import { t } from "@octo/base";
 
@@ -179,6 +181,48 @@ export function getStatusColor(status: TaskStatusType): string {
 /** 总结模式 → 显示文本 */
 export function getModeLabel(mode: SummaryModeType): string {
     return mode === SummaryMode.BY_GROUP ? t("summary.mode.byGroup") : t("summary.mode.byPerson");
+}
+
+/**
+ * 总结是否可被 Agent 引用 — SummaryReferencePicker 与 SummaryDetailPage 共享。
+ *
+ * 当后端已部署 referenceable 字段时，以后端值为准。
+ * 字段缺失时（后端未部署或 mock 未提供），回退到 legacy 行为：
+ * 仅 trigger_type === AGENT 的总结可被引用。
+ */
+export function isReferenceable(item: { referenceable?: boolean; trigger_type: number }): boolean {
+    if (item.referenceable !== undefined) return item.referenceable === true;
+    return item.trigger_type === TriggerType.AGENT;
+}
+
+/**
+ * 总结类型标签 — SummaryReferencePicker 与 SummaryCard 共享。
+ *
+ * - Agent 总结: trigger_type === AGENT
+ * - 定时总结: trigger_type === SCHEDULED 或 schedule_id 存在（本仓契约以 schedule_id 为权威标记）
+ * - 多人总结: trigger_type === MANUAL 且 participants.length > 1
+ * - 快速总结: trigger_type === MANUAL 且 participants.length <= 1
+ * - 未知类型: 返回空字符串（调用方负责条件渲染）
+ *
+ * @param t i18n 翻译函数
+ * @param item 总结列表项
+ */
+export function getSummaryTypeLabel(
+    t: (key: string, opts?: any) => string,
+    item: SummaryListItem,
+): string {
+    const isScheduled = item.trigger_type === TriggerType.SCHEDULED || item.schedule_id != null;
+    if (isScheduled) return t("summary.summaryCard.scheduledType");
+    switch (item.trigger_type) {
+        case TriggerType.AGENT:
+            return t("summary.summaryCard.agentType");
+        case TriggerType.MANUAL:
+            return (item.participants?.length ?? 0) > 1
+                ? t("summary.summaryCard.multiPersonType")
+                : t("summary.summaryCard.quickType");
+        default:
+            return "";
+    }
 }
 
 /** 信息来源类型 → 显示文本 */

--- a/packages/dmworksummary/src/utils/summaryHelpers.ts
+++ b/packages/dmworksummary/src/utils/summaryHelpers.ts
@@ -199,10 +199,10 @@ export function isReferenceable(item: { referenceable?: boolean; trigger_type: n
  * 总结类型标签 — SummaryReferencePicker 与 SummaryCard 共享。
  *
  * - Agent 总结: trigger_type === AGENT
- * - 定时总结: trigger_type === SCHEDULED 或 schedule_id 存在（本仓契约以 schedule_id 为权威标记）
+ * - 定时总结: trigger_type === SCHEDULED 或 schedule_id > 0（0 表示无 schedule）
  * - 多人总结: trigger_type === MANUAL 且 participants.length > 1
  * - 快速总结: trigger_type === MANUAL 且 participants.length <= 1
- * - 未知类型: 返回空字符串（调用方负责条件渲染）
+ * - 未知类型: 回退到"快速总结"（避免空 tooltip/aria-label）
  *
  * @param t i18n 翻译函数
  * @param item 总结列表项
@@ -211,7 +211,7 @@ export function getSummaryTypeLabel(
     t: (key: string, opts?: any) => string,
     item: SummaryListItem,
 ): string {
-    const isScheduled = item.trigger_type === TriggerType.SCHEDULED || item.schedule_id != null;
+    const isScheduled = item.trigger_type === TriggerType.SCHEDULED || (item.schedule_id != null && item.schedule_id > 0);
     if (isScheduled) return t("summary.summaryCard.scheduledType");
     switch (item.trigger_type) {
         case TriggerType.AGENT:
@@ -221,7 +221,7 @@ export function getSummaryTypeLabel(
                 ? t("summary.summaryCard.multiPersonType")
                 : t("summary.summaryCard.quickType");
         default:
-            return "";
+            return t("summary.summaryCard.quickType");
     }
 }
 

--- a/packages/dmworksummary/src/utils/summaryHelpers.ts
+++ b/packages/dmworksummary/src/utils/summaryHelpers.ts
@@ -196,13 +196,34 @@ export function isReferenceable(item: { referenceable?: boolean; trigger_type: n
 }
 
 /**
- * 总结类型标签 — SummaryReferencePicker 与 SummaryCard 共享。
+ * 总结类型分类 — 单一 classifier（R4 yj P2-2）。
  *
- * - Agent 总结: trigger_type === AGENT
- * - 定时总结: trigger_type === SCHEDULED 或 schedule_id > 0（0 表示无 schedule）
- * - 多人总结: trigger_type === MANUAL 且 participants.length > 1
- * - 快速总结: trigger_type === MANUAL 且 participants.length <= 1
- * - 未知类型: 回退到"快速总结"（避免空 tooltip/aria-label）
+ * icon、CSS class 和 label 全部由这个 kind 派生，消除「四路 label 配两路
+ * icon」的分裂（此前定时总结会渲染快速总结的 icon，aria-label 与视觉不符）。
+ *
+ * - agent: trigger_type === AGENT
+ * - scheduled: trigger_type === SCHEDULED 或 schedule_id > 0（0 表示无 schedule）
+ * - multi: trigger_type === MANUAL 且 participants.length > 1
+ * - quick: trigger_type === MANUAL 且 participants.length <= 1，以及未知类型兜底
+ */
+export type SummaryTypeKind = 'agent' | 'scheduled' | 'multi' | 'quick';
+
+export function getSummaryTypeKind(item: SummaryListItem): SummaryTypeKind {
+    const isScheduled = item.trigger_type === TriggerType.SCHEDULED || (item.schedule_id != null && item.schedule_id > 0);
+    if (isScheduled) return 'scheduled';
+    switch (item.trigger_type) {
+        case TriggerType.AGENT:
+            return 'agent';
+        case TriggerType.MANUAL:
+            return (item.participants?.length ?? 0) > 1 ? 'multi' : 'quick';
+        default:
+            return 'quick';
+    }
+}
+
+/**
+ * 总结类型标签 — SummaryReferencePicker 与 SummaryCard 共享。
+ * 由 getSummaryTypeKind 单一 classifier 派生，保证 label/icon 一致。
  *
  * @param t i18n 翻译函数
  * @param item 总结列表项
@@ -211,15 +232,14 @@ export function getSummaryTypeLabel(
     t: (key: string, opts?: any) => string,
     item: SummaryListItem,
 ): string {
-    const isScheduled = item.trigger_type === TriggerType.SCHEDULED || (item.schedule_id != null && item.schedule_id > 0);
-    if (isScheduled) return t("summary.summaryCard.scheduledType");
-    switch (item.trigger_type) {
-        case TriggerType.AGENT:
+    switch (getSummaryTypeKind(item)) {
+        case 'scheduled':
+            return t("summary.summaryCard.scheduledType");
+        case 'agent':
             return t("summary.summaryCard.agentType");
-        case TriggerType.MANUAL:
-            return (item.participants?.length ?? 0) > 1
-                ? t("summary.summaryCard.multiPersonType")
-                : t("summary.summaryCard.quickType");
+        case 'multi':
+            return t("summary.summaryCard.multiPersonType");
+        case 'quick':
         default:
             return t("summary.summaryCard.quickType");
     }


### PR DESCRIPTION
## Summary

Closes #SUM-20. This PR opens all summary types (quick, multi-person, scheduled, agent) for Agent chat reference, rather than only `trigger_type=3` (agent) summaries.

## Changes

### 1. SummaryReferencePicker — remove agent-only filter
- Removed fixed `trigger_type: 3` from `listSummaries()` call
- Filter candidates by backend `referenceable === true` instead of hardcoded agent type
- Keep `status === 3` (COMPLETED) filter — incomplete summaries have no content to reference
- Added type labels (quick / multi-person / scheduled / agent) on candidate cards

### 2. Types — add backend referenceability fields
- `SummaryListItem` and `SummaryDetail` now include:
  - `referenceable?: boolean` — backend authoritative field
  - `reference_artifact_type?: string | null` — team_result | personal_result | null
  - `reference_unavailable_reason?: string | null` — reason when not referenceable

### 3. SummaryDetailPage — broaden "继续优化" entry
- `handleContinueRefine` guard: `trigger_type !== TriggerType.AGENT` → `referenceable !== true`
- Button render condition: `trigger_type === TriggerType.AGENT` → `referenceable === true`
- Other `TriggerType.AGENT` gates (schedule, edit, version history) remain unchanged — they are agent-specific workflow, not referenceability

### 4. i18n
- Added `summaryCard.scheduledType` (Scheduled summary / 定时总结)
- Added `summaryCard.multiPersonType` (Multi-person summary / 多人总结)

### 5. CSS
- Added `.summary-reference-picker-item-main`, `.summary-reference-picker-item-type`, `.summary-reference-picker-item-sep` styles

## Not changed
- **SummaryReferenceSidePanel** — already handles both `summary_result` (team) and `personal_result` (agent) via dual-source fallback; no changes needed
- **SummaryReferencePicker multi-select** — still uses v1 single-select UI (multi-select is out of scope for this round)

## Depends on
Backend (SUM-19) must add `referenceable`, `reference_artifact_type`, `reference_unavailable_reason` to the list API response. Frontend gracefully handles missing fields (optional types, defaults to not referenceable).

## Testing
- [ ] Unit/component tests pending
- [ ] E2E pending
- [x] Manual code review: all diffs verified via `git diff`

## Checklist
- [x] Code follows project conventions (flat i18n under `summary.` namespace, Semi Design components, TypeScript strict)
- [x] No permissions expanded beyond what the detail page already shows
- [x] Citation rules unchanged — `[Pn]` references still handled by existing SidePanel logic
- [x] All free text still passes through `sanitizeRef` and `<引用数据>` fence (unchanged)