### PR TITLE
fix(dmworkmcp): unify market NavRail entry label with page header (LSC-51)

### DIFF
--- a/packages/dmworkmcp/src/i18n/en-US.json
+++ b/packages/dmworkmcp/src/i18n/en-US.json
@@ -1,6 +1,6 @@
 {
   "menu": {
-    "title": "Tools"
+    "title": "Markets"
   },
   "sidebar": {
     "header": "Markets",

--- a/packages/dmworkmcp/src/i18n/zh-CN.json
+++ b/packages/dmworkmcp/src/i18n/zh-CN.json
@@ -1,6 +1,6 @@
 {
   "menu": {
-    "title": "工具"
+    "title": "市场"
   },
   "sidebar": {
     "header": "市场",


### PR DESCRIPTION
## Summary

The top-level "Markets" NavRail entry showed an inconsistent name: the NavRail label was rendered from `mcp.menu.title` ("工具" / "Tools") while the sidebar/page header was rendered from `mcp.sidebar.header` ("市场" / "Markets"). The same entry therefore displayed two different names to users. This PR unifies the NavRail label to the market naming in both locales. Display copy only — no route id, menu id, permission key, `MARKET_API_URL`, API path, or package name is touched.

Octo issue: **LSC-51**

## Related Issue

Fixes Mininglamp-OSS/octo-web#1316 (Octo tracking key: LSC-51)

## Changes

- `packages/dmworkmcp/src/i18n/zh-CN.json` — `menu.title`: `工具` → `市场`
- `packages/dmworkmcp/src/i18n/en-US.json` — `menu.title`: `Tools` → `Markets`

Preserved intentionally (semantics = "tool list / dev tools", unrelated to the market entry name): `category.dev` (开发工具), `detail.tools` / `sectionTools` (工具清单), `probe*`/`toolCount` etc. en-US was fixed alongside zh-CN because it carried the identical nav-vs-header inconsistency (`Tools` vs `Markets`), not because the Chinese requirement was mechanically spread; no other locale/copy was modified.

## Architecture / Module Boundary

- Affected module(s): `@dmwork/mcp` (i18n only)
- New or changed user-visible entry point: no new entry point; renames the label of the existing single "Markets" NavRail entry to match its page header
- Shared layer touched: none (only `packages/dmworkmcp/src/i18n/*.json` value strings)
- If shared code changed, impact scope: n/a
- Duplicate entry point checked: yes — still one NavRail entry (`mcp-market`); `dmworkskillmarket` continues to register no NavRail icon

## Testing

Offline validation (base `upstream/main` = `56126ec169e8b170a5d91fa5cb73155903b19da5`):

- `pnpm i18n:check` → `i18n check passed: 0 candidates within baseline; locale keys healthy`
- `pnpm --filter @dmwork/mcp test` → 12 files / 136 tests passed
- `pnpm build` (turbo, incl. `@octo/web` production build) → success

> **L3 full-application route verification is pending.** It will be completed against a non-production deployment (real octo-server + octo-marketplace, isolated test account/data) by the test role after deployment, pinned to this PR's head SHA. Evidence level for L3 is therefore marked **"待部署验证 / pending deployment verification"** in the tracking issue.

- [x] Unit tests added/updated <!-- existing suite covers the module; change is a copy value with no new logic -->
- [ ] Manually verified <!-- L3 pending non-prod deployment (see note above) -->

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] PR description is in English
- [ ] Added tests for my changes <!-- pure i18n value change; existing 136 tests pass, no new behavior to test -->
- [ ] Updated documentation <!-- not applicable -->
- [x] Ran `pnpm i18n:check` or confirmed the change does not affect UI copy
- [x] Confirmed the change follows module ownership and does not add duplicate user-visible entry points
- [x] Described impact scope when shared components, messages, bridge, or services are changed
- [x] Followed commit message conventions (Conventional Commits)
