### PR TITLE
fix(sidebar): align unfollow context menu presentation

### DIFF
--- a/packages/dmworkbase/src/Components/ConversationListGrouped/index.tsx
+++ b/packages/dmworkbase/src/Components/ConversationListGrouped/index.tsx
@@ -313,7 +313,6 @@ const ConversationListGrouped: React.FC<ConversationListGroupedProps> = ({
         // 1. 取消关注（所有类型都支持）
         const unfollowItem: ContextMenusData = {
             title: t("base.chatSidebar.context.unfollow"),
-            icon: "M19 14c1.49-1.46 3-3.21 3-5.5A5.5 5.5 0 0 0 16.5 3c-1.76 0-3 .5-4.5 2-1.5-1.5-2.74-2-4.5-2A5.5 5.5 0 0 0 2 8.5c0 2.3 1.5 4.05 3 5.5l7 7Z M2.172 15.172a4 4 0 0 0 5.656 0L10 13l2.172 2.172a4 4 0 1 0 5.656-5.656L10 1.686 2.172 9.514a4 4 0 0 0 0 5.658Z",
             onClick: async () => {
                 try {
                     if (channel.channelType === ChannelTypeGroup) {


### PR DESCRIPTION
## Summary

Remove the malformed icon from the Follow-tab unfollow context-menu item so its presentation matches the same action in the Recent tab.

## Related Issue

Fixes #1327

## Changes

- Remove the overlapping SVG path from the Follow-tab unfollow menu item.
- Preserve the existing icon-free Recent-tab presentation and all unfollow behavior.

## Architecture / Module Boundary

- Affected module(s): Conversation sidebar
- New or changed user-visible entry point: no
- Shared layer touched: none
- If shared code changed, impact scope: not applicable
- Duplicate entry point checked: not applicable

## Testing

- [x] Existing unit tests: `pnpm exec vitest run packages/dmworkbase/src/Components/ContextMenus/__tests__/ContextMenus.test.tsx` (4 passed)
- [x] Production build: `pnpm --dir apps/web build`
- [x] `git diff --check`
- [ ] Manually verified after authenticated login
- E2E not run: the change removes one optional icon value and does not change click or data behavior.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [ ] Added tests for my changes
- [ ] Updated documentation
- [x] Ran `pnpm i18n:check` or confirmed the change does not affect UI copy
- [x] Confirmed the change follows module ownership and does not add duplicate user-visible entry points
- [x] Described impact scope when shared components, messages, bridge, or services are changed
- [x] Followed commit message conventions (Conventional Commits)