### PR TITLE
fix(summary): keep version history panel as a right-hand column (#1360)

### DIFF
--- a/packages/dmworksummary/src/components/SummaryVersionPanel.tsx
+++ b/packages/dmworksummary/src/components/SummaryVersionPanel.tsx
@@ -87,14 +87,7 @@ const SummaryVersionPanel: React.FC<SummaryVersionPanelProps> = ({
     const showRestore = canRestore && !!selected && !selectedIsCurrent;
 
     return (
-        <>
-            <button
-                type="button"
-                className="version-panel-scrim"
-                aria-label={t("summary.detail.versionPanelClose")}
-                onClick={onClose}
-            />
-            <aside data-testid={summaryTestIds.versionPanel} className="version-panel" aria-label={t("summary.detail.versionRecords")}>
+        <aside data-testid={summaryTestIds.versionPanel} className="version-panel" aria-label={t("summary.detail.versionRecords")}>
                 <header className="version-panel__header">
                     <span className="version-panel__icon" aria-hidden>
                         <IconHistory />
@@ -177,8 +170,7 @@ const SummaryVersionPanel: React.FC<SummaryVersionPanelProps> = ({
                         </Button>
                     </footer>
                 )}
-            </aside>
-        </>
+        </aside>
     );
 };
 

--- a/packages/dmworksummary/src/index.css
+++ b/packages/dmworksummary/src/index.css
@@ -4186,21 +4186,17 @@ body[theme-mode="dark"] .chat-selector-modal {
     color: var(--wk-color-accent);
 }
 
-/* 桌面端版本栏参与横向布局，不遮挡正文。 */
-.version-panel-scrim {
-    display: none;
-}
-@keyframes version-scrim-in {
-    from { opacity: 0; }
-    to { opacity: 1; }
-}
+/* 版本栏始终参与横向分栏布局，绝不遮挡正文 (#1360)。
+ * 容器较窄（如聊天侧栏，可窄至 320px）时面板按容器宽度收窄，
+ * 正文区域自适应缩窄但保持可见。不使用 viewport media query：
+ * 详情页也会渲染在窄聊天侧栏中，宽度由容器决定。 */
 
 /* 面板本体 */
 .version-panel {
     position: relative;
     z-index: 6;
-    width: 320px;
-    min-width: 320px;
+    width: clamp(200px, 40%, 320px);
+    min-width: 200px;
     height: 100%;
     display: flex;
     flex-direction: column;
@@ -4211,31 +4207,6 @@ body[theme-mode="dark"] .chat-selector-modal {
 @keyframes version-panel-in {
     from { transform: translateX(24px); opacity: 0; }
     to { transform: translateX(0); opacity: 1; }
-}
-
-/* 可用容器宽度不足时退化为覆盖式面板。宽度 class 由 layout ResizeObserver
- * 驱动，不能使用 viewport media query：详情页也会渲染在窄聊天侧栏中。 */
-.summary-detail-layout.version-panel-overlay .version-panel-scrim {
-        position: absolute;
-        inset: 0;
-        z-index: 20;
-        display: block;
-        border: 0;
-        padding: 0;
-        background: rgba(28, 28, 35, 0.28);
-        cursor: pointer;
-        animation: version-scrim-in 160ms ease;
-}
-
-.summary-detail-layout.version-panel-overlay .version-panel {
-        position: absolute;
-        top: 0;
-        right: 0;
-        bottom: 0;
-        z-index: 21;
-        width: min(320px, 100%);
-        min-width: 0;
-        box-shadow: -12px 0 32px rgba(28, 28, 35, 0.10);
 }
 
 .version-panel__header {

--- a/packages/dmworksummary/src/pages/SummaryDetailPage.tsx
+++ b/packages/dmworksummary/src/pages/SummaryDetailPage.tsx
@@ -4081,7 +4081,7 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
             <div data-testid={summaryTestIds.detailPage} className="summary-detail-page">
                 <div
                     ref={this.layoutRef}
-                    className={`summary-detail-layout${this.isVersionPanelActuallyOpen() ? " has-version-panel" : ""}${hasToc ? " has-toc" : ""}${this.state.layoutWidth != null && this.state.layoutWidth > 0 && this.state.layoutWidth < SummaryDetailPage.TOC_MIN_LAYOUT_WIDTH ? " version-panel-overlay" : ""}`}
+                    className={`summary-detail-layout${this.isVersionPanelActuallyOpen() ? " has-version-panel" : ""}${hasToc ? " has-toc" : ""}`}
                 >
                     <div className="summary-detail-content-wrapper">
                     {detail && !loading && this.renderHeader()}

--- a/packages/dmworksummary/src/pages/__tests__/SummaryDetailPage.schedule.test.tsx
+++ b/packages/dmworksummary/src/pages/__tests__/SummaryDetailPage.schedule.test.tsx
@@ -91,11 +91,29 @@ describe('SummaryDetailPage — 历史版本引用隐私', () => {
 });
 
 describe('SummaryDetailPage — 窄容器布局', () => {
-    it('渲染版本面板 overlay class 时不会引用未定义的宽度常量', () => {
+    it('窄容器下版本面板保持并排分栏，绝不退化为覆盖式遮挡正文 (#1360)', () => {
         const page = makePage(1);
-        page.state = { ...(page.state as any), layoutWidth: 360, loading: true };
+        page.state = {
+            ...(page.state as any),
+            layoutWidth: 360,
+            loading: true,
+            detail: baseDetail({
+                result: { result_id: 2, version: 2, content: 'v2 body', citations: [] },
+            }) as any,
+            versionPanelOpen: true,
+            versionsLoading: false,
+            versions: [
+                { result_id: 1, version: 1, operation_type: 'generate', operation_note: '', generated_at: '', created_by: 'u1' },
+                { result_id: 2, version: 2, operation_type: 'edit', operation_note: '', generated_at: '', created_by: 'u1' },
+            ],
+        };
         expect(() => page.render()).not.toThrow();
-        expect(JSON.stringify(page.render())).toContain('version-panel-overlay');
+        const html = JSON.stringify(page.render());
+        // 分栏面板本体仍在场（正文可见性由布局保证，不再被覆盖）
+        expect(html).toContain('version-panel');
+        // 覆盖式退化 + 遮罩必须彻底移除：它们就是 #1360 遮挡正文的根源
+        expect(html).not.toContain('version-panel-overlay');
+        expect(html).not.toContain('version-panel-scrim');
     });
 });
 


### PR DESCRIPTION
## Background

Closes #1360

The version-history panel on the summary detail page used to render as a
right-hand column on wide containers, but in narrow containers (the chat
side panel, clamped to 320-720px) it fell back to an absolute-positioned
overlay with a scrim that covered the summary body. While browsing
versions, the actual content became invisible and had to be closed first.

## Approach

Make the version panel always participate in the horizontal layout — the
panel is a permanent right-hand column and never overlays the body:

- Remove the `version-panel-overlay` fallback class (width-gated via the
  layout ResizeObserver) and the scrim element from `SummaryVersionPanel`.
- Panel width uses `clamp(200px, 40%, 320px)` so it shrinks in narrow
  containers while the body column stays visible and adapts.
- Layout stays keyed off the container width (not viewport media
  queries), since the detail page also renders inside the narrow chat
  side panel.

## Acceptance Criteria

- [x] In narrow containers (e.g. chat side panel), opening version
      history keeps the summary body visible in the left column.
- [x] No scrim / overlay element is rendered anymore.
- [x] Wide-container behaviour unchanged: panel is a 320px right column.
- [x] Regression test added: narrow-container render must not contain
      `version-panel-overlay` / `version-panel-scrim`.

## Out of Scope

- No backend changes.
- No changes to version restore / preview logic.

## Risks & Related

- Risk: on very narrow containers (<500px) the body column becomes
  narrow (~<300px). Accepted trade-off per the issue: both columns stay
  visible instead of one hiding the other.
- Verified: dmworksummary test suite shows the same 53 pre-existing
  failures with and without this change (zero new regressions); the
  targeted layout test was red before and green after the fix.
