### PR TITLE
fix(notifications): 文档专注场景静音 IM 桌面通知音 (WS-161)

### DIFF
--- a/packages/dmworkbase/src/features/notifications/documentScene.test.ts
+++ b/packages/dmworkbase/src/features/notifications/documentScene.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { isDocumentFocusScene, isDocumentScenePath } from "./documentScene";
+
+describe("isDocumentScenePath", () => {
+  it("matches standalone doc paths", () => {
+    expect(isDocumentScenePath("/d/abc123")).toBe(true);
+    expect(isDocumentScenePath("/d/Doc_-123")).toBe(true);
+    // trailing slash is normalized away (parity with normalizeRoutePath)
+    expect(isDocumentScenePath("/d/abc123/")).toBe(true);
+  });
+
+  it("matches standalone ppt doc paths", () => {
+    expect(isDocumentScenePath("/ppt/d/abc123")).toBe(true);
+    expect(isDocumentScenePath("/ppt/d/abc123/")).toBe(true);
+  });
+
+  it("rejects non-doc paths", () => {
+    expect(isDocumentScenePath("/")).toBe(false);
+    expect(isDocumentScenePath("/d")).toBe(false);
+    expect(isDocumentScenePath("/d/")).toBe(false);
+    expect(isDocumentScenePath("/dashboard")).toBe(false);
+    expect(isDocumentScenePath("/docs")).toBe(false);
+    expect(isDocumentScenePath("/chat")).toBe(false);
+    expect(isDocumentScenePath("/s/task123")).toBe(false);
+    // nested / malformed doc ids must not be treated as the doc scene
+    expect(isDocumentScenePath("/d/a/b")).toBe(false);
+    expect(isDocumentScenePath("/d/../etc")).toBe(false);
+    expect(isDocumentScenePath("/ppt/d")).toBe(false);
+  });
+
+  it("ignores query and hash by matching pathname only", () => {
+    // callers pass window.location.pathname (no query/hash), so a raw path
+    // carrying them is not a doc scene — documents the expected input.
+    expect(isDocumentScenePath("/d/abc123?sp=x")).toBe(false);
+  });
+
+  it("handles non-string / empty input defensively", () => {
+    expect(isDocumentScenePath("")).toBe(false);
+    expect(isDocumentScenePath(undefined as unknown as string)).toBe(false);
+    expect(isDocumentScenePath(null as unknown as string)).toBe(false);
+  });
+});
+
+describe("isDocumentFocusScene", () => {
+  const originalPathname = window.location.pathname;
+
+  const setPathname = (pathname: string) => {
+    window.history.replaceState({}, "", pathname);
+  };
+
+  afterEach(() => {
+    window.history.replaceState({}, "", originalPathname);
+  });
+
+  it("returns true on a standalone doc page", () => {
+    setPathname("/d/abc123");
+    expect(isDocumentFocusScene()).toBe(true);
+  });
+
+  it("returns false on the chat / app shell", () => {
+    setPathname("/");
+    expect(isDocumentFocusScene()).toBe(false);
+    setPathname("/chat");
+    expect(isDocumentFocusScene()).toBe(false);
+  });
+});

--- a/packages/dmworkbase/src/features/notifications/documentScene.ts
+++ b/packages/dmworkbase/src/features/notifications/documentScene.ts
@@ -1,0 +1,33 @@
+// 纯函数场景判定：当前是否处于「独立文档专注场景」。
+//
+// 独立文档页（`/d/:docId`、`/ppt/d/:docId`）与 IM 聊天页共用同一套 SPA bundle：登录后同样
+// 会连 IM、注册消息监听。文档=天然专注场景（对齐 Slack / Notion / 飞书文档），此时不应被 IM
+// 桌面通知音 / 横幅打断，仅保留红点 / 未读数。通知的场景抑制以此判定为准。
+//
+// 只按路由 pathname 匹配、零依赖，便于单测直接导入；docId 段用与 `buildDocNavUrl` 一致的
+// URL/path 安全白名单（`[A-Za-z0-9_-]{1,128}`），既挡住 `/d`、`/d/`、`/dashboard` 这类非文档
+// 路径，也不把带 `../`/多段的畸形路径误判成文档场景。
+
+/** `/d/:docId`（标准文档）。 */
+const STANDALONE_DOC_PATH = /^\/d\/[A-Za-z0-9_-]{1,128}$/;
+/** `/ppt/d/:docId`（幻灯片文档，独立命名空间）。 */
+const STANDALONE_PPT_DOC_PATH = /^\/ppt\/d\/[A-Za-z0-9_-]{1,128}$/;
+
+/** 是否为独立文档页路由（末尾斜杠归一，与 `normalizeRoutePath` 一致）。 */
+export function isDocumentScenePath(pathname: string): boolean {
+  if (typeof pathname !== "string" || !pathname) return false;
+  const normalized = pathname.replace(/\/+$/, "") || "/";
+  return (
+    STANDALONE_DOC_PATH.test(normalized) ||
+    STANDALONE_PPT_DOC_PATH.test(normalized)
+  );
+}
+
+/**
+ * 当前窗口是否处于文档专注场景。SSR / 测试环境下 `window` 缺失时返回 false（退化为「非文档
+ * 场景」，即保持 IM 通知现状，fail-open 到既有行为而非误静音）。
+ */
+export function isDocumentFocusScene(): boolean {
+  if (typeof window === "undefined" || !window.location) return false;
+  return isDocumentScenePath(window.location.pathname);
+}

--- a/packages/dmworkbase/src/features/notifications/index.ts
+++ b/packages/dmworkbase/src/features/notifications/index.ts
@@ -1,2 +1,3 @@
 export * from "./messageAttention";
 export * from "./singleAlertCoordinator";
+export * from "./documentScene";

--- a/packages/dmworkbase/src/module.tsx
+++ b/packages/dmworkbase/src/module.tsx
@@ -123,6 +123,7 @@ import { isEffectivelyMuted, parseThreadChannelId } from "./Service/Thread";
 import {
   getBrowserSingleAlertCoordinator,
   isConversationChannelVisible,
+  isDocumentFocusScene,
   isMessageElementVisible,
   isSameMessageAttentionSession,
   shouldSuppressImmediateAlert,
@@ -501,7 +502,10 @@ export default class BaseModule implements IModule {
         friendApply.unread = true;
         friendApply.createdAt = message.timestamp;
         WKApp.shared.addFriendApply(friendApply);
-        this.tipsAudio();
+        // 文档专注场景不播提示音（红点/未读仍会更新）；IM 场景不受影响。
+        if (!isDocumentFocusScene()) {
+          this.tipsAudio();
+        }
       } else if (cmdContent.cmd === "friendAccept") {
         // 接受好友申请
         const toUID = param.to_uid;
@@ -872,6 +876,11 @@ export default class BaseModule implements IModule {
   allowNotify(message: Message) {
     if (WKApp.shared.notificationIsClose) {
       // 用户关闭了通知
+      return false;
+    }
+    if (isDocumentFocusScene()) {
+      // 文档专注场景（独立文档页 /d/:docId、/ppt/d/:docId）：不弹 IM 桌面通知、不播提示音，
+      // 仅保留红点/未读数。IM 场景不受影响。
       return false;
     }
     if (isCurrentImSystemMessage(message.contentType)) {


### PR DESCRIPTION
## 问题

打开独立文档页(`/d/:docId`)后,桌面 IM 通知音持续响起。文档页与 IM 聊天页共用同一套 SPA bundle:登录后同样跑 `startMain() → connectIM()`,`BaseModule.init()` 注册的 IM 消息监听在文档 tab 里照常触发 `tipsAudio()` 与桌面通知横幅——通知/提示音的触发点没有按「当前场景/路由」区分。

## 方案

新增纯函数场景判定 `isDocumentFocusScene()`(按 `window.location.pathname` 匹配 `/d/:docId`、`/ppt/d/:docId`,docId 段用与 `buildDocNavUrl` 一致的 URL/path 安全白名单),在通知触发点加「文档专注场景静音」分支:

- `allowNotify()` 命中文档场景直接 `return false`——它是常规消息路径的唯一中心门,既挡横幅(`alert()`)也挡提示音,且在 `isStillEligible` 里被复查,场景切换实时生效。
- 好友申请分支直接调用 `tipsAudio()`,绕过 `allowNotify()`,同样加文档场景判定。

红点/未读走独立管线,不受影响;IM 场景行为完全不变。SSR/测试环境 `window` 缺失时 fail-open 到既有 IM 行为(不误静音)。

## 验收

- ✅ 文档场景(`/d/:docId`、`/ppt/d/:docId`):IM 桌面通知音不响、不弹横幅,红点/未读正常。
- ✅ IM 场景:通知音/横幅行为不变。
- ✅ 场景判定按路由实时切换。

## 测试

- 新增 `documentScene.test.ts`:覆盖标准/幻灯片文档路由匹配、末尾斜杠归一、`/d`、`/d/`、`/dashboard`、嵌套/畸形 docId 等边界,以及 `isDocumentFocusScene()` 在文档页/应用壳的判定。
- `packages/dmworkbase` 通知模块全量测试通过;`@octo/web` vite build 通过。

Closes #1372
