### PR TITLE
fix: polish custom group avatar interactions

### DIFF
--- a/packages/dmworkbase/src/Components/ChannelAvatar/index.css
+++ b/packages/dmworkbase/src/Components/ChannelAvatar/index.css
@@ -216,8 +216,9 @@
     box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.08), 0 6px 14px rgba(15, 23, 42, 0.1);
 }
 
-.wk-channelavatar-setting-modal .wk-group-avatar-edit-color.selected {
-    box-shadow: inset 0 0 0 2px var(--semi-color-bg-0), 0 0 0 2px var(--semi-color-primary), 0 6px 14px rgba(15, 23, 42, 0.1);
+.wk-channelavatar-setting-modal .wk-group-avatar-edit-color.selected,
+.wk-channelavatar-setting-modal .wk-group-avatar-edit-color.selected:hover:not(:disabled) {
+    box-shadow: inset 0 0 0 2px var(--semi-color-bg-0), 0 0 0 2px var(--wk-group-avatar-color), 0 6px 14px rgba(15, 23, 42, 0.1);
 }
 
 .wk-channelavatar-setting-modal .wk-modal-footer {

--- a/packages/dmworkbase/src/Components/GroupAvatarEditModal/index.tsx
+++ b/packages/dmworkbase/src/Components/GroupAvatarEditModal/index.tsx
@@ -189,10 +189,13 @@ export const GroupAvatarEditForm: React.FC<GroupAvatarEditFormProps> = ({
               "wk-group-avatar-edit-color" +
               (c.index === colorIndex ? " selected" : "")
             }
-            style={{
-              background: c.fill,
-              borderColor: c.index === colorIndex ? c.main : "transparent",
-            }}
+            style={
+              {
+                background: c.fill,
+                borderColor: c.index === colorIndex ? c.main : "transparent",
+                "--wk-group-avatar-color": c.main,
+              } as React.CSSProperties
+            }
             onClick={() => selectColor(c.index)}
             disabled={disabled}
             aria-label={`avatar-color-${c.index}`}

--- a/packages/dmworkcontacts/src/Organizational/GroupNew/index.css
+++ b/packages/dmworkcontacts/src/Organizational/GroupNew/index.css
@@ -246,9 +246,31 @@
 }
 
 .group-create-edit-avatar {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 0;
+  border: 0;
+  background: transparent;
   color: var(--wk-color-theme);
   cursor: pointer;
+  font: inherit;
   font-size: 14px;
+}
+
+.group-create-edit-avatar:hover {
+  color: var(--wk-color-theme);
+  text-decoration: underline;
+}
+
+.group-create-edit-avatar:focus-visible {
+  outline: 2px solid var(--wk-color-theme);
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
+.group-create-edit-avatar-icon {
+  flex-shrink: 0;
 }
 
 .group-create-members {

--- a/packages/dmworkcontacts/src/i18n/en-US.json
+++ b/packages/dmworkcontacts/src/i18n/en-US.json
@@ -19,7 +19,7 @@
   "groupNew.title.selectContacts": "Select contacts",
   "groupCreate.title": "New group chat",
   "groupCreate.avatarLabel": "Group avatar",
-  "groupCreate.editAvatar": "Edit avatar",
+  "groupCreate.editAvatar": "Customize group avatar",
   "groupCreate.nameLabel": "Group name",
   "groupCreate.namePlaceholder": "e.g. Work, Study, Project name...",
   "groupCreate.nameRequired": "Please enter a group name",

--- a/packages/dmworkcontacts/src/i18n/zh-CN.json
+++ b/packages/dmworkcontacts/src/i18n/zh-CN.json
@@ -19,7 +19,7 @@
   "groupNew.title.selectContacts": "请选择联系人",
   "groupCreate.title": "发起群聊",
   "groupCreate.avatarLabel": "群聊头像",
-  "groupCreate.editAvatar": "修改头像",
+  "groupCreate.editAvatar": "自定义群头像",
   "groupCreate.nameLabel": "群聊名称",
   "groupCreate.namePlaceholder": "例：工作，学习，项目名称...",
   "groupCreate.nameRequired": "请输入群聊名称",

--- a/packages/dmworkcontacts/src/ui/GroupCreateDialog/index.tsx
+++ b/packages/dmworkcontacts/src/ui/GroupCreateDialog/index.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { IconEdit } from "@douyinfe/semi-icons";
 import { Input } from "@douyinfe/semi-ui";
 
 import { GroupAvatarEditModal, GroupAvatarPreview, WKModal } from "@octo/base";
@@ -43,12 +44,17 @@ function GroupCreateDialog({
                   name={form.groupName}
                   size={48}
                 />
-                <span
+                <button
+                  type="button"
                   className="group-create-edit-avatar"
                   onClick={actions.onOpenAvatarEditor}
                 >
+                  <IconEdit
+                    className="group-create-edit-avatar-icon"
+                    aria-hidden="true"
+                  />
                   {copy.editAvatar}
-                </span>
+                </button>
               </div>
             </div>
 

--- a/packages/dmworkcontacts/src/ui/GroupCreateDialog/index.tsx
+++ b/packages/dmworkcontacts/src/ui/GroupCreateDialog/index.tsx
@@ -1,6 +1,6 @@
 import React from "react";
-import { IconEdit } from "@douyinfe/semi-icons";
 import { Input } from "@douyinfe/semi-ui";
+import { Pencil } from "lucide-react";
 
 import { GroupAvatarEditModal, GroupAvatarPreview, WKModal } from "@octo/base";
 
@@ -49,7 +49,8 @@ function GroupCreateDialog({
                   className="group-create-edit-avatar"
                   onClick={actions.onOpenAvatarEditor}
                 >
-                  <IconEdit
+                  <Pencil
+                    size={16}
                     className="group-create-edit-avatar-icon"
                     aria-hidden="true"
                   />


### PR DESCRIPTION
## Summary
- Keep the selected avatar color border aligned with the avatar main color.
- Preserve the selected border while hovering.
- Add an edit icon and theme color to the new group chat avatar action.
- Rename the action to “自定义群头像” in Chinese and “Customize group avatar” in English.

## Validation
- `pnpm --filter @octo/contacts test`
- `pnpm exec vitest run packages/dmworkbase/src/Components/GroupAvatarEditModal/__tests__/GroupAvatarEditModal.test.tsx packages/dmworkbase/src/Components/ChannelAvatar/__tests__/ChannelAvatar.test.tsx`
- `pnpm i18n:check`
- `git diff --check`