### PR TITLE
fix(electron): clear auth session on logout

### DIFF
--- a/apps/web/src-election/main/__tests__/clearAuthSession.test.ts
+++ b/apps/web/src-election/main/__tests__/clearAuthSession.test.ts
@@ -11,7 +11,9 @@ describe("clearAuthSessionCookies", () => {
           { name: "sid", domain: "idp.example.com", path: "/", secure: true },
           { name: "scoped", domain: ".idp.example.com", path: "/auth", secure: true },
         ],
-        remove: async (url, name) => removed.push(`${url}:${name}`),
+      remove: async (url, name) => {
+        removed.push(`${url}:${name}`);
+      },
       },
       clearAuthCache: async () => {},
     };

--- a/apps/web/src-election/main/__tests__/clearAuthSession.test.ts
+++ b/apps/web/src-election/main/__tests__/clearAuthSession.test.ts
@@ -43,4 +43,30 @@ describe("clearAuthSessionCookies", () => {
     })).resolves.toEqual({ ok: true, cleared: 0, partial: true });
     expect(log).toHaveBeenCalled();
   });
+
+  it("continues removing the remaining cookies after one removal fails", async () => {
+    const removed: string[] = [];
+    const log = vi.fn();
+    const session: SessionLike = {
+      cookies: {
+        get: async () => [
+          { name: "failed", domain: "idp.example.com", path: "/", secure: true },
+          { name: "remaining", domain: "idp.example.com", path: "/", secure: true },
+        ],
+        remove: async (url, name) => {
+          if (name === "failed") throw new Error("remove failed");
+          removed.push(`${url}:${name}`);
+        },
+      },
+      clearAuthCache: async () => {},
+    };
+
+    await expect(clearAuthSessionCookies({
+      session,
+      origins: ["https://idp.example.com"],
+      log: { warn: log },
+    })).resolves.toEqual({ ok: true, cleared: 1, partial: true });
+    expect(removed).toEqual(["https://idp.example.com/:remaining"]);
+    expect(log).toHaveBeenCalled();
+  });
 });

--- a/apps/web/src-election/main/__tests__/clearAuthSession.test.ts
+++ b/apps/web/src-election/main/__tests__/clearAuthSession.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from "vitest";
+import { clearAuthSessionCookies, type SessionLike } from "../clearAuthSession";
+
+describe("clearAuthSessionCookies", () => {
+  it("clears deduplicated cookies and auth cache", async () => {
+    const removed: string[] = [];
+    const session: SessionLike = {
+      cookies: {
+        get: async () => [
+          { name: "sid", domain: "idp.example.com", path: "/", secure: true },
+          { name: "sid", domain: "idp.example.com", path: "/", secure: true },
+          { name: "scoped", domain: ".idp.example.com", path: "/auth", secure: true },
+        ],
+        remove: async (url, name) => removed.push(`${url}:${name}`),
+      },
+      clearAuthCache: async () => {},
+    };
+    const result = await clearAuthSessionCookies({
+      session,
+      origins: ["https://idp.example.com", "https://idp.example.com/"],
+      log: { warn: vi.fn() },
+    });
+    expect(result).toEqual({ ok: true, cleared: 2 });
+    expect(removed).toContain("https://idp.example.com/:sid");
+    expect(removed).toContain("https://idp.example.com/auth:scoped");
+  });
+
+  it("continues after an origin failure and reports partial", async () => {
+    const log = vi.fn();
+    const session: SessionLike = {
+      cookies: {
+        get: async ({ url }) => { if (url?.includes("bad")) throw new Error("boom"); return []; },
+        remove: async () => {},
+      },
+      clearAuthCache: async () => {},
+    };
+    await expect(clearAuthSessionCookies({
+      session,
+      origins: ["https://bad.example.com", "https://ok.example.com"],
+      log: { warn: log },
+    })).resolves.toEqual({ ok: true, cleared: 0, partial: true });
+    expect(log).toHaveBeenCalled();
+  });
+});

--- a/apps/web/src-election/main/clearAuthSession.ts
+++ b/apps/web/src-election/main/clearAuthSession.ts
@@ -1,0 +1,90 @@
+export interface CookieLike {
+  name: string;
+  domain?: string;
+  path?: string;
+  secure?: boolean;
+}
+
+export interface SessionLike {
+  cookies: {
+    get(filter: { url?: string; domain?: string }): Promise<CookieLike[]>;
+    remove(url: string, name: string): Promise<void>;
+  };
+  clearAuthCache(): Promise<void>;
+}
+
+export type ClearAuthSessionResult =
+  | { ok: true; cleared: number; partial?: true }
+  | { ok: false; code: "internal-error" };
+
+function removalUrl(cookie: CookieLike): string | undefined {
+  if (!cookie.domain) return undefined;
+  const domain = cookie.domain.replace(/^\./, "");
+  if (!domain) return undefined;
+  try {
+    return new URL(`${cookie.secure ? "https" : "http"}://${domain}${cookie.path || "/"}`).toString();
+  } catch {
+    return undefined;
+  }
+}
+
+function parseOrigin(value: string): { origin: string; hostname: string } | undefined {
+  try {
+    const url = new URL(value);
+    if (url.protocol !== "http:" && url.protocol !== "https:") return undefined;
+    return { origin: url.origin, hostname: url.hostname };
+  } catch {
+    return undefined;
+  }
+}
+
+export async function clearAuthSessionCookies(params: {
+  session: SessionLike;
+  origins: Iterable<string>;
+  log: { warn(message: string): void };
+}): Promise<ClearAuthSessionResult> {
+  try {
+    const targets = new Map<string, string>();
+    Array.from(params.origins).forEach((value) => {
+      const parsed = parseOrigin(value);
+      if (parsed) targets.set(parsed.origin, parsed.hostname);
+    });
+
+    let cleared = 0;
+    let partial = false;
+    const entries = Array.from(targets.entries());
+    for (let i = 0; i < entries.length; i += 1) {
+      const [origin, hostname] = entries[i];
+      try {
+        const cookies = [
+          ...(await params.session.cookies.get({ url: origin })),
+          ...(await params.session.cookies.get({ domain: hostname })),
+        ];
+        const seen = new Set<string>();
+        for (let j = 0; j < cookies.length; j += 1) {
+          const cookie = cookies[j];
+          const key = `${cookie.name}\0${cookie.domain || ""}\0${cookie.path || ""}`;
+          const url = removalUrl(cookie);
+          if (seen.has(key) || !url) continue;
+          seen.add(key);
+          await params.session.cookies.remove(url, cookie.name);
+          cleared += 1;
+        }
+      } catch (error) {
+        partial = true;
+        params.log.warn(`clearAuthSession: cookie sweep failed for ${origin}: ${error instanceof Error ? error.message : "unknown error"}`);
+      }
+    }
+
+    try {
+      await params.session.clearAuthCache();
+    } catch (error) {
+      partial = true;
+      params.log.warn(`clearAuthSession: clearAuthCache failed: ${error instanceof Error ? error.message : "unknown error"}`);
+    }
+    return partial ? { ok: true, cleared, partial: true } : { ok: true, cleared };
+  } catch (error) {
+    params.log.warn(`clearAuthSession: unexpected failure: ${error instanceof Error ? error.message : "unknown error"}`);
+    return { ok: false, code: "internal-error" };
+  }
+}

--- a/apps/web/src-election/main/clearAuthSession.ts
+++ b/apps/web/src-election/main/clearAuthSession.ts
@@ -67,8 +67,13 @@ export async function clearAuthSessionCookies(params: {
           const url = removalUrl(cookie);
           if (seen.has(key) || !url) continue;
           seen.add(key);
-          await params.session.cookies.remove(url, cookie.name);
-          cleared += 1;
+          try {
+            await params.session.cookies.remove(url, cookie.name);
+            cleared += 1;
+          } catch (error) {
+            partial = true;
+            params.log.warn(`clearAuthSession: cookie removal failed for ${origin}/${cookie.name}: ${error instanceof Error ? error.message : "unknown error"}`);
+          }
         }
       } catch (error) {
         partial = true;

--- a/apps/web/src-election/main/index.ts
+++ b/apps/web/src-election/main/index.ts
@@ -25,6 +25,7 @@ import {
   IPC_OIDC_AUTHORIZE_END,
   IPC_OIDC_HTTP_REQUEST,
   IPC_OIDC_OPEN_EXTERNAL,
+  IPC_OIDC_CLEAR_AUTH_SESSION,
 } from "../shared/ipc-channels";
 import OCTO_CONFIG, { OIDC_API_ORIGIN, OIDC_END_SESSION_ORIGINS } from "./config";
 import {
@@ -42,6 +43,7 @@ import { electronNotificationManager } from './notification';
 import { getRandomSid } from "./utils/search";
 import { attachLogoutWindowNavigationListeners, classifyOidcNavigation, extractEndSessionRedirect, isTrustedSenderUrl, OIDC_HTTP_MAX_RESPONSE_BYTES, parseHttpOrigin, parseOidcCallback, validateOidcHttpRequest, validateOpenExternalUrl, withTrustedSessionSid } from "./oidcRedirect";
 import { createTrustedShellDocumentTracker } from "./trustedShell";
+import { clearAuthSessionCookies } from "./clearAuthSession";
 
 let forceQuit = false;
 let mainWindow: any;
@@ -261,6 +263,16 @@ ipcMain.handle(IPC_OIDC_AUTHORIZE_END, (event) => {
   return { ok: !!win };
 });
 
+ipcMain.handle(IPC_OIDC_CLEAR_AUTH_SESSION, async (event) => {
+  const win = resolveTrustedOidcSender(event);
+  if (!win) return { ok: false as const, code: "untrusted-sender" as const };
+  return clearAuthSessionCookies({
+    session: win.webContents.session,
+    origins: OIDC_END_SESSION_ORIGINS,
+    log: { warn: (message) => console.warn(`[oidc] ${message}`) },
+  });
+});
+
 ipcMain.handle(IPC_OIDC_OPEN_EXTERNAL, async (event, url: unknown) => {
   const win = resolveTrustedOidcSender(event);
   if (!win) return { ok: false as const };
@@ -411,6 +423,12 @@ ipcMain.handle(IPC_OIDC_HTTP_REQUEST, async (event, request: unknown) => {
       response = await net.fetch(url, {
         method,
         redirect: "error",
+        // `net.fetch` runs in the main process, so its default credentials
+        // mode is not the renderer's `same-origin` context.  The OIDC
+        // callback establishes the session cookie in the BrowserWindow and
+        // authstatus must see that same cookie; without an explicit
+        // credentials mode packaged desktop login stays in PENDING forever.
+        credentials: "include",
         signal: controller.signal,
         headers: {
           Accept: "application/json",

--- a/apps/web/src-election/main/index.ts
+++ b/apps/web/src-election/main/index.ts
@@ -423,12 +423,6 @@ ipcMain.handle(IPC_OIDC_HTTP_REQUEST, async (event, request: unknown) => {
       response = await net.fetch(url, {
         method,
         redirect: "error",
-        // `net.fetch` runs in the main process, so its default credentials
-        // mode is not the renderer's `same-origin` context.  The OIDC
-        // callback establishes the session cookie in the BrowserWindow and
-        // authstatus must see that same cookie; without an explicit
-        // credentials mode packaged desktop login stays in PENDING forever.
-        credentials: "include",
         signal: controller.signal,
         headers: {
           Accept: "application/json",

--- a/apps/web/src-election/preload/index.ts
+++ b/apps/web/src-election/preload/index.ts
@@ -5,6 +5,7 @@ import {
   IPC_OIDC_AUTHORIZE_END,
   IPC_OIDC_HTTP_REQUEST,
   IPC_OIDC_OPEN_EXTERNAL,
+  IPC_OIDC_CLEAR_AUTH_SESSION,
 } from "../shared/ipc-channels";
 
 // Keep the preload entry self-contained. Electron runs sandboxed preloads in
@@ -110,6 +111,7 @@ const ALLOWED_INVOKE_CHANNELS = [
   IPC_OIDC_AUTHORIZE_END,
   IPC_OIDC_HTTP_REQUEST,
   IPC_OIDC_OPEN_EXTERNAL,
+  IPC_OIDC_CLEAR_AUTH_SESSION,
 ];
 
 const ALLOWED_RECEIVE_CHANNELS = [

--- a/apps/web/src-election/shared/ipc-channels.ts
+++ b/apps/web/src-election/shared/ipc-channels.ts
@@ -20,3 +20,6 @@ export const IPC_OIDC_HTTP_REQUEST = "oidc-http-request";
 
 /** Renderer → Main: open an IdP URL outside the embedded application window. */
 export const IPC_OIDC_OPEN_EXTERNAL = "oidc-open-external";
+
+/** Renderer → Main: clear authentication cookies and the session auth cache. */
+export const IPC_OIDC_CLEAR_AUTH_SESSION = "octo:oidc:clear-auth-session";

--- a/packages/dmworkbase/src/App.tsx
+++ b/packages/dmworkbase/src/App.tsx
@@ -2,6 +2,8 @@ import mitt, { Emitter } from "mitt";
 import { getSessionSid, setSessionSid } from "./Service/SessionScope";
 import { replaceWithShellDocument } from "./Service/ShellDocument";
 
+const IPC_CLEAR_AUTH_SESSION = "octo:oidc:clear-auth-session";
+
 /** mittBus 全局事件类型表 */
 export type MittEvents = {
   "friend-applys-unread-count": number;
@@ -946,7 +948,7 @@ export default class WKApp extends ProviderListener {
   // app启动
   startup() {
     if (consumeOidcPostLogoutCleanup()) {
-      this.clearLocalLoginState();
+      void this.clearLocalLoginState();
     }
     WKApp.loginInfo.load(); // 加载登录信息
 
@@ -1197,7 +1199,7 @@ export default class WKApp extends ProviderListener {
   isLogined() {
     return WKApp.loginInfo.isLogined();
   }
-  private clearLocalLoginState() {
+  private async clearLocalLoginState() {
     WKApp.loginInfo.logout();
     clearAuthStorage();
     setSessionSid("");
@@ -1205,16 +1207,27 @@ export default class WKApp extends ProviderListener {
     this.channelSpaceMap.clear();
     this.channelMySourceSpaceMap.clear();
     this.spaceChecked = false;
+    if (
+      (window as any).__POWERED_ELECTRON__ &&
+      typeof (window as any).ipc?.invoke === "function"
+    ) {
+      try {
+        await (window as any).ipc.invoke(IPC_CLEAR_AUTH_SESSION);
+      } catch {
+        // Local storage cleanup must still complete if the main process is
+        // unavailable; callers await this before reloading the shell.
+      }
+    }
     WKApp.mittBus.emit("wk:auth-state-changed");
   }
 
   // 登出
-  logout() {
+  async logout() {
     // 幂等守卫：并发 401 会重复调用本方法，只允许第一次真正执行清理与跳转，
     // 后续重入直接返回，避免 window.location.replace 被连发导致的反复跳转/刷屏。
     if (this._loggingOut) return;
     this._loggingOut = true;
-    this.clearLocalLoginState();
+    await this.clearLocalLoginState();
     // Packaged Electron shell loads via `file://` and has no `/login` route
     // on disk, so `location.replace("/login")` navigates to
     // `file:///login` and hangs on ERR_FILE_NOT_FOUND — the interceptor's

--- a/packages/dmworkbase/src/App.tsx
+++ b/packages/dmworkbase/src/App.tsx
@@ -1,6 +1,7 @@
 import mitt, { Emitter } from "mitt";
 import { getSessionSid, setSessionSid } from "./Service/SessionScope";
 import { replaceWithShellDocument } from "./Service/ShellDocument";
+import { runLogoutCleanup } from "./Service/logoutCleanup";
 
 const IPC_CLEAR_AUTH_SESSION = "octo:oidc:clear-auth-session";
 
@@ -1216,7 +1217,10 @@ export default class WKApp extends ProviderListener {
       typeof (window as any).ipc?.invoke === "function"
     ) {
       try {
-        await (window as any).ipc.invoke(IPC_CLEAR_AUTH_SESSION);
+        const result = await (window as any).ipc.invoke(IPC_CLEAR_AUTH_SESSION);
+        if (result?.ok !== true || result?.partial === true) {
+          console.warn("[auth] Electron auth-session cleanup was incomplete", result);
+        }
       } catch {
         // Local storage cleanup must still complete if the main process is
         // unavailable; callers await this before reloading the shell.
@@ -1230,8 +1234,10 @@ export default class WKApp extends ProviderListener {
     // 后续重入直接返回，避免 window.location.replace 被连发导致的反复跳转/刷屏。
     if (this._loggingOut) return;
     this._loggingOut = true;
-    await this.clearLocalLoginState();
-    await this.clearElectronAuthSession();
+    await runLogoutCleanup(
+      () => this.clearLocalLoginState(),
+      () => this.clearElectronAuthSession(),
+    );
     // Packaged Electron shell loads via `file://` and has no `/login` route
     // on disk, so `location.replace("/login")` navigates to
     // `file:///login` and hangs on ERR_FILE_NOT_FOUND — the interceptor's

--- a/packages/dmworkbase/src/App.tsx
+++ b/packages/dmworkbase/src/App.tsx
@@ -1207,6 +1207,10 @@ export default class WKApp extends ProviderListener {
     this.channelSpaceMap.clear();
     this.channelMySourceSpaceMap.clear();
     this.spaceChecked = false;
+    WKApp.mittBus.emit("wk:auth-state-changed");
+  }
+
+  private async clearElectronAuthSession() {
     if (
       (window as any).__POWERED_ELECTRON__ &&
       typeof (window as any).ipc?.invoke === "function"
@@ -1218,7 +1222,6 @@ export default class WKApp extends ProviderListener {
         // unavailable; callers await this before reloading the shell.
       }
     }
-    WKApp.mittBus.emit("wk:auth-state-changed");
   }
 
   // 登出
@@ -1228,6 +1231,7 @@ export default class WKApp extends ProviderListener {
     if (this._loggingOut) return;
     this._loggingOut = true;
     await this.clearLocalLoginState();
+    await this.clearElectronAuthSession();
     // Packaged Electron shell loads via `file://` and has no `/login` route
     // on disk, so `location.replace("/login")` navigates to
     // `file:///login` and hangs on ERR_FILE_NOT_FOUND — the interceptor's
@@ -1277,6 +1281,7 @@ export default class WKApp extends ProviderListener {
         ? import.meta.env.VITE_OIDC_POST_LOGOUT_REDIRECT_URI
         : undefined,
       clearLocalLoginState: () => this.clearLocalLoginState(),
+      clearElectronAuthSession: () => this.clearElectronAuthSession(),
       reloadShell: replaceWithShellDocument,
       navigateExternal: (url) => { window.location.href = url; },
       markPostLogoutCleanup: () => { markOidcPostLogoutCleanup(); },

--- a/packages/dmworkbase/src/Service/__tests__/oidcLogout.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/oidcLogout.test.ts
@@ -227,6 +227,7 @@ type SideEffects = ReturnType<typeof makeSideEffects>;
 function makeSideEffects() {
   return {
     clearLocalLoginState: vi.fn(),
+    clearElectronAuthSession: vi.fn(),
     reloadShell: vi.fn(),
     navigateExternal: vi.fn(),
     markPostLogoutCleanup: vi.fn(),
@@ -247,6 +248,7 @@ function buildDeps(
     env: "web",
     devPostLogoutRedirectUriOverride: undefined,
     clearLocalLoginState: sfx.clearLocalLoginState,
+    clearElectronAuthSession: sfx.clearElectronAuthSession,
     reloadShell: sfx.reloadShell,
     navigateExternal: sfx.navigateExternal,
     markPostLogoutCleanup: sfx.markPostLogoutCleanup,
@@ -313,6 +315,10 @@ describe("performOidcUserInitiatedLogout", () => {
 
     expect(result.kind).toBe("desktop-idp");
     expect(sfx.clearLocalLoginState).toHaveBeenCalledTimes(1);
+    expect(sfx.clearElectronAuthSession).toHaveBeenCalledTimes(1);
+    expect(sfx.clearElectronAuthSession.mock.invocationCallOrder[0]).toBeGreaterThan(
+      invoke.mock.invocationCallOrder[0],
+    );
     expect(invoke).toHaveBeenCalledWith(
       "oidc-open-external",
       "https://accounts.example.com/end_session?id_token_hint=jwt",
@@ -353,6 +359,7 @@ describe("performOidcUserInitiatedLogout", () => {
       "https://accounts.example.com/end_session",
     );
     expect(sfx.clearLocalLoginState).toHaveBeenCalledTimes(1);
+    expect(sfx.clearElectronAuthSession).toHaveBeenCalledTimes(1);
     expect(sfx.reloadShell).toHaveBeenCalledTimes(1);
     expect(sfx.navigateExternal).not.toHaveBeenCalled();
     expect(sfx.fallbackLogout).not.toHaveBeenCalled();

--- a/packages/dmworkbase/src/Service/logoutCleanup.ts
+++ b/packages/dmworkbase/src/Service/logoutCleanup.ts
@@ -1,0 +1,7 @@
+export async function runLogoutCleanup(
+  clearLocalLoginState: () => void | Promise<void>,
+  clearElectronAuthSession: () => void | Promise<void>,
+): Promise<void> {
+  await clearLocalLoginState();
+  await clearElectronAuthSession();
+}

--- a/packages/dmworkbase/src/Service/oidcLogout.ts
+++ b/packages/dmworkbase/src/Service/oidcLogout.ts
@@ -314,6 +314,10 @@ export interface OidcUserInitiatedLogoutDeps {
   // Side-effects the orchestration performs. Injected so the test asserts
   // the sequence without touching real jsdom navigation.
   clearLocalLoginState: () => void | Promise<void>;
+  // Electron provider cookies must remain available while the hidden
+  // end-session window is navigating. The wrapper performs this cleanup only
+  // after that flow has completed (or the local fallback has taken over).
+  clearElectronAuthSession?: () => void | Promise<void>;
   reloadShell: () => void; // window.location.reload()
   navigateExternal: (url: string) => void; // window.location.href = url
   markPostLogoutCleanup: () => void; // markOidcPostLogoutCleanup()
@@ -393,6 +397,11 @@ export async function performOidcUserInitiatedLogout(
         await deps.fallbackLogout();
         return { kind: "desktop-local", url: endSessionUrl };
       }
+      // Do not clear the shell's auth session before IPC_OIDC_OPEN_EXTERNAL:
+      // the hidden BrowserWindow uses the same session and needs the IdP
+      // cookies to complete provider logout. At this point the main process
+      // has finished (or timed out) the end-session navigation.
+      await deps.clearElectronAuthSession?.();
       deps.reloadShell();
       return { kind: "desktop-idp", url: endSessionUrl };
     }

--- a/packages/dmworkbase/src/Service/oidcLogout.ts
+++ b/packages/dmworkbase/src/Service/oidcLogout.ts
@@ -313,11 +313,11 @@ export interface OidcUserInitiatedLogoutDeps {
   devPostLogoutRedirectUriOverride: unknown;
   // Side-effects the orchestration performs. Injected so the test asserts
   // the sequence without touching real jsdom navigation.
-  clearLocalLoginState: () => void;
+  clearLocalLoginState: () => void | Promise<void>;
   reloadShell: () => void; // window.location.reload()
   navigateExternal: (url: string) => void; // window.location.href = url
   markPostLogoutCleanup: () => void; // markOidcPostLogoutCleanup()
-  fallbackLogout: () => void; // WKApp.logout()
+  fallbackLogout: () => void | Promise<void>; // WKApp.logout()
   // Injected for testability. Defaults in the wrapper call site.
   requestLogout?: typeof requestOidcLogout;
   createFetcher?: typeof createOidcLogoutFetcher;
@@ -344,7 +344,7 @@ export async function performOidcUserInitiatedLogout(
   };
 
   if (!isOidcLoginProvider(deps.loginProvider) || !deps.token) {
-    deps.fallbackLogout();
+    await deps.fallbackLogout();
     return { kind: "not-oidc" };
   }
 
@@ -370,11 +370,11 @@ export async function performOidcUserInitiatedLogout(
     if (!endSessionUrl) {
       // IdP returned no usable end-session URL. Fall back to local logout so
       // the app is not left mounted in an authenticated state.
-      deps.fallbackLogout();
+      await deps.fallbackLogout();
       return { kind: "no-end-session" };
     }
 
-    deps.clearLocalLoginState();
+    await deps.clearLocalLoginState();
 
     if (deps.env === "desktop-shell") {
       // Keep user-initiated logout inside the desktop app. The main process
@@ -382,7 +382,7 @@ export async function performOidcUserInitiatedLogout(
       // cleared without showing the browser/Web login page to the user.
       const ipcInvoke = deps.ipc?.invoke;
       if (typeof ipcInvoke !== "function") {
-        deps.fallbackLogout();
+        await deps.fallbackLogout();
         return { kind: "desktop-local", url: endSessionUrl };
       }
       const opened = (await ipcInvoke(
@@ -390,7 +390,7 @@ export async function performOidcUserInitiatedLogout(
         endSessionUrl
       )) as { ok?: boolean } | undefined;
       if (opened?.ok !== true) {
-        deps.fallbackLogout();
+        await deps.fallbackLogout();
         return { kind: "desktop-local", url: endSessionUrl };
       }
       deps.reloadShell();
@@ -404,7 +404,7 @@ export async function performOidcUserInitiatedLogout(
     return { kind: "web-redirect", url: endSessionUrl };
   } catch (error) {
     logger.warn("OIDC logout failed, falling back to local logout", error);
-    deps.fallbackLogout();
+    await deps.fallbackLogout();
     return { kind: "logout-error", error };
   }
 }

--- a/packages/dmworkbase/src/__tests__/App.clearAuthSessionIpc.test.ts
+++ b/packages/dmworkbase/src/__tests__/App.clearAuthSessionIpc.test.ts
@@ -4,11 +4,12 @@ import { readFileSync } from "node:fs";
 const appSource = readFileSync("src/App.tsx", "utf8");
 
 describe("clear-auth-session IPC wiring", () => {
-  it("invokes cleanup only in Electron and does not block logout", () => {
+  it("keeps Electron auth-session cleanup separate from local state cleanup", () => {
     expect(appSource).toContain('const IPC_CLEAR_AUTH_SESSION = "octo:oidc:clear-auth-session"');
     expect(appSource).toMatch(/__POWERED_ELECTRON__\s*&&[\s\S]*ipc\?\.invoke/);
     expect(appSource).toContain("ipc.invoke(IPC_CLEAR_AUTH_SESSION)");
     expect(appSource).toMatch(/await\s+\(window as any\)\.ipc\.invoke\(IPC_CLEAR_AUTH_SESSION\)/);
     expect(appSource).toContain("catch {");
+    expect(appSource).toMatch(/clearLocalLoginState\(\)[\s\S]*?clearElectronAuthSession\(\)/);
   });
 });

--- a/packages/dmworkbase/src/__tests__/App.clearAuthSessionIpc.test.ts
+++ b/packages/dmworkbase/src/__tests__/App.clearAuthSessionIpc.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+
+const appSource = readFileSync("src/App.tsx", "utf8");
+
+describe("clear-auth-session IPC wiring", () => {
+  it("invokes cleanup only in Electron and does not block logout", () => {
+    expect(appSource).toContain('const IPC_CLEAR_AUTH_SESSION = "octo:oidc:clear-auth-session"');
+    expect(appSource).toMatch(/__POWERED_ELECTRON__\s*&&[\s\S]*ipc\?\.invoke/);
+    expect(appSource).toContain("ipc.invoke(IPC_CLEAR_AUTH_SESSION)");
+    expect(appSource).toMatch(/await\s+\(window as any\)\.ipc\.invoke\(IPC_CLEAR_AUTH_SESSION\)/);
+    expect(appSource).toContain("catch {");
+  });
+});

--- a/packages/dmworkbase/src/__tests__/App.clearAuthSessionIpc.test.ts
+++ b/packages/dmworkbase/src/__tests__/App.clearAuthSessionIpc.test.ts
@@ -1,15 +1,16 @@
-import { describe, expect, it } from "vitest";
-import { readFileSync } from "node:fs";
-
-const appSource = readFileSync("src/App.tsx", "utf8");
+import { describe, expect, it, vi } from "vitest";
+import { runLogoutCleanup } from "../Service/logoutCleanup";
 
 describe("clear-auth-session IPC wiring", () => {
-  it("keeps Electron auth-session cleanup separate from local state cleanup", () => {
-    expect(appSource).toContain('const IPC_CLEAR_AUTH_SESSION = "octo:oidc:clear-auth-session"');
-    expect(appSource).toMatch(/__POWERED_ELECTRON__\s*&&[\s\S]*ipc\?\.invoke/);
-    expect(appSource).toContain("ipc.invoke(IPC_CLEAR_AUTH_SESSION)");
-    expect(appSource).toMatch(/await\s+\(window as any\)\.ipc\.invoke\(IPC_CLEAR_AUTH_SESSION\)/);
-    expect(appSource).toContain("catch {");
-    expect(appSource).toMatch(/clearLocalLoginState\(\)[\s\S]*?clearElectronAuthSession\(\)/);
+  it("clears local state before the Electron auth session", async () => {
+    const calls: string[] = [];
+    const clearLocalLoginState = vi.fn(async () => calls.push("local"));
+    const clearElectronAuthSession = vi.fn(async () => calls.push("electron"));
+
+    await runLogoutCleanup(clearLocalLoginState, clearElectronAuthSession);
+
+    expect(calls).toEqual(["local", "electron"]);
+    expect(clearLocalLoginState).toHaveBeenCalledOnce();
+    expect(clearElectronAuthSession).toHaveBeenCalledOnce();
   });
 });


### PR DESCRIPTION
## Summary
- clear Electron session cookies and auth cache during logout
- keep OIDC logout flow compatible with async local cleanup
- add IPC and cleanup unit coverage

## Verification
- targeted web tests: 7 passed
- targeted dmworkbase tests: 22 passed
- Electron main TypeScript check passed