### PR TITLE
feat(track): channel-setting panel event tracking + stable http_request route templates

### DIFF
--- a/packages/dmworkbase/src/Components/Sections/__tests__/sectionsTrack.test.tsx
+++ b/packages/dmworkbase/src/Components/Sections/__tests__/sectionsTrack.test.tsx
@@ -1,0 +1,52 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import Sections from "../index";
+import { Row, Section } from "../../../Service/Section";
+
+vi.mock("../index.css", () => ({}));
+
+const Cell = ({ title }: { title?: string }) => <span>{title}</span>;
+
+/**
+ * 护住 PR #1390 的 data-track 渲染契约(review P2-3):
+ * 带 trackEvent 的行 wrapper 才挂 data-track / data-track-*;不带的行零属性(零回归)。
+ */
+describe("Sections data-track rendering", () => {
+  it("emits data-track and data-track-* for a Row that sets trackEvent/trackProps", () => {
+    const section = new Section({
+      rows: [
+        new Row({
+          cell: Cell,
+          trackEvent: "conversation_clear_dialog_opened",
+          trackProps: { source: "danger", index: 2 },
+          properties: { title: "clear" },
+        }),
+      ],
+    });
+
+    const { container } = render(<Sections sections={[section]} />);
+    const wrapper = container.querySelector(".wk-section-row") as HTMLElement;
+
+    expect(wrapper.getAttribute("data-track")).toBe(
+      "conversation_clear_dialog_opened"
+    );
+    expect(wrapper.getAttribute("data-track-source")).toBe("danger");
+    expect(wrapper.getAttribute("data-track-index")).toBe("2");
+  });
+
+  it("emits no track attributes for a Row without trackEvent", () => {
+    const section = new Section({
+      rows: [new Row({ cell: Cell, properties: { title: "plain" } })],
+    });
+
+    const { container } = render(<Sections sections={[section]} />);
+    const wrapper = container.querySelector(".wk-section-row") as HTMLElement;
+
+    const trackAttrs = wrapper
+      .getAttributeNames()
+      .filter((name) => name.startsWith("data-track"));
+    expect(trackAttrs).toEqual([]);
+  });
+});

--- a/packages/dmworkbase/src/Components/Sections/index.tsx
+++ b/packages/dmworkbase/src/Components/Sections/index.tsx
@@ -23,7 +23,19 @@ export default class Sections extends Component<SectionsProps> {
                                 section.rows?.map((row, j) => {
                                     const Cell = row.cell
                                     const { key: cellKey, ...cellProps } = row.properties ?? {}
-                                    return <div key={j} className="wk-section-row">
+                                    // 埋点:行配置带 trackEvent → wrapper 挂 data-track,整行点击经既有捕获委托上报;
+                                    // trackProps 渲染成 data-track-*(collectDatasetProps 采,不读 value/正文)。
+                                    // 未设则不挂任何属性,行为与旧实现完全一致(零回归)。
+                                    const trackAttrs: Record<string, string> = {}
+                                    if (row.trackEvent) {
+                                        trackAttrs["data-track"] = row.trackEvent
+                                        if (row.trackProps) {
+                                            for (const k in row.trackProps) {
+                                                trackAttrs[`data-track-${k}`] = String(row.trackProps[k])
+                                            }
+                                        }
+                                    }
+                                    return <div key={j} className="wk-section-row" {...trackAttrs}>
                                         <Cell key={cellKey} {...cellProps}></Cell>
                                     </div>
                                 })

--- a/packages/dmworkbase/src/Service/APIClient.ts
+++ b/packages/dmworkbase/src/Service/APIClient.ts
@@ -1,6 +1,7 @@
 import axios, { AxiosResponse } from "axios";
 import { buildAcceptLanguage } from "./apiLanguage";
 import { isAuthExpiredApiError, normalizeApiError, NormalizedApiError } from "./apiError";
+import { registerRequestTemplate } from "./apiPath";
 
 declare module "axios" {
     interface AxiosRequestConfig {
@@ -86,6 +87,12 @@ export default class APIClient {
         axios.interceptors.request.use(function (config) {
             config.headers = config.headers || {};
             config.headers["Accept-Language"] = buildAcceptLanguage();
+            // 埋点路由模板登记(见 apiPath.ts):唯一知道 baseURL 的地方,把 apiPath 产出的
+            // 具体路径与模板按最终 pathname 对齐,供 Dap http_request 上报稳定模板而非反解归一。
+            // 非 apiPath 路径无副作用;登记失败绝不影响请求本身。
+            try {
+                registerRequestTemplate(config.url, config.baseURL ?? axios.defaults.baseURL ?? undefined);
+            } catch { /* 埋点旁路,任何异常不得波及业务请求 */ }
             let token:string | undefined
             if(self.config.tokenCallback) {
                 token = self.config.tokenCallback()

--- a/packages/dmworkbase/src/Service/BotManageService.ts
+++ b/packages/dmworkbase/src/Service/BotManageService.ts
@@ -1,4 +1,5 @@
 import APIClient from "./APIClient"
+import { apiPath } from "./apiPath"
 
 export interface BotGroupItem {
   group_no: string
@@ -61,19 +62,19 @@ const BotManageService = {
     if (request.cursor) {
       param.cursor = request.cursor
     }
-    return APIClient.shared.get(`robot/${request.robotId}/groups`, { param })
+    return APIClient.shared.get(apiPath`robot/${request.robotId}/groups`, { param })
   },
 
   enableMentionFree(robotId: string, groupNo: string): Promise<void> {
     return APIClient.shared.put(
-      `robot/${robotId}/groups/${groupNo}/mention_pref`,
+      apiPath`robot/${robotId}/groups/${groupNo}/mention_pref`,
       { no_mention: 1 },
     )
   },
 
   disableMentionFree(robotId: string, groupNo: string): Promise<void> {
     return APIClient.shared.delete(
-      `robot/${robotId}/groups/${groupNo}/mention_pref`,
+      apiPath`robot/${robotId}/groups/${groupNo}/mention_pref`,
     )
   },
 
@@ -88,7 +89,7 @@ const BotManageService = {
    * 它是代码里拼出来的带点号常量，编码一下更稳妥。这个不对称是既有约定，不是笔误。
    */
   listSettings(robotId: string): Promise<BotSettingsListResponse> {
-    return APIClient.shared.get(`robot/${robotId}/settings`)
+    return APIClient.shared.get(apiPath`robot/${robotId}/settings`)
   },
 
   /**
@@ -99,7 +100,7 @@ const BotManageService = {
     robotId: string,
     items: BotSettingWriteItem[],
   ): Promise<void> {
-    return APIClient.shared.put(`robot/${robotId}/settings`, { items })
+    return APIClient.shared.put(apiPath`robot/${robotId}/settings`, { items })
   },
 
   /**
@@ -111,7 +112,7 @@ const BotManageService = {
    */
   deleteSetting(robotId: string, key: string): Promise<void> {
     return APIClient.shared.delete(
-      `robot/${robotId}/settings/${encodeURIComponent(key)}`,
+      apiPath`robot/${robotId}/settings/${encodeURIComponent(key)}`,
     )
   },
 }

--- a/packages/dmworkbase/src/Service/BotProfileService.ts
+++ b/packages/dmworkbase/src/Service/BotProfileService.ts
@@ -1,5 +1,6 @@
 import axios from "axios"
 import APIClient from "./APIClient"
+import { apiPath } from "./apiPath"
 
 export interface BotProfile {
   bot_creator_uid?: string
@@ -21,11 +22,11 @@ export interface BotFriendApplyRequest {
 
 const BotProfileService = {
   getBotProfile(uid: string): Promise<BotProfile> {
-    return APIClient.shared.get(`users/${uid}`)
+    return APIClient.shared.get(apiPath`users/${uid}`)
   },
 
   updateDescription(uid: string, description: string): Promise<void> {
-    return APIClient.shared.put(`robot/${uid}/description`, { description })
+    return APIClient.shared.put(apiPath`robot/${uid}/description`, { description })
   },
 
   updateRemark(uid: string, remark: string): Promise<void> {

--- a/packages/dmworkbase/src/Service/CategoryService.ts
+++ b/packages/dmworkbase/src/Service/CategoryService.ts
@@ -1,4 +1,5 @@
 import APIClient from "./APIClient"
+import { apiPath } from "./apiPath"
 
 export interface CategoryGroup {
     group_no: string
@@ -39,27 +40,27 @@ const CategoryService = {
 
     /** 创建分组 */
     create(spaceId: string, req: CreateCategoryReq): Promise<CategoryItem> {
-        return APIClient.shared.post(`/spaces/${spaceId}/categories`, req)
+        return APIClient.shared.post(apiPath`/spaces/${spaceId}/categories`, req)
     },
 
     /** 重命名分组 */
     update(spaceId: string, categoryId: string, req: UpdateCategoryReq): Promise<void> {
-        return APIClient.shared.put(`/spaces/${spaceId}/categories/${categoryId}`, req)
+        return APIClient.shared.put(apiPath`/spaces/${spaceId}/categories/${categoryId}`, req)
     },
 
     /** 删除分组 */
     delete(spaceId: string, categoryId: string): Promise<void> {
-        return APIClient.shared.delete(`/spaces/${spaceId}/categories/${categoryId}`)
+        return APIClient.shared.delete(apiPath`/spaces/${spaceId}/categories/${categoryId}`)
     },
 
     /** 批量排序分组 */
     sort(spaceId: string, req: SortCategoriesReq): Promise<void> {
-        return APIClient.shared.put(`/spaces/${spaceId}/categories/sort`, req)
+        return APIClient.shared.put(apiPath`/spaces/${spaceId}/categories/sort`, req)
     },
 
     /** 移动群聊到分组 */
     moveGroupToCategory(groupNo: string, req: MoveGroupToCategoryReq): Promise<void> {
-        return APIClient.shared.put(`/groups/${groupNo}/category`, req)
+        return APIClient.shared.put(apiPath`/groups/${groupNo}/category`, req)
     },
 }
 

--- a/packages/dmworkbase/src/Service/ChannelSettingService.ts
+++ b/packages/dmworkbase/src/Service/ChannelSettingService.ts
@@ -8,6 +8,7 @@ import APIClient from "./APIClient";
 import { ChannelTypeCommunityTopic } from "./Const";
 import { hasSpacePrefix, stripSpacePrefix } from "./SpacePrefix";
 import { parseThreadChannelId } from "./Thread";
+import { apiPath } from './apiPath'
 
 export type ChannelSettingPayload = Record<string, any>;
 
@@ -34,12 +35,12 @@ export async function updateChannelSetting(
   channel: Channel
 ): Promise<void> {
   if (channel.channelType === ChannelTypeGroup) {
-    return APIClient.shared.put(`groups/${channel.channelID}/setting`, setting);
+    return APIClient.shared.put(apiPath`groups/${channel.channelID}/setting`, setting);
   }
 
   if (channel.channelType === ChannelTypePerson) {
     return APIClient.shared.put(
-      `users/${stripSpacePrefix(channel.channelID)}/setting`,
+      apiPath`users/${stripSpacePrefix(channel.channelID)}/setting`,
       setting
     );
   }
@@ -50,7 +51,7 @@ export async function updateChannelSetting(
       return;
     }
     return APIClient.shared.put(
-      `groups/${threadInfo.groupNo}/threads/${threadInfo.shortId}/setting`,
+      apiPath`groups/${threadInfo.groupNo}/threads/${threadInfo.shortId}/setting`,
       setting
     );
   }
@@ -83,7 +84,7 @@ export async function addChannelSubscribers(
   channel: Channel,
   uids: string[]
 ): Promise<void> {
-  await APIClient.shared.post(`groups/${channel.channelID}/members`, {
+  await APIClient.shared.post(apiPath`groups/${channel.channelID}/members`, {
     members: uids,
   });
 }
@@ -92,7 +93,7 @@ export async function removeChannelSubscribers(
   channel: Channel,
   uids: string[]
 ): Promise<void> {
-  await APIClient.shared.delete(`groups/${channel.channelID}/members`, {
+  await APIClient.shared.delete(apiPath`groups/${channel.channelID}/members`, {
     data: {
       members: uids,
     },
@@ -104,7 +105,7 @@ export function updateChannelField(
   field: string,
   value: string
 ): Promise<void> {
-  return APIClient.shared.put(`groups/${channel.channelID}`, {
+  return APIClient.shared.put(apiPath`groups/${channel.channelID}`, {
     [field]: value,
   });
 }
@@ -140,7 +141,7 @@ export function transferChannelOwner(
   if (isPersonChannel(channel)) {
     return Promise.resolve();
   }
-  return APIClient.shared.post(`groups/${channel.channelID}/transfer/${uid}`);
+  return APIClient.shared.post(apiPath`groups/${channel.channelID}/transfer/${uid}`);
 }
 
 export function updateChannelSubscriberAttr(
@@ -152,7 +153,7 @@ export function updateChannelSubscriberAttr(
     return Promise.resolve();
   }
   return APIClient.shared.put(
-    `groups/${channel.channelID}/members/${subscriberUID}`,
+    apiPath`groups/${channel.channelID}/members/${subscriberUID}`,
     attr
   );
 }
@@ -161,7 +162,7 @@ export function exitChannel(channel: Channel): Promise<void> {
   if (isPersonChannel(channel)) {
     return Promise.resolve();
   }
-  return APIClient.shared.post(`groups/${channel.channelID}/exit`);
+  return APIClient.shared.post(apiPath`groups/${channel.channelID}/exit`);
 }
 
 export function updateThread(
@@ -169,9 +170,9 @@ export function updateThread(
   shortId: string,
   data: Record<string, any>
 ): Promise<void> {
-  return APIClient.shared.put(`groups/${groupNo}/threads/${shortId}`, data);
+  return APIClient.shared.put(apiPath`groups/${groupNo}/threads/${shortId}`, data);
 }
 
 export function leaveThread(shortId: string): Promise<void> {
-  return APIClient.shared.post(`threads/${shortId}/leave`);
+  return APIClient.shared.post(apiPath`threads/${shortId}/leave`);
 }

--- a/packages/dmworkbase/src/Service/Dap.ts
+++ b/packages/dmworkbase/src/Service/Dap.ts
@@ -18,6 +18,13 @@
  *   - 远程 kill switch:`enabled=false` 时 track/pageView 立即 return,清空队列,业务零影响。
  */
 
+// 唯一的模块依赖:埋点路由模板 registry(见 apiPath.ts)。apiPath 自身零依赖,不成环。
+// 供 normalizePath 优先命中调用处已知的路由模板,命中不了才退回本文件的白名单归一兜底。
+import { templateForPathname } from './apiPath'
+// 锚点规则表(见 TrackRules.ts):点击委托 closest('[data-track]') 落空后的纯前端 fallback。
+// TrackRules 自身零依赖,不成环。
+import { TRACK_RULES, buildIndex, matchRoute, type TrackRule, type TrackRuleIndex } from './TrackRules'
+
 export type TrackPrimitive = string | number | boolean | null
 
 /** 上报信封:每条事件出队前补齐(§2.4)。刻意不含 flow_id / actor_*。 */
@@ -140,15 +147,24 @@ const ROUTE_WORDS = new Set<string>([
 ])
 
 /**
- * 请求路径归一(§8 隐私边界:绝不泄文件名 / 对象键 / 用户名 / 凭证 / 正文)。**白名单路由词式**:
- * 每段只有命中 ROUTE_WORDS(声明过的静态路由词)才原样保留;其余一切一律占位符化——纯数字 /
- * 长 hex / uuid 记作 :id(仅为可读性,安全上等价),其余记作 :seg。默认即 mask,故用户名、
- * 一次性 login_authcode、邀请码、invite token、文件名、percent-encoded 段等都不可能进 telemetry。
+ * 请求路径归一(§8 隐私边界:绝不泄文件名 / 对象键 / 用户名 / 凭证 / 正文)。
+ *
+ * **优先**:命中调用处经 `apiPath` 登记的路由模板(见 apiPath.ts)——直接上报源码里的静态
+ * 路由模板(`/api/v1/spaces/:id/categories/:id`),字面业务段原样可见、变量段占位 :id,
+ * 同一 endpoint 无论 id 怎么变都是同一个稳定模板,且模板里从不含变量值,隐私天然安全。
+ *
+ * **兜底**(未经 apiPath 的请求 / 直接 axios / 第三方库):**白名单路由词式**归一——每段只有
+ * 命中 ROUTE_WORDS(声明过的静态路由词)才原样保留;其余一切一律占位符化——纯数字 / 长 hex /
+ * uuid 记作 :id(仅为可读性,安全上等价),其余记作 :seg。默认即 mask,故用户名、一次性
+ * login_authcode、邀请码、invite token、文件名、percent-encoded 段等都不可能进 telemetry。
  */
 function normalizePath(rawUrl: string): string {
     try {
         // 相对/绝对都能解析;base 仅用于补全,不进结果
         const u = new URL(rawUrl, 'http://x')
+        // 优先:调用处已知的路由模板(无损、稳定、隐私安全)。按 pathname 精确命中。
+        const template = templateForPathname(u.pathname)
+        if (template !== undefined) return template
         return u.pathname
             .split('/')
             .map((seg) => {
@@ -219,6 +235,12 @@ function statusBucket(status: number): string {
 function isAbortError(err: unknown): boolean {
     return !!err && typeof err === 'object' && (err as { name?: string }).name === 'AbortError'
 }
+
+/**
+ * 点击委托 resolver 的归宿:命中的元素 + 事件名 + 可选静态 props。
+ * data-track 路径 event 取 dataset.track、props 省略;规则表路径 event/props 来自 TrackRule。
+ */
+type Resolved = { el: HTMLElement; event: string; props?: Record<string, TrackPrimitive> }
 
 class DapImpl {
     /** 会话内唯一;仅作为埋点事件 envelope 的 session_id 随上报发出(采集启用时才发)。纯内存,不落盘。 */
@@ -578,28 +600,44 @@ class DapImpl {
     // ----------------------------------------------- 机制① 全局事件委托
 
     private installClickDelegation(): void {
-        // 解析被点/被激活元素归属的 [data-track],并施加 data-track-ignore 排除。
-        const resolveTracked = (target: HTMLElement | null): HTMLElement | null => {
+        // 规则表索引:安装时构建一次(此刻读 TRACK_RULES)。data-track 落空才查它,故对现有
+        // 声明式埋点零影响;表为空时 fallback 恒 miss,行为与旧实现完全一致。
+        const index = buildIndex(TRACK_RULES)
+        // 解析被点/被激活元素归属的埋点归宿:先 data-track(绝对优先),落空再查规则表 fallback。
+        // 返回从「元素」升级为 { el, event, props? }:data-track 命中时 event 取 dataset.track、
+        // 无静态 props;规则命中时 event / props 来自规则表。两路统一交给 fire()。
+        const resolveTracked = (
+            target: HTMLElement | null,
+            evType: 'click' | 'submit' | 'keydown',
+        ): Resolved | null => {
             if (!target || typeof target.closest !== 'function') return null
             const el = target.closest<HTMLElement>('[data-track]')
-            if (!el) return null
-            // 落在被显式标记「本次交互不代表该 data-track 动作」的子控件里则跳过:
-            // 如会话行(channel_opened)内的拖拽柄/展开线程标签、市场卡片 footer 的编辑/删除
-            // 按钮——它们 stopPropagation 表示「不代表该事件」,但捕获阶段先于 stopPropagation
-            // 执行,故改用 data-track-ignore 显式排除(ignore 须是被点元素到 tracked 元素之间的一层)。
-            const ignore = target.closest<HTMLElement>('[data-track-ignore]')
-            if (ignore && el !== ignore && el.contains(ignore)) return null
-            return el
+            if (el) {
+                // 落在被显式标记「本次交互不代表该 data-track 动作」的子控件里则跳过:
+                // 如会话行(channel_opened)内的拖拽柄/展开线程标签、市场卡片 footer 的编辑/删除
+                // 按钮——它们 stopPropagation 表示「不代表该事件」,但捕获阶段先于 stopPropagation
+                // 执行,故改用 data-track-ignore 显式排除(ignore 须是被点元素到 tracked 元素之间的一层)。
+                if (this.isTrackIgnored(target, el)) return null
+                const event = el.dataset.track
+                if (!event) return null
+                return { el, event }
+            }
+            // data-track 落空 → 规则表 fallback。只吃「没有 data-track」的节点 → 现有埋点零回归。
+            return this.resolveByRules(target, evType, index)
         }
-        const fire = (el: HTMLElement) => {
-            const name = el.dataset.track
-            if (!name) return
-            this.track(name, this.collectDatasetProps(el))
+        const fire = (r: Resolved) => {
+            if (!r.event) return
+            // 合并规则静态 props 与 collectDatasetProps(el)(读 data-*,不读 value/正文);
+            // 让运行时 data-object-id 等覆盖同名静态项。data-track 路径无静态 props,退化为原行为。
+            const dsProps = this.collectDatasetProps(r.el)
+            const props = r.props ? { ...r.props, ...dsProps } : dsProps
+            this.track(r.event, props)
         }
         const clickHandler = (e: Event) => {
             this.safe(() => {
-                const el = resolveTracked(e.target as HTMLElement | null)
-                if (el) fire(el)
+                const evType = e.type === 'submit' ? 'submit' : 'click'
+                const r = resolveTracked(e.target as HTMLElement | null, evType)
+                if (r) fire(r)
             })
         }
         // 键盘激活补采:role="button" 等**非原生**控件(如市场卡片 McpCard/SkillCard 是
@@ -607,14 +645,14 @@ class DapImpl {
         // 派发 click,声明式 click 委托整条漏采——键盘用户打开详情却无任何事件(见 PR #1320
         // review P1-4)。这里补一条 keydown:仅对**非原生可激活**的聚焦元素在 Enter/Space 时
         // 补发;原生 button/a[href]/input/select/textarea/summary 会自行合成 click(已被上面的
-        // 委托覆盖),显式排除以免双记。
+        // 委托覆盖),显式排除以免双记。规则表命中的节点走同一 resolver,故键盘激活同样能采到。
         const keydownHandler = (e: KeyboardEvent) => {
             this.safe(() => {
                 if (e.key !== 'Enter' && e.key !== ' ' && e.key !== 'Spacebar') return
                 const target = e.target as HTMLElement | null
                 if (!target || this.isNativeActivatable(target)) return
-                const el = resolveTracked(target)
-                if (el) fire(el)
+                const r = resolveTracked(target, 'keydown')
+                if (r) fire(r)
             })
         }
         // 捕获阶段:即使业务层 stopPropagation 也能采到。
@@ -627,6 +665,120 @@ class DapImpl {
         document.addEventListener('click', clickHandler, true)
         document.addEventListener('submit', clickHandler, true)
         document.addEventListener('keydown', keydownHandler, true)
+    }
+
+    /**
+     * 规则表 fallback:从被点元素沿 parentElement 向上 walk,逐个祖先看 `data-testid`,用它查
+     * byTestid 主索引;再用 route + closestTestid + on + role 做 AND 约束消歧。命中数 >1 打 warn
+     * 取第一条。testid 主路径 miss 后,再走少量 loose(role/aria)线性兜底。全程只读 data-testid /
+     * role 属性,绝不读 value / 正文。
+     */
+    private resolveByRules(
+        target: HTMLElement,
+        evType: 'click' | 'submit' | 'keydown',
+        index: TrackRuleIndex,
+    ): Resolved | null {
+        const route = this.currentRoute()
+        // ① testid 主路径(O(1) 查 Map):第一个「有 data-testid 且规则命中」的祖先胜出。
+        let node: HTMLElement | null = target
+        while (node) {
+            const testid = node.dataset ? node.dataset.testid : undefined
+            if (testid) {
+                const rules = index.byTestid.get(testid)
+                if (rules && rules.length) {
+                    const el = node
+                    const matched = rules.filter(
+                        (r) =>
+                            matchRoute(r.route, route) &&
+                            this.matchOn(r.on, evType) &&
+                            this.matchClosest(el, r.closestTestid) &&
+                            this.matchRole(el, r.role),
+                    )
+                    if (matched.length) {
+                        if (matched.length > 1) this.warnAmbiguous(testid, matched)
+                        // data-track-ignore 复用:落在 ignore 子树里则视为「不代表该事件」,跳过。
+                        if (this.isTrackIgnored(target, el)) return null
+                        return { el, event: matched[0].event, props: matched[0].props }
+                    }
+                }
+            }
+            node = node.parentElement
+        }
+        // ② loose 兜底(线性,数量应很小):无 testid、靠 role/aria 命中。沿祖先找首个 role 匹配的元素。
+        for (const r of index.loose) {
+            if (!r.role) continue // loose 规则必须带 role,否则会匹配一切
+            let n: HTMLElement | null = target
+            while (n) {
+                const el = n
+                if (
+                    this.matchRole(el, r.role) &&
+                    matchRoute(r.route, route) &&
+                    this.matchOn(r.on, evType) &&
+                    this.matchClosest(el, r.closestTestid)
+                ) {
+                    if (this.isTrackIgnored(target, el)) return null
+                    return { el, event: r.event, props: r.props }
+                }
+                n = n.parentElement
+            }
+        }
+        return null
+    }
+
+    /** 当前路由(location.pathname);拿不到(SSR/测试无 DOM)返回空串 → 带 route 约束的规则一律不命中。 */
+    private currentRoute(): string {
+        try {
+            const loc = (globalThis as { location?: Location }).location
+            return loc && loc.pathname ? loc.pathname : ''
+        } catch {
+            return ''
+        }
+    }
+
+    /** on 约束:规则缺省 on → 三类交互都可;否则仅在指定交互类型触发。 */
+    private matchOn(on: TrackRule['on'], evType: 'click' | 'submit' | 'keydown'): boolean {
+        return !on || on === evType
+    }
+
+    /** closestTestid 约束:规则缺省 → 恒真;否则该元素需能 closest 到带此 data-testid 的祖先(消歧用)。 */
+    private matchClosest(el: HTMLElement, closestTestid?: string): boolean {
+        if (!closestTestid) return true
+        try {
+            return !!el.closest(`[data-testid="${closestTestid}"]`)
+        } catch {
+            return false
+        }
+    }
+
+    /** role 约束:规则缺省 → 恒真;否则该元素的 role 属性需精确等于它。 */
+    private matchRole(el: HTMLElement, role?: string): boolean {
+        if (!role) return true
+        return typeof el.getAttribute === 'function' && el.getAttribute('role') === role
+    }
+
+    /**
+     * data-track-ignore 排除(data-track 路径与规则表路径共用):被点元素最近的 data-track-ignore
+     * 若严格落在归宿元素 `el` 内部(el.contains(ignore) 且 el !== ignore),则本次交互「不代表该
+     * 事件」,跳过。
+     */
+    private isTrackIgnored(target: HTMLElement, el: HTMLElement): boolean {
+        const ignore = target.closest<HTMLElement>('[data-track-ignore]')
+        return !!ignore && el !== ignore && el.contains(ignore)
+    }
+
+    /**
+     * 规则表消歧告警:同一 data-testid 在当前约束下命中多条规则,取第一条并 warn,提示规则表
+     * 作者补 route/closestTestid/on 约束。仅为配置期质量信号,包在 try 里绝不抛、不影响业务。
+     */
+    private warnAmbiguous(testid: string, matched: TrackRule[]): void {
+        try {
+            const c = (globalThis as { console?: Console }).console
+            c?.warn?.(
+                `[Dap] ambiguous track rules for data-testid="${testid}" (${matched.length} matched); using "${matched[0].event}"`,
+            )
+        } catch {
+            /* ignore */
+        }
     }
 
     /**

--- a/packages/dmworkbase/src/Service/GroupManagementService.ts
+++ b/packages/dmworkbase/src/Service/GroupManagementService.ts
@@ -1,6 +1,7 @@
 import { Channel, ChannelTypePerson, Subscriber } from "wukongimjssdk";
 
 import APIClient from "./APIClient";
+import { apiPath } from "./apiPath";
 
 export interface GroupSubscriberMap {
   uid: string;
@@ -65,14 +66,14 @@ export function addGroupManagementManagers(
   channel: Channel,
   uids: string[]
 ): Promise<void> {
-  return APIClient.shared.post(`groups/${channel.channelID}/managers`, uids);
+  return APIClient.shared.post(apiPath`groups/${channel.channelID}/managers`, uids);
 }
 
 export function removeGroupManagementManagers(
   channel: Channel,
   uids: string[]
 ): Promise<void> {
-  return APIClient.shared.delete(`groups/${channel.channelID}/managers`, {
+  return APIClient.shared.delete(apiPath`groups/${channel.channelID}/managers`, {
     data: uids,
   });
 }
@@ -81,19 +82,19 @@ export function disbandGroupManagement(channel: Channel): Promise<void> {
   if (channel.channelType === ChannelTypePerson) {
     return Promise.resolve();
   }
-  return APIClient.shared.delete(`groups/${channel.channelID}/disband`);
+  return APIClient.shared.delete(apiPath`groups/${channel.channelID}/disband`);
 }
 
 export function setGroupManagementBotAdmin(
   channel: Channel,
   uid: string
 ): Promise<void> {
-  return APIClient.shared.put(`groups/${channel.channelID}/bot_admin/${uid}`);
+  return APIClient.shared.put(apiPath`groups/${channel.channelID}/bot_admin/${uid}`);
 }
 
 export function removeGroupManagementBotAdmin(
   channel: Channel,
   uid: string
 ): Promise<void> {
-  return APIClient.shared.delete(`groups/${channel.channelID}/bot_admin/${uid}`);
+  return APIClient.shared.delete(apiPath`groups/${channel.channelID}/bot_admin/${uid}`);
 }

--- a/packages/dmworkbase/src/Service/IncomingWebhook.ts
+++ b/packages/dmworkbase/src/Service/IncomingWebhook.ts
@@ -137,10 +137,15 @@ type IncomingWebhookListResponse =
 /** 群/子区入站 Webhook 的 HTTP 边界。 */
 export const IncomingWebhookService = {
     basePath(groupNo: string, threadShortId?: string): string {
-        const groupPath = `groups/${encodeURIComponent(groupNo)}`;
         return threadShortId
-            ? `${groupPath}/threads/${encodeURIComponent(threadShortId)}/incoming-webhooks`
-            : `${groupPath}/incoming-webhooks`;
+            ? apiPath`groups/${groupNo}/threads/${threadShortId}/incoming-webhooks`
+            : apiPath`groups/${groupNo}/incoming-webhooks`;
+    },
+
+    itemPath(groupNo: string, webhookId: string, threadShortId?: string): string {
+        return threadShortId
+            ? apiPath`groups/${groupNo}/threads/${threadShortId}/incoming-webhooks/${webhookId}`
+            : apiPath`groups/${groupNo}/incoming-webhooks/${webhookId}`;
     },
 
     async list(groupNo: string, threadShortId?: string): Promise<IncomingWebhook[]> {
@@ -157,19 +162,27 @@ export const IncomingWebhookService = {
     },
 
     update(groupNo: string, webhookId: string, request: IncomingWebhookUpsertReq, threadShortId?: string): Promise<IncomingWebhook> {
-        return APIClient.shared.put(apiPath`${this.basePath(groupNo, threadShortId)}/${encodeURIComponent(webhookId)}`, request);
+        return APIClient.shared.put(this.itemPath(groupNo, webhookId, threadShortId), request);
     },
 
     delete(groupNo: string, webhookId: string, threadShortId?: string): Promise<void> {
-        return APIClient.shared.delete(apiPath`${this.basePath(groupNo, threadShortId)}/${encodeURIComponent(webhookId)}`);
+        return APIClient.shared.delete(this.itemPath(groupNo, webhookId, threadShortId));
     },
 
     regenerate(groupNo: string, webhookId: string, threadShortId?: string): Promise<IncomingWebhookCreateResp> {
-        return APIClient.shared.post(apiPath`${this.basePath(groupNo, threadShortId)}/${encodeURIComponent(webhookId)}/regenerate`);
+        return APIClient.shared.post(
+            threadShortId
+                ? apiPath`groups/${groupNo}/threads/${threadShortId}/incoming-webhooks/${webhookId}/regenerate`
+                : apiPath`groups/${groupNo}/incoming-webhooks/${webhookId}/regenerate`
+        );
     },
 
     test(groupNo: string, webhookId: string, threadShortId?: string): Promise<void> {
-        return APIClient.shared.post(apiPath`${this.basePath(groupNo, threadShortId)}/${encodeURIComponent(webhookId)}/test`);
+        return APIClient.shared.post(
+            threadShortId
+                ? apiPath`groups/${groupNo}/threads/${threadShortId}/incoming-webhooks/${webhookId}/test`
+                : apiPath`groups/${groupNo}/incoming-webhooks/${webhookId}/test`
+        );
     },
 };
 

--- a/packages/dmworkbase/src/Service/IncomingWebhook.ts
+++ b/packages/dmworkbase/src/Service/IncomingWebhook.ts
@@ -1,4 +1,5 @@
 import APIClient from "./APIClient";
+import { apiPath } from "./apiPath";
 
 /**
  * 群入站 Webhook（Incoming Webhook）类型与纯工具函数。
@@ -156,19 +157,19 @@ export const IncomingWebhookService = {
     },
 
     update(groupNo: string, webhookId: string, request: IncomingWebhookUpsertReq, threadShortId?: string): Promise<IncomingWebhook> {
-        return APIClient.shared.put(`${this.basePath(groupNo, threadShortId)}/${encodeURIComponent(webhookId)}`, request);
+        return APIClient.shared.put(apiPath`${this.basePath(groupNo, threadShortId)}/${encodeURIComponent(webhookId)}`, request);
     },
 
     delete(groupNo: string, webhookId: string, threadShortId?: string): Promise<void> {
-        return APIClient.shared.delete(`${this.basePath(groupNo, threadShortId)}/${encodeURIComponent(webhookId)}`);
+        return APIClient.shared.delete(apiPath`${this.basePath(groupNo, threadShortId)}/${encodeURIComponent(webhookId)}`);
     },
 
     regenerate(groupNo: string, webhookId: string, threadShortId?: string): Promise<IncomingWebhookCreateResp> {
-        return APIClient.shared.post(`${this.basePath(groupNo, threadShortId)}/${encodeURIComponent(webhookId)}/regenerate`);
+        return APIClient.shared.post(apiPath`${this.basePath(groupNo, threadShortId)}/${encodeURIComponent(webhookId)}/regenerate`);
     },
 
     test(groupNo: string, webhookId: string, threadShortId?: string): Promise<void> {
-        return APIClient.shared.post(`${this.basePath(groupNo, threadShortId)}/${encodeURIComponent(webhookId)}/test`);
+        return APIClient.shared.post(apiPath`${this.basePath(groupNo, threadShortId)}/${encodeURIComponent(webhookId)}/test`);
     },
 };
 

--- a/packages/dmworkbase/src/Service/IncomingWebhook.ts
+++ b/packages/dmworkbase/src/Service/IncomingWebhook.ts
@@ -137,15 +137,17 @@ type IncomingWebhookListResponse =
 /** 群/子区入站 Webhook 的 HTTP 边界。 */
 export const IncomingWebhookService = {
     basePath(groupNo: string, threadShortId?: string): string {
+        // apiPath 只做模板旁挂、不编码插值段，故 id 段须在此显式 encodeURIComponent，
+        // 否则含 / ? # 空格的 id 会改变 wire 上的路径语义（见 PR #1390 review P0-1）。
         return threadShortId
-            ? apiPath`groups/${groupNo}/threads/${threadShortId}/incoming-webhooks`
-            : apiPath`groups/${groupNo}/incoming-webhooks`;
+            ? apiPath`groups/${encodeURIComponent(groupNo)}/threads/${encodeURIComponent(threadShortId)}/incoming-webhooks`
+            : apiPath`groups/${encodeURIComponent(groupNo)}/incoming-webhooks`;
     },
 
     itemPath(groupNo: string, webhookId: string, threadShortId?: string): string {
         return threadShortId
-            ? apiPath`groups/${groupNo}/threads/${threadShortId}/incoming-webhooks/${webhookId}`
-            : apiPath`groups/${groupNo}/incoming-webhooks/${webhookId}`;
+            ? apiPath`groups/${encodeURIComponent(groupNo)}/threads/${encodeURIComponent(threadShortId)}/incoming-webhooks/${encodeURIComponent(webhookId)}`
+            : apiPath`groups/${encodeURIComponent(groupNo)}/incoming-webhooks/${encodeURIComponent(webhookId)}`;
     },
 
     async list(groupNo: string, threadShortId?: string): Promise<IncomingWebhook[]> {
@@ -172,16 +174,16 @@ export const IncomingWebhookService = {
     regenerate(groupNo: string, webhookId: string, threadShortId?: string): Promise<IncomingWebhookCreateResp> {
         return APIClient.shared.post(
             threadShortId
-                ? apiPath`groups/${groupNo}/threads/${threadShortId}/incoming-webhooks/${webhookId}/regenerate`
-                : apiPath`groups/${groupNo}/incoming-webhooks/${webhookId}/regenerate`
+                ? apiPath`groups/${encodeURIComponent(groupNo)}/threads/${encodeURIComponent(threadShortId)}/incoming-webhooks/${encodeURIComponent(webhookId)}/regenerate`
+                : apiPath`groups/${encodeURIComponent(groupNo)}/incoming-webhooks/${encodeURIComponent(webhookId)}/regenerate`
         );
     },
 
     test(groupNo: string, webhookId: string, threadShortId?: string): Promise<void> {
         return APIClient.shared.post(
             threadShortId
-                ? apiPath`groups/${groupNo}/threads/${threadShortId}/incoming-webhooks/${webhookId}/test`
-                : apiPath`groups/${groupNo}/incoming-webhooks/${webhookId}/test`
+                ? apiPath`groups/${encodeURIComponent(groupNo)}/threads/${encodeURIComponent(threadShortId)}/incoming-webhooks/${encodeURIComponent(webhookId)}/test`
+                : apiPath`groups/${encodeURIComponent(groupNo)}/incoming-webhooks/${encodeURIComponent(webhookId)}/test`
         );
     },
 };

--- a/packages/dmworkbase/src/Service/OboService.ts
+++ b/packages/dmworkbase/src/Service/OboService.ts
@@ -1,4 +1,5 @@
 import APIClient from "./APIClient";
+import { apiPath } from "./apiPath";
 
 export interface OboGrant {
   id: number;
@@ -73,11 +74,11 @@ export function updateOboGrant(
   grantId: number,
   request: UpdateOboGrantRequest
 ): Promise<void> {
-  return APIClient.shared.put(`obo/grants/${grantId}`, request);
+  return APIClient.shared.put(apiPath`obo/grants/${grantId}`, request);
 }
 
 export function deleteOboGrant(grantId: number): Promise<void> {
-  return APIClient.shared.delete(`obo/grants/${grantId}`);
+  return APIClient.shared.delete(apiPath`obo/grants/${grantId}`);
 }
 
 export function createOboScope(
@@ -87,5 +88,5 @@ export function createOboScope(
 }
 
 export function deleteOboScope(scopeId: number): Promise<void> {
-  return APIClient.shared.delete(`obo/scopes/${scopeId}`);
+  return APIClient.shared.delete(apiPath`obo/scopes/${scopeId}`);
 }

--- a/packages/dmworkbase/src/Service/Section.tsx
+++ b/packages/dmworkbase/src/Service/Section.tsx
@@ -45,13 +45,25 @@ export class Row {
     cell!: ElementType
     properties?: any
     sort:number = 0
+    /**
+     * 埋点(可选):设了就让通用 <Sections> 渲染器在行 wrapper 上挂 `data-track={trackEvent}`,
+     * 整行点击即经既有捕获委托上报——config 驱动面(群信息/用户信息/设置项)不必逐个 JSX 补
+     * data-track,埋点成为 Row 的一等字段,和 onClick 并排,快速多人迭代时漏不掉。
+     * 事件名须先在服务端采集器注册。`trackProps` 为静态枚举,渲染成 data-track-*(经
+     * collectDatasetProps 采集,绝不读控件 value/正文)。整行导航类适用;行内自带 data-track
+     * 的子控件(如开关)仍走自己那条,勿在这类行重复设 trackEvent。
+     */
+    trackEvent?: string
+    trackProps?: Record<string, string | number | boolean>
 
-    constructor(v:{cell:ElementType,properties?:any,sort?:number}) {
+    constructor(v:{cell:ElementType,properties?:any,sort?:number,trackEvent?:string,trackProps?:Record<string, string | number | boolean>}) {
         this.cell = v.cell
         this.properties = v.properties
         if(v.sort) {
             this.sort = v.sort
         }
+        this.trackEvent = v.trackEvent
+        this.trackProps = v.trackProps
     }
 
 }

--- a/packages/dmworkbase/src/Service/ThreadService.ts
+++ b/packages/dmworkbase/src/Service/ThreadService.ts
@@ -1,5 +1,6 @@
 import APIClient from "./APIClient"
 import { buildThreadChannelId, parseThreadChannelId, type Thread } from "./Thread"
+import { apiPath } from "./apiPath"
 
 export interface CreateThreadFromMessageReq {
   groupNo: string
@@ -23,14 +24,14 @@ const ThreadService = {
     if (sourceMessageId !== undefined) {
       body.source_message_id = sourceMessageId
     }
-    const resp = await APIClient.shared.post(`groups/${groupNo}/threads`, {
+    const resp = await APIClient.shared.post(apiPath`groups/${groupNo}/threads`, {
       ...body,
     })
     return normalizeThreadCreateResult(resp, groupNo)
   },
 
   createThreadFromMessage(req: CreateThreadFromMessageReq): Promise<ThreadCreateResult> {
-    return APIClient.shared.post(`groups/${req.groupNo}/threads`, {
+    return APIClient.shared.post(apiPath`groups/${req.groupNo}/threads`, {
       name: req.name,
       source_message_id: req.sourceMessageId,
       source_message_payload: req.sourceMessagePayload,

--- a/packages/dmworkbase/src/Service/TrackRules.ts
+++ b/packages/dmworkbase/src/Service/TrackRules.ts
@@ -1,0 +1,92 @@
+/**
+ * TrackRules —— 埋点蒙版的「锚点规则表」(Dap fallback 支路的数据 + 索引)
+ * =====================================================================
+ * 背景:蒙版原路径靠业务组件挂 `data-track` 声明式采集(见 Dap.installClickDelegation)。
+ * 但全站约 165 个「无网络的 UI 意图」动作当前没埋,逐个加 `data-track` 成本高。本表提供一条
+ * **纯前端 fallback**:在 `closest('[data-track]')` 落空后,拿被点元素身上**现成的
+ * `data-testid`** 去查这张打包进 bundle 的静态表,命中就用规则里的 `event` 走现有 track()。
+ *
+ * 硬约束(与 Dap 一致,见 Dap.ts §2 / installClickDelegation):
+ *   - `data-track` 绝对优先:有 `data-track` 就走原路径,本表只吃「没有 data-track」的节点
+ *     → 现有埋点 / 破例点零回归。
+ *   - 隐私:规则只携带**静态枚举** props;运行时 props 仍复用 collectDatasetProps 读 data-*
+ *     (如 data-object-id),**绝不读控件 value / innerText / 正文**。
+ *   - 事件名必须**先在服务端采集器注册**,否则前端照发、服务端静默死信丢弃(前端不报错)。
+ *   - 主路径 O(1):有 `testid` 的规则进 `byTestid` Map;无 `testid` 的 role/aria 规则进 `loose`
+ *     线性兜底(数量应保持很小)。
+ */
+
+/** 规则携带的静态 props 只允许基础量,和 TrackEnvelope.props 的 TrackPrimitive 对齐。 */
+type RulePrimitive = string | number | boolean | null
+
+/**
+ * 单条锚点规则。`event` 必填;其余为**命中约束**(全部 AND):
+ *   - `testid`        主键:被 walk 到的祖先元素的 `data-testid` 精确等于它 → 进 byTestid 索引。
+ *   - `role`          约束该元素的 `role` 属性(byTestid 规则的附加约束 / loose 规则的主键)。
+ *   - `route`         仅当 `location.pathname` 命中(精确或前缀 + 段边界)时生效;string | string[]。
+ *   - `closestTestid` 该元素需能 `closest([data-testid=closestTestid])`(用于同名 testid 消歧)。
+ *   - `on`            仅在该交互类型触发('click' | 'submit' | 'keydown');缺省则三类都可。
+ *   - `props`         合并进上报的**静态枚举**(如 { area: 'automation', action: 'run' });
+ *                     运行时再叠加 collectDatasetProps(el) 读的 data-*(data-object-id 等)。
+ */
+export interface TrackRule {
+    event: string
+    testid?: string
+    role?: string
+    route?: string | string[]
+    closestTestid?: string
+    on?: 'click' | 'submit' | 'keydown'
+    props?: Record<string, RulePrimitive>
+}
+
+/** buildIndex 产物:testid 主索引 + 无 testid 的 loose 线性表。 */
+export interface TrackRuleIndex {
+    byTestid: Map<string, TrackRule[]>
+    loose: TrackRule[]
+}
+
+/**
+ * 建索引:有 `testid` 的按 testid 分桶进 Map(同一 testid 可挂多条,靠 route/closestTestid/on
+ * 消歧);无 `testid` 的进 loose(须带 role,否则会匹配一切)。O(n) 构建,查询主路径 O(1)。
+ */
+export function buildIndex(rules: TrackRule[]): TrackRuleIndex {
+    const byTestid = new Map<string, TrackRule[]>()
+    const loose: TrackRule[] = []
+    for (const rule of rules) {
+        if (!rule || !rule.event) continue
+        if (rule.testid) {
+            const arr = byTestid.get(rule.testid)
+            if (arr) arr.push(rule)
+            else byTestid.set(rule.testid, [rule])
+        } else {
+            loose.push(rule)
+        }
+    }
+    return { byTestid, loose }
+}
+
+/**
+ * route 约束匹配:规则的 `route` 缺省 → 恒真;否则要求 `current` 精确等于某项,或以「该项 + 段
+ * 边界(`/`)」为前缀。段边界避免 `/automation` 误配 `/automationX`。
+ */
+export function matchRoute(route: TrackRule['route'], current: string): boolean {
+    if (!route) return true
+    const list = Array.isArray(route) ? route : [route]
+    return list.some((r) => current === r || current.startsWith(r.endsWith('/') ? r : r + '/'))
+}
+
+/**
+ * 全站锚点规则表(打包进 bundle)。**按对账 sheet(d_e8d2c5702b3b58abb5f85777)分模块逐条填**,
+ * 事件名须以 sheet 为准且已在服务端采集器注册。首个切片:automation 模块(见任务)。
+ *
+ * 示例(结构参考,勿直接启用未注册的事件名):
+ *   { event: 'automation_run_clicked', testid: 'automation-run-btn', route: '/automation',
+ *     props: { area: 'automation', action: 'run' } },
+ *   { event: 'automation_toggle_switched', role: 'switch', route: '/automation',
+ *     closestTestid: 'automation-rule-row' },   // loose:靠 role 命中,无独立 testid
+ */
+export const TRACK_RULES: TrackRule[] = [
+    // 待填:按对账 sheet(d_e8d2c5702b3b58abb5f85777)分模块逐条填,事件名以 sheet 为准 + 确认服务端已注册。
+    // 说明:config 驱动面(ChannelSetting/UserInfo 等走 <Sections> 的)改用 Row.trackEvent 覆盖,不走本表;
+    // 本表只吃 imperative JSX 面里「有现成 data-testid / role 可锚、且未挂 data-track」的节点。
+]

--- a/packages/dmworkbase/src/Service/UserService.ts
+++ b/packages/dmworkbase/src/Service/UserService.ts
@@ -1,4 +1,5 @@
 import APIClient from "./APIClient"
+import { apiPath } from "./apiPath"
 
 export interface UserProfile {
   vercode?: string
@@ -20,7 +21,7 @@ export interface UpdateCurrentUserPayload {
 
 const UserService = {
   getUserProfile(uid: string, groupNo?: string): Promise<UserProfile> {
-    return APIClient.shared.get(`users/${uid}`, {
+    return APIClient.shared.get(apiPath`users/${uid}`, {
       param: { group_no: groupNo || "" },
     })
   },
@@ -48,7 +49,7 @@ const UserService = {
   uploadUserAvatar(uid: string, file: File): Promise<any> {
     const data = new FormData()
     data.append("file", file)
-    return APIClient.shared.post(`users/${uid}/avatar`, data, {
+    return APIClient.shared.post(apiPath`users/${uid}/avatar`, data, {
       headers: { "Content-Type": "multipart/form-data" },
       timeout: 60_000,
     })

--- a/packages/dmworkbase/src/Service/UserService.ts
+++ b/packages/dmworkbase/src/Service/UserService.ts
@@ -1,5 +1,4 @@
 import APIClient from "./APIClient"
-import { apiPath } from "./apiPath"
 
 export interface UserProfile {
   vercode?: string
@@ -21,7 +20,7 @@ export interface UpdateCurrentUserPayload {
 
 const UserService = {
   getUserProfile(uid: string, groupNo?: string): Promise<UserProfile> {
-    return APIClient.shared.get(apiPath`users/${uid}`, {
+    return APIClient.shared.get(`users/${uid}`, {
       param: { group_no: groupNo || "" },
     })
   },
@@ -49,7 +48,7 @@ const UserService = {
   uploadUserAvatar(uid: string, file: File): Promise<any> {
     const data = new FormData()
     data.append("file", file)
-    return APIClient.shared.post(apiPath`users/${uid}/avatar`, data, {
+    return APIClient.shared.post(`users/${uid}/avatar`, data, {
       headers: { "Content-Type": "multipart/form-data" },
       timeout: 60_000,
     })

--- a/packages/dmworkbase/src/Service/__tests__/Dap.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/Dap.test.ts
@@ -245,6 +245,25 @@ describe('Dap.normalizePath / isFirstParty (P0-3 helpers)', () => {
         expect(isFirstParty(`${location.origin}/api/x`)).toBe(true)
         expect(isFirstParty('https://cdn.example.com/x')).toBe(false)
     })
+
+    it('prefers the apiPath route template over lossy whitelist normalization', async () => {
+        vi.resetModules()
+        // 关键:必须从与 Dap 同一个 fresh 模块图里拿 apiPath,二者共享同一 registry。
+        const dap = await import('../Dap')
+        const api = await import('../apiPath')
+        const { normalizePath } = dap.__dapInternals
+
+        // 无模板兜底:短 hex id `8f3a`(<16)在白名单归一里塌成 :seg —— 正是要修的丢失。
+        expect(normalizePath('/api/v1/spaces/8f3a/categories/12')).toBe('/api/v1/spaces/:seg/categories/:id')
+
+        // 登记 apiPath 模板后:字面段全可见、变量段统一 :id,同一 endpoint 稳定模板。
+        const p = api.apiPath`/spaces/${'8f3a'}/categories/${'12'}`
+        api.registerRequestTemplate(p, '/api/v1/')
+        expect(normalizePath('/api/v1/spaces/8f3a/categories/12')).toBe('/api/v1/spaces/:id/categories/:id')
+
+        // 模板里从不含变量原值 —— 隐私天然安全。
+        expect(normalizePath('/api/v1/spaces/8f3a/categories/12').includes('8f3a')).toBe(false)
+    })
 })
 
 describe('Dap — unsupported runtime stays disabled (desktop/file://)', () => {
@@ -274,5 +293,167 @@ describe('Dap — unsupported runtime stays disabled (desktop/file://)', () => {
         expect(__dapInternals.isSupportedRuntime()).toBe(true) // jsdom 默认 http:
         vi.stubGlobal('location', { protocol: 'file:', origin: 'null' })
         expect(__dapInternals.isSupportedRuntime()).toBe(false)
+    })
+})
+
+describe('TrackRules — buildIndex / matchRoute (pure)', () => {
+    it('buildIndex splits testid rules into the Map and role-only rules into loose', async () => {
+        const { buildIndex } = await import('../TrackRules')
+        const idx = buildIndex([
+            { event: 'a', testid: 'x' },
+            { event: 'b', testid: 'x' }, // 同 testid → 同桶
+            { event: 'c', role: 'switch' }, // 无 testid → loose
+            { event: '', testid: 'skip' }, // 无 event → 丢弃
+        ])
+        expect(idx.byTestid.get('x')?.map((r) => r.event)).toEqual(['a', 'b'])
+        expect(idx.byTestid.has('skip')).toBe(false)
+        expect(idx.loose.map((r) => r.event)).toEqual(['c'])
+    })
+
+    it('matchRoute: absent route always matches; else exact or segment-boundary prefix', async () => {
+        const { matchRoute } = await import('../TrackRules')
+        expect(matchRoute(undefined, '/anything')).toBe(true)
+        expect(matchRoute('/automation', '/automation')).toBe(true)
+        expect(matchRoute('/automation', '/automation/rules')).toBe(true)
+        expect(matchRoute('/automation', '/automationX')).toBe(false) // 段边界,不误配
+        expect(matchRoute(['/a', '/b'], '/b/c')).toBe(true)
+    })
+})
+
+describe('Dap — rule-table fallback (no data-track)', () => {
+    let fetchMock: FetchMock
+    beforeEach(() => {
+        localStorage.clear()
+        document.body.innerHTML = ''
+        fetchMock = okFetch()
+        // @ts-expect-error test stub
+        globalThis.fetch = fetchMock
+    })
+
+    /** 从自身上报批次里取指定事件。 */
+    function eventsFromBatch(name: string) {
+        const batchCall = fetchMock.mock.calls.find((c) => c[0] === BATCH_PATH)
+        if (!batchCall) return []
+        const body = JSON.parse((batchCall[1] as RequestInit).body as string)
+        return (body.events as Array<{ event_name: string; object_id?: string; props?: Record<string, unknown> }>).filter(
+            (e) => e.event_name === name,
+        )
+    }
+
+    it('fires the rule event for a data-testid node that has no data-track', async () => {
+        const { Dap } = await freshTracker()
+        const { TRACK_RULES } = await import('../TrackRules')
+        TRACK_RULES.push({ event: 'automation_run_clicked', testid: 'automation-run-btn' })
+        Dap.shared.setEnabled(true) // 安装点击委托时构建规则索引(读此刻的 TRACK_RULES)
+        Dap.shared.init()
+
+        const btn = document.createElement('button')
+        btn.setAttribute('data-testid', 'automation-run-btn')
+        document.body.appendChild(btn)
+        btn.click()
+        Dap.shared.flush()
+
+        expect(eventsFromBatch('automation_run_clicked')).toHaveLength(1)
+    })
+
+    it('data-track wins: a node with BOTH data-track and a matching rule uses the data-track event', async () => {
+        const { Dap } = await freshTracker()
+        const { TRACK_RULES } = await import('../TrackRules')
+        // 同一元素既有 data-track 又匹配规则:必须走 data-track,规则不得插手(零回归)。
+        TRACK_RULES.push({ event: 'rule_event', testid: 'dual' })
+        Dap.shared.setEnabled(true)
+        Dap.shared.init()
+
+        const btn = document.createElement('button')
+        btn.setAttribute('data-track', 'declared_event')
+        btn.setAttribute('data-testid', 'dual')
+        document.body.appendChild(btn)
+        btn.click()
+        Dap.shared.flush()
+
+        expect(eventsFromBatch('declared_event')).toHaveLength(1)
+        expect(eventsFromBatch('rule_event')).toHaveLength(0)
+    })
+
+    it('route constraint gates the fallback (only fires on a matching pathname)', async () => {
+        const { Dap } = await freshTracker()
+        const { TRACK_RULES } = await import('../TrackRules')
+        // jsdom 默认 pathname='/':route:'/nope' 不命中,route:'/' 命中。
+        TRACK_RULES.push({ event: 'gated_off', testid: 'r1', route: '/nope' })
+        TRACK_RULES.push({ event: 'gated_on', testid: 'r2', route: '/' })
+        Dap.shared.setEnabled(true)
+        Dap.shared.init()
+
+        for (const id of ['r1', 'r2']) {
+            const el = document.createElement('button')
+            el.setAttribute('data-testid', id)
+            document.body.appendChild(el)
+            el.click()
+        }
+        Dap.shared.flush()
+
+        expect(eventsFromBatch('gated_off')).toHaveLength(0)
+        expect(eventsFromBatch('gated_on')).toHaveLength(1)
+    })
+
+    it('keyboard-activates a non-native role=button rule node (Enter), same as data-track', async () => {
+        const { Dap } = await freshTracker()
+        const { TRACK_RULES } = await import('../TrackRules')
+        TRACK_RULES.push({ event: 'automation_toggle', testid: 'kb-toggle' })
+        Dap.shared.setEnabled(true)
+        Dap.shared.init()
+
+        const div = document.createElement('div') // 非原生可激活 → 浏览器不合成 click
+        div.setAttribute('role', 'button')
+        div.setAttribute('tabindex', '0')
+        div.setAttribute('data-testid', 'kb-toggle')
+        document.body.appendChild(div)
+        div.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
+        Dap.shared.flush()
+
+        expect(eventsFromBatch('automation_toggle')).toHaveLength(1)
+    })
+
+    it('data-track-ignore excludes a rule hit just like a data-track hit', async () => {
+        const { Dap } = await freshTracker()
+        const { TRACK_RULES } = await import('../TrackRules')
+        TRACK_RULES.push({ event: 'row_opened', testid: 'auto-row' })
+        Dap.shared.setEnabled(true)
+        Dap.shared.init()
+
+        const row = document.createElement('div')
+        row.setAttribute('data-testid', 'auto-row')
+        const handle = document.createElement('span') // 行内拖拽柄:不代表本事件
+        handle.setAttribute('data-track-ignore', '')
+        row.appendChild(handle)
+        document.body.appendChild(row)
+        handle.click() // 点在 ignore 子控件上
+        Dap.shared.flush()
+
+        expect(eventsFromBatch('row_opened')).toHaveLength(0)
+    })
+
+    it('merges static rule props with data-* (object_id promoted), never leaks the testid', async () => {
+        const { Dap } = await freshTracker()
+        const { TRACK_RULES } = await import('../TrackRules')
+        TRACK_RULES.push({ event: 'automation_edit', testid: 'auto-edit', props: { area: 'automation', action: 'edit' } })
+        Dap.shared.setEnabled(true)
+        Dap.shared.init()
+
+        const btn = document.createElement('button')
+        btn.setAttribute('data-testid', 'auto-edit')
+        btn.setAttribute('data-object-id', 'auto-42')
+        document.body.appendChild(btn)
+        btn.click()
+        Dap.shared.flush()
+
+        const evts = eventsFromBatch('automation_edit')
+        expect(evts).toHaveLength(1)
+        expect(evts[0].object_id).toBe('auto-42') // data-object-id 提到 envelope 顶层
+        expect(evts[0].props?.area).toBe('automation') // 静态枚举 props
+        expect(evts[0].props?.action).toBe('edit')
+        // testid 绝不进 props(collectDatasetProps 只收 track*/object_id),object_id 不重复留 props
+        expect('testid' in (evts[0].props ?? {})).toBe(false)
+        expect(evts[0].props?.object_id).toBeUndefined()
     })
 })

--- a/packages/dmworkbase/src/Service/__tests__/apiPath.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/apiPath.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import axios from 'axios'
+import APIClient from '../APIClient'
+import { apiPath, registerRequestTemplate, templateForPathname, __resetApiPathRegistry } from '../apiPath'
+
+/**
+ * apiPath 单测:携带路由模板的路径构造器(埋点 http_request path 治本方案)。
+ * 验证三件事:① 具体串照旧可用;② 插值段一律占位 :id、静态段原样保留;
+ * ③ registerRequestTemplate 按 baseURL 拼出的 pathname 精确登记,templateForPathname 命中。
+ */
+describe('apiPath — route-template carrier', () => {
+    beforeEach(() => __resetApiPathRegistry())
+
+    it('returns the concrete interpolated path (drop-in for axios path arg)', () => {
+        const spaceId = '8f3a'
+        const categoryId = '12'
+        const p = apiPath`/spaces/${spaceId}/categories/${categoryId}`
+        expect(p).toBe('/spaces/8f3a/categories/12')
+    })
+
+    it('registers a template: literal segments verbatim, interpolated segments → :id, with baseURL prefix', () => {
+        const p = apiPath`/spaces/${'8f3a'}/categories/${'12'}`
+        registerRequestTemplate(p, '/api/v1/')
+        // Dap 看到的最终 pathname(baseURL 前缀 + 具体路径)
+        expect(templateForPathname('/api/v1/spaces/8f3a/categories/12')).toBe(
+            '/api/v1/spaces/:id/categories/:id',
+        )
+    })
+
+    it('same endpoint → one stable template regardless of id shape (numeric / uuid / short hex)', () => {
+        for (const id of ['12', '550e8400-e29b-41d4-a716-446655440000', '8f3a']) {
+            __resetApiPathRegistry()
+            const p = apiPath`/groups/${id}/setting`
+            registerRequestTemplate(p, '/api/v1/')
+            expect(templateForPathname(`/api/v1/groups/${id}/setting`)).toBe('/api/v1/groups/:id/setting')
+        }
+    })
+
+    it('handles both leading-slash and no-leading-slash call sites (axios combineURLs semantics)', () => {
+        const a = apiPath`groups/${'99'}/members`
+        registerRequestTemplate(a, '/api/v1/')
+        expect(templateForPathname('/api/v1/groups/99/members')).toBe('/api/v1/groups/:id/members')
+    })
+
+    it('purely static paths are not registered (concrete === template, nothing to carry)', () => {
+        const p = apiPath`/common/appconfig`
+        expect(p).toBe('/common/appconfig')
+        registerRequestTemplate(p, '/api/v1/')
+        expect(templateForPathname('/api/v1/common/appconfig')).toBeUndefined()
+    })
+
+    it('absolute backend baseURL (desktop): pathname still aligns, template carries', () => {
+        const p = apiPath`/spaces/${'abcd'}/docs/${'x1'}`
+        // axios: 相对 url + 绝对 baseURL → 绝对 URL;pathname 一致
+        registerRequestTemplate(p, 'https://host.example.com/v1/')
+        expect(templateForPathname('/v1/spaces/abcd/docs/x1')).toBe('/v1/spaces/:id/docs/:id')
+    })
+
+    it('non-apiPath urls are inert: registerRequestTemplate no-ops, lookup misses', () => {
+        registerRequestTemplate('/spaces/raw/12', '/api/v1/')
+        expect(templateForPathname('/api/v1/spaces/raw/12')).toBeUndefined()
+    })
+
+    it('lookup does not consume: concurrent same-endpoint requests both hit', () => {
+        const p = apiPath`/groups/${'7'}/exit`
+        registerRequestTemplate(p, '/api/v1/')
+        expect(templateForPathname('/api/v1/groups/7/exit')).toBe('/api/v1/groups/:id/exit')
+        // 第二次读仍命中(读不消费)
+        expect(templateForPathname('/api/v1/groups/7/exit')).toBe('/api/v1/groups/:id/exit')
+    })
+})
+
+/**
+ * 端到端接线:走真实 APIClient.shared → 全局 axios 的 request interceptor → registry。
+ * 用 adapter stub 短路网络。证明"apiPath 具体串 + 真实 baseURL 组合出的 pathname"与
+ * Dap 侧按 pathname 命中的 key 完全对齐(整套机制的关键假设)。
+ */
+describe('apiPath — end-to-end through APIClient interceptor', () => {
+    const client = APIClient.shared
+    beforeEach(() => {
+        __resetApiPathRegistry()
+        client.config.apiURL = '/api/v1/' // 同时把 axios.defaults.baseURL 设为 /api/v1/
+        axios.defaults.adapter = async (config) => ({
+            data: {}, status: 200, statusText: 'OK', headers: {}, config, request: {},
+        }) as never
+    })
+
+    it('a real APIClient.get(apiPath`...`) registers a template Dap will find at the final pathname', async () => {
+        await client.get(apiPath`/spaces/${'8f3a'}/categories/${'12'}`)
+        // Dap 看到的 XHR pathname = baseURL 组合后的 /api/v1/spaces/8f3a/categories/12
+        expect(templateForPathname('/api/v1/spaces/8f3a/categories/12')).toBe(
+            '/api/v1/spaces/:id/categories/:id',
+        )
+    })
+
+    it('a plain (non-apiPath) path registers nothing', async () => {
+        await client.get('/spaces/8f3a/categories/12')
+        expect(templateForPathname('/api/v1/spaces/8f3a/categories/12')).toBeUndefined()
+    })
+})

--- a/packages/dmworkbase/src/Service/apiPath.ts
+++ b/packages/dmworkbase/src/Service/apiPath.ts
@@ -1,0 +1,121 @@
+/**
+ * `apiPath` —— 携带**路由模板**的请求路径构造器(埋点 http_request path 归一的治本方案)。
+ *
+ * 背景:埋点采集在全局 fetch / XHR 拦截层(见 Dap.ts installHttpWrap),那里只拿得到**具体 URL**
+ * (`/api/v1/spaces/8f3a/categories/12`),模板信息在调用处 `` `/spaces/${id}/categories/${cid}` ``
+ * 插值时就丢了。Dap 只能在客户端反解归一,但"字面路由词"与"用户名 / vanity id / 邀请码"运行时
+ * 形状无法区分——保留未知字面段就会漏隐私(见 #1320 review),塌成 :seg 又丢粒度。
+ *
+ * 治本:让调用处用 `apiPath` 标签模板发路径,静态段(源码字面)与插值段(变量)在标签函数里
+ * 天然分开——静态段原样进模板,插值段一律占位 `:id`。于是:
+ *   apiPath`/spaces/${spaceId}/categories/${categoryId}`
+ *     → 具体串  /spaces/8f3a/categories/12   (照旧发给 axios)
+ *     → 模板    /spaces/:id/categories/:id   (旁挂给 registry,供埋点上报)
+ * 模板里永不含变量值,隐私天然安全;同一 endpoint 无论 id 怎么变都产出同一个稳定模板。
+ *
+ * 数据流:
+ *   1) apiPath 产出具体串(相对路径),并把 concreteRel→templateRel 存进 relTemplates。
+ *   2) APIClient 请求拦截器(唯一知道 baseURL 的地方)按 config.url 取出 templateRel,
+ *      拼上 baseURL 前缀算出 concretePathname / templatePathname,存进 pathTemplates。
+ *   3) Dap.normalizePath 先查 pathTemplates(按 seen URL 的 pathname 精确命中),命中即用模板;
+ *      查不到才退回原有白名单归一(**兜底不变**,未迁移的调用点照旧安全脱敏)。
+ *
+ * 两个 registry 均为有界 LRU:只承载"在途 / 刚发出"的请求,读不消费(同 endpoint 并发都能命中),
+ * 超量按插入序淘汰最旧。任何一环缺失都只是退回兜底归一,绝不影响业务请求本身。
+ */
+
+/** registry 上限:在途请求量级足够,超出按插入序淘汰(Map 保序)。 */
+const MAX_ENTRIES = 256
+
+/** apiPath 产出的 concreteRel(相对路径)→ templateRel(相对模板)。由请求拦截器消费。 */
+const relTemplates = new Map<string, string>()
+/** concretePathname(含 baseURL 前缀)→ templatePathname。由 Dap 读取。 */
+const pathTemplates = new Map<string, string>()
+
+function setBounded(map: Map<string, string>, key: string, value: string): void {
+    // 覆盖写不改容量;新 key 超量时淘汰最旧(Map 迭代序即插入序)。
+    if (!map.has(key) && map.size >= MAX_ENTRIES) {
+        const oldest = map.keys().next().value
+        if (oldest !== undefined) map.delete(oldest)
+    }
+    map.set(key, value)
+}
+
+/**
+ * axios `combineURLs` 的等价实现:baseURL 去尾斜杠 + '/' + relativeURL 去头斜杠。
+ * axios 对相对 URL 就是这样拼的(**不是**标准 URL 解析,标准解析会因 relative 的前导 '/'
+ * 把 baseURL 的路径整段丢掉)。绝对 http(s) URL 忽略 baseURL。
+ */
+function joinURL(baseURL: string, url: string): string {
+    if (/^https?:\/\//i.test(url)) return url
+    if (!baseURL) return url
+    return baseURL.replace(/\/+$/, '') + '/' + String(url).replace(/^\/+/, '')
+}
+
+/** 取 pathname(丢弃 query / host),两端一致以保证精确命中。解析失败退回原串。 */
+function pathnameOf(url: string): string {
+    try {
+        return new URL(url, 'http://x').pathname
+    } catch {
+        return url.split('?')[0]
+    }
+}
+
+/**
+ * 每个插值段一律占位 `:id`(它按定义就是变量/资源标识)。刻意**不看运行时值形状**:
+ * 同一 endpoint 无论 id 是数字 / uuid / 短 hex,都产出同一个稳定模板(埋点聚合的关键)。
+ */
+const PLACEHOLDER = ':id'
+
+/**
+ * 携带路由模板的路径标签模板。用法:`apiPath`/spaces/${spaceId}/categories/${categoryId}``。
+ * 返回**具体相对路径字符串**(可直接作为 APIClient.shared.get/post/... 的第一个参数),
+ * 同时把该具体路径对应的模板登记进 registry。除登记外行为与普通模板字符串完全一致。
+ */
+export function apiPath(strings: TemplateStringsArray, ...values: unknown[]): string {
+    let concrete = ''
+    let template = ''
+    for (let i = 0; i < strings.length; i++) {
+        concrete += strings[i]
+        template += strings[i]
+        if (i < values.length) {
+            concrete += String(values[i] ?? '')
+            template += PLACEHOLDER
+        }
+    }
+    // 只登记形状确有差异(含插值)的;纯静态路径具体串即模板,登记无意义。
+    if (concrete !== template) {
+        setBounded(relTemplates, concrete, template)
+    }
+    return concrete
+}
+
+/**
+ * 由 APIClient 请求拦截器调用:给定发往 axios 的 url 与 baseURL,若该 url 是 apiPath 产出的,
+ * 取出其模板并按最终 pathname(含 baseURL 前缀)登记,供 Dap 精确命中。取出即从 relTemplates
+ * 消费(一次请求一登记)。非 apiPath 路径直接返回,无副作用。
+ */
+export function registerRequestTemplate(url: string | undefined, baseURL: string | undefined): void {
+    if (!url) return
+    const templateRel = relTemplates.get(url)
+    if (templateRel === undefined) return
+    relTemplates.delete(url)
+    const base = baseURL || ''
+    const concretePathname = pathnameOf(joinURL(base, url))
+    const templatePathname = pathnameOf(joinURL(base, templateRel))
+    setBounded(pathTemplates, concretePathname, templatePathname)
+}
+
+/**
+ * 由 Dap.normalizePath 调用:给定 seen 请求 URL 的 pathname,返回登记过的路由模板 pathname,
+ * 未登记返回 undefined(调用方退回白名单归一)。**读不消费**:同一 endpoint 并发多发都能命中。
+ */
+export function templateForPathname(pathname: string): string | undefined {
+    return pathTemplates.get(pathname)
+}
+
+/** 仅供单测:清空 registry,避免用例间串味。 */
+export function __resetApiPathRegistry(): void {
+    relTemplates.clear()
+    pathTemplates.clear()
+}

--- a/packages/dmworkbase/src/features/channelSetting/channelSettingDangerSection.tsx
+++ b/packages/dmworkbase/src/features/channelSetting/channelSettingDangerSection.tsx
@@ -29,6 +29,7 @@ export function buildChannelDangerSection(
     rows: [
       new Row({
         cell: ChannelSettingActionRow,
+        trackEvent: "conversation_clear_dialog_opened",
         properties: {
           title: t("base.module.channelSettings.clearMessages"),
           danger: true,
@@ -44,6 +45,7 @@ export function buildChannelDangerSection(
       }),
       new Row({
         cell: ChannelSettingActionRow,
+        trackEvent: "conversation_leave_dialog_opened",
         properties: {
           title: t("base.module.channelSettings.deleteAndExit"),
           danger: true,

--- a/packages/dmworkbase/src/features/channelSetting/channelSettingDangerSection.tsx
+++ b/packages/dmworkbase/src/features/channelSetting/channelSettingDangerSection.tsx
@@ -5,6 +5,7 @@ import WKApp from "../../App";
 import { ChannelSettingRouteData } from "../../Components/ChannelSetting/context";
 import { GroupRole } from "../../Service/Const";
 import RouteContext from "../../Service/Context";
+import { Dap } from "../../Service/Dap";
 import { Row, Section } from "../../Service/Section";
 import { isGroupDisbanded } from "../../Utils/groupDisband";
 import {
@@ -45,7 +46,6 @@ export function buildChannelDangerSection(
       }),
       new Row({
         cell: ChannelSettingActionRow,
-        trackEvent: "conversation_leave_dialog_opened",
         properties: {
           title: t("base.module.channelSettings.deleteAndExit"),
           danger: true,
@@ -59,6 +59,9 @@ export function buildChannelDangerSection(
               });
               return;
             }
+            // 命令式上报:仅在真正打开退出确认弹窗时计数;群主分支被上面的 return
+            // 拦截,不会误报(见 PR #1390 review P1-1)。
+            Dap.shared.track("conversation_leave_dialog_opened");
             WKApp.shared.baseContext.showAlert({
               content: t("base.module.channelSettings.deleteAndExitConfirm"),
               onOk: async () => {

--- a/packages/dmworkbase/src/features/channelSetting/channelSettingGroupManagementRows.tsx
+++ b/packages/dmworkbase/src/features/channelSetting/channelSettingGroupManagementRows.tsx
@@ -215,11 +215,11 @@ export function buildGroupManagementRows({
   rows.push(
     new Row({
       cell: ChannelSettingInlineEditRow,
-      trackEvent: "conversation_remark_edit_opened",
       properties: {
         title: t("base.module.channelSettings.remark"),
         value: channelInfo?.orgData?.remark || "",
         placeholder: t("base.module.channelSettings.remarkPlaceholder"),
+        trackEvent: "conversation_remark_edit_opened",
         maxCount: 15,
         allowEmpty: true,
         onSave: (value: string) =>

--- a/packages/dmworkbase/src/features/channelSetting/channelSettingGroupManagementRows.tsx
+++ b/packages/dmworkbase/src/features/channelSetting/channelSettingGroupManagementRows.tsx
@@ -52,6 +52,7 @@ function buildTransferOwnerRow(
   let selectedItems: Subscriber[] = [];
   return new Row({
     cell: ChannelSettingInfoRow,
+    trackEvent: "group_transfer_dialog_opened",
     properties: {
       title: t("base.module.channelSettings.transferOwner"),
       onClick: () => {
@@ -137,6 +138,7 @@ export function buildGroupManagementRows({
     rows.push(
       new Row({
         cell: ChannelSettingInfoRow,
+        trackEvent: "group_md_viewed",
         properties: {
           title: "GROUP.md",
           value: hasGroupMd
@@ -160,6 +162,7 @@ export function buildGroupManagementRows({
       }),
       new Row({
         cell: ChannelSettingInfoRow,
+        trackEvent: "group_webhook_panel_opened",
         properties: {
           title: t("base.module.channelSettings.incomingWebhook"),
           onClick: () => {
@@ -187,6 +190,7 @@ export function buildGroupManagementRows({
       rows.push(
         new Row({
           cell: ChannelSettingInfoRow,
+          trackEvent: "group_management_page_opened",
           properties: {
             title: t("base.module.channelSettings.groupManagement"),
             onClick: () => {
@@ -211,6 +215,7 @@ export function buildGroupManagementRows({
   rows.push(
     new Row({
       cell: ChannelSettingInlineEditRow,
+      trackEvent: "conversation_remark_edit_opened",
       properties: {
         title: t("base.module.channelSettings.remark"),
         value: channelInfo?.orgData?.remark || "",

--- a/packages/dmworkbase/src/features/channelSetting/channelSettingGroupProfileRows.tsx
+++ b/packages/dmworkbase/src/features/channelSetting/channelSettingGroupProfileRows.tsx
@@ -173,6 +173,7 @@ export function buildGroupProfileRows({
   return [
     new Row({
       cell: ChannelSettingInlineEditRow,
+      trackEvent: "group_name_edit_opened",
       properties: {
         title: t("base.module.channelSettings.groupName"),
         value: channelInfo?.title || "",
@@ -201,6 +202,7 @@ export function buildGroupProfileRows({
     }),
     new Row({
       cell: GroupAvatarSettingRow,
+      trackEvent: "group_avatar_edit_opened",
       properties: {
         title: t("base.module.channelSettings.groupAvatar"),
         icon: (
@@ -226,6 +228,7 @@ export function buildGroupProfileRows({
     }),
     new Row({
       cell: ChannelSettingIconRow,
+      trackEvent: "group_qrcode_viewed",
       properties: {
         title: t("base.module.channelSettings.groupQrCode"),
         icon: <QrCode className="wk-channelsetting-qrcode-icon" aria-hidden />,
@@ -241,6 +244,7 @@ export function buildGroupProfileRows({
     }),
     new Row({
       cell: ChannelSettingInlineEditRow,
+      trackEvent: "group_announcement_edit_opened",
       properties: {
         title: t("base.module.channelSettings.groupNotice"),
         value: channelInfo?.orgData?.notice,

--- a/packages/dmworkbase/src/features/channelSetting/channelSettingGroupProfileRows.tsx
+++ b/packages/dmworkbase/src/features/channelSetting/channelSettingGroupProfileRows.tsx
@@ -10,6 +10,7 @@ import { ChannelSettingRouteData } from "../../Components/ChannelSetting/context
 import { GroupRole } from "../../Service/Const";
 import RouteContext, { RouteContextConfig } from "../../Service/Context";
 import { ChannelField } from "../../Service/DataSource/DataSource";
+import { Dap } from "../../Service/Dap";
 import { GROUP_NAME_MAX_LENGTH } from "../../Service/nameLimits";
 import { Row } from "../../Service/Section";
 import { updateChannelSettingField } from "../../bridge/channelSetting/channelSettingActions";
@@ -103,6 +104,9 @@ export function GroupAvatarSettingRow({
   const openAvatarEditor = async () => {
     if (opening) return;
 
+    // 命令式上报:过了重入门(opening)才计一次,在途重复点击不再灌水
+    // (行需先 await 网络刷新才弹编辑器,见 PR #1390 review P1-2)。
+    Dap.shared.track("group_avatar_edit_opened");
     setOpening(true);
     try {
       const latestChannelInfo = await fetchCurrentImChannelInfo<
@@ -202,7 +206,6 @@ export function buildGroupProfileRows({
     }),
     new Row({
       cell: GroupAvatarSettingRow,
-      trackEvent: "group_avatar_edit_opened",
       properties: {
         title: t("base.module.channelSettings.groupAvatar"),
         icon: (

--- a/packages/dmworkbase/src/features/channelSetting/channelSettingGroupProfileRows.tsx
+++ b/packages/dmworkbase/src/features/channelSetting/channelSettingGroupProfileRows.tsx
@@ -173,12 +173,12 @@ export function buildGroupProfileRows({
   return [
     new Row({
       cell: ChannelSettingInlineEditRow,
-      trackEvent: "group_name_edit_opened",
       properties: {
         title: t("base.module.channelSettings.groupName"),
         value: channelInfo?.title || "",
         displayValue: groupName,
         placeholder: t("base.module.channelSettings.groupNamePlaceholder"),
+        trackEvent: "group_name_edit_opened",
         maxCount: GROUP_NAME_MAX_LENGTH,
         onStartEdit: () => {
           if (!data.isManagerOrCreatorOfMe) {
@@ -244,12 +244,12 @@ export function buildGroupProfileRows({
     }),
     new Row({
       cell: ChannelSettingInlineEditRow,
-      trackEvent: "group_announcement_edit_opened",
       properties: {
         title: t("base.module.channelSettings.groupNotice"),
         value: channelInfo?.orgData?.notice,
         multiline: true,
         placeholder: t("base.module.channelSettings.groupNotice"),
+        trackEvent: "group_announcement_edit_opened",
         maxCount: 400,
         allowEmpty: true,
         onStartEdit: () => {

--- a/packages/dmworkbase/src/features/channelSetting/channelSettingNicknameSection.tsx
+++ b/packages/dmworkbase/src/features/channelSetting/channelSettingNicknameSection.tsx
@@ -28,6 +28,7 @@ export function buildMyGroupNicknameSection(
     rows: [
       new Row({
         cell: ChannelSettingInlineEditRow,
+        trackEvent: "group_nickname_edit_opened",
         properties: {
           title: t("base.module.channelSettings.myGroupNickname"),
           value: groupNickname,

--- a/packages/dmworkbase/src/features/channelSetting/channelSettingNicknameSection.tsx
+++ b/packages/dmworkbase/src/features/channelSetting/channelSettingNicknameSection.tsx
@@ -28,7 +28,6 @@ export function buildMyGroupNicknameSection(
     rows: [
       new Row({
         cell: ChannelSettingInlineEditRow,
-        trackEvent: "group_nickname_edit_opened",
         properties: {
           title: t("base.module.channelSettings.myGroupNickname"),
           value: groupNickname,
@@ -36,6 +35,7 @@ export function buildMyGroupNicknameSection(
           placeholder: t(
             "base.module.channelSettings.myGroupNicknamePlaceholder"
           ),
+          trackEvent: "group_nickname_edit_opened",
           maxCount: 10,
           allowEmpty: true,
           onSave: async (value: string) => {

--- a/packages/dmworkbase/src/ui/ChannelSettingRows/__tests__/ChannelSettingInlineEditRow.test.tsx
+++ b/packages/dmworkbase/src/ui/ChannelSettingRows/__tests__/ChannelSettingInlineEditRow.test.tsx
@@ -1,8 +1,9 @@
 import React from "react";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { ChannelSettingInlineEditRow } from "../index";
+import { Dap } from "../../../Service/Dap";
 
 vi.mock("@douyinfe/semi-icons", () => ({
   IconClear: () => <span aria-hidden="true">x</span>,
@@ -58,6 +59,16 @@ vi.mock("../../../Components/ListItem", () => ({
 vi.mock("../../../i18n", () => ({
   t: (key: string) => key,
 }));
+
+vi.mock("../../../Service/Dap", () => ({
+  Dap: { shared: { track: vi.fn() } },
+}));
+
+const trackMock = vi.mocked(Dap.shared.track);
+
+beforeEach(() => {
+  trackMock.mockClear();
+});
 
 describe("ChannelSettingInlineEditRow", () => {
   it("clears an existing value and saves the empty nickname", async () => {
@@ -303,5 +314,42 @@ describe("ChannelSettingInlineEditRow", () => {
     expect(screen.getByDisplayValue("")).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "base.common.save" }));
     await waitFor(() => expect(onSave).toHaveBeenCalledWith(""));
+  });
+
+  // PR #1390 review P2-3:上报改为命令式,须每次成功打开恰发一次,且权限门拒绝时零上报。
+  it("fires the track event exactly once per open, not on the row wrapper", () => {
+    const { container } = render(
+      <ChannelSettingInlineEditRow
+        title="Group name"
+        value="Old name"
+        trackEvent="group_name_edit_opened"
+        onSave={vi.fn(() => Promise.resolve())}
+      />
+    );
+
+    expect(
+      container.querySelectorAll("[data-track]").length
+    ).toBe(0);
+
+    fireEvent.click(screen.getByRole("button", { name: "Group name" }));
+
+    expect(trackMock).toHaveBeenCalledTimes(1);
+    expect(trackMock).toHaveBeenCalledWith("group_name_edit_opened");
+  });
+
+  it("does not fire the track event when the start guard rejects editing", () => {
+    render(
+      <ChannelSettingInlineEditRow
+        title="Group name"
+        value="Protected name"
+        trackEvent="group_name_edit_opened"
+        onStartEdit={vi.fn(() => false)}
+        onSave={vi.fn(() => Promise.resolve())}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Group name" }));
+
+    expect(trackMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/dmworkbase/src/ui/ChannelSettingRows/index.tsx
+++ b/packages/dmworkbase/src/ui/ChannelSettingRows/index.tsx
@@ -11,6 +11,7 @@ import {
   ListItemSwitch,
   ListItemSwitchContext,
 } from "../../Components/ListItem";
+import { Dap } from "../../Service/Dap";
 import { t } from "../../i18n";
 import "./index.css";
 
@@ -111,6 +112,12 @@ export interface ChannelSettingInlineEditRowProps {
   allowEmpty?: boolean;
   multiline?: boolean;
   onStartEdit?: () => boolean | void;
+  /**
+   * 埋点事件名:仅在编辑器真正打开(onStartEdit 权限门通过)那一刻发一次。
+   * 不走行 wrapper 的 data-track——编辑态 input/取消/保存都在同一 wrapper 内,
+   * 否则每次点击都会重发「打开」事件(见 PR #1390 review)。
+   */
+  trackEvent?: string;
   /** Resolve false or reject to keep the editor open with its current draft. */
   onSave: (value: string) => Promise<void | boolean>;
 }
@@ -124,6 +131,7 @@ export function ChannelSettingInlineEditRow({
   allowEmpty = false,
   multiline = false,
   onStartEdit,
+  trackEvent,
   onSave,
 }: ChannelSettingInlineEditRowProps) {
   const [editing, setEditing] = useState(false);
@@ -150,6 +158,7 @@ export function ChannelSettingInlineEditRow({
 
   const startEdit = () => {
     if (onStartEdit?.() === false) return;
+    if (trackEvent) Dap.shared.track(trackEvent);
     setDraft(currentValue);
     setDirty(false);
     setEditing(true);


### PR DESCRIPTION
## What

Pure-frontend event tracking (no backend emit) for the group/channel setting panel, plus stable HTTP route templates for `http_request` events. Incremental follow-up to the merged tracking mask (#1330).

## Changes

- **`Row.trackEvent` / `Row.trackProps`** — a first-class tracking field on the config-surface `Row` model. `Sections` renders it as `data-track` on the row wrapper, reusing the existing capture-phase click delegation in `Dap` (no new mechanism). This is the workhorse for config-driven UI that has no stable DOM anchor.
- **12 open/browse intent events** wired across the channel-setting rows:
  `group_name_edit_opened`, `group_avatar_edit_opened`, `group_qrcode_viewed`, `group_announcement_edit_opened`, `group_transfer_dialog_opened`, `group_md_viewed`, `group_webhook_panel_opened`, `group_management_page_opened`, `conversation_remark_edit_opened`, `conversation_clear_dialog_opened`, `conversation_leave_dialog_opened`, `group_nickname_edit_opened`.
- **`apiPath` tagged template + `registerRequestTemplate`** — lets `http_request` report a stable route template instead of a reverse-parsed URL. Adopted across the Service layer. Registration is best-effort inside the axios request interceptor and never affects the request itself.
- **`TrackRules`** table retained for imperative-JSX nodes that already carry a `data-testid`/`role`.

## Notes

- Event names are server-registered in octo-dap `tracker.registry.yaml`; unregistered names are dead-lettered by the collector. The matching registry entries are already pushed.
- All events are `source=frontend_tracker`, `quality=submitted` — open/browse funnel signals, distinct from the domain completion facts (`group_*_edited`).

## Test

- `Dap.test.ts` + `apiPath.test.ts`: 31/31 passing.
