### PR TITLE
fix(electron): align tray unread count with conversations

### DIFF
--- a/apps/web/src/App/__tests__/getElectronUnreadMessageCount.test.ts
+++ b/apps/web/src/App/__tests__/getElectronUnreadMessageCount.test.ts
@@ -29,9 +29,55 @@ vi.mock('wukongimjssdk', () => ({
     }),
   },
   ChannelTypePerson: 1,
+  ChannelTypeGroup: 2,
 }))
 
 vi.mock('@octo/base', () => ({
+  ChannelTypeCommunityTopic: 5,
+  ThreadStatus: { Active: 1, Archived: 2, Deleted: 3 },
+  Channel: class {
+    constructor(public channelID: string, public channelType: number) {}
+  },
+  parseThreadChannelId: (channelID: string) => {
+    const parts = channelID.split('____')
+    return parts.length === 2 ? { groupNo: parts[0], shortId: parts[1] } : null
+  },
+  isEffectivelyMuted: ({ isThread, channelInfo, parentChannelInfo }: any) => {
+    if (!isThread) return Boolean(channelInfo?.mute)
+    return Boolean(parentChannelInfo?.mute) || channelInfo?.orgData?.thread?.mute === 1
+  },
+  ConversationWrap: class {
+    conversation: any
+    constructor(conversation: any) {
+      this.conversation = conversation
+    }
+    get unread() {
+      if (
+        currentSpaceId &&
+        this.conversation.channel.channelType === 1 &&
+        this.conversation.extra?.spaceUnread !== undefined
+      ) {
+        return this.conversation.extra.spaceUnread
+      }
+      const rawUnread = this.conversation.unread
+      if (rawUnread === 0) return 0
+
+      if (
+        currentSpaceId &&
+        this.conversation.channel.channelType === 1 &&
+        this.conversation.channel.channelID === 'botfather' &&
+        !this.conversation.lastMessage?.content?.contentObj?.space_id
+      ) {
+        return 0
+      }
+
+      const systemContentTypes = new Set([1002, 1003, 1005, 1008, 1009])
+      if (rawUnread === 1 && systemContentTypes.has(this.conversation.lastMessage?.contentType)) {
+        return 0
+      }
+      return rawUnread
+    }
+  },
   WKApp: {
     get shared() { return { currentSpaceId } },
   },
@@ -59,7 +105,7 @@ describe('getElectronUnreadMessageCount', () => {
     expect(getElectronUnreadMessageCount()).toBe(0)
   })
 
-  it('sums unread counts across normal conversations', () => {
+  it('sums effective unread messages across normal conversations', () => {
     mockConversations.push(
       { channel: { channelType: 0 }, unread: 3, extra: undefined },
       { channel: { channelType: 0 }, unread: 5, extra: undefined },
@@ -137,5 +183,92 @@ describe('getElectronUnreadMessageCount', () => {
   it('floors fractional unread values', () => {
     mockConversations.push({ channel: { channelType: 0 }, unread: 2.9, extra: undefined })
     expect(getElectronUnreadMessageCount()).toBe(2)
+  })
+
+  it('excludes archived and deleted threads', () => {
+    const archivedThread = {
+      channel: { channelID: 'group-1____thread-1', channelType: 5 },
+      unread: 4,
+    }
+    const deletedThread = {
+      channel: { channelID: 'group-1____thread-2', channelType: 5 },
+      unread: 6,
+    }
+    mockGetChannelInfo.mockImplementation((channel: any) => {
+      if (channel === archivedThread.channel) {
+        return { orgData: { thread: { status: 2 } } }
+      }
+      if (channel === deletedThread.channel) {
+        return { orgData: { thread: { status: 3 } } }
+      }
+      return undefined
+    })
+    mockConversations.push(archivedThread, deletedThread, {
+      channel: { channelType: 0 },
+      unread: 3,
+    })
+
+    expect(getElectronUnreadMessageCount()).toBe(3)
+  })
+
+  it('excludes a thread when its parent group is muted', () => {
+    const threadChannel = { channelID: 'group-1____thread-1', channelType: 5 }
+    mockGetChannelInfo.mockImplementation((channel: any) => {
+      if (channel === threadChannel) return { orgData: { thread: { mute: 0 } } }
+      if (channel.channelID === 'group-1' && channel.channelType === 2) {
+        return { mute: 1 }
+      }
+      return undefined
+    })
+    mockConversations.push(
+      { channel: threadChannel, unread: 8 },
+      { channel: { channelType: 0 }, unread: 2 },
+    )
+
+    expect(getElectronUnreadMessageCount()).toBe(2)
+  })
+
+  it('excludes a thread with its own mute enabled', () => {
+    const threadChannel = { channelID: 'group-1____thread-1', channelType: 5 }
+    mockGetChannelInfo.mockImplementation((channel: any) => {
+      if (channel === threadChannel) return { orgData: { thread: { mute: 1 } } }
+      return undefined
+    })
+    mockConversations.push(
+      { channel: threadChannel, unread: 8 },
+      { channel: { channelType: 0 }, unread: 2 },
+    )
+
+    expect(getElectronUnreadMessageCount()).toBe(2)
+  })
+
+  it('excludes a system-message unread count of one', () => {
+    mockConversations.push(
+      {
+        channel: { channelType: 0 },
+        unread: 1,
+        lastMessage: { contentType: 1002 },
+      },
+      { channel: { channelType: 0 }, unread: 2 },
+    )
+
+    expect(getElectronUnreadMessageCount()).toBe(2)
+  })
+
+  it('excludes BotFather unread without a Space id in Space mode', () => {
+    currentSpaceId = 'space-1'
+    mockConversations.push(
+      {
+        channel: { channelID: 'botfather', channelType: 1 },
+        unread: 7,
+      },
+      {
+        channel: { channelID: 'botfather', channelType: 1 },
+        unread: 3,
+        lastMessage: { content: { contentObj: { space_id: 'space-1' } } },
+      },
+    )
+
+    expect(getElectronUnreadMessageCount()).toBe(3)
   })
 })

--- a/apps/web/src/App/electronUnreadCount.ts
+++ b/apps/web/src/App/electronUnreadCount.ts
@@ -5,41 +5,62 @@
  * Electron main process for tray-badge rendering.  Extracted into its own
  * module so it can be unit-tested without booting the full React app tree.
  */
-import { WKSDK, ChannelTypePerson } from 'wukongimjssdk'
-import { WKApp, shouldSkipChannelForSpace, shouldSkipPersonConversationForSpace } from '@octo/base'
+import { WKSDK, ChannelTypePerson, ChannelTypeGroup } from 'wukongimjssdk'
+import {
+  ConversationWrap,
+  isEffectivelyMuted,
+  ChannelTypeCommunityTopic,
+  ThreadStatus,
+  parseThreadChannelId,
+  Channel,
+  shouldSkipChannelForSpace,
+  shouldSkipPersonConversationForSpace,
+} from '@octo/base'
 
 /**
- * Returns the total unread-message count across all visible conversations,
- * applying the same mute / space-filter logic as the tray listener.
+ * Returns the effective unread-message total used by the desktop tray.
  *
  * Rules:
  *  - Muted channels are excluded.
  *  - Channels / person-conversations filtered by the current Space are excluded.
- *  - Person channels use `extra.spaceUnread` when a Space is active and the
- *    field is present; otherwise fall back to `conversation.unread`.
- *  - Non-finite / negative values are clamped to 0 so a bad IPC payload cannot
- *    corrupt the tray title.
+ *  - Uses the same effective unread value as the conversation list, including
+ *    mute, Space, system-message and system-bot handling.
  */
 export function getElectronUnreadMessageCount(): number {
+  const sdk = WKSDK.shared()
   let total = 0
-  const currentSpaceId = WKApp.shared.currentSpaceId
-
-  for (const conversation of WKSDK.shared().conversationManager.conversations) {
+  for (const conversation of sdk.conversationManager.conversations) {
+    const channel = conversation.channel
     const channelInfo = WKSDK.shared().channelManager.getChannelInfo(conversation.channel)
-    if (channelInfo?.mute) continue
-    if (shouldSkipChannelForSpace(conversation.channel)) continue
-    if (shouldSkipPersonConversationForSpace(conversation)) continue
+    const isThread = channel.channelType === ChannelTypeCommunityTopic
+    const parentGroupNo = isThread
+      ? (channelInfo?.orgData?.parentGroupNo as string | undefined) ||
+        parseThreadChannelId(channel.channelID)?.groupNo
+      : undefined
+    const parentChannelInfo = parentGroupNo
+      ? sdk.channelManager.getChannelInfo(new Channel(parentGroupNo, ChannelTypeGroup))
+      : undefined
+    const threadStatus = channelInfo?.orgData?.thread?.status as number | undefined
 
-    const rawUnread =
-      currentSpaceId &&
-      conversation.channel.channelType === ChannelTypePerson &&
-      conversation.extra?.spaceUnread !== undefined
-        ? conversation.extra.spaceUnread
-        : conversation.unread
+    if (
+      shouldSkipChannelForSpace(channel) ||
+      (channel.channelType === ChannelTypePerson &&
+        shouldSkipPersonConversationForSpace(conversation)) ||
+      isEffectivelyMuted({
+        isThread,
+        channelInfo,
+        parentChannelInfo,
+      }) ||
+      (isThread &&
+        threadStatus !== undefined &&
+        threadStatus !== ThreadStatus.Active)
+    ) {
+      continue
+    }
 
-    const n = Number(rawUnread)
-    if (Number.isFinite(n)) {
-      total += Math.max(0, n)
+    const unread = Number(new ConversationWrap(conversation).unread)
+    if (Number.isFinite(unread)) {
+      total += Math.max(0, unread)
     }
   }
 


### PR DESCRIPTION
## Summary\n\n- Align Electron tray unread counts with conversation-list effective unread logic.\n- Exclude muted channels, inactive threads, system-message noise, and out-of-space BotFather messages.\n- Add regression coverage for the filtering rules.\n\n## Verification\n\n- pnpm --filter @octo/web exec vitest run src/App/__tests__/getElectronUnreadMessageCount.test.ts (15 passed)