### PR TITLE
chore(dev): proxy /docs-html to the HTML docs backend in dev server

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -208,6 +208,16 @@ export default defineConfig(({ mode }) => {
       port: env.VITE_PORT ? Number(env.VITE_PORT) : 3000,
       host: env.VITE_HOST ?? true,
       proxy: {
+        // HTML 文档后端(octo-docs-html)。前端把它的 base 默认解析成 /docs-html,
+        // 没有这条代理时那些请求会落到 dev server 的 SPA 兜底页 —— 返回 200 + index.html,
+        // 看着像通了,其实一个接口都没到后端。本地实测就是这么被骗过一次的。
+        // 放在最前面:它的前缀比 /api/* 更具体,而 vite 按插入顺序匹配、第一个命中的前缀生效。
+        "/docs-html": {
+          target: env.VITE_OCTO_DOC_BASE || "http://127.0.0.1:4100",
+          changeOrigin: true,
+          secure: false,
+          rewrite: (path: string) => path.replace(/^\/docs-html/, ""),
+        },
         // Agent Mail uses one stable browser path in every environment. The
         // development proxy selects the OCTO server origin through
         // configuration, while production uses the equivalent Nginx route.


### PR DESCRIPTION
## Summary
Re-lift of previously-open work from a fork that became unavailable; replayed onto the latest `upstream/main` as a single squashed commit. No functional change vs. the original branch.

## Linked Spec
Supersedes former PR #1384

## How verified
- Replayed onto current `upstream/main` in an isolated worktree with `merge --squash`; zero conflicted paths (`git status` shows no U/A markers).
- Diff scope vs. `upstream/main`: 1 file(s), +10/-0 (this PR's own changes only; the source branch's three-dot count also included upstream commits already merged).
- Squashed to one commit so the PR carries only this feature's changes.

## COMPREHENSION
- **What this does to load-bearing paths:** replay-only; the change set is byte-identical to the branch that was already reviewed, rebased onto a newer base.
- **What it could break:** the newer base may have moved code this patch touches; conflict-free application plus unchanged diff scope is the evidence it did not.
- **What verified it:** conflict-free squash replay onto latest `upstream/main` + diff-scope equality against the source branch.