### PR TITLE
fix(summary): restore create-page mode dropdown and compact topic input

### DIFF
--- a/apps/web/e2e-kit/msw-handlers/chat-baseline.ts
+++ b/apps/web/e2e-kit/msw-handlers/chat-baseline.ts
@@ -68,6 +68,13 @@ export const chatBaselineHandlers = [
       headers: { "content-type": "image/png" },
     })
   ),
+  http.get("*/groups/:groupNo/avatar", () =>
+    // 与 user avatar 同理: group logo 可能为空, 但请求本身不该漏到 Vite proxy
+    // (fake-provider 会为无 logo 的 group 派生 avatar 路径, 见 fake-provider.ts).
+    HttpResponse.arrayBuffer(new Uint8Array([]).buffer, {
+      headers: { "content-type": "image/png" },
+    })
+  ),
   http.get("*/group/avatar_palette", () =>
     // 空 colors 会走前端 fallback palette, 但请求本身不该漏到 Vite proxy.
     HttpResponse.json({ size: 0, colors: [] })

--- a/apps/web/e2e-kit/msw-handlers/s9-summary-agent-chat-save.ts
+++ b/apps/web/e2e-kit/msw-handlers/s9-summary-agent-chat-save.ts
@@ -86,10 +86,11 @@ export async function registerS9SummaryAgentChatSave(page: Page): Promise<void> 
       },
     };
 
-    (window as unknown as { __s9State__: { listCalls: number; streamCalls: number; saveCalls: number } }).__s9State__ = {
+    (window as unknown as { __s9State__: { listCalls: number; streamCalls: number; saveCalls: number; saveBody: unknown } }).__s9State__ = {
       listCalls: 0,
       streamCalls: 0,
       saveCalls: 0,
+      saveBody: null,
     };
 
     worker.use(
@@ -100,6 +101,12 @@ export async function registerS9SummaryAgentChatSave(page: Page): Promise<void> 
       }),
       http.get("*/summary/api/v1/summary-templates", () =>
         env({ templates: [], custom_template_limit: 30 })
+      ),
+      http.get("*/summary/api/v1/summary-chat-candidates", () =>
+        env([{ chat_id: "s9-agent-project-group", chat_type: "group", name: "S9 Agent 项目群", member_count: 2, is_archived: false }])
+      ),
+      http.post("*/sidebar/sync", () =>
+        HttpResponse.json({ items: [], version: 0, follow_version: 0 })
       ),
       http.get("*/summary/api/v1/agent/chat/history", ({ request }: any) => {
         const url = new URL(request.url);
@@ -126,9 +133,11 @@ export async function registerS9SummaryAgentChatSave(page: Page): Promise<void> 
           },
         });
       }),
-      http.post("*/summary/api/v1/summaries/agent", () => {
-        const state = (window as unknown as { __s9State__: { saveCalls: number } }).__s9State__;
+      http.post("*/summary/api/v1/summaries/agent", async ({ request }: any) => {
+        const state = (window as unknown as { __s9State__: { saveCalls: number; saveBody: unknown } }).__s9State__;
         state.saveCalls += 1;
+        // 记录请求体供 spec 断言：Agent 保存不得携带 participants（P1 回归）。
+        state.saveBody = await request.json();
         return env({
           task_id: taskId,
           task_no: "S9-TASK-9901",

--- a/apps/web/e2e-kit/tests/summary/_testids.ts
+++ b/apps/web/e2e-kit/tests/summary/_testids.ts
@@ -23,9 +23,9 @@ export const T = {
     createSelectChat: "summary-create-select-chat",
     createSelectMembers: "summary-create-select-members",
     createSubmit: "summary-create-submit",
+    createModeSwitch: "summary-create-mode-switch",
     createAgentTab: "summary-create-agent-tab",
     createNormalTab: "summary-create-normal-tab",
-    createPanelStartBtn: "summary-create-panel-start-btn",
 
     // Chat/member selector modal
     chatSelectorModal: "summary-chat-selector-modal",

--- a/apps/web/e2e-kit/tests/summary/agent/S10-summary-agent-reference-side-panel.spec.ts
+++ b/apps/web/e2e-kit/tests/summary/agent/S10-summary-agent-reference-side-panel.spec.ts
@@ -26,6 +26,7 @@ test.describe("@S10 @p1 @summary @agent @summary-agent @summary-reference S10 �
     await authedPage.getByTestId(T.createEntry).click();
 
     await expect(authedPage.getByText("邀请同事一起总结信息")).toBeVisible({ timeout: 15_000 });
+    await authedPage.getByTestId(T.createModeSwitch).click();
     await authedPage.getByTestId(T.createAgentTab).click();
     await expect(
       authedPage.getByText("你好，我是总结助手，想总结什么尽管告诉我。")

--- a/apps/web/e2e-kit/tests/summary/agent/S11-summary-agent-continue-refine.spec.ts
+++ b/apps/web/e2e-kit/tests/summary/agent/S11-summary-agent-continue-refine.spec.ts
@@ -35,7 +35,7 @@ test.describe("@S11 @p0 @summary @agent @summary-agent @summary-detail @summary-
     await expect(
       authedPage.getByText("你好，我是总结助手，想总结什么尽管告诉我。")
     ).toBeVisible({ timeout: 15_000 });
-    await expect(authedPage.getByTestId(T.createAgentTab)).toHaveClass(/active/);
+    await expect(authedPage.getByTestId(T.agentInput)).toBeVisible();
     const referenceCard = authedPage.getByTestId(T.agentRefCard);
     await expect(referenceCard.getByText("已引用")).toBeVisible();
     await expect(referenceCard.getByText("S11 Agent 原总结", { exact: true })).toBeVisible();

--- a/apps/web/e2e-kit/tests/summary/agent/S11-summary-agent-continue-refine.spec.ts
+++ b/apps/web/e2e-kit/tests/summary/agent/S11-summary-agent-continue-refine.spec.ts
@@ -35,6 +35,15 @@ test.describe("@S11 @p0 @summary @agent @summary-agent @summary-detail @summary-
     await expect(
       authedPage.getByText("你好，我是总结助手，想总结什么尽管告诉我。")
     ).toBeVisible({ timeout: 15_000 });
+    // dropdown 反映当前模式（agent active）。
+    await authedPage.getByTestId(T.createModeSwitch).click();
+    await expect(authedPage.getByTestId(T.createAgentTab)).toHaveClass(/active/);
+    // Agent → Normal 往返：切回后 topic 输入框重新挂载可见（P2-1/P2-2 覆盖）。
+    await authedPage.getByTestId(T.createNormalTab).click();
+    await expect(authedPage.getByTestId(T.createTopic)).toBeVisible();
+    // 再切回 Agent 继续引用卡片断言。
+    await authedPage.getByTestId(T.createModeSwitch).click();
+    await authedPage.getByTestId(T.createAgentTab).click();
     await expect(authedPage.getByTestId(T.agentInput)).toBeVisible();
     const referenceCard = authedPage.getByTestId(T.agentRefCard);
     await expect(referenceCard.getByText("已引用")).toBeVisible();

--- a/apps/web/e2e-kit/tests/summary/agent/S12-summary-agent-save-failure.spec.ts
+++ b/apps/web/e2e-kit/tests/summary/agent/S12-summary-agent-save-failure.spec.ts
@@ -25,6 +25,7 @@ test.describe("@S12 @p1 @summary @agent @summary-agent @summary-create @error-st
     await authedPage.getByTestId(T.createEntry).click();
 
     await expect(authedPage.getByText("邀请同事一起总结信息")).toBeVisible({ timeout: 15_000 });
+    await authedPage.getByTestId(T.createModeSwitch).click();
     await authedPage.getByTestId(T.createAgentTab).click();
     await authedPage.getByTestId(T.agentInput).fill("S12 生成保存失败测试内容");
     await authedPage.getByTestId(T.agentSendBtn).click();

--- a/apps/web/e2e-kit/tests/summary/agent/S13-summary-agent-new-session.spec.ts
+++ b/apps/web/e2e-kit/tests/summary/agent/S13-summary-agent-new-session.spec.ts
@@ -25,6 +25,7 @@ test.describe("@S13 @p1 @summary @agent @summary-agent @summary-reference S13 �
     await authedPage.getByTestId(T.createEntry).click();
 
     await expect(authedPage.getByText("邀请同事一起总结信息")).toBeVisible({ timeout: 15_000 });
+    await authedPage.getByTestId(T.createModeSwitch).click();
     await authedPage.getByTestId(T.createAgentTab).click();
     await expect(
       authedPage.getByText("你好，我是总结助手，想总结什么尽管告诉我。")

--- a/apps/web/e2e-kit/tests/summary/agent/S9-summary-agent-chat-save.spec.ts
+++ b/apps/web/e2e-kit/tests/summary/agent/S9-summary-agent-chat-save.spec.ts
@@ -101,7 +101,8 @@ test.describe("@S9 @p0 @summary @agent @summary-agent @summary-create @summary-d
     await authedPage.getByTestId(T.agentSaveTitleInput).fill("S9 Agent 风险总结");
     await authedPage.getByTestId(T.agentSaveConfirmBtn).click();
 
-    // P1 回归：切 Agent 时已清空 selectedMembers，保存请求不得携带 participants。
+    // P1 回归：Agent 保存不携带 participants（payload 边界守卫 mode !== 'agent'）。
+    // selectedMembers 不再被清空——往返切换后选择仍保留（见上方 Agent→Normal 断言）。
     await expect(authedPage.getByText("AI 总结已保存")).toBeVisible({ timeout: 15_000 });
     const saveBody = await authedPage.evaluate(
       () => (window as unknown as { __s9State__?: { saveBody: unknown } }).__s9State__?.saveBody

--- a/apps/web/e2e-kit/tests/summary/agent/S9-summary-agent-chat-save.spec.ts
+++ b/apps/web/e2e-kit/tests/summary/agent/S9-summary-agent-chat-save.spec.ts
@@ -67,6 +67,13 @@ test.describe("@S9 @p0 @summary @agent @summary-agent @summary-create @summary-d
     await expect(authedPage.getByTestId(T.createSelectMembers)).toHaveCount(0);
     await expect(authedPage.getByTestId(T.createSubmit)).toHaveCount(0);
 
+    // Agent → Normal 往返：selectedMembers 不再被清空，切回后参与者 chips 保留（P1-2）。
+    await authedPage.getByTestId(T.createModeSwitch).click();
+    await authedPage.getByTestId(T.createNormalTab).click();
+    await expect(authedPage.getByText("S9 Alice", { exact: true })).toBeVisible();
+    await authedPage.getByTestId(T.createModeSwitch).click();
+    await authedPage.getByTestId(T.createAgentTab).click();
+
     await expect(
       authedPage.getByText("你好，我是总结助手，想总结什么尽管告诉我。")
     ).toBeVisible({ timeout: 15_000 });

--- a/apps/web/e2e-kit/tests/summary/agent/S9-summary-agent-chat-save.spec.ts
+++ b/apps/web/e2e-kit/tests/summary/agent/S9-summary-agent-chat-save.spec.ts
@@ -5,6 +5,7 @@
  * S9: Summary Agent 总结 chat → 保存为总结 → 详情.
  */
 import { test, expect } from "../../../fixtures-authed";
+import { installMockImRuntime } from "../../../_kit/mock-im-runtime";
 import { registerS9SummaryAgentChatSave } from "../../../msw-handlers/s9-summary-agent-chat-save";
 import { startRequestMonitor, sanityCheck } from "../../../_lib/sanity";
 import { T } from "../_testids";
@@ -19,6 +20,21 @@ const sanityConfig = {
 test.describe("@S9 @p0 @summary @agent @summary-agent @summary-create @summary-detail S9 — Summary Agent 总结保存主流程", () => {
   test("Agent 对话产出保存为总结后进入详情", async ({ authedPage }) => {
     await registerS9SummaryAgentChatSave(authedPage);
+    // 提供 S9 群与成员，用于验证「选参与者后切 Agent → 保存不带 participants」（P1 回归）。
+    await installMockImRuntime(authedPage, {
+      currentUid: "e2e-user-1",
+      spaceId: "e2e-space-001",
+      users: [
+        { uid: "e2e-user-1", name: "E2E Tester", robot: 0 },
+        { uid: "s9-member-a", name: "S9 Alice", robot: 0 },
+      ],
+      groups: [{ group_no: "s9-agent-project-group", name: "S9 Agent 项目群" }],
+      conversations: [{ channelId: "s9-agent-project-group", channelType: 2, unread: 0 }],
+      subscribers: [
+        { uid: "e2e-user-1", name: "E2E Tester", channelId: "s9-agent-project-group", channelType: 2, role: 1, robot: 0 },
+        { uid: "s9-member-a", name: "S9 Alice", channelId: "s9-agent-project-group", channelType: 2, role: 0, robot: 0 },
+      ],
+    });
     const ctx = startRequestMonitor(authedPage, sanityConfig);
 
     await authedPage.getByRole("button", { name: "智能总结" }).click();
@@ -26,8 +42,30 @@ test.describe("@S9 @p0 @summary @agent @summary-agent @summary-create @summary-d
     await authedPage.getByTestId(T.createEntry).click();
 
     await expect(authedPage.getByText("邀请同事一起总结信息")).toBeVisible({ timeout: 15_000 });
+
+    // 正常模式：选聊天 + 选参与者（随后切 Agent 验证参与者被隔离，P1 回归）。
+    await authedPage.getByTestId(T.createSelectChat).click();
+    await authedPage.getByTestId(T.chatSelectorAllGroupsTab).click();
+    await authedPage.getByText("S9 Agent 项目群", { exact: true }).click();
+    await expect(authedPage.getByText("已选 1 / 30")).toBeVisible();
+    await authedPage.getByTestId(T.chatSelectorConfirmBtn).click();
+    await expect(authedPage.getByText("S9 Agent 项目群", { exact: true })).toBeVisible();
+
+    await authedPage.getByTestId(T.createSelectMembers).click();
+    await expect(authedPage.getByText("选择参与者").last()).toBeVisible({ timeout: 15_000 });
+    await authedPage.getByText("S9 Alice", { exact: true }).click();
+    await expect(authedPage.getByText("已选 1 / 30")).toBeVisible();
+    await authedPage.getByTestId(T.memberSelectorConfirmBtn).click();
+    await expect(authedPage.getByText("S9 Alice", { exact: true })).toBeVisible();
+
+    // dropdown 反映当前模式（normal active），再切到 Agent。
     await authedPage.getByTestId(T.createModeSwitch).click();
+    await expect(authedPage.getByTestId(T.createNormalTab)).toHaveClass(/active/);
     await authedPage.getByTestId(T.createAgentTab).click();
+
+    // Agent 模式：参与者入口与「开始总结」主按钮均消失。
+    await expect(authedPage.getByTestId(T.createSelectMembers)).toHaveCount(0);
+    await expect(authedPage.getByTestId(T.createSubmit)).toHaveCount(0);
 
     await expect(
       authedPage.getByText("你好，我是总结助手，想总结什么尽管告诉我。")
@@ -56,7 +94,13 @@ test.describe("@S9 @p0 @summary @agent @summary-agent @summary-create @summary-d
     await authedPage.getByTestId(T.agentSaveTitleInput).fill("S9 Agent 风险总结");
     await authedPage.getByTestId(T.agentSaveConfirmBtn).click();
 
+    // P1 回归：切 Agent 时已清空 selectedMembers，保存请求不得携带 participants。
     await expect(authedPage.getByText("AI 总结已保存")).toBeVisible({ timeout: 15_000 });
+    const saveBody = await authedPage.evaluate(
+      () => (window as unknown as { __s9State__?: { saveBody: unknown } }).__s9State__?.saveBody
+    );
+    expect(saveBody).not.toBeNull();
+    expect((saveBody as { participants?: unknown }).participants).toBeUndefined();
     await expect(
       authedPage.getByTestId(T.detailTitle)
     ).toBeVisible({ timeout: 15_000 });

--- a/apps/web/e2e-kit/tests/summary/agent/S9-summary-agent-chat-save.spec.ts
+++ b/apps/web/e2e-kit/tests/summary/agent/S9-summary-agent-chat-save.spec.ts
@@ -26,6 +26,7 @@ test.describe("@S9 @p0 @summary @agent @summary-agent @summary-create @summary-d
     await authedPage.getByTestId(T.createEntry).click();
 
     await expect(authedPage.getByText("邀请同事一起总结信息")).toBeVisible({ timeout: 15_000 });
+    await authedPage.getByTestId(T.createModeSwitch).click();
     await authedPage.getByTestId(T.createAgentTab).click();
 
     await expect(

--- a/packages/dmworksummary/src/components/ChatSummaryNewModal.css
+++ b/packages/dmworksummary/src/components/ChatSummaryNewModal.css
@@ -187,8 +187,5 @@
 }
 
 /* 分裂按钮（开始总结 + 下拉切换 Agent 总结）。SplitButtonGroup 自带主体/箭头
-   连接样式，这里仅确保下拉箭头按钮不被文案撑开、与主体等高。 */
-.chat-summary-modal-split .semi-button:last-child {
-    padding-left: var(--wk-sp-2, 8px);
-    padding-right: var(--wk-sp-2, 8px);
-}
+   连接样式，这里仅确保下拉箭头按钮不被文案撑开、与主体等高。padding 规则见
+   index.css .chat-summary-modal-split .semi-button:last-child（全局生效，勿重复定义）。 */

--- a/packages/dmworksummary/src/components/ChatSummaryNewModal.css
+++ b/packages/dmworksummary/src/components/ChatSummaryNewModal.css
@@ -187,5 +187,11 @@
 }
 
 /* 分裂按钮（开始总结 + 下拉切换 Agent 总结）。SplitButtonGroup 自带主体/箭头
-   连接样式，这里仅确保下拉箭头按钮不被文案撑开、与主体等高。padding 规则见
-   index.css .chat-summary-modal-split .semi-button:last-child（全局生效，勿重复定义）。 */
+   连接样式，这里仅确保下拉箭头按钮不被文案撑开、与主体等高。
+   本规则刻意与 index.css 的同名规则共存：Storybook story 直接 import 本组件、
+   不加载 summary 包样式表（index.css），本地保留才能保证独立渲染的 chevron
+   padding 正确；两条规则内容一致、全局生效，重复是幂等的。 */
+.chat-summary-modal-split .semi-button:last-child {
+    padding-left: var(--wk-sp-2, 8px);
+    padding-right: var(--wk-sp-2, 8px);
+}

--- a/packages/dmworksummary/src/index.css
+++ b/packages/dmworksummary/src/index.css
@@ -2438,7 +2438,7 @@ body[theme-mode="dark"] .summary-list-status-trigger:hover {
     gap: 12px;
 }
 
-.summary-workbench--panel .summary-workbench-start-group {
+.summary-workbench--panel .chat-summary-modal-split {
     align-self: flex-end;
 }
 
@@ -2592,46 +2592,11 @@ body[theme-mode="dark"] .summary-list-status-trigger:hover {
     margin-top: 4px;
 }
 
-/* Start button group - 主按钮 + 模式下拉，右下角 */
-.summary-workbench-start-group {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    flex-shrink: 0;
-}
-
-/* Start button - 药丸形，active 状态深色白字，disabled 状态浅灰背景灰字+图标 */
-.summary-workbench-start-btn {
-    border-radius: 99px !important;
-    padding: 0 12px;
-    height: 32px;
-    font-size: 14px;
-    font-weight: 500;
-    flex-shrink: 0;
-}
-
-/* 模式下拉触发按钮 - 药丸形图标按钮 */
-button.summary-workbench-mode-switch-btn {
-    border-radius: 99px;
-    padding: 0;
-    height: 32px;
-    width: 32px;
-    flex-shrink: 0;
-    color: var(--wk-text-secondary);
-}
-
-.summary-workbench-start-btn svg {
-    margin-right: 10px;
-}
-
-.summary-workbench-start-btn:disabled {
-    background-color: var(--wk-bg-elevated) !important;
-    color: var(--wk-text-disabled) !important;
-}
-
-.summary-workbench-start-btn:disabled svg {
-    color: var(--wk-text-disabled);
-    margin-right: 4px;
+/* 右下角按钮组：SplitButtonGroup（主按钮 + 模式下拉），与 ChatSummaryNewModal 一致。
+   chevron 触发按钮加紧凑 padding，避免默认 16px 左右 padding 撑宽图标按钮。 */
+.chat-summary-modal-split .semi-button:last-child {
+    padding-left: var(--wk-sp-2, 8px);
+    padding-right: var(--wk-sp-2, 8px);
 }
 
 @media (max-width: 600px) {
@@ -2641,7 +2606,7 @@ button.summary-workbench-mode-switch-btn {
         gap: 12px;
     }
 
-    .summary-workbench-start-group {
+    .chat-summary-modal-split {
         align-self: flex-end;
     }
 }

--- a/packages/dmworksummary/src/index.css
+++ b/packages/dmworksummary/src/index.css
@@ -2308,47 +2308,6 @@ body[theme-mode="dark"] .summary-list-status-trigger:hover {
     margin-bottom: 16px;
 }
 
-/* Mode switch (normal/agent) */
-.summary-workbench-mode-switch {
-    margin-left: auto;
-    display: flex;
-    gap: 0;
-    background: var(--semi-color-fill-0);
-    border: 1px solid transparent;
-    border-radius: var(--semi-border-radius-full);
-    padding: 2px;
-    flex-shrink: 0;
-}
-
-body[theme-mode="dark"] .summary-workbench-mode-switch {
-    background: var(--wk-bg-elevated);
-    border-color: var(--wk-border-default);
-}
-
-.summary-workbench-mode-btn {
-    border: none;
-    background: transparent;
-    cursor: pointer;
-    font-family: inherit;
-    font-size: var(--semi-font-size-small);
-    font-weight: 600;
-    line-height: 20px;
-    padding: 4px 12px;
-    border-radius: var(--semi-border-radius-full);
-    color: var(--wk-text-tertiary);
-    white-space: nowrap;
-    transition: background 0.15s, color 0.15s;
-}
-
-.summary-workbench-mode-btn--active {
-    background: var(--wk-bg-surface);
-    color: var(--wk-text-primary);
-}
-
-.summary-workbench-mode-btn:not(.summary-workbench-mode-btn--active):hover {
-    color: var(--wk-text-secondary);
-}
-
 .summary-workbench-header-emoji {
     font-size: 28px;
     line-height: 1;
@@ -2378,25 +2337,18 @@ body[theme-mode="dark"] .summary-workbench-mode-switch {
     min-height: 320px;
 }
 
-/* Input wrap - 420px fixed height (设计稿) */
+/* Input wrap - 高度随内容自动撑开，min/max 约束边界 */
 .summary-workbench-input-wrap {
     display: flex;
     flex-direction: column;
-    height: 420px;
     flex-shrink: 0;
-    overflow: hidden;
-}
-
-.summary-workbench-input-wrap > div:first-child {
-    position: relative;
-    flex: 1;
-    min-height: 0;
 }
 
 .summary-workbench-textarea {
     display: block;
     width: 100%;
-    height: 100%;
+    min-height: 200px;
+    max-height: 420px;
     border: none;
     outline: none;
     resize: none;
@@ -2458,8 +2410,7 @@ body[theme-mode="dark"] .summary-workbench-mode-switch {
 }
 
 /* 面板模式：输入框高度缩小 */
-.summary-workbench--panel .summary-workbench-input-wrap {
-    height: auto;
+.summary-workbench--panel .summary-workbench-textarea {
     min-height: 120px;
 }
 
@@ -2487,7 +2438,7 @@ body[theme-mode="dark"] .summary-workbench-mode-switch {
     gap: 12px;
 }
 
-.summary-workbench--panel .summary-workbench-start-btn {
+.summary-workbench--panel .summary-workbench-start-group {
     align-self: flex-end;
 }
 
@@ -2641,6 +2592,14 @@ body[theme-mode="dark"] .summary-workbench-mode-switch {
     margin-top: 4px;
 }
 
+/* Start button group - 主按钮 + 模式下拉，右下角 */
+.summary-workbench-start-group {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-shrink: 0;
+}
+
 /* Start button - 药丸形，active 状态深色白字，disabled 状态浅灰背景灰字+图标 */
 .summary-workbench-start-btn {
     border-radius: 99px !important;
@@ -2649,6 +2608,16 @@ body[theme-mode="dark"] .summary-workbench-mode-switch {
     font-size: 14px;
     font-weight: 500;
     flex-shrink: 0;
+}
+
+/* 模式下拉触发按钮 - 药丸形图标按钮 */
+button.summary-workbench-mode-switch-btn {
+    border-radius: 99px;
+    padding: 0;
+    height: 32px;
+    width: 32px;
+    flex-shrink: 0;
+    color: var(--wk-text-secondary);
 }
 
 .summary-workbench-start-btn svg {
@@ -2672,7 +2641,7 @@ body[theme-mode="dark"] .summary-workbench-mode-switch {
         gap: 12px;
     }
 
-    .summary-workbench-start-btn {
+    .summary-workbench-start-group {
         align-self: flex-end;
     }
 }

--- a/packages/dmworksummary/src/pages/SummaryCreatePage.tsx
+++ b/packages/dmworksummary/src/pages/SummaryCreatePage.tsx
@@ -812,8 +812,9 @@ export default class SummaryCreatePage extends Component<SummaryCreatePageProps,
     /**
      * 进入 agent 模式：读 localStorage 拿 session_id → 拉历史回显。
      * 无历史（新会话）则照旧空白开场；session_id 仍惰性生成于首次发送。
-     * 同时清空 selectedMembers：Agent 模式无参与者入口，残留的不可见
-     * participants 会在「保存为总结」时被误提交给后端（P1 回归）。
+     * 注意：不再清空 selectedMembers —— 静默销毁用户已选的参与者是不可逆的
+     * 数据丢失。participants 泄漏在 payload 边界拦截（handleSaveAsSummary 在
+     * agent 模式下不提交 participants），切回「开始总结」时选择仍然保留。
      */
     private enterAgentMode() {
         const stored = readAgentChatSession(this.agentChannelId());
@@ -822,7 +823,6 @@ export default class SummaryCreatePage extends Component<SummaryCreatePageProps,
         const storedRef = readAgentChatReferenced(this.agentChannelId());
         this.setState((prev) => ({
             mode: 'agent',
-            selectedMembers: [],
             sessionId: stored || prev.sessionId,
             referencedTask: storedRef
                 ? { task_id: storedRef.task_id, title: storedRef.title } as SummaryListItem
@@ -953,7 +953,10 @@ export default class SummaryCreatePage extends Component<SummaryCreatePageProps,
                 }));
             }
 
-            if (selectedMembers.length > 0) {
+            // Agent 模式无参与者入口，selectedMembers 只会残留自 normal 模式的选择，
+            // 不应随 agent 保存提交给后端（P1 回归）。泄漏在 payload 边界拦截，
+            // 而不是销毁表单状态——切回 normal 时选择仍然保留。
+            if (this.state.mode !== 'agent' && selectedMembers.length > 0) {
                 params.participants = selectedMembers.map((m) => ({ 
                     user_id: m.user_id,
                     user_name: m.name,

--- a/packages/dmworksummary/src/pages/SummaryCreatePage.tsx
+++ b/packages/dmworksummary/src/pages/SummaryCreatePage.tsx
@@ -3,6 +3,7 @@ import React, { Component, createRef } from "react";
 import {
     Button,
     Dropdown,
+    SplitButtonGroup,
     Toast,
     Typography,
     Tag,
@@ -199,7 +200,7 @@ export default class SummaryCreatePage extends Component<SummaryCreatePageProps,
         }
         const actions = selectChat.parentElement;
         if (!actions) return;
-        const startGroup = actions.querySelector('.summary-workbench-start-group');
+        const startGroup = actions.querySelector('.chat-summary-modal-split');
         const actionsWidth = actions.clientWidth;
         const groupWidth = startGroup ? (startGroup as HTMLElement).offsetWidth : 0;
         const gap = 24;
@@ -329,6 +330,10 @@ export default class SummaryCreatePage extends Component<SummaryCreatePageProps,
         if (prevState.selectedChats !== this.state.selectedChats || prevState.mode !== this.state.mode) {
             this.updateSelectChatWidth();
             this.setState({ visibleChipCount: 999 }, () => this.updateVisibleChipCount());
+            // Agent→Normal 往返后 textarea 重新挂载（无内联高度），恢复按内容自动增高；
+            // 参与者 chip 区同样重新挂载，需按新宽度重算溢出。
+            this.autoResizeTextarea();
+            this.updateVisibleMemberChipCount();
         }
         if (prevState.selectedMembers !== this.state.selectedMembers) {
             this.setState({ visibleMemberChipCount: 999 }, () => this.updateVisibleMemberChipCount());
@@ -807,6 +812,8 @@ export default class SummaryCreatePage extends Component<SummaryCreatePageProps,
     /**
      * 进入 agent 模式：读 localStorage 拿 session_id → 拉历史回显。
      * 无历史（新会话）则照旧空白开场；session_id 仍惰性生成于首次发送。
+     * 同时清空 selectedMembers：Agent 模式无参与者入口，残留的不可见
+     * participants 会在「保存为总结」时被误提交给后端（P1 回归）。
      */
     private enterAgentMode() {
         const stored = readAgentChatSession(this.agentChannelId());
@@ -815,6 +822,7 @@ export default class SummaryCreatePage extends Component<SummaryCreatePageProps,
         const storedRef = readAgentChatReferenced(this.agentChannelId());
         this.setState((prev) => ({
             mode: 'agent',
+            selectedMembers: [],
             sessionId: stored || prev.sessionId,
             referencedTask: storedRef
                 ? { task_id: storedRef.task_id, title: storedRef.title } as SummaryListItem
@@ -1364,13 +1372,12 @@ export default class SummaryCreatePage extends Component<SummaryCreatePageProps,
                             </div>
                             )}
                         </div>
-                        {/* 右下角：默认「开始总结」主按钮 + 下拉切换总结方式（恢复初版设计） */}
-                        <div className="summary-workbench-start-group">
+                        {/* 右下角：默认「开始总结」主按钮 + 下拉切换总结方式（SplitButtonGroup，与 ChatSummaryNewModal 一致） */}
+                        <SplitButtonGroup className="chat-summary-modal-split">
                             {mode !== 'agent' && (
                                 <Button
                                     data-testid={summaryTestIds.createSubmit}
                                     theme="solid"
-                                    className="summary-workbench-start-btn"
                                     loading={submitting}
                                     disabled={!this.canSubmit() || submitting}
                                     onClick={this.handlePrimaryClick}
@@ -1403,14 +1410,14 @@ export default class SummaryCreatePage extends Component<SummaryCreatePageProps,
                             >
                                 <Button
                                     data-testid={summaryTestIds.createModeSwitch}
-                                    className="summary-workbench-mode-switch-btn"
+                                    theme="solid"
                                     icon={<ChevronDown size={16} />}
                                     aria-label={translate("summary.create.switchMode")}
                                     title={translate("summary.create.switchMode")}
                                     disabled={submitting}
                                 />
                             </Dropdown>
-                        </div>
+                        </SplitButtonGroup>
                     </div>
                 </div>
 

--- a/packages/dmworksummary/src/pages/SummaryCreatePage.tsx
+++ b/packages/dmworksummary/src/pages/SummaryCreatePage.tsx
@@ -1,7 +1,8 @@
-import { Sparkles, X, Plus } from "lucide-react";
+import { Sparkles, X, Plus, ChevronDown } from "lucide-react";
 import React, { Component, createRef } from "react";
 import {
     Button,
+    Dropdown,
     Toast,
     Typography,
     Tag,
@@ -198,11 +199,11 @@ export default class SummaryCreatePage extends Component<SummaryCreatePageProps,
         }
         const actions = selectChat.parentElement;
         if (!actions) return;
-        const startBtn = actions.querySelector('.summary-workbench-start-btn');
+        const startGroup = actions.querySelector('.summary-workbench-start-group');
         const actionsWidth = actions.clientWidth;
-        const btnWidth = startBtn ? (startBtn as HTMLElement).offsetWidth : 0;
+        const groupWidth = startGroup ? (startGroup as HTMLElement).offsetWidth : 0;
         const gap = 24;
-        const width = actionsWidth - btnWidth - gap;
+        const width = actionsWidth - groupWidth - gap;
         selectChat.style.width = width + 'px';
         selectChat.style.flex = 'none';
         selectChat.style.maxWidth = width + 'px';
@@ -535,9 +536,7 @@ export default class SummaryCreatePage extends Component<SummaryCreatePageProps,
     autoResizeTextarea = () => {
         const el = this.textareaRef.current;
         if (!el) return;
-        // 整页模式：input-wrap 有固定 420px 高度，textarea height:100% 填满即可。
-        // 面板模式：input-wrap 无固定高度，需要按内容自动撑开。
-        if (!this.props.embedded) return;
+        // 输入框按内容自动撑开（CSS min/max-height 约束边界，见 index.css）。
         el.style.height = "auto";
         el.style.height = `${el.scrollHeight}px`;
     };
@@ -1052,24 +1051,6 @@ export default class SummaryCreatePage extends Component<SummaryCreatePageProps,
                 <div className="summary-workbench-header">
                     <span className="summary-workbench-header-emoji">🚀</span>
                     <span className="summary-workbench-title">{translate("summary.create.title")}</span>
-                    <div className="summary-workbench-mode-switch">
-                        <button
-                            type="button"
-                            data-testid={summaryTestIds.createNormalTab}
-                            className={`summary-workbench-mode-btn${mode === 'normal' ? ' summary-workbench-mode-btn--active' : ''}`}
-                            onClick={() => this.handleSelectMode('normal')}
-                        >
-                            {translate("summary.create.start")}
-                        </button>
-                        <button
-                            type="button"
-                            data-testid={summaryTestIds.createAgentTab}
-                            className={`summary-workbench-mode-btn${mode === 'agent' ? ' summary-workbench-mode-btn--active' : ''}`}
-                            onClick={() => this.handleSelectMode('agent')}
-                        >
-                            {translate("summary.create.agentStart")}
-                        </button>
-                    </div>
                 </div>
 
                 {/* Content card */}
@@ -1331,7 +1312,8 @@ export default class SummaryCreatePage extends Component<SummaryCreatePageProps,
                                     <span>{translate("summary.create.selectChat")}</span>
                                 </button>
                             )}
-                            {/* 选择参与者 */}
+                            {/* 选择参与者（仅普通模式；Agent 模式不提供多人协作入口） */}
+                            {mode !== 'agent' && (
                             <div className="summary-workbench-chat-row">
                                 {selectedMembers.length > 0 && (
                                     <div className="summary-workbench-chat-chips" ref={this.memberChipsContainerRef}>
@@ -1378,18 +1360,55 @@ export default class SummaryCreatePage extends Component<SummaryCreatePageProps,
                                     <span>{translate("summary.create.selectMembers")}</span>
                                 </button>
                             </div>
+                            )}
                         </div>
-                        <Button
-                            data-testid={summaryTestIds.createSubmit}
-                            theme="solid"
-                            className="summary-workbench-start-btn"
-                            loading={submitting}
-                            disabled={!this.canSubmit() || submitting}
-                            onClick={this.handlePrimaryClick}
-                        >
-                            <Sparkles size={16} />
-                            {submitting ? translate("summary.create.submitting") : translate("summary.create.start")}
-                        </Button>
+                        {/* 右下角：默认「开始总结」主按钮 + 下拉切换总结方式（恢复初版设计） */}
+                        <div className="summary-workbench-start-group">
+                            {mode !== 'agent' && (
+                                <Button
+                                    data-testid={summaryTestIds.createSubmit}
+                                    theme="solid"
+                                    className="summary-workbench-start-btn"
+                                    loading={submitting}
+                                    disabled={!this.canSubmit() || submitting}
+                                    onClick={this.handlePrimaryClick}
+                                >
+                                    <Sparkles size={16} />
+                                    {submitting ? translate("summary.create.submitting") : translate("summary.create.start")}
+                                </Button>
+                            )}
+                            <Dropdown
+                                trigger="click"
+                                position="bottomRight"
+                                render={(
+                                    <Dropdown.Menu>
+                                        <Dropdown.Item
+                                            data-testid={summaryTestIds.createNormalTab}
+                                            active={mode !== 'agent'}
+                                            onClick={() => this.handleSelectMode('normal')}
+                                        >
+                                            {translate("summary.create.start")}
+                                        </Dropdown.Item>
+                                        <Dropdown.Item
+                                            data-testid={summaryTestIds.createAgentTab}
+                                            active={mode === 'agent'}
+                                            onClick={() => this.handleSelectMode('agent')}
+                                        >
+                                            {translate("summary.create.agentStart")}
+                                        </Dropdown.Item>
+                                    </Dropdown.Menu>
+                                )}
+                            >
+                                <Button
+                                    data-testid={summaryTestIds.createModeSwitch}
+                                    className="summary-workbench-mode-switch-btn"
+                                    icon={<ChevronDown size={16} />}
+                                    aria-label={translate("summary.create.switchMode")}
+                                    title={translate("summary.create.switchMode")}
+                                    disabled={submitting}
+                                />
+                            </Dropdown>
+                        </div>
                     </div>
                 </div>
 

--- a/packages/dmworksummary/src/pages/SummaryCreatePage.tsx
+++ b/packages/dmworksummary/src/pages/SummaryCreatePage.tsx
@@ -324,7 +324,9 @@ export default class SummaryCreatePage extends Component<SummaryCreatePageProps,
     }
 
     componentDidUpdate(prevProps: SummaryCreatePageProps, prevState: SummaryCreatePageState) {
-        if (prevState.selectedChats !== this.state.selectedChats) {
+        // selectedChats 或 mode 变化都会改变 start-group 宽度（mode=agent 时主按钮隐藏），
+        // 需要重算 select-chat 宽度与芯片溢出，避免残留上一次计算的宽度。
+        if (prevState.selectedChats !== this.state.selectedChats || prevState.mode !== this.state.mode) {
             this.updateSelectChatWidth();
             this.setState({ visibleChipCount: 999 }, () => this.updateVisibleChipCount());
         }

--- a/packages/dmworksummary/src/utils/testIds.ts
+++ b/packages/dmworksummary/src/utils/testIds.ts
@@ -19,10 +19,10 @@ export const summaryTestIds = {
     createSelectChat: "summary-create-select-chat",
     createSelectMembers: "summary-create-select-members",
     createSubmit: "summary-create-submit",
-    // Agent mode buttons on create page
+    // Mode switch dropdown on create page (trigger + menu items)
+    createModeSwitch: "summary-create-mode-switch",
     createAgentTab: "summary-create-agent-tab",
     createNormalTab: "summary-create-normal-tab",
-    createPanelStartBtn: "summary-create-panel-start-btn",
 
     // ── Chat selector modal ──
     chatSelectorModal: "summary-chat-selector-modal",


### PR DESCRIPTION
## Summary

Restores the summary create page mode switcher back to the original bottom-right dropdown design, per product feedback. PR #1044 replaced it with two tab buttons in the header; the product team wants the original interaction back.

## Related Issue

Not applicable (product design feedback from chat).

## Changes

- Remove the header "Start Summary / Agent Summary" tab buttons
- Restore the bottom-right mode switcher: default "开始总结" primary button + chevron dropdown to switch to "Agent 总结" — unified on Semi `SplitButtonGroup` (`chat-summary-modal-split`), same pattern as `ChatSummaryNewModal`
- Hide the "选择参与者" (select participants) entry in Agent mode
- Topic textarea: replace the fixed 420px block with content-based auto grow (min 200px / max 420px; 120px in panel mode)
- Recompute select-chat width / member chips / textarea height when the mode switches (both directions), not only when chats change
- Update summary e2e locators to the dropdown switching flow; add `createModeSwitch` testid and drop the unused `createPanelStartBtn`

## Participants behaviour (important)

- In **Agent** mode the participant selector is hidden, and `participants` is **never** submitted on agent save — guarded at the payload boundary (`handleSaveAsSummary`, `mode !== 'agent'`) rather than by destroying form state
- Switching to Agent and back to "开始总结" **preserves** the selected chats and participant chips (no silent data loss)
- Normal-mode save still submits `participants` as before

## Architecture / Module Boundary

- Affected module(s): `packages/dmworksummary` (`SummaryCreatePage`, `index.css`, `testIds`)
- New or changed user-visible entry point: yes — mode switch moved from header tabs to the bottom-right dropdown (this is the intended restore)
- Shared layer touched: none
- If shared code changed, impact scope: —
- Duplicate entry point checked: yes — only the dropdown entry remains (header buttons removed)

## Testing

- e2e: full summary suite passes — **25/25** specs, including:
  - S9: participant selection → switch to Agent → save — asserts request body `participants` is `undefined` (P1 regression), and that chips survive an Agent→Normal→Agent round-trip
  - S11: dropdown reflects the active mode; Agent→Normal→Agent round-trip re-mounts the topic input
  - S8: normal-mode save still carries participants
- e2e MSW baseline: added `*/groups/:groupNo/avatar` stub so group-avatar requests (derived for logo-less seeded groups) never escape to the Vite proxy — no proxy errors in the e2e-p0 gate
- `testIdsParity` unit test passes (src vs e2e testids stay in sync)
- Manually verified in browser: normal mode shows the shortened input + bottom-right dropdown; Agent mode hides the participant selector and the primary button
- No UI copy added (reuses existing i18n keys), `pnpm i18n:check` not required

- [x] Unit tests added/updated (e2e specs updated)
- [x] Manually verified
