### PR TITLE
feat(mail): gate navigation with appconfig

### DIFF
--- a/apps/web/src/__tests__/mailOn.test.ts
+++ b/apps/web/src/__tests__/mailOn.test.ts
@@ -1,0 +1,37 @@
+import * as fs from "fs";
+import * as path from "path";
+import { parseRemoteBool } from "../../../../packages/dmworkbase/src/Utils/remoteConfig";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = path.resolve(__dirname, "../../../..");
+
+function readRepoFile(relativePath: string): string {
+  return fs.readFileSync(path.join(repoRoot, relativePath), "utf-8");
+}
+
+describe("mail_on appconfig web integration", () => {
+  it.each([
+    [0, false],
+    ["0", false],
+    [undefined, false],
+    [1, true],
+    ["1", true],
+    [true, true],
+    ["true", true],
+    ["false", false],
+  ])("parses appconfig mail_on value %s as mailOn=%s", (value, expected) => {
+    expect(parseRemoteBool(value)).toBe(expected);
+  });
+
+  it("wires mailOn into WKRemoteConfig from appconfig, defaulting to false", () => {
+    const source = readRepoFile("packages/dmworkbase/src/App.tsx");
+
+    expect(source).toContain("mailOn: boolean = false");
+    expect(source).toContain(
+      'this.mailOn = parseRemoteBool(result["mail_on"])'
+    );
+    expect(source).toContain("previousMailOn");
+    expect(source).toContain("previousMailOn !== this.mailOn");
+    expect(source).toContain("notifyConfigChangeListeners");
+  });
+});

--- a/packages/dmworkbase/src/App.tsx
+++ b/packages/dmworkbase/src/App.tsx
@@ -371,6 +371,13 @@ export class WKRemoteConfig {
    */
   driveOn: boolean = false;
   /**
+   * Agent Mail 模块展示开关。后端字段 mail_on 为 true 时，前端在侧边栏 NavRail
+   * 展示邮件入口；false 或字段缺失时隐藏。
+   *
+   * 默认 false(fail-safe)，仅控制前端入口展示，不承担权限校验。
+   */
+  mailOn: boolean = false;
+  /**
    * OIDC provider 元数据数组, 由后端 /v1/common/appconfig 的 oidc_providers 字段下发。
    * OIDC 关闭时为空数组。前端不再硬编码具体 IdP, 部署 env 切 provider。
    * 顶层 oidc_account_url / oidc_reset_password_url 是后端兼容老前端用的,新前端只读这里。
@@ -480,6 +487,7 @@ export class WKRemoteConfig {
       const previousDmloopOn = this.dmloopOn;
       const previousDmpersonalOn = this.dmpersonalOn;
       const previousDriveOn = this.driveOn;
+      const previousMailOn = this.mailOn;
       const previousRequestFailed = this.requestFailed;
       const previousOidcProviders = this.oidcProviders;
       this.requestSuccess = true;
@@ -507,6 +515,7 @@ export class WKRemoteConfig {
       this.dmloopOn = parseRemoteBool(result["dmloop_on"]);
       this.dmpersonalOn = parseRemoteBool(result["dmpersonal_on"]);
       this.driveOn = parseRemoteBool(result["drive_on"]);
+      this.mailOn = parseRemoteBool(result["mail_on"]);
       this.oidcProviders = parseOidcProviders(result["oidc_providers"]);
       // 仅首次成功通知, 后续重新拉取(重连/手动刷新)不重复打扰订阅方。
       if (!wasSuccessful) this.notifyListeners();
@@ -527,6 +536,7 @@ export class WKRemoteConfig {
         previousDmloopOn !== this.dmloopOn ||
         previousDmpersonalOn !== this.dmpersonalOn ||
         previousDriveOn !== this.driveOn ||
+        previousMailOn !== this.mailOn ||
         previousRequestFailed !== this.requestFailed ||
         !oidcProvidersEqual(previousOidcProviders, this.oidcProviders)
       ) {

--- a/packages/mail/src/module.test.tsx
+++ b/packages/mail/src/module.test.tsx
@@ -14,6 +14,7 @@ const state = vi.hoisted(() => ({
     return true;
   }),
   chatPage: vi.fn(() => null),
+  remoteConfig: { mailOn: true },
 }));
 
 vi.mock("@octo/base", () => {
@@ -36,6 +37,7 @@ vi.mock("@octo/base", () => {
       routeLeft: { popToRoot: state.popToRoot },
       routeRight: { replaceToRoot: state.replaceToRoot },
       mittBus: { emit: state.emit },
+      remoteConfig: state.remoteConfig,
     },
   };
 });
@@ -52,6 +54,7 @@ import MailModule from "./module";
 describe("MailModule integration", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    state.remoteConfig.mailOn = true;
   });
 
   it("registers /mail with the host shell and guards menu navigation", () => {
@@ -68,6 +71,10 @@ describe("MailModule integration", () => {
     const menuFactory = state.menuRegister.mock.calls.find(
       ([id]) => id === "mail"
     )?.[1];
+    state.remoteConfig.mailOn = false;
+    expect(menuFactory()).toBeUndefined();
+
+    state.remoteConfig.mailOn = true;
     const menu = menuFactory();
     menu.onPress();
 

--- a/packages/mail/src/module.tsx
+++ b/packages/mail/src/module.tsx
@@ -72,6 +72,7 @@ export default class MailModule implements IModule {
     WKApp.menus.register(
       "mail",
       () => {
+        if (!WKApp.remoteConfig.mailOn) return undefined;
         const menu = new Menus(
           "mail",
           "/mail",

--- a/packages/mail/types/octo-base.shim.d.ts
+++ b/packages/mail/types/octo-base.shim.d.ts
@@ -69,6 +69,7 @@ declare module "@octo/base" {
   export const WKApp: {
     currentMenuId?: string;
     shared: { currentSpaceId?: string };
+    remoteConfig: { mailOn: boolean };
     route: {
       register(
         path: string,
@@ -77,7 +78,11 @@ declare module "@octo/base" {
       ): void;
     };
     menus: {
-      register(id: string, factory: () => Menus, order: number): void;
+      register(
+        id: string,
+        factory: () => Menus | undefined,
+        order: number
+      ): void;
     };
     routeLeft: { popToRoot(): void };
     routeRight: {


### PR DESCRIPTION
## Summary

Add an appconfig-controlled visibility gate for the Agent Mail navigation entry. The entry is hidden by default and becomes visible when `/v1/common/appconfig` returns `mail_on=true`.

## Related Issue

Fixes #1403

## Changes

- Parse `mail_on` into `WKRemoteConfig.mailOn` with a fail-closed default.
- Refresh menu consumers when the Mail flag changes.
- Gate the Agent Mail menu factory while keeping Mail and authorization routes registered.
- Cover appconfig parsing and both menu visibility states with tests.

## Architecture / Module Boundary

- Affected module(s): `@octo/base`, `@octo/mail`, `@octo/web`
- New or changed user-visible entry point: yes; the existing Agent Mail navigation entry now follows `mail_on`
- Shared layer touched: shared remote configuration
- If shared code changed, impact scope: adds one optional appconfig field and its change notification
- Duplicate entry point checked: yes

## Testing

- [x] Unit tests added/updated
- [ ] Manually verified

- `pnpm --filter @octo/mail test` — 157 tests passed
- `pnpm --filter @octo/mail typecheck` — passed
- `pnpm --filter @octo/base exec vitest run src/__tests__/remoteConfig.test.ts` — passed
- `pnpm --filter @octo/web exec vitest run src/__tests__/mailOn.test.ts` — 9 tests passed
- `pnpm --filter @octo/web build` — passed
- `docker build -t octo-web:local .` — passed

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes
- [ ] Updated documentation
- [x] Ran `pnpm i18n:check` or confirmed the change does not affect UI copy
- [x] Confirmed the change follows module ownership and does not add duplicate user-visible entry points
- [x] Described impact scope when shared components, messages, bridge, or services are changed
- [x] Followed commit message conventions (Conventional Commits)
