### PR TITLE
fix(voice): move consent callbacks above early return in VoiceInputButton (crashes /summary, React #310)

### DIFF
--- a/packages/dmworkbase/src/Components/VoiceInputButton/index.tsx
+++ b/packages/dmworkbase/src/Components/VoiceInputButton/index.tsx
@@ -342,40 +342,11 @@ export default function VoiceInputButton({
     };
   }, [isVoiceEnabled, inputRef, clearShiftTimer, openConsent, t]);
 
-  if (!isVoiceEnabled) return null;
-
-  const handleVoiceClick = () => {
-    setShowMenu(false);
-    if (!canRecord) {
-      Toast.warning(t("base.voiceInput.error.networkUnavailable"));
-      return;
-    }
-    if (!inputRef.current) return;
-    if (!loaded) {
-      return;
-    }
-    if (spaceSetting?.voice_input_enabled !== 1) {
-      openConsent("append_only");
-      return;
-    }
-    onRecordingStart?.();
-    startRecording("append_only");
-  };
-
-  const handleModeSelect = (selectedMode: VoiceMode) => {
-    setShowMenu(false);
-    if (!canRecord || !inputRef.current) return;
-    if (!loaded) {
-      return;
-    }
-    if (spaceSetting?.voice_input_enabled !== 1) {
-      openConsent(selectedMode);
-      return;
-    }
-    onRecordingStart?.();
-    startRecording(selectedMode);
-  };
-
+  // NOTE: these hooks MUST stay above the `if (!isVoiceEnabled) return null`
+  // early return below. isVoiceEnabled flips from false to true once the voice
+  // config loads, so any hook placed after the early return would only run on
+  // the re-render, violating the Rules of Hooks (React error #310 /
+  // "Rendered more hooks than during the previous render").
   const handleConsentAccept = useCallback(async (feedbackOn: boolean) => {
     if (consentPendingRef.current) return;
     const consent = pendingConsentRef.current;
@@ -412,6 +383,40 @@ export default function VoiceInputButton({
     pendingModeRef.current = "append_only";
     setShowFeedbackNotice(false);
   }, []);
+
+  if (!isVoiceEnabled) return null;
+
+  const handleVoiceClick = () => {
+    setShowMenu(false);
+    if (!canRecord) {
+      Toast.warning(t("base.voiceInput.error.networkUnavailable"));
+      return;
+    }
+    if (!inputRef.current) return;
+    if (!loaded) {
+      return;
+    }
+    if (spaceSetting?.voice_input_enabled !== 1) {
+      openConsent("append_only");
+      return;
+    }
+    onRecordingStart?.();
+    startRecording("append_only");
+  };
+
+  const handleModeSelect = (selectedMode: VoiceMode) => {
+    setShowMenu(false);
+    if (!canRecord || !inputRef.current) return;
+    if (!loaded) {
+      return;
+    }
+    if (spaceSetting?.voice_input_enabled !== 1) {
+      openConsent(selectedMode);
+      return;
+    }
+    onRecordingStart?.();
+    startRecording(selectedMode);
+  };
 
   const handleStopClick = () => {
     stopRecordingAndTranscribe();


### PR DESCRIPTION
## P0: this breaks the smart-summary page on main

**https://im-test.deepminer.com.cn/summary currently crashes** with "应用加载出错 / Minified React error #310" since #1412 landed.

## Root cause

#1412 added two hooks — `handleConsentAccept` / `handleConsentCancel` (`useCallback`) — **after** the pre-existing early return in `VoiceInputButton`:

```tsx
if (!isVoiceEnabled) return null;             // voice config not loaded yet on first render
...
const handleConsentAccept = useCallback(...)  // ← added below the return (#1412)
const handleConsentCancel = useCallback(...)  // ← added below the return (#1412)
```

- 1st render: `isVoiceEnabled === false` → early return → 84 hooks
- config loads → re-render: `isVoiceEnabled === true` → renders past the return → 86 hooks
- → **"Rendered more hooks than during the previous render" (React #310)**

Any page rendering `VoiceInputButton` dies — the summary create page is the first casualty (the dev-mode hook table shows the mismatch at position 85: `undefined → useCallback`).

## Fix

Move both `useCallback`s above the early return (they only reference refs/setters already defined above it) and leave a comment so the Rules-of-Hooks invariant is not silently broken again.

## Verification

Reproduced on the deployed commit (`6e52f7e4`) against the im-test API:
- before: `/summary` → ErrorBoundary "应用加载出错", React #310, component `VoiceInputButton`
- after (this patch, dev server): `/summary` renders fully — templates, composer with the voice button, "开始总结" — no #310 in console

Fixes the regression introduced by #1412.
