### PR TITLE
fix(file-preview): preserve filenames on download

### DIFF
--- a/packages/dmworkbase/src/Components/FilePreviewPanel/FilePreviewHeader.tsx
+++ b/packages/dmworkbase/src/Components/FilePreviewPanel/FilePreviewHeader.tsx
@@ -8,6 +8,7 @@ import {
   IconDropdown,
 } from "./icons";
 import { getFileIcon as getFileIconUrl } from "../../Utils/fileIcon";
+import { downloadFile } from "../../Utils/download";
 import { FilePreviewInfo } from "./types";
 import { isImageType } from "./config";
 import { useI18n } from "../../i18n";
@@ -286,14 +287,7 @@ const FilePreviewHeader: React.FC<FilePreviewHeaderProps> = ({
     if (onDownload) {
       onDownload();
     } else {
-      // 默认下载行为
-      const a = document.createElement("a");
-      a.href = file.url;
-      a.download = file.name || "file";
-      a.target = "_blank";
-      document.body.appendChild(a);
-      a.click();
-      document.body.removeChild(a);
+      void downloadFile(file.url, file.name || "file");
     }
   };
 

--- a/packages/dmworkbase/src/Components/FilePreviewPanel/__tests__/previewDownload.test.tsx
+++ b/packages/dmworkbase/src/Components/FilePreviewPanel/__tests__/previewDownload.test.tsx
@@ -1,0 +1,147 @@
+// @vitest-environment jsdom
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  downloadFile: vi.fn(),
+}));
+
+vi.mock("../../../Utils/download", () => ({
+  downloadFile: mocks.downloadFile,
+}));
+
+vi.mock("../../../Utils/fileIcon", () => ({
+  getFileIcon: () => "/file.svg",
+}));
+
+vi.mock("../../../i18n", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../../i18n")>();
+  return {
+    ...actual,
+    useI18n: () => ({ t: (key: string) => key }),
+  };
+});
+
+vi.mock("../registry", () => ({
+  fileRendererRegistry: {
+    getRenderer: () => ({ renderer: () => null }),
+    canPreview: () => true,
+  },
+}));
+
+vi.mock("../renderers", () => ({}));
+
+import FilePreviewPanel from "../index";
+import FilePreviewHeader from "../FilePreviewHeader";
+import CodeRendererBase from "../renderers/CodeRendererBase";
+import FallbackRenderer from "../renderers/FallbackRenderer";
+import FileTooLarge from "../renderers/FileTooLarge";
+
+const pptxFile = {
+  url: "https://files.example.com/random-object-key",
+  name: "quarterly-report.pptx",
+  extension: "pptx",
+};
+
+const xlsxFile = {
+  url: "https://files.example.com/another-random-key",
+  name: "budget.xlsx",
+  extension: "xlsx",
+};
+
+describe("file preview downloads", () => {
+  beforeEach(() => {
+    mocks.downloadFile.mockReset();
+    mocks.downloadFile.mockResolvedValue(undefined);
+  });
+
+  it("preserves the original filename from the conversation preview header", () => {
+    render(<FilePreviewHeader file={pptxFile} onClose={vi.fn()} />);
+
+    fireEvent.click(screen.getByTitle("base.filePreview.download"));
+
+    expect(mocks.downloadFile).toHaveBeenCalledWith(
+      pptxFile.url,
+      pptxFile.name
+    );
+  });
+
+  it("preserves the original filename from the standalone preview panel", () => {
+    render(
+      <FilePreviewPanel
+        file={xlsxFile}
+        onClose={vi.fn()}
+        showOpenExternal={false}
+      />
+    );
+
+    fireEvent.click(screen.getByTitle("base.filePreview.download"));
+
+    expect(mocks.downloadFile).toHaveBeenCalledWith(
+      xlsxFile.url,
+      xlsxFile.name
+    );
+  });
+
+  it("preserves the original PPTX filename from the fallback renderer", () => {
+    render(<FallbackRenderer file={pptxFile} />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "base.filePreview.download" })
+    );
+
+    expect(mocks.downloadFile).toHaveBeenCalledWith(
+      pptxFile.url,
+      pptxFile.name
+    );
+  });
+
+  it("preserves the original XLSX filename for oversized spreadsheets", () => {
+    render(
+      <FileTooLarge
+        fileName={xlsxFile.name}
+        fileSize={30 * 1024 * 1024}
+        fileUrl={xlsxFile.url}
+      />
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "base.filePreview.downloadFile" })
+    );
+
+    expect(mocks.downloadFile).toHaveBeenCalledWith(
+      xlsxFile.url,
+      xlsxFile.name
+    );
+  });
+
+  it("preserves the filename when downloading an oversized code file", () => {
+    render(
+      <CodeRendererBase
+        file={{
+          url: "https://files.example.com/code-object-key",
+          name: "large-source.ts",
+          extension: "ts",
+        }}
+        renderMode="too-large"
+        formattedContent=""
+        language="typescript"
+        loading={false}
+        error={null}
+        onReload={vi.fn()}
+        fileSize={30 * 1024 * 1024}
+        contentSize={0}
+      />
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "base.filePreview.downloadFile" })
+    );
+
+    expect(mocks.downloadFile).toHaveBeenCalledWith(
+      "https://files.example.com/code-object-key",
+      "large-source.ts"
+    );
+  });
+});

--- a/packages/dmworkbase/src/Components/FilePreviewPanel/index.tsx
+++ b/packages/dmworkbase/src/Components/FilePreviewPanel/index.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { X, Download, ExternalLink } from "lucide-react";
 import { fileRendererRegistry } from "./registry";
+import { downloadFile } from "../../Utils/download";
 import { FilePreviewInfo, FilePreviewPanelProps, getExtension } from "./types";
 import { useI18n } from "../../i18n";
 import "./index.css";
@@ -22,13 +23,7 @@ const FilePreviewPanel: React.FC<FilePreviewPanelProps> = ({
   const { renderer: Renderer } = fileRendererRegistry.getRenderer(ext);
 
   const handleDownload = () => {
-    const a = document.createElement("a");
-    a.href = file.url;
-    a.download = file.name || "file";
-    a.target = "_blank";
-    document.body.appendChild(a);
-    a.click();
-    document.body.removeChild(a);
+    void downloadFile(file.url, file.name || "file");
   };
 
   const handleOpenExternal = () => {

--- a/packages/dmworkbase/src/Components/FilePreviewPanel/renderers/CodeRendererBase.tsx
+++ b/packages/dmworkbase/src/Components/FilePreviewPanel/renderers/CodeRendererBase.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import SyntaxHighlighter from "react-syntax-highlighter";
 import { BaseRendererProps } from "../types";
 import { RenderMode, formatFileSize } from "../config";
+import { downloadFile } from "../../../Utils/download";
 import { useI18n } from "../../../i18n";
 import "./CodeRenderer.css";
 import "./code-highlight.css";
@@ -64,13 +65,13 @@ const CodeRendererBase: React.FC<CodeRendererBaseProps> = ({
             values: { size: formatFileSize(fileSize) },
           })}
         </span>
-        <a
-          href={file.url}
-          download={file.name}
+        <button
+          type="button"
+          onClick={() => void downloadFile(file.url, file.name || "file")}
           className="wk-file-preview-code-renderer__download-btn"
         >
           {t("base.filePreview.downloadFile")}
-        </a>
+        </button>
       </div>
     );
   }

--- a/packages/dmworkbase/src/Components/FilePreviewPanel/renderers/FallbackRenderer.tsx
+++ b/packages/dmworkbase/src/Components/FilePreviewPanel/renderers/FallbackRenderer.tsx
@@ -11,6 +11,7 @@ import {
 } from "lucide-react";
 import { BaseRendererProps } from "../types";
 import { formatFileSize } from "../config";
+import { downloadFile } from "../../../Utils/download";
 import { useI18n } from "../../../i18n";
 import "./FallbackRenderer.css";
 
@@ -71,13 +72,7 @@ const FallbackRenderer: React.FC<FallbackRendererProps> = ({ file }) => {
 
     setLoading(true);
     try {
-      const a = document.createElement("a");
-      a.href = file.url;
-      a.download = file.name || "file";
-      a.target = "_blank";
-      document.body.appendChild(a);
-      a.click();
-      document.body.removeChild(a);
+      await downloadFile(file.url, file.name || "file");
     } finally {
       // 模拟下载延迟，给用户反馈
       setTimeout(() => setLoading(false), 500);
@@ -112,6 +107,7 @@ const FallbackRenderer: React.FC<FallbackRendererProps> = ({ file }) => {
 
         {/* 下载按钮 */}
         <button
+          type="button"
           className="wk-file-preview-fallback-renderer__download-btn"
           onClick={handleDownload}
           disabled={loading}

--- a/packages/dmworkbase/src/Components/FilePreviewPanel/renderers/FileTooLarge.tsx
+++ b/packages/dmworkbase/src/Components/FilePreviewPanel/renderers/FileTooLarge.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Download, FileWarning } from "lucide-react";
 import { formatFileSize } from "../config";
+import { downloadFile } from "../../../Utils/download";
 import { useI18n } from "../../../i18n";
 import "./FileTooLarge.css";
 
@@ -27,13 +28,7 @@ const FileTooLarge: React.FC<FileTooLargeProps> = ({
   const { t } = useI18n();
 
   const handleDownload = () => {
-    const a = document.createElement("a");
-    a.href = fileUrl;
-    a.download = fileName || "file";
-    a.target = "_blank";
-    document.body.appendChild(a);
-    a.click();
-    document.body.removeChild(a);
+    void downloadFile(fileUrl, fileName || "file");
   };
 
   return (
@@ -51,7 +46,11 @@ const FileTooLarge: React.FC<FileTooLargeProps> = ({
           })}
         </p>
       </div>
-      <button className="wk-file-too-large__download-btn" onClick={handleDownload}>
+      <button
+        type="button"
+        className="wk-file-too-large__download-btn"
+        onClick={handleDownload}
+      >
         <Download size={16} />
         <span>{t("base.filePreview.downloadFile")}</span>
       </button>

--- a/packages/dmworkbase/src/Components/FilePreviewPanel/renderers/HtmlRenderer.tsx
+++ b/packages/dmworkbase/src/Components/FilePreviewPanel/renderers/HtmlRenderer.tsx
@@ -12,6 +12,7 @@ import { isFileTooLarge, getRenderMode, formatFileSize } from "../config";
 import { useFileContent } from "../hooks/useFileContent";
 import { RendererState } from "./RendererState";
 import FileTooLarge from "./FileTooLarge";
+import { downloadFile } from "../../../Utils/download";
 import { useI18n } from "../../../i18n";
 import "./HtmlRenderer.css";
 import "./code-highlight.css";
@@ -143,13 +144,7 @@ const HtmlRenderer: React.FC<HtmlRendererProps> = ({
   }, [handleViewModeChange, onError, t]);
 
   const handleDownload = useCallback(() => {
-    const a = document.createElement("a");
-    a.href = file.url;
-    a.download = file.name || "file.html";
-    a.target = "_blank";
-    document.body.appendChild(a);
-    a.click();
-    document.body.removeChild(a);
+    void downloadFile(file.url, file.name || "file.html");
   }, [file.name, file.url]);
 
   // 监听来自 iframe 的 postMessage
@@ -181,7 +176,8 @@ const HtmlRenderer: React.FC<HtmlRendererProps> = ({
       if (event.data?.type === "html-render-error") {
         const errorMsg = t("base.filePreview.html.renderError", {
           values: {
-            message: event.data.message || t("base.filePreview.html.unknownError"),
+            message:
+              event.data.message || t("base.filePreview.html.unknownError"),
           },
         });
         setRenderError(errorMsg);


### PR DESCRIPTION
## Summary

- route file preview downloads through the shared presigned download helper
- preserve original filenames across the preview header, fallback, oversized-file, code, and HTML download actions
- add regression coverage for PPTX and XLSX preview downloads

## Root cause

The preview panel created cross-origin anchor downloads directly. Browsers can ignore the anchor `download` filename for cross-origin URLs, causing the object-storage key to be used as the saved filename instead.

## Impact

Downloading a file from its preview now follows the same presigned URL flow as downloading it from the chat message, so the original filename is preserved.

## Validation

- `pnpm --filter @octo/base exec vitest run src/Components/FilePreviewPanel/__tests__/previewDownload.test.tsx src/Utils/download.test.ts src/Components/FilePreviewPanel/__tests__/registry.test.ts src/Components/FilePreviewPanel/__tests__/getExtension.test.ts` (26 tests)
- `pnpm --filter @octo/web exec vitest run src/__tests__/download.test.ts` (18 tests)
- `pnpm --filter @octo/web build`
- Prettier and `git diff --check`

Closes #1414
