### PR TITLE
feat: add document summary star entry

### DIFF
--- a/packages/dmworkbase/src/App.tsx
+++ b/packages/dmworkbase/src/App.tsx
@@ -6,6 +6,13 @@ import { runLogoutCleanup } from "./Service/logoutCleanup";
 const IPC_CLEAR_AUTH_SESSION = "octo:oidc:clear-auth-session";
 
 /** mittBus 全局事件类型表 */
+export interface DocumentSummaryRequestPayload {
+  documentId: string;
+  spaceId?: string;
+  originChannel?: { channelId: string; channelType: number };
+  onSettled?: () => void;
+}
+
 export type MittEvents = {
   "friend-applys-unread-count": number;
   "space-changed": unknown;
@@ -41,6 +48,8 @@ export type MittEvents = {
   "wk:close-thread-panel": undefined;
   "wk:toggle-summary-panel": { channelId: string; channelType: number; summaryPanelView: 'history' | 'new'; forceOpen?: boolean };
   "wk:open-summary-modal": { channelId: string; channelType: number };
+  /** 文档卡请求创建 Agent 文档总结；由 SummaryModule 提供消费方。 */
+  "wk:document-summary-request": DocumentSummaryRequestPayload;
   /** 主聊天框头部搜索入口点击：请求打开该频道的会话内搜索面板（与信息栏「查找聊天内容」同一效果）。 */
   "wk:open-channel-search": { channelId: string; channelType: number };
   "wk:switch-sidebar-tab": string;
@@ -824,6 +833,8 @@ export default class WKApp extends ProviderListener {
     originChannel?: { channelId: string; channelType: number },
   ) => void;
   static searchChatCandidates?: (params: { keyword?: string; chat_type?: string; space_id?: string }) => Promise<any[]>;
+  /** SummaryModule 注册后置 true；未挂载 summary 能力的运行时应隐藏文档总结入口。 */
+  static canCreateDocumentSummary?: boolean;
   // Transfer an IM file message into the drive's personal space. Set by
   // DriveModule.init(). Absent when the drive module isn't registered or the
   // `drive_on` remote flag is false — callers must guard on presence.

--- a/packages/dmworkbase/src/Messages/DocumentShareCard/index.tsx
+++ b/packages/dmworkbase/src/Messages/DocumentShareCard/index.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { WKApp } from "@octo/base";
+import WKApp from "../../App";
 import MessageBase from "../Base";
 import { MessageBaseCellProps, MessageCell } from "../MessageCell";
 import { I18nContext } from "../../i18n";
@@ -21,6 +21,10 @@ interface DocShareCardCellState {
   summaryBusy: boolean;
 }
 
+function canSummarizeDocument(state: DocSharePermissionState): boolean {
+  return Boolean(WKApp.canCreateDocumentSummary) && (state === "reader" || state === "commenter" || state === "writer");
+}
+
 /**
  * 文档转发卡片渲染 Cell（contentType=18）。挂载时按接收者本人权限即时拉 ACL-safe 首屏预览，
  * 无信任门（自定义内容类型，非 type-17 互动卡）。焦点/可见性重查让"别处授权后切回本页"自动更新。
@@ -31,6 +35,7 @@ export class DocumentShareCardCell extends MessageCell<MessageBaseCellProps> {
 
   state: DocShareCardCellState = { status: "loading", summaryBusy: false };
   private aborter?: AbortController;
+  private summarySettleTimer?: number;
 
   componentDidMount(): void {
     super.componentDidMount();
@@ -42,6 +47,7 @@ export class DocumentShareCardCell extends MessageCell<MessageBaseCellProps> {
 
   componentWillUnmount(): void {
     this.aborter?.abort();
+    if (this.summarySettleTimer) window.clearTimeout(this.summarySettleTimer);
     window.removeEventListener("focus", this.handleRecheck);
     document.removeEventListener("visibilitychange", this.handleVisibility);
     super.componentWillUnmount();
@@ -84,12 +90,21 @@ export class DocumentShareCardCell extends MessageCell<MessageBaseCellProps> {
     const content = this.props.message.content as DocumentShareCardContent;
     if (!content.docId) return;
     this.setState({ summaryBusy: true });
+    const settle = () => {
+      if (this.summarySettleTimer) {
+        window.clearTimeout(this.summarySettleTimer);
+        this.summarySettleTimer = undefined;
+      }
+      if (!this.aborter?.signal.aborted) this.setState({ summaryBusy: false });
+    };
+    this.summarySettleTimer = window.setTimeout(settle, 30000);
     WKApp.mittBus.emit('wk:document-summary-request', {
       documentId: content.docId,
-      version: content.updatedAt || undefined,
-      title: content.title,
       spaceId: content.spaceId,
-      onSettled: () => this.setState({ summaryBusy: false }),
+      originChannel: this.props.message.channel
+        ? { channelId: this.props.message.channel.channelID, channelType: this.props.message.channel.channelType }
+        : undefined,
+      onSettled: settle,
     });
   };
 
@@ -152,6 +167,7 @@ export class DocumentShareCardCell extends MessageCell<MessageBaseCellProps> {
     const state = permissionState(this.state.status);
     const strings = this.buildStrings(content, state);
     const { preview, placeholder } = this.buildPreviewOrPlaceholder(state);
+    const summaryAvailable = canSummarizeDocument(state);
 
     return (
       <MessageBase hiddeBubble={true} message={message} context={context}>
@@ -164,7 +180,7 @@ export class DocumentShareCardCell extends MessageCell<MessageBaseCellProps> {
           placeholder={placeholder}
           onOpen={this.handleOpen}
           onCopy={this.handleCopy}
-          onSummary={this.handleSummary}
+          onSummary={summaryAvailable ? this.handleSummary : undefined}
           isSummaryBusy={this.state.summaryBusy}
         />
       </MessageBase>

--- a/packages/dmworkbase/src/Messages/DocumentShareCard/index.tsx
+++ b/packages/dmworkbase/src/Messages/DocumentShareCard/index.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { WKApp } from "@octo/base";
 import MessageBase from "../Base";
 import { MessageBaseCellProps, MessageCell } from "../MessageCell";
 import { I18nContext } from "../../i18n";
@@ -17,6 +18,7 @@ import { fetchDocPreview } from "./preview";
 interface DocShareCardCellState {
   status: DocSharePreviewStatus;
   preview?: DocSharePreview;
+  summaryBusy: boolean;
 }
 
 /**
@@ -27,7 +29,7 @@ export class DocumentShareCardCell extends MessageCell<MessageBaseCellProps> {
   static contextType = I18nContext;
   declare context: React.ContextType<typeof I18nContext>;
 
-  state: DocShareCardCellState = { status: "loading" };
+  state: DocShareCardCellState = { status: "loading", summaryBusy: false };
   private aborter?: AbortController;
 
   componentDidMount(): void {
@@ -77,6 +79,20 @@ export class DocumentShareCardCell extends MessageCell<MessageBaseCellProps> {
     void navigator.clipboard?.writeText(`${window.location.origin}${rel}`);
   };
 
+  private handleSummary = (): void => {
+    if (this.state.summaryBusy) return;
+    const content = this.props.message.content as DocumentShareCardContent;
+    if (!content.docId) return;
+    this.setState({ summaryBusy: true });
+    WKApp.mittBus.emit('wk:document-summary-request', {
+      documentId: content.docId,
+      version: content.updatedAt || undefined,
+      title: content.title,
+      spaceId: content.spaceId,
+      onSettled: () => this.setState({ summaryBusy: false }),
+    });
+  };
+
   private buildStrings(content: DocumentShareCardContent, state: DocSharePermissionState): DocumentShareCardStrings {
     const { t } = this.context;
     return {
@@ -85,6 +101,8 @@ export class DocumentShareCardCell extends MessageCell<MessageBaseCellProps> {
         : undefined,
       permissionLabel: t(`base.docShareCard.permission.${state}`),
       copyLabel: t("base.docShareCard.copy"),
+      summaryLabel: t("base.docShareCard.summary"),
+      summaryBusyLabel: t("base.docShareCard.summaryBusy"),
       openLabel: t("base.docShareCard.open"),
     };
   }
@@ -146,6 +164,8 @@ export class DocumentShareCardCell extends MessageCell<MessageBaseCellProps> {
           placeholder={placeholder}
           onOpen={this.handleOpen}
           onCopy={this.handleCopy}
+          onSummary={this.handleSummary}
+          isSummaryBusy={this.state.summaryBusy}
         />
       </MessageBase>
     );

--- a/packages/dmworkbase/src/i18n/locales/en-US.json
+++ b/packages/dmworkbase/src/i18n/locales/en-US.json
@@ -981,6 +981,8 @@
   "docShareCard.permission.checking": "Checking",
   "docShareCard.createdBy": "Created by {{name}}",
   "docShareCard.copy": "Copy link",
+  "docShareCard.summary": "Summarize document",
+  "docShareCard.summaryBusy": "Summarizing",
   "docShareCard.open": "Open document",
   "docShareCard.placeholder.no_access.title": "Access required",
   "docShareCard.placeholder.no_access.desc": "Open the document to request access",

--- a/packages/dmworkbase/src/i18n/locales/zh-CN.json
+++ b/packages/dmworkbase/src/i18n/locales/zh-CN.json
@@ -981,6 +981,8 @@
   "docShareCard.permission.checking": "检查中",
   "docShareCard.createdBy": "{{name}} 创建",
   "docShareCard.copy": "复制链接",
+  "docShareCard.summary": "总结文档",
+  "docShareCard.summaryBusy": "总结中",
   "docShareCard.open": "打开文档",
   "docShareCard.placeholder.no_access.title": "需要访问权限",
   "docShareCard.placeholder.no_access.desc": "打开文档后可以申请访问",

--- a/packages/dmworkbase/src/ui/DocumentShareCard/DocumentShareCard.stories.tsx
+++ b/packages/dmworkbase/src/ui/DocumentShareCard/DocumentShareCard.stories.tsx
@@ -16,6 +16,8 @@ const strings = (over: Partial<DocumentShareCardStrings> = {}): DocumentShareCar
   subtitle: "Sophie 创建",
   permissionLabel: "可查看",
   copyLabel: "复制链接",
+  summaryLabel: "总结文档",
+  summaryBusyLabel: "总结中",
   openLabel: "打开文档",
   ...over,
 });

--- a/packages/dmworkbase/src/ui/DocumentShareCard/__tests__/DocumentShareCard.test.tsx
+++ b/packages/dmworkbase/src/ui/DocumentShareCard/__tests__/DocumentShareCard.test.tsx
@@ -16,6 +16,8 @@ const strings = (over: Partial<DocumentShareCardStrings> = {}): DocumentShareCar
   subtitle: "Sophie 创建",
   permissionLabel: "可查看",
   copyLabel: "复制链接",
+  summaryLabel: "总结文档",
+  summaryBusyLabel: "总结中",
   openLabel: "打开文档",
   ...over,
 });
@@ -37,6 +39,10 @@ function baseProps(over: Partial<DocumentShareCardProps> = {}): DocumentShareCar
 function previewButtonDisabled(html: string): boolean {
   const m = html.match(/class="document-forward-preview"[^>]*/);
   return m ? m[0].includes("disabled") : /document-forward-preview[^>]*disabled/.test(html);
+}
+
+function summaryButtonMarkup(html: string): string {
+  return html.match(/class="document-forward-summary[^"]*"[^>]*>/)?.[0] ?? "";
 }
 
 describe("DocumentShareCard — 预览区主操作 disabled 门控", () => {
@@ -93,5 +99,18 @@ describe("DocumentShareCard — 预览区主操作 disabled 门控", () => {
     );
     expect(html).toContain("document-preview-placeholder");
     expect(html).toContain("需要访问权限");
+  });
+
+  it("总结入口未注册时保留占位列但不渲染按钮", () => {
+    const html = renderToStaticMarkup(<DocumentShareCard {...baseProps({ onSummary: undefined })} />);
+    expect(html).toContain("document-forward-summary-placeholder");
+    expect(html).not.toContain("总结文档");
+  });
+
+  it("总结中时按钮禁用并切换 aria-label", () => {
+    const html = renderToStaticMarkup(<DocumentShareCard {...baseProps({ onSummary: vi.fn(), isSummaryBusy: true })} />);
+    const summary = summaryButtonMarkup(html);
+    expect(summary).toContain("disabled");
+    expect(summary).toContain("总结中");
   });
 });

--- a/packages/dmworkbase/src/ui/DocumentShareCard/index.css
+++ b/packages/dmworkbase/src/ui/DocumentShareCard/index.css
@@ -120,7 +120,7 @@
 }
 
 .document-forward-copy:hover,
-.document-forward-summary:hover {
+.document-forward-summary:not(:disabled):hover {
   background: var(--wk-bg-elevated);
 }
 
@@ -134,6 +134,11 @@
   animation: document-forward-summary-spin 1.2s linear infinite;
 }
 
+.document-forward-summary-placeholder {
+  width: 28px;
+  height: 28px;
+}
+
 .document-forward-copy .icon,
 .document-forward-summary svg {
   width: 16px;
@@ -143,6 +148,13 @@
 @keyframes document-forward-summary-spin {
   to {
     transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .document-forward-summary.is-busy .icon,
+  .document-forward-summary.is-busy svg {
+    animation: none;
   }
 }
 

--- a/packages/dmworkbase/src/ui/DocumentShareCard/index.css
+++ b/packages/dmworkbase/src/ui/DocumentShareCard/index.css
@@ -20,7 +20,7 @@
 
 .document-forward-card__header {
   display: grid;
-  grid-template-columns: 32px minmax(0, 1fr) auto 28px;
+  grid-template-columns: 32px minmax(0, 1fr) auto 28px 28px;
   align-items: center;
   gap: var(--wk-sp-2);
   padding: 0 0 var(--wk-sp-3);
@@ -105,7 +105,8 @@
   background: var(--wk-brand-tint-06);
 }
 
-.document-forward-copy {
+.document-forward-copy,
+.document-forward-summary {
   display: grid;
   place-items: center;
   width: 28px;
@@ -118,13 +119,31 @@
   cursor: pointer;
 }
 
-.document-forward-copy:hover {
+.document-forward-copy:hover,
+.document-forward-summary:hover {
   background: var(--wk-bg-elevated);
 }
 
-.document-forward-copy .icon {
+.document-forward-summary:disabled {
+  cursor: default;
+  opacity: 0.55;
+}
+
+.document-forward-summary.is-busy .icon,
+.document-forward-summary.is-busy svg {
+  animation: document-forward-summary-spin 1.2s linear infinite;
+}
+
+.document-forward-copy .icon,
+.document-forward-summary svg {
   width: 16px;
   height: 16px;
+}
+
+@keyframes document-forward-summary-spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 .document-forward-preview {

--- a/packages/dmworkbase/src/ui/DocumentShareCard/index.tsx
+++ b/packages/dmworkbase/src/ui/DocumentShareCard/index.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Sparkle } from "lucide-react";
 import "./index.css";
 
 export type DocShareKind = "doc" | "board" | "sheet";
@@ -30,6 +31,10 @@ export interface DocumentShareCardStrings {
   permissionLabel: string;
   /** 复制链接按钮的无障碍label。 */
   copyLabel: string;
+  /** 文档总结按钮的无障碍label。 */
+  summaryLabel: string;
+  /** 文档总结生成中的无障碍label。 */
+  summaryBusyLabel: string;
   /** 预览区（可点开文档）的无障碍label。 */
   openLabel: string;
 }
@@ -44,6 +49,8 @@ export interface DocumentShareCardProps {
   placeholder?: DocSharePlaceholder;
   onOpen?: () => void;
   onCopy?: () => void;
+  onSummary?: () => void;
+  isSummaryBusy?: boolean;
 }
 
 /** 权限态 → 角标/卡片色调。 */
@@ -172,7 +179,7 @@ function PreviewContent({ title, preview }: { title: string; preview: DocSharePr
  * 无 footer；预览区有内容显内容、无权限/失效/检查中显占位。仅 unavailable 禁用点击。
  */
 export function DocumentShareCard(props: DocumentShareCardProps): JSX.Element {
-  const { kind, title, state, strings, preview, placeholder, onOpen, onCopy } = props;
+  const { kind, title, state, strings, preview, placeholder, onOpen, onCopy, onSummary, isSummaryBusy } = props;
   const tone = toneOf(state);
   const disabled = state === "unavailable";
 
@@ -187,6 +194,16 @@ export function DocumentShareCard(props: DocumentShareCardProps): JSX.Element {
           {strings.subtitle ? <p>{strings.subtitle}</p> : null}
         </div>
         <span className={`document-permission is-${tone}`}>{strings.permissionLabel}</span>
+        <button
+          type="button"
+          className={`document-forward-summary${isSummaryBusy ? " is-busy" : ""}`}
+          aria-label={isSummaryBusy ? strings.summaryBusyLabel : strings.summaryLabel}
+          title={isSummaryBusy ? strings.summaryBusyLabel : strings.summaryLabel}
+          disabled={isSummaryBusy || disabled}
+          onClick={onSummary}
+        >
+          <Sparkle size={16} aria-hidden="true" />
+        </button>
         <button
           type="button"
           className="document-forward-copy"

--- a/packages/dmworkbase/src/ui/DocumentShareCard/index.tsx
+++ b/packages/dmworkbase/src/ui/DocumentShareCard/index.tsx
@@ -194,16 +194,20 @@ export function DocumentShareCard(props: DocumentShareCardProps): JSX.Element {
           {strings.subtitle ? <p>{strings.subtitle}</p> : null}
         </div>
         <span className={`document-permission is-${tone}`}>{strings.permissionLabel}</span>
-        <button
-          type="button"
-          className={`document-forward-summary${isSummaryBusy ? " is-busy" : ""}`}
-          aria-label={isSummaryBusy ? strings.summaryBusyLabel : strings.summaryLabel}
-          title={isSummaryBusy ? strings.summaryBusyLabel : strings.summaryLabel}
-          disabled={isSummaryBusy || disabled}
-          onClick={onSummary}
-        >
-          <Sparkle size={16} aria-hidden="true" />
-        </button>
+        {onSummary ? (
+          <button
+            type="button"
+            className={`document-forward-summary${isSummaryBusy ? " is-busy" : ""}`}
+            aria-label={isSummaryBusy ? strings.summaryBusyLabel : strings.summaryLabel}
+            title={isSummaryBusy ? strings.summaryBusyLabel : strings.summaryLabel}
+            disabled={isSummaryBusy || disabled}
+            onClick={onSummary}
+          >
+            <Sparkle size={16} aria-hidden="true" />
+          </button>
+        ) : (
+          <span className="document-forward-summary-placeholder" aria-hidden="true" />
+        )}
         <button
           type="button"
           className="document-forward-copy"

--- a/packages/dmworksummary/src/api/summaryApi.ts
+++ b/packages/dmworksummary/src/api/summaryApi.ts
@@ -10,6 +10,7 @@ import type {
     ChatCandidate,
     CreateSummaryParams,
     CreateAgentSummaryParams,
+    CreateDocumentAgentSummaryParams,
     CreateScheduleParams,
     CustomTopicTemplatePayload,
     InferResult,
@@ -371,6 +372,33 @@ export async function createAgentSummary(
     // 补发 smart_summary_started(此前 agent 模式一次都不发,与 normal 模式不一致)。
     Dap.shared.track('smart_summary_started', trackProps);
     return data;
+}
+
+/** 创建文档 Agent 总结。POST /summary/api/v1/summaries/agent/document */
+export async function createDocumentAgentSummary(
+    params: CreateDocumentAgentSummaryParams,
+): Promise<{ task_id: number; task_no?: string; status: number; created_at?: string }> {
+    const resp = await summaryAxios.post(`${BASE}/summaries/agent/document`, params);
+    if (resp.data?.code !== 0) {
+        const err = new Error(resp.data?.message || 'create document agent summary failed') as Error & {
+            response?: { data?: { code?: number; message?: string } };
+        };
+        err.response = { data: resp.data };
+        throw err;
+    }
+    const data = resp.data?.data as {
+        task_id?: number; task_no?: string; status?: number; created_at?: string;
+    } | undefined;
+    if (!data || typeof data.task_id !== 'number' || data.task_id <= 0) {
+        throw new Error(resp.data?.message || 'create document agent summary returned no task_id');
+    }
+    Dap.shared.track('smart_summary_started', { source: 'document_star' });
+    return {
+        task_id: data.task_id,
+        task_no: data.task_no,
+        status: data.status ?? 0,
+        created_at: data.created_at,
+    };
 }
 
 // Agent 交互式问答（非流式一问一答）。POST /summary/api/v1/agent/chat。

--- a/packages/dmworksummary/src/api/summaryApi.ts
+++ b/packages/dmworksummary/src/api/summaryApi.ts
@@ -377,8 +377,14 @@ export async function createAgentSummary(
 /** 创建文档 Agent 总结。POST /summary/api/v1/summaries/agent/document */
 export async function createDocumentAgentSummary(
     params: CreateDocumentAgentSummaryParams,
+    trackProps: Record<string, unknown> = {},
+    spaceId?: string,
 ): Promise<{ task_id: number; task_no?: string; status: number; created_at?: string }> {
-    const resp = await summaryAxios.post(`${BASE}/summaries/agent/document`, params);
+    const resp = await summaryAxios.post(
+        `${BASE}/summaries/agent/document`,
+        params,
+        spaceId ? { headers: { 'X-Space-Id': spaceId } } : undefined,
+    );
     if (resp.data?.code !== 0) {
         const err = new Error(resp.data?.message || 'create document agent summary failed') as Error & {
             response?: { data?: { code?: number; message?: string } };
@@ -392,7 +398,7 @@ export async function createDocumentAgentSummary(
     if (!data || typeof data.task_id !== 'number' || data.task_id <= 0) {
         throw new Error(resp.data?.message || 'create document agent summary returned no task_id');
     }
-    Dap.shared.track('smart_summary_started', { source: 'document_star' });
+    Dap.shared.track('smart_summary_started', trackProps);
     return {
         task_id: data.task_id,
         task_no: data.task_no,

--- a/packages/dmworksummary/src/i18n/en-US.json
+++ b/packages/dmworksummary/src/i18n/en-US.json
@@ -212,6 +212,12 @@
         "back": "Back",
         "starTooltip": "AI Summary"
     },
+    "documentSummary": {
+        "creating": "Summarizing document...",
+        "created": "Document summary generated",
+        "failed": "Failed to summarize document. Please try again later.",
+        "defaultRequirement": "Summarize this document"
+    },
     "templates": {
         "project_progress": {
             "label": "Summarize project progress",

--- a/packages/dmworksummary/src/i18n/zh-CN.json
+++ b/packages/dmworksummary/src/i18n/zh-CN.json
@@ -212,6 +212,12 @@
         "back": "返回",
         "starTooltip": "智能总结"
     },
+    "documentSummary": {
+        "creating": "正在总结文档…",
+        "created": "文档总结已生成",
+        "failed": "文档总结失败，请稍后重试",
+        "defaultRequirement": "总结这份文档"
+    },
     "templates": {
         "project_progress": {
             "label": "汇总项目进展",

--- a/packages/dmworksummary/src/module.tsx
+++ b/packages/dmworksummary/src/module.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Toast } from "@douyinfe/semi-ui";
 import type { IModule } from "@octo/base";
-import { i18n, WKApp, Menus, t as translate, Dap } from "@octo/base";
+import { i18n, WKApp, Menus, t as translate, Dap, type DocumentSummaryRequestPayload } from "@octo/base";
 import SummaryListPage from "./pages/SummaryListPage";
 import SummaryCreatePage from "./pages/SummaryCreatePage";
 import SummaryDetailPage from "./pages/SummaryDetailPage";
@@ -26,17 +26,9 @@ let _spaceReadyHandler: (() => void) | null = null;
 let _documentSummaryHandler: ((payload: DocumentSummaryRequestPayload) => void) | null = null;
 const openingSummaryShares = new Set<string>();
 
-interface DocumentSummaryRequestPayload {
-    documentId?: string;
-    version?: string;
-    title?: string;
-    spaceId?: string;
-    onSettled?: () => void;
-}
-
-function makeDocumentSummaryIdempotencyKey(documentId: string, version?: string): string {
+function makeDocumentSummaryIdempotencyKey(documentId: string): string {
     const suffix = globalThis.crypto?.randomUUID?.() ?? `${Date.now()}-${Math.random().toString(36).slice(2)}`;
-    return `document:${documentId}:${version || "latest"}:${suffix}`;
+    return `document:${documentId}:latest:${suffix}`;
 }
 
 function afterSummaryMenuSwitch(action: () => void) {
@@ -220,22 +212,30 @@ export class SummaryModule implements IModule {
         };
         WKApp.mittBus.on('space-changed', _spaceChangedHandler);
         WKApp.mittBus.on('space-ready', _spaceReadyHandler);
+        WKApp.canCreateDocumentSummary = true;
 
         _documentSummaryHandler = (payload: DocumentSummaryRequestPayload) => {
             const documentId = payload?.documentId?.trim();
-            if (!documentId) return;
-            if (payload.spaceId) WKApp.shared.currentSpaceId = payload.spaceId;
+            if (!documentId) {
+                payload?.onSettled?.();
+                return;
+            }
             Toast.info(translate("summary.documentSummary.creating"));
             void createDocumentAgentSummary({
-                document_refs: [{ document_id: documentId, version: payload.version || undefined }],
+                document_refs: [{ document_id: documentId }],
                 requirement: translate("summary.documentSummary.defaultRequirement"),
-                idempotency_key: makeDocumentSummaryIdempotencyKey(documentId, payload.version),
-            }).then((res) => {
+                idempotency_key: makeDocumentSummaryIdempotencyKey(documentId),
+            }, { source: 'document_star' }, payload.spaceId).then(() => {
                 Toast.success(translate("summary.documentSummary.created"));
-                WKApp.openSummaryDetail?.(res.task_id, payload.spaceId || WKApp.shared.currentSpaceId);
+                if (payload.originChannel) {
+                    notifyChatSummaryCreated({
+                        channelID: payload.originChannel.channelId,
+                        channelType: payload.originChannel.channelType,
+                    });
+                }
             }).catch((err: unknown) => {
-                const message = err instanceof Error ? err.message : translate("summary.documentSummary.failed");
-                Toast.error(message || translate("summary.documentSummary.failed"));
+                console.warn("[summary] create document summary failed", err);
+                Toast.error(translate("summary.documentSummary.failed"));
             }).finally(() => {
                 payload.onSettled?.();
             });
@@ -285,6 +285,7 @@ if (import.meta.hot) {
             WKApp.mittBus.off('wk:document-summary-request', _documentSummaryHandler);
             _documentSummaryHandler = null;
         }
+        WKApp.canCreateDocumentSummary = false;
     });
 }
 

--- a/packages/dmworksummary/src/module.tsx
+++ b/packages/dmworksummary/src/module.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Toast } from "@douyinfe/semi-ui";
 import type { IModule } from "@octo/base";
 import { i18n, WKApp, Menus, t as translate, Dap } from "@octo/base";
 import SummaryListPage from "./pages/SummaryListPage";
@@ -8,7 +9,7 @@ import SummaryShareDetailPage from "./pages/SummaryShareDetailPage";
 import SummarySharePreviewFeature from "./features/summaryShare/SummarySharePreviewFeature";
 import SummaryConfirmPage from "./pages/SummaryConfirmPage";
 import ScheduleListPage from "./pages/ScheduleListPage";
-import { getChatCandidates, getSummaryShare } from "./api/summaryApi";
+import { createDocumentAgentSummary, getChatCandidates, getSummaryShare } from "./api/summaryApi";
 import { getOriginalSummaryTaskId, shouldOpenOriginalSummary } from "./features/summaryShare/navigation";
 import { notifyChatSummaryCreated } from "./utils/chatSummaryActions";
 import { getPendingInvitationBadge, refreshPendingInvitationBadge } from "./utils/summaryMenuBadge";
@@ -22,7 +23,21 @@ import "./index.css";
 
 let _spaceChangedHandler: (() => void) | null = null;
 let _spaceReadyHandler: (() => void) | null = null;
+let _documentSummaryHandler: ((payload: DocumentSummaryRequestPayload) => void) | null = null;
 const openingSummaryShares = new Set<string>();
+
+interface DocumentSummaryRequestPayload {
+    documentId?: string;
+    version?: string;
+    title?: string;
+    spaceId?: string;
+    onSettled?: () => void;
+}
+
+function makeDocumentSummaryIdempotencyKey(documentId: string, version?: string): string {
+    const suffix = globalThis.crypto?.randomUUID?.() ?? `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    return `document:${documentId}:${version || "latest"}:${suffix}`;
+}
 
 function afterSummaryMenuSwitch(action: () => void) {
     if (WKApp.switchToMenuById && WKApp.currentMenuId !== "summary") {
@@ -206,6 +221,27 @@ export class SummaryModule implements IModule {
         WKApp.mittBus.on('space-changed', _spaceChangedHandler);
         WKApp.mittBus.on('space-ready', _spaceReadyHandler);
 
+        _documentSummaryHandler = (payload: DocumentSummaryRequestPayload) => {
+            const documentId = payload?.documentId?.trim();
+            if (!documentId) return;
+            if (payload.spaceId) WKApp.shared.currentSpaceId = payload.spaceId;
+            Toast.info(translate("summary.documentSummary.creating"));
+            void createDocumentAgentSummary({
+                document_refs: [{ document_id: documentId, version: payload.version || undefined }],
+                requirement: translate("summary.documentSummary.defaultRequirement"),
+                idempotency_key: makeDocumentSummaryIdempotencyKey(documentId, payload.version),
+            }).then((res) => {
+                Toast.success(translate("summary.documentSummary.created"));
+                WKApp.openSummaryDetail?.(res.task_id, payload.spaceId || WKApp.shared.currentSpaceId);
+            }).catch((err: unknown) => {
+                const message = err instanceof Error ? err.message : translate("summary.documentSummary.failed");
+                Toast.error(message || translate("summary.documentSummary.failed"));
+            }).finally(() => {
+                payload.onSettled?.();
+            });
+        };
+        WKApp.mittBus.on('wk:document-summary-request', _documentSummaryHandler);
+
         WKApp.searchChatCandidates = async (params) => {
             return getChatCandidates(params);
         };
@@ -244,6 +280,10 @@ if (import.meta.hot) {
         if (_spaceReadyHandler) {
             WKApp.mittBus.off('space-ready', _spaceReadyHandler);
             _spaceReadyHandler = null;
+        }
+        if (_documentSummaryHandler) {
+            WKApp.mittBus.off('wk:document-summary-request', _documentSummaryHandler);
+            _documentSummaryHandler = null;
         }
     });
 }

--- a/packages/dmworksummary/src/types/summary.ts
+++ b/packages/dmworksummary/src/types/summary.ts
@@ -350,6 +350,16 @@ export interface CreateAgentSummaryParams {
     referenced_task_ids?: number[];
 }
 
+/** 文档 Agent 总结创建请求。 */
+export interface CreateDocumentAgentSummaryParams {
+    document_refs: Array<{
+        document_id: string;
+        version?: string;
+    }>;
+    requirement?: string;
+    idempotency_key: string;
+}
+
 /** Agent 对话单条消息（user 右气泡 / assistant 左气泡） */
 export interface ChatMessage {
     role: 'user' | 'assistant';


### PR DESCRIPTION
## Summary
- add a Sparkle star entry to document share cards
- emit document summary requests from dmworkbase without depending on dmworksummary
- handle document summary creation in dmworksummary and open the generated summary detail
- add document summary API typings and i18n strings

## Verification
- pnpm i18n:check
- pnpm --filter @octo/base test -- src/ui/DocumentShareCard src/Messages/DocumentShareCard
- git diff --check
- Attempted: pnpm --filter @dmwork/summary typecheck, blocked by existing dependency/test type errors in node_modules/@douyinfe/semi-foundation, React type resolution, and existing tests