### PR TITLE
fix(skillmarket): identify official skills by system visibility

### DIFF
--- a/.i18n/scan-config.json
+++ b/.i18n/scan-config.json
@@ -77,10 +77,6 @@
       "reason": "Agent prompt template for the Bot publish flow. Same rationale as installPrompt.ts above — generated prompt content pasted into an agent client, must byte-match; not translatable UI chrome."
     },
     {
-      "path": "packages/dmworkskillmarket/src/utils/publisher.ts",
-      "reason": "Publisher classification helper. The Chinese literal is a backend identity value used to recognize administrator-created records, not user-facing UI copy; the displayed label is localized separately."
-    },
-    {
       "path": "packages/dmworkmcp/src/utils/mcpBotPublishPrompt.ts",
       "reason": "Agent prompt template for the MCP marketplace publish flow. Same rationale as dmworkskillmarket/src/utils/botPublishPrompt.ts — generated prompt content pasted into an agent client, must byte-match; not translatable UI chrome."
     },

--- a/packages/dmworkskillmarket/src/api/skillApiReal.test.ts
+++ b/packages/dmworkskillmarket/src/api/skillApiReal.test.ts
@@ -856,6 +856,34 @@ describe("skillApiReal", () => {
     expect(skill.fileSize).toBe(0);
   });
 
+  it("preserves system visibility when mapping a skill response", async () => {
+    mockFetch.mockReturnValueOnce(
+      jsonResponse({
+        skill_id: "official-skill",
+        name: "Official Skill",
+        description: "Published by the platform",
+        category_id: "other",
+        tags: [],
+        owner_id: "admin",
+        owner_name: "Admin",
+        space_id: "",
+        visibility: "system",
+        version: "1.0.0",
+        readme_content: "# Official Skill",
+        file_name: "official-skill.zip",
+        file_url: "https://example.com/official-skill.zip",
+        file_size: 1024,
+        file_sha256: "abc",
+        created_at: "2026-08-18T00:00:00Z",
+        updated_at: "2026-08-18T00:00:00Z",
+      }),
+    );
+
+    const skill = await getSkill("official-skill");
+
+    expect(skill.visibility).toBe("system");
+  });
+
   it("getCategories passes signal to fetch and aborts correctly", async () => {
     const controller = new AbortController();
     mockFetch.mockImplementation(() => {

--- a/packages/dmworkskillmarket/src/components/__tests__/SkillCard.test.tsx
+++ b/packages/dmworkskillmarket/src/components/__tests__/SkillCard.test.tsx
@@ -62,13 +62,12 @@ describe("SkillCard", () => {
     expect(screen.getByText("我")).toBeInTheDocument();
   });
 
-  it("shows platform attribution for administrator-created global skills", () => {
+  it("shows platform attribution for system skills", () => {
     const { container } = render(
       <SkillCard
         skill={{
           ...skill,
-          visibility: "public",
-          spaceId: undefined as unknown as string,
+          visibility: "system",
           ownerName: "超级管理员",
           creatorName: "超级管理员",
         }}
@@ -81,6 +80,25 @@ describe("SkillCard", () => {
     expect(screen.queryByText("超级管理员")).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "ci-helper 官方发布" })).toBeInTheDocument();
     expect(container.querySelector(".skill-market-card__owner-platform-icon")).toBeInTheDocument();
+  });
+
+  it("does not treat historical public administrator skills as platform-published", () => {
+    render(
+      <SkillCard
+        skill={{
+          ...skill,
+          visibility: "public",
+          spaceId: "",
+          ownerName: "超级管理员",
+          creatorName: "超级管理员",
+        }}
+        categories={categories}
+        onOpen={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByText("官方发布")).not.toBeInTheDocument();
+    expect(screen.getAllByText("超级管理员").length).toBeGreaterThan(0);
   });
 
   it("shows creator and owner when they are different", () => {

--- a/packages/dmworkskillmarket/src/components/__tests__/SkillDetailModal.test.tsx
+++ b/packages/dmworkskillmarket/src/components/__tests__/SkillDetailModal.test.tsx
@@ -94,11 +94,10 @@ describe("SkillDetailModal", () => {
     expect(screen.getByTitle("我")).toBeInTheDocument();
   });
 
-  it("shows platform attribution for administrator-created global skills", async () => {
+  it("shows platform attribution for system skills", async () => {
     vi.mocked(api.getSkill).mockResolvedValue({
       ...skill,
-      visibility: "public",
-      spaceId: undefined as unknown as string,
+      visibility: "system",
       ownerName: "超级管理员",
       creatorName: "超级管理员",
     });
@@ -109,6 +108,22 @@ describe("SkillDetailModal", () => {
     expect(screen.queryByText("超级管理员")).not.toBeInTheDocument();
     expect(screen.getByTitle("官方发布")).toBeInTheDocument();
     expect(container.querySelector(".skill-market-detail-header__platform-icon")).toBeInTheDocument();
+  });
+
+  it("does not treat historical public administrator skills as platform-published", async () => {
+    vi.mocked(api.getSkill).mockResolvedValue({
+      ...skill,
+      visibility: "public",
+      spaceId: "",
+      ownerName: "超级管理员",
+      creatorName: "超级管理员",
+    });
+
+    render(<SkillDetailModal skillId={skill.id} categories={categories} onClose={vi.fn()} />);
+
+    expect(await screen.findByText("test")).toBeInTheDocument();
+    expect(screen.queryByText("官方发布")).not.toBeInTheDocument();
+    expect(screen.getAllByText("超级管理员").length).toBeGreaterThan(0);
   });
 
   it("shows bot creator and owner with icons when they are different", async () => {

--- a/packages/dmworkskillmarket/src/types/skill.ts
+++ b/packages/dmworkskillmarket/src/types/skill.ts
@@ -1,4 +1,4 @@
-export type Visibility = "public" | "space" | "private";
+export type Visibility = "system" | "public" | "space" | "private";
 export type SkillSort = "comprehensive" | "latest" | "views" | "downloads";
 
 // ─── Frontend (camelCase) types ────────────────────────────────────────────

--- a/packages/dmworkskillmarket/src/types/skill.ts
+++ b/packages/dmworkskillmarket/src/types/skill.ts
@@ -1,4 +1,5 @@
 export type Visibility = "system" | "public" | "space" | "private";
+export type WritableVisibility = Exclude<Visibility, "system">;
 export type SkillSort = "comprehensive" | "latest" | "views" | "downloads";
 
 // ─── Frontend (camelCase) types ────────────────────────────────────────────
@@ -73,7 +74,7 @@ export interface NewSkillForm {
   description: string;
   categoryId: string;
   tags: string[];
-  visibility: Visibility;
+  visibility: WritableVisibility;
   version?: string;
   changelog?: string;
   readmeContent: string;
@@ -89,7 +90,7 @@ export interface UpdateSkillForm {
   description?: string;
   categoryId?: string;
   tags?: string[];
-  visibility?: Visibility;
+  visibility?: WritableVisibility;
   version?: string;
   changelog?: string;
   readmeContent?: string;

--- a/packages/dmworkskillmarket/src/types/skill.ts
+++ b/packages/dmworkskillmarket/src/types/skill.ts
@@ -1,5 +1,5 @@
 export type Visibility = "system" | "public" | "space" | "private";
-export type WritableVisibility = Exclude<Visibility, "system">;
+export type WritableVisibility = Exclude<Visibility, "system" | "public">;
 export type SkillSort = "comprehensive" | "latest" | "views" | "downloads";
 
 // ─── Frontend (camelCase) types ────────────────────────────────────────────

--- a/packages/dmworkskillmarket/src/utils/publisher.test.ts
+++ b/packages/dmworkskillmarket/src/utils/publisher.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+import { isPlatformPublishedSkill } from "./publisher";
+
+describe("isPlatformPublishedSkill", () => {
+  it("identifies only system visibility as platform-published", () => {
+    expect(isPlatformPublishedSkill({ visibility: "system" })).toBe(true);
+    expect(isPlatformPublishedSkill({ visibility: "public" })).toBe(false);
+    expect(isPlatformPublishedSkill({ visibility: "space" })).toBe(false);
+    expect(isPlatformPublishedSkill({ visibility: "private" })).toBe(false);
+  });
+});

--- a/packages/dmworkskillmarket/src/utils/publisher.ts
+++ b/packages/dmworkskillmarket/src/utils/publisher.ts
@@ -1,17 +1,5 @@
 import type { Skill } from "../types/skill";
 
-// Administrator-created Skills are stored as public records in the global
-// Marketplace scope. The backend currently represents that scope with an
-// empty space_id, so keep the heuristic isolated until an explicit publisher
-// type is available in the API contract.
-export function isPlatformPublishedSkill(
-  skill: Pick<Skill, "creatorName" | "ownerName" | "spaceId" | "visibility">,
-): boolean {
-  if (skill.visibility !== "public") return false;
-
-  // space_id is intentionally omitted from current public Skill responses, so
-  // recognize the administrator role name already returned by the API. Keep
-  // the global-scope check for endpoints/fixtures that do expose space_id.
-  const publisherName = (skill.creatorName || skill.ownerName).trim();
-  return skill.spaceId === "" || publisherName === "超级管理员" || publisherName === "Super Admin";
+export function isPlatformPublishedSkill(skill: Pick<Skill, "visibility">): boolean {
+  return skill.visibility === "system";
 }


### PR DESCRIPTION
## Summary
- extend Skill Marketplace read visibility with `system`
- identify official/platform-published Skills exclusively via `visibility === "system"`
- remove legacy `spaceId` and publisher-name heuristics
- keep both `system` and `public` read-only in the frontend write contract
- retain the shared helper for card and detail rendering and cover both surfaces with tests

## Backend dependency / merge order
This frontend PR depends on Mininglamp-OSS/octo-marketplace#58, which introduces Skill `system` end-to-end (ENUM migration, Admin write/manage, list/detail/category visibility, and user/bot write rejection).

There is no historical Skill data to migrate. Deploy the backend migration/service before or together with this frontend change.

## Validation
- `NODE_OPTIONS=--localstorage-file=/tmp/octo-web-vitest-localstorage pnpm --filter @dmwork/skillmarket test` (14 files, 132 tests passed)
- `pnpm --filter @octo/web build` (passed on the previous revision; current change is type-only narrowing)
- `git diff --check`

Related: Mininglamp-OSS/octo-marketplace#57
Depends on: Mininglamp-OSS/octo-marketplace#58
