### PR TITLE
feat(electron): add typed desktop IPC bridge

### DIFF
--- a/apps/web/src-election/main/index.ts
+++ b/apps/web/src-election/main/index.ts
@@ -21,11 +21,19 @@ import { pathToFileURL } from "url";
 import logo, { getNoMessageTrayIcon } from "./logo";
 import {
   IPC_CONVERSATION_UNREAD_COUNT,
+  IPC_DEEP_LINK,
   IPC_OIDC_AUTHORIZE_START,
   IPC_OIDC_AUTHORIZE_END,
   IPC_OIDC_HTTP_REQUEST,
   IPC_OIDC_OPEN_EXTERNAL,
   IPC_OIDC_CLEAR_AUTH_SESSION,
+  IPC_NOTIFICATION_TEST_ICON,
+  IPC_MEDIA_ACCESS_STATUS,
+  IPC_RESTART_APP,
+  IPC_SCREENSHOTS_OK,
+  IPC_SCREENSHOTS_START,
+  IPC_SHOW_CONVERSATIONS,
+  IPC_WINDOW_IS_FOCUSED,
 } from "../shared/ipc-channels";
 import OCTO_CONFIG, { OIDC_API_ORIGIN, OIDC_END_SESSION_ORIGINS } from "./config";
 import {
@@ -176,6 +184,16 @@ function resolveTrustedOidcSender(
   const win = BrowserWindow.fromWebContents(event.sender);
   if (!win || win.isDestroyed()) return undefined;
   return win;
+}
+
+function isTrustedShellIpcSender(
+  event: Electron.IpcMainEvent | Electron.IpcMainInvokeEvent,
+): boolean {
+  const frame = "senderFrame" in event ? event.senderFrame : undefined;
+  if (frame && frame.top !== frame) return false;
+  if (!trustedShellContents.has(event.sender)) return false;
+  const win = BrowserWindow.fromWebContents(event.sender);
+  return Boolean(win && !win.isDestroyed());
 }
 
 
@@ -596,7 +614,8 @@ function registerOidcReturnRedirect(win: BrowserWindow, webUrl: string, sid: str
 const registerWindowFocusHandler = () => {
   if (isWindowFocusHandlerRegistered) return;
 
-  ipcMain.handle("is-window-focused", (event) => {
+  ipcMain.handle(IPC_WINDOW_IS_FOCUSED, (event) => {
+    if (!isTrustedShellIpcSender(event)) return false;
     // Query the window that owns the renderer making the request. This also
     // keeps focus suppression correct for auxiliary windows.
     const senderWindow = BrowserWindow.fromWebContents(event.sender);
@@ -689,7 +708,7 @@ let mainMenu: (Electron.MenuItemConstructorOptions | Electron.MenuItem)[] = [
         accelerator: "Shift+Cmd+M",
         click() {
           mainWindow.show();
-          mainWindow.webContents.send("show-conversations");
+          mainWindow.webContents.send(IPC_SHOW_CONVERSATIONS);
         },
       },
       {
@@ -1028,13 +1047,15 @@ const createMainWindow = async () => {
     attachFileRootGuard(mainWindow, WEB_URL);
   }
 
-  ipcMain.on("screenshots-start", (event, args) => {
+  ipcMain.on(IPC_SCREENSHOTS_START, (event, args) => {
+    if (!isTrustedShellIpcSender(event)) return;
     console.log("main voip-message event", args);
     screenShotWindowId = event.sender.id;
     screenshots.startCapture();
   });
 
-  ipcMain.on("get-media-access-status", async (event, mediaType: 'camera' | 'microphone')=>{
+  ipcMain.handle(IPC_MEDIA_ACCESS_STATUS, async (event, mediaType: 'camera' | 'microphone')=>{
+    if (!isTrustedShellIpcSender(event)) return 'denied';
     console.log(mediaType)
     //检测麦克风权限是否开启
     const getMediaAccessStatus = systemPreferences.getMediaAccessStatus(mediaType);
@@ -1061,12 +1082,14 @@ const createMainWindow = async () => {
     updateTray(num, false); // 不需要闪烁，闪烁很消耗性能
   });
 
-  ipcMain.on("restart-app",()=>{
+  ipcMain.on(IPC_RESTART_APP,(event)=>{
+    if (!isTrustedShellIpcSender(event)) return;
     restartApp()
   })
 
   // Test notification handler for debugging (development only)
-  ipcMain.handle("test-notification-icon", () => {
+  ipcMain.handle(IPC_NOTIFICATION_TEST_ICON, (event) => {
+    if (!isTrustedShellIpcSender(event)) return false;
     if (!isDevelopment) return false;
     // Show a test notification
     electronNotificationManager.showNotification({
@@ -1084,6 +1107,7 @@ const createMainWindow = async () => {
 
   // Set up notification manager with main window
   electronNotificationManager.setMainWindow(mainWindow);
+  electronNotificationManager.setSenderGuard(isTrustedShellIpcSender);
 
   // 检查更新
   checkUpdate(mainWindow)
@@ -1127,7 +1151,7 @@ function onDeepLink(url: string) {
     console.warn("Deep link dropped: main window not ready:", url);
     return;
   }
-  mainWindow.webContents.send("deep-link", url);
+  mainWindow.webContents.send(IPC_DEEP_LINK, url);
 }
 
 app.setName(OCTO_CONFIG.name);
@@ -1435,7 +1459,7 @@ app.on("ready", () => {
     );
     if (isMainWindowFocusedWhenStartScreenshot) {
       if (result) {
-        mainWindow.webContents.send("screenshots-ok", result);
+        mainWindow.webContents.send(IPC_SCREENSHOTS_OK, result);
       }
       mainWindow.show();
       isMainWindowFocusedWhenStartScreenshot = false;
@@ -1446,7 +1470,7 @@ app.on("ready", () => {
       );
       if (tms.length > 0) {
         if (result) {
-          tms[0].webContents.send("screenshots-ok", result);
+          tms[0].webContents.send(IPC_SCREENSHOTS_OK, result);
         }
         tms[0].show();
       }

--- a/apps/web/src-election/main/notification.ts
+++ b/apps/web/src-election/main/notification.ts
@@ -1,5 +1,12 @@
 import { Notification, BrowserWindow, ipcMain } from "electron";
 import { Channel } from "wukongimjssdk";
+import {
+  IPC_NOTIFICATION_ACTION_CLICKED,
+  IPC_NOTIFICATION_CLICKED,
+  IPC_NOTIFICATION_CLOSE,
+  IPC_NOTIFICATION_CLOSE_ALL,
+  IPC_NOTIFICATION_SHOW,
+} from "../shared/ipc-channels";
 
 const isDevelopment = process.env.NODE_ENV !== "production";
 
@@ -45,6 +52,7 @@ class ElectronNotificationManager {
   private static instance: ElectronNotificationManager;
   private activeNotifications: Map<string, Notification> = new Map();
   private mainWindow: BrowserWindow | null = null;
+  private isTrustedSender: (event: Electron.IpcMainInvokeEvent) => boolean = () => false;
 
   private constructor() {
     this.setupIpcHandlers();
@@ -61,24 +69,32 @@ class ElectronNotificationManager {
     this.mainWindow = window;
   }
 
+  public setSenderGuard(guard: (event: Electron.IpcMainInvokeEvent) => boolean): void {
+    this.isTrustedSender = guard;
+  }
+
   private setupIpcHandlers(): void {
     // Handle notification requests from renderer process
-    ipcMain.handle('show-native-notification', async (_event, options: ElectronNotificationOptions) => {
-      return this.showNotification(options);
+    ipcMain.handle(IPC_NOTIFICATION_SHOW, async (event, options: ElectronNotificationOptions) => {
+      if (!this.isTrustedSender(event)) return false;
+      const ownerWindow = BrowserWindow.fromWebContents(event.sender);
+      return this.showNotification(options, ownerWindow || undefined);
     });
 
     // Handle notification close requests
-    ipcMain.handle('close-native-notification', async (_event, tag: string) => {
+    ipcMain.handle(IPC_NOTIFICATION_CLOSE, async (event, tag: string) => {
+      if (!this.isTrustedSender(event)) return;
       this.closeNotification(tag);
     });
 
     // Handle close all notifications
-    ipcMain.handle('close-all-native-notifications', async () => {
+    ipcMain.handle(IPC_NOTIFICATION_CLOSE_ALL, async (event) => {
+      if (!this.isTrustedSender(event)) return;
       this.closeAllNotifications();
     });
   }
 
-  public showNotification(options: ElectronNotificationOptions): boolean {
+  public showNotification(options: ElectronNotificationOptions, ownerWindow = this.mainWindow || undefined): boolean {
     try {
       // Close existing notification with same tag
       if (options.tag) {
@@ -97,16 +113,16 @@ class ElectronNotificationManager {
       // Set up event handlers
       notification.on('click', () => {
         debugLog('Notification clicked');
-        // Bring main window to front
-        if (this.mainWindow) {
-          if (this.mainWindow.isMinimized()) {
-            this.mainWindow.restore();
+        // Bring the window that created this notification to front.
+        if (ownerWindow && !ownerWindow.isDestroyed()) {
+          if (ownerWindow.isMinimized()) {
+            ownerWindow.restore();
           }
-          this.mainWindow.show();
-          this.mainWindow.focus();
+          ownerWindow.show();
+          ownerWindow.focus();
 
           // Send click event to renderer process with channel info
-          this.mainWindow.webContents.send('notification-clicked', {
+          ownerWindow.webContents.send(IPC_NOTIFICATION_CLICKED, {
             tag: options.tag,
             title: options.title,
             body: options.body,
@@ -129,8 +145,8 @@ class ElectronNotificationManager {
 
       notification.on('action', (_event, index) => {
         debugLog('Notification action clicked:', index);
-        if (this.mainWindow) {
-          this.mainWindow.webContents.send('notification-action-clicked', {
+        if (ownerWindow && !ownerWindow.isDestroyed()) {
+          ownerWindow.webContents.send(IPC_NOTIFICATION_ACTION_CLICKED, {
             tag: options.tag,
             actionIndex: index,
           });

--- a/apps/web/src-election/main/update.ts
+++ b/apps/web/src-election/main/update.ts
@@ -3,9 +3,21 @@ import { autoUpdater } from "electron-updater";
 import logger from "electron-log";
 import path from "path";
 import OCTO_CONFIG from "./config";
+import {
+  IPC_UPDATE_AVAILABLE,
+  IPC_UPDATE_CHECK,
+  IPC_UPDATE_DOWNLOADED,
+  IPC_UPDATE_DOWNLOAD,
+  IPC_UPDATE_DOWNLOAD_PROGRESS,
+  IPC_UPDATE_ERROR,
+  IPC_UPDATE_INSTALL,
+  IPC_UPDATE_NOT_AVAILABLE,
+} from "../shared/ipc-channels";
 const feedUrl = `${OCTO_CONFIG.updateUrl}v1/common/pcupdater/`;
 
 let mainWindow: BrowserWindow;
+const isMainWindowSender = (event: Electron.IpcMainEvent): boolean =>
+  Boolean(mainWindow && !mainWindow.isDestroyed() && event.sender === mainWindow.webContents);
 // 封装更新相关的进程通信方法
 const sendUpdateMessage = (opt: { cmd: string; data: any }) => {
   mainWindow.webContents.send(opt.cmd, opt.data);
@@ -35,7 +47,7 @@ function checkUpdate(win: BrowserWindow) {
   autoUpdater.on("error", (error) => {
     logger.info(error);
     sendUpdateMessage({
-      cmd: "update-error",
+      cmd: IPC_UPDATE_ERROR,
       data: error,
     });
   });
@@ -45,7 +57,7 @@ function checkUpdate(win: BrowserWindow) {
     logger.info('检查到有更新');
     logger.info(message);
     sendUpdateMessage({
-      cmd: "update-available",
+      cmd: IPC_UPDATE_AVAILABLE,
       data: message,
     });
   });
@@ -53,7 +65,7 @@ function checkUpdate(win: BrowserWindow) {
   // 监听没有可用更新事件
   autoUpdater.on("update-not-available", (message) => {
     sendUpdateMessage({
-      cmd: "update-not-available",
+      cmd: IPC_UPDATE_NOT_AVAILABLE,
       data: message,
     });
   });
@@ -64,7 +76,7 @@ function checkUpdate(win: BrowserWindow) {
     // 计算下载百分比
     const downloadPercent = parseInt(`${progress.percent}`);
     sendUpdateMessage({
-      cmd: "download-progress",
+      cmd: IPC_UPDATE_DOWNLOAD_PROGRESS,
       data: downloadPercent,
     });
   });
@@ -73,24 +85,27 @@ function checkUpdate(win: BrowserWindow) {
   autoUpdater.on("update-downloaded", (releaseObj) => {
     logger.info('下载完毕！提示安装更新');
     sendUpdateMessage({
-      cmd: "update-downloaded",
+      cmd: IPC_UPDATE_DOWNLOADED,
       data: releaseObj,
     });
   });
 
   // 接收渲染进程消息，开始检查更新
-  ipcMain.on("check-update", () => {
+  ipcMain.on(IPC_UPDATE_CHECK, (event) => {
+    if (!isMainWindowSender(event)) return;
     //执行自动更新检查
     logger.info("开始检查更新");
     autoUpdater.checkForUpdates();
   });
 
   // 触发更新
-  ipcMain.on("update-app", () => {
+  ipcMain.on(IPC_UPDATE_DOWNLOAD, (event) => {
+    if (!isMainWindowSender(event)) return;
     autoUpdater.downloadUpdate();
   });
   // 退出并安装更新包
-  ipcMain.on("install-update", () => {
+  ipcMain.on(IPC_UPDATE_INSTALL, (event) => {
+    if (!isMainWindowSender(event)) return;
     autoUpdater.quitAndInstall();
   });
 }

--- a/apps/web/src-election/main/utils/createWindow.ts
+++ b/apps/web/src-election/main/utils/createWindow.ts
@@ -31,7 +31,9 @@ export function createWindow() {
     webPreferences: {
       // 加载脚本
       preload: join(__dirname, "../..", "preload", "index.js"),
-      nodeIntegration: true,
+      nodeIntegration: false,
+      contextIsolation: true,
+      sandbox: true,
     },
   });
 

--- a/apps/web/src-election/preload/index.ts
+++ b/apps/web/src-election/preload/index.ts
@@ -1,13 +1,33 @@
 import { contextBridge, ipcRenderer } from "electron";
 import {
   IPC_CONVERSATION_UNREAD_COUNT,
+  IPC_DEEP_LINK,
+  IPC_SHOW_CONVERSATIONS,
+  IPC_NOTIFICATION_ACTION_CLICKED,
+  IPC_NOTIFICATION_CLICKED,
+  IPC_NOTIFICATION_CLOSE,
+  IPC_NOTIFICATION_CLOSE_ALL,
+  IPC_NOTIFICATION_SHOW,
+  IPC_NOTIFICATION_TEST_ICON,
+  IPC_MEDIA_ACCESS_STATUS,
   IPC_OIDC_AUTHORIZE_START,
   IPC_OIDC_AUTHORIZE_END,
   IPC_OIDC_HTTP_REQUEST,
   IPC_OIDC_OPEN_EXTERNAL,
   IPC_OIDC_CLEAR_AUTH_SESSION,
+  IPC_RESTART_APP,
+  IPC_SCREENSHOTS_OK,
+  IPC_SCREENSHOTS_START,
+  IPC_UPDATE_AVAILABLE,
+  IPC_UPDATE_CHECK,
+  IPC_UPDATE_DOWNLOADED,
+  IPC_UPDATE_DOWNLOAD,
+  IPC_UPDATE_DOWNLOAD_PROGRESS,
+  IPC_UPDATE_ERROR,
+  IPC_UPDATE_INSTALL,
+  IPC_UPDATE_NOT_AVAILABLE,
+  IPC_WINDOW_IS_FOCUSED,
 } from "../shared/ipc-channels";
-
 // Keep the preload entry self-contained. Electron runs sandboxed preloads in
 // a restricted loader where relative CommonJS imports can fail even when the
 // imported file is present in app.asar. A failed preload means the whole IPC
@@ -92,21 +112,21 @@ if (!trustedShellAtLoad) {
 const isTrustedShell = () => trustedShellAtLoad;
 
 const ALLOWED_SEND_CHANNELS = [
-  "check-update",
-  "install-update",
-  "update-app",
+  IPC_UPDATE_CHECK,
+  IPC_UPDATE_INSTALL,
+  IPC_UPDATE_DOWNLOAD,
   IPC_CONVERSATION_UNREAD_COUNT,
-  "screenshots-start",
-  "restart-app",
+  IPC_SCREENSHOTS_START,
+  IPC_RESTART_APP,
 ];
 
 const ALLOWED_INVOKE_CHANNELS = [
-  "get-media-access-status",
-  "show-native-notification",
-  "close-native-notification",
-  "close-all-native-notifications",
-  "test-notification-icon",
-  "is-window-focused",
+  IPC_MEDIA_ACCESS_STATUS,
+  IPC_NOTIFICATION_SHOW,
+  IPC_NOTIFICATION_CLOSE,
+  IPC_NOTIFICATION_CLOSE_ALL,
+  IPC_NOTIFICATION_TEST_ICON,
+  IPC_WINDOW_IS_FOCUSED,
   IPC_OIDC_AUTHORIZE_START,
   IPC_OIDC_AUTHORIZE_END,
   IPC_OIDC_HTTP_REQUEST,
@@ -115,102 +135,150 @@ const ALLOWED_INVOKE_CHANNELS = [
 ];
 
 const ALLOWED_RECEIVE_CHANNELS = [
-  "notification-clicked",
-  "notification-action-clicked",
-  "screenshots-ok",
-  "deep-link",
-  "show-conversations",
-  "update-error",
-  "update-available",
-  "update-not-available",
-  "download-progress",
-  "update-downloaded",
+  IPC_NOTIFICATION_CLICKED,
+  IPC_NOTIFICATION_ACTION_CLICKED,
+  IPC_SCREENSHOTS_OK,
+  IPC_DEEP_LINK,
+  IPC_SHOW_CONVERSATIONS,
+  IPC_UPDATE_ERROR,
+  IPC_UPDATE_AVAILABLE,
+  IPC_UPDATE_NOT_AVAILABLE,
+  IPC_UPDATE_DOWNLOAD_PROGRESS,
+  IPC_UPDATE_DOWNLOADED,
 ];
 
 contextBridge.exposeInMainWorld("__POWERED_ELECTRON__", true);
 
-contextBridge.exposeInMainWorld("ipc", {
+const unavailable = () => Promise.reject(new Error("IPC unavailable outside app shell"));
+
+const sendAllowed = (channel: string, ...args: any[]) => {
+  if (!isTrustedShell()) return;
+  if (ALLOWED_SEND_CHANNELS.includes(channel)) {
+    ipcRenderer.send(channel, ...args);
+  } else {
+    console.warn(`[preload] Blocked send to unknown channel: ${channel}`);
+  }
+};
+
+const invokeAllowed = (channel: string, ...args: any[]): Promise<any> => {
+  if (!isTrustedShell()) return unavailable();
+  if (ALLOWED_INVOKE_CHANNELS.includes(channel)) {
+    return ipcRenderer.invoke(channel, ...args);
+  }
+  console.warn(`[preload] Blocked invoke to unknown channel: ${channel}`);
+  return Promise.reject(new Error(`IPC channel not allowed: ${channel}`));
+};
+
+const onAllowed = (
+  channel: string,
+  listener: (event: Electron.IpcRendererEvent, ...args: any[]) => void
+) => {
+  if (!isTrustedShell()) return;
+  if (ALLOWED_RECEIVE_CHANNELS.includes(channel)) {
+    ipcRenderer.on(channel, listener);
+  } else {
+    console.warn(`[preload] Blocked listener on unknown channel: ${channel}`);
+  }
+};
+
+const onceAllowed = (
+  channel: string,
+  listener: (event: Electron.IpcRendererEvent, ...args: any[]) => void
+) => {
+  if (!isTrustedShell()) return;
+  if (ALLOWED_RECEIVE_CHANNELS.includes(channel)) {
+    ipcRenderer.once(channel, listener);
+  } else {
+    console.warn(`[preload] Blocked listener on unknown channel: ${channel}`);
+  }
+};
+
+const removeListenerAllowed = (
+  channel: string,
+  listener: (event: Electron.IpcRendererEvent, ...args: any[]) => void
+) => {
+  if (!isTrustedShell()) return;
+  if (ALLOWED_RECEIVE_CHANNELS.includes(channel)) {
+    ipcRenderer.removeListener(channel, listener);
+  } else {
+    console.warn(`[preload] Blocked removal on unknown channel: ${channel}`);
+  }
+};
+
+const ipcBridge = {
   send: (channel: string, ...args: any[]) => {
-    if (!isTrustedShell()) return;
-    if (ALLOWED_SEND_CHANNELS.includes(channel)) {
-      ipcRenderer.send(channel, ...args);
-    } else {
-      console.warn(`[preload] Blocked send to unknown channel: ${channel}`);
-    }
+    sendAllowed(channel, ...args);
   },
   invoke: (channel: string, ...args: any[]): Promise<any> => {
-    if (!isTrustedShell()) return Promise.reject(new Error("IPC unavailable outside app shell"));
-    if (ALLOWED_INVOKE_CHANNELS.includes(channel)) {
-      return ipcRenderer.invoke(channel, ...args);
-    }
-    console.warn(`[preload] Blocked invoke to unknown channel: ${channel}`);
-    return Promise.reject(new Error(`IPC channel not allowed: ${channel}`));
+    return invokeAllowed(channel, ...args);
   },
   on: (
     channel: string,
     listener: (event: Electron.IpcRendererEvent, ...args: any[]) => void
   ) => {
-    if (!isTrustedShell()) return;
-    if (ALLOWED_RECEIVE_CHANNELS.includes(channel)) {
-      ipcRenderer.on(channel, listener);
-    } else {
-      console.warn(`[preload] Blocked listener on unknown channel: ${channel}`);
-    }
+    onAllowed(channel, listener);
   },
   once: (
     channel: string,
     listener: (event: Electron.IpcRendererEvent, ...args: any[]) => void
   ) => {
-    if (!isTrustedShell()) return;
-    if (ALLOWED_RECEIVE_CHANNELS.includes(channel)) {
-      ipcRenderer.once(channel, listener);
-    } else {
-      console.warn(`[preload] Blocked listener on unknown channel: ${channel}`);
-    }
+    onceAllowed(channel, listener);
   },
   removeListener: (
     channel: string,
     listener: (event: Electron.IpcRendererEvent, ...args: any[]) => void
   ) => {
-    if (!isTrustedShell()) return;
-    if (ALLOWED_RECEIVE_CHANNELS.includes(channel)) {
-      ipcRenderer.removeListener(channel, listener);
-    } else {
-      console.warn(`[preload] Blocked removal on unknown channel: ${channel}`);
-    }
+    removeListenerAllowed(channel, listener);
   },
-});
+};
 
-// Expose native notification API
-contextBridge.exposeInMainWorld("electronNotification", {
-  show: (options: any) =>
-    isTrustedShell()
-      ? ipcRenderer.invoke("show-native-notification", options)
-      : Promise.reject(new Error("IPC unavailable outside app shell")),
-  close: (tag: string) =>
-    isTrustedShell()
-      ? ipcRenderer.invoke("close-native-notification", tag)
-      : Promise.reject(new Error("IPC unavailable outside app shell")),
-  closeAll: () =>
-    isTrustedShell()
-      ? ipcRenderer.invoke("close-all-native-notifications")
-      : Promise.reject(new Error("IPC unavailable outside app shell")),
+const notificationBridge = {
+  show: (options: any) => invokeAllowed(IPC_NOTIFICATION_SHOW, options),
+  close: (tag: string) => invokeAllowed(IPC_NOTIFICATION_CLOSE, tag),
+  closeAll: () => invokeAllowed(IPC_NOTIFICATION_CLOSE_ALL),
   onClicked: (callback: (data: any) => void) =>
     isTrustedShell()
-      ? subscribeDisposable(ipcRenderer, "notification-clicked", callback)
+      ? subscribeDisposable(ipcRenderer, IPC_NOTIFICATION_CLICKED, callback)
       : () => {},
   onActionClicked: (callback: (data: any) => void) =>
     isTrustedShell()
-      ? subscribeDisposable(ipcRenderer, "notification-action-clicked", callback)
+      ? subscribeDisposable(ipcRenderer, IPC_NOTIFICATION_ACTION_CLICKED, callback)
       : () => {},
+  testNotificationIcon: () => invokeAllowed(IPC_NOTIFICATION_TEST_ICON),
+};
+
+const octoElectron = {
+  ipc: ipcBridge,
+  oidc: {
+    authorizeStart: (apiURL, authcode, providerId, authorizeUrl) =>
+      invokeAllowed(IPC_OIDC_AUTHORIZE_START, apiURL, authcode, providerId, authorizeUrl),
+    authorizeEnd: () => invokeAllowed(IPC_OIDC_AUTHORIZE_END),
+    httpRequest: (request) => invokeAllowed(IPC_OIDC_HTTP_REQUEST, request),
+    openExternal: (url) => invokeAllowed(IPC_OIDC_OPEN_EXTERNAL, url),
+    clearAuthSession: () => invokeAllowed(IPC_OIDC_CLEAR_AUTH_SESSION),
+  },
+  notification: notificationBridge,
+  window: {
+    isFocused: () => invokeAllowed(IPC_WINDOW_IS_FOCUSED),
+  },
+  conversation: {
+    setUnreadCount: (count) => sendAllowed(IPC_CONVERSATION_UNREAD_COUNT, count),
+  },
+  system: {
+    startScreenshot: (args) => sendAllowed(IPC_SCREENSHOTS_START, args),
+    getMediaAccessStatus: (mediaType) => invokeAllowed(IPC_MEDIA_ACCESS_STATUS, mediaType),
+    restartApp: () => sendAllowed(IPC_RESTART_APP),
+  },
+};
+
+contextBridge.exposeInMainWorld("ipc", ipcBridge);
+contextBridge.exposeInMainWorld("octoElectron", octoElectron);
+
+// Expose native notification API
+contextBridge.exposeInMainWorld("electronNotification", {
+  ...notificationBridge,
   // Test notification icon
-  testNotificationIcon: () =>
-    isTrustedShell()
-      ? ipcRenderer.invoke("test-notification-icon")
-      : Promise.reject(new Error("IPC unavailable outside app shell")),
+  testNotificationIcon: notificationBridge.testNotificationIcon,
   // Query real window focus state from main process
-  isWindowFocused: () =>
-    isTrustedShell()
-      ? ipcRenderer.invoke("is-window-focused")
-      : Promise.reject(new Error("IPC unavailable outside app shell")),
+  isWindowFocused: octoElectron.window.isFocused,
 });

--- a/apps/web/src-election/shared/ipc-channels.ts
+++ b/apps/web/src-election/shared/ipc-channels.ts
@@ -9,6 +9,41 @@
 /** Renderer → Main: sync the current unread-message count to the tray. */
 export const IPC_CONVERSATION_UNREAD_COUNT = "conversation-manager-unread-count";
 
+/** Renderer → Main: desktop system capabilities. */
+export const IPC_SCREENSHOTS_START = "screenshots-start";
+export const IPC_SCREENSHOTS_OK = "screenshots-ok";
+export const IPC_MEDIA_ACCESS_STATUS = "get-media-access-status";
+export const IPC_RESTART_APP = "restart-app";
+
+/** Renderer → Main: check, download, and install app updates. */
+export const IPC_UPDATE_CHECK = "check-update";
+export const IPC_UPDATE_DOWNLOAD = "update-app";
+export const IPC_UPDATE_INSTALL = "install-update";
+
+/** Main → Renderer: app update lifecycle. */
+export const IPC_UPDATE_ERROR = "update-error";
+export const IPC_UPDATE_AVAILABLE = "update-available";
+export const IPC_UPDATE_NOT_AVAILABLE = "update-not-available";
+export const IPC_UPDATE_DOWNLOAD_PROGRESS = "download-progress";
+export const IPC_UPDATE_DOWNLOADED = "update-downloaded";
+
+/** Main → Renderer: desktop navigation events. */
+export const IPC_DEEP_LINK = "deep-link";
+export const IPC_SHOW_CONVERSATIONS = "show-conversations";
+
+/** Renderer → Main: native notification lifecycle. */
+export const IPC_NOTIFICATION_SHOW = "show-native-notification";
+export const IPC_NOTIFICATION_CLOSE = "close-native-notification";
+export const IPC_NOTIFICATION_CLOSE_ALL = "close-all-native-notifications";
+export const IPC_NOTIFICATION_TEST_ICON = "test-notification-icon";
+
+/** Main → Renderer: native notification user interactions. */
+export const IPC_NOTIFICATION_CLICKED = "notification-clicked";
+export const IPC_NOTIFICATION_ACTION_CLICKED = "notification-action-clicked";
+
+/** Renderer → Main: query the real BrowserWindow focus state. */
+export const IPC_WINDOW_IS_FOCUSED = "is-window-focused";
+
 /** Renderer → Main: register the API origin expected for the OIDC callback. */
 export const IPC_OIDC_AUTHORIZE_START = "oidc-authorize-start";
 

--- a/apps/web/src/App/index.tsx
+++ b/apps/web/src/App/index.tsx
@@ -1,4 +1,4 @@
-import { addImChannelInfoListener, ChatPage, EndpointCategory, WKApp, Menus, t } from '@octo/base';
+import { addImChannelInfoListener, ChatPage, EndpointCategory, WKApp, Menus, t, isElectronPowered, sendElectronConversationUnreadCount } from '@octo/base';
 import { ContactsList } from '@octo/contacts';
 import React, { useEffect } from 'react';
 // lucide icons replaced with filled SVGs per Figma
@@ -10,7 +10,6 @@ import { ContactsIcon } from '../Components/Icons/ContactsIcon';
 import { Toast } from '@douyinfe/semi-ui';
 import { clearDeprecatedFriendApplyReddotOnce } from './friendApplyReddotCleanup';
 import { createOctoDocumentTitleController } from '../features/documentTitle/octoDocumentTitle';
-import { IPC_CONVERSATION_UNREAD_COUNT } from '../../src-election/shared/ipc-channels';
 import { getElectronUnreadMessageCount } from './electronUnreadCount';
 
 /**
@@ -90,11 +89,8 @@ function useDeprecatedFriendApplyReddotCleanup() {
 }
 
 function syncElectronUnreadMessageCount() {
-  if ((window as any).__POWERED_ELECTRON__) {
-    (window as any).ipc.send(
-      IPC_CONVERSATION_UNREAD_COUNT,
-      getElectronUnreadMessageCount(),
-    )
+  if (isElectronPowered()) {
+    sendElectronConversationUnreadCount(getElectronUnreadMessageCount())
   }
 }
 

--- a/apps/web/src/Pages/Main/vm.ts
+++ b/apps/web/src/Pages/Main/vm.ts
@@ -1,8 +1,26 @@
-import { WKApp, Menus, ProviderListener, normalizeRoutePath, startVersionCheck, t } from "@octo/base";
+import {
+  WKApp,
+  Menus,
+  ProviderListener,
+  normalizeRoutePath,
+  startVersionCheck,
+  t,
+  getElectronIpcBridge,
+  isElectronPowered,
+  sendElectronInstallUpdate,
+  sendElectronUpdateApp,
+} from "@octo/base";
 import { Toast } from "@douyinfe/semi-ui";
 import { requestMailWorkspaceSwitch } from "@octo/mail";
 import { requestGuardedBrowserRouteChange } from "./menuChange";
 import { reconcileMenuState, resolvePendingRouteActivation } from "./menuReconcile";
+import {
+  IPC_UPDATE_AVAILABLE,
+  IPC_UPDATE_DOWNLOADED,
+  IPC_UPDATE_DOWNLOAD_PROGRESS,
+  IPC_UPDATE_ERROR,
+  IPC_UPDATE_NOT_AVAILABLE,
+} from "../../../src-election/shared/ipc-channels";
 
 export default class MainVM extends ProviderListener {
   private _currentMenus?: Menus;
@@ -142,7 +160,7 @@ export default class MainVM extends ProviderListener {
     window.addEventListener("popstate", this._onBrowserRouteGuard, true);
     window.addEventListener("popstate", this._onBrowserRouteChange);
 
-    if ((window as any).__POWERED_ELECTRON__) {
+    if (isElectronPowered()) {
       this.appUpdateInit();
     } else {
       // 轮询 /version.json 检测 Web 端新版本，有新版本时亮设置按钮气泡
@@ -168,17 +186,19 @@ export default class MainVM extends ProviderListener {
   }
 
   private addIpcListener(event: string, handler: (...args: any[]) => void) {
-    (window as any).ipc.on(event, handler);
+    const ipc = getElectronIpcBridge();
+    if (!ipc) return;
+    ipc.on(event, handler);
     this.ipcListeners.push({ event, handler });
   }
 
   appUpdateInit() {
     // 监听升级失败事件
-    this.addIpcListener("update-error", (event, message) => {
+    this.addIpcListener(IPC_UPDATE_ERROR, (event, message) => {
     });
     // 发现可用更新事件
-    this.addIpcListener("update-available", (event, message) => {
-      (window as any).ipc.send("update-app");
+    this.addIpcListener(IPC_UPDATE_AVAILABLE, (event, message) => {
+      sendElectronUpdateApp();
       this.lastVersionInfo = {
         appVersion: message.version,
         updateDesc: message.releaseNotes,
@@ -187,21 +207,21 @@ export default class MainVM extends ProviderListener {
       this.notifyListener();
     });
     // 没有可用更新事件
-    this.addIpcListener("update-not-available", (event, message) => {
+    this.addIpcListener(IPC_UPDATE_NOT_AVAILABLE, (event, message) => {
       this.showAppUpdate = false;
       this.showAppUpdateOperation = false;
       this.showAppUpdateOperation = false;
       Toast.success(t("app.main.updateAlreadyLatest"));
     });
     // 更新下载进度事件
-    this.addIpcListener("download-progress", (event, message) => {
+    this.addIpcListener(IPC_UPDATE_DOWNLOAD_PROGRESS, (event, message) => {
       this.showAppUpdate = true;
       this.showAppUpdateOperation = false;
       this.appUpdateProgress = message;
       this.notifyListener();
     });
     // 监听下载完成事件
-    this.addIpcListener("update-downloaded", (event, message) => {
+    this.addIpcListener(IPC_UPDATE_DOWNLOADED, (event, message) => {
       this.lastVersionInfo = {
         appVersion: message.version,
         updateDesc: message.releaseNotes,
@@ -216,7 +236,7 @@ export default class MainVM extends ProviderListener {
   didUnMount(): void {
     // Clean up IPC listeners to prevent memory leaks
     for (const { event, handler } of this.ipcListeners) {
-      (window as any).ipc?.removeListener(event, handler);
+      getElectronIpcBridge()?.removeListener(event, handler);
     }
     this.ipcListeners = [];
     this.stopVersionCheck?.();
@@ -343,7 +363,7 @@ export default class MainVM extends ProviderListener {
 
   // 安装更新
   installUpdate() {
-    (window as any).ipc.send("install-update");
+    sendElectronInstallUpdate();
   }
 
   get menusList() {

--- a/apps/web/src/index.tsx
+++ b/apps/web/src/index.tsx
@@ -4,7 +4,7 @@ import '@octo/base/src/theme/tokens.css';
 import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
-import  { BaseModule, I18nProvider, i18n, WKApp, Dap } from '@octo/base';
+import  { BaseModule, I18nProvider, i18n, WKApp, Dap, isElectronPowered } from '@octo/base';
 import  { LoginModule, BindModule } from '@octo/login';
 import  { DataSourceModule } from '@octo/datasource';
 import {ContactsModule} from '@octo/contacts';
@@ -27,7 +27,8 @@ import { LoopIcon } from './Components/Icons/LoopIcon';
 // preload 标记仍然保留，用于开发环境和 IPC 能力；但不能只依赖 preload 判断 API
 // 环境，否则 preload 加载异常时会误走 Web 分支，把 `/api/v1/` 解析成 `file:///api/v1/`。
 const isDesktopRuntime =
-  Boolean((window as any).__TAURI_IPC__ || (window as any).__POWERED_ELECTRON__) ||
+  Boolean((window as any).__TAURI_IPC__) ||
+  isElectronPowered() ||
   import.meta.env.VITE_ELECTRON_BUILD === "true" ||
   window.location.protocol === "file:"
 

--- a/packages/dmworkbase/src/App.tsx
+++ b/packages/dmworkbase/src/App.tsx
@@ -2,8 +2,13 @@ import mitt, { Emitter } from "mitt";
 import { getSessionSid, setSessionSid } from "./Service/SessionScope";
 import { replaceWithShellDocument } from "./Service/ShellDocument";
 import { runLogoutCleanup } from "./Service/logoutCleanup";
-
-const IPC_CLEAR_AUTH_SESSION = "octo:oidc:clear-auth-session";
+import {
+  clearElectronAuthSession as clearElectronAuthSessionBridge,
+  getElectronIpcBridge,
+  getOctoElectronBridge,
+  isElectronPowered,
+  isElectronShellBridgeAvailable,
+} from "./electron/desktopBridge";
 
 /** mittBus 全局事件类型表 */
 export type MittEvents = {
@@ -967,7 +972,7 @@ export default class WKApp extends ProviderListener {
 
     // 是否是PC端
     if (
-      (window as any)?.__POWERED_ELECTRON__ ||
+      isElectronPowered() ||
       (window as any).__TAURI_IPC__
     ) {
       this.isPC = true;
@@ -1224,13 +1229,12 @@ export default class WKApp extends ProviderListener {
   }
 
   private async clearElectronAuthSession() {
-    if (
-      (window as any).__POWERED_ELECTRON__ &&
-      typeof (window as any).ipc?.invoke === "function"
-    ) {
+    if (isElectronPowered()) {
       try {
-        const result = await (window as any).ipc.invoke(IPC_CLEAR_AUTH_SESSION);
-        if (result?.ok !== true || result?.partial === true) {
+        const result = (await clearElectronAuthSessionBridge()) as
+          | { ok?: boolean; partial?: boolean }
+          | undefined;
+        if (result && (result.ok !== true || result.partial === true)) {
           console.warn("[auth] Electron auth-session cleanup was incomplete", result);
         }
       } catch {
@@ -1274,10 +1278,7 @@ export default class WKApp extends ProviderListener {
    * logout through the web redirect path.
    */
   private isElectronShell() {
-    return Boolean(
-      (window as any).__POWERED_ELECTRON__ &&
-      typeof (window as any).ipc?.invoke === "function",
-    );
+    return isElectronShellBridgeAvailable();
   }
 
   async logoutUserInitiated() {
@@ -1289,7 +1290,7 @@ export default class WKApp extends ProviderListener {
       loginProvider: WKApp.loginInfo.loginProvider,
       token: WKApp.loginInfo.token || "",
       apiURL: WKApp.apiClient.config.apiURL || "",
-      ipc: (window as any).ipc,
+      ipc: getOctoElectronBridge()?.oidc ?? getElectronIpcBridge(),
       env: this.isElectronShell() ? "desktop-shell" : "web",
       // Only forward the dev override when actually in a dev build; in
       // production `import.meta.env.DEV` is false and we must not read the

--- a/packages/dmworkbase/src/Service/Dap.ts
+++ b/packages/dmworkbase/src/Service/Dap.ts
@@ -30,6 +30,7 @@ import { FETCH_RULES, buildFetchIndex, matchFetchEvent, rawPathname, type FetchR
 // 中央映射·body 键通道(②,见 BodyRules.ts):对白名单端点 clone 请求体、只读顶层枚举键映射事件。
 // 受控放宽「不读正文」边界:只碰白名单端点、只读键不读值、只解析 JSON 串体、同源+2xx 才触发。
 import { BODY_RULES, buildBodyIndex, computeBodyEvent, type BodyRuleIndex } from './BodyRules'
+import { isElectronPowered } from '../electron/desktopBridge'
 
 export type TrackPrimitive = string | number | boolean | null
 
@@ -216,11 +217,8 @@ function isSupportedRuntime(): boolean {
     try {
         const loc = (globalThis as { location?: Location }).location
         if (!loc || (loc.protocol !== 'http:' && loc.protocol !== 'https:')) return false
-        const w = globalThis as {
-            __TAURI_IPC__?: unknown
-            __POWERED_ELECTRON__?: unknown
-        }
-        if (w.__TAURI_IPC__ || w.__POWERED_ELECTRON__) return false
+        const w = globalThis as { __TAURI_IPC__?: unknown }
+        if (w.__TAURI_IPC__ || isElectronPowered()) return false
         if (import.meta.env.VITE_ELECTRON_BUILD === 'true') return false
         return true
     } catch {

--- a/packages/dmworkbase/src/Service/__tests__/oidcLogout.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/oidcLogout.test.ts
@@ -109,6 +109,26 @@ describe("oidcLogout helpers", () => {
     });
   });
 
+  it("resolves Electron logout through typed OIDC bridge methods when available", async () => {
+    const httpRequest = vi.fn(async () => ({
+      __octoOidcHttpResponse: true,
+      ok: true,
+      status: 200,
+      body: { end_session_url: "https://accounts.example.com/end_session" },
+    }));
+    const fetcher = createOidcLogoutFetcher("https://api.example.com/v1/", { httpRequest });
+    expect(fetcher).toBeDefined();
+
+    await requestOidcLogout("corp/sso", "octo-token", fetcher);
+
+    expect(httpRequest).toHaveBeenCalledWith({
+      url: "https://api.example.com/v1/auth/oidc/corp%2Fsso/logout",
+      method: "POST",
+      body: undefined,
+      headers: { Accept: "application/json", token: "octo-token" },
+    });
+  });
+
   it("rejects failed backend logout responses", async () => {
     const fetcher = vi.fn(
       async () => new Response("login required", { status: 401 })
@@ -327,6 +347,29 @@ describe("performOidcUserInitiatedLogout", () => {
     expect(sfx.navigateExternal).not.toHaveBeenCalled();
     expect(sfx.markPostLogoutCleanup).not.toHaveBeenCalled();
     expect(sfx.fallbackLogout).not.toHaveBeenCalled();
+  });
+
+  it("packaged desktop: opens provider logout through typed OIDC bridge", async () => {
+    const sfx = makeSideEffects();
+    const openExternal = vi.fn(async () => ({ ok: true }));
+
+    const result = await performOidcUserInitiatedLogout(
+      buildDeps(
+        {
+          env: "desktop-shell",
+          ipc: { openExternal },
+          requestLogout: vi.fn(async () => ({
+            end_session_url: "https://accounts.example.com/end_session?id_token_hint=jwt",
+          })),
+        },
+        sfx,
+      ),
+    );
+
+    expect(result.kind).toBe("desktop-idp");
+    expect(openExternal).toHaveBeenCalledWith(
+      "https://accounts.example.com/end_session?id_token_hint=jwt",
+    );
   });
 
   it("packaged desktop: uses the hidden logout bridge without opening a browser", async () => {

--- a/packages/dmworkbase/src/Service/oidcLogout.ts
+++ b/packages/dmworkbase/src/Service/oidcLogout.ts
@@ -35,6 +35,12 @@ const AUTH_STORAGE_KEYS = [
 const IPC_OIDC_HTTP_REQUEST = "oidc-http-request";
 export const IPC_OIDC_OPEN_EXTERNAL = "oidc-open-external";
 
+export interface DesktopOidcIpc {
+  invoke?: (channel: string, request: unknown) => Promise<unknown>;
+  httpRequest?: (request: unknown) => Promise<unknown>;
+  openExternal?: (url: string) => Promise<unknown>;
+}
+
 export interface OidcLogoutResponse {
   status?: number;
   end_session_url?: unknown;
@@ -172,11 +178,12 @@ export async function requestOidcLogout(
 
 export function createOidcLogoutFetcher(
   apiURL: string,
-  ipc:
-    | { invoke?: (channel: string, request: unknown) => Promise<unknown> }
-    | undefined
+  ipc: DesktopOidcIpc | undefined
 ): typeof fetch | undefined {
-  if (!/^https?:\/\//i.test(apiURL) || typeof ipc?.invoke !== "function")
+  if (
+    !/^https?:\/\//i.test(apiURL) ||
+    (typeof ipc?.httpRequest !== "function" && typeof ipc?.invoke !== "function")
+  )
     return undefined;
   return async (input, init) => {
     // Main-process validates the API origin inline on every IPC round-trip
@@ -199,12 +206,16 @@ export function createOidcLogoutFetcher(
         body = init.body;
       }
     }
-    const result = await ipc.invoke(IPC_OIDC_HTTP_REQUEST, {
+    const request = {
       url,
       method: init?.method || "POST",
       body,
       headers: init?.headers,
-    });
+    };
+    const result =
+      typeof ipc.httpRequest === "function"
+        ? await ipc.httpRequest(request)
+        : await ipc.invoke!(IPC_OIDC_HTTP_REQUEST, request);
     const envelope =
       result &&
       typeof result === "object" &&
@@ -298,11 +309,9 @@ export interface OidcUserInitiatedLogoutDeps {
   // API origin used to build the packaged-desktop IPC fetcher. Empty string
   // is treated as "no API URL configured", matching WKApp.apiClient.config.
   apiURL: string;
-  // Packaged desktop preload injects `window.ipc.invoke`; web renderer has
-  // no ipc. `undefined` on web is the normal case.
-  ipc:
-    | { invoke?: (channel: string, request: unknown) => Promise<unknown> }
-    | undefined;
+  // Packaged desktop preload injects `window.octoElectron.oidc` and keeps
+  // `window.ipc.invoke` for compatibility; web renderer has neither.
+  ipc: DesktopOidcIpc | undefined;
   // Discriminates the packaged file:// shell from a browser tab. Passed in
   // rather than read from `window.location.protocol` so tests do not have
   // to patch jsdom's location.
@@ -384,15 +393,17 @@ export async function performOidcUserInitiatedLogout(
       // Keep user-initiated logout inside the desktop app. The main process
       // runs the IdP end-session URL in a hidden window so the IdP session is
       // cleared without showing the browser/Web login page to the user.
-      const ipcInvoke = deps.ipc?.invoke;
-      if (typeof ipcInvoke !== "function") {
+      const openExternal =
+        typeof deps.ipc?.openExternal === "function"
+          ? deps.ipc.openExternal
+          : typeof deps.ipc?.invoke === "function"
+            ? (url: string) => deps.ipc!.invoke!(IPC_OIDC_OPEN_EXTERNAL, url)
+            : undefined;
+      if (!openExternal) {
         await deps.fallbackLogout();
         return { kind: "desktop-local", url: endSessionUrl };
       }
-      const opened = (await ipcInvoke(
-        IPC_OIDC_OPEN_EXTERNAL,
-        endSessionUrl
-      )) as { ok?: boolean } | undefined;
+      const opened = (await openExternal(endSessionUrl)) as { ok?: boolean } | undefined;
       if (opened?.ok !== true) {
         await deps.fallbackLogout();
         return { kind: "desktop-local", url: endSessionUrl };

--- a/packages/dmworkbase/src/Utils/NotificationUtil.ts
+++ b/packages/dmworkbase/src/Utils/NotificationUtil.ts
@@ -5,21 +5,11 @@ import { t } from "../i18n";
 import { getImChannelInfo } from "../im-runtime/channelRuntime";
 import { ChannelTypeCommunityTopic } from "../Service/Const";
 import { isEffectivelyMuted, parseThreadChannelId } from "../Service/Thread";
-
-// Extend window interface for Electron APIs
-declare global {
-  interface Window {
-    __POWERED_ELECTRON__?: boolean;
-    electronNotification?: {
-      show: (options: any) => Promise<boolean>;
-      close: (tag: string) => Promise<void>;
-      closeAll: () => Promise<void>;
-      onClicked: (callback: (data: any) => void) => (() => void) | void;
-      onActionClicked: (callback: (data: any) => void) => (() => void) | void;
-      isWindowFocused: () => Promise<boolean>;
-    };
-  }
-}
+import {
+  getElectronNotificationBridge,
+  getElectronWindowBridge,
+  isElectronPowered,
+} from "../electron/desktopBridge";
 
 type NotificationHandle = Notification & {
   dispose?: () => void;
@@ -144,7 +134,7 @@ export class NotificationUtil {
    * Check if Electron native notifications are available
    */
   private isElectronNativeNotificationAvailable(): boolean {
-    return !!(window.__POWERED_ELECTRON__ && window.electronNotification);
+    return isElectronPowered() && !!getElectronNotificationBridge();
   }
 
   /**
@@ -159,16 +149,14 @@ export class NotificationUtil {
    * decision immediately.
    */
   public async isWindowFocused(): Promise<boolean> {
-    if (
-      this.isElectronNativeNotificationAvailable() &&
-      window.electronNotification?.isWindowFocused
-    ) {
+    const electronWindow = getElectronWindowBridge();
+    if (this.isElectronNativeNotificationAvailable() && electronWindow) {
       if (this.focusQueryInFlight) {
         return this.focusQueryInFlight;
       }
       this.focusQueryInFlight = (async () => {
         try {
-          const value = await window.electronNotification!.isWindowFocused();
+          const value = await electronWindow.isFocused();
           return value;
         } catch {
           // IPC failure — fall back to document.hasFocus()
@@ -208,9 +196,8 @@ export class NotificationUtil {
           timeoutType: "default" as const,
         };
 
-        const success = await window.electronNotification!.show(
-          electronOptions
-        );
+        const electronNotification = getElectronNotificationBridge();
+        const success = await electronNotification!.show(electronOptions);
         if (success) {
           // Set up click handler for Electron notifications.
           // The listener is bound to a generation so it can be invalidated
@@ -219,7 +206,7 @@ export class NotificationUtil {
           let listenerInvalidated = false;
           if (options.onClick) {
             cleanupClickListener =
-              window.electronNotification!.onClicked((data: any) => {
+              electronNotification!.onClicked((data: any) => {
                 if (listenerInvalidated) return;
                 if (data.tag === options.tag) {
                   options.onClick!();
@@ -239,7 +226,7 @@ export class NotificationUtil {
             close: () => {
               invalidateAndCleanup();
               if (options.tag) {
-                window.electronNotification!.close(options.tag);
+                electronNotification!.close(options.tag);
               }
             },
             dispose: () => {

--- a/packages/dmworkbase/src/electron/__tests__/desktopBridge.test.ts
+++ b/packages/dmworkbase/src/electron/__tests__/desktopBridge.test.ts
@@ -1,0 +1,161 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  clearElectronAuthSession,
+  getElectronIpcBridge,
+  getElectronMediaAccessStatus,
+  getElectronNotificationBridge,
+  getElectronWindowBridge,
+  getOctoElectronBridge,
+  isElectronPowered,
+  isElectronShellBridgeAvailable,
+  restartElectronApp,
+  sendElectronConversationUnreadCount,
+  sendElectronInstallUpdate,
+  sendElectronUpdateApp,
+  startElectronScreenshot,
+} from "../desktopBridge";
+
+describe("desktopBridge", () => {
+  afterEach(() => {
+    delete window.__POWERED_ELECTRON__;
+    delete window.ipc;
+    delete window.octoElectron;
+    delete window.electronNotification;
+  });
+
+  it("prefers the typed octoElectron bridge over legacy ipc/notification globals", () => {
+    const typedIpc = { send: vi.fn(), invoke: vi.fn(), on: vi.fn(), once: vi.fn(), removeListener: vi.fn() };
+    const legacyIpc = { send: vi.fn(), invoke: vi.fn(), on: vi.fn(), once: vi.fn(), removeListener: vi.fn() };
+    const typedNotification = {
+      show: vi.fn(),
+      close: vi.fn(),
+      closeAll: vi.fn(),
+      onClicked: vi.fn(),
+      onActionClicked: vi.fn(),
+      testNotificationIcon: vi.fn(),
+    };
+    const legacyNotification = { ...typedNotification, show: vi.fn() };
+    window.octoElectron = {
+      ipc: typedIpc,
+      oidc: {
+        authorizeStart: vi.fn(),
+        authorizeEnd: vi.fn(),
+        httpRequest: vi.fn(),
+        openExternal: vi.fn(),
+        clearAuthSession: vi.fn(),
+      },
+      notification: typedNotification,
+      window: { isFocused: vi.fn() },
+      conversation: { setUnreadCount: vi.fn() },
+      system: {
+        startScreenshot: vi.fn(),
+        getMediaAccessStatus: vi.fn(),
+        restartApp: vi.fn(),
+      },
+    };
+    window.ipc = legacyIpc;
+    window.electronNotification = legacyNotification;
+
+    expect(getOctoElectronBridge()).toBe(window.octoElectron);
+    expect(getElectronIpcBridge()).toBe(typedIpc);
+    expect(getElectronNotificationBridge()).toBe(typedNotification);
+    expect(getElectronWindowBridge()).toBe(window.octoElectron.window);
+  });
+
+  it("falls back to legacy ipc for update, unread-count, and system IPC", async () => {
+    const send = vi.fn();
+    const invoke = vi.fn().mockResolvedValue({ status: "granted" });
+    window.ipc = { send, invoke, on: vi.fn(), once: vi.fn(), removeListener: vi.fn() };
+
+    sendElectronConversationUnreadCount(7);
+    sendElectronUpdateApp();
+    sendElectronInstallUpdate();
+    startElectronScreenshot({ silent: true });
+    await expect(getElectronMediaAccessStatus("camera")).resolves.toEqual({ status: "granted" });
+    restartElectronApp();
+
+    expect(send).toHaveBeenNthCalledWith(1, "conversation-manager-unread-count", 7);
+    expect(send).toHaveBeenNthCalledWith(2, "update-app");
+    expect(send).toHaveBeenNthCalledWith(3, "install-update");
+    expect(send).toHaveBeenNthCalledWith(4, "screenshots-start", { silent: true });
+    expect(send).toHaveBeenNthCalledWith(5, "restart-app");
+    expect(invoke).toHaveBeenCalledWith("get-media-access-status", "camera");
+  });
+
+  it("uses typed conversation and system bridge methods when available", async () => {
+    const setUnreadCount = vi.fn();
+    const startScreenshot = vi.fn();
+    const getMediaAccessStatus = vi.fn().mockResolvedValue({ status: "prompt" });
+    const restartApp = vi.fn();
+    const clearAuthSession = vi.fn().mockResolvedValue({ ok: true });
+    window.octoElectron = {
+      ipc: { send: vi.fn(), invoke: vi.fn(), on: vi.fn(), once: vi.fn(), removeListener: vi.fn() },
+      oidc: {
+        authorizeStart: vi.fn(),
+        authorizeEnd: vi.fn(),
+        httpRequest: vi.fn(),
+        openExternal: vi.fn(),
+        clearAuthSession,
+      },
+      notification: {
+        show: vi.fn(),
+        close: vi.fn(),
+        closeAll: vi.fn(),
+        onClicked: vi.fn(),
+        onActionClicked: vi.fn(),
+        testNotificationIcon: vi.fn(),
+      },
+      window: { isFocused: vi.fn() },
+      conversation: { setUnreadCount },
+      system: { startScreenshot, getMediaAccessStatus, restartApp },
+    };
+
+    sendElectronConversationUnreadCount(3);
+    startElectronScreenshot();
+    await expect(getElectronMediaAccessStatus("microphone")).resolves.toEqual({ status: "prompt" });
+    restartElectronApp();
+    await expect(clearElectronAuthSession()).resolves.toEqual({ ok: true });
+
+    expect(setUnreadCount).toHaveBeenCalledWith(3);
+    expect(startScreenshot).toHaveBeenCalledWith(undefined);
+    expect(getMediaAccessStatus).toHaveBeenCalledWith("microphone");
+    expect(restartApp).toHaveBeenCalledOnce();
+    expect(clearAuthSession).toHaveBeenCalledOnce();
+  });
+
+  it("adapts the legacy notification focus API as a window bridge", async () => {
+    const isWindowFocused = vi.fn().mockResolvedValue(false);
+    window.electronNotification = {
+      show: vi.fn(),
+      close: vi.fn(),
+      closeAll: vi.fn(),
+      onClicked: vi.fn(),
+      onActionClicked: vi.fn(),
+      testNotificationIcon: vi.fn(),
+      isWindowFocused,
+    };
+
+    await expect(getElectronWindowBridge()?.isFocused()).resolves.toBe(false);
+    expect(isWindowFocused).toHaveBeenCalledOnce();
+  });
+
+  it("reports shell availability only when Electron marker and a bridge both exist", () => {
+    expect(isElectronPowered()).toBe(false);
+    expect(isElectronShellBridgeAvailable()).toBe(false);
+
+    window.__POWERED_ELECTRON__ = true;
+    expect(isElectronPowered()).toBe(true);
+    expect(isElectronShellBridgeAvailable()).toBe(false);
+
+    window.ipc = { send: vi.fn(), invoke: vi.fn(), on: vi.fn(), once: vi.fn(), removeListener: vi.fn() };
+    expect(isElectronShellBridgeAvailable()).toBe(true);
+  });
+
+  it("falls back to legacy IPC for auth-session cleanup", async () => {
+    const invoke = vi.fn().mockResolvedValue({ ok: true, partial: false });
+    window.ipc = { send: vi.fn(), invoke, on: vi.fn(), once: vi.fn(), removeListener: vi.fn() };
+
+    await expect(clearElectronAuthSession()).resolves.toEqual({ ok: true, partial: false });
+    expect(invoke).toHaveBeenCalledWith("octo:oidc:clear-auth-session");
+  });
+});

--- a/packages/dmworkbase/src/electron/desktopBridge.ts
+++ b/packages/dmworkbase/src/electron/desktopBridge.ts
@@ -1,0 +1,158 @@
+export interface LegacyElectronIpcBridge {
+  send(channel: string, ...args: unknown[]): void;
+  invoke(channel: string, ...args: unknown[]): Promise<unknown>;
+  on(channel: string, listener: (event: unknown, ...args: unknown[]) => void): void;
+  once(channel: string, listener: (event: unknown, ...args: unknown[]) => void): void;
+  removeListener(channel: string, listener: (event: unknown, ...args: unknown[]) => void): void;
+}
+
+export interface DesktopOidcBridge {
+  authorizeStart(apiURL: string, authcode: string, providerId: string, authorizeUrl: string): Promise<unknown>;
+  authorizeEnd(): Promise<unknown>;
+  httpRequest(request: unknown): Promise<unknown>;
+  openExternal(url: string): Promise<unknown>;
+  clearAuthSession(): Promise<unknown>;
+}
+
+export interface DesktopNotificationBridge {
+  show(options: unknown): Promise<boolean>;
+  close(tag: string): Promise<void>;
+  closeAll(): Promise<void>;
+  onClicked(callback: (data: unknown) => void): (() => void) | void;
+  onActionClicked(callback: (data: unknown) => void): (() => void) | void;
+  testNotificationIcon(): Promise<unknown>;
+}
+
+export interface DesktopWindowBridge {
+  isFocused(): Promise<boolean>;
+}
+
+export interface DesktopConversationBridge {
+  setUnreadCount(count: number): void;
+}
+
+export interface DesktopSystemBridge {
+  startScreenshot(args?: unknown): void;
+  getMediaAccessStatus(mediaType: "camera" | "microphone"): Promise<unknown>;
+  restartApp(): void;
+}
+
+export interface OctoElectronBridge {
+  ipc: LegacyElectronIpcBridge;
+  oidc: DesktopOidcBridge;
+  notification: DesktopNotificationBridge;
+  window: DesktopWindowBridge;
+  conversation: DesktopConversationBridge;
+  system: DesktopSystemBridge;
+}
+
+declare global {
+  interface Window {
+    __POWERED_ELECTRON__?: boolean;
+    ipc?: LegacyElectronIpcBridge;
+    octoElectron?: OctoElectronBridge;
+    electronNotification?: DesktopNotificationBridge & {
+      isWindowFocused?: () => Promise<boolean>;
+    };
+  }
+}
+
+const IPC_CONVERSATION_UNREAD_COUNT = "conversation-manager-unread-count";
+const IPC_UPDATE_DOWNLOAD = "update-app";
+const IPC_UPDATE_INSTALL = "install-update";
+const IPC_SCREENSHOTS_START = "screenshots-start";
+const IPC_MEDIA_ACCESS_STATUS = "get-media-access-status";
+const IPC_RESTART_APP = "restart-app";
+const IPC_OIDC_CLEAR_AUTH_SESSION = "octo:oidc:clear-auth-session";
+
+export function getOctoElectronBridge(): OctoElectronBridge | undefined {
+  return typeof window === "undefined" ? undefined : window.octoElectron;
+}
+
+export function getElectronIpcBridge(): LegacyElectronIpcBridge | undefined {
+  if (typeof window === "undefined") return undefined;
+  return window.octoElectron?.ipc ?? window.ipc;
+}
+
+export function getElectronNotificationBridge(): DesktopNotificationBridge | undefined {
+  if (typeof window === "undefined") return undefined;
+  return window.octoElectron?.notification ?? window.electronNotification;
+}
+
+export function getElectronWindowBridge(): DesktopWindowBridge | undefined {
+  if (typeof window === "undefined") return undefined;
+  if (window.octoElectron?.window) return window.octoElectron.window;
+  if (window.electronNotification?.isWindowFocused) {
+    return { isFocused: window.electronNotification.isWindowFocused };
+  }
+  return undefined;
+}
+
+export function getElectronSystemBridge(): DesktopSystemBridge | undefined {
+  if (typeof window === "undefined") return undefined;
+  return window.octoElectron?.system;
+}
+
+export function isElectronPowered(): boolean {
+  return Boolean(typeof window !== "undefined" && window.__POWERED_ELECTRON__);
+}
+
+export function isElectronShellBridgeAvailable(): boolean {
+  return Boolean(
+    isElectronPowered() &&
+      (window.octoElectron || window.ipc),
+  );
+}
+
+export function sendElectronConversationUnreadCount(count: number): void {
+  const bridge = getOctoElectronBridge();
+  if (bridge) {
+    bridge.conversation.setUnreadCount(count);
+    return;
+  }
+  getElectronIpcBridge()?.send(IPC_CONVERSATION_UNREAD_COUNT, count);
+}
+
+export function sendElectronUpdateApp(): void {
+  getElectronIpcBridge()?.send(IPC_UPDATE_DOWNLOAD);
+}
+
+export function sendElectronInstallUpdate(): void {
+  getElectronIpcBridge()?.send(IPC_UPDATE_INSTALL);
+}
+
+export function startElectronScreenshot(args?: unknown): void {
+  const bridge = getElectronSystemBridge();
+  if (bridge) {
+    bridge.startScreenshot(args);
+    return;
+  }
+  getElectronIpcBridge()?.send(IPC_SCREENSHOTS_START, args);
+}
+
+export function getElectronMediaAccessStatus(
+  mediaType: "camera" | "microphone",
+): Promise<unknown> | undefined {
+  const bridge = getElectronSystemBridge();
+  if (bridge) {
+    return bridge.getMediaAccessStatus(mediaType);
+  }
+  return getElectronIpcBridge()?.invoke(IPC_MEDIA_ACCESS_STATUS, mediaType);
+}
+
+export function restartElectronApp(): void {
+  const bridge = getElectronSystemBridge();
+  if (bridge) {
+    bridge.restartApp();
+    return;
+  }
+  getElectronIpcBridge()?.send(IPC_RESTART_APP);
+}
+
+export function clearElectronAuthSession(): Promise<unknown> | undefined {
+  const oidc = getOctoElectronBridge()?.oidc;
+  if (oidc) {
+    return oidc.clearAuthSession();
+  }
+  return getElectronIpcBridge()?.invoke(IPC_OIDC_CLEAR_AUTH_SESSION);
+}

--- a/packages/dmworkbase/src/index.tsx
+++ b/packages/dmworkbase/src/index.tsx
@@ -71,6 +71,7 @@ export * from './Utils/docLink'
 export * from './Utils/asyncCache'
 export * from './features/documentTitle'
 export * from './features/notifications'
+export * from './electron/desktopBridge'
 
 export { default as MessageBase } from "./Messages/Base"
 export  * from "./Messages/Image"

--- a/packages/dmworkbase/src/module.tsx
+++ b/packages/dmworkbase/src/module.tsx
@@ -19,6 +19,7 @@ import { Howl, Howler } from "howler";
 import WKApp, { FriendApply, FriendApplyState, ThemeMode } from "./App";
 import { isChannelSearchEnabled } from "./features/channelSearch/feature";
 import ChatSearchEntryButton from "./features/channelSearch/ChatSearchEntryButton";
+import { isElectronPowered } from "./electron/desktopBridge";
 import { ChannelSettingRouteData } from "./Components/ChannelSetting/context";
 import { InputEdit } from "./Components/InputEdit";
 import { ListItem, ListItemTip } from "./Components/ListItem";
@@ -716,7 +717,7 @@ export default class BaseModule implements IModule {
    * processMessageAttention.
    */
   private isElectronEnvironment(): boolean {
-    return !!(window as any).__POWERED_ELECTRON__;
+    return isElectronPowered();
   }
 
   private scheduleMessageAttention(

--- a/packages/dmworklogin/src/login.tsx
+++ b/packages/dmworklogin/src/login.tsx
@@ -4,7 +4,7 @@ import { Button, Select, Spin, Toast } from '@douyinfe/semi-ui';
 // 主按钮纯文字, 避免锁定到任意一种登录方式让用户产生 "我没邮箱不能登" 的误判.
 import './login.css'
 import { QRCodeSVG } from 'qrcode.react';
-import { WKApp, Provider, useI18n } from "@octo/base"
+import { WKApp, Provider, useI18n, isElectronPowered } from "@octo/base"
 import type { Locale } from "@octo/base"
 import { LoginStatus, LoginType, LoginVM } from "./login_vm";
 import classNames from "classnames";
@@ -23,7 +23,7 @@ const ENTERPRISE_SSO_ENABLED =
 // Local Electron development keeps the password-login workflow, while plain
 // web development should still exercise the enterprise SSO entry point.
 const isElectronRuntime = typeof window !== 'undefined' && (
-    Boolean((window as any).__POWERED_ELECTRON__) ||
+    isElectronPowered() ||
     Boolean((window as any).__TAURI_IPC__) ||
     import.meta.env.VITE_ELECTRON_BUILD === 'true'
 )

--- a/packages/dmworklogin/src/oidc/__tests__/electron.test.ts
+++ b/packages/dmworklogin/src/oidc/__tests__/electron.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { getOidcClient, isElectronDesktop } from '../electron'
+import { beginOidcAuthorize, endOidcAuthorize, getOidcClient, isElectronDesktop } from '../electron'
 import { OidcBindHttpError } from '../http'
 import { createFetchHttpClient, fetchHttpClient } from '../http'
 
@@ -19,6 +19,8 @@ describe('electron runtime helpers', () => {
       configurable: true,
       value: origLocation,
     })
+    delete (window as any).ipc
+    delete (window as any).octoElectron
   })
 
   it('detects Electron packaged shell via file:// protocol', () => {
@@ -68,6 +70,52 @@ describe('electron runtime helpers', () => {
         status: 409,
         msg: 'already_verified',
       })
+  })
+
+  it('prefers the typed octoElectron OIDC HTTP bridge over legacy ipc.invoke', async () => {
+    setProtocol('file:')
+    const httpRequest = vi.fn().mockResolvedValue({
+      __octoOidcHttpResponse: true,
+      ok: true,
+      status: 200,
+      body: { ok: true },
+    })
+    const invoke = vi.fn()
+    Object.defineProperty(window, 'octoElectron', {
+      configurable: true,
+      value: { oidc: { httpRequest } },
+    })
+    Object.defineProperty(window, 'ipc', { configurable: true, value: { invoke } })
+
+    const client = getOidcClient('https://api.example.com')
+    await expect(client.get('/v1/user/thirdlogin/authstatus')).resolves.toEqual({ ok: true })
+
+    expect(httpRequest).toHaveBeenCalledWith({
+      url: 'https://api.example.com/v1/user/thirdlogin/authstatus',
+      method: 'GET',
+    })
+    expect(invoke).not.toHaveBeenCalled()
+  })
+
+  it('uses the typed octoElectron OIDC authorize bridge when available', async () => {
+    const authorizeStart = vi.fn().mockResolvedValue({ ok: true })
+    const authorizeEnd = vi.fn().mockResolvedValue(undefined)
+    Object.defineProperty(window, 'octoElectron', {
+      configurable: true,
+      value: { oidc: { authorizeStart, authorizeEnd } },
+    })
+
+    await expect(beginOidcAuthorize('https://api.example.com', 'code', 'aegis', 'https://idp.example.com/auth'))
+      .resolves.toEqual({ ok: true })
+    await endOidcAuthorize()
+
+    expect(authorizeStart).toHaveBeenCalledWith(
+      'https://api.example.com',
+      'code',
+      'aegis',
+      'https://idp.example.com/auth',
+    )
+    expect(authorizeEnd).toHaveBeenCalledOnce()
   })
 
   it('stops awaiting an in-flight IPC request when the caller aborts', async () => {

--- a/packages/dmworklogin/src/oidc/electron.ts
+++ b/packages/dmworklogin/src/oidc/electron.ts
@@ -1,6 +1,16 @@
 import type { OidcHttpClient, OidcRequestInit } from './api'
 import { createFetchHttpClient, fetchHttpClient, OidcBindHttpError } from './http'
 
+interface OidcDesktopBridge {
+  authorizeStart?: (apiURL: string, authcode: string, providerId: string, authorizeUrl: string) => Promise<unknown>
+  authorizeEnd?: () => Promise<unknown>
+  httpRequest?: (request: unknown) => Promise<unknown>
+}
+
+function getOidcDesktopBridge(): OidcDesktopBridge | undefined {
+  return typeof window === 'undefined' ? undefined : (window as any).octoElectron?.oidc
+}
+
 interface OidcIpcHttpResponse {
   __octoOidcHttpResponse: true
   ok: boolean
@@ -25,12 +35,18 @@ function errorMessage(body: unknown): string | undefined {
 }
 
 async function invokeOidcHttp<T>(
-  ipc: { invoke(channel: string, request: unknown): Promise<unknown> },
+  ipc: {
+    invoke?: (channel: string, request: unknown) => Promise<unknown>
+    httpRequest?: (request: unknown) => Promise<unknown>
+  },
   request: unknown,
   signal?: AbortSignal,
 ): Promise<T> {
   if (signal?.aborted) throw new DOMException('The operation was aborted', 'AbortError')
-  const pending = ipc.invoke(IPC_OIDC_HTTP_REQUEST, request)
+  const pending =
+    typeof ipc.httpRequest === 'function'
+      ? ipc.httpRequest(request)
+      : ipc.invoke!(IPC_OIDC_HTTP_REQUEST, request)
   const result = signal
     ? await new Promise<unknown>((resolve, reject) => {
         const onAbort = () => reject(new DOMException('The operation was aborted', 'AbortError'))
@@ -90,12 +106,21 @@ export async function beginOidcAuthorize(
   // and P1-1 in the review notes for the rationale.
   authorizeUrl: string,
 ): Promise<OidcAuthorizeStartResult> {
+  const oidc = getOidcDesktopBridge()
+  if (typeof oidc?.authorizeStart === 'function') {
+    return oidc.authorizeStart(apiURL, authcode, providerId, authorizeUrl) as Promise<OidcAuthorizeStartResult>
+  }
   const ipc = typeof window !== 'undefined' ? (window as any).ipc : undefined
   if (typeof ipc?.invoke !== 'function') return { ok: false, code: 'no-window' }
   return ipc.invoke(IPC_OIDC_AUTHORIZE_START, apiURL, authcode, providerId, authorizeUrl) as Promise<OidcAuthorizeStartResult>
 }
 
 export async function endOidcAuthorize(): Promise<void> {
+  const oidc = getOidcDesktopBridge()
+  if (typeof oidc?.authorizeEnd === 'function') {
+    try { await oidc.authorizeEnd() } catch { /* best effort cleanup */ }
+    return
+  }
   const ipc = typeof window !== 'undefined' ? (window as any).ipc : undefined
   if (typeof ipc?.invoke !== 'function') return
   try { await ipc.invoke(IPC_OIDC_AUTHORIZE_END) } catch { /* best effort cleanup */ }
@@ -113,8 +138,8 @@ export async function endOidcAuthorize(): Promise<void> {
  */
 export function getOidcClient(apiURL: string): OidcHttpClient {
   if (isElectronDesktop() && /^https?:\/\//i.test(apiURL)) {
-    const ipc = (window as any).ipc
-    if (typeof ipc?.invoke === 'function') {
+    const ipc = getOidcDesktopBridge() ?? (window as any).ipc
+    if (typeof ipc?.httpRequest === 'function' || typeof ipc?.invoke === 'function') {
       return {
         async get<T>(url: string, init?: OidcRequestInit): Promise<T> {
           const absoluteURL = new URL(url, apiURL.endsWith('/') ? apiURL : `${apiURL}/`).toString()


### PR DESCRIPTION
## Summary
- add a typed window.octoElectron bridge while preserving legacy window.ipc and window.electronNotification compatibility
- centralize Electron IPC channel constants and migrate renderer call sites for notifications, updates, unread counts, OIDC, and runtime checks
- harden Electron IPC sender validation and BrowserWindow webPreferences for context isolation, sandbox, and disabled node integration

## Validation
- corepack pnpm --dir apps/web run compile:electron
- corepack pnpm --dir apps/web run build:electron
- corepack pnpm --dir apps/web exec vitest run src-election/main/__tests__ src/__tests__/electronNotificationListenerCleanup.test.ts
- corepack pnpm --dir packages/dmworkbase exec vitest run src/electron/__tests__/desktopBridge.test.ts src/Service/__tests__/oidcLogout.test.ts src/Utils/__tests__/NotificationUtil.test.ts src/Service/__tests__/Dap.test.ts
- corepack pnpm --dir packages/dmworklogin exec vitest run src/oidc/__tests__/electron.test.ts
- git diff --check

## Packaging note
- local mac arm64 zip packaging was produced and verified separately, but dmg generation still needs follow-up for the local electron-builder/dmg-builder environment.