### PR TITLE
feat(summary): add copy and convert-to-document buttons (#195)

### DIFF
--- a/packages/dmworksummary/src/api/summaryApi.ts
+++ b/packages/dmworksummary/src/api/summaryApi.ts
@@ -353,3 +353,69 @@ export async function getMemberCandidates(params?: { keyword?: string }): Promis
     const data = await get<MemberCandidate[]>('/summary-member-candidates', params as Record<string, unknown>);
     return data || [];
 }
+
+// ─── Document: Copy & Convert ──────────────────────────
+
+// 复制总结内容到剪贴板（纯前端，不走后端 API）。
+// 优先使用 navigator.clipboard.writeText，降级到 execCommand 兜底。
+export async function copySummaryContent(content: string): Promise<boolean> {
+    if (navigator.clipboard?.writeText) {
+        try {
+            await navigator.clipboard.writeText(content);
+            return true;
+        } catch {
+            // fall through to fallback
+        }
+    }
+    // execCommand 降级
+    try {
+        const textarea = document.createElement('textarea');
+        textarea.value = content;
+        textarea.readOnly = true;
+        textarea.style.position = 'fixed';
+        textarea.style.top = '0';
+        textarea.style.left = '0';
+        textarea.style.opacity = '0';
+        textarea.style.fontSize = '16px';
+        document.body.appendChild(textarea);
+        textarea.select();
+        const ok = document.execCommand('copy');
+        document.body.removeChild(textarea);
+        return ok;
+    } catch {
+        return false;
+    }
+}
+
+// 创建在线文档（POST /api/v1/docs — docs-backend），返回 docId。
+// 调用者成为文档 owner/admin。
+export async function createDoc(title?: string): Promise<{ docId: string }> {
+    const resp = await WKApp.apiClient.post('/docs', { title: title || '' });
+    return { docId: (resp as { docId: string }).docId };
+}
+
+// 将 Markdown 内容导入到已有文档（POST /api/v1/docs/:docId/import/markdown — docs-backend）。
+// 后端原子替换文档内容；支持 .md/.markdown 格式。
+// 使用全局 axios（APIClient 拦截器自动注入 token / spaceId / Accept-Language）。
+export async function importMarkdownToDoc(docId: string, markdown: string): Promise<void> {
+    const blob = new Blob([markdown], { type: 'text/markdown;charset=utf-8' });
+    const formData = new FormData();
+    formData.append('file', blob, 'summary.md');
+
+    // 走全局 axios（拦截器自动注入 auth headers）；axios 会自动设置 multipart/form-data boundary
+    const apiURL = WKApp.apiClient.config.apiURL;
+    const baseURL = apiURL || '/api/v1/';
+    await axios.post(`${baseURL}docs/${encodeURIComponent(docId)}/import/markdown`, formData, {
+        // 覆盖默认超时（导入可能较慢）
+        timeout: 30_000,
+    });
+}
+
+// 创建文档并导入 Markdown 内容，返回文档 ID 和跳转链接。
+export async function convertSummaryToDoc(title: string, markdown: string): Promise<{ docId: string; url: string }> {
+    const { docId } = await createDoc(title);
+    await importMarkdownToDoc(docId, markdown);
+    // docs 模块用 ?doc=<docId> 路由
+    const url = `/docs?doc=${encodeURIComponent(docId)}`;
+    return { docId, url };
+}

--- a/packages/dmworksummary/src/i18n/en-US.json
+++ b/packages/dmworksummary/src/i18n/en-US.json
@@ -357,7 +357,13 @@
     "leaveTask": "Leave collaboration",
     "leaveConfirm": "Leave this collaboration?",
     "leaveSuccess": "Left",
-    "leaveFailed": "Failed to leave"
+    "leaveFailed": "Failed to leave",
+    "copy": "Copy",
+    "copySuccess": "Copied to clipboard",
+    "copyFailed": "Copy failed, please retry",
+    "convertToDoc": "Convert to document",
+    "convertSuccess": "Document created, redirecting...",
+    "convertFailed": "Conversion failed, please retry"
   },
   "summaryCard": {
     "createdBy": "Created by {{name}}",

--- a/packages/dmworksummary/src/i18n/en-US.json
+++ b/packages/dmworksummary/src/i18n/en-US.json
@@ -363,7 +363,9 @@
     "copyFailed": "Copy failed, please retry",
     "convertToDoc": "Convert to document",
     "convertSuccess": "Document created, redirecting...",
-    "convertFailed": "Conversion failed, please retry"
+    "convertFailed": "Conversion failed, please retry",
+    "copyTeamSummary": "Copy team summary",
+    "convertTeamSummary": "Convert team summary"
   },
   "summaryCard": {
     "createdBy": "Created by {{name}}",

--- a/packages/dmworksummary/src/i18n/zh-CN.json
+++ b/packages/dmworksummary/src/i18n/zh-CN.json
@@ -357,7 +357,13 @@
     "leaveTask": "退出多人协作",
     "leaveConfirm": "确定退出该多人协作吗？",
     "leaveSuccess": "已退出",
-    "leaveFailed": "退出失败"
+    "leaveFailed": "退出失败",
+    "copy": "复制",
+    "copySuccess": "已复制到剪贴板",
+    "copyFailed": "复制失败，请重试",
+    "convertToDoc": "转为在线文档",
+    "convertSuccess": "已创建文档，正在跳转...",
+    "convertFailed": "转换失败，请重试"
   },
   "summaryCard": {
     "createdBy": "{{name}} 发起",

--- a/packages/dmworksummary/src/i18n/zh-CN.json
+++ b/packages/dmworksummary/src/i18n/zh-CN.json
@@ -363,7 +363,9 @@
     "copyFailed": "复制失败，请重试",
     "convertToDoc": "转为在线文档",
     "convertSuccess": "已创建文档，正在跳转...",
-    "convertFailed": "转换失败，请重试"
+    "convertFailed": "转换失败，请重试",
+    "copyTeamSummary": "复制团队总结",
+    "convertTeamSummary": "团队总结转文档"
   },
   "summaryCard": {
     "createdBy": "{{name}} 发起",

--- a/packages/dmworksummary/src/pages/SummaryDetailPage.tsx
+++ b/packages/dmworksummary/src/pages/SummaryDetailPage.tsx
@@ -1142,6 +1142,30 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
                         </Button>
                     </div>
                 )}
+                {/* BY_PERSON 单人模式下 renderTeamSummary() 不显示（members.length <= 1），
+                    但 detail.result 可能仍有团队总结内容。在此提供复制/转文档入口。 */}
+                {detail?.result?.content && detail.result.content.trim() && (
+                    <div className="summary-detail-result-footer" style={{ display: "flex", justifyContent: "flex-end", gap: 8, marginTop: 4 }}>
+                        <Button
+                            size="small"
+                            theme="borderless"
+                            icon={<Copy size={14} />}
+                            loading={this.state.copying}
+                            onClick={() => this.handleCopyContent(detail.result!.content)}
+                        >
+                            {t("summary.detail.copyTeamSummary")}
+                        </Button>
+                        <Button
+                            size="small"
+                            theme="borderless"
+                            icon={<FileText size={14} />}
+                            loading={this.state.convertingDoc}
+                            onClick={() => this.handleConvertToDoc(detail.result!.content, detail.title)}
+                        >
+                            {t("summary.detail.convertTeamSummary")}
+                        </Button>
+                    </div>
+                )}
             </div>
         );
     }

--- a/packages/dmworksummary/src/pages/SummaryDetailPage.tsx
+++ b/packages/dmworksummary/src/pages/SummaryDetailPage.tsx
@@ -973,12 +973,13 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
     }
 
     /** 复制总结内容到剪贴板 */
-    handleCopyContent = async () => {
-        const { detail } = this.state;
-        if (!detail?.result?.content) return;
+    handleCopyContent = async (contentOverride?: string) => {
+        const { detail, personalResult } = this.state;
+        const content = contentOverride ?? detail?.result?.content;
+        if (!content) return;
         this.setState({ copying: true });
         try {
-            const ok = await api.copySummaryContent(detail.result.content);
+            const ok = await api.copySummaryContent(content);
             if (ok) {
                 Toast.success(this.context.t("summary.detail.copySuccess"));
             } else {
@@ -992,13 +993,14 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
     };
 
     /** 转为在线文档 */
-    handleConvertToDoc = async () => {
+    handleConvertToDoc = async (contentOverride?: string, titleOverride?: string) => {
         const { detail } = this.state;
-        if (!detail?.result?.content) return;
+        const content = contentOverride ?? detail?.result?.content;
+        if (!content) return;
         this.setState({ convertingDoc: true });
         try {
-            const title = detail.title || this.context.t("summary.detail.defaultTitle");
-            const { url } = await api.convertSummaryToDoc(title, detail.result.content);
+            const title = titleOverride ?? detail?.title ?? this.context.t("summary.detail.defaultTitle");
+            const { url } = await api.convertSummaryToDoc(title, content);
             Toast.success(this.context.t("summary.detail.convertSuccess"));
             // 在新标签页打开文档
             window.open(url, "_blank");
@@ -1055,7 +1057,7 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
                             theme="borderless"
                             icon={<Copy size={14} />}
                             loading={this.state.copying}
-                            onClick={this.handleCopyContent}
+                            onClick={() => this.handleCopyContent()}
                         >
                             {t("summary.detail.copy")}
                         </Button>
@@ -1064,7 +1066,7 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
                             theme="borderless"
                             icon={<FileText size={14} />}
                             loading={this.state.convertingDoc}
-                            onClick={this.handleConvertToDoc}
+                            onClick={() => this.handleConvertToDoc()}
                         >
                             {t("summary.detail.convertToDoc")}
                         </Button>
@@ -1116,6 +1118,28 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
                 {personalResult.content && (
                     <div className="summary-detail-content-box">
                         <CitationText content={personalResult.content} citations={personalResult.citations || []} />
+                    </div>
+                )}
+                {personalResult.content && (
+                    <div className="summary-detail-result-footer" style={{ display: "flex", justifyContent: "flex-end", gap: 8, marginTop: 8 }}>
+                        <Button
+                            size="small"
+                            theme="borderless"
+                            icon={<Copy size={14} />}
+                            loading={this.state.copying}
+                            onClick={() => this.handleCopyContent(personalResult.content)}
+                        >
+                            {t("summary.detail.copy")}
+                        </Button>
+                        <Button
+                            size="small"
+                            theme="borderless"
+                            icon={<FileText size={14} />}
+                            loading={this.state.convertingDoc}
+                            onClick={() => this.handleConvertToDoc(personalResult.content, detail?.title)}
+                        >
+                            {t("summary.detail.convertToDoc")}
+                        </Button>
                     </div>
                 )}
             </div>
@@ -1254,6 +1278,26 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
                         members={members}
                         hidePlainCitations
                     />
+                </div>
+                <div className="summary-detail-result-footer" style={{ display: "flex", justifyContent: "flex-end", gap: 8, marginTop: 8 }}>
+                    <Button
+                        size="small"
+                        theme="borderless"
+                        icon={<Copy size={14} />}
+                        loading={this.state.copying}
+                        onClick={() => this.handleCopyContent()}
+                    >
+                        {t("summary.detail.copy")}
+                    </Button>
+                    <Button
+                        size="small"
+                        theme="borderless"
+                        icon={<FileText size={14} />}
+                        loading={this.state.convertingDoc}
+                        onClick={() => this.handleConvertToDoc()}
+                    >
+                        {t("summary.detail.convertToDoc")}
+                    </Button>
                 </div>
             </div>
         );

--- a/packages/dmworksummary/src/pages/SummaryDetailPage.tsx
+++ b/packages/dmworksummary/src/pages/SummaryDetailPage.tsx
@@ -11,6 +11,7 @@ import {
     Popconfirm,
 } from "@douyinfe/semi-ui";
 import { IconEdit, IconMore, IconSend, IconClock, IconTick, IconClose, IconInfoCircle, IconHistory, IconUser, IconPlus, IconMinusCircle, IconExit } from "@douyinfe/semi-icons";
+import { Copy, FileText } from "lucide-react";
 import { Channel, ChannelTypeGroup, ChannelTypePerson, MessageText, WKSDK } from "wukongimjssdk";
 import { I18nContext, t } from "@octo/base";
 import WKApp from "@octo/base/src/App";
@@ -81,6 +82,10 @@ interface SummaryDetailPageState {
     regenerateSubmitting: boolean;
     /** V5：schedule 级一次性确认提交中 */
     confirmingSchedule: boolean;
+    /** 复制总结内容中 */
+    copying: boolean;
+    /** 转为在线文档中 */
+    convertingDoc: boolean;
 }
 
 const INTER_MESSAGE_DELAY_MS = 200;
@@ -115,6 +120,8 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
         regenerateTopic: "",
         regenerateSubmitting: false,
         confirmingSchedule: false,
+        copying: false,
+        convertingDoc: false,
     };
 
     private personalPollTimer: ReturnType<typeof setInterval> | null = null;
@@ -965,6 +972,44 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
         );
     }
 
+    /** 复制总结内容到剪贴板 */
+    handleCopyContent = async () => {
+        const { detail } = this.state;
+        if (!detail?.result?.content) return;
+        this.setState({ copying: true });
+        try {
+            const ok = await api.copySummaryContent(detail.result.content);
+            if (ok) {
+                Toast.success(this.context.t("summary.detail.copySuccess"));
+            } else {
+                Toast.error(this.context.t("summary.detail.copyFailed"));
+            }
+        } catch {
+            Toast.error(this.context.t("summary.detail.copyFailed"));
+        } finally {
+            this.setState({ copying: false });
+        }
+    };
+
+    /** 转为在线文档 */
+    handleConvertToDoc = async () => {
+        const { detail } = this.state;
+        if (!detail?.result?.content) return;
+        this.setState({ convertingDoc: true });
+        try {
+            const title = detail.title || this.context.t("summary.detail.defaultTitle");
+            const { url } = await api.convertSummaryToDoc(title, detail.result.content);
+            Toast.success(this.context.t("summary.detail.convertSuccess"));
+            // 在新标签页打开文档
+            window.open(url, "_blank");
+        } catch (err) {
+            const msg = err instanceof Error ? err.message : this.context.t("summary.detail.convertFailed");
+            Toast.error(msg);
+        } finally {
+            this.setState({ convertingDoc: false });
+        }
+    };
+
     renderCompleted() {
         const { detail } = this.state;
         const { t } = this.context;
@@ -1004,6 +1049,26 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
                             {t("summary.detail.lastEditedAt", { values: { time: formatDate(detail.result_edited_at) } })}
                         </span>
                     )}
+                    <div className="summary-detail-result-actions" style={{ marginLeft: "auto", display: "flex", gap: 8 }}>
+                        <Button
+                            size="small"
+                            theme="borderless"
+                            icon={<Copy size={14} />}
+                            loading={this.state.copying}
+                            onClick={this.handleCopyContent}
+                        >
+                            {t("summary.detail.copy")}
+                        </Button>
+                        <Button
+                            size="small"
+                            theme="borderless"
+                            icon={<FileText size={14} />}
+                            loading={this.state.convertingDoc}
+                            onClick={this.handleConvertToDoc}
+                        >
+                            {t("summary.detail.convertToDoc")}
+                        </Button>
+                    </div>
                 </div>
             </div>
         );


### PR DESCRIPTION
## Summary

Implements #195 — adds two action buttons below the summary result content on the summary detail page, covering ALL summary types.

### Changes

**1. Copy button (复制)**
- Copies the summary's markdown content (`detail.result.content`) to clipboard
- Uses `navigator.clipboard.writeText` with `execCommand` fallback for older browsers
- Shows success/error toast

**2. Convert to document button (转为在线文档)**
- Creates a new online document via `POST /api/v1/docs` (docs-backend)
- Imports the markdown content via `POST /api/v1/docs/:docId/import/markdown`
- Opens the newly created document in a new browser tab
- Shows success/error toast with loading state

### Covers All Summary Types

| Render path | Summary type | Buttons added |
|-------------|-------------|---------------|
| `renderCompleted()` | BY_GROUP (agent, workflow, group) | ✅ |
| `renderPersonalSummary()` | BY_PERSON single (personal) | ✅ |
| `renderTeamSummary()` | BY_PERSON multi (team collaboration) | ✅ |

### Files Modified

| File | Change |
|------|--------|
| `packages/dmworksummary/src/api/summaryApi.ts` | +4 functions: `copySummaryContent`, `createDoc`, `importMarkdownToDoc`, `convertSummaryToDoc` |
| `packages/dmworksummary/src/pages/SummaryDetailPage.tsx` | +state, +event handlers, +2 Buttons in `renderCompleted()`, `renderPersonalSummary()`, `renderTeamSummary()` |
| `packages/dmworksummary/src/i18n/zh-CN.json` | +6 i18n keys |
| `packages/dmworksummary/src/i18n/en-US.json` | +6 i18n keys |

### No Backend Changes Required

Uses existing docs-backend REST API:
- `POST /api/v1/docs` — create an empty document
- `POST /api/v1/docs/:docId/import/markdown` — import markdown content atomically

Closes #195