### PR TITLE
fix(skillmarket): render public skills as official

### DIFF
--- a/.i18n/scan-config.json
+++ b/.i18n/scan-config.json
@@ -77,10 +77,6 @@
       "reason": "Agent prompt template for the Bot publish flow. Same rationale as installPrompt.ts above — generated prompt content pasted into an agent client, must byte-match; not translatable UI chrome."
     },
     {
-      "path": "packages/dmworkskillmarket/src/utils/publisher.ts",
-      "reason": "Publisher classification helper. The Chinese literal is a backend identity value used to recognize administrator-created records, not user-facing UI copy; the displayed label is localized separately."
-    },
-    {
       "path": "packages/dmworkmcp/src/utils/mcpBotPublishPrompt.ts",
       "reason": "Agent prompt template for the MCP marketplace publish flow. Same rationale as dmworkskillmarket/src/utils/botPublishPrompt.ts — generated prompt content pasted into an agent client, must byte-match; not translatable UI chrome."
     },

--- a/packages/dmworkskillmarket/src/components/__tests__/SkillCard.test.tsx
+++ b/packages/dmworkskillmarket/src/components/__tests__/SkillCard.test.tsx
@@ -49,8 +49,8 @@ describe("SkillCard", () => {
     expect(screen.getByLabelText("下载次数：0")).toHaveTextContent("0");
   });
 
-  it("shows publisher metadata for public skills", () => {
-    render(
+  it("renders public skills as platform-published", () => {
+    const { container } = render(
       <SkillCard
         skill={{ ...skill, visibility: "public" }}
         categories={categories}
@@ -58,27 +58,8 @@ describe("SkillCard", () => {
       />,
     );
 
-    expect(screen.getByRole("button", { name: "ci-helper 我" })).toBeInTheDocument();
-    expect(screen.getByText("我")).toBeInTheDocument();
-  });
-
-  it("shows platform attribution for administrator-created global skills", () => {
-    const { container } = render(
-      <SkillCard
-        skill={{
-          ...skill,
-          visibility: "public",
-          spaceId: undefined as unknown as string,
-          ownerName: "超级管理员",
-          creatorName: "超级管理员",
-        }}
-        categories={categories}
-        onOpen={vi.fn()}
-      />,
-    );
-
     expect(screen.getByText("官方发布")).toBeInTheDocument();
-    expect(screen.queryByText("超级管理员")).not.toBeInTheDocument();
+    expect(screen.queryByText("我")).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "ci-helper 官方发布" })).toBeInTheDocument();
     expect(container.querySelector(".skill-market-card__owner-platform-icon")).toBeInTheDocument();
   });

--- a/packages/dmworkskillmarket/src/components/__tests__/SkillDetailModal.test.tsx
+++ b/packages/dmworkskillmarket/src/components/__tests__/SkillDetailModal.test.tsx
@@ -84,29 +84,14 @@ describe("SkillDetailModal", () => {
     expect(screen.queryByText("4 KB")).not.toBeInTheDocument();
   });
 
-  it("shows publisher metadata for public skills", async () => {
+  it("renders public skills as platform-published", async () => {
     vi.mocked(api.getSkill).mockResolvedValue({ ...skill, visibility: "public" });
-
-    render(<SkillDetailModal skillId={skill.id} categories={categories} onClose={vi.fn()} />);
-
-    expect(await screen.findByText("test")).toBeInTheDocument();
-    expect(screen.getByTitle("meeting-note-cleaner")).toBeInTheDocument();
-    expect(screen.getByTitle("我")).toBeInTheDocument();
-  });
-
-  it("shows platform attribution for administrator-created global skills", async () => {
-    vi.mocked(api.getSkill).mockResolvedValue({
-      ...skill,
-      visibility: "public",
-      spaceId: undefined as unknown as string,
-      ownerName: "超级管理员",
-      creatorName: "超级管理员",
-    });
 
     const { container } = render(<SkillDetailModal skillId={skill.id} categories={categories} onClose={vi.fn()} />);
 
     expect(await screen.findByText("官方发布")).toBeInTheDocument();
-    expect(screen.queryByText("超级管理员")).not.toBeInTheDocument();
+    expect(screen.getByTitle("meeting-note-cleaner")).toBeInTheDocument();
+    expect(screen.queryByText("我")).not.toBeInTheDocument();
     expect(screen.getByTitle("官方发布")).toBeInTheDocument();
     expect(container.querySelector(".skill-market-detail-header__platform-icon")).toBeInTheDocument();
   });

--- a/packages/dmworkskillmarket/src/utils/publisher.test.ts
+++ b/packages/dmworkskillmarket/src/utils/publisher.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+import { isPlatformPublishedSkill } from "./publisher";
+
+describe("isPlatformPublishedSkill", () => {
+  it("identifies public visibility as platform-published", () => {
+    expect(isPlatformPublishedSkill({ visibility: "public" })).toBe(true);
+    expect(isPlatformPublishedSkill({ visibility: "space" })).toBe(false);
+    expect(isPlatformPublishedSkill({ visibility: "private" })).toBe(false);
+  });
+});

--- a/packages/dmworkskillmarket/src/utils/publisher.ts
+++ b/packages/dmworkskillmarket/src/utils/publisher.ts
@@ -1,17 +1,5 @@
 import type { Skill } from "../types/skill";
 
-// Administrator-created Skills are stored as public records in the global
-// Marketplace scope. The backend currently represents that scope with an
-// empty space_id, so keep the heuristic isolated until an explicit publisher
-// type is available in the API contract.
-export function isPlatformPublishedSkill(
-  skill: Pick<Skill, "creatorName" | "ownerName" | "spaceId" | "visibility">,
-): boolean {
-  if (skill.visibility !== "public") return false;
-
-  // space_id is intentionally omitted from current public Skill responses, so
-  // recognize the administrator role name already returned by the API. Keep
-  // the global-scope check for endpoints/fixtures that do expose space_id.
-  const publisherName = (skill.creatorName || skill.ownerName).trim();
-  return skill.spaceId === "" || publisherName === "超级管理员" || publisherName === "Super Admin";
+export function isPlatformPublishedSkill(skill: Pick<Skill, "visibility">): boolean {
+  return skill.visibility === "public";
 }


### PR DESCRIPTION
## Summary

- Treat every Skill with `visibility: public` as platform-published.
- Render the existing localized “官方发布” / “Official” attribution in both Skill cards and the detail modal.
- Remove the administrator-name and `space_id` heuristics; keep `space` and `private` behavior unchanged.
- Add focused helper and component coverage.

## Linked Spec

- Implements Mininglamp-OSS/octo-marketplace#57
- https://github.com/Mininglamp-OSS/octo-marketplace/issues/57

## How verified

- `cd packages/dmworkskillmarket && pnpm test` — 14 files, 127 tests passed.
- `pnpm i18n:check` — passed.
- `git diff --check` — passed.

## COMPREHENSION

1. **What does this change actually do** to the affected path?
   Skill list cards and detail modals previously labeled a public Skill as official only when its publisher metadata looked like an administrator or its global `space_id` was empty. They now use the API visibility contract directly: `public` displays the official attribution, while `space` and `private` do not.

2. **What could break** because of it?
   Any public Skill that was previously shown with its creator/owner name will now show the official attribution instead. Space-private ownership rendering remains on the existing path. The main failure risk is inconsistent card/detail attribution, covered in both component test suites.

3. **How do you know it works**?
   The helper test verifies all visibility values, and card/detail tests assert that a regular public fixture renders “官方发布”, hides the owner name, and includes the existing platform icon. The full Skill Market suite passes.