### PR TITLE
chore(html): enable source/diff runtime switch by default

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -20,6 +20,10 @@ AGENT_MAIL_API_URL=http://octo-mail:8080
 MAIL_CLIENT_MAX_BODY_SIZE=50m
 # Docker default. Set this to the cluster DNS resolver outside Docker.
 NGINX_RESOLVER=127.0.0.11
+# HTML source view + version diff entry. Defaults on; set to "false" to hide it.
+# The entrypoint writes it into runtime-config.js, so a change needs a container
+# restart plus a hard reload (the file is not cache-busted).
+OCTO_HTML_SOURCE_DIFF_ENABLED=true
 
 # Marketplace (octo-marketplace) service URL for local dev.
 # The Vite proxy rewrites /market/api/v1/* → target/api/v1/*

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -29,8 +29,9 @@ export DOC_APP_URL
 DOCS_BACKEND_URL="${DOCS_BACKEND_URL%/}"
 export DOCS_BACKEND_URL
 
-# Runtime HTML source/diff switch. Only the literal "true" enables it.
-: "${OCTO_HTML_SOURCE_DIFF_ENABLED:=false}"
+# Runtime HTML source/diff switch. Defaults on; any value other than the
+# literal "true" (including "false") disables it.
+: "${OCTO_HTML_SOURCE_DIFF_ENABLED:=true}"
 if [ "$OCTO_HTML_SOURCE_DIFF_ENABLED" = "true" ]; then
   HTML_SOURCE_DIFF_JS=true
 else


### PR DESCRIPTION
## 背景

`docker-entrypoint.sh` 在容器启动时把 HTML 源码/版本 Diff 开关写进 `runtime-config.js`：

```
window.__OCTO_HTML_SOURCE_DIFF_ENABLED__ = <true|false>;
```

前端 `htmlSourceDiffFeature` 读这个全局量决定是否渲染「源码 / 版本对比」入口，且是 fail-closed（只认字面量 `true`）。此前 entrypoint 的默认值是 `false`，意味着**每个部署都必须显式设置环境变量才能看到这个入口**，否则功能虽已上线却对所有人不可见。

## 改动

| 文件 | 改动 |
|---|---|
| `docker-entrypoint.sh` | 默认值 `false` → `true`，注释同步 |
| `apps/web/.env.example` | 在容器 runtime 变量段补充该变量的说明与默认值 |

`+7 −2`，两个文件，纯配置，无生产代码改动。

**匹配语义一字未改**：仍然只有字面量 `true` 打开，其他任何值（含 `false`、`yes`、空串前的显式赋值）都关闭。所以显式设 `OCTO_HTML_SOURCE_DIFF_ENABLED=false` 的部署行为不变。

## 验证

在改后的脚本上跑同一段逻辑，五种输入实测：

```
input=[UNSET]  -> window.__OCTO_HTML_SOURCE_DIFF_ENABLED__ = true;
input=[true]   -> window.__OCTO_HTML_SOURCE_DIFF_ENABLED__ = true;
input=[false]  -> window.__OCTO_HTML_SOURCE_DIFF_ENABLED__ = false;
input=[yes]    -> window.__OCTO_HTML_SOURCE_DIFF_ENABLED__ = false;
input=[空串]   -> window.__OCTO_HTML_SOURCE_DIFF_ENABLED__ = true;
```

`sh -n docker-entrypoint.sh` 语法检查通过。未跑前端单测：本 PR 不含任何 `.ts/.tsx` 改动。

## 部署注意

`runtime-config.js` 由 entrypoint 每次启动重写，且响应头没有 `Cache-Control`。所以升级后已访问过的浏览器可能仍拿到旧值，需要硬刷新一次。缓存头本身是另一个独立问题，不在本 PR 范围。
