### PR TITLE
feat(summary): 文档 AI 速览 —— 自包含接入端口 (@dmwork/summary/preview)

### DIFF
--- a/packages/dmworksummary/package.json
+++ b/packages/dmworksummary/package.json
@@ -2,6 +2,11 @@
   "name": "@dmwork/summary",
   "version": "1.0.0",
   "main": "src/index.tsx",
+  "exports": {
+    ".": "./src/index.tsx",
+    "./api": "./src/api/summaryApi.ts",
+    "./preview": "./src/preview/index.ts"
+  },
   "scripts": {
     "test": "vitest run",
     "typecheck": "tsc --noEmit"

--- a/packages/dmworksummary/src/api/summaryApi.ts
+++ b/packages/dmworksummary/src/api/summaryApi.ts
@@ -1017,3 +1017,161 @@ export async function getMemberCandidates(params?: { keyword?: string }): Promis
     const data = await get<MemberCandidate[]>('/summary-member-candidates', params as Record<string, unknown>);
     return data || [];
 }
+
+// ─── Document AI 速览 (ephemeral streaming preview) ───────────────────────────
+//
+// POST /summary/api/v1/summaries/document/preview — streams an AI 速览 for a single
+// document over SSE. Backend never persists anything (no Summary Task), so this is a
+// throwaway quick-glance, not a deliverable. Events: `delta` (content chunk), `done`,
+// `error`. Same SSE-over-POST consumption as agentChatStream (EventSource can't POST).
+
+export interface DocumentPreviewParams {
+    documentId: string;
+    version?: string;
+    /** Viewer's current space; falls back to WKApp.shared.currentSpaceId. */
+    spaceId?: string;
+}
+
+export interface DocumentPreviewHandlers {
+    /** A content chunk arrived — append to the rendered markdown. */
+    onDelta?: (text: string) => void;
+    /** Stream finished cleanly. */
+    onDone?: () => void;
+    /** Fetch/stream/generation failed, or the stream closed without `done`. */
+    onError?: (err: { code?: number; message: string }) => void;
+}
+
+export function streamDocumentPreview(
+    params: DocumentPreviewParams,
+    handlers: DocumentPreviewHandlers,
+): { close: () => void } {
+    let reader: ReadableStreamDefaultReader<Uint8Array> | null = null;
+    let aborted = false;
+
+    const url = `${resolveSummaryBaseURL()}${BASE}/summaries/document/preview`;
+    const token = WKApp.loginInfo.token;
+    const spaceId = params.spaceId || WKApp.shared.currentSpaceId;
+
+    const dispatch = (event: string, data: string) => {
+        if (event === 'delta') {
+            try {
+                const parsed = JSON.parse(data) as { content?: string };
+                if (parsed.content) handlers.onDelta?.(parsed.content);
+            } catch {
+                // ignore malformed delta frame
+            }
+        } else if (event === 'done') {
+            handlers.onDone?.();
+        } else if (event === 'error') {
+            let message = '文档速览生成失败';
+            try {
+                const parsed = JSON.parse(data) as { content?: string; message?: string };
+                message = parsed.content || parsed.message || message;
+            } catch {
+                // keep default message
+            }
+            handlers.onError?.({ code: 50000, message });
+        }
+    };
+
+    (async () => {
+        try {
+            const headers: Record<string, string> = {
+                'Content-Type': 'application/json',
+                'Accept': 'text/event-stream',
+                'Accept-Language': buildAcceptLanguage(),
+            };
+            if (token) headers['token'] = token;
+            if (spaceId) headers['X-Space-Id'] = spaceId;
+
+            const resp = await fetch(url, {
+                method: 'POST',
+                headers,
+                body: JSON.stringify({ document_id: params.documentId, version: params.version }),
+            });
+
+            if (resp.status === 401) {
+                WKApp.shared.logout();
+                handlers.onError?.({ code: 401, message: 'Unauthorized' });
+                return;
+            }
+            if (!resp.ok) {
+                const text = await resp.text();
+                let errMsg = `HTTP ${resp.status}`;
+                try {
+                    const json = JSON.parse(text);
+                    errMsg = json?.message || errMsg;
+                } catch {
+                    // non-JSON body; keep HTTP status
+                }
+                handlers.onError?.({ code: resp.status, message: errMsg });
+                return;
+            }
+            if (!resp.body) {
+                handlers.onError?.({ code: 50000, message: 'Response body is null' });
+                return;
+            }
+
+            reader = resp.body.getReader();
+            const decoder = new TextDecoder('utf-8');
+            let buffer = '';
+            let pendingEvent = '';
+            let pendingData = '';
+            let receivedDone = false;
+
+            while (!aborted) {
+                const { done, value } = await reader.read();
+                if (done) break;
+                buffer += decoder.decode(value, { stream: true });
+                // Normalize CRLF/CR → LF before splitting on \n (see agentChatStream / SUM-850).
+                const lines = buffer.replace(/\r\n?/g, '\n').split('\n');
+                buffer = lines.pop() || '';
+                for (const line of lines) {
+                    if (line.startsWith('event:')) {
+                        pendingEvent = line.slice(6).trim();
+                    } else if (line.startsWith('data:')) {
+                        pendingData += (pendingData ? '\n' : '') + line.slice(5).trim();
+                    } else if (line === '') {
+                        if (pendingEvent && pendingData) {
+                            if (pendingEvent === 'done') receivedDone = true;
+                            dispatch(pendingEvent, pendingData);
+                        }
+                        pendingEvent = '';
+                        pendingData = '';
+                    }
+                }
+            }
+            // Tail flush for a final frame not terminated by a blank line.
+            if (!aborted) {
+                if (buffer) {
+                    const trailing = buffer.replace(/\r\n?/g, '\n');
+                    if (trailing.startsWith('event:')) {
+                        pendingEvent = trailing.slice(6).trim();
+                    } else if (trailing.startsWith('data:')) {
+                        pendingData += (pendingData ? '\n' : '') + trailing.slice(5).trim();
+                    }
+                }
+                if (pendingEvent && pendingData) {
+                    if (pendingEvent === 'done') receivedDone = true;
+                    dispatch(pendingEvent, pendingData);
+                }
+            }
+            if (!aborted && !receivedDone) {
+                handlers.onError?.({ code: 50000, message: 'stream closed without done' });
+            }
+        } catch (err: unknown) {
+            if (aborted) return; // user closed the panel — not an error
+            const msg = err instanceof Error ? err.message : String(err);
+            handlers.onError?.({ code: 50000, message: msg });
+        } finally {
+            reader?.releaseLock();
+        }
+    })();
+
+    return {
+        close: () => {
+            aborted = true;
+            reader?.cancel();
+        },
+    };
+}

--- a/packages/dmworksummary/src/preview/DocumentPreviewEntry.css
+++ b/packages/dmworksummary/src/preview/DocumentPreviewEntry.css
@@ -1,0 +1,125 @@
+/* DocumentPreviewEntry — self-contained styles for the AI 速览 port.
+   All selectors are prefixed `dm-doc-preview-` to avoid colliding with the host. */
+
+.dm-doc-preview-trigger {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    height: 28px;
+    padding: 0 10px;
+    border: 1px solid transparent;
+    border-radius: 6px;
+    background: transparent;
+    color: inherit;
+    font-size: 13px;
+    line-height: 1;
+    cursor: pointer;
+    white-space: nowrap;
+}
+.dm-doc-preview-trigger:hover {
+    background: rgba(0, 0, 0, 0.05);
+}
+.dm-doc-preview-trigger.is-active {
+    background: rgba(59, 130, 246, 0.12);
+    color: #2563eb;
+}
+
+.dm-doc-preview-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 1000;
+    background: rgba(0, 0, 0, 0.18);
+    display: flex;
+    justify-content: flex-end;
+}
+
+.dm-doc-preview-drawer {
+    width: 380px;
+    max-width: 92vw;
+    height: 100%;
+    background: #fff;
+    box-shadow: -2px 0 16px rgba(0, 0, 0, 0.12);
+    display: flex;
+    flex-direction: column;
+    animation: dm-doc-preview-slide-in 0.18s ease-out;
+}
+@keyframes dm-doc-preview-slide-in {
+    from { transform: translateX(24px); opacity: 0.6; }
+    to { transform: translateX(0); opacity: 1; }
+}
+
+.dm-doc-preview-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 12px 16px;
+    border-bottom: 1px solid #eee;
+    flex: 0 0 auto;
+}
+.dm-doc-preview-title {
+    font-size: 14px;
+    font-weight: 600;
+}
+.dm-doc-preview-head-actions {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.dm-doc-preview-btn {
+    height: 26px;
+    padding: 0 10px;
+    border: 1px solid #e2e2e2;
+    border-radius: 6px;
+    background: #fff;
+    color: #333;
+    font-size: 12px;
+    cursor: pointer;
+}
+.dm-doc-preview-btn:hover {
+    background: #f5f5f5;
+}
+.dm-doc-preview-askbot {
+    border-color: #c7d2fe;
+    color: #2563eb;
+}
+
+.dm-doc-preview-body {
+    flex: 1 1 auto;
+    overflow-y: auto;
+    padding: 16px;
+    font-size: 14px;
+    line-height: 1.6;
+    color: #1f2937;
+}
+.dm-doc-preview-hint {
+    color: #6b7280;
+    font-size: 13px;
+}
+.dm-doc-preview-error {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    color: #b91c1c;
+    font-size: 13px;
+}
+.dm-doc-preview-md :first-child {
+    margin-top: 0;
+}
+.dm-doc-preview-md h2 {
+    font-size: 15px;
+    margin: 14px 0 6px;
+}
+.dm-doc-preview-caret {
+    color: #9ca3af;
+    animation: dm-doc-preview-blink 1s steps(1) infinite;
+}
+@keyframes dm-doc-preview-blink {
+    50% { opacity: 0; }
+}
+
+.dm-doc-preview-foot {
+    flex: 0 0 auto;
+    padding: 12px 16px;
+    border-top: 1px solid #eee;
+}

--- a/packages/dmworksummary/src/preview/DocumentPreviewEntry.tsx
+++ b/packages/dmworksummary/src/preview/DocumentPreviewEntry.tsx
@@ -1,0 +1,235 @@
+// DocumentPreviewEntry — the drop-in "port" for document AI 速览.
+//
+// A fully self-contained capability: renders a trigger button and, on click, a
+// portal-mounted side panel that streams an ephemeral quick-glance of the document
+// (backend never persists it — not a Summary deliverable). Everything is inside
+// @dmwork/summary; the host (the detached docs module) only needs to render this
+// one component in its header:
+//
+//     import { DocumentPreviewEntry } from '@dmwork/summary/preview'
+//     <DocumentPreviewEntry docId={docId} spaceId={space} />
+//
+// The host does NOT need to know about the summary service, SSE, i18n, or state
+// handling — all of it lives here. See ./README.md for the integration contract.
+
+import React, { useEffect, useRef, useState } from 'react';
+import type { ReactNode } from 'react';
+import { createPortal } from 'react-dom';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import rehypeSanitize from 'rehype-sanitize';
+import { t } from '@octo/base';
+import { streamDocumentPreview } from '../api/summaryApi';
+import { ensurePreviewI18n } from './i18n';
+import './DocumentPreviewEntry.css';
+
+ensurePreviewI18n();
+
+export interface DocumentPreviewEntryProps {
+    /** The document to glance. Required. */
+    docId: string;
+    /** Viewer's current space; falls back to WKApp.shared.currentSpaceId. */
+    spaceId?: string;
+    /** Optional pinned version; omit for the latest. */
+    version?: string;
+    /**
+     * Optional bot 升级出口: called with docId when the user clicks "问 Bot 追问"
+     * (only shown after a completed glance). Omit to hide the action.
+     */
+    onAskBot?: (docId: string) => void;
+    /** Extra className for the default trigger button. */
+    className?: string;
+    /**
+     * Optional custom trigger. Receives `open()` and the current open state, so the
+     * host can render its own header button instead of the default ✨AI速览 one.
+     */
+    renderTrigger?: (open: () => void, active: boolean) => ReactNode;
+}
+
+type PreviewStatus = 'loading' | 'streaming' | 'done' | 'error' | 'empty';
+
+function classifyError(message: string): { status: PreviewStatus; text: string } {
+    // Empty-doc comes back as a pre-stream 400 whose message contains "没有可总结内容".
+    if (message.includes('没有可总结内容')) {
+        return { status: 'empty', text: t('summaryPreview.empty') };
+    }
+    if (message.includes('不可访问') || message.includes('权限') || message.includes('403')) {
+        return { status: 'error', text: t('summaryPreview.errorForbidden') };
+    }
+    if (message.includes('超时') || message.includes('timeout') || message.includes('暂不可用')) {
+        return { status: 'error', text: t('summaryPreview.errorTimeout') };
+    }
+    return { status: 'error', text: t('summaryPreview.errorGeneric') };
+}
+
+const REMARK_PLUGINS = [remarkGfm];
+
+function DocumentPreviewPanel(props: {
+    docId: string;
+    spaceId?: string;
+    version?: string;
+    onClose: () => void;
+    onAskBot?: (docId: string) => void;
+}) {
+    const { docId, spaceId, version, onClose, onAskBot } = props;
+    const [status, setStatus] = useState<PreviewStatus>('loading');
+    const [text, setText] = useState('');
+    const [errorText, setErrorText] = useState('');
+    const [reloadKey, setReloadKey] = useState(0);
+    const handleRef = useRef<{ close: () => void } | null>(null);
+
+    useEffect(() => {
+        let cancelled = false;
+        setStatus('loading');
+        setText('');
+        setErrorText('');
+        let acc = '';
+
+        const handle = streamDocumentPreview(
+            { documentId: docId, version, spaceId },
+            {
+                onDelta: (chunk) => {
+                    if (cancelled) return;
+                    acc += chunk;
+                    setText(acc);
+                    setStatus((s) => (s === 'loading' ? 'streaming' : s));
+                },
+                onDone: () => {
+                    if (cancelled) return;
+                    setStatus(acc.trim() ? 'done' : 'empty');
+                },
+                onError: (err) => {
+                    if (cancelled) return;
+                    const { status: st, text: msg } = classifyError(err.message || '');
+                    // Keep partial content rather than wiping it on a late error.
+                    if (acc.trim() && st === 'error') {
+                        setStatus('done');
+                        return;
+                    }
+                    setErrorText(msg);
+                    setStatus(st);
+                },
+            },
+        );
+        handleRef.current = handle;
+        return () => {
+            cancelled = true;
+            handle.close();
+        };
+    }, [docId, version, spaceId, reloadKey]);
+
+    const busy = status === 'loading' || status === 'streaming';
+    const stop = () => {
+        handleRef.current?.close();
+        setStatus((s) => (s === 'loading' || s === 'streaming' ? 'done' : s));
+    };
+
+    return (
+        <div className="dm-doc-preview-overlay" role="presentation" onMouseDown={onClose}>
+            <aside
+                className="dm-doc-preview-drawer"
+                role="complementary"
+                aria-label={t('summaryPreview.title')}
+                onMouseDown={(e) => e.stopPropagation()}
+            >
+                <header className="dm-doc-preview-head">
+                    <span className="dm-doc-preview-title">✨ {t('summaryPreview.title')}</span>
+                    <div className="dm-doc-preview-head-actions">
+                        {busy && (
+                            <button type="button" className="dm-doc-preview-btn" onClick={stop}>
+                                {t('summaryPreview.stop')}
+                            </button>
+                        )}
+                        <button
+                            type="button"
+                            className="dm-doc-preview-btn"
+                            onClick={onClose}
+                            aria-label="close"
+                        >
+                            ✕
+                        </button>
+                    </div>
+                </header>
+
+                <div className="dm-doc-preview-body">
+                    {status === 'loading' && (
+                        <div className="dm-doc-preview-hint">{t('summaryPreview.loading')}</div>
+                    )}
+
+                    {(status === 'streaming' || status === 'done') && (
+                        <div className="dm-doc-preview-md">
+                            <ReactMarkdown remarkPlugins={REMARK_PLUGINS} rehypePlugins={[rehypeSanitize]}>
+                                {text}
+                            </ReactMarkdown>
+                            {status === 'streaming' && <span className="dm-doc-preview-caret">▍</span>}
+                        </div>
+                    )}
+
+                    {status === 'empty' && (
+                        <div className="dm-doc-preview-hint">{t('summaryPreview.empty')}</div>
+                    )}
+
+                    {status === 'error' && (
+                        <div className="dm-doc-preview-error">
+                            <div>{errorText}</div>
+                            <button
+                                type="button"
+                                className="dm-doc-preview-btn"
+                                onClick={() => setReloadKey((k) => k + 1)}
+                            >
+                                {t('summaryPreview.retry')}
+                            </button>
+                        </div>
+                    )}
+                </div>
+
+                {status === 'done' && onAskBot && (
+                    <footer className="dm-doc-preview-foot">
+                        <button
+                            type="button"
+                            className="dm-doc-preview-btn dm-doc-preview-askbot"
+                            onClick={() => onAskBot(docId)}
+                        >
+                            💬 {t('summaryPreview.askBot')}
+                        </button>
+                    </footer>
+                )}
+            </aside>
+        </div>
+    );
+}
+
+export function DocumentPreviewEntry(props: DocumentPreviewEntryProps) {
+    const { docId, spaceId, version, onAskBot, className, renderTrigger } = props;
+    const [open, setOpen] = useState(false);
+    const openPanel = () => setOpen(true);
+
+    return (
+        <>
+            {renderTrigger ? (
+                renderTrigger(openPanel, open)
+            ) : (
+                <button
+                    type="button"
+                    className={`dm-doc-preview-trigger${className ? ' ' + className : ''}${open ? ' is-active' : ''}`}
+                    title={t('summaryPreview.button')}
+                    aria-pressed={open}
+                    onClick={openPanel}
+                >
+                    ✨ {t('summaryPreview.button')}
+                </button>
+            )}
+            {open &&
+                createPortal(
+                    <DocumentPreviewPanel
+                        docId={docId}
+                        spaceId={spaceId}
+                        version={version}
+                        onClose={() => setOpen(false)}
+                        onAskBot={onAskBot}
+                    />,
+                    document.body,
+                )}
+        </>
+    );
+}

--- a/packages/dmworksummary/src/preview/README.md
+++ b/packages/dmworksummary/src/preview/README.md
@@ -1,0 +1,49 @@
+# 文档 AI 速览 · 接入端口（`@dmwork/summary/preview`）
+
+给文档模块（`octo-enterprise-modules` 里的编辑器）用的**一行接入**能力。速览的全部逻辑
+（触发按钮、流式面板、加载/流式/失败/空 四态、Markdown 渲染、i18n、调后端）都封装在
+`@dmwork/summary` 内部，宿主**不需要**了解 summary 服务、SSE 或状态处理。
+
+## 接入方式（文档模块侧）
+
+在文档标题栏渲染一个组件即可：
+
+```tsx
+import { DocumentPreviewEntry } from '@dmwork/summary/preview'
+
+// 文档页标题栏右侧
+<DocumentPreviewEntry docId={docId} spaceId={currentSpaceId} />
+```
+
+就这样。点击按钮会弹出右侧速览面板并开始流式生成；关闭即丢弃（不落库、不进列表）。
+
+## Props
+
+| prop | 必填 | 说明 |
+|---|---|---|
+| `docId` | ✅ | 要速览的文档 id |
+| `spaceId` | | 当前空间；缺省回退 `WKApp.shared.currentSpaceId` |
+| `version` | | 指定版本；缺省取最新 |
+| `onAskBot(docId)` | | 「问 Bot 追问」出口回调；只在速览完成后显示。不传则不显示该按钮 |
+| `className` | | 默认触发按钮的额外 class |
+| `renderTrigger(open, active)` | | 自定义触发器（用宿主自己的标题栏按钮），返回你的节点、内部调用 `open()` 打开面板 |
+
+### 用宿主自己的按钮（可选）
+
+```tsx
+<DocumentPreviewEntry
+  docId={docId}
+  spaceId={space}
+  renderTrigger={(open, active) => (
+    <MyHeaderButton active={active} onClick={open}>✨ 速览</MyHeaderButton>
+  )}
+/>
+```
+
+## 依赖前提
+
+- 宿主构建能解析 `@dmwork/summary`（enterprise module 与 octo-web 一起构建，通常已满足）。
+- 后端需部署 `POST /summary/api/v1/summaries/document/preview`（octo-smart-summary）
+  且配好 `DOCUMENT_SOURCE_API_URL`。
+- i18n 自带并**自注册** `summaryPreview` 命名空间，无需宿主注册。
+- 该端口**不依赖** SummaryModule 是否加载，可独立使用。

--- a/packages/dmworksummary/src/preview/i18n.ts
+++ b/packages/dmworksummary/src/preview/i18n.ts
@@ -1,0 +1,42 @@
+// Self-contained i18n for the document AI 速览 port. Registers its OWN namespace
+// so the component works even when the host (e.g. the detached docs module) has
+// not loaded the full SummaryModule. Idempotent.
+
+import { i18n } from '@octo/base';
+
+const zhCN = {
+    button: 'AI速览',
+    title: 'AI速览',
+    loading: '正在读取文档…',
+    stop: '停止',
+    retry: '重试',
+    askBot: '问 Bot 追问',
+    empty: '这份文档暂无足够内容可速览',
+    errorForbidden: '你没有权限查看这份文档',
+    errorTimeout: '文档服务响应超时，请稍后重试',
+    errorGeneric: '文档速览生成失败，请重试',
+};
+
+const enUS = {
+    button: 'AI Glance',
+    title: 'AI Glance',
+    loading: 'Reading the document…',
+    stop: 'Stop',
+    retry: 'Retry',
+    askBot: 'Ask the Bot',
+    empty: 'This document has too little content to glance',
+    errorForbidden: "You don't have access to this document",
+    errorTimeout: 'The document service timed out, please retry',
+    errorGeneric: 'Failed to generate the glance, please retry',
+};
+
+let registered = false;
+
+export function ensurePreviewI18n(): void {
+    if (registered) return;
+    registered = true;
+    i18n.registerNamespace('summaryPreview', {
+        'zh-CN': zhCN,
+        'en-US': enUS,
+    });
+}

--- a/packages/dmworksummary/src/preview/index.ts
+++ b/packages/dmworksummary/src/preview/index.ts
@@ -1,0 +1,4 @@
+// Public entry for the document AI 速览 port.
+// Host integration: `import { DocumentPreviewEntry } from '@dmwork/summary/preview'`
+export { DocumentPreviewEntry } from './DocumentPreviewEntry';
+export type { DocumentPreviewEntryProps } from './DocumentPreviewEntry';


### PR DESCRIPTION
## 背景
把「文档 AI 速览」这一能力做成 **@dmwork/summary 内的自包含端口**。上游 #1363 已将 `packages/docs` 从 octo-web 拆到独立的 `octo-enterprise-modules`,因此速览 UI 不再直接改文档编辑器,而是封装成一个组件,文档模块**一行接入**即可:

```tsx
import { DocumentPreviewEntry } from '@dmwork/summary/preview'
<DocumentPreviewEntry docId={docId} spaceId={space} />
```

宿主无需了解 summary 服务 / SSE / i18n / 状态处理。

## 改动
- `summaryApi.ts`:`streamDocumentPreview()` —— SSE-over-POST 客户端(与 `agentChatStream` 同构)。
- `src/preview/`:`DocumentPreviewEntry`(触发按钮 + portal 挂载的流式面板;`react-markdown` 渲染;加载/流式/失败/空 四态;可选「问 Bot 追问」出口),自注册 `summaryPreview` i18n 命名空间,自带 CSS,附 `README.md` 接入说明。
- `package.json`:新增 UI-free 的 `@dmwork/summary/api` 与 `@dmwork/summary/preview` 子路径导出(避免宿主从 barrel 拉入 Semi/react-markdown 整个 UI 图)。

## 特性
- **不落库**:速览是临时快览,不创建 Summary Task、不进列表/权限/历史。
- **自包含**:不依赖已移除的 `packages/docs`,不依赖 SummaryModule 是否加载。

## 后端配套
- `POST /summary/api/v1/summaries/document/preview`(octo-smart-summary,单独 PR),需配置 `DOCUMENT_SOURCE_API_URL`。

## 验证
- 端口组件零逻辑类型错误(仓库现存的 react/Semi 类型解析噪音为既有环境问题,与本改动无关)。
- 未跑 e2e bundle build。

🤖 Generated with [Claude Code](https://claude.com/claude-code)