### PR TITLE
feat(summary): freeze v2 agent contract — request_id/run_id + finish_status/gaps (WEB-01)

### DIFF
--- a/packages/dmworksummary/src/api/__tests__/agentChatStream.test.ts
+++ b/packages/dmworksummary/src/api/__tests__/agentChatStream.test.ts
@@ -163,6 +163,51 @@ data: {"reply":"test result"}
         close();
     });
 
+    it('surfaces run_id in the done event (SS-11 v2 contract)', async () => {
+        const onDone = vi.fn();
+        const sseData = `event: done
+data: {"reply":"r","session_id":"s1","run_id":"run-abc"}
+
+`;
+        const mockReader = {
+            read: vi.fn()
+                .mockResolvedValueOnce({ done: false, value: new TextEncoder().encode(sseData) })
+                .mockResolvedValueOnce({ done: true, value: undefined }),
+            cancel: vi.fn(),
+            releaseLock: vi.fn(),
+        };
+        fetchMock.mockResolvedValueOnce({ ok: true, body: { getReader: () => mockReader } });
+
+        const { close } = agentChatStream(
+            { session_id: 's1', message: 'q', profile: 'summary' },
+            { onDone },
+        );
+        await new Promise(resolve => setTimeout(resolve, 100));
+
+        expect(onDone).toHaveBeenCalledWith({ reply: 'r', session_id: 's1', run_id: 'run-abc' });
+        close();
+    });
+
+    it('sends request_id and run_id in the request body when provided (SS-11)', async () => {
+        const mockReader = {
+            read: vi.fn().mockResolvedValueOnce({ done: true, value: undefined }),
+            cancel: vi.fn(),
+            releaseLock: vi.fn(),
+        };
+        fetchMock.mockResolvedValueOnce({ ok: true, body: { getReader: () => mockReader } });
+
+        const { close } = agentChatStream(
+            { session_id: 's1', message: 'q', profile: 'summary', request_id: 'req-1', run_id: 'run-1' },
+            { onDone: vi.fn(), onError: vi.fn() },
+        );
+        await new Promise(resolve => setTimeout(resolve, 50));
+
+        const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+        expect(body.request_id).toBe('req-1');
+        expect(body.run_id).toBe('run-1');
+        close();
+    });
+
     it('should call onError when fetch fails', async () => {
         const onProgress = vi.fn();
         const onDone = vi.fn();

--- a/packages/dmworksummary/src/api/__tests__/summaryApi.test.ts
+++ b/packages/dmworksummary/src/api/__tests__/summaryApi.test.ts
@@ -418,6 +418,21 @@ describe('summaryApi', () => {
             expect(res).toEqual({ reply: '总结如下…', session_id: 's-1' });
         });
 
+        it('surfaces run_id + passes request_id through (SS-11 v2 contract)', async () => {
+            const { agentChat } = await import('../summaryApi');
+            mockPost.mockResolvedValueOnce({
+                data: { code: 0, data: { reply: 'r', session_id: 's-1', run_id: 'run-xyz' } },
+            });
+            const res = await agentChat({ message: 'q', session_id: 's-1', request_id: 'req-9' });
+            // request_id flows through in the posted body (idempotency key).
+            expect(mockPost).toHaveBeenCalledWith(
+                '/summary/api/v1/agent/chat',
+                { message: 'q', session_id: 's-1', request_id: 'req-9' },
+                { timeout: 120000 },
+            );
+            expect(res).toEqual({ reply: 'r', session_id: 's-1', run_id: 'run-xyz' });
+        });
+
         it('throws on non-zero envelope code (no silent success)', async () => {
             const { agentChat } = await import('../summaryApi');
             mockPost.mockResolvedValueOnce({
@@ -490,6 +505,52 @@ describe('summaryApi', () => {
             expect(started).toHaveLength(1);
             expect(started[0][1]).toMatchObject({ trigger_mode: 'agent' });
             track.mockRestore();
+        });
+
+        it('returns finish_status + gaps when the v2 backend provides them (SS-11)', async () => {
+            const { Dap } = await import('@octo/base');
+            const track = vi.spyOn(Dap.shared, 'track').mockImplementation(() => undefined);
+            const { createAgentSummary } = await import('../summaryApi');
+            mockPost.mockResolvedValueOnce({
+                data: {
+                    code: 0,
+                    data: {
+                        task_id: 5, task_no: 'n5', status: 1, created_at: 'x',
+                        finish_status: 'PARTIAL',
+                        gaps: [{ kind: 'coverage', detail: '频道 X 未覆盖', error_code: 'COV_MISS' }],
+                    },
+                },
+            });
+            const res = await createAgentSummary({} as any, {});
+            expect(res.task_id).toBe(5);
+            expect(res.finish_status).toBe('PARTIAL');
+            expect(res.gaps).toEqual([{ kind: 'coverage', detail: '频道 X 未覆盖', error_code: 'COV_MISS' }]);
+            track.mockRestore();
+        });
+
+        it('omits finish_status/gaps for a legacy backend (SS-11 back-compat)', async () => {
+            const { Dap } = await import('@octo/base');
+            const track = vi.spyOn(Dap.shared, 'track').mockImplementation(() => undefined);
+            const { createAgentSummary } = await import('../summaryApi');
+            mockPost.mockResolvedValueOnce({ data: { code: 0, data: { task_id: 6, task_no: 'n6', status: 1, created_at: 'x' } } });
+            const res = await createAgentSummary({} as any, {});
+            expect(res.task_id).toBe(6);
+            expect(res.finish_status).toBeUndefined();
+            expect(res.gaps).toBeUndefined();
+            track.mockRestore();
+        });
+
+        it('propagates 422/42200 FAILED with the code accessible (SS-07b/SS-11)', async () => {
+            const { createAgentSummary } = await import('../summaryApi');
+            // A FAILED verdict is HTTP 422 → axios rejects; the caller keeps the chat
+            // open and must be able to read err.response.data.code === 42200.
+            const axiosErr = Object.assign(new Error('failed'), {
+                response: { status: 422, data: { code: 42200, message: '总结未通过完成校验（FAILED），未保存' } },
+            });
+            mockPost.mockRejectedValueOnce(axiosErr);
+            await expect(createAgentSummary({} as any, {})).rejects.toMatchObject({
+                response: { data: { code: 42200 } },
+            });
         });
 
         it('agent mode does NOT emit on business failure (code!==0)', async () => {

--- a/packages/dmworksummary/src/api/summaryApi.ts
+++ b/packages/dmworksummary/src/api/summaryApi.ts
@@ -10,6 +10,7 @@ import type {
     ChatCandidate,
     CreateSummaryParams,
     CreateAgentSummaryParams,
+    CreateAgentSummaryResult,
     CreateScheduleParams,
     CustomTopicTemplatePayload,
     InferResult,
@@ -339,7 +340,7 @@ export async function createSummary(
 export async function createAgentSummary(
     params: CreateAgentSummaryParams,
     trackProps: Record<string, unknown> = {},
-): Promise<{ task_id: number; task_no: string; status: number; created_at: string }> {
+): Promise<CreateAgentSummaryResult> {
     const resp = await summaryAxios.post(`${BASE}/summaries/agent`, params);
     const envelopeCode = resp.data?.code;
     // 七审 P1:与 trackOnEnvelopeSuccess 同口径,严格 code===0 才算成功。
@@ -359,9 +360,7 @@ export async function createAgentSummary(
     // 故只从 data 取;此前的 `?? resp.data` 回退是给「无信封裸响应」用的,而那正是 code===undefined 的情形,
     // 已在上面 :350 rejected —— 回退再也走不到(裸响应没有 task_id,反而会在下面 :361 抛),留着只会
     // 误导「仍支持裸响应」。去掉,语义与实际行为一致。
-    const data = resp.data?.data as {
-        task_id: number; task_no: string; status: number; created_at: string;
-    } | undefined;
+    const data = resp.data?.data as CreateAgentSummaryResult | undefined;
     if (!data || typeof data.task_id !== 'number' || data.task_id <= 0) {
         // 后端返成功但 task_id 缺失/非法 —— 视为保存失败,不能清 chat
         throw new Error(resp.data?.message || 'create agent summary returned no task_id');
@@ -389,7 +388,8 @@ export async function agentChat(params: AgentChatParams): Promise<AgentChatResul
         if (!data?.reply) {
             throw new Error(resp.data?.message || 'agent chat failed');
         }
-        return { reply: data.reply, session_id: data.session_id };
+        // SS-11: surface run_id when present (V2 on); omitted by legacy backend.
+        return { reply: data.reply, session_id: data.session_id, run_id: data.run_id };
     } catch (err) {
         if (axios.isCancel(err)) throw err;
         if (err instanceof Error) throw err;

--- a/packages/dmworksummary/src/types/summary.ts
+++ b/packages/dmworksummary/src/types/summary.ts
@@ -350,7 +350,39 @@ export interface CreateAgentSummaryParams {
     referenced_task_ids?: number[];
 }
 
-/** Agent 对话单条消息（user 右气泡 / assistant 左气泡） */
+/**
+ * v2 完成判定(SS-07 / SS-11)。COMPLETE = 完整交付;PARTIAL = 有缺口但可保存
+ * (前端应展示警示 + gaps)。FAILED 不会出现在成功响应里——后端直接 422/42200 拒存。
+ */
+export type FinishStatus = 'COMPLETE' | 'PARTIAL';
+
+/**
+ * v2 覆盖/质量缺口(SS-07 finishgate.Gap)。用于 PARTIAL 时向用户披露"哪里没盖全"。
+ */
+export interface CoverageGap {
+    /** 缺口种类,如 tool_error / coverage / evidence 等(后端枚举,前端按需归类展示)。 */
+    kind: string;
+    /** 人类可读的缺口说明。 */
+    detail: string;
+    /** 可选:关联的结构化错误码。 */
+    error_code?: string;
+}
+
+/**
+ * createAgentSummary 保存成功响应(SS-11 起附带 finish_status + gaps)。
+ * 与传统 createSummary 同构的 {task_id,task_no,status,created_at} 之上,
+ * v2 后端(AGENT_SUMMARY_V2_MODE!=off)追加完成判定;旧后端 / V2 off 时缺省。
+ */
+export interface CreateAgentSummaryResult {
+    task_id: number;
+    task_no: string;
+    status: number;
+    created_at: string;
+    /** v2:COMPLETE / PARTIAL(FAILED 走 422,不会到这里)。 */
+    finish_status?: FinishStatus;
+    /** v2:PARTIAL 时的覆盖缺口清单;COMPLETE 时为空数组。 */
+    gaps?: CoverageGap[];
+}
 export interface ChatMessage {
     role: 'user' | 'assistant';
     content: string;
@@ -369,6 +401,17 @@ export interface AgentChatParams {
      * 后续轮次此字段被忽略(引用一次锁定)。见 CHAT-REFERENCE-BASED-DESIGN-v1。
      */
     referenced_task_ids?: number[];
+    /**
+     * v2 契约(SS-11 · AGENT_SUMMARY_V2_MODE!=off 时后端才产出对应产物):
+     * 本次提交的幂等键。调用方**每次逻辑提交生成一个,重试时复用同一个**,
+     * 后端据此去重(同 request_id 不重复建 Run/执行工具)。可选,旧后端忽略。
+     */
+    request_id?: string;
+    /**
+     * v2 契约:续跑一个已存在的 Run。首轮由后端在响应里返回 run_id,
+     * 前端在同一 session 的后续提交带回。可选,旧后端忽略。
+     */
+    run_id?: string;
     /** 用户在 UI 中明确选定、希望 agent 默认处理的聊天。 */
     selected_channels?: Array<Pick<ChatCandidate, 'chat_id' | 'chat_type' | 'name' | 'is_archived'>>;
 }
@@ -377,6 +420,8 @@ export interface AgentChatParams {
 export interface AgentChatResult {
     reply: string;
     session_id: string;
+    /** v2 契约(SS-11):持久化 Run 的 id;旧后端 / V2 off 时缺省。 */
+    run_id?: string;
 }
 
 /**
@@ -420,6 +465,8 @@ export interface AgentProgressEvent {
 export interface AgentDoneEvent {
     reply: string;
     session_id: string;
+    /** v2 契约(SS-11):持久化 Run 的 id;旧后端 / V2 off 时缺省。 */
+    run_id?: string;
 }
 
 /**


### PR DESCRIPTION
## What
对齐后端 v2 契约(SS-03/07/11)。全部可选、向后兼容:legacy 后端缺省即 undefined,现有调用方不受影响。
- types:AgentChatParams +request_id?/run_id?;AgentChatResult/AgentDoneEvent +run_id?;新增 FinishStatus、CoverageGap、CreateAgentSummaryResult(+finish_status?/gaps?)。
- api:agentChat 吐出 run_id;createAgentSummary 返回加宽结果(finish_status/gaps 透传);422/42200 FAILED 上抛且 code 可读;request_id/run_id 随 params 整体序列化,无需改发送侧。

## 依赖
需后端 **PR(SS-11,surface run_id/finish_status/gaps)** 的契约。可先开 PR 走 review,合并前确认后端契约已合。属地基批次,后端对应 Wave 1/Wave 2 数据契约。

## Tests(vitest 直跑,绕过 repo 级 React-19 tsc 噪音)
- done 事件 run_id、请求体 request_id/run_id、agentChat 吐 run_id、save 返回 finish_status+gaps(legacy 缺省)、42200 传播 —— **46/46**;改动的 2 个源文件 **0 tsc 错**。

## Review checklist
- [ ] 新字段全可选、缺省 undefined(back-compat)
- [ ] createAgentSummary 返回 finish_status/gaps 透传
- [ ] 42200 error 保留 err.response.data.code

## Note
仓库 HEAD 的 `tsc --noEmit` 对本包本就有大量 node_modules/React-19 基线报错(非本 PR),故用 vitest 直跑取信号并 grep 确认改动文件 0 tsc 错。
