### PR TITLE
feat(summary): send request_id per submit to activate the v2 run pipeline (WEB-03)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,13 @@ jobs:
         run: |
           pnpm --filter @octo/base exec vitest run src/__tests__/EndpointCommon.menuSwitch.test.tsx
           pnpm --filter @dmwork/summary exec vitest run src/__tests__/module.menuSwitch.test.tsx
+      - name: Agent summary v2 run-binding tests (WEB-03)
+        run: >-
+          pnpm --filter @dmwork/summary exec vitest run
+          src/utils/__tests__/genRequestId.test.ts
+          src/utils/agentChatSession.test.ts
+          src/api/__tests__/agentChatStream.test.ts
+          src/components/__tests__/AgentChatPanel.sse.test.tsx
       - name: I18n check
         run: pnpm i18n:check
       - name: Voice and settings regression tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,7 @@ jobs:
           src/utils/agentChatSession.test.ts
           src/api/__tests__/agentChatStream.test.ts
           src/api/__tests__/summaryApi.test.ts
+          src/components/__tests__/AgentChatPanel.test.tsx
           src/components/__tests__/AgentChatPanel.sse.test.tsx
           src/components/__tests__/ChatSummaryNewModal.test.tsx
           src/pages/__tests__/SummaryCreatePage.test.tsx

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,10 @@ jobs:
           src/utils/__tests__/genRequestId.test.ts
           src/utils/agentChatSession.test.ts
           src/api/__tests__/agentChatStream.test.ts
+          src/api/__tests__/summaryApi.test.ts
           src/components/__tests__/AgentChatPanel.sse.test.tsx
+          src/components/__tests__/ChatSummaryNewModal.test.tsx
+          src/pages/__tests__/SummaryCreatePage.test.tsx
       - name: I18n check
         run: pnpm i18n:check
       - name: Voice and settings regression tests

--- a/packages/dmworksummary/src/api/__tests__/agentChatStream.test.ts
+++ b/packages/dmworksummary/src/api/__tests__/agentChatStream.test.ts
@@ -208,6 +208,32 @@ data: {"reply":"r","session_id":"s1","run_id":"run-abc"}
         close();
     });
 
+    it('does not synthesize a transient close error after a backend error event', async () => {
+        const onError = vi.fn();
+        const sseData = `event: error
+data: {"code":50001,"message":"backend failed"}
+
+`;
+        const mockReader = {
+            read: vi.fn()
+                .mockResolvedValueOnce({ done: false, value: new TextEncoder().encode(sseData) })
+                .mockResolvedValueOnce({ done: true, value: undefined }),
+            cancel: vi.fn(),
+            releaseLock: vi.fn(),
+        };
+        fetchMock.mockResolvedValueOnce({ ok: true, body: { getReader: () => mockReader } });
+
+        const { close } = agentChatStream(
+            { session_id: 's1', message: 'q', profile: 'summary', request_id: 'req-1' },
+            { onError },
+        );
+        await new Promise(resolve => setTimeout(resolve, 100));
+
+        expect(onError).toHaveBeenCalledTimes(1);
+        expect(onError).toHaveBeenCalledWith({ code: 50001, message: 'backend failed' });
+        close();
+    });
+
     it('should call onError when fetch fails', async () => {
         const onProgress = vi.fn();
         const onDone = vi.fn();

--- a/packages/dmworksummary/src/api/__tests__/agentChatStream.test.ts
+++ b/packages/dmworksummary/src/api/__tests__/agentChatStream.test.ts
@@ -234,6 +234,68 @@ data: {"code":50001,"message":"backend failed"}
         close();
     });
 
+    it('synthesizes a transient close error when an error frame is malformed', async () => {
+        const onDone = vi.fn();
+        const onError = vi.fn();
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        const sseData = `event: error
+data: {"code":50001
+
+`;
+        const mockReader = {
+            read: vi.fn()
+                .mockResolvedValueOnce({ done: false, value: new TextEncoder().encode(sseData) })
+                .mockResolvedValueOnce({ done: true, value: undefined }),
+            cancel: vi.fn(),
+            releaseLock: vi.fn(),
+        };
+        fetchMock.mockResolvedValueOnce({ ok: true, body: { getReader: () => mockReader } });
+
+        const { close } = agentChatStream(
+            { session_id: 's1', message: 'q', profile: 'summary', request_id: 'req-1' },
+            { onDone, onError },
+        );
+        await new Promise(resolve => setTimeout(resolve, 100));
+
+        expect(onDone).not.toHaveBeenCalled();
+        expect(onError).toHaveBeenCalledTimes(1);
+        expect(onError).toHaveBeenCalledWith({
+            code: 50000,
+            message: 'stream closed without done',
+            transient: true,
+        });
+        expect(warn).toHaveBeenCalled();
+        close();
+    });
+
+    it('synthesizes a transient close error when the final done frame is truncated', async () => {
+        const onDone = vi.fn();
+        const onError = vi.fn();
+        vi.spyOn(console, 'warn').mockImplementation(() => {});
+        const mockReader = {
+            read: vi.fn()
+                .mockResolvedValueOnce({
+                    done: false,
+                    value: new TextEncoder().encode('event: done\ndata: {"reply":"partial'),
+                })
+                .mockResolvedValueOnce({ done: true, value: undefined }),
+            cancel: vi.fn(),
+            releaseLock: vi.fn(),
+        };
+        fetchMock.mockResolvedValueOnce({ ok: true, body: { getReader: () => mockReader } });
+
+        const { close } = agentChatStream(
+            { session_id: 's1', message: 'q', profile: 'summary' },
+            { onDone, onError },
+        );
+        await new Promise(resolve => setTimeout(resolve, 100));
+
+        expect(onDone).not.toHaveBeenCalled();
+        expect(onError).toHaveBeenCalledTimes(1);
+        expect(onError).toHaveBeenCalledWith(expect.objectContaining({ transient: true }));
+        close();
+    });
+
     it('should call onError when fetch fails', async () => {
         const onProgress = vi.fn();
         const onDone = vi.fn();

--- a/packages/dmworksummary/src/api/__tests__/summaryApi.test.ts
+++ b/packages/dmworksummary/src/api/__tests__/summaryApi.test.ts
@@ -507,6 +507,19 @@ describe('summaryApi', () => {
             track.mockRestore();
         });
 
+        it('passes request_id through on agent save so the backend can bind the Run manifest', async () => {
+            const { Dap } = await import('@octo/base');
+            const track = vi.spyOn(Dap.shared, 'track').mockImplementation(() => undefined);
+            const { createAgentSummary } = await import('../summaryApi');
+            mockPost.mockResolvedValueOnce({ data: { code: 0, data: { task_id: 4, task_no: 'n', status: 1, created_at: 'x' } } });
+            await createAgentSummary({ session_id: 's1', title: 't', request_id: 'req-save-1' }, {});
+            expect(mockPost).toHaveBeenCalledWith(
+                expect.any(String),
+                expect.objectContaining({ session_id: 's1', title: 't', request_id: 'req-save-1' }),
+            );
+            track.mockRestore();
+        });
+
         it('returns finish_status + gaps when the v2 backend provides them (SS-11)', async () => {
             const { Dap } = await import('@octo/base');
             const track = vi.spyOn(Dap.shared, 'track').mockImplementation(() => undefined);

--- a/packages/dmworksummary/src/api/summaryApi.ts
+++ b/packages/dmworksummary/src/api/summaryApi.ts
@@ -473,6 +473,7 @@ export function agentChatStream(
             let pendingEvent = '';
             let pendingData = '';
             let receivedDone = false;
+            let receivedError = false;
             while (!aborted) {
                 const { done, value } = await reader.read();
                 if (done) break;
@@ -496,6 +497,8 @@ export function agentChatStream(
                         if (pendingEvent && pendingData) {
                             if (pendingEvent === 'done') {
                                 receivedDone = true;
+                            } else if (pendingEvent === 'error') {
+                                receivedError = true;
                             }
                             parseAndDispatch(pendingEvent, pendingData, handlers);
                         }
@@ -520,12 +523,14 @@ export function agentChatStream(
                 if (pendingEvent && pendingData) {
                     if (pendingEvent === 'done') {
                         receivedDone = true;
+                    } else if (pendingEvent === 'error') {
+                        receivedError = true;
                     }
                     parseAndDispatch(pendingEvent, pendingData, handlers);
                 }
             }
             // 流已关闭,但如果没收到 done 事件,触发错误让 UI 解锁
-            if (!aborted && !receivedDone) {
+            if (!aborted && !receivedDone && !receivedError) {
                 handlers.onError?.({ code: 50000, message: 'stream closed without done', transient: true });
             }
         } catch (err: unknown) {

--- a/packages/dmworksummary/src/api/summaryApi.ts
+++ b/packages/dmworksummary/src/api/summaryApi.ts
@@ -495,12 +495,14 @@ export function agentChatStream(
                     } else if (line === '') {
                         // 空行是帧边界,解析并分发
                         if (pendingEvent && pendingData) {
-                            if (pendingEvent === 'done') {
-                                receivedDone = true;
-                            } else if (pendingEvent === 'error') {
-                                receivedError = true;
+                            const dispatched = parseAndDispatch(pendingEvent, pendingData, handlers);
+                            if (dispatched) {
+                                if (pendingEvent === 'done') {
+                                    receivedDone = true;
+                                } else if (pendingEvent === 'error') {
+                                    receivedError = true;
+                                }
                             }
-                            parseAndDispatch(pendingEvent, pendingData, handlers);
                         }
                         pendingEvent = '';
                         pendingData = '';
@@ -521,12 +523,14 @@ export function agentChatStream(
                     buffer = '';
                 }
                 if (pendingEvent && pendingData) {
-                    if (pendingEvent === 'done') {
-                        receivedDone = true;
-                    } else if (pendingEvent === 'error') {
-                        receivedError = true;
+                    const dispatched = parseAndDispatch(pendingEvent, pendingData, handlers);
+                    if (dispatched) {
+                        if (pendingEvent === 'done') {
+                            receivedDone = true;
+                        } else if (pendingEvent === 'error') {
+                            receivedError = true;
+                        }
                     }
-                    parseAndDispatch(pendingEvent, pendingData, handlers);
                 }
             }
             // 流已关闭,但如果没收到 done 事件,触发错误让 UI 解锁
@@ -550,27 +554,28 @@ export function agentChatStream(
     };
 }
 
-/** 解析 SSE data 并分发到对应 handler */
-function parseAndDispatch(event: string, data: string, handlers: AgentStreamHandlers): void {
+/** 解析 SSE data 并分发；仅成功处理已知事件时返回 true。 */
+function parseAndDispatch(event: string, data: string, handlers: AgentStreamHandlers): boolean {
     try {
         const parsed = JSON.parse(data);
         switch (event) {
             case 'progress':
                 handlers.onProgress?.(parsed as AgentProgressEvent);
-                break;
+                return true;
             case 'done':
                 handlers.onDone?.(parsed as AgentDoneEvent);
-                break;
+                return true;
             case 'error':
                 handlers.onError?.(parsed as AgentErrorEvent);
-                break;
+                return true;
             default:
                 // 未知事件忽略
-                break;
+                return false;
         }
     } catch (err) {
         // JSON 解析失败,忽略该帧
         console.warn('Failed to parse SSE data:', data, err);
+        return false;
     }
 }
 

--- a/packages/dmworksummary/src/components/AgentChatPanel.tsx
+++ b/packages/dmworksummary/src/components/AgentChatPanel.tsx
@@ -165,15 +165,17 @@ export default class AgentChatPanel extends Component<AgentChatPanelProps, Agent
         // 先本地追加 user 消息(纯 UI,不发请求)
         onUserMessage?.(text, sessionId);
 
-        // 每轮都把引用传给后端(和 CHAT-REFERENCE-BASED-DESIGN-v1 多轮上下文修复对齐)。
-        // 这里先冻结本次 submit 的 scope，fallback 复用同一份，避免同一 request_id
-        // 下前后两次请求的 scope 发生漂移。
-        const refIds = this.props.referencedTaskIds && this.props.referencedTaskIds.length > 0
-            ? this.props.referencedTaskIds
-            : undefined;
-        const selectedChannels = this.requestSelectedChannels();
+        let refIds: number[] | undefined;
+        let selectedChannels: ReturnType<AgentChatPanel['requestSelectedChannels']>;
 
         try {
+            // 每轮都把引用传给后端(和 CHAT-REFERENCE-BASED-DESIGN-v1 多轮上下文修复对齐)。
+            // 在 try 内冻结本次 submit 的 scope，fallback 复用同一份，避免同一
+            // request_id 下前后两次请求的 scope 发生漂移；scope 构造异常也能解锁。
+            refIds = this.props.referencedTaskIds && this.props.referencedTaskIds.length > 0
+                ? [...this.props.referencedTaskIds]
+                : undefined;
+            selectedChannels = this.requestSelectedChannels();
             const { close } = agentChatStream({
                 session_id: sessionId,
                 message: text,
@@ -226,13 +228,14 @@ export default class AgentChatPanel extends Component<AgentChatPanelProps, Agent
                 onError: (evt: AgentErrorEvent) => {
                     const { t } = this.context;
                     Toast.error(`${t('summary.common.agentChat.error')}: ${evt.message}`);
-                    this.setState({ isStreaming: false });
                     this.streamCloseHandle = null;
                     // 仅传输层失败(transient: true)才重试；summaryApi 会在收到
                     // 后端 error frame 后抑制 close-without-done 的二次 transient。
                     if (evt.transient) {
                         this.fallbackToNormalChat(text, sessionId, profile, requestId, refIds, selectedChannels);
+                        return;
                     }
+                    this.setState({ isStreaming: false });
                 },
             });
 

--- a/packages/dmworksummary/src/components/AgentChatPanel.tsx
+++ b/packages/dmworksummary/src/components/AgentChatPanel.tsx
@@ -3,7 +3,7 @@ import { Button, Modal, Input, Toast } from '@douyinfe/semi-ui';
 import { I18nContext, Dap } from '@octo/base';
 import type { ChatMessage, ChatCandidate, AgentProgressEvent, AgentDoneEvent, AgentErrorEvent } from '../types/summary';
 import { agentChatStream, agentChat } from '../api/summaryApi';
-import { genSessionId } from '../utils/summaryHelpers';
+import { genSessionId, genRequestId } from '../utils/summaryHelpers';
 import { summaryTestIds } from '../utils/testIds';
 import './AgentChatPanel.css';
 
@@ -72,6 +72,10 @@ export default class AgentChatPanel extends Component<AgentChatPanelProps, Agent
 
     private listRef = createRef<HTMLDivElement>();
     private streamCloseHandle: (() => void) | null = null;
+    // WEB-03: run_id captured from the last agent response (SS-11). Forward-looking
+    // (the backend keys idempotency on request_id, not this) — kept for future
+    // run-aware UI / debugging.
+    private lastRunId: string | null = null;
 
     state: AgentChatPanelState = { 
         input: '', 
@@ -145,6 +149,11 @@ export default class AgentChatPanel extends Component<AgentChatPanelProps, Agent
         // onAssistantMessage 的 sessionId 参数上抛让父组件同步持久化。
         // 见 CHAT-REFERENCE-BASED-DESIGN-v1: chat session 生命周期。
         const sessionId = propsSessionId || genSessionId();
+        // WEB-03: one idempotency key per logical submit. Reused across
+        // stream→fallback so a transient retry does NOT create a second Run
+        // (SS-03 dedupes on uid+session_id+request_id). Without it the whole v2
+        // pipeline (Run/Spec/finish_status/gaps) stays inert.
+        const requestId = genRequestId();
 
         this.setState({
             input: '',
@@ -169,6 +178,7 @@ export default class AgentChatPanel extends Component<AgentChatPanelProps, Agent
                 session_id: sessionId,
                 message: text,
                 profile,
+                request_id: requestId,
                 referenced_task_ids: refIds,
                 selected_channels: selectedChannels,
             }, {
@@ -203,6 +213,8 @@ export default class AgentChatPanel extends Component<AgentChatPanelProps, Agent
                 onDone: (evt: AgentDoneEvent) => {
                     const { t } = this.context;
                     const reply = evt.reply || t('summary.common.agentPanel.noReply');
+                    // WEB-03: capture run_id (SS-11) for forward-looking run-aware UI.
+                    this.lastRunId = evt.run_id ?? this.lastRunId;
                     // 优先用后端回传的 session_id(它可能对老 session 做过 canonicalize);
                     // 兜底用我们本地生成的 sessionId(和请求时发出去的一致,父组件据此持久化)。
                     onAssistantMessage?.(reply, evt.session_id || sessionId);
@@ -219,7 +231,7 @@ export default class AgentChatPanel extends Component<AgentChatPanelProps, Agent
                     this.streamCloseHandle = null;
                     // 仅传输层失败(transient: true)才重试,后端真实 error 不重试
                     if (evt.transient) {
-                        this.fallbackToNormalChat(text, sessionId, profile);
+                        this.fallbackToNormalChat(text, sessionId, profile, requestId);
                     }
                 },
             });
@@ -230,11 +242,11 @@ export default class AgentChatPanel extends Component<AgentChatPanelProps, Agent
             const { t } = this.context;
             console.error('[AgentChatPanel] SSE stream failed:', err);
             Toast.warning(t('summary.common.agentChat.streamInterrupted'));
-            this.fallbackToNormalChat(text, sessionId, profile);
+            this.fallbackToNormalChat(text, sessionId, profile, requestId);
         }
     };
 
-    private fallbackToNormalChat = async (text: string, sessionId: string, profile: string) => {
+    private fallbackToNormalChat = async (text: string, sessionId: string, profile: string, requestId: string) => {
         const { t } = this.context;
         const { onAssistantMessage } = this.props;
         try {
@@ -247,10 +259,13 @@ export default class AgentChatPanel extends Component<AgentChatPanelProps, Agent
                 session_id: sessionId,
                 message: text,
                 profile,
+                request_id: requestId,
                 referenced_task_ids: refIds,
                 selected_channels: this.requestSelectedChannels(),
             });
             const reply = result.reply || t('summary.common.agentPanel.noReply');
+            // WEB-03: capture run_id from the fallback response too (SS-11).
+            this.lastRunId = result.run_id ?? this.lastRunId;
             // 上抛 sessionId 让父组件持久化(和 SSE onDone 一致)
             onAssistantMessage?.(reply, result.session_id || sessionId);
         } catch (err: any) {

--- a/packages/dmworksummary/src/components/AgentChatPanel.tsx
+++ b/packages/dmworksummary/src/components/AgentChatPanel.tsx
@@ -12,13 +12,13 @@ interface AgentChatPanelProps {
     onSend: (text: string) => void;
     sending: boolean;
     welcome?: string;
-    onSaveAsSummary?: (title: string) => Promise<boolean>;
+    onSaveAsSummary?: (title: string, requestId?: string) => Promise<boolean>;
     savingSummary?: boolean;
     onNewSession?: () => void;
     useStream?: boolean;
     sessionId?: string;
     profile?: string;
-    onAssistantMessage?: (text: string, sessionId?: string) => void;
+    onAssistantMessage?: (text: string, sessionId?: string, requestId?: string) => void;
     onUserMessage?: (text: string, sessionId?: string) => void;
     /**
      * 引用的已有总结 task_id 列表。仅在**首轮**(messages.length===0)时随
@@ -72,10 +72,9 @@ export default class AgentChatPanel extends Component<AgentChatPanelProps, Agent
 
     private listRef = createRef<HTMLDivElement>();
     private streamCloseHandle: (() => void) | null = null;
-    // WEB-03: run_id captured from the last agent response (SS-11). Forward-looking
-    // (the backend keys idempotency on request_id, not this) — kept for future
-    // run-aware UI / debugging.
-    private lastRunId: string | null = null;
+    // request_id for the most recent successful agent generation. Save uses it
+    // to bind the summary to the frozen v2 Run manifest for that turn.
+    private lastRequestId: string | null = null;
 
     state: AgentChatPanelState = { 
         input: '', 
@@ -166,14 +165,15 @@ export default class AgentChatPanel extends Component<AgentChatPanelProps, Agent
         // 先本地追加 user 消息(纯 UI,不发请求)
         onUserMessage?.(text, sessionId);
 
-        try {
-            // 每轮都把引用传给后端(和 CHAT-REFERENCE-BASED-DESIGN-v1 多轮上下文修复对齐)。
-            // 后端每轮重新拼进 system prompt,让 agent 在多轮追问/迭代中始终能看到引用材料。
-            const refIds = this.props.referencedTaskIds && this.props.referencedTaskIds.length > 0
-                ? this.props.referencedTaskIds
-                : undefined;
-            const selectedChannels = this.requestSelectedChannels();
+        // 每轮都把引用传给后端(和 CHAT-REFERENCE-BASED-DESIGN-v1 多轮上下文修复对齐)。
+        // 这里先冻结本次 submit 的 scope，fallback 复用同一份，避免同一 request_id
+        // 下前后两次请求的 scope 发生漂移。
+        const refIds = this.props.referencedTaskIds && this.props.referencedTaskIds.length > 0
+            ? this.props.referencedTaskIds
+            : undefined;
+        const selectedChannels = this.requestSelectedChannels();
 
+        try {
             const { close } = agentChatStream({
                 session_id: sessionId,
                 message: text,
@@ -213,11 +213,10 @@ export default class AgentChatPanel extends Component<AgentChatPanelProps, Agent
                 onDone: (evt: AgentDoneEvent) => {
                     const { t } = this.context;
                     const reply = evt.reply || t('summary.common.agentPanel.noReply');
-                    // WEB-03: capture run_id (SS-11) for forward-looking run-aware UI.
-                    this.lastRunId = evt.run_id ?? this.lastRunId;
+                    this.lastRequestId = requestId;
                     // 优先用后端回传的 session_id(它可能对老 session 做过 canonicalize);
                     // 兜底用我们本地生成的 sessionId(和请求时发出去的一致,父组件据此持久化)。
-                    onAssistantMessage?.(reply, evt.session_id || sessionId);
+                    onAssistantMessage?.(reply, evt.session_id || sessionId, requestId);
                     this.setState({
                         isStreaming: false,
                         processExpanded: false,
@@ -229,9 +228,10 @@ export default class AgentChatPanel extends Component<AgentChatPanelProps, Agent
                     Toast.error(`${t('summary.common.agentChat.error')}: ${evt.message}`);
                     this.setState({ isStreaming: false });
                     this.streamCloseHandle = null;
-                    // 仅传输层失败(transient: true)才重试,后端真实 error 不重试
+                    // 仅传输层失败(transient: true)才重试；summaryApi 会在收到
+                    // 后端 error frame 后抑制 close-without-done 的二次 transient。
                     if (evt.transient) {
-                        this.fallbackToNormalChat(text, sessionId, profile, requestId);
+                        this.fallbackToNormalChat(text, sessionId, profile, requestId, refIds, selectedChannels);
                     }
                 },
             });
@@ -242,32 +242,33 @@ export default class AgentChatPanel extends Component<AgentChatPanelProps, Agent
             const { t } = this.context;
             console.error('[AgentChatPanel] SSE stream failed:', err);
             Toast.warning(t('summary.common.agentChat.streamInterrupted'));
-            this.fallbackToNormalChat(text, sessionId, profile, requestId);
+            this.fallbackToNormalChat(text, sessionId, profile, requestId, refIds, selectedChannels);
         }
     };
 
-    private fallbackToNormalChat = async (text: string, sessionId: string, profile: string, requestId: string) => {
+    private fallbackToNormalChat = async (
+        text: string,
+        sessionId: string,
+        profile: string,
+        requestId: string,
+        refIds?: number[],
+        selectedChannels?: ReturnType<AgentChatPanel['requestSelectedChannels']>,
+    ) => {
         const { t } = this.context;
         const { onAssistantMessage } = this.props;
         try {
-            // Fallback 也每轮带引用(和 SSE 主链一致)
-            const refIds = this.props.referencedTaskIds && this.props.referencedTaskIds.length > 0
-                ? this.props.referencedTaskIds
-                : undefined;
-
             const result = await agentChat({
                 session_id: sessionId,
                 message: text,
                 profile,
                 request_id: requestId,
                 referenced_task_ids: refIds,
-                selected_channels: this.requestSelectedChannels(),
+                selected_channels: selectedChannels,
             });
             const reply = result.reply || t('summary.common.agentPanel.noReply');
-            // WEB-03: capture run_id from the fallback response too (SS-11).
-            this.lastRunId = result.run_id ?? this.lastRunId;
+            this.lastRequestId = requestId;
             // 上抛 sessionId 让父组件持久化(和 SSE onDone 一致)
-            onAssistantMessage?.(reply, result.session_id || sessionId);
+            onAssistantMessage?.(reply, result.session_id || sessionId, requestId);
         } catch (err: any) {
             Toast.error(t('summary.common.createFailed'));
             console.error('[AgentChatPanel] Fallback agentChat failed:', err);
@@ -317,7 +318,7 @@ export default class AgentChatPanel extends Component<AgentChatPanelProps, Agent
         }
         if (!this.props.onSaveAsSummary) return;
         
-        const success = await this.props.onSaveAsSummary(title);
+        const success = await this.props.onSaveAsSummary(title, this.lastRequestId || undefined);
         if (success) {
             this.setState({ showSaveDialog: false, summaryTitle: '' });
         }

--- a/packages/dmworksummary/src/components/ChatSummaryNewModal.tsx
+++ b/packages/dmworksummary/src/components/ChatSummaryNewModal.tsx
@@ -550,21 +550,33 @@ export default class ChatSummaryNewModal extends Component<
 
     /** SSE 模式：追加 assistant 消息(仅 UI,不发请求)。 */
     private handleAgentAssistantMessage = (text: string, sessionId?: string, requestId?: string) => {
-        if (requestId) {
-            writeAgentChatRequestId(this.agentChannelId(), requestId);
-        }
+        let sessionChanged = false;
         this.setState((prev) => {
             const nextState: Pick<ChatSummaryNewModalState, 'messages'> & Partial<ChatSummaryNewModalState> = {
                 messages: [...prev.messages, { role: 'assistant', content: text }],
             };
             if (sessionId && sessionId !== prev.sessionId) {
-                writeAgentChatSession(this.agentChannelId(), sessionId);
+                sessionChanged = true;
                 nextState.sessionId = sessionId;
             }
             if (requestId) {
                 nextState.agentRequestId = requestId;
             }
             return nextState;
+        }, () => {
+            const channelId = this.agentChannelId();
+            const pairedSessionId = sessionId || this.state.sessionId;
+            // Persist the successful session/request pair after state commits.
+            // If two tabs still interleave these separate localStorage keys,
+            // the backend's full tuple lookup safely falls back to legacy mode.
+            if (sessionChanged && sessionId) {
+                writeAgentChatSession(channelId, sessionId);
+            } else if (requestId && pairedSessionId) {
+                writeAgentChatSession(channelId, pairedSessionId);
+            }
+            if (requestId) {
+                writeAgentChatRequestId(channelId, requestId);
+            }
         });
     };
     /** 主按钮点击：normal 走普通提交；agent 输入走面板底部输入框，主按钮无需提交。 */

--- a/packages/dmworksummary/src/components/ChatSummaryNewModal.tsx
+++ b/packages/dmworksummary/src/components/ChatSummaryNewModal.tsx
@@ -11,7 +11,18 @@ import { markAgentSummaryNotificationEligible } from '../utils/groupSummaryNotif
 import { channelToChatCandidate } from '../utils/channelConvert';
 import { resolveTemplate, computeTemplateSelection, getTemplateEditableFields, deriveSummaryTitle, limitTemplateSummaryContent, type ResolvableTemplate } from '../utils/templateResolver';
 
-import { describeSchedule, scheduleToParams, genSessionId, readAgentChatSession, writeAgentChatSession, clearAgentChatSession } from '../utils/summaryHelpers';
+import {
+    describeSchedule,
+    scheduleToParams,
+    genSessionId,
+    genRequestId,
+    readAgentChatSession,
+    writeAgentChatSession,
+    clearAgentChatSession,
+    readAgentChatRequestId,
+    writeAgentChatRequestId,
+    clearAgentChatRequestId,
+} from '../utils/summaryHelpers';
 import * as summaryApi from '../api/summaryApi';
 import { getTopicTemplatesConfig } from '../api/summaryApi';
 import { TOPIC_TEMPLATES } from '../constants/templates';
@@ -55,6 +66,7 @@ interface ChatSummaryNewModalState {
     // Agent 多轮问答：气泡 UI + session_id。后端按 session_id 持久化记忆，同一会话复用即可续上下文。
     messages: ChatMessage[];
     sessionId: string;
+    agentRequestId: string;
 }
 
 export default class ChatSummaryNewModal extends Component<
@@ -136,6 +148,7 @@ export default class ChatSummaryNewModal extends Component<
             savingTemplate: false,
             messages: [],
             sessionId: '',
+            agentRequestId: '',
         };
     }
 
@@ -171,6 +184,7 @@ export default class ChatSummaryNewModal extends Component<
                 savingTemplate: false,
                 messages: [],
                 sessionId: '',
+                agentRequestId: '',
             });
             void this.loadTemplates();
         }
@@ -477,6 +491,7 @@ export default class ChatSummaryNewModal extends Component<
 
         // 惰性生成 session_id，整会话复用。
         const sessionId = this.state.sessionId || genSessionId();
+        const requestId = genRequestId();
         // 持久化到 localStorage：关闭弹窗/刷新后再进来可按 session_id 拉回历史（「退出不丢」）。
         writeAgentChatSession(this.agentChannelId(), sessionId);
 
@@ -487,13 +502,20 @@ export default class ChatSummaryNewModal extends Component<
         }));
 
         try {
-            const res = await summaryApi.agentChat({ message: trimmed, session_id: sessionId, profile: 'summary' });
+            const res = await summaryApi.agentChat({
+                message: trimmed,
+                session_id: sessionId,
+                profile: 'summary',
+                request_id: requestId,
+            });
             // 后端回传 session_id 非空则回填并持久化（与后端持久化的会话保持一致）。
             const nextSessionId = res.session_id || sessionId;
             writeAgentChatSession(this.agentChannelId(), nextSessionId);
+            writeAgentChatRequestId(this.agentChannelId(), requestId);
             this.setState((prev) => ({
                 messages: [...prev.messages, { role: 'assistant', content: res.reply }],
                 sessionId: nextSessionId,
+                agentRequestId: requestId,
             }));
         } catch (err: unknown) {
             // 失败：Toast + 追一条 assistant 错误气泡（让失败在对话流里可见）。
@@ -527,19 +549,23 @@ export default class ChatSummaryNewModal extends Component<
     };
 
     /** SSE 模式：追加 assistant 消息(仅 UI,不发请求)。 */
-    private handleAgentAssistantMessage = (text: string, sessionId?: string) => {
-        // 后端回传 session_id 非空则回填并持久化（与后端持久化的会话保持一致）
-        if (sessionId && sessionId !== this.state.sessionId) {
-            writeAgentChatSession(this.agentChannelId(), sessionId);
-            this.setState((prev) => ({
-                messages: [...prev.messages, { role: 'assistant', content: text }],
-                sessionId,
-            }));
-        } else {
-            this.setState((prev) => ({
-                messages: [...prev.messages, { role: 'assistant', content: text }],
-            }));
+    private handleAgentAssistantMessage = (text: string, sessionId?: string, requestId?: string) => {
+        if (requestId) {
+            writeAgentChatRequestId(this.agentChannelId(), requestId);
         }
+        this.setState((prev) => {
+            const nextState: Pick<ChatSummaryNewModalState, 'messages'> & Partial<ChatSummaryNewModalState> = {
+                messages: [...prev.messages, { role: 'assistant', content: text }],
+            };
+            if (sessionId && sessionId !== prev.sessionId) {
+                writeAgentChatSession(this.agentChannelId(), sessionId);
+                nextState.sessionId = sessionId;
+            }
+            if (requestId) {
+                nextState.agentRequestId = requestId;
+            }
+            return nextState;
+        });
     };
     /** 主按钮点击：normal 走普通提交；agent 输入走面板底部输入框，主按钮无需提交。 */
     private handlePrimaryClick = () => {
@@ -565,9 +591,11 @@ export default class ChatSummaryNewModal extends Component<
      */
     private enterAgentMode() {
         const stored = readAgentChatSession(this.agentChannelId());
+        const storedRequestId = readAgentChatRequestId(this.agentChannelId());
         this.setState((prev) => ({
             mode: 'agent',
             sessionId: stored || prev.sessionId,
+            agentRequestId: storedRequestId || prev.agentRequestId,
         }));
         if (stored) void this.loadAgentHistory(stored);
     }
@@ -593,9 +621,10 @@ export default class ChatSummaryNewModal extends Component<
     /** 「新会话」：清 localStorage 的 session_id、清空消息，下次发送重新生成新 session_id。 */
     private handleNewSession = () => {
         clearAgentChatSession(this.agentChannelId());
+        clearAgentChatRequestId(this.agentChannelId());
         // 作废在途历史拉取，避免旧会话历史回灌到新会话。
         this.historyLoadToken++;
-        this.setState({ messages: [], sessionId: '' });
+        this.setState({ messages: [], sessionId: '', agentRequestId: '' });
     };
 
     /** 保存为总结（agent 模式）。将当前 session 的产出落库为可检索的交付物。返回成功/失败。
@@ -606,10 +635,11 @@ export default class ChatSummaryNewModal extends Component<
      * agent_message 的 tool_calls 反查作为 fallback(见 agent_summary.go
      * resolveOriginChannelFromSession)。
      */
-    handleSaveAsSummary = async (title: string): Promise<boolean> => {
+    handleSaveAsSummary = async (title: string, requestId?: string): Promise<boolean> => {
         const { sessionId, selectedChats } = this.state;
         const { onSubmit } = this.props;
         const { t } = this.context;
+        const agentRequestId = requestId || this.state.agentRequestId;
 
         if (!sessionId) {
             Toast.warning(t('summary.create.noOutputToSave'));
@@ -633,6 +663,7 @@ export default class ChatSummaryNewModal extends Component<
             const { channel } = this.props;
             const res = await summaryApi.createAgentSummary({
                 session_id: sessionId,
+                ...(agentRequestId ? { request_id: agentRequestId } : {}),
                 title,
                 sources,
                 origin_channel_id: channel.channelID,
@@ -659,6 +690,8 @@ export default class ChatSummaryNewModal extends Component<
                     detail: { taskId: res.task_id, channelId: '' },
                 }),
             );
+            clearAgentChatRequestId(this.agentChannelId());
+            this.setState({ agentRequestId: '' });
             onSubmit(res.task_id);
             return true;
         } catch (err: unknown) {

--- a/packages/dmworksummary/src/components/__tests__/AgentChatPanel.sse.test.tsx
+++ b/packages/dmworksummary/src/components/__tests__/AgentChatPanel.sse.test.tsx
@@ -288,6 +288,51 @@ describe('AgentChatPanel SSE Mode', () => {
         expect(onAssistantMessage).not.toHaveBeenCalled();
     });
 
+    it('stays busy until a transient stream fallback settles', async () => {
+        let resolveFallback: ((value: { reply: string; session_id: string }) => void) | undefined;
+        const onNewSession = vi.fn();
+
+        (summaryApi.agentChatStream as any).mockImplementation((_params: any, handlers: any) => {
+            setImmediate(() => handlers.onError({ code: 50000, message: 'transport closed', transient: true }));
+            return { close: vi.fn() };
+        });
+        (summaryApi.agentChat as any).mockImplementation(() => new Promise((resolve) => {
+            resolveFallback = resolve;
+        }));
+
+        render(
+            <I18nContext.Provider value={{ t: mockT, locale: 'zh-CN' }}>
+                <AgentChatPanel
+                    messages={[]}
+                    onSend={vi.fn()}
+                    sending={false}
+                    useStream
+                    sessionId="busy-session"
+                    profile="summary"
+                    onNewSession={onNewSession}
+                    onUserMessage={vi.fn()}
+                    onAssistantMessage={vi.fn()}
+                />
+            </I18nContext.Provider>,
+        );
+
+        const textarea = screen.getByPlaceholderText('summary.create.agentChatPlaceholder');
+        fireEvent.change(textarea, { target: { value: '需要回退' } });
+        fireEvent.click(screen.getByText('summary.create.send'));
+
+        await waitFor(() => expect(summaryApi.agentChat).toHaveBeenCalled(), { timeout: 2000 });
+        expect(textarea).toBeDisabled();
+        expect(screen.getByText('summary.create.newSession')).toBeDisabled();
+
+        await act(async () => {
+            resolveFallback?.({ reply: 'fallback reply', session_id: 'busy-session' });
+        });
+
+        await waitFor(() => expect(textarea).not.toBeDisabled(), { timeout: 2000 });
+        expect(screen.getByText('summary.create.newSession')).not.toBeDisabled();
+        expect(onNewSession).not.toHaveBeenCalled();
+    });
+
     it('should handle successful SSE stream completion', async () => {
         let savedHandlers: any = null;
         const onUserMessage = vi.fn();

--- a/packages/dmworksummary/src/components/__tests__/AgentChatPanel.sse.test.tsx
+++ b/packages/dmworksummary/src/components/__tests__/AgentChatPanel.sse.test.tsx
@@ -78,6 +78,42 @@ describe('AgentChatPanel SSE Mode', () => {
         })), { timeout: 2000 });
     });
 
+    it('generates a request_id and reuses it across stream→fallback (WEB-03)', async () => {
+        let streamRequestId: string | undefined;
+        (summaryApi.agentChatStream as any).mockImplementation((params: any, handlers: any) => {
+            streamRequestId = params.request_id;
+            setImmediate(() => handlers.onError({ code: 0, message: 'transport closed', transient: true }));
+            return { close: vi.fn() };
+        });
+        (summaryApi.agentChat as any).mockResolvedValue({ reply: 'ok', session_id: 's', run_id: 'run-1' });
+
+        render(
+            <I18nContext.Provider value={{ t: mockT, locale: 'zh-CN' }}>
+                <AgentChatPanel
+                    messages={[]}
+                    onSend={vi.fn()}
+                    sending={false}
+                    useStream
+                    sessionId="s"
+                    profile="summary"
+                    onUserMessage={vi.fn()}
+                    onAssistantMessage={vi.fn()}
+                />
+            </I18nContext.Provider>,
+        );
+        fireEvent.change(screen.getByPlaceholderText('summary.create.agentChatPlaceholder'), { target: { value: '总结' } });
+        fireEvent.click(screen.getByText('summary.create.send'));
+
+        await waitFor(() => expect(summaryApi.agentChat).toHaveBeenCalled(), { timeout: 2000 });
+        // request_id generated on the stream request…
+        expect(typeof streamRequestId).toBe('string');
+        expect(streamRequestId).toBeTruthy();
+        // …and the SAME id reused on the fallback (idempotent retry, one Run).
+        expect(summaryApi.agentChat).toHaveBeenCalledWith(
+            expect.objectContaining({ request_id: streamRequestId }),
+        );
+    });
+
     it('keeps old request behavior when no chat is selected', async () => {
         (summaryApi.agentChatStream as any).mockImplementation((params: any) => {
             expect(params.selected_channels).toBeUndefined();

--- a/packages/dmworksummary/src/components/__tests__/AgentChatPanel.sse.test.tsx
+++ b/packages/dmworksummary/src/components/__tests__/AgentChatPanel.sse.test.tsx
@@ -80,6 +80,7 @@ describe('AgentChatPanel SSE Mode', () => {
 
     it('generates a request_id and reuses it across stream→fallback (WEB-03)', async () => {
         let streamRequestId: string | undefined;
+        const onAssistantMessage = vi.fn();
         (summaryApi.agentChatStream as any).mockImplementation((params: any, handlers: any) => {
             streamRequestId = params.request_id;
             setImmediate(() => handlers.onError({ code: 0, message: 'transport closed', transient: true }));
@@ -97,7 +98,7 @@ describe('AgentChatPanel SSE Mode', () => {
                     sessionId="s"
                     profile="summary"
                     onUserMessage={vi.fn()}
-                    onAssistantMessage={vi.fn()}
+                    onAssistantMessage={onAssistantMessage}
                 />
             </I18nContext.Provider>,
         );
@@ -112,6 +113,113 @@ describe('AgentChatPanel SSE Mode', () => {
         expect(summaryApi.agentChat).toHaveBeenCalledWith(
             expect.objectContaining({ request_id: streamRequestId }),
         );
+        expect(onAssistantMessage).toHaveBeenCalledWith('ok', 's', streamRequestId);
+    });
+
+    it('gives each logical submit a distinct request_id (WEB-03)', async () => {
+        const seen: string[] = [];
+        (summaryApi.agentChatStream as any).mockImplementation((params: any, handlers: any) => {
+            seen.push(params.request_id);
+            setImmediate(() => handlers.onDone?.({ reply: 'ok', session_id: 's' }));
+            return { close: vi.fn() };
+        });
+
+        render(
+            <I18nContext.Provider value={{ t: mockT, locale: 'zh-CN' }}>
+                <AgentChatPanel
+                    messages={[]}
+                    onSend={vi.fn()}
+                    sending={false}
+                    useStream
+                    sessionId="s"
+                    profile="summary"
+                    onUserMessage={vi.fn()}
+                    onAssistantMessage={vi.fn()}
+                />
+            </I18nContext.Provider>,
+        );
+        const textarea = screen.getByPlaceholderText('summary.create.agentChatPlaceholder');
+        const send = screen.getByText('summary.create.send');
+
+        await act(async () => {
+            fireEvent.change(textarea, { target: { value: '第一轮' } });
+            fireEvent.click(send);
+        });
+        await waitFor(() => expect(seen).toHaveLength(1), { timeout: 2000 });
+
+        await act(async () => {
+            fireEvent.change(textarea, { target: { value: '第二轮' } });
+            fireEvent.click(send);
+        });
+        await waitFor(() => expect(seen).toHaveLength(2), { timeout: 2000 });
+
+        // Two genuinely distinct submits must NOT collapse into one backend Run.
+        expect(seen[0]).toBeTruthy();
+        expect(seen[1]).toBeTruthy();
+        expect(seen[0]).not.toBe(seen[1]);
+    });
+
+    it('binds save to the last SUCCESSFUL turn, not a later failed one (WEB-03)', async () => {
+        const onSaveAsSummary = vi.fn().mockResolvedValue(true);
+        const seen: string[] = [];
+        let call = 0;
+        (summaryApi.agentChatStream as any).mockImplementation((params: any, handlers: any) => {
+            seen.push(params.request_id);
+            call++;
+            // 1st submit succeeds; 2nd fails with a NON-transient backend error
+            // (no fallback), so it must not overwrite the bound request_id.
+            if (call === 1) {
+                setImmediate(() => handlers.onDone?.({ reply: 'good answer', session_id: 's' }));
+            } else {
+                setImmediate(() => handlers.onError?.({ code: 50001, message: 'backend failed' }));
+            }
+            return { close: vi.fn() };
+        });
+
+        const ref = React.createRef<AgentChatPanel>();
+        render(
+            <I18nContext.Provider value={{ t: mockT, locale: 'zh-CN' }}>
+                <AgentChatPanel
+                    ref={ref}
+                    messages={[{ role: 'assistant', content: 'good answer' } as ChatMessage]}
+                    onSend={vi.fn()}
+                    sending={false}
+                    useStream
+                    sessionId="s"
+                    profile="summary"
+                    onUserMessage={vi.fn()}
+                    onAssistantMessage={vi.fn()}
+                    onSaveAsSummary={onSaveAsSummary}
+                />
+            </I18nContext.Provider>,
+        );
+        const textarea = screen.getByPlaceholderText('summary.create.agentChatPlaceholder');
+        const send = screen.getByText('summary.create.send');
+
+        await act(async () => {
+            fireEvent.change(textarea, { target: { value: '第一轮' } });
+            fireEvent.click(send);
+        });
+        await waitFor(() => expect(seen).toHaveLength(1), { timeout: 2000 });
+
+        await act(async () => {
+            fireEvent.change(textarea, { target: { value: '第二轮' } });
+            fireEvent.click(send);
+        });
+        await waitFor(() => expect(seen).toHaveLength(2), { timeout: 2000 });
+
+        // Drive the real save-confirm path (the Semi Modal mock does not render okText).
+        const instance = ref.current as any;
+        await act(async () => {
+            instance.setState({ showSaveDialog: true, summaryTitle: '标题' });
+        });
+        await act(async () => {
+            await instance.handleSaveConfirm();
+        });
+
+        await waitFor(() => expect(onSaveAsSummary).toHaveBeenCalled(), { timeout: 2000 });
+        // The failed 2nd turn froze no manifest — save must still point at turn 1.
+        expect(onSaveAsSummary).toHaveBeenCalledWith('标题', seen[0]);
     });
 
     it('keeps old request behavior when no chat is selected', async () => {
@@ -273,10 +381,12 @@ describe('AgentChatPanel SSE Mode', () => {
 
     it('should pass session_id from onDone event to onAssistantMessage callback', async () => {
         let savedHandlers: any = null;
+        let streamRequestId: string | undefined;
         const onAssistantMessage = vi.fn();
 
         // Mock agentChatStream to capture handlers
         (summaryApi.agentChatStream as any).mockImplementation((params: any, handlers: any) => {
+            streamRequestId = params.request_id;
             savedHandlers = handlers;
             return { close: vi.fn() };
         });
@@ -319,7 +429,7 @@ describe('AgentChatPanel SSE Mode', () => {
         // Verify panel passes BOTH text and session_id to the callback
         // (Parent component is responsible for persisting and updating state)
         await waitFor(() => {
-            expect(onAssistantMessage).toHaveBeenCalledWith('Server response', 'server-session-xyz');
+            expect(onAssistantMessage).toHaveBeenCalledWith('Server response', 'server-session-xyz', streamRequestId);
         }, { timeout: 1000 });
     });
 
@@ -424,9 +534,11 @@ describe('AgentChatPanel SSE Mode', () => {
     it('should allow first send with empty sessionId and pass it to backend', async () => {
         const onUserMessage = vi.fn();
         const onAssistantMessage = vi.fn();
+        let streamRequestId: string | undefined;
         
         // Mock agentChatStream to capture params and simulate successful response
         (summaryApi.agentChatStream as any).mockImplementation((params: any, handlers: any) => {
+            streamRequestId = params.request_id;
             // P2.1: AgentChatPanel generates UUID when sessionId is empty
             expect(params.session_id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
             expect(params.message).toBe('First message');
@@ -471,7 +583,9 @@ describe('AgentChatPanel SSE Mode', () => {
         await waitFor(() => {
             expect(summaryApi.agentChatStream).toHaveBeenCalledWith(expect.objectContaining({ session_id: expect.any(String), message: 'First message', profile: 'summary' }), expect.any(Object));
             expect(onUserMessage).toHaveBeenCalledWith('First message', expect.any(String));
-            expect(onAssistantMessage).toHaveBeenCalledWith('Backend response', 'new-session-123');
+            // WEB-03: the generation turn's request_id rides along so the parent can
+            // persist it and bind the save call to that run's frozen manifest.
+            expect(onAssistantMessage).toHaveBeenCalledWith('Backend response', 'new-session-123', streamRequestId);
         }, { timeout: 1000 });
     });
 });

--- a/packages/dmworksummary/src/components/__tests__/AgentChatPanel.test.tsx
+++ b/packages/dmworksummary/src/components/__tests__/AgentChatPanel.test.tsx
@@ -180,7 +180,8 @@ describe('AgentChatPanel - Save as Summary', () => {
         // 等待异步操作完成
         await waitFor(() => {
             // 验证 onSaveAsSummary 被正确调用
-            expect(onSaveAsSummary).toHaveBeenCalledWith('测试总结');
+            // WEB-03: 第二参是绑定的 request_id；本用例没发过消息，故为 undefined。
+            expect(onSaveAsSummary).toHaveBeenCalledWith('测试总结', undefined);
             expect(onSaveAsSummary).toHaveBeenCalledTimes(1);
         });
         
@@ -225,7 +226,8 @@ describe('AgentChatPanel - Save as Summary', () => {
         // 等待异步操作完成
         await waitFor(() => {
             // 验证 onSaveAsSummary 被调用
-            expect(onSaveAsSummary).toHaveBeenCalledWith('测试总结');
+            // WEB-03: 第二参是绑定的 request_id；本用例没发过消息，故为 undefined。
+            expect(onSaveAsSummary).toHaveBeenCalledWith('测试总结', undefined);
             expect(onSaveAsSummary).toHaveBeenCalledTimes(1);
         });
         

--- a/packages/dmworksummary/src/components/__tests__/ChatSummaryNewModal.test.tsx
+++ b/packages/dmworksummary/src/components/__tests__/ChatSummaryNewModal.test.tsx
@@ -153,7 +153,7 @@ describe('ChatSummaryNewModal', () => {
             await flushPromises();
         });
 
-        expect(screen.getByText('试试这些总结模板')).toBeInTheDocument();
+        expect(screen.getByText('试试下列模版')).toBeInTheDocument();
         expect(screen.getByTestId('template-weekly_report')).toBeInTheDocument();
         expect(screen.getByTestId('template-chat_content')).toBeInTheDocument();
     });
@@ -227,7 +227,7 @@ describe('ChatSummaryNewModal', () => {
         const input = screen.getByPlaceholderText('输入聊天内你想总结的主题');
         fireEvent.change(input, { target: { value: '测试主题' } });
 
-        expect(screen.queryByText('试试这些总结模板')).not.toBeInTheDocument();
+        expect(screen.queryByText('试试下列模版')).not.toBeInTheDocument();
         expect(screen.queryByTestId('template-weekly_report')).not.toBeInTheDocument();
     });
 
@@ -239,10 +239,10 @@ describe('ChatSummaryNewModal', () => {
 
         const input = screen.getByPlaceholderText('输入聊天内你想总结的主题');
         fireEvent.change(input, { target: { value: '测试' } });
-        expect(screen.queryByText('试试这些总结模板')).not.toBeInTheDocument();
+        expect(screen.queryByText('试试下列模版')).not.toBeInTheDocument();
 
         fireEvent.change(input, { target: { value: '' } });
-        expect(screen.getByText('试试这些总结模板')).toBeInTheDocument();
+        expect(screen.getByText('试试下列模版')).toBeInTheDocument();
         expect(screen.getByTestId('template-weekly_report')).toBeInTheDocument();
     });
 
@@ -262,7 +262,7 @@ describe('ChatSummaryNewModal', () => {
 
         const templatesLabel = inputArea!.querySelector('.chat-summary-modal-templates-label');
         expect(templatesLabel).toBeInTheDocument();
-        expect(templatesLabel!.textContent).toBe('试试这些总结模板');
+        expect(templatesLabel!.textContent).toBe('试试下列模版');
 
         const templatesContainer = inputArea!.querySelector('.chat-summary-modal-templates');
         expect(templatesContainer).toBeInTheDocument();

--- a/packages/dmworksummary/src/components/__tests__/ChatSummaryNewModal.test.tsx
+++ b/packages/dmworksummary/src/components/__tests__/ChatSummaryNewModal.test.tsx
@@ -730,4 +730,33 @@ describe('ChatSummaryNewModal agent save — explicit origin_channel_id (#930)',
         );
         expect(isAgentSummaryNotificationEligible(1)).toBe(true);
     });
+
+    it('passes the successful agent request_id when saving', async () => {
+        const ref = React.createRef<ChatSummaryNewModal>();
+        await act(async () => {
+            render(
+                <ChatSummaryNewModal
+                    visible
+                    channel={{ channelID: 'ch1', channelType: 2 }}
+                    onClose={vi.fn()}
+                    onSubmit={vi.fn()}
+                    ref={ref}
+                />,
+            );
+            await flushPromises();
+        });
+
+        await act(async () => {
+            (ref.current as any).setState({ sessionId: 'sess-modal-1', agentRequestId: 'req-modal-1' });
+        });
+        await act(async () => {
+            await (ref.current as any).handleSaveAsSummary('t');
+            await flushPromises();
+        });
+
+        expect(summaryApi.createAgentSummary).toHaveBeenCalledWith(
+            expect.objectContaining({ session_id: 'sess-modal-1', request_id: 'req-modal-1' }),
+            expect.any(Object),
+        );
+    });
 });

--- a/packages/dmworksummary/src/pages/SummaryCreatePage.tsx
+++ b/packages/dmworksummary/src/pages/SummaryCreatePage.tsx
@@ -815,21 +815,33 @@ export default class SummaryCreatePage extends Component<SummaryCreatePageProps,
 
     /** SSE 模式：追加 assistant 消息(仅 UI,不发请求)。 */
     handleAgentAssistantMessage = (text: string, sessionId?: string, requestId?: string) => {
-        if (requestId) {
-            writeAgentChatRequestId(this.agentChannelId(), requestId);
-        }
+        let sessionChanged = false;
         this.setState((prev) => {
             const nextState: Pick<SummaryCreatePageState, 'messages'> & Partial<SummaryCreatePageState> = {
                 messages: [...prev.messages, { role: 'assistant', content: text }],
             };
             if (sessionId && sessionId !== prev.sessionId) {
-                writeAgentChatSession(this.agentChannelId(), sessionId);
+                sessionChanged = true;
                 nextState.sessionId = sessionId;
             }
             if (requestId) {
                 nextState.agentRequestId = requestId;
             }
             return nextState;
+        }, () => {
+            const channelId = this.agentChannelId();
+            const pairedSessionId = sessionId || this.state.sessionId;
+            // Persist the successful session/request pair after state commits.
+            // If two tabs still interleave these separate localStorage keys,
+            // the backend's full tuple lookup safely falls back to legacy mode.
+            if (sessionChanged && sessionId) {
+                writeAgentChatSession(channelId, sessionId);
+            } else if (requestId && pairedSessionId) {
+                writeAgentChatSession(channelId, pairedSessionId);
+            }
+            if (requestId) {
+                writeAgentChatRequestId(channelId, requestId);
+            }
         });
     };
     handlePrimaryClick = () => {

--- a/packages/dmworksummary/src/pages/SummaryCreatePage.tsx
+++ b/packages/dmworksummary/src/pages/SummaryCreatePage.tsx
@@ -43,7 +43,21 @@ import type {
 } from "../types/summary";
 import { SummaryMode, SourceType } from "../types/summary";
 import { Channel, WKSDK } from "wukongimjssdk";
-import { describeSchedule, scheduleToParams, genSessionId, readAgentChatSession, writeAgentChatSession, clearAgentChatSession, readAgentChatReferenced, writeAgentChatReferenced, clearAgentChatReferenced } from "../utils/summaryHelpers";
+import {
+    describeSchedule,
+    scheduleToParams,
+    genSessionId,
+    genRequestId,
+    readAgentChatSession,
+    writeAgentChatSession,
+    clearAgentChatSession,
+    readAgentChatReferenced,
+    writeAgentChatReferenced,
+    clearAgentChatReferenced,
+    readAgentChatRequestId,
+    writeAgentChatRequestId,
+    clearAgentChatRequestId,
+} from "../utils/summaryHelpers";
 import { resolveTemplate, computeTemplateSelection, getTemplateEditableFields, deriveSummaryTitle, limitTemplateSummaryContent, type ResolvableTemplate } from "../utils/templateResolver";
 import { summaryTestIds } from "../utils/testIds";
 
@@ -99,6 +113,7 @@ interface SummaryCreatePageState {
     // Agent 多轮问答：气泡 UI + session_id。后端按 session_id 持久化记忆，同一会话复用即可续上下文。
     messages: ChatMessage[];
     sessionId: string;
+    agentRequestId: string;
     /**
      * chat 引用的已有总结(单选,v1)。仅首轮生效,选中后随 first message 发给后端。
      * 见 CHAT-REFERENCE-BASED-DESIGN-v1。
@@ -164,6 +179,7 @@ export default class SummaryCreatePage extends Component<SummaryCreatePageProps,
         savingSummary: false,
         messages: [],
         sessionId: '',
+        agentRequestId: '',
         referencedTask: null,
         showReferencePicker: false,
         previewTaskId: null,
@@ -314,10 +330,12 @@ export default class SummaryCreatePage extends Component<SummaryCreatePageProps,
             // 保存时血统被污染。所以进入时先原子清一遍 session · 再 write
             // 新 reference · 保证 storage 里的两条永远一致。
             clearAgentChatSession(this.agentChannelId());
+            clearAgentChatRequestId(this.agentChannelId());
             this.setState({
                 mode: 'agent',
                 referencedTask: this.props.derivedFromTask,
                 sessionId: '',
+                agentRequestId: '',
                 messages: [],
             });
             // 与 session_id 同生命周期持久化引用总结，避免 refresh/重进后
@@ -738,6 +756,7 @@ export default class SummaryCreatePage extends Component<SummaryCreatePageProps,
 
         // 惰性生成 session_id，整会话复用。
         const sessionId = this.state.sessionId || genSessionId();
+        const requestId = genRequestId();
         // 持久化到 localStorage：关闭/刷新后再进来可按 session_id 拉回历史（「退出不丢」）。
         writeAgentChatSession(this.agentChannelId(), sessionId);
 
@@ -749,13 +768,20 @@ export default class SummaryCreatePage extends Component<SummaryCreatePageProps,
         }));
 
         try {
-            const res = await api.agentChat({ message: trimmed, session_id: sessionId, profile: 'summary' });
+            const res = await api.agentChat({
+                message: trimmed,
+                session_id: sessionId,
+                profile: 'summary',
+                request_id: requestId,
+            });
             // 后端回传 session_id 非空则回填并持久化（与后端持久化的会话保持一致）。
             const nextSessionId = res.session_id || sessionId;
             writeAgentChatSession(this.agentChannelId(), nextSessionId);
+            writeAgentChatRequestId(this.agentChannelId(), requestId);
             this.setState((prev) => ({
                 messages: [...prev.messages, { role: 'assistant', content: res.reply }],
                 sessionId: nextSessionId,
+                agentRequestId: requestId,
             }));
         } catch (err: any) {
             // 失败：Toast + 追一条 assistant 错误气泡（让失败在对话流里可见）。
@@ -788,19 +814,23 @@ export default class SummaryCreatePage extends Component<SummaryCreatePageProps,
     };
 
     /** SSE 模式：追加 assistant 消息(仅 UI,不发请求)。 */
-    handleAgentAssistantMessage = (text: string, sessionId?: string) => {
-        // 后端回传 session_id 非空则回填并持久化（与后端持久化的会话保持一致）
-        if (sessionId && sessionId !== this.state.sessionId) {
-            writeAgentChatSession(this.agentChannelId(), sessionId);
-            this.setState((prev) => ({
-                messages: [...prev.messages, { role: 'assistant', content: text }],
-                sessionId,
-            }));
-        } else {
-            this.setState((prev) => ({
-                messages: [...prev.messages, { role: 'assistant', content: text }],
-            }));
+    handleAgentAssistantMessage = (text: string, sessionId?: string, requestId?: string) => {
+        if (requestId) {
+            writeAgentChatRequestId(this.agentChannelId(), requestId);
         }
+        this.setState((prev) => {
+            const nextState: Pick<SummaryCreatePageState, 'messages'> & Partial<SummaryCreatePageState> = {
+                messages: [...prev.messages, { role: 'assistant', content: text }],
+            };
+            if (sessionId && sessionId !== prev.sessionId) {
+                writeAgentChatSession(this.agentChannelId(), sessionId);
+                nextState.sessionId = sessionId;
+            }
+            if (requestId) {
+                nextState.agentRequestId = requestId;
+            }
+            return nextState;
+        });
     };
     handlePrimaryClick = () => {
         if (this.state.mode !== 'agent') {
@@ -838,12 +868,14 @@ export default class SummaryCreatePage extends Component<SummaryCreatePageProps,
      */
     private enterAgentMode() {
         const stored = readAgentChatSession(this.agentChannelId());
+        const storedRequestId = readAgentChatRequestId(this.agentChannelId());
         // 恢复引用总结与 session 同生命周期：storage 里有 → 自动回填。
         // 无 → 保持 state 现值（可能是 mount 时 derivedFromTask 塞进来的）。
         const storedRef = readAgentChatReferenced(this.agentChannelId());
         this.setState((prev) => ({
             mode: 'agent',
             sessionId: stored || prev.sessionId,
+            agentRequestId: storedRequestId || prev.agentRequestId,
             referencedTask: storedRef
                 ? { task_id: storedRef.task_id, title: storedRef.title } as SummaryListItem
                 : prev.referencedTask,
@@ -872,6 +904,7 @@ export default class SummaryCreatePage extends Component<SummaryCreatePageProps,
     /** 「新会话」：清 localStorage 的 session_id、清空消息，下次发送重新生成新 session_id。 */
     handleNewSession = () => {
         clearAgentChatSession(this.agentChannelId());
+        clearAgentChatRequestId(this.agentChannelId());
         // 引用总结跟 session 同生命周期 → 一起清。
         clearAgentChatReferenced(this.agentChannelId());
         // 作废在途历史拉取，避免旧会话历史回灌到新会话。
@@ -879,6 +912,7 @@ export default class SummaryCreatePage extends Component<SummaryCreatePageProps,
         this.setState({
             messages: [],
             sessionId: '',
+            agentRequestId: '',
             referencedTask: null,
             showReferencePicker: false,
             error: null,
@@ -942,9 +976,10 @@ export default class SummaryCreatePage extends Component<SummaryCreatePageProps,
     };
 
     /** 保存为总结（agent 模式）。将当前 session 的产出落库为可检索的交付物。返回成功/失败。 */
-    handleSaveAsSummary = async (title: string): Promise<boolean> => {
+    handleSaveAsSummary = async (title: string, requestId?: string): Promise<boolean> => {
         const { sessionId, selectedChats, selectedMembers } = this.state;
         const { t } = this.context;
+        const agentRequestId = requestId || this.state.agentRequestId;
         
         if (!sessionId) {
             Toast.warning(t('summary.create.noOutputToSave'));
@@ -962,6 +997,9 @@ export default class SummaryCreatePage extends Component<SummaryCreatePageProps,
                 session_id: sessionId,
                 title,
             };
+            if (agentRequestId) {
+                params.request_id = agentRequestId;
+            }
 
             if (selectedChats.length > 0) {
                 const origin = selectedChats[0];
@@ -1008,12 +1046,14 @@ export default class SummaryCreatePage extends Component<SummaryCreatePageProps,
             //   2. 重置组件内 state(messages/sessionId/referencedTask)
             //   3. 后端会在保存事务里 DELETE agent_message 表对应行
             clearAgentChatSession(this.agentChannelId());
+            clearAgentChatRequestId(this.agentChannelId());
             // 引用总结跟 session 同生命周期 → 一起清。
             clearAgentChatReferenced(this.agentChannelId());
             this.historyLoadToken++;
             this.setState({
                 messages: [],
                 sessionId: '',
+                agentRequestId: '',
                 referencedTask: null,
                 showReferencePicker: false,
             });

--- a/packages/dmworksummary/src/pages/__tests__/SummaryCreatePage.test.tsx
+++ b/packages/dmworksummary/src/pages/__tests__/SummaryCreatePage.test.tsx
@@ -578,6 +578,7 @@ describe('SummaryCreatePage agent SSE session_id sync', () => {
         });
 
         expect(writeRequestSpy).toHaveBeenCalledWith(undefined, 'req-success-1');
+        expect(writeSessionSpy).toHaveBeenCalledWith(undefined, 'same-session-id');
         expect(instance.state.agentRequestId).toBe('req-success-1');
     });
 });

--- a/packages/dmworksummary/src/pages/__tests__/SummaryCreatePage.test.tsx
+++ b/packages/dmworksummary/src/pages/__tests__/SummaryCreatePage.test.tsx
@@ -100,7 +100,7 @@ describe('SummaryCreatePage templates', () => {
             await flushPromises();
         });
 
-        expect(screen.getByText('试试这些总结模板')).toBeInTheDocument();
+        expect(screen.getByText('试试下列模版')).toBeInTheDocument();
         // v2: all builtin templates render directly (no "more templates" modal)
         expect(screen.getByText('汇总项目进展')).toBeInTheDocument();
         expect(screen.getByText('跟踪任务进度')).toBeInTheDocument();
@@ -125,7 +125,7 @@ describe('SummaryCreatePage templates', () => {
             fireEvent.change(textarea, { target: { value: '总结本周进展' } });
         });
 
-        expect(screen.queryByText('试试这些总结模板')).not.toBeInTheDocument();
+        expect(screen.queryByText('试试下列模版')).not.toBeInTheDocument();
         expect(screen.queryByText('汇总项目进展')).not.toBeInTheDocument();
     });
 
@@ -142,7 +142,7 @@ describe('SummaryCreatePage templates', () => {
         const textarea = document.querySelector('.summary-workbench-textarea') as HTMLTextAreaElement;
         expect(textarea.value).toBe('总结主题: 总结团队周报\n内容重点: 总结团队成员每周工作，按成员、重点进展、成果产出、风险问题、下周计划整理');
         // templates hidden after selection
-        expect(screen.queryByText('试试这些总结模板')).not.toBeInTheDocument();
+        expect(screen.queryByText('试试下列模版')).not.toBeInTheDocument();
     });
 
     it('fills the topic frame from a project progress template', async () => {
@@ -446,15 +446,18 @@ describe('SummaryCreatePage agent session_id persistence + history rehydrate + n
 
 describe('SummaryCreatePage agent SSE session_id sync', () => {
     let writeSessionSpy: any;
+    let writeRequestSpy: any;
 
     beforeEach(() => {
         vi.clearAllMocks();
         // Spy on the actual writeAgentChatSession from summaryHelpers
         writeSessionSpy = vi.spyOn(summaryHelpers, 'writeAgentChatSession').mockImplementation(() => {});
+        writeRequestSpy = vi.spyOn(summaryHelpers, 'writeAgentChatRequestId').mockImplementation(() => {});
     });
 
     afterEach(() => {
         writeSessionSpy?.mockRestore();
+        writeRequestSpy?.mockRestore();
     });
 
     it('updates sessionId and persists when backend returns different session_id', async () => {
@@ -555,6 +558,27 @@ describe('SummaryCreatePage agent SSE session_id sync', () => {
         const lastMessage = instance.state.messages[instance.state.messages.length - 1];
         expect(lastMessage.role).toBe('assistant');
         expect(lastMessage.content).toBe('Server response');
+    });
+
+    it('persists request_id from the successful SSE generation turn', async () => {
+        const ref = React.createRef<SummaryCreatePage>();
+        await act(async () => {
+            render(<SummaryCreatePage ref={ref} />);
+            await flushPromises();
+        });
+
+        const instance = ref.current as any;
+        await act(async () => {
+            instance.setState({ sessionId: 'same-session-id', mode: 'agent' });
+        });
+
+        await act(async () => {
+            instance.handleAgentAssistantMessage('Server response', 'same-session-id', 'req-success-1');
+            await flushPromises();
+        });
+
+        expect(writeRequestSpy).toHaveBeenCalledWith(undefined, 'req-success-1');
+        expect(instance.state.agentRequestId).toBe('req-success-1');
     });
 });
 
@@ -790,6 +814,23 @@ describe('SummaryCreatePage agent save — explicit origin_channel_id (#930)', (
         const arg = (api.createAgentSummary as any).mock.calls[0][0];
         expect(arg.origin_channel_id).toBeUndefined();
         expect(arg.origin_channel_type).toBeUndefined();
+    });
+
+    it('passes the successful agent request_id when saving', async () => {
+        const instance = await mountInstance();
+        await act(async () => {
+            instance.setState({
+                sessionId: 'sess-4',
+                mode: 'agent',
+                selectedChats: [],
+                agentRequestId: 'req-page-1',
+            });
+        });
+        await act(async () => { await instance.handleSaveAsSummary('t'); });
+        expect(api.createAgentSummary).toHaveBeenCalledWith(
+            expect.objectContaining({ session_id: 'sess-4', request_id: 'req-page-1' }),
+            expect.any(Object),
+        );
     });
 });
 

--- a/packages/dmworksummary/src/types/summary.ts
+++ b/packages/dmworksummary/src/types/summary.ts
@@ -329,6 +329,12 @@ export interface CreateAgentSummaryParams {
     /** 当前 agent 对话的 session_id */
     session_id: string;
     /**
+     * 最近一次成功 agent submit 的幂等键。保存时后端用
+     * (user_id, session_id, request_id) 找回该轮冻结的 v2 Run manifest。
+     * 可选，旧后端忽略。
+     */
+    request_id?: string;
+    /**
      * 触发对话的频道 id。可选:agent 对话入口没有"选来源"控件,
      * 前端一般不传;后端会从 session 的 tool_calls 记录反查 agent
      * 实际读过的第一个 channel_id 作为 origin。
@@ -407,10 +413,7 @@ export interface AgentChatParams {
      * 后端据此去重(同 request_id 不重复建 Run/执行工具)。可选,旧后端忽略。
      */
     request_id?: string;
-    /**
-     * v2 契约:续跑一个已存在的 Run。首轮由后端在响应里返回 run_id,
-     * 前端在同一 session 的后续提交带回。可选,旧后端忽略。
-     */
+    /** v2 预留:后端可能返回 run_id；当前保存链路使用 request_id 绑定 Run。 */
     run_id?: string;
     /** 用户在 UI 中明确选定、希望 agent 默认处理的聊天。 */
     selected_channels?: Array<Pick<ChatCandidate, 'chat_id' | 'chat_type' | 'name' | 'is_archived'>>;

--- a/packages/dmworksummary/src/utils/__tests__/genRequestId.test.ts
+++ b/packages/dmworksummary/src/utils/__tests__/genRequestId.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { genRequestId, genSessionId } from '../summaryHelpers';
+
+describe('genRequestId (WEB-03 idempotency key)', () => {
+    it('returns a non-empty, unique id per call', () => {
+        const a = genRequestId();
+        const b = genRequestId();
+        expect(typeof a).toBe('string');
+        expect(a.length).toBeGreaterThan(0);
+        expect(a).not.toBe(b);
+    });
+    it('does not collide with a session id', () => {
+        expect(genRequestId()).not.toBe(genSessionId());
+    });
+});

--- a/packages/dmworksummary/src/utils/agentChatSession.test.ts
+++ b/packages/dmworksummary/src/utils/agentChatSession.test.ts
@@ -4,6 +4,10 @@ import {
     readAgentChatSession,
     writeAgentChatSession,
     clearAgentChatSession,
+    agentChatRequestIdKey,
+    readAgentChatRequestId,
+    writeAgentChatRequestId,
+    clearAgentChatRequestId,
 } from './summaryHelpers';
 
 describe('agent chat session_id localStorage helpers', () => {
@@ -44,5 +48,22 @@ describe('agent chat session_id localStorage helpers', () => {
         clearAgentChatSession('ch1');
         expect(readAgentChatSession('ch1')).toBe('');
         expect(readAgentChatSession('ch2')).toBe('sid-2');
+    });
+
+    it('persists the last successful request_id per channel', () => {
+        expect(agentChatRequestIdKey('ch1')).toBe('agent-chat-request:ch1');
+        expect(agentChatRequestIdKey()).toBe('agent-chat-request:__workbench__');
+        writeAgentChatRequestId('ch1', 'req-1');
+        writeAgentChatRequestId('ch2', 'req-2');
+        expect(readAgentChatRequestId('ch1')).toBe('req-1');
+        expect(readAgentChatRequestId('ch2')).toBe('req-2');
+        clearAgentChatRequestId('ch1');
+        expect(readAgentChatRequestId('ch1')).toBe('');
+        expect(readAgentChatRequestId('ch2')).toBe('req-2');
+    });
+
+    it('does not persist an empty request_id', () => {
+        writeAgentChatRequestId('ch1', '');
+        expect(localStorage.getItem('agent-chat-request:ch1')).toBeNull();
     });
 });

--- a/packages/dmworksummary/src/utils/summaryHelpers.ts
+++ b/packages/dmworksummary/src/utils/summaryHelpers.ts
@@ -20,6 +20,15 @@ export function genSessionId(): string {
         : 'sid-' + Date.now() + '-' + Math.random().toString(16).slice(2);
 }
 
+// WEB-03: 每次逻辑提交的幂等键 request_id。后端(SS-03)据 (uid, session_id,
+// request_id) 去重建 Run —— request_id 为空时整条 v2 链路(Run/Spec/finish_status)
+// 不激活。stream→fallback 的重试必须复用同一个,避免同一提交建两个 Run。
+export function genRequestId(): string {
+    return crypto?.randomUUID
+        ? crypto.randomUUID()
+        : 'req-' + Date.now() + '-' + Math.random().toString(16).slice(2);
+}
+
 // ─── Agent 对话 session_id 持久化（「退出不丢」） ──────────────
 // session_id 写入 localStorage，按 channel/入口隔离，避免不同群会话串号。
 // 无 channelId 的入口（完整创建页无频道上下文）落到统一兜底 key。

--- a/packages/dmworksummary/src/utils/summaryHelpers.ts
+++ b/packages/dmworksummary/src/utils/summaryHelpers.ts
@@ -71,6 +71,44 @@ export function clearAgentChatSession(channelId?: string | null): void {
     }
 }
 
+// ─── Agent 对话 request_id 持久化（保存时绑定最后一次成功生成） ──────────────
+// request_id 与 session_id 同生命周期：它标识最近一次成功生成的交付轮次，
+// 保存为总结时需要带给后端以读取该轮冻结的 v2 manifest。
+const AGENT_CHAT_REQUEST_KEY_PREFIX = 'agent-chat-request:';
+
+/** 构造该入口最近一次成功 agent submit 的 request_id localStorage key。 */
+export function agentChatRequestIdKey(channelId?: string | null): string {
+    return AGENT_CHAT_REQUEST_KEY_PREFIX + (channelId || AGENT_CHAT_SESSION_FALLBACK);
+}
+
+/** 读取该入口最近一次成功 agent submit 的 request_id；无则返回空串。 */
+export function readAgentChatRequestId(channelId?: string | null): string {
+    try {
+        return localStorage.getItem(agentChatRequestIdKey(channelId)) || '';
+    } catch {
+        return '';
+    }
+}
+
+/** 写入最近一次成功 agent submit 的 request_id（空串跳过）。异常静默降级。 */
+export function writeAgentChatRequestId(channelId: string | null | undefined, requestId: string): void {
+    if (!requestId) return;
+    try {
+        localStorage.setItem(agentChatRequestIdKey(channelId), requestId);
+    } catch {
+        // localStorage 不可用时不持久化，不影响当前会话保存。
+    }
+}
+
+/** 清除该入口的 request_id（新会话 / 保存成功时与 session 一起清）。 */
+export function clearAgentChatRequestId(channelId?: string | null): void {
+    try {
+        localStorage.removeItem(agentChatRequestIdKey(channelId));
+    } catch {
+        // 同上，忽略。
+    }
+}
+
 // ─── Agent 对话 referencedTask 持久化（「退出不丢引用」） ──────────────
 // referencedTask 与 session_id 同生命周期：session 存活时它也存活，session
 // 清掉（新会话/保存成功）时它也被清。修 SUM-161 fast-follow：未保存的


### PR DESCRIPTION
## What

补齐 WEB-03 的 `request_id` 生命周期，让前端创建的 agent chat Run 能在保存总结时通过 `(uid, session_id, request_id)` 找回冻结的 citation manifest。

- 每次逻辑提交生成一个新的 `request_id`。
- SSE 失败转普通请求时复用同一个 `request_id`，避免重复 Run。
- 两个保存入口都发送最后一次成功回复对应的 `request_id`。
- `session_id` / `request_id` 同步持久化；完整 tuple 不匹配时，后端安全降级到 legacy 重算。
- 当前 PR 已 rebase，diff 仅包含 WEB-03，不再叠加 WEB-01。

## Review fixes

1. SSE 仅在 `done` / `error` 帧成功解析和分发后记录终态；malformed 或 truncated 帧会触发 transient error，不再永久锁住输入框。
2. transient SSE fallback 完成前保持 busy，禁止重复发送和新建会话。
3. fallback 使用提交时冻结的 `referenced_task_ids` / `selected_channels`，且 scope 构造位于 `try` 内。
4. localStorage 写入移出 `setState` updater；成功回复会持久化配对的 session/request id。
5. CI 纳入 chat、save binding 和两个保存入口的回归测试，并修复旧模板文案断言。

## Verification

```text
7 test files passed
127 tests passed
i18n check passed
git diff --check passed
```

包级 `tsc --noEmit` 仍受仓库既有 React/Semi 类型依赖问题影响；本次修改的回归测试和 CI 定向测试均通过。

## Deployment note

后端 `AGENT_SUMMARY_V2_MODE` 当前默认仍为 `off`。合并本 PR 后，需要由部署侧显式开启，v2 frozen-manifest 路径才会生效。

## Review checklist

- [x] 每次提交一个新 `request_id`
- [x] stream → fallback 复用同一 `request_id`
- [x] save 带最后一次成功轮的 `request_id`
- [x] malformed/truncated SSE 会解锁并回退
- [x] save-leg 测试已纳入 CI
