### PR TITLE
fix(chat): preview same-host Fleet links across protocols

### DIFF
--- a/packages/dmworkbase/src/bridge/message/__tests__/webhookPreview.test.ts
+++ b/packages/dmworkbase/src/bridge/message/__tests__/webhookPreview.test.ts
@@ -29,6 +29,19 @@ describe("parseWebhookIssuePreviewTarget", () => {
     });
   });
 
+  it("accepts a same-host Fleet link when only the protocol differs", () => {
+    expect(
+      parseWebhookIssuePreviewTarget(
+        "http://octo.example/fleet/team-a/issues/OPS-9",
+        "https://octo.example/chat"
+      )
+    ).toEqual({
+      workspaceSlug: "team-a",
+      issueIdentifier: "OPS-9",
+      sourceUrl: "http://octo.example/fleet/team-a/issues/OPS-9",
+    });
+  });
+
   it("rejects unrelated and unsafe links", () => {
     expect(parseWebhookIssuePreviewTarget("https://example.com/docs/1")).toBeNull();
     expect(
@@ -40,6 +53,12 @@ describe("parseWebhookIssuePreviewTarget", () => {
     expect(parseWebhookIssuePreviewTarget("javascript:alert(1)")).toBeNull();
     expect(parseWebhookIssuePreviewTarget("https://example.com/fleet/a/issues"))
       .toBeNull();
+    expect(
+      parseWebhookIssuePreviewTarget(
+        "http://octo.example:8080/fleet/a/issues/OPS-9",
+        "https://octo.example/chat"
+      )
+    ).toBeNull();
   });
 });
 

--- a/packages/dmworkbase/src/bridge/message/webhookPreview.ts
+++ b/packages/dmworkbase/src/bridge/message/webhookPreview.ts
@@ -18,7 +18,11 @@ function isTrustedFleetHost(url: URL, baseUrl: string): boolean {
   } catch {
     return false;
   }
-  return url.origin === base.origin || FLEET_PREVIEW_HOSTS.has(url.hostname);
+  // Some on-prem deployments are reached through HTTPS externally while the
+  // backend still emits the matching HTTP Fleet URL. Treat the same host as
+  // trusted across that protocol boundary, but keep rejecting other hosts and
+  // explicit ports.
+  return url.host === base.host || FLEET_PREVIEW_HOSTS.has(url.hostname);
 }
 
 function decodePathSegment(value: string): string {


### PR DESCRIPTION
## Summary

- recognize Fleet issue links as trusted when their hostname and explicit port match the current web app, even if HTTP/HTTPS differs
- preserve the existing trusted production hostname fallback
- keep rejecting different hosts and explicit port mismatches

## Context

Some on-prem deployments terminate TLS at an external proxy while backend-generated Fleet links still use HTTP. Comparing full origins causes those otherwise same-host webhook links to bypass the chat preview and open in a new tab.

## Verification

- `pnpm exec vitest run packages/dmworkbase/src/bridge/message/__tests__/webhookPreview.test.ts` (5 passed)
- `git diff --check`
