### PR TITLE
fix(mail): refresh Agent Mail workspace

### DIFF
--- a/packages/mail/src/Service/MailService.test.ts
+++ b/packages/mail/src/Service/MailService.test.ts
@@ -51,6 +51,28 @@ describe("MailService", () => {
     });
   });
 
+  it("reads the lightweight account state through the selected mailbox", async () => {
+    api.get.mockResolvedValue({ state: "128" });
+
+    await expect(MailService.getState("42")).resolves.toBe("128");
+    expect(api.get).toHaveBeenCalledWith("/mail-api/webapi/v0/state", {
+      headers: { "X-Octo-Mailbox-ID": "42" },
+      timeout: MAIL_REQUEST_TIMEOUT_MS,
+      signal: undefined,
+    });
+  });
+
+  it("rejects an invalid account state response", async () => {
+    api.get.mockResolvedValueOnce({ state: 128 }).mockResolvedValueOnce(null);
+
+    await expect(MailService.getState("42")).rejects.toThrow(
+      "Invalid mail state response"
+    );
+    await expect(MailService.getState("42")).rejects.toThrow(
+      "Invalid mail state response"
+    );
+  });
+
   it("loads the authenticated mailbox identity", async () => {
     api.get.mockResolvedValue({ address: "agent@example.com" });
 

--- a/packages/mail/src/Service/MailService.ts
+++ b/packages/mail/src/Service/MailService.ts
@@ -186,6 +186,24 @@ function mailboxContextConfig(
 }
 
 const MailService = {
+  async getState(
+    mailboxContextId: string,
+    signal?: AbortSignal
+  ): Promise<string> {
+    const response = await APIClient.shared.get<{ state?: unknown } | null>(
+      mailApiUrl("/state"),
+      mailboxContextConfig(mailboxContextId, { signal })
+    );
+    if (
+      !response ||
+      typeof response.state !== "string" ||
+      response.state.trim() === ""
+    ) {
+      throw new Error("Invalid mail state response");
+    }
+    return response.state;
+  },
+
   getIdentity(mailboxContextId: string): Promise<MailIdentity> {
     return APIClient.shared.get<MailIdentity>(
       mailApiUrl("/identity"),

--- a/packages/mail/src/bridge/useMailWorkspace.test.tsx
+++ b/packages/mail/src/bridge/useMailWorkspace.test.tsx
@@ -394,18 +394,48 @@ describe("useMailWorkspace read state", () => {
     await waitFor(() => expect(result.current.total).toBe(1));
     expect(result.current.selectedMessageId).toBe("E1");
     expect(result.current.messages.map((message) => message.id)).toEqual([
-      "E1",
       "E2",
     ]);
     expect(result.current.loading).toBe(false);
 
     act(() => result.current.reload());
-    await waitFor(() =>
-      expect(result.current.messages.map((message) => message.id)).toEqual([
-        "E2",
-      ])
-    );
-    expect(result.current.selectedMessageId).toBe("");
+    await waitFor(() => expect(result.current.selectedMessageId).toBe(""));
+    unmount();
+  });
+
+  it("keeps the selection when a silent refresh moves it off the page", async () => {
+    const { result, unmount } = renderHook(() => useMailWorkspace("fallback"));
+    await waitFor(() => expect(result.current.messages).toHaveLength(1));
+    act(() => result.current.selectMessage("E1"));
+
+    testState.getState.mockResolvedValue("2");
+    testState.listMessages.mockResolvedValue({
+      messages: [
+        {
+          id: "E2",
+          mailbox: "Inbox",
+          subject: "New message",
+          from: "new@example.test",
+          to: ["agent@example.test"],
+          preview: "new body",
+          receivedAt: "2026-08-10T00:01:00Z",
+          size: 8,
+          keywords: [],
+          unread: true,
+        },
+      ],
+      total: 1,
+      offset: 0,
+      limit: 30,
+    });
+    act(() => document.dispatchEvent(new Event("visibilitychange")));
+
+    await waitFor(() => expect(result.current.messages[0]?.id).toBe("E2"));
+    expect(result.current.selectedMessageId).toBe("E1");
+    expect(result.current.loading).toBe(false);
+
+    act(() => result.current.reload());
+    await waitFor(() => expect(result.current.selectedMessageId).toBe(""));
     unmount();
   });
 });

--- a/packages/mail/src/bridge/useMailWorkspace.test.tsx
+++ b/packages/mail/src/bridge/useMailWorkspace.test.tsx
@@ -7,6 +7,7 @@ const testState = vi.hoisted(() => ({
   emit: vi.fn(),
   on: vi.fn(),
   off: vi.fn(),
+  getState: vi.fn(),
   listMailboxes: vi.fn(),
   listMessages: vi.fn(),
   updateKeywords: vi.fn(),
@@ -24,6 +25,7 @@ vi.mock("@octo/base", () => ({
 
 vi.mock("../Service/MailService", () => ({
   default: {
+    getState: testState.getState,
     listMailboxes: testState.listMailboxes,
     listMessages: testState.listMessages,
     updateKeywords: testState.updateKeywords,
@@ -40,6 +42,7 @@ describe("useMailWorkspace read state", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     resetAgentMailboxContextForTests();
+    testState.getState.mockResolvedValue("1");
     testState.listMailboxes.mockResolvedValue([
       { id: "inbox", name: "Inbox", total: 1, unread: 1 },
     ]);
@@ -111,6 +114,298 @@ describe("useMailWorkspace read state", () => {
     expect(result.current.messages[0]?.keywords).toContain("\\Flagged");
     expect(testState.listMessages).toHaveBeenCalledTimes(initialListCalls);
     expect(result.current.starringMessageIds).toEqual([]);
+    unmount();
+  });
+
+  it("refreshes folder counts and the open message list in the background", async () => {
+    const { result, unmount } = renderHook(() => useMailWorkspace("fallback"));
+    await waitFor(() => expect(result.current.messages).toHaveLength(1));
+    const initialListCalls = testState.listMessages.mock.calls.length;
+
+    await act(async () => {
+      document.dispatchEvent(new Event("visibilitychange"));
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(testState.getState).toHaveBeenCalledTimes(1));
+    await waitFor(() =>
+      expect(testState.listMessages.mock.calls.length).toBeGreaterThan(
+        initialListCalls
+      )
+    );
+    const unchangedListCalls = testState.listMessages.mock.calls.length;
+
+    await act(async () => {
+      document.dispatchEvent(new Event("visibilitychange"));
+      await Promise.resolve();
+    });
+    expect(testState.listMessages).toHaveBeenCalledTimes(unchangedListCalls);
+
+    testState.getState.mockResolvedValue("2");
+    testState.listMailboxes.mockResolvedValue([
+      { id: "inbox", name: "Inbox", total: 2, unread: 2 },
+      { id: "sent", name: "Sent", total: 4, unread: 0 },
+    ]);
+    testState.listMessages.mockResolvedValue({
+      messages: [
+        {
+          id: "E2",
+          mailbox: "Inbox",
+          subject: "New message",
+          from: "new@example.test",
+          to: ["agent@example.test"],
+          preview: "new body",
+          receivedAt: "2026-08-10T00:01:00Z",
+          size: 8,
+          keywords: [],
+          unread: true,
+        },
+        ...result.current.messages,
+      ],
+      total: 2,
+      offset: 0,
+      limit: 30,
+    });
+
+    act(() => document.dispatchEvent(new Event("visibilitychange")));
+
+    await waitFor(() => expect(result.current.messages).toHaveLength(2));
+    expect(result.current.mailboxes).toEqual([
+      { id: "inbox", name: "Inbox", total: 2, unread: 2 },
+      { id: "sent", name: "Sent", total: 4, unread: 0 },
+    ]);
+    expect(result.current.messages[0]?.id).toBe("E2");
+    expect(result.current.total).toBe(2);
+    expect(result.current.loading).toBe(false);
+    expect(testState.getState).toHaveBeenCalledWith(
+      "42",
+      expect.any(AbortSignal)
+    );
+
+    unmount();
+  });
+
+  it("keeps later user navigation foreground after a silent refresh", async () => {
+    testState.listMailboxes.mockResolvedValue([
+      { id: "inbox", name: "Inbox", total: 1, unread: 1 },
+      { id: "sent", name: "Sent", total: 0, unread: 0 },
+    ]);
+    const { result, unmount } = renderHook(() => useMailWorkspace("fallback"));
+    await waitFor(() => expect(result.current.messages).toHaveLength(1));
+
+    act(() => document.dispatchEvent(new Event("visibilitychange")));
+    await waitFor(() => expect(testState.getState).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    testState.listMessages.mockRejectedValue(new Error("network down"));
+    act(() => result.current.selectMailbox("Sent"));
+
+    await waitFor(() => expect(result.current.error).toBe("fallback"));
+    expect(result.current.loading).toBe(false);
+    unmount();
+  });
+
+  it("clears a stale error after a successful silent refresh", async () => {
+    testState.listMessages.mockRejectedValueOnce(new Error("network down"));
+    const { result, unmount } = renderHook(() => useMailWorkspace("fallback"));
+    await waitFor(() => expect(result.current.error).toBe("fallback"));
+
+    act(() => document.dispatchEvent(new Event("visibilitychange")));
+
+    await waitFor(() => expect(result.current.messages).toHaveLength(1));
+    expect(result.current.error).toBe("");
+    expect(result.current.loading).toBe(false);
+    unmount();
+  });
+
+  it("keeps a message error when only mailbox resources refresh", async () => {
+    testState.listMessages.mockRejectedValue(new Error("network down"));
+    const { result, unmount } = renderHook(() => useMailWorkspace("fallback"));
+    await waitFor(() => expect(result.current.error).toBe("fallback"));
+    const initialMailboxCalls = testState.listMailboxes.mock.calls.length;
+
+    act(() => document.dispatchEvent(new Event("visibilitychange")));
+
+    await waitFor(() =>
+      expect(testState.listMailboxes.mock.calls.length).toBeGreaterThan(
+        initialMailboxCalls
+      )
+    );
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(result.current.error).toBe("fallback");
+    unmount();
+  });
+
+  it("keeps a mailbox-resource error when only messages refresh", async () => {
+    const { result, unmount } = renderHook(() => useMailWorkspace("fallback"));
+    await waitFor(() => expect(result.current.messages).toHaveLength(1));
+
+    testState.listMailboxes.mockRejectedValue(new Error("network down"));
+    act(() => result.current.reload());
+    await waitFor(() => expect(result.current.error).toBe("fallback"));
+    const initialMessageCalls = testState.listMessages.mock.calls.length;
+
+    act(() => document.dispatchEvent(new Event("visibilitychange")));
+
+    await waitFor(() =>
+      expect(testState.listMessages.mock.calls.length).toBeGreaterThan(
+        initialMessageCalls
+      )
+    );
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(result.current.error).toBe("fallback");
+    unmount();
+  });
+
+  it("keeps a poll foreground while a user request is in flight", async () => {
+    testState.listMailboxes.mockResolvedValue([
+      { id: "inbox", name: "Inbox", total: 1, unread: 1 },
+      { id: "sent", name: "Sent", total: 0, unread: 0 },
+    ]);
+    const { result, unmount } = renderHook(() => useMailWorkspace("fallback"));
+    await waitFor(() => expect(result.current.messages).toHaveLength(1));
+    const initialMessageCalls = testState.listMessages.mock.calls.length;
+    let resolveUserRequest!: (value: {
+      messages: never[];
+      total: number;
+      offset: number;
+      limit: number;
+    }) => void;
+    const userRequest = new Promise<{
+      messages: never[];
+      total: number;
+      offset: number;
+      limit: number;
+    }>((resolve) => {
+      resolveUserRequest = resolve;
+    });
+    testState.listMessages
+      .mockImplementationOnce(() => userRequest)
+      .mockRejectedValueOnce(new Error("network down"));
+
+    act(() => result.current.selectMailbox("Sent"));
+    await waitFor(() =>
+      expect(testState.listMessages).toHaveBeenCalledTimes(
+        initialMessageCalls + 1
+      )
+    );
+
+    act(() => document.dispatchEvent(new Event("visibilitychange")));
+
+    await waitFor(() => expect(result.current.error).toBe("fallback"));
+    expect(result.current.loading).toBe(false);
+
+    await act(async () => {
+      resolveUserRequest({ messages: [], total: 0, offset: 0, limit: 30 });
+      await userRequest;
+    });
+    unmount();
+  });
+
+  it("keeps a queued reload foreground when a poll settles in the same batch", async () => {
+    const { result, unmount } = renderHook(() => useMailWorkspace("fallback"));
+    await waitFor(() => expect(result.current.messages).toHaveLength(1));
+    let resolveState!: (value: string) => void;
+    const pendingState = new Promise<string>((resolve) => {
+      resolveState = resolve;
+    });
+    testState.getState.mockImplementationOnce(() => pendingState);
+    testState.listMailboxes.mockRejectedValue(new Error("network down"));
+    testState.listMessages.mockRejectedValue(new Error("network down"));
+
+    act(() => document.dispatchEvent(new Event("visibilitychange")));
+    await waitFor(() => expect(testState.getState).toHaveBeenCalledTimes(1));
+
+    await act(async () => {
+      result.current.reload();
+      resolveState("2");
+      await pendingState;
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(result.current.error).toBe("fallback"));
+    expect(result.current.loading).toBe(false);
+    unmount();
+  });
+
+  it("keeps the open message during a silent unread-only refresh", async () => {
+    const secondMessage = {
+      id: "E2",
+      mailbox: "Inbox",
+      subject: "Another unread message",
+      from: "another@example.test",
+      to: ["agent@example.test"],
+      preview: "another body",
+      receivedAt: "2026-08-10T00:01:00Z",
+      size: 8,
+      keywords: [],
+      unread: true,
+    };
+    testState.listMessages.mockResolvedValue({
+      messages: [
+        {
+          id: "E1",
+          mailbox: "Inbox",
+          subject: "Unread",
+          from: "sender@example.test",
+          to: ["agent@example.test"],
+          preview: "body",
+          receivedAt: "2026-08-10T00:00:00Z",
+          size: 4,
+          keywords: [],
+          unread: true,
+        },
+        secondMessage,
+      ],
+      total: 2,
+      offset: 0,
+      limit: 30,
+    });
+    const { result, unmount } = renderHook(() => useMailWorkspace("fallback"));
+    await waitFor(() => expect(result.current.messages).toHaveLength(2));
+
+    act(() => result.current.setUnreadOnly(true));
+    await waitFor(() =>
+      expect(testState.listMessages).toHaveBeenLastCalledWith(
+        expect.objectContaining({ unread: true })
+      )
+    );
+    await act(async () => {
+      result.current.selectMessage("E1");
+      result.current.markMessageRead(result.current.messages[0]!);
+      await Promise.resolve();
+    });
+    expect(result.current.messages[0]?.unread).toBe(false);
+
+    testState.getState.mockResolvedValue("2");
+    testState.listMessages.mockResolvedValue({
+      messages: [secondMessage],
+      total: 1,
+      offset: 0,
+      limit: 30,
+    });
+    act(() => document.dispatchEvent(new Event("visibilitychange")));
+
+    await waitFor(() => expect(result.current.total).toBe(1));
+    expect(result.current.selectedMessageId).toBe("E1");
+    expect(result.current.messages.map((message) => message.id)).toEqual([
+      "E1",
+      "E2",
+    ]);
+    expect(result.current.loading).toBe(false);
+
+    act(() => result.current.reload());
+    await waitFor(() =>
+      expect(result.current.messages.map((message) => message.id)).toEqual([
+        "E2",
+      ])
+    );
+    expect(result.current.selectedMessageId).toBe("");
     unmount();
   });
 });

--- a/packages/mail/src/bridge/useMailWorkspace.ts
+++ b/packages/mail/src/bridge/useMailWorkspace.ts
@@ -6,6 +6,41 @@ import { getErrorMessage, hasKeyword } from "../utils";
 import { useAgentMailboxContext } from "./mailboxContext";
 
 const PAGE_SIZE = 30;
+const STATE_POLL_INTERVAL_MS = 10_000;
+const FULL_REFRESH_FALLBACK_INTERVAL_MS = 5 * 60_000;
+
+interface RefreshRequest {
+  revision: number;
+  silent: boolean;
+}
+
+type WorkspaceErrorSource = "resources" | "messages" | "mutation";
+
+function useSilentRefreshFlag(
+  request: RefreshRequest,
+  foregroundKey: unknown
+): boolean {
+  const previousRef = useRef<{
+    revision: number;
+    foregroundKey: unknown;
+    silent: boolean;
+  }>();
+  const previous = previousRef.current;
+  let silent = previous?.silent ?? false;
+
+  if (previous && !Object.is(previous.foregroundKey, foregroundKey)) {
+    silent = false;
+  } else if (!previous || previous.revision !== request.revision) {
+    silent = request.silent;
+  }
+
+  previousRef.current = {
+    revision: request.revision,
+    foregroundKey,
+    silent,
+  };
+  return silent;
+}
 
 export interface MailWorkspaceState {
   mailboxes: Mailbox[];
@@ -49,15 +84,58 @@ export default function useMailWorkspace(
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
   const [starringMessageIds, setStarringMessageIds] = useState<string[]>([]);
-  const [revision, setRevision] = useState(0);
+  const [refreshRequest, setRefreshRequest] = useState<RefreshRequest>({
+    revision: 0,
+    silent: false,
+  });
   const context = useAgentMailboxContext();
   const mailboxContextId = context?.mailbox.id || "";
   const requestRef = useRef(0);
   const resourcesRequestRef = useRef(0);
   const starringMessageIdsRef = useRef(new Set<string>());
+  const foregroundInteractionRef = useRef(0);
+  const foregroundRequestCountRef = useRef(0);
+  const pendingForegroundRefreshRef = useRef(false);
+  const errorSourceRef = useRef<WorkspaceErrorSource | null>(null);
+  const messagesRef = useRef(messages);
+  const selectedMessageIdRef = useRef(selectedMessageId);
 
-  const reload = useCallback(() => setRevision((value) => value + 1), []);
+  const clearWorkspaceError = useCallback((source?: WorkspaceErrorSource) => {
+    if (source && errorSourceRef.current !== source) return;
+    errorSourceRef.current = null;
+    setError("");
+  }, []);
+  const setWorkspaceError = useCallback(
+    (source: WorkspaceErrorSource, reason: unknown) => {
+      errorSourceRef.current = source;
+      setError(getErrorMessage(reason, fallbackError));
+    },
+    [fallbackError]
+  );
+
+  useEffect(() => {
+    messagesRef.current = messages;
+    selectedMessageIdRef.current = selectedMessageId;
+  }, [messages, selectedMessageId]);
+
+  const reload = useCallback(() => {
+    pendingForegroundRefreshRef.current = true;
+    setRefreshRequest((current) => ({
+      revision: current.revision + 1,
+      silent: false,
+    }));
+  }, []);
+  const refreshSilently = useCallback(() => {
+    const silent =
+      foregroundRequestCountRef.current === 0 &&
+      !pendingForegroundRefreshRef.current;
+    setRefreshRequest((current) => ({
+      revision: current.revision + 1,
+      silent,
+    }));
+  }, []);
   const selectMailbox = useCallback((name: string) => {
+    foregroundInteractionRef.current += 1;
     setSelectedMailbox(name);
     setSelectedMessageId("");
     setMessages([]);
@@ -105,21 +183,24 @@ export default function useMailWorkspace(
         []
       ).catch((reason) => {
         applyReadState(true);
-        setError(getErrorMessage(reason, fallbackError));
+        setWorkspaceError("mutation", reason);
       });
     },
-    [fallbackError, mailboxContextId, selectedMailbox]
+    [mailboxContextId, selectedMailbox, setWorkspaceError]
   );
   const setSearch = useCallback((value: string) => {
+    foregroundInteractionRef.current += 1;
     setSearchState(value);
     setPageState(1);
   }, []);
   const setUnreadOnly = useCallback((value: boolean) => {
+    foregroundInteractionRef.current += 1;
     setUnreadOnlyState(value);
     setSelectedMessageId("");
     setPageState(1);
   }, []);
   const setPage = useCallback((value: number) => {
+    foregroundInteractionRef.current += 1;
     setPageState(Math.max(1, value));
   }, []);
   const toggleStar = useCallback(
@@ -153,7 +234,7 @@ export default function useMailWorkspace(
         starred ? ["\\Flagged"] : []
       )
         .catch((reason) => {
-          setError(getErrorMessage(reason, fallbackError));
+          setWorkspaceError("mutation", reason);
           reload();
         })
         .finally(() => {
@@ -163,7 +244,18 @@ export default function useMailWorkspace(
           );
         });
     },
-    [fallbackError, mailboxContextId, reload]
+    [mailboxContextId, reload, setWorkspaceError]
+  );
+
+  const resourcesRefreshSilent = useSilentRefreshFlag(
+    refreshRequest,
+    `${mailboxContextId}\u0000${
+      context?.mailbox.address || ""
+    }\u0000${fallbackError}`
+  );
+  const messagesRefreshSilent = useSilentRefreshFlag(
+    refreshRequest,
+    `${mailboxContextId}\u0000${fallbackError}\u0000${foregroundInteractionRef.current}`
   );
 
   useEffect(() => {
@@ -176,8 +268,8 @@ export default function useMailWorkspace(
     setUnreadOnlyState(false);
     starringMessageIdsRef.current.clear();
     setStarringMessageIds([]);
-    setError("");
-  }, [mailboxContextId]);
+    clearWorkspaceError();
+  }, [clearWorkspaceError, mailboxContextId]);
 
   useEffect(() => {
     if (!mailboxContextId) {
@@ -188,14 +280,28 @@ export default function useMailWorkspace(
       return undefined;
     }
     let active = true;
+    let foregroundActive = !resourcesRefreshSilent;
+    if (foregroundActive) {
+      foregroundRequestCountRef.current += 1;
+      pendingForegroundRefreshRef.current = false;
+    }
+    const finishForegroundRequest = () => {
+      if (!foregroundActive) return;
+      foregroundActive = false;
+      foregroundRequestCountRef.current = Math.max(
+        0,
+        foregroundRequestCountRef.current - 1
+      );
+    };
     const request = ++resourcesRequestRef.current;
-    setLoading(true);
+    if (!resourcesRefreshSilent) setLoading(true);
     setIdentity({ address: context?.mailbox.address || "" });
     setIdentityUnavailable(false);
     void MailService.listMailboxes(mailboxContextId)
       .then((nextMailboxes) => {
         if (!active || request !== resourcesRequestRef.current) return;
         setMailboxes(nextMailboxes);
+        if (resourcesRefreshSilent) clearWorkspaceError("resources");
         setSelectedMailbox((current) => {
           if (
             current &&
@@ -216,15 +322,26 @@ export default function useMailWorkspace(
       })
       .catch((reason) => {
         if (active && request === resourcesRequestRef.current) {
-          setError(getErrorMessage(reason, fallbackError));
-          setLoading(false);
+          if (!resourcesRefreshSilent) {
+            setWorkspaceError("resources", reason);
+            setLoading(false);
+          }
         }
-      });
+      })
+      .finally(finishForegroundRequest);
 
     return () => {
       active = false;
+      finishForegroundRequest();
     };
-  }, [context?.mailbox.address, fallbackError, mailboxContextId, revision]);
+  }, [
+    clearWorkspaceError,
+    context?.mailbox.address,
+    mailboxContextId,
+    refreshRequest.revision,
+    resourcesRefreshSilent,
+    setWorkspaceError,
+  ]);
 
   useEffect(() => {
     if (!mailboxContextId || !selectedMailbox) {
@@ -236,8 +353,23 @@ export default function useMailWorkspace(
 
     const request = ++requestRef.current;
     const controller = new AbortController();
-    setLoading(true);
-    setError("");
+    let foregroundActive = !messagesRefreshSilent;
+    if (foregroundActive) {
+      foregroundRequestCountRef.current += 1;
+      pendingForegroundRefreshRef.current = false;
+    }
+    const finishForegroundRequest = () => {
+      if (!foregroundActive) return;
+      foregroundActive = false;
+      foregroundRequestCountRef.current = Math.max(
+        0,
+        foregroundRequestCountRef.current - 1
+      );
+    };
+    if (!messagesRefreshSilent) {
+      setLoading(true);
+      clearWorkspaceError();
+    }
     const timer = window.setTimeout(
       () => {
         void MailService.listMessages({
@@ -251,22 +383,56 @@ export default function useMailWorkspace(
         })
           .then((response) => {
             if (request !== requestRef.current) return;
-            setMessages(response.messages ?? []);
-            setTotal(response.total ?? 0);
-            setSelectedMessageId((current) =>
-              current &&
-              response.messages?.some((message) => message.id === current)
-                ? current
-                : ""
+            const responseMessages = response.messages ?? [];
+            const selectedMessageId = selectedMessageIdRef.current;
+            const selectedMessage = messagesRef.current.find(
+              (message) => message.id === selectedMessageId
             );
+            const preserveSelectedMessage =
+              messagesRefreshSilent &&
+              unreadOnly &&
+              selectedMessage &&
+              !selectedMessage.unread &&
+              !responseMessages.some(
+                (message) => message.id === selectedMessage.id
+              );
+            const nextMessages = preserveSelectedMessage
+              ? [...responseMessages]
+              : responseMessages;
+            if (preserveSelectedMessage) {
+              const previousIndex = messagesRef.current.findIndex(
+                (message) => message.id === selectedMessage.id
+              );
+              nextMessages.splice(
+                Math.min(Math.max(previousIndex, 0), nextMessages.length),
+                0,
+                selectedMessage
+              );
+            }
+            messagesRef.current = nextMessages;
+            setMessages(nextMessages);
+            setTotal(response.total ?? 0);
+            if (messagesRefreshSilent) clearWorkspaceError("messages");
+            setSelectedMessageId((current) => {
+              const nextSelectedMessageId =
+                current &&
+                nextMessages.some((message) => message.id === current)
+                  ? current
+                  : "";
+              selectedMessageIdRef.current = nextSelectedMessageId;
+              return nextSelectedMessageId;
+            });
           })
           .catch((reason) => {
             if (controller.signal.aborted || request !== requestRef.current)
               return;
-            setError(getErrorMessage(reason, fallbackError));
+            if (!messagesRefreshSilent) {
+              setWorkspaceError("messages", reason);
+            }
           })
           .finally(() => {
             if (request === requestRef.current) setLoading(false);
+            finishForegroundRequest();
           });
       },
       search ? 250 : 0
@@ -275,16 +441,83 @@ export default function useMailWorkspace(
     return () => {
       window.clearTimeout(timer);
       controller.abort();
+      finishForegroundRequest();
     };
   }, [
-    fallbackError,
+    clearWorkspaceError,
     mailboxContextId,
+    messagesRefreshSilent,
     page,
-    revision,
+    refreshRequest.revision,
     search,
     selectedMailbox,
+    setWorkspaceError,
     unreadOnly,
   ]);
+
+  useEffect(() => {
+    if (!mailboxContextId) return undefined;
+
+    let active = true;
+    let polling = false;
+    let pollWhenSettled = false;
+    let knownState: string | null = null;
+    let stateController: AbortController | null = null;
+
+    const pollState = () => {
+      if (!active || polling || document.visibilityState === "hidden") {
+        return;
+      }
+      polling = true;
+      stateController = new AbortController();
+      void MailService.getState(mailboxContextId, stateController.signal)
+        .then((nextState) => {
+          if (!active || document.visibilityState === "hidden") return;
+          const changed = knownState === null || knownState !== nextState;
+          knownState = nextState;
+          if (changed) refreshSilently();
+        })
+        .catch(() => {
+          // State polling is an optimization. The low-frequency full refresh
+          // below remains the fail-safe when this lightweight request fails.
+        })
+        .finally(() => {
+          polling = false;
+          stateController = null;
+          if (pollWhenSettled) {
+            pollWhenSettled = false;
+            pollState();
+          }
+        });
+    };
+    const refreshWhenVisible = () => {
+      if (document.visibilityState !== "hidden") refreshSilently();
+    };
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "hidden") {
+        stateController?.abort();
+        return;
+      }
+      if (polling) {
+        pollWhenSettled = true;
+        return;
+      }
+      pollState();
+    };
+    const stateInterval = window.setInterval(pollState, STATE_POLL_INTERVAL_MS);
+    const fallbackInterval = window.setInterval(
+      refreshWhenVisible,
+      FULL_REFRESH_FALLBACK_INTERVAL_MS
+    );
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    return () => {
+      active = false;
+      stateController?.abort();
+      window.clearInterval(stateInterval);
+      window.clearInterval(fallbackInterval);
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+    };
+  }, [mailboxContextId, refreshSilently]);
 
   useEffect(() => {
     const refresh = () => reload();
@@ -302,7 +535,7 @@ export default function useMailWorkspace(
       setSearchState("");
       setUnreadOnlyState(false);
       setLoading(true);
-      setError("");
+      clearWorkspaceError();
       reload();
     };
     const handleMenu = (payload: { menuId?: string }) => {
@@ -316,7 +549,7 @@ export default function useMailWorkspace(
       WKApp.mittBus.off("wk:nav-menu-activated", handleMenu);
       WKApp.mittBus.off("space-changed", handleSpaceChanged);
     };
-  }, [reload]);
+  }, [clearWorkspaceError, reload]);
 
   const pageCount = useMemo(
     () => Math.max(1, Math.ceil(total / PAGE_SIZE)),

--- a/packages/mail/src/bridge/useMailWorkspace.ts
+++ b/packages/mail/src/bridge/useMailWorkspace.ts
@@ -97,8 +97,6 @@ export default function useMailWorkspace(
   const foregroundRequestCountRef = useRef(0);
   const pendingForegroundRefreshRef = useRef(false);
   const errorSourceRef = useRef<WorkspaceErrorSource | null>(null);
-  const messagesRef = useRef(messages);
-  const selectedMessageIdRef = useRef(selectedMessageId);
 
   const clearWorkspaceError = useCallback((source?: WorkspaceErrorSource) => {
     if (source && errorSourceRef.current !== source) return;
@@ -112,11 +110,6 @@ export default function useMailWorkspace(
     },
     [fallbackError]
   );
-
-  useEffect(() => {
-    messagesRef.current = messages;
-    selectedMessageIdRef.current = selectedMessageId;
-  }, [messages, selectedMessageId]);
 
   const reload = useCallback(() => {
     pendingForegroundRefreshRef.current = true;
@@ -384,44 +377,16 @@ export default function useMailWorkspace(
           .then((response) => {
             if (request !== requestRef.current) return;
             const responseMessages = response.messages ?? [];
-            const selectedMessageId = selectedMessageIdRef.current;
-            const selectedMessage = messagesRef.current.find(
-              (message) => message.id === selectedMessageId
-            );
-            const preserveSelectedMessage =
-              messagesRefreshSilent &&
-              unreadOnly &&
-              selectedMessage &&
-              !selectedMessage.unread &&
-              !responseMessages.some(
-                (message) => message.id === selectedMessage.id
-              );
-            const nextMessages = preserveSelectedMessage
-              ? [...responseMessages]
-              : responseMessages;
-            if (preserveSelectedMessage) {
-              const previousIndex = messagesRef.current.findIndex(
-                (message) => message.id === selectedMessage.id
-              );
-              nextMessages.splice(
-                Math.min(Math.max(previousIndex, 0), nextMessages.length),
-                0,
-                selectedMessage
-              );
-            }
-            messagesRef.current = nextMessages;
-            setMessages(nextMessages);
+            setMessages(responseMessages);
             setTotal(response.total ?? 0);
             if (messagesRefreshSilent) clearWorkspaceError("messages");
-            setSelectedMessageId((current) => {
-              const nextSelectedMessageId =
-                current &&
-                nextMessages.some((message) => message.id === current)
-                  ? current
-                  : "";
-              selectedMessageIdRef.current = nextSelectedMessageId;
-              return nextSelectedMessageId;
-            });
+            setSelectedMessageId((current) =>
+              messagesRefreshSilent ||
+              (current &&
+                responseMessages.some((message) => message.id === current))
+                ? current
+                : ""
+            );
           })
           .catch((reason) => {
             if (controller.signal.aborted || request !== requestRef.current)

--- a/packages/mail/src/features/MailAddressManagementFeature.test.tsx
+++ b/packages/mail/src/features/MailAddressManagementFeature.test.tsx
@@ -137,6 +137,23 @@ describe("MailAddressManagementFeature", () => {
     expect(state.emit).toHaveBeenCalledWith("mail-refresh");
   });
 
+  it("refreshes the sidebar when the management view is refreshed", async () => {
+    await act(async () => {
+      root.render(<MailAddressManagementFeature />);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    state.emit.mockClear();
+    await act(async () => {
+      state.viewProps?.onRefresh();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(state.emit).toHaveBeenCalledWith("mail-refresh");
+  });
+
   it("switches from the existing OpenClaw prompt to the CLI prompt", async () => {
     await act(async () => {
       root.render(<MailAddressManagementFeature />);

--- a/packages/mail/src/features/MailAddressManagementFeature.tsx
+++ b/packages/mail/src/features/MailAddressManagementFeature.tsx
@@ -47,7 +47,10 @@ export default function MailAddressManagementFeature() {
   const setupPromptCopyRevisionRef = useRef(0);
   const mailboxContext = useAgentMailboxContext();
 
-  const reload = useCallback(() => setRevision((value) => value + 1), []);
+  const reload = useCallback(() => {
+    setRevision((value) => value + 1);
+    WKApp.mittBus.emit("mail-refresh" as never);
+  }, []);
 
   useEffect(() => {
     let active = true;

--- a/packages/mail/src/features/MailRecordsFeature.test.tsx
+++ b/packages/mail/src/features/MailRecordsFeature.test.tsx
@@ -110,6 +110,25 @@ describe("MailRecordsFeature composer sessions", () => {
     resetAgentMailboxContextForTests();
   });
 
+  it("keeps the reader open when a silent refresh moves the selection off-page", () => {
+    const selectMessage = vi.fn();
+    state.workspace = { ...state.workspace, selectMessage };
+    const { rerender } = render(<MailRecordsFeature initialRole="drafts" />);
+    expect(screen.getByRole("button", { name: "edit draft" })).toBeTruthy();
+    selectMessage.mockClear();
+
+    state.workspace = {
+      ...state.workspace,
+      messages: [{ id: "E2" }],
+      selectedMessageId: "E1",
+      selectMessage,
+    };
+    rerender(<MailRecordsFeature initialRole="drafts" />);
+
+    expect(screen.getByRole("button", { name: "edit draft" })).toBeTruthy();
+    expect(selectMessage).not.toHaveBeenCalled();
+  });
+
   it("starts a clean composer when Compose replaces an edited Draft", () => {
     render(<MailRecordsFeature initialRole="drafts" />);
 

--- a/packages/mail/src/features/MailRecordsFeature.tsx
+++ b/packages/mail/src/features/MailRecordsFeature.tsx
@@ -116,16 +116,8 @@ export default function MailRecordsFeature({
     const first = workspace.messages.find(
       (message) => message.id !== removedMessageId
     );
-    if (!first) {
-      if (workspace.selectedMessageId) workspace.selectMessage("");
-      return;
-    }
-    if (
-      !workspace.selectedMessageId ||
-      !workspace.messages.some(
-        (message) => message.id === workspace.selectedMessageId
-      )
-    ) {
+    if (!first) return;
+    if (!workspace.selectedMessageId) {
       workspace.selectMessage(first.id);
     }
   }, [
@@ -141,11 +133,25 @@ export default function MailRecordsFeature({
     workspace.markMessageRead(message);
   };
 
-  const selectedMessage = workspace.messages.find(
+  const selectedMessageInList = workspace.messages.find(
     (message) =>
       message.id === workspace.selectedMessageId &&
       message.id !== removedMessageId
   );
+  const [selectedMessageCache, setSelectedMessageCache] =
+    useState<MessageSummary | null>(null);
+  useEffect(() => {
+    if (selectedMessageInList) {
+      setSelectedMessageCache(selectedMessageInList);
+    } else if (!workspace.selectedMessageId) {
+      setSelectedMessageCache(null);
+    }
+  }, [selectedMessageInList, workspace.selectedMessageId]);
+  const selectedMessage =
+    selectedMessageInList ||
+    (selectedMessageCache?.id === workspace.selectedMessageId
+      ? selectedMessageCache
+      : undefined);
   const selectedMailbox = workspace.mailboxes.find(
     (mailbox) => mailbox.name === workspace.selectedMailbox
   );

--- a/packages/mail/src/ui/MailRuleManagementView/index.css
+++ b/packages/mail/src/ui/MailRuleManagementView/index.css
@@ -487,7 +487,7 @@
   min-height: var(--wk-sp-8);
   padding: 0 var(--wk-sp-2);
   color: var(--wk-text-secondary);
-  background: var(--wk-bg-elevated);
+  background: var(--wk-bg-surface);
   border: 1px solid var(--wk-border-default);
   border-radius: var(--wk-r-xs);
   outline: 0;

--- a/packages/mail/src/ui/MailSidebarView/MailSidebarView.test.tsx
+++ b/packages/mail/src/ui/MailSidebarView/MailSidebarView.test.tsx
@@ -41,4 +41,57 @@ describe("MailSidebarView", () => {
       "octo-mail-sidebar__brand-beta"
     );
   });
+
+  it("keeps the standard mailbox navigation visible when no Agent mailbox exists", () => {
+    render(
+      <MailSidebarView
+        mailboxes={[]}
+        agentMailboxes={[]}
+        selectedAgentMailbox={null}
+        identity={null}
+        identityUnavailable
+        selectedMailbox=""
+        addressManagementActive
+        loading={false}
+        error=""
+        t={(key) =>
+          ({
+            "mail.header.title": "Agent Mail",
+            "mail.header.beta": "Beta",
+            "mail.identity.unavailable": "Mailbox address unavailable",
+            "mail.identity.switchLabel": "Switch active mailbox",
+            "mail.actions.compose": "Compose",
+            "mail.addresses.manage": "Manage Agent mailboxes",
+            "mail.navigation.mailboxes": "Mailboxes",
+            "mail.actions.refresh": "Refresh",
+            "mail.mailbox.inbox": "Inbox",
+            "mail.mailbox.starred": "Starred",
+            "mail.mailbox.drafts": "Drafts",
+            "mail.mailbox.sent": "Sent",
+            "mail.mailbox.trash": "Trash",
+            "mail.mailbox.junk": "Junk",
+          }[key] || key)
+        }
+        onCompose={() => undefined}
+        onManageAddresses={() => undefined}
+        onRefresh={() => undefined}
+        onSelectMailbox={() => undefined}
+        onSelectAgentMailbox={() => undefined}
+      />
+    );
+
+    for (const label of [
+      "Inbox",
+      "Starred",
+      "Drafts",
+      "Sent",
+      "Trash",
+      "Junk",
+    ]) {
+      expect(
+        (screen.getByRole("button", { name: label }) as HTMLButtonElement)
+          .disabled
+      ).toBe(true);
+    }
+  });
 });

--- a/packages/mail/src/ui/MailSidebarView/index.css
+++ b/packages/mail/src/ui/MailSidebarView/index.css
@@ -315,6 +315,17 @@
   background: var(--wk-bg-hover);
 }
 
+.octo-mail-mailboxes > button:disabled {
+  color: var(--wk-text-tertiary);
+  cursor: default;
+  opacity: 0.72;
+}
+
+.octo-mail-mailboxes > button:disabled:hover {
+  color: var(--wk-text-tertiary);
+  background: transparent;
+}
+
 .octo-mail-mailboxes > button.is-active {
   color: var(--wk-text-primary);
   background: var(--wk-bg-selected);

--- a/packages/mail/src/ui/MailSidebarView/index.tsx
+++ b/packages/mail/src/ui/MailSidebarView/index.tsx
@@ -42,6 +42,21 @@ export interface MailSidebarViewProps {
   onSelectAgentMailbox: (mailbox: AgentMailbox) => void;
 }
 
+const emptyMailboxNavigation: Mailbox[] = [
+  { id: "empty-inbox", name: "Inbox", role: "inbox", total: 0, unread: 0 },
+  {
+    id: "empty-starred",
+    name: "Starred",
+    role: "starred",
+    total: 0,
+    unread: 0,
+  },
+  { id: "empty-drafts", name: "Drafts", role: "drafts", total: 0, unread: 0 },
+  { id: "empty-sent", name: "Sent", role: "sent", total: 0, unread: 0 },
+  { id: "empty-trash", name: "Trash", role: "trash", total: 0, unread: 0 },
+  { id: "empty-junk", name: "Junk", role: "junk", total: 0, unread: 0 },
+];
+
 function mailboxIcon(mailbox: Mailbox) {
   switch (inferMailboxRole(mailbox)) {
     case "inbox":
@@ -83,6 +98,14 @@ export default function MailSidebarView(props: MailSidebarViewProps) {
   const visibleMailboxes = mailboxes.filter(
     (mailbox) => inferMailboxRole(mailbox) !== "archive"
   );
+  const showEmptyMailboxNavigation =
+    !loading &&
+    !error &&
+    props.agentMailboxes.length === 0 &&
+    visibleMailboxes.length === 0;
+  const mailboxNavigation = showEmptyMailboxNavigation
+    ? emptyMailboxNavigation
+    : visibleMailboxes;
   const [accountOpen, setAccountOpen] = useState(false);
   const accountRef = useRef<HTMLDivElement>(null);
   const selectedAddress =
@@ -254,10 +277,11 @@ export default function MailSidebarView(props: MailSidebarViewProps) {
             </div>
           ) : null}
           {!loading && !error
-            ? visibleMailboxes.map((mailbox) => (
+            ? mailboxNavigation.map((mailbox) => (
                 <button
                   key={mailbox.id}
                   type="button"
+                  disabled={showEmptyMailboxNavigation}
                   className={
                     !props.addressManagementActive &&
                     mailbox.name === props.selectedMailbox


### PR DESCRIPTION
## Summary

Refresh Agent Mail data when the authenticated account state changes and preserve the mailbox navigation in an empty Space.

## Related Issue

Fixes #1463

Depends on Mininglamp-OSS/octo-mail#65. The backend change must be merged and deployed before this frontend release.

## Changes

- Poll the lightweight mail state and silently refresh mailbox data only when it changes.
- Keep a bounded full-refresh fallback and refresh workspace data from address management.
- Preserve the active reader when a silent refresh moves the selected message outside the current page.
- Show disabled standard mailbox navigation when no Agent mailbox exists.
- Align the mail-rule input background with the surrounding surface.
- Add regression tests for polling, silent refresh, reader stability, address refresh, and empty navigation.

## Architecture / Module Boundary

- Affected module(s): `@octo/mail`
- New or changed user-visible entry point: no
- Shared layer touched: UI, bridge, service
- If shared code changed, impact scope: Agent Mail workspace; live polling depends on the `/webapi/v0/state` endpoint from Mininglamp-OSS/octo-mail#65
- Duplicate entry point checked: not applicable

## Testing

- [x] Unit tests added/updated
- [x] Manually verified
- `pnpm --filter @octo/mail test` — 25 files, 182 tests passed
- `pnpm --filter @octo/mail typecheck` — passed
- `pnpm i18n:check` — passed

## Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Documentation update is not required for this internal workspace behavior
- [x] Ran `pnpm i18n:check`
- [x] Confirmed the change follows module ownership and does not add duplicate user-visible entry points
- [x] Described the impact scope for shared UI, bridge, and service changes
- [x] Followed Conventional Commits
