### PR TITLE
fix(electron): adjust dmg installer layout

### DIFF
--- a/apps/web/electron-builder.js
+++ b/apps/web/electron-builder.js
@@ -65,10 +65,10 @@ module.exports = {
     iconSize: 100, // 安装图标大小
     // 安装窗口中包含的项目和配置
     contents: [
-      { x: 380, y: 280, type: "link", path: "/Applications" },
-      { x: 110, y: 280, type: "file" },
+      { x: 410, y: 220, type: "link", path: "/Applications" },
+      { x: 140, y: 220, type: "file" },
     ],
-    window: { width: 500, height: 500 }, // 安装窗口大小
+    window: { width: 560, height: 380 }, // 安装窗口大小
   },
   win: {
     icon: "resources/icons/icon.ico",


### PR DESCRIPTION
## Summary
- adjust macOS DMG installer window size from 500x500 to 560x380
- move OCTO and Applications icons upward and slightly outward so labels are not clipped in Finder

## Validation
- git diff --check
- local arm64 DMG layout verified manually by opening the generated DMG