### PR TITLE
fix(interactive-card): expand choice card hit area

### DIFF
--- a/packages/dmworkbase/src/Messages/InteractiveCard/__tests__/renderOctoCard.test.tsx
+++ b/packages/dmworkbase/src/Messages/InteractiveCard/__tests__/renderOctoCard.test.tsx
@@ -154,6 +154,8 @@ describe("renderOctoCard", () => {
     const input = row?.querySelector<HTMLInputElement>("input");
     row?.click();
     expect(input?.checked).toBe(false);
+    row?.querySelector<HTMLLabelElement>("label")?.click();
+    expect(input?.checked).toBe(false);
 
     target.classList.remove("wk-interactive-card-sdk--readonly");
     row?.querySelector<HTMLLabelElement>("label")?.click();

--- a/packages/dmworkbase/src/Messages/InteractiveCard/__tests__/renderOctoCard.test.tsx
+++ b/packages/dmworkbase/src/Messages/InteractiveCard/__tests__/renderOctoCard.test.tsx
@@ -73,6 +73,94 @@ describe("renderOctoCard", () => {
     target.remove();
   });
 
+  it("Forge 展开选项点击整张卡片即可切换 radio/checkbox", () => {
+    const target = mountTarget();
+    target.className = "wk-interactive-card-forge octo-card-profile";
+    renderOctoCard({
+      card: {
+        type: "AdaptiveCard",
+        version: "1.5",
+        body: [
+          {
+            type: "Input.ChoiceSet",
+            id: "single",
+            style: "expanded",
+            choices: [
+              { title: "A", value: "a" },
+              { title: "B", value: "b" },
+            ],
+          },
+          {
+            type: "Input.ChoiceSet",
+            id: "multiple",
+            isMultiSelect: true,
+            choices: [{ title: "C", value: "c" }],
+          },
+        ],
+      },
+      target,
+      renderProfile: "octo-chat/v1",
+      onAction: () => {},
+    });
+
+    const radioRows = target.querySelectorAll<HTMLElement>(
+      ".ac-choiceSetInput-expanded > div"
+    );
+    const secondRadio = radioRows[1].querySelector<HTMLInputElement>("input");
+    radioRows[1].click();
+    expect(secondRadio?.checked).toBe(true);
+
+    const checkboxRow = target.querySelector<HTMLElement>(
+      ".ac-choiceSetInput-multiSelect > div"
+    );
+    const checkbox = checkboxRow?.querySelector<HTMLInputElement>("input");
+    // Cell 更新后会重复执行增强；必须保持幂等，避免一次点击切换两次。
+    enhanceRenderedOctoCard({
+      card: {},
+      target,
+      renderProfile: "octo-chat/v1",
+      onAction: () => {},
+    });
+    checkboxRow?.click();
+    expect(checkbox?.checked).toBe(true);
+    target.remove();
+  });
+
+  it("Forge 选项保留 label 原生点击，且只读卡片不响应空白区域", () => {
+    const target = mountTarget();
+    target.className =
+      "wk-interactive-card-forge octo-card-profile wk-interactive-card-sdk--readonly";
+    renderOctoCard({
+      card: {
+        type: "AdaptiveCard",
+        version: "1.5",
+        body: [
+          {
+            type: "Input.ChoiceSet",
+            id: "multiple",
+            isMultiSelect: true,
+            choices: [{ title: "A", value: "a" }],
+          },
+        ],
+      },
+      target,
+      renderProfile: "octo-chat/v1",
+      onAction: () => {},
+    });
+
+    const row = target.querySelector<HTMLElement>(
+      ".ac-choiceSetInput-multiSelect > div"
+    );
+    const input = row?.querySelector<HTMLInputElement>("input");
+    row?.click();
+    expect(input?.checked).toBe(false);
+
+    target.classList.remove("wk-interactive-card-sdk--readonly");
+    row?.querySelector<HTMLLabelElement>("label")?.click();
+    expect(input?.checked).toBe(true);
+    target.remove();
+  });
+
   it("渲染 RichTextBlock/TextRun（服务端 manifest 展示元素）", () => {
     const target = mountTarget();
     renderOctoCard({

--- a/packages/dmworkbase/src/Messages/InteractiveCard/sdk/renderOctoCard.ts
+++ b/packages/dmworkbase/src/Messages/InteractiveCard/sdk/renderOctoCard.ts
@@ -54,9 +54,41 @@ export function createCardHostConfig(
     : buildOctoHostConfig(browserCssVarResolver(target));
 }
 
+function enhanceForgeChoiceCardHitAreas(target: HTMLElement): void {
+  const rows = target.querySelectorAll<HTMLElement>(
+    ".ac-choiceSetInput-expanded > div, .ac-choiceSetInput-multiSelect > div"
+  );
+  rows.forEach((row) => {
+    if (row.dataset.octoChoiceCardHitArea === "true") return;
+    row.dataset.octoChoiceCardHitArea = "true";
+    row.addEventListener("click", (event) => {
+      const eventTarget = event.target;
+      if (!(eventTarget instanceof Element)) return;
+      // input/label 已由 AdaptiveCards SDK 原生关联，避免二次切换 checkbox。
+      if (eventTarget.closest("input, label")) return;
+      if (target.classList.contains("wk-interactive-card-sdk--readonly"))
+        return;
+      const input = row.querySelector<HTMLInputElement>(
+        'input[type="radio"], input[type="checkbox"]'
+      );
+      if (!input || input.disabled) return;
+      input.click();
+    });
+  });
+}
+
 export function enhanceRenderedOctoCard(options: RenderOctoCardOptions): void {
-  const { card, target, tableCopyLabel, onTableCopy } = options;
+  const {
+    card,
+    target,
+    tableCopyLabel,
+    onTableCopy,
+    renderProfile = "legacy",
+  } = options;
   enhanceAgentProgressLayout(card, target);
+  if (renderProfile === FORGE_RENDER_PROFILE) {
+    enhanceForgeChoiceCardHitAreas(target);
+  }
   if (tableCopyLabel && onTableCopy) {
     attachTableCopyButtons({
       card,
@@ -92,6 +124,7 @@ export function renderOctoCard(options: RenderOctoCardOptions): void {
       onAction,
       tableCopyLabel,
       onTableCopy,
+      renderProfile,
     });
 }
 

--- a/packages/dmworkbase/src/Messages/InteractiveCard/sdk/renderOctoCard.ts
+++ b/packages/dmworkbase/src/Messages/InteractiveCard/sdk/renderOctoCard.ts
@@ -64,10 +64,13 @@ function enhanceForgeChoiceCardHitAreas(target: HTMLElement): void {
     row.addEventListener("click", (event) => {
       const eventTarget = event.target;
       if (!(eventTarget instanceof Element)) return;
+      if (target.classList.contains("wk-interactive-card-sdk--readonly")) {
+        // CSS pointer-events 不会阻止 label 激活关联 input，显式取消默认行为。
+        event.preventDefault();
+        return;
+      }
       // input/label 已由 AdaptiveCards SDK 原生关联，避免二次切换 checkbox。
       if (eventTarget.closest("input, label")) return;
-      if (target.classList.contains("wk-interactive-card-sdk--readonly"))
-        return;
       const input = row.querySelector<HTMLInputElement>(
         'input[type="radio"], input[type="checkbox"]'
       );


### PR DESCRIPTION
## Summary

- make the full Forge expanded ChoiceSet option card clickable
- preserve native input and label behavior without duplicate toggles
- keep read-only cards non-interactive and make repeated enhancement idempotent

## Impact

Only Forge `octo-chat/v1` expanded radio and checkbox ChoiceSets are affected. Legacy cards and other message renderers are unchanged.

## Verification

- `pnpm --filter @octo/base exec vitest run src/Messages/InteractiveCard/__tests__` (317 passed)
- `pnpm --filter @octo/base exec vitest run src/Messages/InteractiveCard/__tests__/renderOctoCard.test.tsx` (16 passed)
- `pnpm --filter @octo/web build`
- `git diff --check`

Closes #1466