### PR TITLE
fix(electron): enable desktop window shadow

### DIFF
--- a/apps/web/src-election/main/index.ts
+++ b/apps/web/src-election/main/index.ts
@@ -1291,7 +1291,7 @@ const getWindowConfig = () => {
     // frame: true, // * app边框(包括关闭,全屏,最小化按钮的导航栏) @false: 隐藏
     // titleBarStyle: "hidden",
     // transparent: true, // * app 背景透明
-    hasShadow: false, // * app 边框阴影
+    hasShadow: true, // * app 边框阴影
     show: false, // 启动窗口时隐藏,直到渲染进程加载完成「ready-to-show 监听事件」 再显示窗口,防止加载时闪烁
     resizable: true, // 禁止手动修改窗口尺寸
     // Windows: 允许用户按 Alt 键显示/隐藏菜单栏

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -17,6 +17,13 @@
   --topbar-bg:    var(--wk-bg-base);
 }
 
+/* The native frame provides the traffic lights/title area. This renderer
+ * border completes the quiet, rounded desktop shell without changing Web. */
+html[data-octo-desktop] #root {
+  border: 1px solid var(--wk-border-default);
+  box-shadow: var(--wk-shadow-sm);
+}
+
 /**
 * =====================================
 * 滚动条美化

--- a/apps/web/src/index.tsx
+++ b/apps/web/src/index.tsx
@@ -32,6 +32,10 @@ const isDesktopRuntime =
   import.meta.env.VITE_ELECTRON_BUILD === "true" ||
   window.location.protocol === "file:"
 
+if (isElectronPowered()) {
+  document.documentElement.dataset.octoDesktop = "1"
+}
+
 if(isDesktopRuntime) {
   // 开发环境的 Tauri/Electron 页面运行在 localhost:3000，走 Vite 同源代理，
   // 避免直接请求远程 API 时被浏览器 CORS 拦截。正式桌面包没有 Vite 代理，


### PR DESCRIPTION
## Summary
- enable the native Electron window shadow
- add a subtle renderer border and shadow for the desktop shell
- keep the styling scoped to the desktop renderer

## Validation
- `git diff --check`

基于最新 `main`（`e55acf05`）。