### PR TITLE
fix(electron): enable native window shadow

### DIFF
--- a/apps/web/src-election/main/index.ts
+++ b/apps/web/src-election/main/index.ts
@@ -1291,7 +1291,7 @@ const getWindowConfig = () => {
     // frame: true, // * app边框(包括关闭,全屏,最小化按钮的导航栏) @false: 隐藏
     // titleBarStyle: "hidden",
     // transparent: true, // * app 背景透明
-    hasShadow: false, // * app 边框阴影
+    hasShadow: true, // * app 边框阴影
     show: false, // 启动窗口时隐藏,直到渲染进程加载完成「ready-to-show 监听事件」 再显示窗口,防止加载时闪烁
     resizable: true, // 禁止手动修改窗口尺寸
     // Windows: 允许用户按 Alt 键显示/隐藏菜单栏


### PR DESCRIPTION
## Summary
- enable the native Electron window shadow with `hasShadow: true`

## Validation
- `git diff --check`
- based on the latest `main` (`e55acf05`)

This PR intentionally contains no renderer CSS changes.