### PR TITLE
fix(electron): remove macOS services menu

### DIFF
--- a/apps/web/src-election/main/index.ts
+++ b/apps/web/src-election/main/index.ts
@@ -970,7 +970,6 @@ let mainMenu: (Electron.MenuItemConstructorOptions | Electron.MenuItem)[] = [
       {
         label: `关于OCTO`,
       },
-      { label: "服务", role: "services" },
       { type: "separator" },
       {
         label: "退出",


### PR DESCRIPTION
## Summary

<!-- What does this PR do? -->

## Related Issue

<!-- Link the issue this PR addresses, e.g. Fixes #123 -->

## Changes

<!-- Bullet list of concrete changes -->

-
-

## Architecture / Module Boundary

<!-- Fill this when the PR changes business code, shared components, service APIs, routing, or user-visible entry points. -->

- Affected module(s):
- New or changed user-visible entry point: <!-- yes / no; if yes, describe it -->
- Shared layer touched: <!-- ui / Components / Messages / bridge / service / none -->
- If shared code changed, impact scope:
- Duplicate entry point checked: <!-- yes / no / not applicable -->

## Testing

<!-- How was this tested? Include commands, screenshots, or test output. -->

- [ ] Unit tests added/updated
- [ ] Manually verified

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] PR description is in English
- [ ] Added tests for my changes
- [ ] Updated documentation
- [ ] Ran `pnpm i18n:check` or confirmed the change does not affect UI copy
- [ ] Confirmed the change follows module ownership and does not add duplicate user-visible entry points
- [ ] Described impact scope when shared components, messages, bridge, or services are changed
- [ ] Followed commit message conventions (Conventional Commits)
