### PR TITLE
chore(e2e): sync reliable execution helpers from e2e-kit

### DIFF
--- a/apps/web/e2e-kit/_lib/README.md
+++ b/apps/web/e2e-kit/_lib/README.md
@@ -5,8 +5,12 @@
 ## 现有文件
 
 - `sanity.ts` — sanityCheck: URL 检查 / MSW 无 fallthrough / 无 retry
-- `spec-history.sh` — 封装 `git log -- e2e-kit/case-specs/<caseId>-*.md`
+- `spec-history.sh` — 封装 `git log -- e2e/case-specs/<caseId>-*.md`
 - `collect-evidence.sh` — 从 Playwright json reporter 生成两级 report + trace/keyframes tar.gz
+- `preflight.mjs` — 只读检查 lockfile、env、包管理器、服务端口，并选择附近可用端口
+- `verify-case.sh` — 统一执行单 case 的 3x 稳定性 gate
+- `e2eReady.ts` — 统一等待 app/MSW/mock seed readiness marker，并保留明确错误原因
+- `target-layout.mjs` — 自动识别 `e2e` / `e2e-kit` / `apps/web/e2e-kit`，避免接入方手改脚本路径
 - `tokens.ts` — (midscene optional) LLM token 消耗采集
 - `new-case.mjs` — case scaffolder (v0.4): 一条命令生成 spec + test + handler 三件套
 - `lint-spec-format.mjs` — case-spec md 格式 lint (v0.4): 必需段 + Metadata 字段 + 反例非空, 支持 --diff-mode 存量豁免
@@ -14,7 +18,7 @@
 ## `new-case.mjs` 用法
 
 ```bash
-# 建议 package.json 加脚本: "e2e:new": "node e2e-kit/_lib/new-case.mjs"
+# 建议 package.json 加脚本: "e2e:new": "node e2e/_lib/new-case.mjs"
 pnpm e2e:new M5 matter-list-filter --module matter --submodule list
 
 # 完整参数
@@ -40,16 +44,16 @@ CaseId 前缀只是项目自定义 ID, 不参与模块语义; 筛选靠 `@module
 
 **接入方按需改脚本顶部 config 常量** (搜 `---- config ----`):
 - `CASE_SPECS_DIR` / `TESTS_DIR` / `HANDLERS_DIR` — 项目路径 (默认对齐 kit v0.4)
-- `FIXTURES_IMPORT_PATH` / `MOCK_IM_IMPORT_PATH` / `SANITY_IMPORT_PATH` / `HANDLERS_IMPORT_ROOT` — import 路径 (相对 e2e-kit/ 根)
+- `FIXTURES_IMPORT_PATH` / `MOCK_IM_IMPORT_PATH` / `SANITY_IMPORT_PATH` / `HANDLERS_IMPORT_ROOT` — import 路径 (相对 e2e/ 根)
 - `USE_MOCK_IM` — **默认 false**. 项目装了 `mock-im-wksdk` optional 后改成 true
 - `USE_SANITY` — 默认 true, 无 sanity helper 项目关掉
 - `FMT_CMD` — 生成后自动 fmt (`null` 关闭)
 
 **产出布局** (默认):
 ```
-e2e-kit/case-specs/[module/[sub/]]<CaseId>-<slug>.md    (spec)
-e2e-kit/tests/[module/[sub/]]<CaseId>-<slug>.spec.ts    (test)
-e2e-kit/msw-handlers/<caseidLower>-<slug>.ts             (handler, --no-http-mock 关掉)
+e2e/case-specs/[module/[sub/]]<CaseId>-<slug>.md    (spec)
+e2e/tests/[module/[sub/]]<CaseId>-<slug>.spec.ts    (test)
+e2e/msw-handlers/<caseidLower>-<slug>.ts             (handler, --no-http-mock 关掉)
 ```
 
 Handler 不追加 index.ts (case-specific 由 test 显式 register, 避免污染 baseline).

--- a/apps/web/e2e-kit/_lib/README.md
+++ b/apps/web/e2e-kit/_lib/README.md
@@ -5,7 +5,7 @@
 ## 现有文件
 
 - `sanity.ts` — sanityCheck: URL 检查 / MSW 无 fallthrough / 无 retry
-- `spec-history.sh` — 封装 `git log -- e2e/case-specs/<caseId>-*.md`
+- `spec-history.sh` — 封装 `git log -- apps/web/e2e-kit/case-specs/<caseId>-*.md`
 - `collect-evidence.sh` — 从 Playwright json reporter 生成两级 report + trace/keyframes tar.gz
 - `preflight.mjs` — 只读检查 lockfile、env、包管理器、服务端口，并选择附近可用端口
 - `verify-case.sh` — 统一执行单 case 的 3x 稳定性 gate
@@ -18,7 +18,7 @@
 ## `new-case.mjs` 用法
 
 ```bash
-# 建议 package.json 加脚本: "e2e:new": "node e2e/_lib/new-case.mjs"
+# octo-web 可直接运行: `node apps/web/e2e-kit/_lib/new-case.mjs`
 pnpm e2e:new M5 matter-list-filter --module matter --submodule list
 
 # 完整参数
@@ -44,16 +44,16 @@ CaseId 前缀只是项目自定义 ID, 不参与模块语义; 筛选靠 `@module
 
 **接入方按需改脚本顶部 config 常量** (搜 `---- config ----`):
 - `CASE_SPECS_DIR` / `TESTS_DIR` / `HANDLERS_DIR` — 项目路径 (默认对齐 kit v0.4)
-- `FIXTURES_IMPORT_PATH` / `MOCK_IM_IMPORT_PATH` / `SANITY_IMPORT_PATH` / `HANDLERS_IMPORT_ROOT` — import 路径 (相对 e2e/ 根)
+- `FIXTURES_IMPORT_PATH` / `MOCK_IM_IMPORT_PATH` / `SANITY_IMPORT_PATH` / `HANDLERS_IMPORT_ROOT` — import 路径 (相对 e2e 根)
 - `USE_MOCK_IM` — **默认 false**. 项目装了 `mock-im-wksdk` optional 后改成 true
 - `USE_SANITY` — 默认 true, 无 sanity helper 项目关掉
 - `FMT_CMD` — 生成后自动 fmt (`null` 关闭)
 
 **产出布局** (默认):
 ```
-e2e/case-specs/[module/[sub/]]<CaseId>-<slug>.md    (spec)
-e2e/tests/[module/[sub/]]<CaseId>-<slug>.spec.ts    (test)
-e2e/msw-handlers/<caseidLower>-<slug>.ts             (handler, --no-http-mock 关掉)
+apps/web/e2e-kit/case-specs/[module/[sub/]]<CaseId>-<slug>.md    (spec)
+apps/web/e2e-kit/tests/[module/[sub/]]<CaseId>-<slug>.spec.ts    (test)
+apps/web/e2e-kit/msw-handlers/<caseidLower>-<slug>.ts             (handler, --no-http-mock 关掉)
 ```
 
 Handler 不追加 index.ts (case-specific 由 test 显式 register, 避免污染 baseline).

--- a/apps/web/e2e-kit/_lib/e2eReady.ts
+++ b/apps/web/e2e-kit/_lib/e2eReady.ts
@@ -1,0 +1,42 @@
+import type { Page } from "@playwright/test";
+
+type ReadyOptions = {
+  readyKey: string;
+  errorKey?: string;
+  timeout?: number;
+  label?: string;
+};
+
+/** Wait for a browser-side readiness marker and surface an explicit error marker. */
+export async function waitForE2EReady(page: Page, options: ReadyOptions): Promise<void> {
+  const { readyKey, errorKey, timeout = 15_000, label = readyKey } = options;
+  await page.waitForFunction(
+    ({ readyKey: key, errorKey: error }) => {
+      const state = globalThis as Record<string, unknown>;
+      if (error && state[error]) throw new Error(String(state[error]));
+      return state[key] === true;
+    },
+    { readyKey, errorKey },
+    { timeout },
+  ).catch((cause) => {
+    throw new Error(`[e2e readiness] ${label} 未就绪 (${timeout}ms): ${cause.message}`);
+  });
+}
+
+export function waitForMswReady(page: Page, timeout = 15_000): Promise<void> {
+  return waitForE2EReady(page, {
+    readyKey: "__MSW_READY__",
+    errorKey: "__MSW_ERROR__",
+    timeout,
+    label: "MSW",
+  });
+}
+
+export function waitForMockSeedReady(page: Page, timeout = 15_000): Promise<void> {
+  return waitForE2EReady(page, {
+    readyKey: "__e2eVoiceSeedReady__",
+    errorKey: "__e2eVoiceSeedError__",
+    timeout,
+    label: "mock seed",
+  });
+}

--- a/apps/web/e2e-kit/_lib/e2eReady.ts
+++ b/apps/web/e2e-kit/_lib/e2eReady.ts
@@ -26,7 +26,6 @@ export async function waitForE2EReady(page: Page, options: ReadyOptions): Promis
 export function waitForMswReady(page: Page, timeout = 15_000): Promise<void> {
   return waitForE2EReady(page, {
     readyKey: "__MSW_READY__",
-    errorKey: "__MSW_ERROR__",
     timeout,
     label: "MSW",
   });

--- a/apps/web/e2e-kit/_lib/lint-spec-format.mjs
+++ b/apps/web/e2e-kit/_lib/lint-spec-format.mjs
@@ -2,7 +2,7 @@
 /**
  * _lib/lint-spec-format.mjs — spec 格式 lint (kit-provided).
  *
- * 校验 e2e-kit/case-specs/**​/*.md 合规:
+ * 校验 e2e/case-specs/**​/*.md 合规:
  *   - 必需段: Metadata / 目标 / 前置条件 / 用户操作步骤 / 预期结果 / 反例
  *     (视觉基准 / 摸清依据可选)
  *   - Metadata 段有 "Case 类型" / "目标模式" / "优先级" / "Tags"
@@ -11,31 +11,41 @@
  *   - 无残留 "**待补**" marker (scaffolder 骨架填完应删)
  *
  * **接入方需改的占位** (脚本顶部 config):
- *   - SPECS_DIR    — case-spec md 目录 (默认 "e2e-kit/case-specs")
+ *   - SPECS_DIR    — case-spec md 目录 (默认 "e2e/case-specs")
  *
  * 用法:
- *   node e2e-kit/_lib/lint-spec-format.mjs                 # 全部 spec, 不合规 exit 1
- *   node e2e-kit/_lib/lint-spec-format.mjs --files a.md b.md   # 指定文件 (pre-commit)
- *   node e2e-kit/_lib/lint-spec-format.mjs --diff-mode     # 只校验 git 里新加/改的 spec
+ *   node e2e/_lib/lint-spec-format.mjs                 # 全部 spec, 不合规 exit 1
+ *   node e2e/_lib/lint-spec-format.mjs --files a.md b.md   # 指定文件 (pre-commit)
+ *   node e2e/_lib/lint-spec-format.mjs --diff-mode     # 只校验 git 里新加/改的 spec
  *                                                     # (存量老格式豁免, 只挡漂移)
  *
  * 建议 package.json 加脚本:
- *   "check:spec-format": "node e2e-kit/_lib/lint-spec-format.mjs"
- *   "check:spec-format:diff": "node e2e-kit/_lib/lint-spec-format.mjs --diff-mode"
+ *   "check:spec-format": "node e2e/_lib/lint-spec-format.mjs"
+ *   "check:spec-format:diff": "node e2e/_lib/lint-spec-format.mjs --diff-mode"
  *
- * CI: quality stage, MR 里 e2e-kit/case-specs/ 有变更时触发 --diff-mode
- * pre-commit: .husky/pre-commit 里 staged 涉及 e2e-kit/case-specs/ 时跑一次 --files
+ * CI: quality stage, MR 里 case-specs/ 有变更时触发 --diff-mode
+ * pre-commit: .husky/pre-commit 里 staged 涉及 case-specs/ 时跑一次 --files
  */
 import { readFileSync, readdirSync, statSync } from "node:fs";
 import { join, relative } from "node:path";
 import { execSync } from "node:child_process";
+import { resolveE2ERoot } from "./target-layout.mjs";
 
 // ---------- config (接入方按需改) ----------
 
 const REPO_ROOT = process.cwd();
-const SPECS_DIR = join(REPO_ROOT, "e2e-kit/case-specs");
+const E2E_ROOT = resolveE2ERoot(REPO_ROOT);
+const SPECS_DIR = join(E2E_ROOT, "case-specs");
+let GIT_ROOT = REPO_ROOT;
+try {
+  GIT_ROOT = execSync("git rev-parse --show-toplevel", {
+    stdio: ["ignore", "pipe", "ignore"],
+  }).toString().trim();
+} catch {
+  // Full lint still works from an exported source tree; diff-mode will fall back to full lint.
+}
+const CASE_SPECS_PATH = `${relative(GIT_ROOT, SPECS_DIR).replaceAll("\\", "/")}/`;
 const EXCLUDE_FILENAMES = new Set(["README.md", "COVERAGE.md", "BACKLOG.md", "TEMPLATE.md"]);
-const CASE_SPECS_PATH = "e2e-kit/case-specs/";
 
 // 必需段落. 允许小变体 (中英文冒号 / 前后空格 / heading 级别 2 或 3).
 const REQUIRED_SECTIONS = [
@@ -49,9 +59,9 @@ const REQUIRED_SECTIONS = [
 
 // Metadata 段内必需字段
 const REQUIRED_METADATA_FIELDS = [
-  { name: "Case 类型", pattern: /^-\s*Case\s*类型\s*[：:]/im },
-  { name: "目标模式", pattern: /^-\s*目标模式\s*[：:]/im },
-  { name: "优先级", pattern: /^-\s*优先级\s*[：:]/im },
+  { name: "Case 类型", pattern: /^-\s*Case\s*类型\s*[::]/im },
+  { name: "目标模式", pattern: /^-\s*目标模式\s*[::]/im },
+  { name: "优先级", pattern: /^-\s*优先级\s*[::]/im },
 ];
 
 // ---------- helpers ----------
@@ -95,9 +105,9 @@ function caseIdFromFilename(filePath) {
 function parseTags(metadata) {
   const line = metadata
     .split("\n")
-    .find((l) => /^-\s*Tags?\s*[：:]/i.test(l));
+    .find((l) => /^-\s*Tags?\s*:/i.test(l));
   if (!line) return null;
-  const raw = line.replace(/^-\s*Tags?\s*[：:]/i, "").replace(/`/g, "").trim();
+  const raw = line.replace(/^-\s*Tags?\s*:/i, "").replace(/`/g, "").trim();
   return new Set(raw.split(/\s+/).filter((t) => t.startsWith("@")));
 }
 
@@ -135,20 +145,15 @@ function diffModeFiles() {
     }
   }
   if (!base) return null;
-  const repoRoot = execSync("git rev-parse --show-toplevel", {
-    stdio: ["ignore", "pipe", "ignore"],
-  })
-    .toString()
-    .trim();
+  // diff-filter=AM: A 新加 / M 修改, 不含 deleted
   const out = execSync(`git diff --name-only --diff-filter=AM ${base}...HEAD`, {
-    cwd: repoRoot,
     stdio: ["ignore", "pipe", "ignore"],
   }).toString();
   return out
     .split("\n")
     .filter((f) => f && f.endsWith(".md") && f.includes(CASE_SPECS_PATH))
     .filter((f) => !EXCLUDE_FILENAMES.has(f.split("/").pop() || f))
-    .map((f) => join(repoRoot, f));
+    .map((f) => join(GIT_ROOT, f));
 }
 
 // ---------- CLI ----------
@@ -180,7 +185,7 @@ if (args.includes("--diff-mode")) {
       .filter((f) => f.endsWith(".md") && !EXCLUDE_FILENAMES.has(f.split("/").pop() || f))
       .filter((f) => f.includes(CASE_SPECS_PATH));
     if (files.length === 0) {
-      console.log("[lint-spec-format] ✔ 无 e2e-kit/case-specs/ 下的 spec 文件, skip");
+      console.log(`[lint-spec-format] ✔ 无 ${CASE_SPECS_PATH} 下的 spec 文件, skip`);
       process.exit(0);
     }
   } else {
@@ -262,5 +267,5 @@ for (const e of errors) console.error(`  - ${e}`);
 console.error("");
 console.error("  必需段: Metadata / 目标 / 前置条件 / 用户操作步骤 / 预期结果 / 反例");
 console.error("  Metadata 字段: Case 类型 / 目标模式 / 优先级 / Tags");
-console.error("  格式规约见 e2e-kit/case-specs/TEMPLATE.md");
+console.error("  格式规约见 e2e/case-specs/TEMPLATE.md");
 process.exit(1);

--- a/apps/web/e2e-kit/_lib/lint-spec-format.mjs
+++ b/apps/web/e2e-kit/_lib/lint-spec-format.mjs
@@ -2,7 +2,7 @@
 /**
  * _lib/lint-spec-format.mjs — spec 格式 lint (kit-provided).
  *
- * 校验 e2e/case-specs/**​/*.md 合规:
+ * 校验 e2e 根目录下 case-specs/**​/*.md 合规:
  *   - 必需段: Metadata / 目标 / 前置条件 / 用户操作步骤 / 预期结果 / 反例
  *     (视觉基准 / 摸清依据可选)
  *   - Metadata 段有 "Case 类型" / "目标模式" / "优先级" / "Tags"
@@ -11,17 +11,17 @@
  *   - 无残留 "**待补**" marker (scaffolder 骨架填完应删)
  *
  * **接入方需改的占位** (脚本顶部 config):
- *   - SPECS_DIR    — case-spec md 目录 (默认 "e2e/case-specs")
+ *   - SPECS_DIR    — case-spec md 目录 (由 target-layout.mjs 自动解析)
  *
  * 用法:
- *   node e2e/_lib/lint-spec-format.mjs                 # 全部 spec, 不合规 exit 1
- *   node e2e/_lib/lint-spec-format.mjs --files a.md b.md   # 指定文件 (pre-commit)
- *   node e2e/_lib/lint-spec-format.mjs --diff-mode     # 只校验 git 里新加/改的 spec
+ *   node apps/web/e2e-kit/_lib/lint-spec-format.mjs                 # 全部 spec, 不合规 exit 1
+ *   node apps/web/e2e-kit/_lib/lint-spec-format.mjs --files a.md b.md   # 指定文件 (pre-commit)
+ *   node apps/web/e2e-kit/_lib/lint-spec-format.mjs --diff-mode     # 只校验 git 里新加/改的 spec
  *                                                     # (存量老格式豁免, 只挡漂移)
  *
  * 建议 package.json 加脚本:
- *   "check:spec-format": "node e2e/_lib/lint-spec-format.mjs"
- *   "check:spec-format:diff": "node e2e/_lib/lint-spec-format.mjs --diff-mode"
+ *   "check:spec-format": "node apps/web/e2e-kit/_lib/lint-spec-format.mjs"
+ *   "check:spec-format:diff": "node apps/web/e2e-kit/_lib/lint-spec-format.mjs --diff-mode"
  *
  * CI: quality stage, MR 里 case-specs/ 有变更时触发 --diff-mode
  * pre-commit: .husky/pre-commit 里 staged 涉及 case-specs/ 时跑一次 --files
@@ -59,9 +59,9 @@ const REQUIRED_SECTIONS = [
 
 // Metadata 段内必需字段
 const REQUIRED_METADATA_FIELDS = [
-  { name: "Case 类型", pattern: /^-\s*Case\s*类型\s*[::]/im },
-  { name: "目标模式", pattern: /^-\s*目标模式\s*[::]/im },
-  { name: "优先级", pattern: /^-\s*优先级\s*[::]/im },
+  { name: "Case 类型", pattern: /^-\s*Case\s*类型\s*[:：]/im },
+  { name: "目标模式", pattern: /^-\s*目标模式\s*[:：]/im },
+  { name: "优先级", pattern: /^-\s*优先级\s*[:：]/im },
 ];
 
 // ---------- helpers ----------
@@ -105,9 +105,9 @@ function caseIdFromFilename(filePath) {
 function parseTags(metadata) {
   const line = metadata
     .split("\n")
-    .find((l) => /^-\s*Tags?\s*:/i.test(l));
+    .find((l) => /^-\s*Tags?\s*[:：]/i.test(l));
   if (!line) return null;
-  const raw = line.replace(/^-\s*Tags?\s*:/i, "").replace(/`/g, "").trim();
+  const raw = line.replace(/^-\s*Tags?\s*[:：]/i, "").replace(/`/g, "").trim();
   return new Set(raw.split(/\s+/).filter((t) => t.startsWith("@")));
 }
 
@@ -136,6 +136,7 @@ function diffModeFiles() {
     try {
       base = execSync(`git merge-base HEAD ${ref}`, {
         stdio: ["ignore", "pipe", "ignore"],
+        cwd: GIT_ROOT,
       })
         .toString()
         .trim();
@@ -148,6 +149,7 @@ function diffModeFiles() {
   // diff-filter=AM: A 新加 / M 修改, 不含 deleted
   const out = execSync(`git diff --name-only --diff-filter=AM ${base}...HEAD`, {
     stdio: ["ignore", "pipe", "ignore"],
+    cwd: GIT_ROOT,
   }).toString();
   return out
     .split("\n")
@@ -267,5 +269,5 @@ for (const e of errors) console.error(`  - ${e}`);
 console.error("");
 console.error("  必需段: Metadata / 目标 / 前置条件 / 用户操作步骤 / 预期结果 / 反例");
 console.error("  Metadata 字段: Case 类型 / 目标模式 / 优先级 / Tags");
-console.error("  格式规约见 e2e/case-specs/TEMPLATE.md");
+console.error("  格式规约见 e2e 根目录/case-specs/TEMPLATE.md");
 process.exit(1);

--- a/apps/web/e2e-kit/_lib/new-case.mjs
+++ b/apps/web/e2e-kit/_lib/new-case.mjs
@@ -9,7 +9,7 @@
  * **接入方需改的占位** (脚本顶部 config 常量):
  *   - CASE_SPECS_DIR / TESTS_DIR / HANDLERS_DIR  — 项目路径 (默认对齐 kit v0.4 扁平布局)
  *   - FIXTURES_IMPORT_PATH / MOCK_IM_IMPORT_PATH / SANITY_IMPORT_PATH / HANDLERS_IMPORT_ROOT
- *                       — import 路径 (相对 e2e-kit/ 根)
+ *                       — import 路径 (相对 e2e/ 根)
  *   - USE_MOCK_IM      — 是否装 mock-im-runtime (默认 **false**; 项目装了 mock-im-wksdk optional 后改成 true)
  *   - USE_SANITY       — 是否装 sanity helper (默认 true, 无 sanity 关掉)
  *   - FMT_CMD          — 生成后自动 fmt 命令 (默认 null, 项目要用 prettier 之类改这里)
@@ -41,9 +41,9 @@
  *     --tags "@p1 @matter @matter-list" --http-mock --im-seed
  *
  * 产出 (以默认路径 + 上例参数为例):
- *   e2e-kit/case-specs/matter/list/M5-matter-list-filter.md
- *   e2e-kit/tests/matter/list/M5-matter-list-filter.spec.ts
- *   e2e-kit/msw-handlers/m5-matter-list-filter.ts   (**默认生成**, 传 --no-http-mock 关掉)
+ *   e2e/case-specs/matter/list/M5-matter-list-filter.md
+ *   e2e/tests/matter/list/M5-matter-list-filter.spec.ts
+ *   e2e/msw-handlers/m5-matter-list-filter.ts   (**默认生成**, 传 --no-http-mock 关掉)
  *
  * --no-http-mock → 不出 handler, test 骨架也不 register handler.
  * --no-im-seed → test 骨架不装 mock IM runtime.
@@ -53,23 +53,25 @@
 import { writeFileSync, existsSync, mkdirSync } from "node:fs";
 import { dirname, resolve, relative } from "node:path";
 import { spawnSync } from "node:child_process";
+import { resolveE2ERoot } from "./target-layout.mjs";
 
 // ---------- config (接入方按需改) ----------
 //
-// **octo-web 当前布局**:
-//   e2e-kit/fixtures-authed.ts        (template 落根)
-//   e2e-kit/_kit/mock-im-runtime/     (overwrite 落 _kit/)
-//   e2e-kit/_lib/sanity.ts            (overwrite 落 _lib/)
-//   e2e-kit/msw-handlers/             (hands_off 目录, kit 首次落 README 占位)
+// **默认值对齐 kit v0.4 sync 产物的扁平布局**:
+//   e2e/fixtures-authed.ts        (template 落根)
+//   e2e/_kit/mock-im-runtime/     (overwrite 落 _kit/)
+//   e2e/_lib/sanity.ts            (overwrite 落 _lib/)
+//   e2e/msw-handlers/             (hands_off 目录, kit 首次落 README 占位)
 //
-// 其他接入方可按自身布局修改下面常量.
+// 若接入方项目采用其他布局 (例如 e2e-research 的 shared/), 改下面常量即可.
 
 const REPO_ROOT = process.cwd();
-const CASE_SPECS_DIR = resolve(REPO_ROOT, "e2e-kit/case-specs");
-const TESTS_DIR = resolve(REPO_ROOT, "e2e-kit/tests");
-const HANDLERS_DIR = resolve(REPO_ROOT, "e2e-kit/msw-handlers");
+const E2E_ROOT = resolveE2ERoot(REPO_ROOT);
+const CASE_SPECS_DIR = resolve(E2E_ROOT, "case-specs");
+const TESTS_DIR = resolve(E2E_ROOT, "tests");
+const HANDLERS_DIR = resolve(E2E_ROOT, "msw-handlers");
 
-// import path segments (相对 e2e-kit/ 根). test 到根的相对前缀由 upToE2eRoot() 算.
+// import path segments (相对 e2e/ 根). test 到根的相对前缀由 upToE2eRoot() 算.
 const FIXTURES_IMPORT_PATH = "fixtures-authed";
 const MOCK_IM_IMPORT_PATH = "_kit/mock-im-runtime";
 const SANITY_IMPORT_PATH = "_lib/sanity";
@@ -79,7 +81,7 @@ const USE_MOCK_IM = false; // 项目装了 mock-im-wksdk optional 后, 改成 tr
 const USE_SANITY = true;
 const FMT_CMD = null; // 例: ["pnpm", "exec", "prettier", "--write"]
 
-// test 到 e2e-kit/ 根的相对前缀. tests/[module/[sub/]]<file>.spec.ts → depth 决定 ../ 个数.
+// test 到 e2e/ 根的相对前缀. tests/[module/[sub/]]<file>.spec.ts → depth 决定 ../ 个数.
 function upToE2eRoot(moduleName, subModule) {
   const depth = 1 + (moduleName ? 1 : 0) + (subModule ? 1 : 0);
   return "../".repeat(depth);
@@ -276,13 +278,7 @@ const testTemplate = `/* eslint-disable no-undef -- e2e code runs in Node */
  * ${caseId}: **待补** 一句话主线 + 反例守护点.
  */
 import { test, expect } from "${sharedRoot}${FIXTURES_IMPORT_PATH}";
-${withHttpMock ? `import { ${registerFnName} } from "${sharedRoot}${HANDLERS_IMPORT_ROOT}/${caseId.toLowerCase()}-${slug}";\n` : ""}${withImSeed ? `import { installMockImRuntime } from "${sharedRoot}${MOCK_IM_IMPORT_PATH}";\n` : ""}${USE_SANITY ? `import { startRequestMonitor, sanityCheck, type SanityConfig } from "${sharedRoot}${SANITY_IMPORT_PATH}";\n` : ""}
-${USE_SANITY ? `const sanityConfig: SanityConfig = {
-  realHosts: ["127.0.0.1:9", "mock.e2e.local"],
-  apiPrefixRe: /^\\/(api|summary\\/api)(\\/|$)/,
-  loginPathRe: /\\/login(\\?|$)/,
-};
-` : ""}
+${withHttpMock ? `import { ${registerFnName} } from "${sharedRoot}${HANDLERS_IMPORT_ROOT}/${caseId.toLowerCase()}-${slug}";\n` : ""}${withImSeed ? `import { installMockImRuntime } from "${sharedRoot}${MOCK_IM_IMPORT_PATH}";\n` : ""}${USE_SANITY ? `import { startRequestMonitor, sanityCheck } from "${sharedRoot}${SANITY_IMPORT_PATH}";\n` : ""}
 
 test.describe("${tags} ${caseId} — **待补** case 描述", () => {
   test("**待补** 一句话操作 + 预期", async ({ authedPage }) => {
@@ -290,8 +286,7 @@ test.describe("${tags} ${caseId} — **待补** case 描述", () => {
     // 若忘删, batch 跑 (--grep @p0 等) 会 skip 而不是假绿.
     test.fixme(true, "scaffolder 骨架, 待作者补真实操作步骤 + UI 断言");
 
-${USE_SANITY ? `    const ctx = startRequestMonitor(authedPage, sanityConfig);
-` : ""}${withHttpMock ? `\n    await ${registerFnName}(authedPage);\n` : ""}${withImSeed ? `
+${USE_SANITY ? `    const ctx = startRequestMonitor(authedPage);\n` : ""}${withHttpMock ? `\n    await ${registerFnName}(authedPage);\n` : ""}${withImSeed ? `
     await installMockImRuntime(authedPage, {
       currentUid: "e2e-user-1",
       spaceId: "e2e-space-001",
@@ -327,41 +322,46 @@ import type { Page } from "@playwright/test";
  */
 
 export async function ${registerFnName}(page: Page): Promise<void> {
-  // Browser context boundary: only explicit data and window globals cross evaluate.
+  // 示例：把 spec/业务源码确认的外部值通过 evaluate 第二参数传入。
+  const exampleId = "**待补**";
   await page.evaluate(
-    () => {
-      // 这里只使用显式传入参数和浏览器全局变量, 不引用 Node 模块变量.
-      const msw = (window as unknown as {
-        __msw?: {
-          worker: { use: (...h: unknown[]) => void };
-          http: {
-            get: (path: string, resolver: (info: any) => unknown) => unknown;
-            post: (path: string, resolver: (info: any) => unknown) => unknown;
-          };
-          HttpResponse: { json: (body: unknown, init?: unknown) => unknown };
+    ({ exampleId }) => {
+      // 这里只使用参数和浏览器全局变量, 不引用 Node 模块变量.
+      void exampleId;
+      const w = (window as unknown as { __mswWorker__?: { use: (...h: unknown[]) => void } })
+      .__mswWorker__;
+    const http = (
+      window as unknown as {
+        __mswHttp__?: {
+          get: (path: string, resolver: (info: any) => unknown) => unknown;
+          post: (path: string, resolver: (info: any) => unknown) => unknown;
         };
-      }).__msw;
-      if (!msw) {
-        throw new Error("[${caseId}] MSW worker 未就绪 (等 __MSW_READY__).");
       }
-      const { worker: w, http, HttpResponse } = msw;
-
-      // module-scope state 每 install 重置, 避免 --repeat-each=3 相互泄漏.
-      (window as unknown as { ${stateKey}: { calls: number } }).${stateKey} = {
-        calls: 0,
-      };
-
-      w.use(
-        // **待补** 本 case 的 endpoint handler
-        // http.post("*​/v1/matter/xxx", async (info: any) => {
-        //   const state = (window as unknown as { ${stateKey}: { calls: number } }).${stateKey};
-        //   state.calls += 1;
-        //   const body = await info.request.json();
-        //   return HttpResponse.json({ code: 0, message: "ok", data: {} });
-        // }),
-      );
+    ).__mswHttp__;
+    const HttpResponse = (
+      window as unknown as {
+        __mswHttpResponse__?: { json: (body: unknown, init?: unknown) => unknown };
+      }
+    ).__mswHttpResponse__;
+    if (!w || !http || !HttpResponse) {
+      throw new Error("[${caseId}] MSW worker 未就绪 (等 __MSW_READY__).");
     }
-  );
+
+    // module-scope state 每 install 重置, 避免 --repeat-each=3 相互泄漏.
+    (window as unknown as { ${stateKey}: { calls: number } }).${stateKey} = {
+      calls: 0,
+    };
+
+    w.use(
+      // **待补** 本 case 的 endpoint handler
+      // http.post("*​/v1/matter/xxx", async (info: any) => {
+      //   const state = (window as unknown as { ${stateKey}: { calls: number } }).${stateKey};
+      //   state.calls += 1;
+      //   const body = await info.request.json();
+      //   return HttpResponse.json({ code: 0, message: "ok", data: {} });
+      // }),
+    );
+  }, { exampleId });
 }
 `;
 

--- a/apps/web/e2e-kit/_lib/new-case.mjs
+++ b/apps/web/e2e-kit/_lib/new-case.mjs
@@ -9,7 +9,7 @@
  * **接入方需改的占位** (脚本顶部 config 常量):
  *   - CASE_SPECS_DIR / TESTS_DIR / HANDLERS_DIR  — 项目路径 (默认对齐 kit v0.4 扁平布局)
  *   - FIXTURES_IMPORT_PATH / MOCK_IM_IMPORT_PATH / SANITY_IMPORT_PATH / HANDLERS_IMPORT_ROOT
- *                       — import 路径 (相对 e2e/ 根)
+ *                       — import 路径 (相对 e2e 根)
  *   - USE_MOCK_IM      — 是否装 mock-im-runtime (默认 **false**; 项目装了 mock-im-wksdk optional 后改成 true)
  *   - USE_SANITY       — 是否装 sanity helper (默认 true, 无 sanity 关掉)
  *   - FMT_CMD          — 生成后自动 fmt 命令 (默认 null, 项目要用 prettier 之类改这里)
@@ -41,9 +41,9 @@
  *     --tags "@p1 @matter @matter-list" --http-mock --im-seed
  *
  * 产出 (以默认路径 + 上例参数为例):
- *   e2e/case-specs/matter/list/M5-matter-list-filter.md
- *   e2e/tests/matter/list/M5-matter-list-filter.spec.ts
- *   e2e/msw-handlers/m5-matter-list-filter.ts   (**默认生成**, 传 --no-http-mock 关掉)
+ *   <e2e-root>/case-specs/matter/list/M5-matter-list-filter.md
+ *   <e2e-root>/tests/matter/list/M5-matter-list-filter.spec.ts
+ *   <e2e-root>/msw-handlers/m5-matter-list-filter.ts   (**默认生成**, 传 --no-http-mock 关掉)
  *
  * --no-http-mock → 不出 handler, test 骨架也不 register handler.
  * --no-im-seed → test 骨架不装 mock IM runtime.
@@ -58,10 +58,10 @@ import { resolveE2ERoot } from "./target-layout.mjs";
 // ---------- config (接入方按需改) ----------
 //
 // **默认值对齐 kit v0.4 sync 产物的扁平布局**:
-//   e2e/fixtures-authed.ts        (template 落根)
-//   e2e/_kit/mock-im-runtime/     (overwrite 落 _kit/)
-//   e2e/_lib/sanity.ts            (overwrite 落 _lib/)
-//   e2e/msw-handlers/             (hands_off 目录, kit 首次落 README 占位)
+//   <e2e-root>/fixtures-authed.ts        (template 落根)
+//   <e2e-root>/_kit/mock-im-runtime/     (overwrite 落 _kit/)
+//   <e2e-root>/_lib/sanity.ts            (overwrite 落 _lib/)
+//   <e2e-root>/msw-handlers/             (hands_off 目录, kit 首次落 README 占位)
 //
 // 若接入方项目采用其他布局 (例如 e2e-research 的 shared/), 改下面常量即可.
 
@@ -71,7 +71,7 @@ const CASE_SPECS_DIR = resolve(E2E_ROOT, "case-specs");
 const TESTS_DIR = resolve(E2E_ROOT, "tests");
 const HANDLERS_DIR = resolve(E2E_ROOT, "msw-handlers");
 
-// import path segments (相对 e2e/ 根). test 到根的相对前缀由 upToE2eRoot() 算.
+// import path segments (相对 e2e 根). test 到根的相对前缀由 upToE2eRoot() 算.
 const FIXTURES_IMPORT_PATH = "fixtures-authed";
 const MOCK_IM_IMPORT_PATH = "_kit/mock-im-runtime";
 const SANITY_IMPORT_PATH = "_lib/sanity";
@@ -81,7 +81,7 @@ const USE_MOCK_IM = false; // 项目装了 mock-im-wksdk optional 后, 改成 tr
 const USE_SANITY = true;
 const FMT_CMD = null; // 例: ["pnpm", "exec", "prettier", "--write"]
 
-// test 到 e2e/ 根的相对前缀. tests/[module/[sub/]]<file>.spec.ts → depth 决定 ../ 个数.
+// test 到 e2e 根的相对前缀. tests/[module/[sub/]]<file>.spec.ts → depth 决定 ../ 个数.
 function upToE2eRoot(moduleName, subModule) {
   const depth = 1 + (moduleName ? 1 : 0) + (subModule ? 1 : 0);
   return "../".repeat(depth);
@@ -278,7 +278,7 @@ const testTemplate = `/* eslint-disable no-undef -- e2e code runs in Node */
  * ${caseId}: **待补** 一句话主线 + 反例守护点.
  */
 import { test, expect } from "${sharedRoot}${FIXTURES_IMPORT_PATH}";
-${withHttpMock ? `import { ${registerFnName} } from "${sharedRoot}${HANDLERS_IMPORT_ROOT}/${caseId.toLowerCase()}-${slug}";\n` : ""}${withImSeed ? `import { installMockImRuntime } from "${sharedRoot}${MOCK_IM_IMPORT_PATH}";\n` : ""}${USE_SANITY ? `import { startRequestMonitor, sanityCheck } from "${sharedRoot}${SANITY_IMPORT_PATH}";\n` : ""}
+${withHttpMock ? `import { ${registerFnName} } from "${sharedRoot}${HANDLERS_IMPORT_ROOT}/${caseId.toLowerCase()}-${slug}";\n` : ""}${withImSeed ? `import { installMockImRuntime } from "${sharedRoot}${MOCK_IM_IMPORT_PATH}";\n` : ""}${USE_SANITY ? `import { startRequestMonitor, sanityCheck, type SanityConfig } from "${sharedRoot}${SANITY_IMPORT_PATH}";\n` : ""}${USE_SANITY ? `const sanityConfig: SanityConfig = {\n  realHosts: ["127.0.0.1:9", "mock.e2e.local"],\n  apiPrefixRe: /^\\/(api|summary\\/api)(\\/|$)/,\n  loginPathRe: /\\/login(\\?|$)/,\n};\n` : ""}
 
 test.describe("${tags} ${caseId} — **待补** case 描述", () => {
   test("**待补** 一句话操作 + 预期", async ({ authedPage }) => {
@@ -286,7 +286,7 @@ test.describe("${tags} ${caseId} — **待补** case 描述", () => {
     // 若忘删, batch 跑 (--grep @p0 等) 会 skip 而不是假绿.
     test.fixme(true, "scaffolder 骨架, 待作者补真实操作步骤 + UI 断言");
 
-${USE_SANITY ? `    const ctx = startRequestMonitor(authedPage);\n` : ""}${withHttpMock ? `\n    await ${registerFnName}(authedPage);\n` : ""}${withImSeed ? `
+${USE_SANITY ? `    const ctx = startRequestMonitor(authedPage, sanityConfig);\n` : ""}${withHttpMock ? `\n    await ${registerFnName}(authedPage);\n` : ""}${withImSeed ? `
     await installMockImRuntime(authedPage, {
       currentUid: "e2e-user-1",
       spaceId: "e2e-space-001",
@@ -322,46 +322,39 @@ import type { Page } from "@playwright/test";
  */
 
 export async function ${registerFnName}(page: Page): Promise<void> {
-  // 示例：把 spec/业务源码确认的外部值通过 evaluate 第二参数传入。
-  const exampleId = "**待补**";
   await page.evaluate(
-    ({ exampleId }) => {
-      // 这里只使用参数和浏览器全局变量, 不引用 Node 模块变量.
-      void exampleId;
-      const w = (window as unknown as { __mswWorker__?: { use: (...h: unknown[]) => void } })
-      .__mswWorker__;
-    const http = (
-      window as unknown as {
-        __mswHttp__?: {
-          get: (path: string, resolver: (info: any) => unknown) => unknown;
-          post: (path: string, resolver: (info: any) => unknown) => unknown;
+    () => {
+      const msw = (window as unknown as {
+        __msw?: {
+          worker: { use: (...h: unknown[]) => void };
+          http: {
+            get: (path: string, resolver: (info: any) => unknown) => unknown;
+            post: (path: string, resolver: (info: any) => unknown) => unknown;
+          };
+          HttpResponse: { json: (body: unknown, init?: unknown) => unknown };
         };
+      }).__msw;
+      if (!msw) {
+        throw new Error("[${caseId}] MSW worker 未就绪 (等 __MSW_READY__).");
       }
-    ).__mswHttp__;
-    const HttpResponse = (
-      window as unknown as {
-        __mswHttpResponse__?: { json: (body: unknown, init?: unknown) => unknown };
-      }
-    ).__mswHttpResponse__;
-    if (!w || !http || !HttpResponse) {
-      throw new Error("[${caseId}] MSW worker 未就绪 (等 __MSW_READY__).");
-    }
+      const { worker: w, http, HttpResponse } = msw;
 
-    // module-scope state 每 install 重置, 避免 --repeat-each=3 相互泄漏.
-    (window as unknown as { ${stateKey}: { calls: number } }).${stateKey} = {
-      calls: 0,
-    };
+      // module-scope state 每 install 重置, 避免 --repeat-each=3 相互泄漏.
+      (window as unknown as { ${stateKey}: { calls: number } }).${stateKey} = {
+        calls: 0,
+      };
 
-    w.use(
-      // **待补** 本 case 的 endpoint handler
-      // http.post("*​/v1/matter/xxx", async (info: any) => {
-      //   const state = (window as unknown as { ${stateKey}: { calls: number } }).${stateKey};
-      //   state.calls += 1;
-      //   const body = await info.request.json();
-      //   return HttpResponse.json({ code: 0, message: "ok", data: {} });
-      // }),
-    );
-  }, { exampleId });
+      w.use(
+        // **待补** 本 case 的 endpoint handler
+        // http.post("*​/v1/matter/xxx", async (info: any) => {
+        //   const state = (window as unknown as { ${stateKey}: { calls: number } }).${stateKey};
+        //   state.calls += 1;
+        //   const body = await info.request.json();
+        //   return HttpResponse.json({ code: 0, message: "ok", data: {} });
+        // }),
+      );
+    },
+  );
 }
 `;
 

--- a/apps/web/e2e-kit/_lib/preflight.mjs
+++ b/apps/web/e2e-kit/_lib/preflight.mjs
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+
+/**
+ * Fast, read-only e2e environment check.
+ * Usage: node e2e/_lib/preflight.mjs [--port=3000] [--check-env-file=apps/web/env.local]
+ *        [--require-env=VITE_API_URL] [--check-url=http://localhost:3000]
+ */
+import { existsSync, readFileSync } from "node:fs";
+import { createServer } from "node:net";
+import { spawnSync } from "node:child_process";
+
+const args = Object.fromEntries(process.argv.slice(2).map((arg) => {
+  const [key, ...rest] = arg.replace(/^--/, "").split("=");
+  return [key, rest.join("=") || true];
+}));
+
+const requestedPort = Number(args.port || process.env.PORT || 3000);
+const envFile = typeof args["check-env-file"] === "string" ? args["check-env-file"] : null;
+const requiredEnv = typeof args["require-env"] === "string"
+  ? args["require-env"].split(",").map((name) => name.trim()).filter(Boolean)
+  : [];
+const checkUrl = typeof args["check-url"] === "string" ? args["check-url"] : null;
+const failures = [];
+
+function check(condition, message) {
+  if (condition) console.log(`✓ ${message}`);
+  else { console.error(`✗ ${message}`); failures.push(message); }
+}
+
+function portAvailable(port) {
+  return new Promise((resolve) => {
+    const server = createServer();
+    server.once("error", () => resolve(false));
+    server.listen(port, "127.0.0.1", () => server.close(() => resolve(true)));
+  });
+}
+
+async function choosePort(start) {
+  for (let offset = 0; offset <= 20; offset += 1) {
+    for (const port of offset === 0 ? [start] : [start + offset, start - offset]) {
+      if (port > 0 && port < 65536 && await portAvailable(port)) return port;
+    }
+  }
+  return null;
+}
+
+check(existsSync("package.json"), "当前目录存在 package.json");
+check(
+  ["pnpm-lock.yaml", "yarn.lock", "package-lock.json"].some(existsSync),
+  "找到包管理器 lockfile",
+);
+
+if (envFile) {
+  const content = existsSync(envFile) ? readFileSync(envFile, "utf8") : "";
+  check(Boolean(content), `env 文件存在: ${envFile}`);
+  for (const name of requiredEnv) {
+    const present = new RegExp(`^${name}\\s*=\\s*.+$`, "m").test(content);
+    check(present, `${envFile} 包含 ${name}`);
+  }
+}
+
+const selectedPort = await choosePort(requestedPort);
+check(selectedPort !== null, `端口可用: ${selectedPort ?? requestedPort}`);
+if (selectedPort !== null) console.log(`E2E_SELECTED_PORT=${selectedPort}`);
+
+const packageManager = existsSync("pnpm-lock.yaml") ? "pnpm" : existsSync("yarn.lock") ? "yarn" : "npm";
+const version = spawnSync(packageManager, ["--version"], { encoding: "utf8" });
+check(version.status === 0, `${packageManager} 可执行`);
+
+if (checkUrl) {
+  try {
+    const response = await fetch(checkUrl, { signal: AbortSignal.timeout(3000) });
+    check(response.ok, `服务可访问: ${checkUrl} (${response.status})`);
+  } catch (error) {
+    check(false, `服务可访问: ${checkUrl} (${error.message})`);
+  }
+}
+
+if (failures.length) {
+  console.error(`\npreflight failed: ${failures.length} check(s)`);
+  process.exit(1);
+}
+console.log("\npreflight passed");

--- a/apps/web/e2e-kit/_lib/preflight.mjs
+++ b/apps/web/e2e-kit/_lib/preflight.mjs
@@ -2,17 +2,37 @@
 
 /**
  * Fast, read-only e2e environment check.
- * Usage: node e2e/_lib/preflight.mjs [--port=3000] [--check-env-file=apps/web/env.local]
+ * Usage: node apps/web/e2e-kit/_lib/preflight.mjs [--port=3000] [--check-env-file=apps/web/env.local]
  *        [--require-env=VITE_API_URL] [--check-url=http://localhost:3000]
  */
 import { existsSync, readFileSync } from "node:fs";
 import { createServer } from "node:net";
+import { dirname, join } from "node:path";
 import { spawnSync } from "node:child_process";
 
 const args = Object.fromEntries(process.argv.slice(2).map((arg) => {
   const [key, ...rest] = arg.replace(/^--/, "").split("=");
   return [key, rest.join("=") || true];
 }));
+
+function findWorkspaceRoot(start) {
+  let current = start;
+  while (true) {
+    if (
+      existsSync(join(current, "package.json")) &&
+      ["pnpm-lock.yaml", "yarn.lock", "package-lock.json"].some((name) => existsSync(join(current, name)))
+    ) {
+      return current;
+    }
+    const parent = dirname(current);
+    if (parent === current) return start;
+    current = parent;
+  }
+}
+
+const workspaceRoot = findWorkspaceRoot(process.cwd());
+const packageJsonPath = join(workspaceRoot, "package.json");
+const packageJson = existsSync(packageJsonPath) ? JSON.parse(readFileSync(packageJsonPath, "utf8")) : {};
 
 const requestedPort = Number(args.port || process.env.PORT || 3000);
 const envFile = typeof args["check-env-file"] === "string" ? args["check-env-file"] : null;
@@ -44,9 +64,9 @@ async function choosePort(start) {
   return null;
 }
 
-check(existsSync("package.json"), "当前目录存在 package.json");
+check(existsSync(packageJsonPath), `工作区存在 package.json: ${workspaceRoot}`);
 check(
-  ["pnpm-lock.yaml", "yarn.lock", "package-lock.json"].some(existsSync),
+  ["pnpm-lock.yaml", "yarn.lock", "package-lock.json"].some((name) => existsSync(join(workspaceRoot, name))),
   "找到包管理器 lockfile",
 );
 
@@ -63,7 +83,13 @@ const selectedPort = await choosePort(requestedPort);
 check(selectedPort !== null, `端口可用: ${selectedPort ?? requestedPort}`);
 if (selectedPort !== null) console.log(`E2E_SELECTED_PORT=${selectedPort}`);
 
-const packageManager = existsSync("pnpm-lock.yaml") ? "pnpm" : existsSync("yarn.lock") ? "yarn" : "npm";
+const packageManager = typeof packageJson.packageManager === "string"
+  ? packageJson.packageManager.split("@")[0]
+  : existsSync(join(workspaceRoot, "pnpm-lock.yaml"))
+    ? "pnpm"
+    : existsSync(join(workspaceRoot, "yarn.lock"))
+      ? "yarn"
+      : "npm";
 const version = spawnSync(packageManager, ["--version"], { encoding: "utf8" });
 check(version.status === 0, `${packageManager} 可执行`);
 

--- a/apps/web/e2e-kit/_lib/target-layout.mjs
+++ b/apps/web/e2e-kit/_lib/target-layout.mjs
@@ -1,0 +1,18 @@
+import { existsSync } from "node:fs";
+import { isAbsolute, resolve } from "node:path";
+
+const CANDIDATES = ["e2e", "e2e-kit", "apps/web/e2e-kit"];
+
+/** Resolve the project's e2e root without requiring downstream script edits. */
+export function resolveE2ERoot(repoRoot = process.cwd()) {
+  const configured = process.env.E2E_TARGET_DIR;
+  const candidates = configured ? [configured, ...CANDIDATES] : CANDIDATES;
+  for (const candidate of candidates) {
+    const root = isAbsolute(candidate) ? candidate : resolve(repoRoot, candidate);
+    const markers = ["manifest.yaml", "fixtures-authed.ts", "case-specs/TEMPLATE.md"];
+    if (markers.some((marker) => existsSync(resolve(root, marker)))) {
+      return root;
+    }
+  }
+  return resolve(repoRoot, configured || "e2e");
+}

--- a/apps/web/e2e-kit/_lib/target-layout.mjs
+++ b/apps/web/e2e-kit/_lib/target-layout.mjs
@@ -2,17 +2,29 @@ import { existsSync } from "node:fs";
 import { isAbsolute, resolve } from "node:path";
 
 const CANDIDATES = ["e2e", "e2e-kit", "apps/web/e2e-kit"];
+const MARKERS = ["manifest.yaml", "fixtures-authed.ts", "case-specs/TEMPLATE.md"];
+
+function hasMarker(root) {
+  return MARKERS.some((marker) => existsSync(resolve(root, marker)));
+}
 
 /** Resolve the project's e2e root without requiring downstream script edits. */
 export function resolveE2ERoot(repoRoot = process.cwd()) {
   const configured = process.env.E2E_TARGET_DIR;
-  const candidates = configured ? [configured, ...CANDIDATES] : CANDIDATES;
-  for (const candidate of candidates) {
-    const root = isAbsolute(candidate) ? candidate : resolve(repoRoot, candidate);
-    const markers = ["manifest.yaml", "fixtures-authed.ts", "case-specs/TEMPLATE.md"];
-    if (markers.some((marker) => existsSync(resolve(root, marker)))) {
-      return root;
+  if (configured) {
+    const root = isAbsolute(configured) ? configured : resolve(repoRoot, configured);
+    if (!hasMarker(root)) {
+      throw new Error(
+        `[e2e] E2E_TARGET_DIR=${configured} has no kit markers (${MARKERS.join(", ")})`,
+      );
     }
+    return root;
   }
-  return resolve(repoRoot, configured || "e2e");
+  for (const candidate of CANDIDATES) {
+    const root = resolve(repoRoot, candidate);
+    if (hasMarker(root)) return root;
+  }
+  throw new Error(
+    `[e2e] 无法识别 e2e 根目录，请在仓库根目录运行，或设置包含 kit markers 的 E2E_TARGET_DIR (${MARKERS.join(", ")})`,
+  );
 }

--- a/apps/web/e2e-kit/_lib/verify-case.sh
+++ b/apps/web/e2e-kit/_lib/verify-case.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run one case through the kit stability gate.
+# Usage: e2e/_lib/verify-case.sh --grep='@C7' [--config=e2e/playwright.ci.config.ts]
+
+GREP=""
+CONFIG=""
+REPEAT_EACH="3"
+EXTRA=()
+
+for arg in "$@"; do
+  case "$arg" in
+    --grep=*) GREP="${arg#*=}" ;;
+    --config=*) CONFIG="${arg#*=}" ;;
+    --repeat-each=*) REPEAT_EACH="${arg#*=}" ;;
+    --) shift; EXTRA+=("$@") ; break ;;
+    *) EXTRA+=("$arg") ;;
+  esac
+done
+
+if [ -z "$GREP" ]; then
+  echo "缺少 --grep=<case tag>，例如 --grep='@C7'" >&2
+  exit 2
+fi
+
+CMD=(pnpm exec playwright test --grep "$GREP" --repeat-each="$REPEAT_EACH" --workers=1)
+[ -n "$CONFIG" ] && CMD+=(--config "$CONFIG")
+CMD+=("${EXTRA[@]}")
+
+echo "[e2e verify] ${CMD[*]}"
+"${CMD[@]}"
+echo "[e2e verify] $GREP: ${REPEAT_EACH}/${REPEAT_EACH} runs passed"

--- a/apps/web/e2e-kit/_lib/verify-case.sh
+++ b/apps/web/e2e-kit/_lib/verify-case.sh
@@ -2,19 +2,23 @@
 set -euo pipefail
 
 # Run one case through the kit stability gate.
-# Usage: e2e/_lib/verify-case.sh --grep='@C7' [--config=e2e/playwright.ci.config.ts]
+# Usage: apps/web/e2e-kit/_lib/verify-case.sh --grep='@C7' [--config=/path/to/playwright.ci.config.ts]
 
 GREP=""
 CONFIG=""
 REPEAT_EACH="3"
 EXTRA=()
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+E2E_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-for arg in "$@"; do
+while [ "$#" -gt 0 ]; do
+  arg="$1"
+  shift
   case "$arg" in
     --grep=*) GREP="${arg#*=}" ;;
     --config=*) CONFIG="${arg#*=}" ;;
     --repeat-each=*) REPEAT_EACH="${arg#*=}" ;;
-    --) shift; EXTRA+=("$@") ; break ;;
+    --) EXTRA+=("$@"); break ;;
     *) EXTRA+=("$arg") ;;
   esac
 done
@@ -24,9 +28,13 @@ if [ -z "$GREP" ]; then
   exit 2
 fi
 
-CMD=(pnpm exec playwright test --grep "$GREP" --repeat-each="$REPEAT_EACH" --workers=1)
-[ -n "$CONFIG" ] && CMD+=(--config "$CONFIG")
-CMD+=("${EXTRA[@]}")
+if [ -z "$CONFIG" ]; then
+  CONFIG="$E2E_ROOT/playwright.ci.config.ts"
+fi
+CMD=(pnpm exec playwright test --grep "$GREP" --repeat-each="$REPEAT_EACH" --workers=1 --config "$CONFIG")
+if [ "${#EXTRA[@]}" -gt 0 ]; then
+  CMD+=("${EXTRA[@]}")
+fi
 
 echo "[e2e verify] ${CMD[*]}"
 "${CMD[@]}"

--- a/apps/web/e2e-kit/case-specs/TES8-profile-online-status.md
+++ b/apps/web/e2e-kit/case-specs/TES8-profile-online-status.md
@@ -2,11 +2,11 @@
 
 ## Metadata
 
-- Case 类型：feature e2e
-- 目标模式：real page seed（chat 页 + Global Search + 资料弹窗）
+- Case 类型: feature e2e
+- 目标模式: real page seed（chat 页 + Global Search + 资料弹窗）
 - 登录状态：已登录 fixture
-- 优先级：P0
-- Tags：`@TES8 @p0 @chat @profile`
+- 优先级: P0
+- Tags: `@TES8 @p0 @chat @profile`
 
 ## 目标
 

--- a/apps/web/e2e-kit/manifest.yaml
+++ b/apps/web/e2e-kit/manifest.yaml
@@ -1,6 +1,6 @@
 # 由 e2e-kit sync 维护, 请勿手动改 kit_version / installed_optionals / template_checksums 字段
 kit_name: e2e-kit
-kit_version: 0.4.5
+kit_version: 0.4.9
 kit_source: https://codex.mlamp.cn/e2e/e2e-kit
 
 # 已装 optional 层 (由 --with-optional 追加, 追加不移除)
@@ -9,10 +9,10 @@ installed_optionals:
 
 # 每次 sync 时更新的 template checksum, 用于判"接入方是否改过某模板文件"
 template_checksums:
-  case-specs/TEMPLATE.md: a63ea27cd9e1c1587403912fa4c81fb9
-  fixtures-authed.ts: 4f7da7ede980985ea2b46d5829016c1e
   .github/workflows/e2e.yml.template: c1baa97459908a509a753ff61b336b4e
   .gitlab-ci.yml.template: d3f32d4ca4d51ff84e92c9e2488a47c7
+  case-specs/TEMPLATE.md: a63ea27cd9e1c1587403912fa4c81fb9
+  fixtures-authed.ts: 4f7da7ede980985ea2b46d5829016c1e
   playwright.ci.config.ts: 8ffc630f52cce6cfd9061dfb6e88bcbd
   playwright.config.ts: 46ca199b2b90122014cd1b7fc559eeba
   tests/example.spec.ts: 7aa527a9ecabac1c7bd1ad63b9f0255c


### PR DESCRIPTION
## Summary
- sync the reliable execution helpers from e2e-kit 0.4.9
- add preflight, readiness, target layout, and 3x case verification helpers
- align the existing TES8 metadata with the stricter spec lint format

## Validation
- 38 e2e case specs pass lint
- preflight passed
- Node and shell syntax checks passed
- git diff --check passed

This PR is based directly on upstream/main and intentionally contains only e2e-kit sync changes.