### PR TITLE
feat(mail): validate Agent mailbox names

### DIFF
--- a/packages/mail/src/features/MailAddressManagementFeature.test.tsx
+++ b/packages/mail/src/features/MailAddressManagementFeature.test.tsx
@@ -154,6 +154,25 @@ describe("MailAddressManagementFeature", () => {
     expect(state.emit).toHaveBeenCalledWith("mail-refresh");
   });
 
+  it.each(["bot1", "admin", "postmaster"])(
+    "does not submit invalid mailbox name %s",
+    async (localpart) => {
+      await act(async () => {
+        root.render(<MailAddressManagementFeature />);
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      act(() => state.viewProps?.onLocalpartChange(localpart));
+      await act(async () => {
+        state.viewProps?.onCreate();
+        await Promise.resolve();
+      });
+
+      expect(state.createMailbox).not.toHaveBeenCalled();
+    }
+  );
+
   it("switches from the existing OpenClaw prompt to the CLI prompt", async () => {
     await act(async () => {
       root.render(<MailAddressManagementFeature />);

--- a/packages/mail/src/features/MailAddressManagementFeature.tsx
+++ b/packages/mail/src/features/MailAddressManagementFeature.tsx
@@ -4,7 +4,7 @@ import { sanitizeShellSpaceId } from "@octo/base/src/Utils/spaceId";
 import MailService from "../Service/MailService";
 import type { AgentMailbox, AgentOutboundMode } from "../bridge/types";
 import { resolveAgentMailboxBotNames } from "../bridge/agentIdentity";
-import { getErrorMessage } from "../utils";
+import { getErrorMessage, isValidAgentMailboxLocalpart } from "../utils";
 import MailAddressManagementView from "../ui/MailAddressManagementView";
 import MailRuleManagementFeature from "./MailRuleManagementFeature";
 import MailRecordsFeature from "./MailRecordsFeature";
@@ -123,7 +123,7 @@ export default function MailAddressManagementFeature() {
 
   const create = async () => {
     if (
-      !localpart.trim() ||
+      !isValidAgentMailboxLocalpart(localpart) ||
       !domain ||
       maxMailboxes === null ||
       submitting ||

--- a/packages/mail/src/i18n/en-US.json
+++ b/packages/mail/src/i18n/en-US.json
@@ -146,7 +146,7 @@
   "mail.addresses.localpart": "Mailbox name",
   "mail.addresses.placeholder": "For example, alerts",
   "mail.addresses.create": "Create mailbox",
-  "mail.addresses.createHint": "Use lowercase letters, numbers, dots, hyphens, or underscores. After creation, connect any Bot you own.",
+  "mail.addresses.createHint": "Use 5–64 lowercase letters, numbers, dots, hyphens, or underscores. Reserved system names such as admin and postmaster are unavailable. After creation, connect any Bot you own.",
   "mail.addresses.createLimitHint": "Each Space allows up to {{limit}} Agent mailboxes; {{count}} created.",
   "mail.agentMailboxes.unconnected": "Agent not connected",
   "mail.agentMailboxes.connected": "Connected",

--- a/packages/mail/src/i18n/zh-CN.json
+++ b/packages/mail/src/i18n/zh-CN.json
@@ -146,7 +146,7 @@
   "mail.addresses.localpart": "邮箱名称",
   "mail.addresses.placeholder": "例如 alerts",
   "mail.addresses.create": "创建邮箱",
-  "mail.addresses.createHint": "可使用小写字母、数字、点、短横线和下划线；创建后可选择任意自己的 Bot 完成接入。",
+  "mail.addresses.createHint": "名称需为 5–64 位，可使用小写字母、数字、点、短横线和下划线；不可使用 admin、postmaster 等系统保留名称。创建后可选择任意自己的 Bot 完成接入。",
   "mail.addresses.createLimitHint": "每个 Space 最多创建 {{limit}} 个 Agent 邮箱，当前已创建 {{count}} 个。",
   "mail.agentMailboxes.unconnected": "未接入 Agent",
   "mail.agentMailboxes.connected": "已接入",

--- a/packages/mail/src/ui/MailAddressManagementView/MailAddressManagementView.test.tsx
+++ b/packages/mail/src/ui/MailAddressManagementView/MailAddressManagementView.test.tsx
@@ -77,6 +77,27 @@ describe("MailAddressManagementView automation mode", () => {
     expect(createButton?.disabled).toBe(true);
   });
 
+  it.each(["bot1", "admin", "postmaster"])(
+    "disables mailbox creation for invalid name %s",
+    (localpart) => {
+      const container = document.createElement("div");
+      const root = createRoot(container);
+      containers.push({ container, root });
+      document.body.appendChild(container);
+      const invalidProps = props(vi.fn());
+      invalidProps.localpart = localpart;
+
+      act(() => {
+        root.render(<MailAddressManagementView {...invalidProps} />);
+      });
+
+      const createButton = Array.from(
+        container.querySelectorAll("button")
+      ).find((button) => button.textContent?.includes("mail.addresses.create"));
+      expect(createButton?.disabled).toBe(true);
+    }
+  );
+
   it("offers CLI setup without changing or closing the existing setup dialog", () => {
     const onSetupMethodChange = vi.fn();
     const onCloseSetup = vi.fn();

--- a/packages/mail/src/ui/MailAddressManagementView/index.tsx
+++ b/packages/mail/src/ui/MailAddressManagementView/index.tsx
@@ -15,6 +15,11 @@ import {
   X,
 } from "lucide-react";
 import type { AgentMailbox, AgentOutboundMode } from "../../bridge/types";
+import {
+  agentMailboxLocalpartMaxLength,
+  agentMailboxLocalpartMinLength,
+  isValidAgentMailboxLocalpart,
+} from "../../utils";
 import "./index.css";
 
 interface Translator {
@@ -280,6 +285,8 @@ export default function MailAddressManagementView(
                 <input
                   value={props.localpart}
                   disabled={props.mailboxes.length >= props.maxMailboxes}
+                  minLength={agentMailboxLocalpartMinLength}
+                  maxLength={agentMailboxLocalpartMaxLength}
                   placeholder={t("mail.addresses.placeholder")}
                   onChange={(event) =>
                     props.onLocalpartChange(event.target.value.toLowerCase())
@@ -295,7 +302,7 @@ export default function MailAddressManagementView(
               type="button"
               disabled={
                 props.submitting ||
-                !props.localpart.trim() ||
+                !isValidAgentMailboxLocalpart(props.localpart) ||
                 !props.domain ||
                 props.mailboxes.length >= props.maxMailboxes
               }

--- a/packages/mail/src/utils.test.ts
+++ b/packages/mail/src/utils.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { getMessageText, hasKeyword, splitAddresses } from "./utils";
+import {
+  getMessageText,
+  hasKeyword,
+  isValidAgentMailboxLocalpart,
+  splitAddresses,
+} from "./utils";
 
 describe("mail utilities", () => {
   it("splits recipient input without empty entries", () => {
@@ -10,6 +15,19 @@ describe("mail utilities", () => {
 
   it("matches protocol keywords case-insensitively", () => {
     expect(hasKeyword(["\\SEEN", "\\Flagged"], "\\seen")).toBe(true);
+  });
+
+  it.each([
+    ["agent", true],
+    ["support", true],
+    ["agent.alerts_1", true],
+    ["bot1", false],
+    ["admin", false],
+    ["POSTMASTER", false],
+    ["agent..alerts", false],
+    ["a".repeat(65), false],
+  ] as const)("validates Agent mailbox name %s", (localpart, expected) => {
+    expect(isValidAgentMailboxLocalpart(localpart)).toBe(expected);
   });
 
   it("prefers plain text bodies", () => {

--- a/packages/mail/src/utils.ts
+++ b/packages/mail/src/utils.ts
@@ -1,6 +1,34 @@
 import { extractErrorMsg } from "@octo/base/src/Service/APIClient";
 import type { MessageDetail } from "./bridge/types";
 
+export const agentMailboxLocalpartMinLength = 5;
+export const agentMailboxLocalpartMaxLength = 64;
+
+const agentMailboxLocalpartPattern = /^[a-z0-9](?:[a-z0-9._-]{0,62}[a-z0-9])?$/;
+const reservedAgentMailboxLocalparts = new Set([
+  "abuse",
+  "admin",
+  "administrator",
+  "hostmaster",
+  "mailer-daemon",
+  "noc",
+  "postmaster",
+  "root",
+  "security",
+  "webmaster",
+]);
+
+export function isValidAgentMailboxLocalpart(value: string): boolean {
+  const localpart = value.trim().toLowerCase();
+  return (
+    localpart.length >= agentMailboxLocalpartMinLength &&
+    localpart.length <= agentMailboxLocalpartMaxLength &&
+    agentMailboxLocalpartPattern.test(localpart) &&
+    !localpart.includes("..") &&
+    !reservedAgentMailboxLocalparts.has(localpart)
+  );
+}
+
 export function getErrorMessage(error: unknown, fallback: string): string {
   return extractErrorMsg(error) || fallback;
 }


### PR DESCRIPTION
## Summary

Adds client-side Agent mailbox name validation that matches the backend naming policy.

## Related Issue

Closes #1475

## Changes

- Validate mailbox names as 5–64 allowed ASCII characters.
- Reject reserved system and operational mailbox names before submission.
- Apply input length limits and disable creation for invalid values.
- Add Chinese and English naming guidance.
- Add utility, feature, and view coverage for accepted and rejected names.

## Architecture / Module Boundary

- Affected module(s): `@octo/mail`
- New or changed user-visible entry point: no
- Shared layer touched: ui
- If shared code changed, impact scope: Agent mailbox management form only
- Duplicate entry point checked: not applicable

## Testing

- [x] Unit tests added/updated
- [ ] Manually verified
- `pnpm --filter @octo/mail test` — 196 tests passed
- `pnpm --filter @octo/mail typecheck` — passed
- `pnpm i18n:check` — passed
- `pnpm turbo run build --filter=@octo/web` — passed
- Prettier check for all touched files — passed

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes
- [ ] Updated documentation
- [x] Ran `pnpm i18n:check` or confirmed the change does not affect UI copy
- [x] Confirmed the change follows module ownership and does not add duplicate user-visible entry points
- [x] Described impact scope when shared components, messages, bridge, or services are changed
- [x] Followed commit message conventions (Conventional Commits)
