### PR TITLE
fix(summary): remount create page when switching summary mode from list entry

### DIFF
--- a/packages/dmworksummary/src/pages/SummaryListPage.tsx
+++ b/packages/dmworksummary/src/pages/SummaryListPage.tsx
@@ -571,6 +571,10 @@ export default class SummaryListPage extends Component<SummaryListPageProps, Sum
         WKApp.routeRight.popToRoot();
         WKApp.routeRight.push(
             <SummaryCreatePage
+                // key 绑定模式：右侧已有创建页时再次选择模式需强制重挂载
+                // （WKViewQueue 按下标做 key，同类型组件会被复用，state.mode 不随
+                // 新 initialMode 重读 → 界面不切换）。从列表页选模式 = 发起一次新建。
+                key={mode}
                 onCreated={() => this.loadData()}
                 source="summary_list"
                 initialMode={mode}

--- a/packages/dmworksummary/src/pages/__tests__/SummaryListPage.modeEntry.test.tsx
+++ b/packages/dmworksummary/src/pages/__tests__/SummaryListPage.modeEntry.test.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@octo/base', async () => {
+    const actual = await vi.importActual<Record<string, unknown>>('../../__mocks__/dmworkBase');
+    return { ...actual };
+});
+vi.mock('@douyinfe/semi-ui', () => ({
+    Button: () => null,
+    Dropdown: () => null,
+    SplitButtonGroup: ({ children }: any) => <div>{children}</div>,
+    Spin: () => null,
+    Toast: { success: vi.fn(), error: vi.fn() },
+    Banner: () => null,
+    Tooltip: ({ children }: any) => <>{children}</>,
+}));
+vi.mock('@douyinfe/semi-icons', () => ({
+    IconSearch: () => null,
+    IconPlus: () => null,
+}));
+vi.mock('lucide-react', () => ({
+    X: () => null,
+    ChevronDown: () => null,
+}));
+vi.mock('../../components/SummaryCard', () => ({ default: () => null }));
+vi.mock('../SummaryCreatePage', () => ({ default: () => null }));
+vi.mock('../SummaryDetailPage', () => ({ default: () => null }));
+vi.mock('../../api/summaryApi');
+
+import { WKApp } from '@octo/base';
+import SummaryListPage from '../SummaryListPage';
+
+/**
+ * 回归：#1461 后总结方式选择上移到列表页「+」下拉。
+ * WKViewQueue 按数组下标渲染 pushed 视图（外层 div key={i}），右侧已有
+ * SummaryCreatePage 时再次 push 同类型组件会命中 React 复用分支——组件不重挂载、
+ * state.mode 不随新 initialMode 重读 → 点「Agent 总结」界面毫无反应。
+ * 修复：push 的元素 key 绑定模式，模式变化即视为一次全新创建（强制重挂载）。
+ */
+describe('SummaryListPage mode entry navigation', () => {
+    beforeEach(() => vi.clearAllMocks());
+
+    function makePage() {
+        const page = new SummaryListPage({} as any);
+        (page as any).isMounted_ = true;
+        return page;
+    }
+
+    it('pushes the create page keyed by mode so switching modes remounts instead of being silently reused', () => {
+        const page = makePage();
+        const pushSpy = vi.spyOn(WKApp.routeRight, 'push');
+        const popToRootSpy = vi.spyOn(WKApp.routeRight, 'popToRoot');
+
+        (page as any).handleCreate('normal');
+        expect(pushSpy).toHaveBeenCalledTimes(1);
+        expect(popToRootSpy).toHaveBeenCalledTimes(1);
+        const normalEl = pushSpy.mock.calls[0][0] as React.ReactElement;
+        expect(React.isValidElement(normalEl)).toBe(true);
+        expect(normalEl.key).toBe('normal');
+        expect(normalEl.props.initialMode).toBe('normal');
+
+        // 再次选择 Agent：必须 push 一个 key 不同的新元素（key 相同会被 React 复用，
+        // state.mode 保持 normal —— 正是线上「点了没反应」的根因）。
+        (page as any).handleCreate('agent');
+        expect(pushSpy).toHaveBeenCalledTimes(2);
+        const agentEl = pushSpy.mock.calls[1][0] as React.ReactElement;
+        expect(agentEl.key).toBe('agent');
+        expect(agentEl.props.initialMode).toBe('agent');
+        expect(agentEl.key).not.toBe(normalEl.key);
+    });
+
+    it('default (no-arg) entry still lands on the normal-mode create page', () => {
+        const page = makePage();
+        const pushSpy = vi.spyOn(WKApp.routeRight, 'push');
+
+        (page as any).handleCreate();
+        const el = pushSpy.mock.calls[0][0] as React.ReactElement;
+        expect(el.key).toBe('normal');
+        expect(el.props.initialMode).toBe('normal');
+    });
+
+    it('panel mode forwards the selected mode to the host via onCreateNew instead of pushing a route', () => {
+        const onCreateNew = vi.fn();
+        const page = new SummaryListPage({ onCreateNew } as any);
+        const pushSpy = vi.spyOn(WKApp.routeRight, 'push');
+
+        (page as any).handleCreate('agent');
+        expect(onCreateNew).toHaveBeenCalledWith('agent');
+        expect(pushSpy).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
## Summary

Follow-up fix for #1461 (move summary-mode select from create page to list-page entry).

**Bug:** after #1461, selecting a different mode from the list-page "+" dropdown while a create page is already mounted in `routeRight` had no visible effect — the right pane stayed on the previous mode's UI.

**Root cause:** `WKViewQueue` renders pushed views keyed by array index (`key={i}`). `handleCreate(mode)` does `popToRoot()` + `push(<SummaryCreatePage initialMode={mode} />)`. When the right pane already held a `SummaryCreatePage`, the newly pushed element had the same type and same index-key, so React's reconciliation took the reuse branch: the component was **not** remounted, and `state.mode` (initialized once from `props.initialMode`) kept its previous value. Reproduced both ways:

- normal create page mounted → select "Agent Summary" → nothing happens (the reported case)
- agent page mounted → select "Quick Summary" → nothing happens

**Fix:** key the pushed element by mode (`key={mode}`). Selecting a mode from the list entry is semantically "start a new creation", so a mode change now forces a fresh mount with the requested `initialMode`. Re-selecting the same mode keeps the existing draft (unchanged behavior).

## Changes

- `packages/dmworksummary/src/pages/SummaryListPage.tsx` — add `key={mode}` to the pushed `SummaryCreatePage` (+4 lines, incl. comment)
- `packages/dmworksummary/src/pages/__tests__/SummaryListPage.modeEntry.test.tsx` — new regression test (3 cases):
  - pushed element is keyed by mode, so switching modes produces a different key (the reuse trap)
  - default (no-arg) entry still lands on the normal-mode create page
  - panel mode still forwards the selected mode via `onCreateNew(mode)` instead of pushing a route

## Verification

Manual (dev server, logged-in session on `/summary`):

| Step | Result |
|---|---|
| click "+" → quick summary | normal create page (submit button + topic input) |
| dropdown → "Agent Summary" | agent chat UI + welcome message ✅ (was: no-op before fix) |
| dropdown → "Quick Summary" (back) | normal create page restored ✅ (was: no-op before fix) |

Tests:

- new `SummaryListPage.modeEntry.test.tsx`: 3/3 pass
- existing `SummaryListPage.*` suites (autoRefresh / summaryRead / statusFilter / inviteBadge): 25/25 pass
- typecheck: error count for `SummaryListPage.tsx` identical before/after the change (46 pre-existing env errors, zero new)
