### PR TITLE
fix(mail): refresh authorization and proxy responses

### DIFF
--- a/apps/web/src/__tests__/mailProxyParity.test.ts
+++ b/apps/web/src/__tests__/mailProxyParity.test.ts
@@ -184,16 +184,21 @@ describe("Agent Mail proxy path parity", () => {
       "utf8"
     );
 
+    const browserMailLocation = "location /mail-api/";
     const bootstrapLocation =
       "location ~ ^/agent-mail-api/webapi/v0/agent-auth/(device|token)$";
     const credentialedLocation = "location ~ ^/agent-mail-api(?:/|$)";
+    const browserMailStart = nginx.indexOf(browserMailLocation);
     const bootstrapStart = nginx.indexOf(bootstrapLocation);
     const credentialedStart = nginx.indexOf(credentialedLocation);
-    expect(bootstrapStart).toBeGreaterThanOrEqual(0);
+    expect(browserMailStart).toBeGreaterThanOrEqual(0);
+    expect(bootstrapStart).toBeGreaterThan(browserMailStart);
     expect(credentialedStart).toBeGreaterThan(bootstrapStart);
 
+    const browserMailBlock = nginx.slice(browserMailStart, bootstrapStart);
     const bootstrapBlock = nginx.slice(bootstrapStart, credentialedStart);
     const credentialedBlock = nginx.slice(credentialedStart);
+    expect(browserMailBlock).toContain("proxy_http_version 1.1;");
     expect(bootstrapBlock).toContain(
       "rewrite ^/agent-mail-api/?(.*)$ /$1 break;",
     );

--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -131,6 +131,7 @@ server {
             resolver ${NGINX_RESOLVER} ipv6=off valid=30s;
             rewrite ^/mail-api/(.*)$ /v1/mail-gateway/$1 break;
             proxy_pass $mail_api_url;
+            proxy_http_version 1.1;
             proxy_set_header token $http_token;
             proxy_set_header X-Space-ID $http_x_space_id;
             proxy_set_header Authorization "";

--- a/packages/mail/src/bridge/useMailNavigation.test.tsx
+++ b/packages/mail/src/bridge/useMailNavigation.test.tsx
@@ -295,6 +295,32 @@ describe("useMailNavigation", () => {
     expect(getAgentMailboxContext()).toBeNull();
   });
 
+  it("clears a stale mailbox error after a silent refresh succeeds", async () => {
+    const account = {
+      id: "11",
+      address: "agent@demo.octo.test",
+      connectState: "connected" as const,
+    };
+    const inbox = { id: "inbox", name: "Inbox", total: 3, unread: 1 };
+    testState.listAgentMailboxes.mockResolvedValue([account]);
+    testState.listMailboxes
+      .mockRejectedValueOnce(new Error("mailbox refresh failed"))
+      .mockResolvedValueOnce([inbox]);
+
+    const { result } = renderHook(() => useMailNavigation("fallback"));
+    await waitFor(() => expect(result.current.error).toBe("fallback"));
+    expect(result.current.mailboxes).toEqual([]);
+
+    act(() => {
+      window.dispatchEvent(new Event("blur"));
+      window.dispatchEvent(new Event("focus"));
+    });
+
+    await waitFor(() => expect(result.current.error).toBe(""));
+    expect(result.current.mailboxes).toEqual([inbox]);
+    expect(result.current.loading).toBe(false);
+  });
+
   it("coalesces visible and focus events into one binding refresh", async () => {
     let visibilityState: DocumentVisibilityState = "visible";
     vi.spyOn(document, "visibilityState", "get").mockImplementation(

--- a/packages/mail/src/bridge/useMailNavigation.test.tsx
+++ b/packages/mail/src/bridge/useMailNavigation.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
-import { act, renderHook } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const testState = vi.hoisted(() => {
   const listeners = new Map<string, Set<(...args: unknown[]) => void>>();
@@ -48,6 +48,7 @@ vi.mock("../Service/MailService", () => ({
 
 import useMailNavigation from "./useMailNavigation";
 import {
+  getAgentMailboxContext,
   replaceAgentMailboxContext,
   resetAgentMailboxContextForTests,
 } from "./mailboxContext";
@@ -62,7 +63,7 @@ function deferred<T>() {
   return { promise, resolve, reject };
 }
 
-describe("useMailNavigation Space isolation", () => {
+describe("useMailNavigation", () => {
   beforeEach(() => {
     testState.listeners.clear();
     testState.currentSpaceId = "space-a";
@@ -70,6 +71,11 @@ describe("useMailNavigation Space isolation", () => {
     testState.listMailboxes.mockReset();
     resetAgentMailboxContextForTests();
     window.sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
   });
 
   it("clears old state and ignores a stale mailbox-account response", async () => {
@@ -184,5 +190,141 @@ describe("useMailNavigation Space isolation", () => {
     });
 
     expect(result.current.selectedAgentMailbox?.id).toBe("12");
+  });
+
+  it("refreshes Agent mailbox binding after returning from an authorization tab", async () => {
+    const refreshedAccounts = deferred<
+      Array<{
+        id: string;
+        address: string;
+        connectState: "connected" | "unconnected";
+      }>
+    >();
+    testState.listAgentMailboxes
+      .mockResolvedValueOnce([
+        {
+          id: "11",
+          address: "agent@demo.octo.test",
+          connectState: "unconnected",
+        },
+      ])
+      .mockReturnValueOnce(refreshedAccounts.promise);
+    testState.listMailboxes.mockResolvedValue([]);
+
+    const { result, unmount } = renderHook(() => useMailNavigation("fallback"));
+    await waitFor(() =>
+      expect(result.current.selectedAgentMailbox?.connectState).toBe(
+        "unconnected"
+      )
+    );
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    act(() => window.dispatchEvent(new Event("focus")));
+    expect(testState.listAgentMailboxes).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      window.dispatchEvent(new Event("blur"));
+      window.dispatchEvent(new Event("focus"));
+    });
+
+    expect(testState.listAgentMailboxes).toHaveBeenCalledTimes(2);
+    expect(result.current.loading).toBe(false);
+
+    await act(async () => {
+      refreshedAccounts.resolve([
+        {
+          id: "11",
+          address: "agent@demo.octo.test",
+          connectState: "connected",
+        },
+      ]);
+      await refreshedAccounts.promise;
+    });
+
+    await waitFor(() =>
+      expect(result.current.selectedAgentMailbox?.connectState).toBe(
+        "connected"
+      )
+    );
+    expect(testState.listAgentMailboxes).toHaveBeenCalledTimes(2);
+    expect(result.current.loading).toBe(false);
+    unmount();
+  });
+
+  it("keeps existing navigation state when a background refresh fails", async () => {
+    const account = {
+      id: "11",
+      address: "agent@demo.octo.test",
+      connectState: "connected" as const,
+    };
+    const inbox = { id: "inbox", name: "Inbox", total: 3, unread: 1 };
+    testState.listAgentMailboxes
+      .mockResolvedValueOnce([account])
+      .mockRejectedValueOnce(new Error("background refresh failed"))
+      .mockRejectedValueOnce(new Error("manual refresh failed"));
+    testState.listMailboxes.mockResolvedValue([inbox]);
+
+    const { result } = renderHook(() => useMailNavigation("fallback"));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.mailboxes).toEqual([inbox]);
+
+    act(() => {
+      window.dispatchEvent(new Event("blur"));
+      window.dispatchEvent(new Event("focus"));
+    });
+
+    await waitFor(() =>
+      expect(testState.listAgentMailboxes).toHaveBeenCalledTimes(2)
+    );
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(result.current.agentMailboxes).toEqual([account]);
+    expect(result.current.selectedAgentMailbox).toEqual(account);
+    expect(result.current.mailboxes).toEqual([inbox]);
+    expect(getAgentMailboxContext()?.mailbox).toEqual(account);
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBe("");
+
+    act(() => testState.emit("mail-refresh"));
+
+    await waitFor(() => expect(result.current.error).toBe("fallback"));
+    expect(result.current.agentMailboxes).toEqual([]);
+    expect(result.current.selectedAgentMailbox).toBeNull();
+    expect(getAgentMailboxContext()).toBeNull();
+  });
+
+  it("coalesces visible and focus events into one binding refresh", async () => {
+    let visibilityState: DocumentVisibilityState = "visible";
+    vi.spyOn(document, "visibilityState", "get").mockImplementation(
+      () => visibilityState
+    );
+    testState.listAgentMailboxes.mockResolvedValue([
+      {
+        id: "11",
+        address: "agent@demo.octo.test",
+        connectState: "unconnected",
+      },
+    ]);
+    testState.listMailboxes.mockResolvedValue([]);
+
+    const { unmount } = renderHook(() => useMailNavigation("fallback"));
+    await waitFor(() =>
+      expect(testState.listAgentMailboxes).toHaveBeenCalledTimes(1)
+    );
+
+    act(() => {
+      visibilityState = "hidden";
+      document.dispatchEvent(new Event("visibilitychange"));
+      visibilityState = "visible";
+      document.dispatchEvent(new Event("visibilitychange"));
+      window.dispatchEvent(new Event("focus"));
+    });
+
+    await waitFor(() =>
+      expect(testState.listAgentMailboxes).toHaveBeenCalledTimes(2)
+    );
+    unmount();
   });
 });

--- a/packages/mail/src/bridge/useMailNavigation.ts
+++ b/packages/mail/src/bridge/useMailNavigation.ts
@@ -179,6 +179,7 @@ export default function useMailNavigation(fallbackError: string) {
       .then((nextMailboxes) => {
         if (!active || request !== mailboxRequestRef.current) return;
         setMailboxes(nextMailboxes);
+        if (mailboxRefreshSilent) setError("");
       })
       .catch((reason) => {
         if (!active || request !== mailboxRequestRef.current) return;

--- a/packages/mail/src/bridge/useMailNavigation.ts
+++ b/packages/mail/src/bridge/useMailNavigation.ts
@@ -12,23 +12,100 @@ import {
   useAgentMailboxContext,
 } from "./mailboxContext";
 
+interface RefreshRequest {
+  revision: number;
+  silent: boolean;
+}
+
+function useSilentRefreshFlag(
+  request: RefreshRequest,
+  foregroundKey: unknown
+): boolean {
+  const previousRef = useRef<{
+    revision: number;
+    foregroundKey: unknown;
+    silent: boolean;
+  }>();
+  const previous = previousRef.current;
+  let silent = previous?.silent ?? false;
+
+  if (previous && !Object.is(previous.foregroundKey, foregroundKey)) {
+    silent = false;
+  } else if (!previous || previous.revision !== request.revision) {
+    silent = request.silent;
+  }
+
+  previousRef.current = {
+    revision: request.revision,
+    foregroundKey,
+    silent,
+  };
+  return silent;
+}
+
 export default function useMailNavigation(fallbackError: string) {
   const context = useAgentMailboxContext();
   const [agentMailboxes, setAgentMailboxes] = useState<AgentMailbox[]>([]);
   const [mailboxes, setMailboxes] = useState<Mailbox[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
-  const [revision, setRevision] = useState(0);
+  const [refreshRequest, setRefreshRequest] = useState<RefreshRequest>({
+    revision: 0,
+    silent: false,
+  });
   const accountRequestRef = useRef(0);
   const mailboxRequestRef = useRef(0);
-  const reload = useCallback(() => setRevision((value) => value + 1), []);
+  const foregroundRequestCountRef = useRef(0);
+  const pendingForegroundRefreshRef = useRef(false);
+  const reload = useCallback(() => {
+    pendingForegroundRefreshRef.current = true;
+    setRefreshRequest((current) => ({
+      revision: current.revision + 1,
+      silent: false,
+    }));
+  }, []);
+  const refreshSilently = useCallback(() => {
+    const silent =
+      foregroundRequestCountRef.current === 0 &&
+      !pendingForegroundRefreshRef.current;
+    setRefreshRequest((current) => ({
+      revision: current.revision + 1,
+      silent,
+    }));
+  }, []);
+  const beginForegroundRequest = useCallback((silent: boolean) => {
+    if (silent) return () => undefined;
+    foregroundRequestCountRef.current += 1;
+    pendingForegroundRefreshRef.current = false;
+    let active = true;
+    return () => {
+      if (!active) return;
+      active = false;
+      foregroundRequestCountRef.current = Math.max(
+        0,
+        foregroundRequestCountRef.current - 1
+      );
+    };
+  }, []);
   const spaceId = WKApp.shared.currentSpaceId || "";
+  const accountRefreshSilent = useSilentRefreshFlag(
+    refreshRequest,
+    `${spaceId}\u0000${fallbackError}`
+  );
+  const mailboxRefreshSilent = useSilentRefreshFlag(
+    refreshRequest,
+    `${spaceId}\u0000${context?.mailbox.id || ""}\u0000${fallbackError}`
+  );
 
   useEffect(() => {
     let active = true;
+    const finishForegroundRequest =
+      beginForegroundRequest(accountRefreshSilent);
     const request = ++accountRequestRef.current;
-    setLoading(true);
-    setError("");
+    if (!accountRefreshSilent) {
+      setLoading(true);
+      setError("");
+    }
     void MailService.listAgentMailboxes()
       .then(async (nextMailboxes) => {
         if (!active || request !== accountRequestRef.current) return;
@@ -57,18 +134,29 @@ export default function useMailNavigation(fallbackError: string) {
       })
       .catch((reason) => {
         if (!active || request !== accountRequestRef.current) return;
+        if (accountRefreshSilent) return;
         setAgentMailboxes([]);
         replaceAgentMailboxContext(null);
         setError(getErrorMessage(reason, fallbackError));
         setLoading(false);
+      })
+      .finally(() => {
+        finishForegroundRequest();
       });
     return () => {
       active = false;
+      finishForegroundRequest();
     };
     // Context metadata is reconciled from the server response using the live
     // snapshot; changing it must not restart the account-list request.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [fallbackError, revision, spaceId]);
+  }, [
+    accountRefreshSilent,
+    beginForegroundRequest,
+    fallbackError,
+    refreshRequest.revision,
+    spaceId,
+  ]);
 
   useEffect(() => {
     if (!context || context.spaceId !== spaceId) {
@@ -80,9 +168,13 @@ export default function useMailNavigation(fallbackError: string) {
     }
 
     let active = true;
+    const finishForegroundRequest =
+      beginForegroundRequest(mailboxRefreshSilent);
     const request = ++mailboxRequestRef.current;
-    setLoading(true);
-    setError("");
+    if (!mailboxRefreshSilent) {
+      setLoading(true);
+      setError("");
+    }
     void MailService.listMailboxes(context.mailbox.id)
       .then((nextMailboxes) => {
         if (!active || request !== mailboxRequestRef.current) return;
@@ -90,16 +182,32 @@ export default function useMailNavigation(fallbackError: string) {
       })
       .catch((reason) => {
         if (!active || request !== mailboxRequestRef.current) return;
+        if (mailboxRefreshSilent) return;
         setMailboxes([]);
         setError(getErrorMessage(reason, fallbackError));
       })
       .finally(() => {
-        if (active && request === mailboxRequestRef.current) setLoading(false);
+        if (
+          active &&
+          request === mailboxRequestRef.current &&
+          !mailboxRefreshSilent
+        ) {
+          setLoading(false);
+        }
+        finishForegroundRequest();
       });
     return () => {
       active = false;
+      finishForegroundRequest();
     };
-  }, [context, fallbackError, revision, spaceId]);
+  }, [
+    beginForegroundRequest,
+    context,
+    fallbackError,
+    mailboxRefreshSilent,
+    refreshRequest.revision,
+    spaceId,
+  ]);
 
   useEffect(() => {
     const handleSpaceChanged = () => {
@@ -119,6 +227,34 @@ export default function useMailNavigation(fallbackError: string) {
       WKApp.mittBus.off("space-changed", handleSpaceChanged);
     };
   }, [reload]);
+
+  useEffect(() => {
+    let inactive = document.visibilityState === "hidden";
+    const markInactive = () => {
+      inactive = true;
+    };
+    const reloadAfterReturning = () => {
+      if (!inactive || document.visibilityState === "hidden") return;
+      inactive = false;
+      refreshSilently();
+    };
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "hidden") {
+        markInactive();
+        return;
+      }
+      reloadAfterReturning();
+    };
+
+    window.addEventListener("blur", markInactive);
+    window.addEventListener("focus", reloadAfterReturning);
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    return () => {
+      window.removeEventListener("blur", markInactive);
+      window.removeEventListener("focus", reloadAfterReturning);
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+    };
+  }, [refreshSilently]);
 
   const selectAgentMailbox = useCallback(
     (mailbox: AgentMailbox, afterSwitch?: () => void) => {


### PR DESCRIPTION
## Summary

Refresh Agent mailbox bindings after browser authorization and preserve streamed Mail API responses through the production proxy.

## Related Issue

Closes #1481

## Changes

- Refresh Agent mailbox data after the page returns from an inactive state.
- Keep focus-triggered refreshes silent and coalesce focus and visibility events.
- Proxy `/mail-api/` requests to octo-server with HTTP/1.1 so chunked message details can be forwarded.
- Add regression coverage for authorization-tab return, event coalescing, and the Nginx proxy protocol.

## Architecture / Module Boundary

- Affected module(s): `@octo/mail`, web Nginx proxy
- New or changed user-visible entry point: no
- Shared layer touched: bridge
- If shared code changed, impact scope: Agent mailbox binding refresh and browser Mail API response forwarding
- Duplicate entry point checked: not applicable

## Testing

- [x] Unit tests added/updated
- [x] `pnpm --filter @octo/mail test` — 25 files, 201 tests passed
- [x] `pnpm --filter @octo/mail typecheck`
- [x] `pnpm exec vitest run src/__tests__/mailProxyParity.test.ts` — 15 tests passed

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Documentation update is not required because the public contract and UI copy are unchanged
- [x] Confirmed the change does not affect UI copy
- [x] Confirmed the change follows module ownership and does not add duplicate user-visible entry points
- [x] Described impact scope when shared components, messages, bridge, or services are changed
- [x] Followed commit message conventions (Conventional Commits)

