### PR TITLE
fix(skillmarket): allow HTTP presigned URLs

### DIFF
--- a/packages/dmworkskillmarket/src/api/skillApiReal.test.ts
+++ b/packages/dmworkskillmarket/src/api/skillApiReal.test.ts
@@ -537,7 +537,7 @@ describe("skillApiReal", () => {
     );
   });
 
-  it("uploadFile PUTs with presigned headers and reports progress", async () => {
+  it("uploadFile PUTs HTTP and HTTPS presigned URLs with headers and reports progress", async () => {
     const xhrInstances: MockXHR[] = [];
     class MockXHR {
       upload = new EventTarget();
@@ -596,6 +596,27 @@ describe("skillApiReal", () => {
       "x-amz-meta-id": "upload-1",
     });
     expect(onProgress).toHaveBeenCalledWith(50);
+
+    await uploadFile(
+      "http://storage.example/upload",
+      new File(["zip"], "skill.zip", { type: "application/zip" })
+    );
+
+    expect(xhrInstances[1].method).toBe("PUT");
+    expect(xhrInstances[1].url).toBe("http://storage.example/upload");
+  });
+
+  it("uploadFile rejects non-HTTP presigned URL schemes", async () => {
+    await expect(
+      uploadFile(
+        "file:///tmp/skill.zip",
+        new File(["zip"], "skill.zip", { type: "application/zip" })
+      )
+    ).rejects.toMatchObject({
+      name: "SkillMarketApiError",
+      code: "invalid_response",
+      message: "URL scheme 不允许",
+    });
   });
 
   it("triggerParse returns the backend task id", async () => {

--- a/packages/dmworkskillmarket/src/api/skillApiReal.ts
+++ b/packages/dmworkskillmarket/src/api/skillApiReal.ts
@@ -207,13 +207,12 @@ function wait(ms: number): Promise<void> {
 }
 
 /**
- * Reject presigned upload / download URLs whose scheme is not http(s), or
- * whose http-scheme host is not loopback. Blocks `javascript:` / `data:` /
- * `file:` / arbitrary non-web schemes before an anchor.href / xhr.open
- * accepts them.
+ * Reject presigned upload / download URLs whose scheme is not http(s).
+ * Blocks `javascript:` / `data:` / `file:` / arbitrary non-web schemes
+ * before an anchor.href / xhr.open accepts them.
  *
- * Scope: scheme-level only. `https://10.x` / `https://169.254.169.254`
- * still passes — internal-host filtering would need a marketplace-side
+ * Scope: scheme-level only. `http(s)://10.x` / `http(s)://169.254.169.254`
+ * still pass — internal-host filtering would need a marketplace-side
  * allowlist not shipped here. Blast radius stays bounded because the PUT
  * runs with no app credentials (bare XHR / no interceptors).
  */
@@ -224,12 +223,7 @@ function assertSafeExternalURL(raw: string): void {
   } catch {
     throw normalizeError({ code: "invalid_response", message: t("skillMarket.errors.invalidUrl") });
   }
-  if (u.protocol === "https:") return;
-  if (
-    u.protocol === "http:" &&
-    (u.hostname === "localhost" || u.hostname === "127.0.0.1")
-  )
-    return;
+  if (u.protocol === "https:" || u.protocol === "http:") return;
   throw normalizeError({
     code: "invalid_response",
     message: t("skillMarket.errors.urlSchemeNotAllowed"),


### PR DESCRIPTION
## Summary

- allow Skill Market presigned upload and download URLs over HTTP as well as HTTPS
- continue rejecting non-web URL schemes such as `file:`, `data:`, and `javascript:`
- add regression coverage for a non-loopback HTTP storage URL

## Testing

- `cd packages/dmworkskillmarket && pnpm test -- src/api/skillApiReal.test.ts` (14 files, 129 tests passed)

## Notes

- package-level `tsc --noEmit` remains blocked by existing workspace dependency/type errors outside this change