### PR TITLE
feat(summary): land on create page by default and use a single + mode dropdown

### DIFF
--- a/apps/web/e2e-kit/case-specs/summary/agent/S9-summary-agent-chat-save.md
+++ b/apps/web/e2e-kit/case-specs/summary/agent/S9-summary-agent-chat-save.md
@@ -60,9 +60,9 @@
 
 ## 摸清依据
 
-- `packages/dmworksummary/src/module.tsx:122`: `/summary` 路由真实挂载 `SummaryListPage`；`module.tsx:176` NavRail「智能总结」`onPress` 进入 `/summary` 列表页。
-- `packages/dmworksummary/src/pages/SummaryListPage.tsx:558`: `handleCreate(mode)` 对非 onCreateNew 路径推入 `SummaryCreatePage`（`initialMode` 透传模式）；空态/头部「+」也汇聚于此。
-- `packages/dmworksummary/src/pages/SummaryListPage.tsx:594-631`: 列表页 header「+」`SplitButtonGroup`——主按钮「快速总结」+ 下拉含「Agent 总结」（`listModeSwitch`/`listAgentTab`）。
+- `packages/dmworksummary/src/module.tsx:122`: `/summary` 路由真实挂载 `SummaryListPage`；`module.tsx` NavRail「智能总结」`onPress` 进入列表页并把右栏 `replaceToRoot` 为新建总结页（默认 `initialMode="normal"`，取代欢迎占位页）。
+- `packages/dmworksummary/src/pages/SummaryListPage.tsx:558`: `handleCreate(mode)` 对非 onCreateNew 路径推入 `SummaryCreatePage`（`initialMode` 透传模式）；空态入口也汇聚于此。
+- `packages/dmworksummary/src/pages/SummaryListPage.tsx`: 列表页 header 为单一「+」按钮（`listModeSwitch`）——点击只弹下拉（快速总结 / Agent 总结，`listNormalTab`/`listAgentTab`），不再有独立的主按钮 + 箭头组合。
 - `packages/dmworksummary/src/pages/SummaryCreatePage.tsx:76,145,327`: `initialMode="agent"` 时 mount 调用 `enterAgentMode()` 恢复历史 session 并回显。
 - `packages/dmworksummary/src/components/AgentChatPanel.tsx:159`: 发送时调用 `agentChatStream()`。
 - `packages/dmworksummary/src/components/AgentChatPanel.tsx:421`: 有 assistant 输出后渲染「保存为总结」按钮。

--- a/apps/web/e2e-kit/case-specs/summary/agent/S9-summary-agent-chat-save.md
+++ b/apps/web/e2e-kit/case-specs/summary/agent/S9-summary-agent-chat-save.md
@@ -61,7 +61,7 @@
 ## 摸清依据
 
 - `packages/dmworksummary/src/module.tsx:122`: `/summary` 路由真实挂载 `SummaryListPage`；`module.tsx` NavRail「智能总结」`onPress` 进入列表页并把右栏 `replaceToRoot` 为新建总结页（默认 `initialMode="normal"`，取代欢迎占位页）。
-- `packages/dmworksummary/src/pages/SummaryListPage.tsx:558`: `handleCreate(mode)` 对非 onCreateNew 路径推入 `SummaryCreatePage`（`initialMode` 透传模式）；空态入口也汇聚于此。
+- `packages/dmworksummary/src/pages/SummaryListPage.tsx:559`: `handleCreate(mode)` 对非 onCreateNew 路径推入 `SummaryCreatePage`（`initialMode` 透传模式）；空态入口也汇聚于此。
 - `packages/dmworksummary/src/pages/SummaryListPage.tsx`: 列表页 header 为单一「+」按钮（`listModeSwitch`）——点击只弹下拉（快速总结 / Agent 总结，`listNormalTab`/`listAgentTab`），不再有独立的主按钮 + 箭头组合。
 - `packages/dmworksummary/src/pages/SummaryCreatePage.tsx:76,145,327`: `initialMode="agent"` 时 mount 调用 `enterAgentMode()` 恢复历史 session 并回显。
 - `packages/dmworksummary/src/components/AgentChatPanel.tsx:159`: 发送时调用 `agentChatStream()`。

--- a/apps/web/e2e-kit/msw-handlers/s14-summary-detail-version-restore.ts
+++ b/apps/web/e2e-kit/msw-handlers/s14-summary-detail-version-restore.ts
@@ -134,7 +134,10 @@ export async function registerS14SummaryDetailVersionRestore(page: Page): Promis
         const state = (window as unknown as { __s14State__: { restored: boolean } }).__s14State__;
         state.restored = true;
         return env({ task_id: taskId, result_id: restoredResultId, version: 3 });
-      })
+      }),
+      http.get("*/summary/api/v1/summary-templates", () =>
+        env({ templates: [], custom_template_limit: 30 })
+      )
     );
   });
 }

--- a/apps/web/e2e-kit/msw-handlers/s15-summary-detail-edit-save.ts
+++ b/apps/web/e2e-kit/msw-handlers/s15-summary-detail-edit-save.ts
@@ -111,7 +111,10 @@ export async function registerS15SummaryDetailEditSave(page: Page): Promise<void
           ? "S15 已保存正文内容"
           : String(body.content || "");
         return env({ edited_at: "2026-08-06T15:18:00Z" });
-      })
+      }),
+      http.get("*/summary/api/v1/summary-templates", () =>
+        env({ templates: [], custom_template_limit: 30 })
+      )
     );
   });
 }

--- a/apps/web/e2e-kit/msw-handlers/s16-summary-detail-refine.ts
+++ b/apps/web/e2e-kit/msw-handlers/s16-summary-detail-refine.ts
@@ -99,7 +99,10 @@ export async function registerS16SummaryDetailRefine(page: Page): Promise<void> 
             "cache-control": "no-cache",
           },
         });
-      })
+      }),
+      http.get("*/summary/api/v1/summary-templates", () =>
+        env({ templates: [], custom_template_limit: 30 })
+      )
     );
   });
 }

--- a/apps/web/e2e-kit/msw-handlers/s17-summary-detail-delete.ts
+++ b/apps/web/e2e-kit/msw-handlers/s17-summary-detail-delete.ts
@@ -105,7 +105,10 @@ export async function registerS17SummaryDetailDelete(page: Page): Promise<void> 
         const state = (window as unknown as { __s17State__: { deleted: boolean } }).__s17State__;
         state.deleted = true;
         return env({});
-      })
+      }),
+      http.get("*/summary/api/v1/summary-templates", () =>
+        env({ templates: [], custom_template_limit: 30 })
+      )
     );
   });
 }

--- a/apps/web/e2e-kit/msw-handlers/s18-summary-list-poll-completed.ts
+++ b/apps/web/e2e-kit/msw-handlers/s18-summary-list-poll-completed.ts
@@ -108,6 +108,9 @@ export async function registerS18SummaryListPollCompleted(page: Page): Promise<v
       ),
       http.get("*/summary/api/v1/summaries/18018/versions", () =>
         env({ versions: [], keep_limit: 3 })
+      ),
+      http.get("*/summary/api/v1/summary-templates", () =>
+        env({ templates: [], custom_template_limit: 30 })
       )
     );
   });

--- a/apps/web/e2e-kit/msw-handlers/s19-summary-list-cancel-task.ts
+++ b/apps/web/e2e-kit/msw-handlers/s19-summary-list-cancel-task.ts
@@ -65,7 +65,10 @@ export async function registerS19SummaryListCancelTask(page: Page): Promise<void
       http.post("*/summary/api/v1/summaries/batch-status", () => {
         const state = (window as unknown as { __s19State__: { cancelled: boolean } }).__s19State__;
         return env({ tasks: [{ id: taskId, status: state.cancelled ? 5 : 2 }] });
-      })
+      }),
+      http.get("*/summary/api/v1/summary-templates", () =>
+        env({ templates: [], custom_template_limit: 30 })
+      )
     );
   }, [S19_TASK_ID]);
 }

--- a/apps/web/e2e-kit/msw-handlers/s20-summary-list-retry-failed.ts
+++ b/apps/web/e2e-kit/msw-handlers/s20-summary-list-retry-failed.ts
@@ -65,7 +65,10 @@ export async function registerS20SummaryListRetryFailed(page: Page): Promise<voi
       http.post("*/summary/api/v1/summaries/batch-status", () => {
         const state = (window as unknown as { __s20State__: { retried: boolean } }).__s20State__;
         return env({ tasks: [{ id: taskId, status: state.retried ? 2 : 4 }] });
-      })
+      }),
+      http.get("*/summary/api/v1/summary-templates", () =>
+        env({ templates: [], custom_template_limit: 30 })
+      )
     );
   }, [S20_TASK_ID]);
 }

--- a/apps/web/e2e-kit/msw-handlers/s21-summary-list-load-more.ts
+++ b/apps/web/e2e-kit/msw-handlers/s21-summary-list-load-more.ts
@@ -53,7 +53,10 @@ export async function registerS21SummaryListLoadMore(page: Page): Promise<void> 
         const url = new URL(request.url);
         const page = Number(url.searchParams.get("page") || "1");
         return env({ items: page >= 2 ? secondPage : firstPage, total: 21, attention_count: 0, unread_count: 0, pending_invitation_count: 0 });
-      })
+      }),
+      http.get("*/summary/api/v1/summary-templates", () =>
+        env({ templates: [], custom_template_limit: 30 })
+      )
     );
   });
 }

--- a/apps/web/e2e-kit/msw-handlers/s24-summary-multi-collab-submit.ts
+++ b/apps/web/e2e-kit/msw-handlers/s24-summary-multi-collab-submit.ts
@@ -149,7 +149,10 @@ export async function registerS24SummaryMultiCollabSubmit(page: Page): Promise<v
         return env({});
       }),
       http.post(`*/summary/api/v1/summaries/${TASK_ID}/read`, () => env({ is_unread: false, has_pending_invitation: false, needs_attention: false })),
-      http.get(`*/summary/api/v1/summaries/${TASK_ID}/versions`, () => env({ versions: [], keep_limit: 3 }))
+      http.get(`*/summary/api/v1/summaries/${TASK_ID}/versions`, () => env({ versions: [], keep_limit: 3 })),
+      http.get("*/summary/api/v1/summary-templates", () =>
+        env({ templates: [], custom_template_limit: 30 })
+      )
     );
   }, [S24_TASK_ID, S24_MY_USER_ID, S24_OTHER_USER_ID]);
 }

--- a/apps/web/e2e-kit/msw-handlers/s25-summary-invite-respond.ts
+++ b/apps/web/e2e-kit/msw-handlers/s25-summary-invite-respond.ts
@@ -86,7 +86,10 @@ export async function registerS25SummaryInviteRespond(page: Page): Promise<void>
             { id: REJECT_TASK_ID, status: state.rejected ? 5 : 1 },
           ],
         });
-      })
+      }),
+      http.get("*/summary/api/v1/summary-templates", () =>
+        env({ templates: [], custom_template_limit: 30 })
+      )
     );
   }, { ACCEPT_TASK_ID: S25_ACCEPT_TASK_ID, REJECT_TASK_ID: S25_REJECT_TASK_ID });
 }

--- a/apps/web/e2e-kit/tests/summary/_testids.ts
+++ b/apps/web/e2e-kit/tests/summary/_testids.ts
@@ -8,7 +8,6 @@ export const T = {
     listContent: "summary-list-content",
     listSearch: "summary-list-search",
     listStatusFilter: "summary-list-status-filter",
-    listCreate: "summary-list-create",
     createEntry: "summary-create-entry",
 
     // Card (per-task)
@@ -23,7 +22,7 @@ export const T = {
     createSelectChat: "summary-create-select-chat",
     createSelectMembers: "summary-create-select-members",
     createSubmit: "summary-create-submit",
-    // Mode-select dropdown on the list-page "+" entry (mirror of prod testIds.ts)
+    // Mode-select dropdown on the single list-page "+" entry (mirror of prod testIds.ts)
     listModeSwitch: "summary-list-mode-switch",
     listNormalTab: "summary-list-normal-tab",
     listAgentTab: "summary-list-agent-tab",

--- a/packages/dmworksummary/src/__tests__/module.menuSwitch.test.tsx
+++ b/packages/dmworksummary/src/__tests__/module.menuSwitch.test.tsx
@@ -88,6 +88,13 @@ function registeredHandler(event: string): () => void {
   return call[1] as () => void;
 }
 
+function summaryMenuFactory(): () => { onPress?: (reentry?: boolean) => void } {
+  const reg = vi.mocked(WKApp.menus.register);
+  const factory = reg.mock.calls.find(([id]) => id === "summary")?.[1] as unknown as () => { onPress?: (reentry?: boolean) => void };
+  expect(factory).toBeTruthy();
+  return factory;
+}
+
 describe("SummaryModule guarded menu switching", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -162,10 +169,7 @@ describe("SummaryModule guarded menu switching", () => {
     // /summary 会造出双实例（e2e strict mode violation）。
     // 新需求：进入智能总结右栏默认展示新建总结页（取代欢迎占位页）——只推创建页，
     // 绝不推列表页。
-    const reg = vi.mocked(WKApp.menus.register);
-    const factory = reg.mock.calls.find(([id]) => id === "summary")?.[1] as () => { onPress?: (reentry?: boolean) => void };
-    expect(factory).toBeTruthy();
-    const menu = factory();
+    const menu = summaryMenuFactory()();
     menu.onPress?.(false);
 
     // 只清左栈；右栈由 replaceToRoot 直接落创建页。
@@ -176,6 +180,31 @@ describe("SummaryModule guarded menu switching", () => {
     expect(pushed.type).toBe(SummaryCreatePage); // 创建页，不是 SummaryListPage
     expect(pushed.props.source).toBe("summary_home");
     expect(pushed.props.initialMode).toBe("normal");
+    // P2-1/P2-5：key 必须存在且随每次进入变化——固定 key 会命中 WKViewQueue 的
+    // React 复用分支，重复点菜单不会「重置回默认创建页」。
+    expect(String(pushed.key).startsWith("home-normal-")).toBe(true);
+
+    // 再次进入：key 必须不同（强制重挂载，保证重置语义）。
+    menu.onPress?.(true);
+    expect(state.replaceToRoot).toHaveBeenCalledTimes(2);
+    const second = state.replaceToRoot.mock.calls[1][0] as React.ReactElement;
+    expect(second.key).not.toBe(pushed.key);
+  });
+
+  it("small screens (≤640px) keep landing on the list: no create page pushed into the overlay right pane", () => {
+    // P1-2：WKLayout 在 ≤640px 把右栏渲染为覆盖 NavRail 的 fixed 层（z-index 20 > 10），
+    // 创建页非面板模式没有返回控件，推入即困住用户。小屏应保持 popToRoot 旧行为。
+    const originalWidth = window.innerWidth;
+    Object.defineProperty(window, "innerWidth", { value: 600, configurable: true, writable: true });
+    try {
+      const menu = summaryMenuFactory()();
+      menu.onPress?.(false);
+
+      expect(state.popToRoot).toHaveBeenCalledTimes(2); // routeLeft + routeRight
+      expect(state.replaceToRoot).not.toHaveBeenCalled();
+    } finally {
+      Object.defineProperty(window, "innerWidth", { value: originalWidth, configurable: true, writable: true });
+    }
   });
 
   it("does not double-fetch when boot repairs Space before publishing ready", () => {

--- a/packages/dmworksummary/src/__tests__/module.menuSwitch.test.tsx
+++ b/packages/dmworksummary/src/__tests__/module.menuSwitch.test.tsx
@@ -73,8 +73,10 @@ vi.mock("../components/ChatSummaryStarButton", () => ({
 }));
 vi.mock("../components/ChatSummaryPanel", () => ({ default: () => null }));
 
+import React from "react";
 import { WKApp } from "@octo/base";
 import { getSummaryShare } from "../api/summaryApi";
+import SummaryCreatePage from "../pages/SummaryCreatePage";
 import { SummaryModule } from "../module";
 import { refreshPendingInvitationBadge } from "../utils/summaryMenuBadge";
 
@@ -154,18 +156,26 @@ describe("SummaryModule guarded menu switching", () => {
     expect(refreshPendingInvitationBadge).toHaveBeenCalledTimes(1);
   });
 
-  it("NavRail summary onPress clears both nav stacks without pushing a duplicate list page", () => {
+  it("NavRail summary onPress opens the create page by default without pushing a duplicate list page", () => {
     // #1461 回归：菜单激活后主区 SummaryListPage 已由 MainContentLeft 按
     // currentMenus.routePath(/summary) 渲染唯一实例，onPress 若再 replaceToRoot
     // /summary 会造出双实例（e2e strict mode violation）。
+    // 新需求：进入智能总结右栏默认展示新建总结页（取代欢迎占位页）——只推创建页，
+    // 绝不推列表页。
     const reg = vi.mocked(WKApp.menus.register);
     const factory = reg.mock.calls.find(([id]) => id === "summary")?.[1] as () => { onPress?: (reentry?: boolean) => void };
     expect(factory).toBeTruthy();
     const menu = factory();
     menu.onPress?.(false);
 
-    expect(state.popToRoot).toHaveBeenCalledTimes(2); // routeLeft + routeRight
-    expect(state.replaceToRoot).not.toHaveBeenCalled();
+    // 只清左栈；右栈由 replaceToRoot 直接落创建页。
+    expect(state.popToRoot).toHaveBeenCalledTimes(1); // routeLeft only
+    expect(state.replaceToRoot).toHaveBeenCalledTimes(1);
+
+    const pushed = state.replaceToRoot.mock.calls[0][0] as React.ReactElement;
+    expect(pushed.type).toBe(SummaryCreatePage); // 创建页，不是 SummaryListPage
+    expect(pushed.props.source).toBe("summary_home");
+    expect(pushed.props.initialMode).toBe("normal");
   });
 
   it("does not double-fetch when boot repairs Space before publishing ready", () => {

--- a/packages/dmworksummary/src/module.tsx
+++ b/packages/dmworksummary/src/module.tsx
@@ -172,11 +172,12 @@ export class SummaryModule implements IModule {
                 // #1359 未处理邀请红点：badge 字段与 NavRail 渲染已存在，
                 // 此处每次 render 读最新计数即可（宿主 forceUpdate 驱动重绘）。
                 menu.badge = getPendingInvitationBadge();
-                // 点击「总结」进入列表页：主区 SummaryListPage 已由 MainContentLeft 按
+                // 点击「总结」：主区 SummaryListPage 已由 MainContentLeft 按
                 // currentMenus.routePath(/summary) 渲染（Menu 激活即挂载唯一实例）。
-                // 这里不再 replaceToRoot 页面——否则会在导航栈额外推入一份 /summary
-                // 造成列表页双实例（strict mode violation），只清空左/右导航栈，
-                // 与无 onPress 菜单的宿主默认分支（popToRoot both）行为一致。
+                // 右栏默认展示新建总结页（取代原先的欢迎占位页）——产品要求进入
+                // 智能总结即落在创建页。注意只 replaceToRoot 创建页：列表页由
+                // MainContentLeft 持有，往 routeRight 再推一份 /summary 会造成列表页
+                // 双实例（#1461 e2e S1/S9/S11 strict mode violation 的教训）。
                 menu.onPress = (reentry?: boolean) => {
                     // 埋点 290:从 NavRail「总结」顶层入口进入模块（隐私 props 恒空）。
                     // 重复点击已激活的总结菜单不计（reentry），宿主按 prevMenuId===id 传入（见二审 P2-4）。
@@ -184,7 +185,9 @@ export class SummaryModule implements IModule {
                         Dap.shared.track("smart_summary_module_entered", {});
                     }
                     WKApp.routeLeft.popToRoot();
-                    WKApp.routeRight.popToRoot();
+                    WKApp.routeRight.replaceToRoot(
+                        <SummaryCreatePage source="summary_home" key="normal" initialMode="normal" />
+                    );
                 };
                 return menu;
             },

--- a/packages/dmworksummary/src/module.tsx
+++ b/packages/dmworksummary/src/module.tsx
@@ -13,16 +13,19 @@ import { getOriginalSummaryTaskId, shouldOpenOriginalSummary } from "./features/
 import { notifyChatSummaryCreated } from "./utils/chatSummaryActions";
 import { getPendingInvitationBadge, refreshPendingInvitationBadge } from "./utils/summaryMenuBadge";
 import { isSupportedChannelType } from "./utils/channelType";
+import { SMALL_SCREEN_WIDTH } from "@octo/base/src/Components/WKLayout/layoutWidth";
 import ChatSummaryStarButton from "./components/ChatSummaryStarButton";
 import ChatSummaryPanel from "./components/ChatSummaryPanel";
 import enUS from "./i18n/en-US.json";
 import zhCN from "./i18n/zh-CN.json";
 import "./index.css";
-import "./index.css";
 
 let _spaceChangedHandler: (() => void) | null = null;
 let _spaceReadyHandler: (() => void) | null = null;
 const openingSummaryShares = new Set<string>();
+// NavRail 每次进入的序号：并入默认创建页元素的 key。key 若固定，重复点菜单时
+// React 会复用旧实例（WKViewQueue 按数组下标渲染），「重置回默认创建页」不生效。
+let summaryHomeEntrySeq = 0;
 
 function afterSummaryMenuSwitch(action: () => void) {
     if (WKApp.switchToMenuById && WKApp.currentMenuId !== "summary") {
@@ -185,8 +188,19 @@ export class SummaryModule implements IModule {
                         Dap.shared.track("smart_summary_module_entered", {});
                     }
                     WKApp.routeLeft.popToRoot();
+                    if (window.innerWidth <= SMALL_SCREEN_WIDTH) {
+                        // 小屏（≤640px）：WKLayout 把右栏渲染为盖住 NavRail 的 fixed 覆盖层
+                        // （z-index 20 > 10），而创建页非面板模式没有返回控件——推入创建页
+                        // 会困住用户。小屏保持原行为：落在列表，创建走「+」下拉。
+                        WKApp.routeRight.popToRoot();
+                        return;
+                    }
                     WKApp.routeRight.replaceToRoot(
-                        <SummaryCreatePage source="summary_home" key="normal" initialMode="normal" />
+                        <SummaryCreatePage
+                            source="summary_home"
+                            key={`home-normal-${++summaryHomeEntrySeq}`}
+                            initialMode="normal"
+                        />
                     );
                 };
                 return menu;

--- a/packages/dmworksummary/src/pages/SummaryCreatePage.tsx
+++ b/packages/dmworksummary/src/pages/SummaryCreatePage.tsx
@@ -710,6 +710,10 @@ export default class SummaryCreatePage extends Component<SummaryCreatePageProps,
             if (this.props.embedded) {
                 this.props.onSubmit?.(result.task_id);
             } else {
+                // 非面板路径（NavRail 默认创建页 / /summary/create / 列表「+」）创建成功后
+                // 通知左侧列表刷新：新总结应立即出现在列表，而不是等切模块重进才可见。
+                // 面板路径由宿主 ChatSummaryPanel 自行派发，这里不重复。
+                WKApp.mittBus.emit("summary-list-refresh-requested" as any);
                 WKApp.routeRight.popToRoot();
                 WKApp.routeRight.push(<SummaryDetailPage taskId={result.task_id} emitSelection />);
             }
@@ -1030,6 +1034,8 @@ export default class SummaryCreatePage extends Component<SummaryCreatePageProps,
             if (this.props.embedded) {
                 this.props.onSubmit?.(result.task_id);
             } else {
+                // 非面板路径：保存为总结成功后通知左侧列表刷新（同 handleSubmit）。
+                WKApp.mittBus.emit("summary-list-refresh-requested" as any);
                 WKApp.routeRight.popToRoot();
                 WKApp.routeRight.push(<SummaryDetailPage taskId={result.task_id} emitSelection />);
             }

--- a/packages/dmworksummary/src/pages/SummaryListPage.tsx
+++ b/packages/dmworksummary/src/pages/SummaryListPage.tsx
@@ -2,7 +2,6 @@ import React, { Component } from "react";
 import {
     Button,
     Dropdown,
-    SplitButtonGroup,
     Spin,
     Toast,
     Banner,
@@ -597,44 +596,37 @@ export default class SummaryListPage extends Component<SummaryListPageProps, Sum
                     </h2>
                     <div className="summary-list-header-actions">
                         <Tooltip content={translate("summary.list.createTooltip")} position="bottom">
-                            <SplitButtonGroup className="summary-list-create-split">
+                            {/* 单一「+」入口：点击只弹下拉（快速总结 / Agent 总结），
+                                不再是「主按钮直接建 + 独立箭头下拉」的组合按钮。 */}
+                            <Dropdown
+                                trigger="click"
+                                position="bottomRight"
+                                render={(
+                                    <Dropdown.Menu>
+                                        <Dropdown.Item
+                                            data-testid={summaryTestIds.listNormalTab}
+                                            onClick={() => this.handleCreate("normal")}
+                                        >
+                                            {translate("summary.create.start")}
+                                        </Dropdown.Item>
+                                        <Dropdown.Item
+                                            data-testid={summaryTestIds.listAgentTab}
+                                            onClick={() => this.handleCreate("agent")}
+                                        >
+                                            {translate("summary.create.agentStart")}
+                                        </Dropdown.Item>
+                                    </Dropdown.Menu>
+                                )}
+                            >
                                 <Button
-                                    data-testid={summaryTestIds.listCreate}
+                                    data-testid={summaryTestIds.listModeSwitch}
                                     className="summary-list-create-icon-btn"
                                     icon={<IconPlus />}
                                     theme="borderless"
-                                    onClick={() => this.handleCreate("normal")}
+                                    aria-label={translate("summary.list.createTooltip")}
+                                    title={translate("summary.list.createTooltip")}
                                 />
-                                <Dropdown
-                                    trigger="click"
-                                    position="bottomRight"
-                                    render={(
-                                        <Dropdown.Menu>
-                                            <Dropdown.Item
-                                                data-testid={summaryTestIds.listNormalTab}
-                                                onClick={() => this.handleCreate("normal")}
-                                            >
-                                                {translate("summary.create.start")}
-                                            </Dropdown.Item>
-                                            <Dropdown.Item
-                                                data-testid={summaryTestIds.listAgentTab}
-                                                onClick={() => this.handleCreate("agent")}
-                                            >
-                                                {translate("summary.create.agentStart")}
-                                            </Dropdown.Item>
-                                        </Dropdown.Menu>
-                                    )}
-                                >
-                                    <Button
-                                        data-testid={summaryTestIds.listModeSwitch}
-                                        className="summary-list-create-icon-btn"
-                                        theme="borderless"
-                                        icon={<ChevronDown size={16} />}
-                                        aria-label={translate("summary.create.switchMode")}
-                                        title={translate("summary.create.switchMode")}
-                                    />
-                                </Dropdown>
-                            </SplitButtonGroup>
+                            </Dropdown>
                         </Tooltip>
                         {isPanel && onClose && (
                             <Button

--- a/packages/dmworksummary/src/pages/SummaryListPage.tsx
+++ b/packages/dmworksummary/src/pages/SummaryListPage.tsx
@@ -5,7 +5,6 @@ import {
     Spin,
     Toast,
     Banner,
-    Tooltip,
 } from "@douyinfe/semi-ui";
 import { IconSearch, IconPlus } from "@douyinfe/semi-icons";
 import { X, ChevronDown } from "lucide-react";
@@ -86,6 +85,9 @@ export default class SummaryListPage extends Component<SummaryListPageProps, Sum
     // user-driven state. loadMore also captures pre-await and drops its
     // batch on mismatch — closes loadMore-starts-first, loadData-bumps-after.
     private loadDataSeq = 0;
+    // 「+」每次新建的序号：并入 push 元素的 key，保证连续两次选同一模式也强制重挂载
+    // （见 handleCreate 注释）。key 只按 mode 时，同模式重选会命中 React 复用分支。
+    private createEntrySeq = 0;
     // Synchronous "is a loadData in flight" flag. React 18 batching means
     // this.state.loading is not visible immediately after setState from a
     // promise continuation, so loadMore reading state.loading would miss a
@@ -479,7 +481,7 @@ export default class SummaryListPage extends Component<SummaryListPageProps, Sum
                 } else {
                     WKApp.routeRight.popToRoot();
                     WKApp.routeRight.push(
-                        <SummaryCreatePage onCreated={() => this.loadData()} source="summary_list" />
+                        <SummaryCreatePage source="summary_list" />
                     );
                 }
             });
@@ -570,11 +572,11 @@ export default class SummaryListPage extends Component<SummaryListPageProps, Sum
         WKApp.routeRight.popToRoot();
         WKApp.routeRight.push(
             <SummaryCreatePage
-                // key 绑定模式：右侧已有创建页时再次选择模式需强制重挂载
-                // （WKViewQueue 按下标做 key，同类型组件会被复用，state.mode 不随
-                // 新 initialMode 重读 → 界面不切换）。从列表页选模式 = 发起一次新建。
-                key={mode}
-                onCreated={() => this.loadData()}
+                // key 绑定「模式 + 每次新建序号」：从列表页选模式 = 发起一次全新创建。
+                // 只按模式做 key 时，连续两次选同模式（如 NavRail 默认创建页上再点
+                // 「+ → 快速总结」）会命中 React 复用分支——WKViewQueue 按数组下标渲染，
+                // 同类型同 key 组件不重挂载，state 不随新 initialMode 重读，界面无反馈。
+                key={`${mode}-${++this.createEntrySeq}`}
                 source="summary_list"
                 initialMode={mode}
             />
@@ -595,39 +597,40 @@ export default class SummaryListPage extends Component<SummaryListPageProps, Sum
                         {isPanel ? translate("summary.chatSummary.panelTitle") : translate("summary.list.title")}
                     </h2>
                     <div className="summary-list-header-actions">
-                        <Tooltip content={translate("summary.list.createTooltip")} position="bottom">
-                            {/* 单一「+」入口：点击只弹下拉（快速总结 / Agent 总结），
-                                不再是「主按钮直接建 + 独立箭头下拉」的组合按钮。 */}
-                            <Dropdown
-                                trigger="click"
-                                position="bottomRight"
-                                render={(
-                                    <Dropdown.Menu>
-                                        <Dropdown.Item
-                                            data-testid={summaryTestIds.listNormalTab}
-                                            onClick={() => this.handleCreate("normal")}
-                                        >
-                                            {translate("summary.create.start")}
-                                        </Dropdown.Item>
-                                        <Dropdown.Item
-                                            data-testid={summaryTestIds.listAgentTab}
-                                            onClick={() => this.handleCreate("agent")}
-                                        >
-                                            {translate("summary.create.agentStart")}
-                                        </Dropdown.Item>
-                                    </Dropdown.Menu>
-                                )}
-                            >
-                                <Button
-                                    data-testid={summaryTestIds.listModeSwitch}
-                                    className="summary-list-create-icon-btn"
-                                    icon={<IconPlus />}
-                                    theme="borderless"
-                                    aria-label={translate("summary.list.createTooltip")}
-                                    title={translate("summary.list.createTooltip")}
-                                />
-                            </Dropdown>
-                        </Tooltip>
+                        {/* 单一「+」入口：点击只弹下拉（快速总结 / Agent 总结），
+                            不再是「主按钮直接建 + 独立箭头下拉」的组合按钮。
+                            不用 Semi Tooltip 包 Dropdown——Semi Tooltip 把 hover 处理器
+                            注入到直接子节点，Dropdown 不会把事件转发给触发按钮，
+                            hover 提示会失效；用原生 title + aria-label 兜底。 */}
+                        <Dropdown
+                            trigger="click"
+                            position="bottomRight"
+                            render={(
+                                <Dropdown.Menu>
+                                    <Dropdown.Item
+                                        data-testid={summaryTestIds.listNormalTab}
+                                        onClick={() => this.handleCreate("normal")}
+                                    >
+                                        {translate("summary.create.start")}
+                                    </Dropdown.Item>
+                                    <Dropdown.Item
+                                        data-testid={summaryTestIds.listAgentTab}
+                                        onClick={() => this.handleCreate("agent")}
+                                    >
+                                        {translate("summary.create.agentStart")}
+                                    </Dropdown.Item>
+                                </Dropdown.Menu>
+                            )}
+                        >
+                            <Button
+                                data-testid={summaryTestIds.listModeSwitch}
+                                className="summary-list-create-icon-btn"
+                                icon={<IconPlus />}
+                                theme="borderless"
+                                aria-label={translate("summary.list.createTooltip")}
+                                title={translate("summary.list.createTooltip")}
+                            />
+                        </Dropdown>
                         {isPanel && onClose && (
                             <Button
                                 icon={<X size={18} />}

--- a/packages/dmworksummary/src/pages/__tests__/SummaryListPage.modeEntry.test.tsx
+++ b/packages/dmworksummary/src/pages/__tests__/SummaryListPage.modeEntry.test.tsx
@@ -7,12 +7,25 @@ vi.mock('@octo/base', async () => {
 });
 vi.mock('@douyinfe/semi-ui', () => ({
     Button: () => null,
-    Dropdown: () => null,
-    SplitButtonGroup: ({ children }: any) => <div>{children}</div>,
+    Dropdown: Object.assign(
+        ({ children, render }: any) => (
+            <div data-testid="dropdown">
+                {children}
+                <div data-testid="dropdown-menu">{typeof render === 'function' ? render() : render}</div>
+            </div>
+        ),
+        {
+            Menu: ({ children }: any) => <div data-testid="dropdown-menu-list">{children}</div>,
+            Item: ({ children, onClick, active }: any) => (
+                <button data-testid="dropdown-item" data-active={active} onClick={onClick}>
+                    {children}
+                </button>
+            ),
+        },
+    ),
     Spin: () => null,
     Toast: { success: vi.fn(), error: vi.fn() },
     Banner: () => null,
-    Tooltip: ({ children }: any) => <>{children}</>,
 }));
 vi.mock('@douyinfe/semi-icons', () => ({
     IconSearch: () => null,
@@ -30,18 +43,38 @@ vi.mock('../../api/summaryApi');
 import { WKApp } from '@octo/base';
 import SummaryListPage from '../SummaryListPage';
 
+/** 递归遍历 React 元素树，收集满足条件的节点（不依赖 @testing-library）。 */
+function findInTree(node: unknown, predicate: (n: any) => boolean, out: any[] = []): any[] {
+    if (!node || typeof node !== 'object') return out;
+    if (predicate(node)) out.push(node);
+    const children = (node as any).props?.children;
+    if (children != null) {
+        const kids = Array.isArray(children) ? children : [children];
+        for (const c of kids) findInTree(c, predicate, out);
+    }
+    return out;
+}
+
+function findOne(node: unknown, predicate: (n: any) => boolean): any {
+    const hits = findInTree(node, predicate);
+    expect(hits.length).toBe(1);
+    return hits[0];
+}
+
 /**
  * 回归：#1461 后总结方式选择上移到列表页「+」下拉。
- * WKViewQueue 按数组下标渲染 pushed 视图（外层 div key={i}），右侧已有
- * SummaryCreatePage 时再次 push 同类型组件会命中 React 复用分支——组件不重挂载、
- * state.mode 不随新 initialMode 重读 → 点「Agent 总结」界面毫无反应。
- * 修复：push 的元素 key 绑定模式，模式变化即视为一次全新创建（强制重挂载）。
+ * WKViewQueue 按数组下标渲染 pushed 视图（外层 div key={i}），push 的元素若与
+ * 旧栈同类型同 key 会命中 React 复用分支——组件不重挂载、state 不随新 initialMode
+ * 重读 → 点「Agent 总结」界面毫无反应。
+ * #1484 评审 P2-1：key 只按 mode 时，连续两次选同模式（如 NavRail 默认创建页上
+ * 再点「+ → 快速总结」）同样命中复用分支。修复：key 绑定「模式 + 每次新建序号」，
+ * 每次选择都强制全新挂载。
  */
 describe('SummaryListPage mode entry navigation', () => {
     beforeEach(() => vi.clearAllMocks());
 
-    function makePage() {
-        const page = new SummaryListPage({} as any);
+    function makePage(props: Record<string, unknown> = {}) {
+        const page = new SummaryListPage(props as any);
         (page as any).isMounted_ = true;
         return page;
     }
@@ -56,7 +89,7 @@ describe('SummaryListPage mode entry navigation', () => {
         expect(popToRootSpy).toHaveBeenCalledTimes(1);
         const normalEl = pushSpy.mock.calls[0][0] as React.ReactElement;
         expect(React.isValidElement(normalEl)).toBe(true);
-        expect(normalEl.key).toBe('normal');
+        expect(String(normalEl.key).startsWith('normal-')).toBe(true);
         expect(normalEl.props.initialMode).toBe('normal');
 
         // 再次选择 Agent：必须 push 一个 key 不同的新元素（key 相同会被 React 复用，
@@ -64,9 +97,23 @@ describe('SummaryListPage mode entry navigation', () => {
         (page as any).handleCreate('agent');
         expect(pushSpy).toHaveBeenCalledTimes(2);
         const agentEl = pushSpy.mock.calls[1][0] as React.ReactElement;
-        expect(agentEl.key).toBe('agent');
+        expect(String(agentEl.key).startsWith('agent-')).toBe(true);
         expect(agentEl.props.initialMode).toBe('agent');
         expect(agentEl.key).not.toBe(normalEl.key);
+    });
+
+    it('P2-1: two consecutive picks of the SAME mode get distinct keys (no silent reuse)', () => {
+        const page = makePage();
+        const pushSpy = vi.spyOn(WKApp.routeRight, 'push');
+
+        (page as any).handleCreate('normal');
+        (page as any).handleCreate('normal');
+        expect(pushSpy).toHaveBeenCalledTimes(2);
+        const first = pushSpy.mock.calls[0][0] as React.ReactElement;
+        const second = pushSpy.mock.calls[1][0] as React.ReactElement;
+        expect(first.key).not.toBe(second.key);
+        expect(first.props.initialMode).toBe('normal');
+        expect(second.props.initialMode).toBe('normal');
     });
 
     it('default (no-arg) entry still lands on the normal-mode create page', () => {
@@ -75,17 +122,54 @@ describe('SummaryListPage mode entry navigation', () => {
 
         (page as any).handleCreate();
         const el = pushSpy.mock.calls[0][0] as React.ReactElement;
-        expect(el.key).toBe('normal');
+        expect(String(el.key).startsWith('normal-')).toBe(true);
         expect(el.props.initialMode).toBe('normal');
     });
 
     it('panel mode forwards the selected mode to the host via onCreateNew instead of pushing a route', () => {
         const onCreateNew = vi.fn();
-        const page = new SummaryListPage({ onCreateNew } as any);
+        const page = makePage({ onCreateNew });
         const pushSpy = vi.spyOn(WKApp.routeRight, 'push');
 
         (page as any).handleCreate('agent');
         expect(onCreateNew).toHaveBeenCalledWith('agent');
         expect(pushSpy).not.toHaveBeenCalled();
+    });
+
+    it('the single "+" trigger has no instant-create handler; modes are only entered via dropdown items', () => {
+        const page = makePage();
+        (page as any).context = { locale: 'zh-CN', t: (k: string) => k };
+        const pushSpy = vi.spyOn(WKApp.routeRight, 'push');
+
+        const tree = (page as any).render();
+
+        // 触发按钮：只有 data-testid/icon/aria-label，没有 onClick（点击只弹下拉）。
+        const trigger = findOne(
+            tree,
+            (n) => n?.props?.['data-testid'] === 'summary-list-mode-switch',
+        );
+        expect(trigger.props.onClick).toBeUndefined();
+        expect(pushSpy).not.toHaveBeenCalled();
+
+        // 下拉菜单项才是模式入口：普通项与 Agent 项分别调 handleCreate 对应模式。
+        // 注意：semi Dropdown 的 render prop 传的是元素（render={( <Menu/> )}），不是函数。
+        const dropdowns = findInTree(
+            tree,
+            (n) => n?.props?.render && React.isValidElement(n.props.render),
+        );
+        const items = dropdowns.flatMap((dropdown) => findInTree(dropdown.props.render, (n) => n?.props?.onClick));
+        const byTestId = (id: string) =>
+            items.find((n) => n.props?.['data-testid'] === id) ?? null;
+        expect(byTestId('summary-list-normal-tab')).not.toBeNull();
+        expect(byTestId('summary-list-agent-tab')).not.toBeNull();
+
+        byTestId('summary-list-agent-tab').props.onClick();
+        expect(pushSpy).toHaveBeenCalledTimes(1);
+        const el = pushSpy.mock.calls[0][0] as React.ReactElement;
+        expect(el.props.initialMode).toBe('agent');
+
+        byTestId('summary-list-normal-tab').props.onClick();
+        expect(pushSpy).toHaveBeenCalledTimes(2);
+        expect((pushSpy.mock.calls[1][0] as React.ReactElement).props.initialMode).toBe('normal');
     });
 });

--- a/packages/dmworksummary/src/utils/testIds.ts
+++ b/packages/dmworksummary/src/utils/testIds.ts
@@ -4,9 +4,8 @@ export const summaryTestIds = {
     listContent: "summary-list-content",
     listSearch: "summary-list-search",
     listStatusFilter: "summary-list-status-filter",
-    listCreate: "summary-list-create",
     createEntry: "summary-create-entry",
-    // Mode-select dropdown on the list-page "+" entry (trigger + menu items)
+    // Mode-select dropdown on the single list-page "+" entry (trigger + menu items)
     listModeSwitch: "summary-list-mode-switch",
     listNormalTab: "summary-list-normal-tab",
     listAgentTab: "summary-list-agent-tab",


### PR DESCRIPTION
## Summary

Two product follow-ups on the summary entry UX (per PM feedback):

1. **Entering the module lands on the create page by default.** Clicking the NavRail「智能总结」item used to clear the right pane to the host welcome placeholder ("选择对话，激活连接"). Now `menu.onPress` does `routeRight.replaceToRoot(<SummaryCreatePage source="summary_home" initialMode="normal" />)` so the create workbench shows immediately. The list page itself is still owned by `MainContentLeft` (rendered from `currentMenus.routePath`); we deliberately push only the create page and never `/summary`, preserving the #1461 fix against duplicate list-page instances (e2e S1/S9/S11 strict-mode violation).

2. **Single "+" dropdown entry.** The list header previously had a `SplitButtonGroup`: a "+" button that instantly created a normal summary plus a separate chevron that opened the mode dropdown. They are merged into one "+" button that only opens the dropdown (快速总结 / Agent 总结); a mode is only entered after an explicit choice.

> **Note for external automation owners:** the testid `summary-list-create` has been removed (its direct-create behavior no longer exists). The trigger testid is `summary-list-mode-switch`; the dropdown items are `summary-list-normal-tab` / `summary-list-agent-tab`. The empty-state button `summary-create-entry` is unchanged.

## Changes

- `packages/dmworksummary/src/module.tsx` — NavRail onPress: `replaceToRoot` the create page instead of clearing to the welcome placeholder; each entry uses a fresh key (`home-normal-<seq>`) so re-clicking the menu resets to a clean create page; on ≤640px viewports keep the previous list-landing behavior (the right pane becomes a full-viewport overlay that covers the NavRail, and the create page has no back control — pushing it there would trap the user)
- `packages/dmworksummary/src/pages/SummaryListPage.tsx` — replace `SplitButtonGroup` with a single `Dropdown`-wrapped "+" (`listModeSwitch` trigger; `listNormalTab` / `listAgentTab` items); drop the broken Semi `Tooltip` wrapper (Semi injects hover handlers into the Dropdown, which does not forward them to the trigger — verified dead in browser) and keep the native `title` + `aria-label`; push the create page with a per-entry key (`<mode>-<seq>`) so consecutive picks of the same mode also remount instead of being silently reused
- `packages/dmworksummary/src/pages/SummaryCreatePage.tsx` — in the non-embedded success paths (normal submit + agent save), emit `summary-list-refresh-requested` so the left list shows the new task immediately (previously the NavRail default entry and the `/summary/create` route created summaries that never appeared in the list until a module switch); panel mode keeps the host-side emit to avoid double refresh
- `packages/dmworksummary/src/utils/testIds.ts` + `apps/web/e2e-kit/tests/summary/_testids.ts` — drop the now-unused `listCreate` testid (mirror kept in sync; parity test green)
- `apps/web/e2e-kit/msw-handlers/s1{4,5,6,7,8,9}-*`, `s20-*`, `s21-*`, `s24-*`, `s25-*` (10 files) — register the `summary-templates` handler; the create page now mounts on every module entry so every spec that clicks 智能总结 issues that request
- `packages/dmworksummary/src/__tests__/module.menuSwitch.test.tsx` — NavRail onPress regression: asserts one `popToRoot` + one `replaceToRoot` whose element is the create page (not the list page), key present and unique per entry; new small-screen test asserts ≤640px keeps the list-landing behavior
- `packages/dmworksummary/src/pages/__tests__/SummaryListPage.modeEntry.test.tsx` — key assertions updated to `<mode>-<seq>`; new P2-1 regression (two same-mode picks get distinct keys); new render-tree test asserting the single "+" trigger has no instant-create handler and modes are only entered via the dropdown items
- `apps/web/e2e-kit/case-specs/summary/agent/S9-summary-agent-chat-save.md` — implementation-pointers section updated (entry behavior + corrected line ref)

## Verification

Manual (dev server, logged-in session):

| Step | Result |
|---|---|
| click NavRail 智能总结 (desktop) | create page visible, welcome placeholder covered |
| click "+" | only the dropdown opens (no direct navigation) |
| dropdown → Agent 总结 | agent chat UI + welcome message |
| dropdown → 快速总结 (back) | normal create page restored |
| type a topic, then "+" → 快速总结 | page remounts fresh (topic cleared — no silent reuse) |
| switch to 会话 and back to 智能总结 | create page shows again (default on every entry) |
| re-click 智能总结 while inside the module | right pane resets to a fresh normal create page |
| 560px viewport, click 智能总结 | stays on the list; right pane parked off-screen (no lock-out) |
| hover "+" | native title tooltip only (no broken Semi tooltip) |

Tests:

- `module.menuSwitch.test.tsx`: 7/7 (incl. small-screen gate + per-entry key)
- `SummaryListPage.modeEntry.test.tsx`: 5/5 (incl. same-mode remount + trigger render-tree test)
- `testIdsParity.test.ts`: 13/13 (prod/e2e testid mirror)
- other `SummaryListPage.*` suites: 22/22
- typecheck: zero new error categories vs the previous head (only pre-existing environment noise)
