### PR TITLE
fix(mail): render HTML bodies and sync mode copy

### DIFF
--- a/packages/mail/package.json
+++ b/packages/mail/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@octo/base": "workspace:*",
+    "dompurify": "^3.4.2",
     "lucide-react": "^0.577.0"
   },
   "devDependencies": {

--- a/packages/mail/src/bridge/types.ts
+++ b/packages/mail/src/bridge/types.ts
@@ -201,6 +201,7 @@ export interface MessageDetail extends MessageSummary {
   bcc?: string[];
   bodyText?: string;
   bodyHtml?: string;
+  bodyTruncated?: boolean;
   originalFrom?: string;
   sentBy?: string;
   attachments?: ReceivedAttachment[];

--- a/packages/mail/src/features/MailAuthorizationPage.test.tsx
+++ b/packages/mail/src/features/MailAuthorizationPage.test.tsx
@@ -294,7 +294,15 @@ describe("MailAuthorizationPage return target lifecycle", () => {
     expect((manual as HTMLInputElement).checked).toBe(true);
     expect((automatic as HTMLInputElement).checked).toBe(false);
     expect(
-      screen.getByText("mail.authorization.requestedAutomatic")
+      screen.getByText("mail.authorization.selectedManual")
+    ).toBeTruthy();
+
+    fireEvent.click(automatic);
+
+    expect((manual as HTMLInputElement).checked).toBe(false);
+    expect((automatic as HTMLInputElement).checked).toBe(true);
+    expect(
+      screen.getByText("mail.authorization.selectedAutomatic")
     ).toBeTruthy();
   });
 

--- a/packages/mail/src/features/MailAuthorizationPage.tsx
+++ b/packages/mail/src/features/MailAuthorizationPage.tsx
@@ -490,9 +490,9 @@ export default function MailAuthorizationPage({
             <legend>{t("mail.authorization.permissionLegend")}</legend>
             <p className="mail-auth-card__status">
               {t(
-                request?.outboundMode === "automatic_send"
-                  ? "mail.authorization.requestedAutomatic"
-                  : "mail.authorization.requestedManual"
+                outboundMode === "automatic_send"
+                  ? "mail.authorization.selectedAutomatic"
+                  : "mail.authorization.selectedManual"
               )}
             </p>
             <label

--- a/packages/mail/src/features/MessageDetailFeature.test.tsx
+++ b/packages/mail/src/features/MessageDetailFeature.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 
 import React from "react";
+import DOMPurify from "dompurify";
 import {
   cleanup,
   fireEvent,
@@ -14,6 +15,7 @@ import type { MessageDetail } from "../bridge/types";
 const state = vi.hoisted(() => ({
   getMessage: vi.fn(),
   getThread: vi.fn(),
+  getRawMessage: vi.fn(),
   sendDraft: vi.fn(),
   emit: vi.fn(),
   t: vi.fn((key: string) => key),
@@ -36,7 +38,7 @@ vi.mock("../Service/MailService", () => ({
     updateKeywords: vi.fn(),
     deleteMessage: vi.fn(),
     sendDraft: state.sendDraft,
-    getRawMessage: vi.fn(),
+    getRawMessage: state.getRawMessage,
     downloadAttachment: vi.fn(),
   },
 }));
@@ -72,6 +74,7 @@ describe("MessageDetailFeature action errors", () => {
     state.getMessage.mockReset();
     state.sendDraft.mockReset();
     state.getThread.mockReset();
+    state.getRawMessage.mockReset();
     state.getMessage.mockResolvedValue(draft);
   });
 
@@ -158,6 +161,32 @@ describe("MessageDetailFeature action errors", () => {
     ).toHaveProperty("disabled", false);
   });
 
+  it("shows a raw-message download for an oversized HTML body", async () => {
+    state.getMessage.mockResolvedValue({
+      ...draft,
+      bodyTruncated: true,
+    });
+    state.getRawMessage.mockResolvedValue(new Blob(["raw message"]));
+
+    render(
+      <MessageDetailFeature
+        mailboxContextId="42"
+        mailboxAddress="bot@mail.imocto.cn"
+        messageId="E1"
+        mailboxRole="drafts"
+      />
+    );
+
+    expect(await screen.findByText("mail.reader.bodyTruncated")).toBeTruthy();
+    const downloadButtons = screen.getAllByRole("button", {
+      name: "mail.actions.downloadRaw",
+    });
+    fireEvent.click(downloadButtons.at(-1)!);
+    await waitFor(() =>
+      expect(state.getRawMessage).toHaveBeenCalledWith("42", "E1")
+    );
+  });
+
   it("keeps the current message when one thread member fails to load", async () => {
     state.getMessage
       .mockResolvedValueOnce({ ...draft, threadId: "T1" })
@@ -182,6 +211,333 @@ describe("MessageDetailFeature action errors", () => {
     expect(await screen.findByText("Owner review")).toBeTruthy();
     expect(screen.queryByRole("alert")).toBeNull();
     expect(state.getMessage).toHaveBeenCalledTimes(2);
+  });
+
+  it("renders an available HTML body in an isolated frame", async () => {
+    state.getMessage.mockResolvedValue({
+      ...draft,
+      bodyText: "Plain fallback",
+      bodyHtml:
+        '<html lang="ar" dir="rtl"><head><style>body.invoice .formatted-body{color:purple}</style></head><body class="invoice" dir="rtl" style="background:#123456"><section class="formatted-body"><strong>HTML body</strong><a id="safe-link" href="https://example.com/invoice">Invoice</a><a id="unsafe-link" href="javascript:alert(1)">Unsafe</a><svg><a id="svg-link" xlink:href="https://example.com/svg-link"><text>SVG link</text></a><a id="unsafe-svg-link" xlink:href="javascript:alert(1)"><text>Unsafe SVG link</text></a></svg><map name="links"><area href="https://example.com/phish"></map></section><script>window.top.location="https://example.com"</script></body></html>',
+    });
+
+    render(
+      <MessageDetailFeature
+        mailboxContextId="42"
+        mailboxAddress="bot@mail.imocto.cn"
+        messageId="E1"
+        mailboxRole="drafts"
+      />
+    );
+
+    const frame = await screen.findByTitle("mail.reader.htmlBody");
+    expect(frame.getAttribute("sandbox")).toBe(
+      "allow-same-origin allow-popups allow-popups-to-escape-sandbox"
+    );
+    expect(frame.getAttribute("referrerpolicy")).toBe("no-referrer");
+    expect(frame.getAttribute("srcdoc")).toContain("HTML body");
+    expect(frame.getAttribute("srcdoc")).not.toContain("<script>");
+    const source = new DOMParser().parseFromString(
+      frame.getAttribute("srcdoc") || "",
+      "text/html"
+    );
+    expect(source.querySelector("base")?.getAttribute("href")).toBe(
+      "about:blank"
+    );
+    expect(source.querySelector("base")?.getAttribute("target")).toBe("_blank");
+    expect(
+      source
+        .querySelector('meta[http-equiv="Content-Security-Policy"]')
+        ?.getAttribute("content")
+    ).toBe(
+      "default-src 'none'; img-src data: blob:; style-src 'unsafe-inline'; font-src data:"
+    );
+    const defaultStyle = source.querySelector("style")?.textContent || "";
+    expect(defaultStyle).toContain("color-scheme:only light");
+    expect(defaultStyle).toContain("background:Canvas");
+    expect(
+      Array.from(source.querySelectorAll("style"))
+        .map((style) => style.textContent)
+        .join("\n")
+    ).toContain("body.invoice .formatted-body{color:purple}");
+    expect(source.documentElement.getAttribute("lang")).toBe("ar");
+    expect(source.documentElement.getAttribute("dir")).toBe("rtl");
+    expect(source.body.getAttribute("class")).toBe("invoice");
+    expect(source.body.getAttribute("dir")).toBe("rtl");
+    expect(source.body.getAttribute("style")).toContain("background:#123456");
+    expect(source.querySelector("#safe-link")?.getAttribute("target")).toBe(
+      "_blank"
+    );
+    expect(source.querySelector("#safe-link")?.getAttribute("rel")).toBe(
+      "noopener noreferrer"
+    );
+    expect(source.querySelector("#unsafe-link")?.hasAttribute("href")).toBe(
+      false
+    );
+    expect(source.querySelector("#svg-link")?.getAttribute("href")).toBe(
+      "https://example.com/svg-link"
+    );
+    expect(source.querySelector("#svg-link")?.hasAttribute("xlink:href")).toBe(
+      false
+    );
+    expect(source.querySelector("#svg-link")?.getAttribute("target")).toBe(
+      "_blank"
+    );
+    expect(source.querySelector("#svg-link")?.getAttribute("rel")).toBe(
+      "noopener noreferrer"
+    );
+    expect(source.querySelector("#unsafe-svg-link")?.hasAttribute("href")).toBe(
+      false
+    );
+    expect(
+      source.querySelector("#unsafe-svg-link")?.hasAttribute("xlink:href")
+    ).toBe(false);
+    expect(source.querySelector("map, area")).toBeNull();
+    expect(screen.queryByText("Plain fallback")).toBeNull();
+  });
+
+  it.each([
+    ["wrapper-only HTML", "<html><body></body></html>"],
+    ["empty element HTML", "<div></div>"],
+  ])("falls back to text for %s", async (_name, bodyHtml) => {
+    state.getMessage.mockResolvedValue({
+      ...draft,
+      bodyText: "Plain fallback",
+      bodyHtml,
+    });
+
+    render(
+      <MessageDetailFeature
+        mailboxContextId="42"
+        mailboxAddress="bot@mail.imocto.cn"
+        messageId="E1"
+        mailboxRole="drafts"
+      />
+    );
+
+    expect(await screen.findByText("Plain fallback")).toBeTruthy();
+    expect(screen.queryByTitle("mail.reader.htmlBody")).toBeNull();
+  });
+
+  it.each([
+    ["remote image", '<img src="https://example.com/hero.png">'],
+    ["CID image", '<img src="cid:image001@example.com">'],
+    ["remote video", '<video src="https://example.com/movie.mp4"></video>'],
+  ])("falls back to text for a blocked %s", async (_name, bodyHtml) => {
+    state.getMessage.mockResolvedValue({
+      ...draft,
+      bodyText: "Plain fallback",
+      bodyHtml,
+    });
+
+    render(
+      <MessageDetailFeature
+        mailboxContextId="42"
+        mailboxAddress="bot@mail.imocto.cn"
+        messageId="E1"
+        mailboxRole="drafts"
+      />
+    );
+
+    expect(await screen.findByText("Plain fallback")).toBeTruthy();
+    expect(screen.queryByTitle("mail.reader.htmlBody")).toBeNull();
+  });
+
+  it.each([
+    [
+      "opacity-hidden preheader",
+      '<div style="opacity:0">Hidden preheader</div><img src="https://example.com/blocked.png" width="600" height="300">',
+    ],
+    [
+      "zero-size preheader",
+      '<div style="font-size:0;line-height:0">Hidden preheader</div><img src="https://example.com/blocked.png" width="600" height="300">',
+    ],
+    [
+      "clipped transparent preheader",
+      '<div style="color:transparent;height:0;overflow:hidden">Hidden preheader</div><img src="https://example.com/blocked.png" width="600" height="300">',
+    ],
+  ])("falls back to text for a %s", async (_name, bodyHtml) => {
+    state.getMessage.mockResolvedValue({
+      ...draft,
+      bodyText: "Plain fallback",
+      bodyHtml,
+    });
+
+    render(
+      <MessageDetailFeature
+        mailboxContextId="42"
+        mailboxAddress="bot@mail.imocto.cn"
+        messageId="E1"
+        mailboxRole="drafts"
+      />
+    );
+
+    const frame = (await screen.findByTitle(
+      "mail.reader.htmlBody"
+    )) as HTMLIFrameElement;
+    Object.defineProperty(frame, "clientWidth", {
+      configurable: true,
+      value: 800,
+    });
+    const frameDocument = frame.contentDocument!;
+    frameDocument.body.setAttribute("data-octo-mail-body", "");
+    frameDocument.body.innerHTML = bodyHtml;
+    fireEvent.load(frame);
+
+    expect(await screen.findByText("Plain fallback")).toBeTruthy();
+    expect(screen.queryByTitle("mail.reader.htmlBody")).toBeNull();
+  });
+
+  it("does not latch the text fallback while the frame is zero-width", async () => {
+    let resizeCallback: ResizeObserverCallback | undefined;
+    class TestResizeObserver {
+      constructor(callback: ResizeObserverCallback) {
+        resizeCallback = callback;
+      }
+      disconnect() {}
+      observe() {}
+      unobserve() {}
+    }
+    vi.stubGlobal("ResizeObserver", TestResizeObserver);
+    state.getMessage.mockResolvedValue({
+      ...draft,
+      bodyText: "Plain fallback",
+      bodyHtml:
+        '<img alt="Inline chart" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==">',
+    });
+
+    try {
+      render(
+        <MessageDetailFeature
+          mailboxContextId="42"
+          mailboxAddress="bot@mail.imocto.cn"
+          messageId="E1"
+          mailboxRole="drafts"
+        />
+      );
+
+      const frame = (await screen.findByTitle(
+        "mail.reader.htmlBody"
+      )) as HTMLIFrameElement;
+      let width = 800;
+      Object.defineProperty(frame, "clientWidth", {
+        configurable: true,
+        get: () => width,
+      });
+      const frameDocument = frame.contentDocument!;
+      frameDocument.body.setAttribute("data-octo-mail-body", "");
+      frameDocument.body.innerHTML =
+        '<img alt="Inline chart" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==">';
+      const image = frameDocument.querySelector("img")!;
+      Object.defineProperties(image, {
+        complete: { configurable: true, value: true },
+        naturalHeight: { configurable: true, value: 1 },
+        naturalWidth: { configurable: true, value: 1 },
+      });
+      image.getBoundingClientRect = () =>
+        ({
+          bottom: width > 0 ? 1 : 0,
+          height: width > 0 ? 1 : 0,
+          left: 0,
+          right: width > 0 ? 1 : 0,
+          toJSON: () => ({}),
+          top: 0,
+          width: width > 0 ? 1 : 0,
+          x: 0,
+          y: 0,
+        } as DOMRect);
+      fireEvent.load(frame);
+
+      width = 0;
+      resizeCallback?.(
+        [{ contentRect: { width: 0 } } as ResizeObserverEntry],
+        {} as ResizeObserver
+      );
+
+      expect(screen.queryByText("Plain fallback")).toBeNull();
+      expect(screen.getByTitle("mail.reader.htmlBody")).toBeTruthy();
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("caps the auto-sized HTML body height", async () => {
+    state.getMessage.mockResolvedValue({
+      ...draft,
+      bodyHtml: '<div style="min-height:300vh">HTML body</div>',
+    });
+
+    render(
+      <MessageDetailFeature
+        mailboxContextId="42"
+        mailboxAddress="bot@mail.imocto.cn"
+        messageId="E1"
+        mailboxRole="drafts"
+      />
+    );
+
+    const frame = await screen.findByTitle("mail.reader.htmlBody");
+    Object.defineProperty(frame, "clientWidth", {
+      configurable: true,
+      value: 800,
+    });
+    const frameDocument = (frame as HTMLIFrameElement).contentDocument;
+    expect(frameDocument).toBeTruthy();
+    frameDocument!.body.setAttribute("data-octo-mail-body", "");
+    frameDocument!.body.innerHTML = "<p>HTML body</p>";
+    Object.defineProperty(frameDocument!.documentElement, "scrollHeight", {
+      configurable: true,
+      value: 60_000,
+    });
+    Object.defineProperty(frameDocument!.body, "scrollHeight", {
+      configurable: true,
+      value: 60_000,
+    });
+    fireEvent.load(frame);
+
+    expect((frame as HTMLIFrameElement).style.height).toBe("20000px");
+  });
+
+  it("measures viewport-unit content from a stable baseline", async () => {
+    state.getMessage.mockResolvedValue({
+      ...draft,
+      bodyHtml: '<div style="height:110vh">HTML body</div>',
+    });
+
+    render(
+      <MessageDetailFeature
+        mailboxContextId="42"
+        mailboxAddress="bot@mail.imocto.cn"
+        messageId="E1"
+        mailboxRole="drafts"
+      />
+    );
+
+    const frame = (await screen.findByTitle(
+      "mail.reader.htmlBody"
+    )) as HTMLIFrameElement;
+    Object.defineProperty(frame, "clientWidth", {
+      configurable: true,
+      value: 800,
+    });
+    const frameDocument = frame.contentDocument!;
+    frameDocument.body.setAttribute("data-octo-mail-body", "");
+    frameDocument.body.innerHTML = "<p>HTML body</p>";
+    const viewportRelativeHeight = () =>
+      Math.round((Number.parseFloat(frame.style.height) || 150) * 1.1);
+    Object.defineProperty(frameDocument.documentElement, "scrollHeight", {
+      configurable: true,
+      get: viewportRelativeHeight,
+    });
+    Object.defineProperty(frameDocument.body, "scrollHeight", {
+      configurable: true,
+      get: viewportRelativeHeight,
+    });
+
+    fireEvent.load(frame);
+    expect(frame.style.height).toBe("88px");
+    fireEvent.load(frame);
+    expect(frame.style.height).toBe("88px");
   });
 
   it("caps full-message thread fan-out", async () => {
@@ -211,8 +567,8 @@ describe("MessageDetailFeature action errors", () => {
     await waitFor(() => expect(state.getMessage).toHaveBeenCalledTimes(20));
   });
 
-  it("does not reparse HTML bodies when unrelated view state changes", async () => {
-    const parse = vi.spyOn(DOMParser.prototype, "parseFromString");
+  it("does not resanitize the displayed HTML body when the thread summary expands", async () => {
+    const sanitize = vi.spyOn(DOMPurify, "sanitize");
     const htmlDraft = {
       ...draft,
       bodyText: undefined,
@@ -241,10 +597,10 @@ describe("MessageDetailFeature action errors", () => {
     );
 
     await screen.findByText("Owner review");
-    await waitFor(() => expect(parse).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(sanitize).toHaveBeenCalledTimes(1));
     fireEvent.click(
       screen.getByRole("button", { name: /mail.reader.threadCount/ })
     );
-    expect(parse).toHaveBeenCalledTimes(2);
+    expect(sanitize).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/mail/src/features/MessageDetailFeature.tsx
+++ b/packages/mail/src/features/MessageDetailFeature.tsx
@@ -1,4 +1,11 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import DOMPurify from "dompurify";
 import {
   AlertTriangle,
   ArrowLeft,
@@ -67,6 +74,343 @@ const KNOWN_DELIVERY_REASONS = new Set([
   "recipient_suppressed",
   "delivery_failed",
 ]);
+
+const EMAIL_HTML_CSP = [
+  "default-src 'none'",
+  "img-src data: blob:",
+  "style-src 'unsafe-inline'",
+  "font-src data:",
+].join("; ");
+
+const EMAIL_HTML_MIN_HEIGHT = 80;
+const EMAIL_HTML_MAX_HEIGHT = 20_000;
+const XLINK_NAMESPACE = "http://www.w3.org/1999/xlink";
+const EMAIL_SVG_PAINT_SELECTOR =
+  "circle, ellipse, line, path, polygon, polyline, rect, text";
+
+interface SanitizedEmailHtml {
+  bodyAttributes: Array<[string, string]>;
+  bodyHtml: string;
+  headHtml: string;
+  htmlAttributes: Array<[string, string]>;
+}
+
+function sanitizeEmailHtml(html: string) {
+  const sanitized = DOMPurify.sanitize(html, {
+    WHOLE_DOCUMENT: true,
+    FORBID_TAGS: [
+      "area",
+      "base",
+      "button",
+      "embed",
+      "form",
+      "iframe",
+      "input",
+      "link",
+      "map",
+      "meta",
+      "object",
+      "script",
+      "select",
+      "textarea",
+    ],
+  });
+  const sanitizedDocument = new DOMParser().parseFromString(
+    sanitized,
+    "text/html"
+  );
+  const visibilityBody = sanitizedDocument.body.cloneNode(true) as HTMLElement;
+  visibilityBody.querySelectorAll("style").forEach((style) => style.remove());
+  const hasRenderableImage = Array.from(
+    visibilityBody.querySelectorAll<HTMLImageElement>("img[src]")
+  ).some((image) =>
+    /^(data|blob):/i.test((image.getAttribute("src") || "").trim())
+  );
+  const hasPotentiallyVisibleContent =
+    Boolean(visibilityBody.textContent?.trim()) ||
+    hasRenderableImage ||
+    Boolean(visibilityBody.querySelector(EMAIL_SVG_PAINT_SELECTOR));
+  if (!hasPotentiallyVisibleContent) return null;
+
+  sanitizedDocument.querySelectorAll("a").forEach((anchor) => {
+    const href = anchor.getAttribute("href");
+    const xlinkHref = anchor.getAttributeNS(XLINK_NAMESPACE, "href");
+    if (href === null && xlinkHref === null) return;
+    if (xlinkHref !== null) {
+      anchor.removeAttributeNS(XLINK_NAMESPACE, "href");
+      if (href === null) anchor.setAttribute("href", xlinkHref);
+    }
+    anchor.setAttribute("target", "_blank");
+    anchor.setAttribute("rel", "noopener noreferrer");
+  });
+  return {
+    bodyAttributes: Array.from(
+      sanitizedDocument.body.attributes,
+      (attribute) => [attribute.name, attribute.value]
+    ),
+    bodyHtml: sanitizedDocument.body.innerHTML,
+    headHtml: sanitizedDocument.head.innerHTML,
+    htmlAttributes: ["dir", "lang"].flatMap((name) => {
+      const value = sanitizedDocument.documentElement.getAttribute(name);
+      return value === null ? [] : [[name, value]];
+    }),
+  } satisfies SanitizedEmailHtml;
+}
+
+function hasZeroOpacity(style: CSSStyleDeclaration) {
+  const opacity = Number.parseFloat(style.opacity);
+  return Number.isFinite(opacity) && opacity === 0;
+}
+
+function hasTransparentColor(style: CSSStyleDeclaration) {
+  const color = style.color.trim().toLowerCase();
+  return (
+    color === "transparent" ||
+    /rgba\([^)]*,\s*0(?:\.0+)?\s*\)$/.test(color) ||
+    /\/\s*0(?:\.0+)?\s*\)$/.test(color)
+  );
+}
+
+function isClippedToNothing(element: Element, style: CSSStyleDeclaration) {
+  const clipsOverflow = [style.overflow, style.overflowX, style.overflowY].some(
+    (value) => value === "hidden" || value === "clip"
+  );
+  if (!clipsOverflow) return false;
+  const rect = element.getBoundingClientRect();
+  return rect.width <= 0 || rect.height <= 0;
+}
+
+function hasVisibleAncestors(element: Element) {
+  const view = element.ownerDocument.defaultView;
+  for (
+    let current: Element | null = element;
+    current;
+    current = current.parentElement
+  ) {
+    const style = view?.getComputedStyle(current);
+    if (!style) continue;
+    if (
+      style.display === "none" ||
+      hasZeroOpacity(style) ||
+      isClippedToNothing(current, style)
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function isRenderedElement(element: Element) {
+  const view = element.ownerDocument.defaultView;
+  const style = view?.getComputedStyle(element);
+  if (
+    !style ||
+    style.visibility === "hidden" ||
+    style.visibility === "collapse" ||
+    !hasVisibleAncestors(element)
+  ) {
+    return false;
+  }
+  const rect = element.getBoundingClientRect();
+  return rect.width > 0 && rect.height > 0;
+}
+
+function isRenderedTextNode(node: Text) {
+  const parent = node.parentElement;
+  const view = node.ownerDocument.defaultView;
+  const style = parent && view?.getComputedStyle(parent);
+  if (
+    !node.textContent?.trim() ||
+    !parent ||
+    !style ||
+    style.visibility === "hidden" ||
+    style.visibility === "collapse" ||
+    Number.parseFloat(style.fontSize) === 0 ||
+    hasTransparentColor(style) ||
+    !hasVisibleAncestors(parent)
+  ) {
+    return false;
+  }
+  return true;
+}
+
+function hasRenderedText(body: HTMLElement) {
+  const showText = body.ownerDocument.defaultView?.NodeFilter.SHOW_TEXT ?? 4;
+  const walker = body.ownerDocument.createTreeWalker(body, showText);
+  for (let node = walker.nextNode(); node; node = walker.nextNode()) {
+    if (isRenderedTextNode(node as Text)) return true;
+  }
+  return false;
+}
+
+function hasRenderedEmailContent(frameDocument: Document) {
+  const body = frameDocument.body;
+  if (!body) return false;
+  if (hasRenderedText(body)) return true;
+
+  const hasLoadedImage = Array.from(
+    body.querySelectorAll<HTMLImageElement>("img[src]")
+  ).some(
+    (image) =>
+      image.complete &&
+      image.naturalWidth > 0 &&
+      image.naturalHeight > 0 &&
+      isRenderedElement(image)
+  );
+  if (hasLoadedImage) return true;
+
+  return Array.from(body.querySelectorAll(EMAIL_SVG_PAINT_SELECTOR)).some(
+    isRenderedElement
+  );
+}
+
+function buildEmailFrameSource(html: SanitizedEmailHtml) {
+  const frameDocument = new DOMParser().parseFromString(
+    "<!doctype html><html><head></head><body></body></html>",
+    "text/html"
+  );
+  html.htmlAttributes.forEach(([name, value]) =>
+    frameDocument.documentElement.setAttribute(name, value)
+  );
+  html.bodyAttributes.forEach(([name, value]) =>
+    frameDocument.body.setAttribute(name, value)
+  );
+  frameDocument.body.setAttribute("data-octo-mail-body", "");
+  frameDocument.body.innerHTML = html.bodyHtml;
+
+  const base = frameDocument.createElement("base");
+  base.href = "about:blank";
+  base.target = "_blank";
+  const charset = frameDocument.createElement("meta");
+  charset.setAttribute("charset", "utf-8");
+  const csp = frameDocument.createElement("meta");
+  csp.httpEquiv = "Content-Security-Policy";
+  csp.content = EMAIL_HTML_CSP;
+  const defaults = frameDocument.createElement("style");
+  defaults.textContent =
+    'html{color-scheme:only light;background:Canvas}html,body{margin:0;padding:0}body{color:CanvasText;background:Canvas;font:14px/1.6 -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;overflow-wrap:anywhere}img,table{max-width:100%}img{height:auto}';
+  frameDocument.head.append(base, charset, csp, defaults);
+  frameDocument.head.insertAdjacentHTML("beforeend", html.headHtml);
+  return `<!doctype html>${frameDocument.documentElement.outerHTML}`;
+}
+
+function EmailMessageBody({
+  html,
+  title,
+  onEmpty,
+}: {
+  html: SanitizedEmailHtml;
+  title: string;
+  onEmpty: () => void;
+}) {
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+  const source = useMemo(() => buildEmailFrameSource(html), [html]);
+
+  useEffect(() => {
+    const iframe = iframeRef.current;
+    if (!iframe) return undefined;
+    let active = true;
+    let widthObserver: ResizeObserver | undefined;
+    const mediaCleanups: Array<() => void> = [];
+    const resize = () => {
+      const frameDocument = iframe.contentDocument;
+      if (!frameDocument) return;
+      iframe.style.height = `${EMAIL_HTML_MIN_HEIGHT}px`;
+      const measured = Math.max(
+        EMAIL_HTML_MIN_HEIGHT,
+        frameDocument.documentElement.scrollHeight,
+        frameDocument.body.scrollHeight
+      );
+      iframe.style.height = `${Math.min(measured, EMAIL_HTML_MAX_HEIGHT)}px`;
+    };
+    const refresh = () => {
+      const frameDocument = iframe.contentDocument;
+      if (!frameDocument?.body.hasAttribute("data-octo-mail-body")) {
+        return false;
+      }
+      if (iframe.clientWidth <= 0) return true;
+      if (!hasRenderedEmailContent(frameDocument)) {
+        onEmpty();
+        return false;
+      }
+      resize();
+      return true;
+    };
+    const loaded = () => {
+      widthObserver?.disconnect();
+      while (mediaCleanups.length > 0) mediaCleanups.pop()?.();
+      const frameDocument = iframe.contentDocument;
+      if (!frameDocument?.body.hasAttribute("data-octo-mail-body")) return;
+      if (!refresh()) return;
+
+      frameDocument.querySelectorAll("img").forEach((image) => {
+        const handleImageSettled = () => {
+          if (active) refresh();
+        };
+        image.addEventListener("load", handleImageSettled);
+        image.addEventListener("error", handleImageSettled);
+        mediaCleanups.push(() => {
+          image.removeEventListener("load", handleImageSettled);
+          image.removeEventListener("error", handleImageSettled);
+        });
+      });
+      void frameDocument.fonts?.ready.then(() => {
+        if (active) refresh();
+      });
+
+      if (typeof ResizeObserver !== "undefined") {
+        let width = iframe.clientWidth;
+        widthObserver = new ResizeObserver((entries) => {
+          const nextWidth = entries[0]?.contentRect.width ?? iframe.clientWidth;
+          if (nextWidth === width) return;
+          width = nextWidth;
+          refresh();
+        });
+        widthObserver.observe(iframe);
+      }
+    };
+    iframe.addEventListener("load", loaded);
+    if (iframe.contentDocument?.readyState === "complete") loaded();
+    return () => {
+      active = false;
+      iframe.removeEventListener("load", loaded);
+      widthObserver?.disconnect();
+      while (mediaCleanups.length > 0) mediaCleanups.pop()?.();
+    };
+  }, [onEmpty, source]);
+
+  return (
+    <iframe
+      ref={iframeRef}
+      className="octo-mail-thread-card__html-body"
+      srcDoc={source}
+      // Keep scripts disabled. allow-same-origin is required only for auto-sizing.
+      sandbox="allow-same-origin allow-popups allow-popups-to-escape-sandbox"
+      referrerPolicy="no-referrer"
+      title={title}
+    />
+  );
+}
+
+function EmailMessageContent({
+  html,
+  text,
+  title,
+}: {
+  html?: string;
+  text: string;
+  title: string;
+}) {
+  const sanitized = useMemo(() => sanitizeEmailHtml(html || ""), [html]);
+  const [emptyHtml, setEmptyHtml] = useState<SanitizedEmailHtml | null>(null);
+  const useTextFallback = !sanitized || emptyHtml === sanitized;
+  const handleEmpty = useCallback(() => setEmptyHtml(sanitized), [sanitized]);
+  return !useTextFallback ? (
+    <EmailMessageBody html={sanitized} title={title} onEmpty={handleEmpty} />
+  ) : (
+    <p className="octo-mail-thread-card__body">{text}</p>
+  );
+}
 
 function deliveryIcon(status: DeliveryStatus, size = 16) {
   if (status === "delivered") return <CheckCircle2 size={size} />;
@@ -735,9 +1079,26 @@ export default function MessageDetailFeature({
                     </>
                   ) : null}
                 </div>
-                <p className="octo-mail-thread-card__body">
-                  {memoizedMessageText(message)}
-                </p>
+                {message.bodyTruncated ? (
+                  <div className="octo-mail-body-truncated" role="status">
+                    <AlertTriangle size={16} />
+                    <span>{t("mail.reader.bodyTruncated")}</span>
+                    <button
+                      className="octo-mail-action octo-mail-action--bordered"
+                      type="button"
+                      disabled={busy}
+                      onClick={() => void downloadRaw()}
+                    >
+                      <Download size={15} />
+                      <span>{t("mail.actions.downloadRaw")}</span>
+                    </button>
+                  </div>
+                ) : null}
+                <EmailMessageContent
+                  html={message.bodyHtml}
+                  text={memoizedMessageText(message)}
+                  title={t("mail.reader.htmlBody")}
+                />
                 {message.attachments?.length ? (
                   <section
                     className="octo-mail-thread-card__attachments"

--- a/packages/mail/src/i18n/en-US.json
+++ b/packages/mail/src/i18n/en-US.json
@@ -81,6 +81,8 @@
   "mail.reader.sentBy": "Sent by {{sender}} on behalf of the original sender",
   "mail.reader.thread": "Messages in this thread",
   "mail.reader.threadCount": "Mail thread · {{count}} messages",
+  "mail.reader.htmlBody": "HTML email body",
+  "mail.reader.bodyTruncated": "This HTML email is too large to display here. Download the raw message to view the complete content.",
   "mail.reader.rawHint": "Download the raw message for complete headers and MIME content.",
   "mail.attachment.list": "Attachments",
   "mail.attachment.download": "Download attachment",
@@ -309,6 +311,6 @@
   "mail.authorization.approvalMismatch": "The server returned a different mailbox permission than the one you approved. Nothing was connected.",
   "mail.authorization.targetSpace": "Target Space: {{spaceName}}",
   "mail.authorization.spaceMismatchConfirmation": "This link targets Space {{targetSpaceName}}, but you are currently in Space {{currentSpaceName}}. I understand and want to authorize the target Space.",
-  "mail.authorization.requestedAutomatic": "The Agent requested automatic sending. For safety, this page starts with confirmation required; choose automatic sending only if you intend to grant it.",
-  "mail.authorization.requestedManual": "The Agent requested confirmation before every send."
+  "mail.authorization.selectedAutomatic": "Automatic sending is selected.",
+  "mail.authorization.selectedManual": "Confirmation before every send is selected."
 }

--- a/packages/mail/src/i18n/en-US.json
+++ b/packages/mail/src/i18n/en-US.json
@@ -82,7 +82,7 @@
   "mail.reader.thread": "Messages in this thread",
   "mail.reader.threadCount": "Mail thread · {{count}} messages",
   "mail.reader.htmlBody": "HTML email body",
-  "mail.reader.bodyTruncated": "This HTML email is too large to display here. Download the raw message to view the complete content.",
+  "mail.reader.bodyTruncated": "This HTML email is not displayed here. Download the raw message to view the complete content.",
   "mail.reader.rawHint": "Download the raw message for complete headers and MIME content.",
   "mail.attachment.list": "Attachments",
   "mail.attachment.download": "Download attachment",

--- a/packages/mail/src/i18n/zh-CN.json
+++ b/packages/mail/src/i18n/zh-CN.json
@@ -81,6 +81,8 @@
   "mail.reader.sentBy": "由 {{sender}} 代发",
   "mail.reader.thread": "会话中的邮件",
   "mail.reader.threadCount": "邮件线程 · {{count}} 封",
+  "mail.reader.htmlBody": "HTML 邮件正文",
+  "mail.reader.bodyTruncated": "HTML 邮件正文过大，未在此处直接展示。可下载原始邮件查看完整内容。",
   "mail.reader.rawHint": "可下载邮件原文查看完整头信息和 MIME 内容。",
   "mail.attachment.list": "附件",
   "mail.attachment.download": "下载附件",
@@ -309,6 +311,6 @@
   "mail.authorization.approvalMismatch": "服务端返回的邮箱或权限与刚才确认的内容不一致，本次未完成接入。",
   "mail.authorization.targetSpace": "目标 Space：{{spaceName}}",
   "mail.authorization.spaceMismatchConfirmation": "当前所在 Space 为 {{currentSpaceName}}，但此链接将授权 Space {{targetSpaceName}}。我已了解，并确认授权目标 Space。",
-  "mail.authorization.requestedAutomatic": "Agent 请求自动发信。为保证安全，页面默认仍选择每次发信前确认；只有确实需要时再主动选择自动发信。",
-  "mail.authorization.requestedManual": "Agent 请求每次发信前都由你确认。"
+  "mail.authorization.selectedAutomatic": "当前选择允许 Agent 自动发信。",
+  "mail.authorization.selectedManual": "当前选择每次发信前都由你确认。"
 }

--- a/packages/mail/src/i18n/zh-CN.json
+++ b/packages/mail/src/i18n/zh-CN.json
@@ -82,7 +82,7 @@
   "mail.reader.thread": "会话中的邮件",
   "mail.reader.threadCount": "邮件线程 · {{count}} 封",
   "mail.reader.htmlBody": "HTML 邮件正文",
-  "mail.reader.bodyTruncated": "HTML 邮件正文过大，未在此处直接展示。可下载原始邮件查看完整内容。",
+  "mail.reader.bodyTruncated": "HTML 邮件正文未在此处直接展示。可下载原始邮件查看完整内容。",
   "mail.reader.rawHint": "可下载邮件原文查看完整头信息和 MIME 内容。",
   "mail.attachment.list": "附件",
   "mail.attachment.download": "下载附件",

--- a/packages/mail/src/ui/MailContent/index.css
+++ b/packages/mail/src/ui/MailContent/index.css
@@ -555,6 +555,16 @@
   white-space: pre-wrap;
 }
 
+.octo-mail-thread-card__html-body {
+  display: block;
+  width: 100%;
+  min-height: 80px;
+  margin: 0;
+  border: 0;
+  color-scheme: only light;
+  background: Canvas;
+}
+
 .octo-mail-thread-card__attachments {
   display: grid;
   gap: var(--wk-sp-2);
@@ -633,6 +643,22 @@
 .octo-mail-thread-card__attachments-note {
   color: var(--wk-text-tertiary);
   font-size: var(--wk-text-size-xs);
+}
+
+.octo-mail-body-truncated {
+  display: flex;
+  align-items: center;
+  gap: var(--wk-sp-2);
+  margin-bottom: var(--wk-sp-3);
+  padding: var(--wk-sp-3);
+  color: var(--wk-text-secondary);
+  background: var(--wk-bg-base);
+  border-radius: var(--wk-r-sm);
+  font-size: var(--wk-text-size-sm);
+}
+
+.octo-mail-body-truncated > span {
+  flex: 1;
 }
 
 .octo-mail-raw-hint {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -840,6 +840,9 @@ importers:
       '@octo/base':
         specifier: workspace:*
         version: link:../dmworkbase
+      dompurify:
+        specifier: ^3.4.2
+        version: 3.4.2
       lucide-react:
         specifier: ^0.577.0
         version: 0.577.0(react@18.3.1)


### PR DESCRIPTION
## Summary

Render sanitized HTML email bodies with their formatting and keep the authorization description synchronized with the selected outbound mode.

## Related Issue

Fixes #1488

Related backend: Mininglamp-OSS/octo-mail#69

## Changes

- Render `bodyHtml` in an isolated, sanitized iframe and retain the plain-text fallback.
- Use an isolated light canvas so HTML email text remains readable under the app dark theme.
- Fall back to `bodyText` when sanitized HTML has no visible content.
- Treat only CSP-renderable inline images as visible and fall back for blocked remote, CID, or media-only bodies.
- Preserve sanitized `<head>` styles, body attributes, and document language/direction inside the isolated email document.
- Open HTML and SVG email links in a separate, non-referring window and keep scripts disabled.
- Prevent relative email links from resolving against the Octo Web origin.
- Fall back to `bodyText` after load when sanitized HTML paints no visible content, including visually hidden preheaders.
- Remove image-map navigation, defer empty-content decisions at zero width, and measure iframe height from a stable bounded baseline.
- Show an explicit notice when the backend omits oversized or multiple HTML bodies and marks the response as truncated.
- Reuse the existing raw-message download from the omitted-HTML notice.
- Update the authorization description when the user switches between manual confirmation and automatic sending.
- Pin the iframe CSP, base URL, and light-canvas defaults in unit coverage.
- Add unit coverage and localized copy for both behaviors.

## Architecture / Module Boundary

- Affected module(s): `packages/mail`
- New or changed user-visible entry point: no
- Shared layer touched: none
- If shared code changed, impact scope: N/A
- Duplicate entry point checked: not applicable

## Testing

- [x] Unit tests added/updated
- [x] Manually verified
- `pnpm --filter @octo/mail test` — 25 files, 214 tests passed
- `pnpm --filter @octo/mail typecheck`
- `pnpm i18n:check`
- `pnpm lint:css`
- `pnpm build`
- Headless Chrome — dark-theme HTML rendered on a readable light canvas; relative links stayed detached from the app origin; absolute links remained intact; SVG links opened in a popup without replacing the reader frame; hidden HTML fell back; viewport-relative height stabilized.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes
- [ ] Updated documentation
- [x] Ran `pnpm i18n:check` or confirmed the change does not affect UI copy
- [x] Confirmed the change follows module ownership and does not add duplicate user-visible entry points
- [x] Described impact scope when shared components, messages, bridge, or services are changed
- [x] Followed commit message conventions (Conventional Commits)




