### PR TITLE
fix(summary): segmented collapse for citation group badge labels

### DIFF
--- a/packages/dmworksummary/src/components/__tests__/CitationBadge.test.ts
+++ b/packages/dmworksummary/src/components/__tests__/CitationBadge.test.ts
@@ -5,7 +5,11 @@ import { formatGroupLabel, RANGE_THRESHOLD, buildDisplayIndexMap } from '../cita
 //   len=1  -> handled by CitationBadge (single [N]), not tested here
 //   len=2  -> comma joined:  [37,38]
 //   len=3  -> comma joined:  [37,38,39]      (threshold)
-//   len>3  -> range:         [30-35]         (first-last)
+//   len>3  -> segmented collapse: each run of >=3 consecutive indices folds to
+//            `first-last`, runs are comma joined:  [27,31-35]
+// The former rule only folded a >3 group when EVERY index was contiguous, so a
+// partially-gapped cluster listed all of its indices while a fully contiguous
+// one collapsed — inconsistent for the same kind of citation cluster.
 describe('formatGroupLabel', () => {
     it('joins 2 indices with a comma', () => {
         expect(formatGroupLabel([37, 38])).toBe('37,38');
@@ -29,6 +33,33 @@ describe('formatGroupLabel', () => {
 
     it('does not render duplicate indices as a misleading range', () => {
         expect(formatGroupLabel([1, 1, 1, 1])).toBe('1');
+    });
+
+    it('folds the consecutive run of a partially gapped group', () => {
+        // The reported case: was rendered in full as 27,31,32,33,34,35.
+        expect(formatGroupLabel([27, 31, 32, 33, 34, 35])).toBe('27,31-35');
+    });
+
+    it('folds a trailing run after a leading singleton', () => {
+        expect(formatGroupLabel([1, 6, 7, 8])).toBe('1,6-8');
+    });
+
+    it('folds every run when a group has several of them', () => {
+        expect(formatGroupLabel([1, 2, 3, 7, 8, 9, 20])).toBe('1-3,7-9,20');
+    });
+
+    it('leaves a 2-long run listed (a range would not be shorter)', () => {
+        expect(formatGroupLabel([1, 5, 6, 10])).toBe('1,5,6,10');
+    });
+
+    it('folds runs after deduplicating and sorting a messy input', () => {
+        expect(formatGroupLabel([33, 31, 35, 27, 32, 34, 31])).toBe('27,31-35');
+    });
+
+    it('lists a duplicate-heavy group whose deduped run is only 2 long', () => {
+        // Dedup happens after the threshold check, so this reaches the run
+        // logic with [5,6]; the old all-or-nothing rule folded it to 5-6.
+        expect(formatGroupLabel([5, 5, 5, 5, 6])).toBe('5,6');
     });
 
     it('RANGE_THRESHOLD is the documented value (guards against silent regressions)', () => {

--- a/packages/dmworksummary/src/components/citationFormat.ts
+++ b/packages/dmworksummary/src/components/citationFormat.ts
@@ -14,17 +14,55 @@ export const RANGE_THRESHOLD = 3;
  * Group-label formatting rule (per product spec):
  *   1  citation  -> single [N] badge (handled by remarkCitation, not here)
  *   2-3 citations -> comma joined:  [37,38,39]
- *   >3 contiguous citations -> range: [30-35]
- *   >3 gapped citations     -> list:  [1,6,7,8]
+ *   >3 citations  -> segmented collapse: every RUN of consecutive indices is
+ *                    folded to `first-last`, runs are then comma joined.
+ *
+ * Segmented collapse (the bibliography / page-range convention) replaces the
+ * former all-or-nothing rule, which only folded a >3 group when EVERY index
+ * was contiguous and otherwise listed all of them. A partially-gapped group
+ * like [27,31,32,33,34,35] therefore rendered in full and dominated the line,
+ * while [21,22,23,24,25] collapsed to `21-25` — visibly inconsistent for the
+ * same kind of citation cluster.
+ *
+ * Only runs of length >= 3 are folded: a 2-long run (`5,6`) is left listed,
+ * because `5-6` is the same width as `5,6` yet reads as an open-ended range.
+ *
+ * This DOES change existing labels — every >3 group that mixes a gap with a
+ * run of >= 3 now renders shorter. Only fully-contiguous and run-free groups
+ * are guaranteed unchanged:
+ *   [30,31,32,33,34,35]    -> 30-35     (unchanged: one run)
+ *   [2,5,9,14]             -> 2,5,9,14  (unchanged: no run)
+ *   [27,31,32,33,34,35]    -> 27,31-35  (was 27,31,32,33,34,35)
+ *   [1,6,7,8]              -> 1,6-8     (was 1,6,7,8)
+ *   [5,5,5,5,6]            -> 5,6       (was 5-6; dedup happens after the
+ *                                        threshold check, so a duplicate-heavy
+ *                                        group reaches the run logic)
+ *
+ * Unlike a first-last collapse over a gapped set, this never claims the gap
+ * was cited: `27,31-35` says exactly which messages back the sentence.
  */
 export function formatGroupLabel(indices: number[]): string {
     if (indices.length <= RANGE_THRESHOLD) {
         return indices.join(',');
     }
     const sorted = [...new Set(indices)].sort((a, b) => a - b);
-    const contiguous = sorted.every((value, i) => i === 0 || value === sorted[i - 1] + 1);
     if (sorted.length === 1) return `${sorted[0]}`;
-    return contiguous ? `${sorted[0]}-${sorted[sorted.length - 1]}` : sorted.join(',');
+
+    const parts: string[] = [];
+    let runStart = 0;
+    for (let i = 1; i <= sorted.length; i++) {
+        // Close the current run when the sequence breaks or input is exhausted.
+        if (i === sorted.length || sorted[i] !== sorted[i - 1] + 1) {
+            const runLength = i - runStart;
+            if (runLength >= 3) {
+                parts.push(`${sorted[runStart]}-${sorted[i - 1]}`);
+            } else {
+                for (let j = runStart; j < i; j++) parts.push(`${sorted[j]}`);
+            }
+            runStart = i;
+        }
+    }
+    return parts.join(',');
 }
 
 /**


### PR DESCRIPTION
## What

引用角标 group label（>3 条引用）改为**分段折叠**：把每一段 >=3 的连续 index 折成 `first-last`，段间逗号连接。

```
[27,31,32,33,34,35] -> 27,31-35   (原:27,31,32,33,34,35)
[1,6,7,8]           -> 1,6-8      (原:1,6,7,8)
[1,2,3,7,8,9,20]    -> 1-3,7-9,20
[30,31,32,33,34,35] -> 30-35      (不变)
[2,5,9,14]          -> 2,5,9,14   (不变)
```

## Why

旧规则是全有或全无：只有当 >3 组里**每一个** index 都连续时才折成 `first-last`，否则整组全列。所以 `[21,22,23,24,25]` 折成 `21-25`，而只差一个缺口的 `[27,31,32,33,34,35]` 全列出来占满一行 —— 同类引用簇表现不一致。

只折长度 >=3 的段：2 长的段（`5,6`）保持列出，因为 `5-6` 宽度相同却读起来像开区间。

不同于对带缺口集合做 first-last 折叠，分段折叠**不会宣称缺口被引用**：`27,31-35` 精确表达了哪几条消息支撑该句。

## Scope note

本改动会**改变已有 label**，不是纯增量：任何「带缺口 + 含 >=3 连续段」的 >3 组都会变短；`[5,5,5,5,6]` 这类去重后只剩 2 长段的输入从 `5-6` 变成 `5,6`（去重发生在阈值判断之后）。只有「完全连续」和「完全无连续段」两类保证不变。doc comment 已按此改写。

原先这个 commit 搭在 #1465（WEB-04 async finalize）上，与该 PR 主题无关，按 review 意见拆出独立 PR，便于产品若不认可新 label 形态时独立回滚。

## Blast radius

`formatGroupLabel` 只有一个消费方 `CitationBadge.tsx`，且无反向解析器（label 仅用于展示，点击态走 index 数组），改动范围封闭。

## Tests

- `../../node_modules/.bin/vitest run src/components/__tests__/CitationBadge.test.ts`
- Result: 21 tests passed（含缺口折叠、多段折叠、2 长段保持、乱序去重、重复 index 等用例）。
