### PR TITLE
feat(summary): fall back to absolute date for list items older than 10 days

### DIFF
--- a/packages/dmworksummary/src/components/SummaryCard.test.tsx
+++ b/packages/dmworksummary/src/components/SummaryCard.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import '@testing-library/jest-dom/vitest';
 import { cleanup, render as rtlRender, screen } from '@testing-library/react';
-import { afterEach, describe, it, expect, vi } from 'vitest';
+import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest';
 import SummaryCard from './SummaryCard';
 import { ParticipantStatus, TaskStatus, TriggerType } from '../types/summary';
 
@@ -372,6 +372,49 @@ describe('SummaryCard creator vs participant footer (问题1)', () => {
         // creator_id 缺失 + 非参与者 → 既不删除也不退出。
         expect(screen.queryByTestId('delete-icon')).not.toBeInTheDocument();
         expect(screen.queryByTestId('exit-icon')).not.toBeInTheDocument();
+    });
+});
+
+describe('SummaryCard relative time fallback (issue #1440)', () => {
+    // 冻结时钟：formatRelativeTime 用真实 new Date()，不冻结断言会随真实时间漂移。
+    const NOW = '2026-08-18T12:00:00Z';
+    const daysAgoIso = (days: number) =>
+        new Date(new Date(NOW).getTime() - days * 86400 * 1000).toISOString();
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date(NOW));
+    });
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('超过十天的总结显示具体日期而不是「X天前」', () => {
+        render(
+            <SummaryCard task={makeItem({ created_at: daysAgoIso(15) }) as any} onClick={noop} onDelete={noop} />,
+        );
+        // 本地时区下的绝对日期（formatDateOnly 用本地时间）。
+        const expected = (() => {
+            const d = new Date(daysAgoIso(15));
+            const pad = (n: number) => String(n).padStart(2, '0');
+            return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+        })();
+        expect(screen.getByText(new RegExp(`于${expected}`))).toBeInTheDocument();
+        expect(screen.queryByText(/天前/)).not.toBeInTheDocument();
+    });
+
+    it('恰好十天仍显示相对时间（issue 要求是「超过」十天）', () => {
+        render(
+            <SummaryCard task={makeItem({ created_at: daysAgoIso(10) }) as any} onClick={noop} onDelete={noop} />,
+        );
+        expect(screen.getByText(/10天前/)).toBeInTheDocument();
+    });
+
+    it('十天以内的总结保持相对时间', () => {
+        render(
+            <SummaryCard task={makeItem({ created_at: daysAgoIso(3) }) as any} onClick={noop} onDelete={noop} />,
+        );
+        expect(screen.getByText(/3天前/)).toBeInTheDocument();
     });
 });
 

--- a/packages/dmworksummary/src/components/SummaryCard.tsx
+++ b/packages/dmworksummary/src/components/SummaryCard.tsx
@@ -4,7 +4,7 @@ import { MoreHorizontal, AlertTriangle, Bot, Clock, FileText, UsersRound, X } fr
 import { useI18n, Dap } from "@octo/base";
 import WKApp from "@octo/base/src/App";
 import { ParticipantStatus, TaskStatus, TriggerType, type SummaryListItem } from "../types/summary";
-import { getStatusLabel, getSummaryTypeKind, getSummaryTypeLabel } from "../utils/summaryHelpers";
+import { formatDateOnly, getStatusLabel, getSummaryTypeKind, getSummaryTypeLabel } from "../utils/summaryHelpers";
 import { deriveSummaryDisplayContent } from "../utils/templateResolver";
 import { summaryTestIds } from "../utils/testIds";
 
@@ -30,6 +30,10 @@ function formatRelativeTime(dateStr: string, t: (key: string, opts?: any) => str
     if (diff < 60) return t("summary.summaryCard.justNow");
     if (diff < 3600) return t("summary.summaryCard.minutesAgo", { values: { count: Math.floor(diff / 60) } });
     if (diff < 86400) return t("summary.summaryCard.hoursAgo", { values: { count: Math.floor(diff / 3600) } });
+    // 超过十天回落到具体日期（issue #1440）：「45天前」这类相对值对定位
+    // 总结已没有参考价值。阈值按 issue 取「超过」十天，与 dmworkbase
+    // relativeTime.ts 的「超过 N 天回落绝对日期」模式一致。
+    if (diff > 10 * 86400) return formatDateOnly(dateStr);
     return t("summary.summaryCard.daysAgo", { values: { count: Math.floor(diff / 86400) } });
 }
 


### PR DESCRIPTION
Closes #1440

## Background

Summary list cards render the creation time purely as relative wording ("just now" / "N minutes ago" / "N hours ago" / "N days ago"). For old summaries this grows unbounded — "45 days ago" carries no useful information and makes it hard to tell which date a summary belongs to.

## What changed

`SummaryCard.formatRelativeTime` gains one branch: when a summary is **older than 10 days**, it renders the absolute date (`YYYY-MM-DD`) instead of "N days ago". Within 10 days the wording is unchanged, and **exactly 10 days still shows relative time** since the issue asks for "超过十天" (more than ten days).

## Why

- Reuses the existing `formatDateOnly` helper (`summaryHelpers.ts`, already used by `SummaryDetailPage`) instead of adding new formatting logic.
- Mirrors the existing precedent in `dmworkbase/Components/SecretsSettings/relativeTime.ts`, which already falls back to an absolute date after a day threshold (30 days there).
- No new i18n keys: the absolute date renders identically in zh-CN and en-US.

## Tests

Three new cases in `SummaryCard.test.tsx` with the clock frozen via `vi.setSystemTime`:

- a summary 15 days old renders its absolute date and no "天前" copy
- a summary exactly 10 days old still shows "10天前"
- a summary 3 days old still shows "3天前"

`vitest run src/components/SummaryCard.test.tsx`: the 3 new cases pass; the 12 failing cases in this file are pre-existing at merge-base (verified the failure set is byte-identical before and after this change — only the 3 new tests differ).

## Impact scope

- `packages/dmworksummary/src/components/SummaryCard.tsx` — one added branch + import of `formatDateOnly`
- `packages/dmworksummary/src/components/SummaryCard.test.tsx` — new test describe block

No CSS, i18n, API, or other-page changes.
