### PR TITLE
fix(mail): sync authorization mode copy

### DIFF
--- a/packages/mail/src/features/MailAuthorizationPage.test.tsx
+++ b/packages/mail/src/features/MailAuthorizationPage.test.tsx
@@ -294,7 +294,15 @@ describe("MailAuthorizationPage return target lifecycle", () => {
     expect((manual as HTMLInputElement).checked).toBe(true);
     expect((automatic as HTMLInputElement).checked).toBe(false);
     expect(
-      screen.getByText("mail.authorization.requestedAutomatic")
+      screen.getByText("mail.authorization.selectedManual")
+    ).toBeTruthy();
+
+    fireEvent.click(automatic);
+
+    expect((manual as HTMLInputElement).checked).toBe(false);
+    expect((automatic as HTMLInputElement).checked).toBe(true);
+    expect(
+      screen.getByText("mail.authorization.selectedAutomatic")
     ).toBeTruthy();
   });
 

--- a/packages/mail/src/features/MailAuthorizationPage.tsx
+++ b/packages/mail/src/features/MailAuthorizationPage.tsx
@@ -490,9 +490,9 @@ export default function MailAuthorizationPage({
             <legend>{t("mail.authorization.permissionLegend")}</legend>
             <p className="mail-auth-card__status">
               {t(
-                request?.outboundMode === "automatic_send"
-                  ? "mail.authorization.requestedAutomatic"
-                  : "mail.authorization.requestedManual"
+                outboundMode === "automatic_send"
+                  ? "mail.authorization.selectedAutomatic"
+                  : "mail.authorization.selectedManual"
               )}
             </p>
             <label

--- a/packages/mail/src/i18n/en-US.json
+++ b/packages/mail/src/i18n/en-US.json
@@ -309,6 +309,6 @@
   "mail.authorization.approvalMismatch": "The server returned a different mailbox permission than the one you approved. Nothing was connected.",
   "mail.authorization.targetSpace": "Target Space: {{spaceName}}",
   "mail.authorization.spaceMismatchConfirmation": "This link targets Space {{targetSpaceName}}, but you are currently in Space {{currentSpaceName}}. I understand and want to authorize the target Space.",
-  "mail.authorization.requestedAutomatic": "The Agent requested automatic sending. For safety, this page starts with confirmation required; choose automatic sending only if you intend to grant it.",
-  "mail.authorization.requestedManual": "The Agent requested confirmation before every send."
+  "mail.authorization.selectedAutomatic": "Automatic sending is selected.",
+  "mail.authorization.selectedManual": "Confirmation before every send is selected."
 }

--- a/packages/mail/src/i18n/zh-CN.json
+++ b/packages/mail/src/i18n/zh-CN.json
@@ -309,6 +309,6 @@
   "mail.authorization.approvalMismatch": "服务端返回的邮箱或权限与刚才确认的内容不一致，本次未完成接入。",
   "mail.authorization.targetSpace": "目标 Space：{{spaceName}}",
   "mail.authorization.spaceMismatchConfirmation": "当前所在 Space 为 {{currentSpaceName}}，但此链接将授权 Space {{targetSpaceName}}。我已了解，并确认授权目标 Space。",
-  "mail.authorization.requestedAutomatic": "Agent 请求自动发信。为保证安全，页面默认仍选择每次发信前确认；只有确实需要时再主动选择自动发信。",
-  "mail.authorization.requestedManual": "Agent 请求每次发信前都由你确认。"
+  "mail.authorization.selectedAutomatic": "当前选择允许 Agent 自动发信。",
+  "mail.authorization.selectedManual": "当前选择每次发信前都由你确认。"
 }


### PR DESCRIPTION
## Summary

Keep the Agent Mail authorization explanation synchronized with the outbound mode currently selected by the user.

## Related Issue

Fixes #1493

Related MIME compatibility work: Mininglamp-OSS/octo-mail#70

## Changes

- Derive the authorization description from the current mode selection.
- Add localized manual-confirmation and automatic-sending descriptions.
- Extend the authorization-page test to verify the copy changes when the mode changes.

## Architecture / Module Boundary

- Affected module(s): `packages/mail`
- New or changed user-visible entry point: no
- Shared layer touched: none
- If shared code changed, impact scope: N/A
- Duplicate entry point checked: not applicable

## Testing

- [x] Unit tests added/updated
- [x] Manually verified
- `pnpm --filter @octo/mail test` — 25 files, 201 tests passed
- `pnpm --filter @octo/mail typecheck`
- `pnpm i18n:check`
- `pnpm lint:css`
- `pnpm build`

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes
- [ ] Updated documentation
- [x] Ran `pnpm i18n:check`
- [x] Confirmed the change follows module ownership and does not add duplicate user-visible entry points
- [x] Described impact scope when shared components, messages, bridge, or services are changed
- [x] Followed commit message conventions (Conventional Commits)
