### PR TITLE
fix(mail): show only unread counts in the mailbox sidebar

### DIFF
--- a/packages/mail/src/ui/MailSidebarView/MailSidebarView.test.tsx
+++ b/packages/mail/src/ui/MailSidebarView/MailSidebarView.test.tsx
@@ -153,8 +153,8 @@ describe("MailSidebarView", () => {
       return button?.querySelector(".octo-mail-mailboxes__count")?.textContent;
     };
 
-    expect(countFor("Inbox")).toBe("");
+    expect(countFor("Inbox")).toBeUndefined();
     expect(countFor("Starred")).toBe("2");
-    expect(countFor("Sent")).toBe("");
+    expect(countFor("Sent")).toBeUndefined();
   });
 });

--- a/packages/mail/src/ui/MailSidebarView/MailSidebarView.test.tsx
+++ b/packages/mail/src/ui/MailSidebarView/MailSidebarView.test.tsx
@@ -94,4 +94,67 @@ describe("MailSidebarView", () => {
       ).toBe(true);
     }
   });
+
+  it("shows unread counts and hides total counts when a mailbox is fully read", () => {
+    const { container } = render(
+      <MailSidebarView
+        mailboxes={[
+          { id: "inbox", name: "Inbox", role: "inbox", total: 12, unread: 0 },
+          {
+            id: "starred",
+            name: "Starred",
+            role: "starred",
+            total: 4,
+            unread: 2,
+          },
+          { id: "sent", name: "Sent", role: "sent", total: 9, unread: 0 },
+        ]}
+        agentMailboxes={[]}
+        selectedAgentMailbox={null}
+        identity={null}
+        identityUnavailable
+        selectedMailbox="Inbox"
+        addressManagementActive={false}
+        loading={false}
+        error=""
+        t={(key) =>
+          ({
+            "mail.header.title": "Agent Mail",
+            "mail.header.beta": "Beta",
+            "mail.identity.unavailable": "Mailbox address unavailable",
+            "mail.identity.switchLabel": "Switch active mailbox",
+            "mail.actions.compose": "Compose",
+            "mail.addresses.manage": "Manage Agent mailboxes",
+            "mail.navigation.mailboxes": "Mailboxes",
+            "mail.actions.refresh": "Refresh",
+            "mail.mailbox.inbox": "Inbox",
+            "mail.mailbox.starred": "Starred",
+            "mail.mailbox.sent": "Sent",
+          }[key] || key)
+        }
+        onCompose={() => undefined}
+        onManageAddresses={() => undefined}
+        onRefresh={() => undefined}
+        onSelectMailbox={() => undefined}
+        onSelectAgentMailbox={() => undefined}
+      />
+    );
+
+    const countFor = (label: string) => {
+      const button = Array.from(
+        container.querySelectorAll<HTMLButtonElement>(
+          ".octo-mail-mailboxes > button"
+        )
+      ).find(
+        (candidate) =>
+          candidate.querySelector(".octo-mail-mailboxes__label")
+            ?.textContent === label
+      );
+      return button?.querySelector(".octo-mail-mailboxes__count")?.textContent;
+    };
+
+    expect(countFor("Inbox")).toBe("");
+    expect(countFor("Starred")).toBe("2");
+    expect(countFor("Sent")).toBe("");
+  });
 });

--- a/packages/mail/src/ui/MailSidebarView/index.tsx
+++ b/packages/mail/src/ui/MailSidebarView/index.tsx
@@ -297,7 +297,7 @@ export default function MailSidebarView(props: MailSidebarViewProps) {
                     {mailboxLabel(mailbox, t)}
                   </span>
                   <span className="octo-mail-mailboxes__count">
-                    {mailbox.unread > 0 ? mailbox.unread : mailbox.total || ""}
+                    {mailbox.unread > 0 ? mailbox.unread : ""}
                   </span>
                 </button>
               ))

--- a/packages/mail/src/ui/MailSidebarView/index.tsx
+++ b/packages/mail/src/ui/MailSidebarView/index.tsx
@@ -296,9 +296,11 @@ export default function MailSidebarView(props: MailSidebarViewProps) {
                   <span className="octo-mail-mailboxes__label">
                     {mailboxLabel(mailbox, t)}
                   </span>
-                  <span className="octo-mail-mailboxes__count">
-                    {mailbox.unread > 0 ? mailbox.unread : ""}
-                  </span>
+                  {mailbox.unread > 0 ? (
+                    <span className="octo-mail-mailboxes__count">
+                      {mailbox.unread}
+                    </span>
+                  ) : null}
                 </button>
               ))
             : null}


### PR DESCRIPTION
## Summary

Show unread message counts in the Agent Mail sidebar without falling back to total mailbox counts when all messages are read.

## Related Issue

Fixes #1499

## Changes

- Render a mailbox count only when `unread` is greater than zero.
- Add coverage for unread and fully read mailbox states.

## Architecture / Module Boundary

- Affected module(s): `@octo/mail`
- New or changed user-visible entry point: no
- Shared layer touched: ui
- If shared code changed, impact scope: Agent Mail sidebar mailbox counters only
- Duplicate entry point checked: not applicable

## Testing

- [x] Unit tests added/updated
- [ ] Manually verified
- `pnpm --filter @octo/mail test -- MailSidebarView.test.tsx` — 25 files, 202 tests passed
- `pnpm --filter @octo/mail typecheck` — passed
- `pnpm i18n:check` — passed
- `docker build -t octo-web:local .` — passed
- `git diff --check` — passed

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes
- [ ] Updated documentation
- [x] Ran `pnpm i18n:check` or confirmed the change does not affect UI copy
- [x] Confirmed the change follows module ownership and does not add duplicate user-visible entry points
- [x] Described impact scope when shared components, messages, bridge, or services are changed
- [x] Followed commit message conventions (Conventional Commits)
