### PR TITLE
feat(mail): default authorization to automatic sending

### DIFF
--- a/packages/mail/src/Service/MailService.ts
+++ b/packages/mail/src/Service/MailService.ts
@@ -276,26 +276,6 @@ const MailService = {
     return requireAgentMailbox(mailbox);
   },
 
-  async getAgentAuthorization(
-    code: string,
-    spaceId: string
-  ): Promise<AgentAuthorizationView> {
-    const view = await APIClient.shared.get<AgentAuthorizationViewWire>(
-      mailApiUrl(`/agent-auth/requests/${encodeURIComponent(code)}`),
-      {
-        headers: { "X-Space-ID": spaceId },
-        suppressAuthExpiredLogout: true,
-      }
-    );
-    return {
-      request: {
-        ...view.request,
-        outboundMode: resolveOutboundMode(view.request),
-      },
-      mailboxes: (view.mailboxes ?? []).map(normalizeAgentMailbox),
-    };
-  },
-
   async approveAgentAuthorization(
     code: string,
     mailboxId: string,
@@ -315,6 +295,26 @@ const MailService = {
       }
     );
     return requireAuthorizationApproval(approval);
+  },
+
+  async getAgentAuthorization(
+    code: string,
+    spaceId: string
+  ): Promise<AgentAuthorizationView> {
+    const view = await APIClient.shared.get<AgentAuthorizationViewWire>(
+      mailApiUrl(`/agent-auth/requests/${encodeURIComponent(code)}`),
+      {
+        headers: { "X-Space-ID": spaceId },
+        suppressAuthExpiredLogout: true,
+      }
+    );
+    return {
+      request: {
+        ...view.request,
+        outboundMode: resolveOutboundMode(view.request),
+      },
+      mailboxes: (view.mailboxes ?? []).map(normalizeAgentMailbox),
+    };
   },
 
   revokeAgentMailboxBinding(id: string): Promise<void> {

--- a/packages/mail/src/bridge/types.ts
+++ b/packages/mail/src/bridge/types.ts
@@ -104,6 +104,13 @@ export interface AgentAuthorizationRequest {
   requestedAt: string;
   expiresAt: string;
   pollIntervalSeconds?: number;
+  /**
+   * Server-owned authorization-record mode. Device authorization creation
+   * does not accept an outbound mode, and pending records default to manual
+   * confirmation. Owner approval persists the selected mode to the same
+   * record, so approved/exchanged reads expose the owner's actual grant here,
+   * not an Agent-requested value.
+   */
   outboundMode: AgentOutboundMode;
   /** @deprecated Compatibility projection during the local enum migration. */
   autoReplyEnabled?: boolean;

--- a/packages/mail/src/features/MailAuthorizationPage.test.tsx
+++ b/packages/mail/src/features/MailAuthorizationPage.test.tsx
@@ -71,6 +71,7 @@ const authorization = {
 describe("MailAuthorizationPage return target lifecycle", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    state.t = vi.fn((key: string) => key);
     state.currentSpaceId = "space-a";
     window.history.replaceState(null, "", `/mail/authorize${initialSearch}`);
     sessionStorage.clear();
@@ -86,7 +87,7 @@ describe("MailAuthorizationPage return target lifecycle", () => {
     state.approveAgentAuthorization.mockResolvedValue({
       approved: true,
       mailboxId: "42",
-      outboundMode: "manual_confirmation",
+      outboundMode: "automatic_send",
     });
   });
 
@@ -134,7 +135,7 @@ describe("MailAuthorizationPage return target lifecycle", () => {
       expect(state.approveAgentAuthorization).toHaveBeenCalledWith(
         "ABCD-1234",
         "42",
-        "manual_confirmation",
+        "automatic_send",
         "space-a"
       )
     );
@@ -223,7 +224,27 @@ describe("MailAuthorizationPage return target lifecycle", () => {
 
     await waitFor(() => expect(resolved).toHaveBeenCalledTimes(1));
     expect(sessionStorage.length).toBe(0);
+    expect(
+      screen.queryByText("mail.authorization.automaticSendEnabled")
+    ).toBeNull();
     window.removeEventListener(MAIL_AUTHORIZATION_RESOLVED_EVENT, resolved);
+  });
+
+  it("shows the automatic-send status for an exchanged automatic grant", async () => {
+    state.getAgentAuthorization.mockResolvedValue({
+      ...authorization,
+      request: {
+        ...authorization.request,
+        status: "exchanged",
+        outboundMode: "automatic_send",
+      },
+    });
+
+    render(<MailAuthorizationPage initialSearch={initialSearch} />);
+
+    expect(
+      await screen.findByText("mail.authorization.automaticSendEnabled")
+    ).toBeTruthy();
   });
 
   it("hands an approval 401 to the same expired-session recovery", async () => {
@@ -276,34 +297,58 @@ describe("MailAuthorizationPage return target lifecycle", () => {
     window.removeEventListener(MAIL_AUTHORIZATION_RESOLVED_EVENT, resolved);
   });
 
-  it("does not preselect automatic sending merely because the Agent requested it", async () => {
+  it("defaults to automatic sending and still allows manual confirmation", async () => {
+    state.approveAgentAuthorization.mockResolvedValue({
+      approved: true,
+      mailboxId: "42",
+      outboundMode: "manual_confirmation",
+    });
     state.getAgentAuthorization.mockResolvedValue({
       ...authorization,
       request: {
         ...authorization.request,
-        outboundMode: "automatic_send",
+        outboundMode: "manual_confirmation",
       },
     });
 
-    render(<MailAuthorizationPage initialSearch={initialSearch} />);
+    const view = render(
+      <MailAuthorizationPage initialSearch={initialSearch} />
+    );
 
     const manual = await screen.findByRole("radio", {
       name: /manualReviewTitle/,
     });
     const automatic = screen.getByRole("radio", { name: /automaticSendTitle/ });
-    expect((manual as HTMLInputElement).checked).toBe(true);
-    expect((automatic as HTMLInputElement).checked).toBe(false);
-    expect(
-      screen.getByText("mail.authorization.selectedManual")
-    ).toBeTruthy();
-
-    fireEvent.click(automatic);
-
     expect((manual as HTMLInputElement).checked).toBe(false);
     expect((automatic as HTMLInputElement).checked).toBe(true);
     expect(
       screen.getByText("mail.authorization.selectedAutomatic")
     ).toBeTruthy();
+
+    fireEvent.click(manual);
+
+    expect((manual as HTMLInputElement).checked).toBe(true);
+    expect((automatic as HTMLInputElement).checked).toBe(false);
+    expect(screen.getByText("mail.authorization.selectedManual")).toBeTruthy();
+
+    state.t = vi.fn((key: string) => key);
+    view.rerender(<MailAuthorizationPage initialSearch={initialSearch} />);
+    await waitFor(() =>
+      expect(state.getAgentAuthorization).toHaveBeenCalledTimes(2)
+    );
+    expect((manual as HTMLInputElement).checked).toBe(true);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "mail.authorization.approve" })
+    );
+    await waitFor(() =>
+      expect(state.approveAgentAuthorization).toHaveBeenCalledWith(
+        "ABCD-1234",
+        "42",
+        "manual_confirmation",
+        "space-a"
+      )
+    );
   });
 
   it("requires explicit confirmation when the link targets another Space", async () => {

--- a/packages/mail/src/features/MailAuthorizationPage.tsx
+++ b/packages/mail/src/features/MailAuthorizationPage.tsx
@@ -61,9 +61,8 @@ export default function MailAuthorizationPage({
     AgentAuthorizationView["request"] | undefined
   >(undefined);
   const [mailboxId, setMailboxId] = useState("");
-  const [outboundMode, setOutboundMode] = useState<AgentOutboundMode>(
-    "manual_confirmation"
-  );
+  const [outboundMode, setOutboundMode] =
+    useState<AgentOutboundMode>("automatic_send");
   const [loading, setLoading] = useState(true);
   const [submitting, setSubmitting] = useState(false);
   const [phase, setPhase] = useState<MailAuthorizationPhase>("approval");
@@ -167,7 +166,6 @@ export default function MailAuthorizationPage({
         );
         authorizationRequestRef.current = result.request;
         setAuthorization(result);
-        setOutboundMode("manual_confirmation");
         if (isAuthorizationExpired(result.request)) {
           setPhase("failed");
           setError(t("mail.authorization.expired"));
@@ -540,7 +538,7 @@ export default function MailAuthorizationPage({
             {selectedMailbox.address}
           </div>
         )}
-        {connected && outboundMode === "automatic_send" && (
+        {connected && request?.outboundMode === "automatic_send" && (
           <div className="mail-auth-card__status">
             {t("mail.authorization.automaticSendEnabled")}
           </div>


### PR DESCRIPTION
## Summary

Use automatic sending as the default outbound mode on the Agent Mail authorization page while keeping manual confirmation available and preserving the user's selected mode.

## Related Issue

Closes #1501

## Changes

- Select automatic sending when the authorization page initializes.
- Keep an explicit manual-confirmation selection unchanged when authorization data reloads.
- Render the connected-state automatic-send notice from the authorization record returned by the service.
- Cover automatic defaults, manual-mode submission, reload behavior, and completed authorization status.

## Architecture / Module Boundary

- Affected module(s): `@octo/mail`
- New or changed user-visible entry point: no
- Shared layer touched: none
- If shared code changed, impact scope: not applicable
- Duplicate entry point checked: not applicable
- Authorization contract: Agent authorization creation does not accept an outbound mode. The mail service initializes the authorization record to `manual_confirmation`; owner approval persists the selected `outboundMode` to that record, and subsequent authorization reads return the persisted value. The connected-state notice therefore reads the server-returned authorization record rather than unverified client state.
- Backend contract evidence (`octo-mail` main at [`2a46c39`](https://github.com/Mininglamp-OSS/octo-mail/commit/2a46c39ea463bfbede54cf2166a9c3e6ace6a676)):
  - [The device-authorization creation payload has no outbound-mode field](https://github.com/Mininglamp-OSS/octo-mail/blob/2a46c39ea463bfbede54cf2166a9c3e6ace6a676/protocol/webapi/agent_authorization.go#L16-L23), so an Agent cannot request either mode.
  - [`agent_auth_requests.outbound_mode` starts as `manual_confirmation`](https://github.com/Mininglamp-OSS/octo-mail/blob/2a46c39ea463bfbede54cf2166a9c3e6ace6a676/storage/postgres/schema/15_agent_automation_policy.sql#L17-L19) while the request is pending.
  - [Owner approval writes the selected mode into that same authorization record](https://github.com/Mininglamp-OSS/octo-mail/blob/2a46c39ea463bfbede54cf2166a9c3e6ace6a676/storage/postgres/agent_authorization.go#L177-L181).
  - [Authorization reads load the persisted value](https://github.com/Mininglamp-OSS/octo-mail/blob/2a46c39ea463bfbede54cf2166a9c3e6ace6a676/storage/postgres/agent_authorization.go#L89-L108), and [the Web API returns it as `request.outboundMode`](https://github.com/Mininglamp-OSS/octo-mail/blob/2a46c39ea463bfbede54cf2166a9c3e6ace6a676/protocol/webapi/agent_authorization.go#L156-L165). In the connected phase this is the owner-approved value, not an Agent-requested value.

## Testing

- [x] Unit tests added/updated
- [ ] Manually verified
- `pnpm --filter @octo/mail test` — 25 files, 203 tests passed
- `pnpm --filter @octo/mail typecheck` — passed
- `pnpm i18n:check` — passed
- `pnpm build` — passed
- `pnpm exec prettier --check packages/mail/src/features/MailAuthorizationPage.tsx packages/mail/src/features/MailAuthorizationPage.test.tsx` — passed
- `git diff --check` — passed

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes
- [ ] Updated documentation
- [x] Ran `pnpm i18n:check` or confirmed the change does not affect UI copy
- [x] Confirmed the change follows module ownership and does not add duplicate user-visible entry points
- [x] Described impact scope when shared components, messages, bridge, or services are changed
- [x] Followed commit message conventions (Conventional Commits)
