### PR TITLE
fix(mail): refresh sidebar unread counts after reading

### DIFF
--- a/packages/mail/src/bridge/useMailNavigation.test.tsx
+++ b/packages/mail/src/bridge/useMailNavigation.test.tsx
@@ -251,6 +251,33 @@ describe("useMailNavigation", () => {
     unmount();
   });
 
+  it("refreshes mailbox unread counts without showing a loading state", async () => {
+    const account = {
+      id: "11",
+      address: "agent@demo.octo.test",
+      connectState: "connected" as const,
+    };
+    testState.listAgentMailboxes.mockResolvedValue([account]);
+    testState.listMailboxes
+      .mockResolvedValueOnce([
+        { id: "drafts", name: "Drafts", total: 1, unread: 1 },
+      ])
+      .mockResolvedValueOnce([
+        { id: "drafts", name: "Drafts", total: 1, unread: 0 },
+      ]);
+
+    const { result, unmount } = renderHook(() => useMailNavigation("fallback"));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.mailboxes[0]?.unread).toBe(1);
+
+    act(() => testState.emit("mail-navigation-refresh"));
+
+    expect(result.current.loading).toBe(false);
+    await waitFor(() => expect(result.current.mailboxes[0]?.unread).toBe(0));
+    expect(result.current.loading).toBe(false);
+    unmount();
+  });
+
   it("keeps existing navigation state when a background refresh fails", async () => {
     const account = {
       id: "11",

--- a/packages/mail/src/bridge/useMailNavigation.ts
+++ b/packages/mail/src/bridge/useMailNavigation.ts
@@ -222,12 +222,14 @@ export default function useMailNavigation(fallbackError: string) {
       reload();
     };
     WKApp.mittBus.on("mail-refresh" as never, reload);
+    WKApp.mittBus.on("mail-navigation-refresh" as never, refreshSilently);
     WKApp.mittBus.on("space-changed", handleSpaceChanged);
     return () => {
       WKApp.mittBus.off("mail-refresh" as never, reload);
+      WKApp.mittBus.off("mail-navigation-refresh" as never, refreshSilently);
       WKApp.mittBus.off("space-changed", handleSpaceChanged);
     };
-  }, [reload]);
+  }, [refreshSilently, reload]);
 
   useEffect(() => {
     let inactive = document.visibilityState === "hidden";

--- a/packages/mail/src/bridge/useMailWorkspace.test.tsx
+++ b/packages/mail/src/bridge/useMailWorkspace.test.tsx
@@ -95,6 +95,7 @@ describe("useMailWorkspace read state", () => {
       ["\\Seen"],
       []
     );
+    expect(testState.emit).toHaveBeenCalledWith("mail-navigation-refresh");
     expect(testState.emit).not.toHaveBeenCalledWith("mail-refresh");
 
     unmount();

--- a/packages/mail/src/bridge/useMailWorkspace.ts
+++ b/packages/mail/src/bridge/useMailWorkspace.ts
@@ -174,10 +174,14 @@ export default function useMailWorkspace(
         message.id,
         ["\\Seen"],
         []
-      ).catch((reason) => {
-        applyReadState(true);
-        setWorkspaceError("mutation", reason);
-      });
+      )
+        .then(() => {
+          WKApp.mittBus.emit("mail-navigation-refresh" as never);
+        })
+        .catch((reason) => {
+          applyReadState(true);
+          setWorkspaceError("mutation", reason);
+        });
     },
     [mailboxContextId, selectedMailbox, setWorkspaceError]
   );


### PR DESCRIPTION
## Summary

Refresh Agent Mail sidebar unread counts after a message is successfully marked as read, without interrupting the active mailbox view.

## Related Issue

Closes #1506

## Changes

- Emit a navigation refresh after a successful read-state mutation.
- Refresh mailbox navigation data silently so the current message, list, and loading state remain unchanged.
- Preserve the existing optimistic rollback and error handling when marking a message as read fails.
- Add regression tests for the refresh event and unread-count update.

## Architecture / Module Boundary

- Affected module(s): `@octo/mail`
- New or changed user-visible entry point: no
- Shared layer touched: bridge
- If shared code changed, impact scope: Agent Mail workspace read-state handling and mailbox navigation data only
- Duplicate entry point checked: not applicable

## Testing

- [x] Unit tests added/updated
- [ ] Manually verified
- `pnpm --filter @octo/mail test` — 25 files, 204 tests passed
- `pnpm --filter @octo/mail typecheck` — passed
- `pnpm i18n:check` — passed
- `pnpm build` — passed
- `pnpm exec prettier --check packages/mail/src/bridge/useMailNavigation.test.tsx packages/mail/src/bridge/useMailNavigation.ts packages/mail/src/bridge/useMailWorkspace.test.tsx packages/mail/src/bridge/useMailWorkspace.ts` — passed
- `git diff --check` — passed

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes
- [ ] Updated documentation
- [x] Ran `pnpm i18n:check` or confirmed the change does not affect UI copy
- [x] Confirmed the change follows module ownership and does not add duplicate user-visible entry points
- [x] Described impact scope when shared components, messages, bridge, or services are changed
- [x] Followed commit message conventions (Conventional Commits)
