### PR TITLE
fix(desktop): bilingual fleet trust dialog (zh/en via app.getLocale)

### DIFF
--- a/apps/web/src-election/main/__tests__/fleetTrustDialog.test.ts
+++ b/apps/web/src-election/main/__tests__/fleetTrustDialog.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { fleetTrustDialogCopy } from "../fleetTrustDialog";
+
+describe("fleetTrustDialogCopy", () => {
+  const host = "onprem.customer.com";
+  const href = "https://onprem.customer.com/fleet/1/issues/WS-4";
+
+  it("returns zh copy for Chinese locales", () => {
+    for (const locale of ["zh-CN", "zh-TW", "zh-Hans", "zh"]) {
+      const copy = fleetTrustDialogCopy(locale, host, href);
+      expect(copy.title).toBe("信任此域名以打开任务预览？");
+      expect(copy.message).toContain(host);
+      expect(copy.detail).toContain(href);
+      expect(copy.buttons).toEqual(["允许", "拒绝"]);
+      expect(copy.checkboxLabel).toBe("允许并记住此域名");
+    }
+  });
+
+  it("returns en copy for non-Chinese locales", () => {
+    for (const locale of ["en-US", "en-GB", "ja-JP", "fr-FR", "de-DE", "en"]) {
+      const copy = fleetTrustDialogCopy(locale, host, href);
+      expect(copy.title).toBe("Trust this domain to open task previews?");
+      expect(copy.message).toContain(host);
+      expect(copy.detail).toContain(href);
+      expect(copy.buttons).toEqual(["Allow", "Deny"]);
+      expect(copy.checkboxLabel).toBe("Allow and remember this domain");
+    }
+  });
+
+  it("interpolates the host and href into the copy", () => {
+    const en = fleetTrustDialogCopy("en-US", host, href);
+    expect(en.message).toContain(host);
+    expect(en.detail).toContain(href);
+    const zh = fleetTrustDialogCopy("zh-CN", host, href);
+    expect(zh.message).toContain(host);
+    expect(zh.detail).toContain(href);
+  });
+});

--- a/apps/web/src-election/main/fleetTrustDialog.ts
+++ b/apps/web/src-election/main/fleetTrustDialog.ts
@@ -1,0 +1,55 @@
+/**
+ * Copy for the fleet trust dialog (unknown-host issue-preview prompt).
+ *
+ * Main-process native dialogs cannot reach the renderer i18n bundle, so the
+ * copy is resolved here from a locale string, mirroring the MIGRATION_DIALOGS
+ * pattern in main/index.ts. Pure on purpose: callers pass the resolved
+ * locale (typically `app.getLocale()` once `ready`), which keeps this module
+ * unit-testable without mocking Electron.
+ */
+
+export interface FleetTrustDialogCopy {
+  title: string;
+  message: string;
+  detail: string;
+  buttons: [string, string];
+  checkboxLabel: string;
+}
+
+export type FleetTrustDialogCopyFn = (
+  host: string,
+  href: string,
+) => FleetTrustDialogCopy;
+
+const FLEET_TRUST_DIALOG: {
+  zh: FleetTrustDialogCopyFn;
+  en: FleetTrustDialogCopyFn;
+} = {
+  zh: (host, href) => ({
+    title: "信任此域名以打开任务预览？",
+    message: `是否允许在“${host}”下打开任务预览？`,
+    detail: `链接：${href}`,
+    buttons: ["允许", "拒绝"],
+    checkboxLabel: "允许并记住此域名",
+  }),
+  en: (host, href) => ({
+    title: "Trust this domain to open task previews?",
+    message: `Allow task previews from “${host}”?`,
+    detail: `Link: ${href}`,
+    buttons: ["Allow", "Deny"],
+    checkboxLabel: "Allow and remember this domain",
+  }),
+};
+
+/**
+ * Resolve the dialog copy for the given locale. Any locale whose primary
+ * language is Chinese gets zh; everything else gets en.
+ */
+export function fleetTrustDialogCopy(
+  locale: string,
+  host: string,
+  href: string,
+): FleetTrustDialogCopy {
+  const zh = locale.toLowerCase().startsWith("zh");
+  return FLEET_TRUST_DIALOG[zh ? "zh" : "en"](host, href);
+}

--- a/apps/web/src-election/main/index.ts
+++ b/apps/web/src-election/main/index.ts
@@ -24,6 +24,7 @@ import { pathToFileURL } from "url";
 import logo, { getNoMessageTrayIcon } from "./logo";
 import { decideWindowOpen } from "./externalLink";
 import { isFleetIssuePathShape } from "./fleetTrust";
+import { fleetTrustDialogCopy } from "./fleetTrustDialog";
 import {
   IPC_CONVERSATION_UNREAD_COUNT,
   IPC_KEEP_AWAKE_GET,
@@ -455,20 +456,21 @@ async function promptFleetTrustOnce(
 ): Promise<boolean> {
   const existing = inflightFleetTrustPrompts.get(host);
   if (existing) return existing;
+  const copy = fleetTrustDialogCopy(app.getLocale(), host, href);
   const prompt = (async (): Promise<boolean> => {
     const { response, checkboxChecked } = await dialog.showMessageBox(win, {
       type: "warning",
-      title: "信任此域名以打开任务预览？",
-      message: `是否允许在“${host}”下打开任务预览？`,
-      detail: `链接：${href}`,
-      buttons: ["允许", "拒绝"],
-      defaultId: 1, // 默认拒绝
+      title: copy.title,
+      message: copy.message,
+      detail: copy.detail,
+      buttons: copy.buttons,
+      defaultId: 1, // 默认拒绝 / default deny
       cancelId: 1, // Esc / 关闭窗口也按"拒绝"处理，弹窗失败永远 fail-closed
       noLink: true, // plain buttons, no command-link Enter mapping
       // Allow-only semantics: the checkbox is persisted only when the user
-      // clicks 允许 (rememberFleetTrustedHost runs for response === 0), so
-      // the label must not promise "never ask again" for the reject side.
-      checkboxLabel: "允许并记住此域名",
+      // clicks 允许/Allow (rememberFleetTrustedHost runs for response === 0),
+      // so the label must not promise "never ask again" for the reject side.
+      checkboxLabel: copy.checkboxLabel,
       checkboxChecked: false,
     });
     if (checkboxChecked && response === 0) {


### PR DESCRIPTION
## Summary

The fleet trust dialog (unknown-host issue-preview prompt, introduced in #1505) was hard-coded **zh-CN**. This PR makes it bilingual via the same `app.getLocale()` pattern the main process already uses for native dialogs (`MIGRATION_DIALOGS`).

- New pure module `apps/web/src-election/main/fleetTrustDialog.ts`: `FLEET_TRUST_DIALOG` (zh/en copy) + `fleetTrustDialogCopy(locale, host, href)`. The locale is passed in as an argument so the module is unit-testable without mocking Electron (same shape as the existing `fleetTrust.ts`).
- `promptFleetTrustOnce` in `main/index.ts` resolves the dialog copy through `fleetTrustDialogCopy(app.getLocale(), host, href)` — `title`, `message`, `detail`, `buttons`, `checkboxLabel` all come from the copy. Chinese locales keep the existing copy; everything else gets English (`Trust this domain to open task previews?` / Allow / Deny / `Allow and remember this domain`).
- No behaviour change for zh users; en users no longer see Chinese buttons.

## Related Issue

Follow-up #1508 (i18n item), listed by both reviewers (yujiawei P2-9, Jerry-Xin N2, mochashanyao P2) as non-blocking for #1505.

## Changes

- `apps/web/src-election/main/fleetTrustDialog.ts` — new pure module (dialog copy + locale resolver)
- `apps/web/src-election/main/__tests__/fleetTrustDialog.test.ts` — 3 cases: zh variants (zh-CN/zh-TW/zh-Hans/zh), non-zh variants (en-US/en-GB/ja-JP/fr-FR/de-DE/en), host/href interpolation
- `apps/web/src-election/main/index.ts` — `promptFleetTrustOnce` uses the resolver

## Testing

- [x] `fleetTrustDialog` suite 3/3
- [x] `src-election` full suite 173/173
- [x] `tsc -p tsconfig.e.json` + `tsconfig.e.tests.json` clean
- [x] Local `build:electron` passes (56.9s)

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Ran relevant unit tests
- [x] Confirmed the change follows module ownership
