### PR TITLE
fix(skillmarket): give platform-published cards the official surface

### DIFF
--- a/packages/dmworkskillmarket/src/components/SkillCard.tsx
+++ b/packages/dmworkskillmarket/src/components/SkillCard.tsx
@@ -171,7 +171,11 @@ export default function SkillCard({ skill, categories: _categories, onOpen, onEd
 
   return (
     <article
-      className={isOwnerCard ? "skill-market-card skill-market-card--owner" : "skill-market-card"}
+      className={[
+        "skill-market-card",
+        isOwnerCard ? "skill-market-card--owner" : "",
+        isPlatformPublished ? "skill-market-card--official" : "",
+      ].filter(Boolean).join(" ")}
       role="button"
       tabIndex={0}
       aria-label={ariaLabel}

--- a/packages/dmworkskillmarket/src/components/__tests__/SkillCard.test.tsx
+++ b/packages/dmworkskillmarket/src/components/__tests__/SkillCard.test.tsx
@@ -62,6 +62,7 @@ describe("SkillCard", () => {
     expect(screen.queryByText("我")).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "ci-helper 官方发布" })).toBeInTheDocument();
     expect(container.querySelector(".skill-market-card__owner-platform-icon")).toBeInTheDocument();
+    expect(container.querySelector(".skill-market-card--official")).toBeInTheDocument();
   });
 
   it("shows creator and owner when they are different", () => {

--- a/packages/dmworkskillmarket/src/index.css
+++ b/packages/dmworkskillmarket/src/index.css
@@ -670,6 +670,18 @@
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
 }
 
+/* Platform-published cards get the same AI-tinted surface as
+   `.wk-mcp-card--official` in dmworkmcp so all markets read alike. */
+.skill-market-card--official {
+  border-color: var(--wk-ai-border);
+  background: var(--wk-ai-surface);
+}
+
+.skill-market-card--official:hover,
+.skill-market-card--official:focus-visible {
+  border-color: var(--wk-color-accent);
+}
+
 .skill-market-card__top {
   display: flex;
   align-items: flex-start;


### PR DESCRIPTION
## Summary

Skill market cards already show the ShieldCheck icon + "官方发布" label for platform-published (`visibility === "public"`) skills, but the card surface stayed identical to regular cards. MCP and Expert market cards tint official entries via `wk-mcp-card--official` (`--wk-ai-border` border + `--wk-ai-surface` background, accent border on hover).

This adds a matching `skill-market-card--official` modifier to `SkillCard` using the same theme tokens and hover behavior, so official cards look consistent across all three markets. The modifier composes with the existing `--owner` modifier and reuses the same `isPlatformPublishedSkill` predicate as the label, so surface and label can never disagree.

## How verified

- `npx vitest run` in `packages/dmworkskillmarket`: 14 files / 129 tests pass.
- Extended the existing "renders public skills as platform-published" test to assert the `--official` class is applied.
- Confirmed `--wk-ai-border` / `--wk-ai-surface` are defined in both light and dark themes in `dmworkbase/src/theme/semantic.css`, and that the official hover rule sits after the base hover rule so it wins at equal specificity.

Trivial presentation-only change — no spec/COMPREHENSION section required per `pr.md`.