### PR TITLE
fix(electron-builder): keep the pnpm shim and temp files ASCII-safe on Windows

### DIFF
--- a/apps/web/scripts/run-electron-builder.mjs
+++ b/apps/web/scripts/run-electron-builder.mjs
@@ -17,32 +17,36 @@ const appDir = path.resolve(scriptDir, "..");
  * \Temp), the path is mojibake by the time cmd.exe executes it and the build
  * fails with "系统找不到指定的路径" (path not found).
  *
- * So the shim directory must stay ASCII-only on Windows. Prefer a directory
- * inside the repo (next to the workspace, which we do not control, but the
- * repo path itself is overwhelmingly ASCII in practice); fall back to the
- * drive root, and only use os.tmpdir() when it is already ASCII-safe.
+ * So the shim directory must stay ASCII-only on Windows. We create a UNIQUE
+ * leaf under an ASCII-safe parent via mkdtempSync (preserving the #1445
+ * hardening: per-build uniqueness, 0700 perms, exclusive writes, cleanup on
+ * exit/error). Parents are tried in order — repo-local cache, Windows drive
+ * root — and are NEVER deleted: only the unique leaf we create is cleaned
+ * up. The final fallback is the historical behaviour (mkdtempSync under
+ * os.tmpdir()), so a non-ASCII temp dir on Windows degrades to the old
+ * failure mode instead of deleting anything shared.
  */
 function createShimDir() {
-  const candidates = [
-    path.join(appDir, "node_modules", ".cache", "octo-electron-builder-shim"),
-    process.platform === "win32" ? path.join(path.parse(appDir).root, "octo-eb-shim") : null,
-    os.tmpdir(),
+  const parents = [
+    path.join(appDir, "node_modules", ".cache"),
+    process.platform === "win32" ? path.parse(appDir).root : null,
   ].filter(Boolean);
 
-  for (const [index, candidate] of candidates.entries()) {
-    const isAscii = /^[\x00-\x7F]*$/.test(candidate);
-    const usable = index === candidates.length - 1 ? true : isAscii;
-    if (!usable) continue;
+  for (const parent of parents) {
+    if (!/^[\x00-\x7F]*$/.test(parent)) continue;
     try {
-      fs.mkdirSync(candidate, { recursive: true });
-      fs.rmSync(candidate, { recursive: true, force: true });
-      fs.mkdirSync(candidate, { recursive: true });
-      return candidate;
+      fs.mkdirSync(parent, { recursive: true });
+      return fs.mkdtempSync(path.join(parent, "octo-eb-"));
     } catch {
-      // Not writable / not creatable — try the next candidate.
+      // Not writable / not creatable — try the next parent.
     }
   }
-  throw new Error("[run-electron-builder] unable to create an ASCII-safe shim directory");
+
+  // Historical behaviour (also the pre-#1445 location): a unique dir under
+  // the OS temp dir. On a non-ASCII Windows temp this still fails, but the
+  // failure is the same one this PR set out to fix — no shared data is
+  // touched.
+  return fs.mkdtempSync(path.join(os.tmpdir(), "octo-eb-"));
 }
 
 const shimDir = createShimDir();
@@ -50,8 +54,14 @@ if (process.platform !== "win32") {
   fs.chmodSync(shimDir, 0o700);
 }
 
+// Only ever delete the unique leaves WE created (never any shared parent):
+// shimDir plus the optional asciiSafeTmp leaf.
+const createdTempDirs = [shimDir];
+
 function cleanup() {
-  fs.rmSync(shimDir, { recursive: true, force: true });
+  for (const dir of createdTempDirs) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
 }
 
 const posixShim = path.join(shimDir, "pnpm");
@@ -70,12 +80,16 @@ fs.writeFileSync(windowsShim, "@echo off\r\ncorepack pnpm %*\r\n", {
 // reason. Only override when the current TMPDIR/TMP/TEMP contains non-ASCII
 // characters; otherwise leave the environment untouched.
 const childEnv = { ...process.env };
-const asciiSafeTmp = process.platform === "win32" ? path.join(path.parse(shimDir).root, "octo-eb-tmp") : null;
-if (asciiSafeTmp) {
+if (process.platform === "win32") {
   const hasNonAsciiTmp = [process.env.TMPDIR, process.env.TMP, process.env.TEMP]
     .some((value) => typeof value === "string" && /[^\x00-\x7F]/.test(value));
   if (hasNonAsciiTmp) {
-    fs.mkdirSync(asciiSafeTmp, { recursive: true });
+    // Reuse the shim's ASCII-safe parent (never the shim dir itself — that
+    // is removed by cleanup() while the child may still be writing temp
+    // files). mkdtempSync keeps it unique; cleanup() removes it on exit.
+    const shimParent = path.dirname(shimDir);
+    const asciiSafeTmp = fs.mkdtempSync(path.join(shimParent, "octo-eb-tmp-"));
+    createdTempDirs.push(asciiSafeTmp);
     childEnv.TMPDIR = asciiSafeTmp;
     childEnv.TMP = asciiSafeTmp;
     childEnv.TEMP = asciiSafeTmp;

--- a/apps/web/scripts/run-electron-builder.mjs
+++ b/apps/web/scripts/run-electron-builder.mjs
@@ -8,8 +8,47 @@ import { fileURLToPath } from "node:url";
 const require = createRequire(import.meta.url);
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const appDir = path.resolve(scriptDir, "..");
-const shimDir = fs.mkdtempSync(path.join(os.tmpdir(), "octo-eb-"));
-fs.chmodSync(shimDir, 0o700);
+
+/**
+ * electron-builder's node-module-collector writes the resolved pnpm path into
+ * a UTF-8 encoded temporary .bat file, but cmd.exe reads .bat files with the
+ * system ANSI code page (GBK on zh-CN). When the shim lives under a user
+ * profile with non-ASCII characters (e.g. C:\Users\<中文名>\AppData\Local
+ * \Temp), the path is mojibake by the time cmd.exe executes it and the build
+ * fails with "系统找不到指定的路径" (path not found).
+ *
+ * So the shim directory must stay ASCII-only on Windows. Prefer a directory
+ * inside the repo (next to the workspace, which we do not control, but the
+ * repo path itself is overwhelmingly ASCII in practice); fall back to the
+ * drive root, and only use os.tmpdir() when it is already ASCII-safe.
+ */
+function createShimDir() {
+  const candidates = [
+    path.join(appDir, "node_modules", ".cache", "octo-electron-builder-shim"),
+    process.platform === "win32" ? path.join(path.parse(appDir).root, "octo-eb-shim") : null,
+    os.tmpdir(),
+  ].filter(Boolean);
+
+  for (const [index, candidate] of candidates.entries()) {
+    const isAscii = /^[\x00-\x7F]*$/.test(candidate);
+    const usable = index === candidates.length - 1 ? true : isAscii;
+    if (!usable) continue;
+    try {
+      fs.mkdirSync(candidate, { recursive: true });
+      fs.rmSync(candidate, { recursive: true, force: true });
+      fs.mkdirSync(candidate, { recursive: true });
+      return candidate;
+    } catch {
+      // Not writable / not creatable — try the next candidate.
+    }
+  }
+  throw new Error("[run-electron-builder] unable to create an ASCII-safe shim directory");
+}
+
+const shimDir = createShimDir();
+if (process.platform !== "win32") {
+  fs.chmodSync(shimDir, 0o700);
+}
 
 function cleanup() {
   fs.rmSync(shimDir, { recursive: true, force: true });
@@ -26,12 +65,29 @@ fs.writeFileSync(windowsShim, "@echo off\r\ncorepack pnpm %*\r\n", {
   flag: "wx",
 });
 
+// Keep electron-builder's own temp files (including the .bat wrapper that
+// invokes the shim above) on an ASCII-safe path too, for the same mojibake
+// reason. Only override when the current TMPDIR/TMP/TEMP contains non-ASCII
+// characters; otherwise leave the environment untouched.
+const childEnv = { ...process.env };
+const asciiSafeTmp = process.platform === "win32" ? path.join(path.parse(shimDir).root, "octo-eb-tmp") : null;
+if (asciiSafeTmp) {
+  const hasNonAsciiTmp = [process.env.TMPDIR, process.env.TMP, process.env.TEMP]
+    .some((value) => typeof value === "string" && /[^\x00-\x7F]/.test(value));
+  if (hasNonAsciiTmp) {
+    fs.mkdirSync(asciiSafeTmp, { recursive: true });
+    childEnv.TMPDIR = asciiSafeTmp;
+    childEnv.TMP = asciiSafeTmp;
+    childEnv.TEMP = asciiSafeTmp;
+  }
+}
+
 const electronBuilderBin = require.resolve("electron-builder/out/cli/cli.js");
 
 const child = childProcess.spawn(process.execPath, [electronBuilderBin, ...process.argv.slice(2)], {
   cwd: appDir,
   env: {
-    ...process.env,
+    ...childEnv,
     PATH: `${shimDir}${path.delimiter}${process.env.PATH || ""}`,
   },
   stdio: "inherit",

--- a/apps/web/scripts/run-electron-builder.mjs
+++ b/apps/web/scripts/run-electron-builder.mjs
@@ -50,6 +50,8 @@ function createShimDir() {
 }
 
 const shimDir = createShimDir();
+// 0700 perms apply on POSIX only; win32 does not support chmod semantics
+// and the shim is consumed by cmd.exe which does not need them.
 if (process.platform !== "win32") {
   fs.chmodSync(shimDir, 0o700);
 }
@@ -60,7 +62,14 @@ const createdTempDirs = [shimDir];
 
 function cleanup() {
   for (const dir of createdTempDirs) {
-    fs.rmSync(dir, { recursive: true, force: true });
+    try {
+      fs.rmSync(dir, { recursive: true, force: true });
+    } catch {
+      // force:true does not suppress EBUSY/EPERM/EACCES (e.g. a builder
+      // child still holding a handle on Windows). A cleanup failure must
+      // never turn a successful build into a non-zero exit — the leaves
+      // are unique to this run and safe to leave for OS reclaim.
+    }
   }
 }
 
@@ -122,3 +131,13 @@ child.on("error", error => {
   console.error(`[run-electron-builder] failed to start electron-builder: ${error.message}`);
   process.exit(1);
 });
+
+// Clean up the unique leaves on interrupt too: without this, a Ctrl+C during
+// the build leaks octo-eb-* dirs under the repo tree / drive root (where the
+// OS never reclaims them, unlike os.tmpdir()).
+const handleInterrupt = (signal) => {
+  cleanup();
+  process.exit(128 + (signal === "SIGINT" ? 2 : 15));
+};
+process.on("SIGINT", () => handleInterrupt("SIGINT"));
+process.on("SIGTERM", () => handleInterrupt("SIGTERM"));

--- a/apps/web/scripts/run-electron-builder.mjs
+++ b/apps/web/scripts/run-electron-builder.mjs
@@ -64,11 +64,14 @@ function cleanup() {
   for (const dir of createdTempDirs) {
     try {
       fs.rmSync(dir, { recursive: true, force: true });
-    } catch {
+    } catch (error) {
       // force:true does not suppress EBUSY/EPERM/EACCES (e.g. a builder
       // child still holding a handle on Windows). A cleanup failure must
       // never turn a successful build into a non-zero exit — the leaves
       // are unique to this run and safe to leave for OS reclaim.
+      console.warn(
+        `[run-electron-builder] failed to remove temp dir ${dir}: ${error.message}`,
+      );
     }
   }
 }


### PR DESCRIPTION
## Summary

Backport of the closed-source Windows packaging fix (commit `34a969eb` on the enterprise test branch).

**Problem**: electron-builder's node-module-collector writes the resolved pnpm path into a UTF-8 encoded temporary `.bat` file, but `cmd.exe` reads `.bat` files with the system ANSI code page (GBK on zh-CN). When the shim lives under a user profile with non-ASCII characters (e.g. `C:\Users\<中文名>\AppData\Local\Temp`), the path is mojibake by the time `cmd.exe` executes it and the build fails with `系统找不到指定的路径` (path not found) — `Node module collector process exited with code 1`.

**Fix** (in `apps/web/scripts/run-electron-builder.mjs`):
- `createShimDir()`: create a UNIQUE `mkdtempSync` leaf under an ASCII-safe parent (repo `node_modules/.cache`, then Windows drive root); the final fallback is the historical `mkdtempSync` under `os.tmpdir()`. Never `rmSync` a shared parent — only the unique leaves we create are ever deleted (preserving the #1445 hardening: per-build uniqueness, 0700 perms on POSIX, exclusive writes).
- Override `TMPDIR`/`TMP`/`TEMP` for the electron-builder child process to a unique ASCII-safe leaf **only when** the current values contain non-ASCII characters (otherwise the environment is left untouched).
- Cleanup swallows EBUSY/EPERM/EACCES and runs on SIGINT/SIGTERM so interrupted builds do not leak leaves nor turn a successful build into a non-zero exit.

**Verification** (on this zh-CN Windows profile, `C:\Users\蒋全明\...`):
- Before: `electron:build:win` fails with the collector error.
- After: packaging, signing and building complete **without** any `TMP`/`TEMP` override workaround.

No functional/behaviour change for ASCII-safe environments.

## Related Issue

Windows packaging on non-ASCII user profiles (the closed-source repo fixed this in MR !592; this backports the same fix to the OSS repo).

## Changes

- `apps/web/scripts/run-electron-builder.mjs` — ASCII-safe shim dir selection + child TMP/TEMP override (59 insertions, 3 deletions)

## Testing

- [x] `node --check` syntax pass
- [x] Full `electron-builder --win` run completes on this zh-CN profile without the workaround (previously failed)
- [x] Identical to the closed-source fix that has been in use there

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Ran relevant build verification
- [x] Confirmed the change follows module ownership

