### PR TITLE
fix(desktop): resolve public sticker URLs in packaged shells

### DIFF
--- a/packages/dmworkbase/src/Service/EmojiService.ts
+++ b/packages/dmworkbase/src/Service/EmojiService.ts
@@ -407,6 +407,30 @@ export class DefaultEmojiService implements EmojiService {
         if (/^data:image\//i.test(url)) {
             return url
         }
+        // Sticker/emoji files are exposed by the public object-storage route.
+        // A packaged Electron page has a file:// origin, so resolving this
+        // against window.location.origin would produce null/file/... (or a
+        // local file path). Prefer the absolute API origin in that shell.
+        const previewMatch = url.match(/^\/?file\/preview\/(.+)$/)
+        if (previewMatch) {
+            let apiBase = ""
+            try {
+                apiBase = (APIClient.shared?.config?.apiURL as string) || ""
+            } catch {
+                apiBase = ""
+            }
+            const locationHref = typeof window !== "undefined" ? window.location.href : ""
+            for (const candidate of [apiBase, locationHref]) {
+                try {
+                    const resolved = new URL(candidate, locationHref || undefined)
+                    if (resolved.protocol === "http:" || resolved.protocol === "https:") {
+                        return `${resolved.origin}/file/${previewMatch[1]}`
+                    }
+                } catch {
+                    // Try the next candidate.
+                }
+            }
+        }
         // 相对 url 拼到 API v1 base（如 "/api/v1/" 或 "https://host/v1/"）。
         let base = ""
         try {

--- a/packages/dmworkbase/src/Service/__tests__/EmojiService.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/EmojiService.test.ts
@@ -96,6 +96,23 @@ describe("EmojiService load() 拉取服务端 manifest", () => {
     expect(cached.list).toHaveLength(3)
   })
 
+  it("file/preview 表情路径在桌面包中使用 API origin，不拼成 file:// 路径", async () => {
+    const originalApiURL = APIClient.shared.config.apiURL
+    APIClient.shared.config.apiURL = "https://im.deepminer.com.cn/v1/"
+    apiGet.mockResolvedValueOnce({
+      version: 8,
+      list: [{ key: "[服务端贴图]", name: "服务端贴图", url: "file/preview/emoji/u/x.png" }],
+    })
+
+    try {
+      const svc = freshService()
+      await svc.load?.()
+      expect(svc.getImage("[服务端贴图]")).toBe("https://im.deepminer.com.cn/file/emoji/u/x.png")
+    } finally {
+      APIClient.shared.config.apiURL = originalApiURL
+    }
+  })
+
   it("过滤空/非法 key：空分支绝不进正则（防零宽匹配渲染死循环）", async () => {
     const manifest = {
       version: 9,

--- a/packages/dmworkdatasource/src/datasource.test.ts
+++ b/packages/dmworkdatasource/src/datasource.test.ts
@@ -120,7 +120,7 @@ vi.mock("wukongimjssdk", () => ({
     },
 }))
 
-import { ChannelDataSource, CommonDataSource, shouldAttachUploadToken } from "./datasource"
+import { ChannelDataSource, CommonDataSource, resolvePublicFileURL, shouldAttachUploadToken } from "./datasource"
 import { Channel } from "wukongimjssdk"
 
 describe("ChannelDataSource.threadDelete", () => {
@@ -251,6 +251,38 @@ describe("shouldAttachUploadToken (sticker upload same-origin guard)", () => {
 
     it("withholds on a malformed upload URL", () => {
         expect(shouldAttachUploadToken("http://[::::", "/api/v1/", loc)).toBe(false)
+    })
+})
+
+describe("resolvePublicFileURL (web and packaged Electron)", () => {
+    it("uses the web document origin when the API URL is relative", () => {
+        expect(
+            resolvePublicFileURL(
+                "file/preview/sticker/u/x.png",
+                "/api/v1/",
+                "https://app.example.com/chat",
+            ),
+        ).toBe("https://app.example.com/file/sticker/u/x.png")
+    })
+
+    it("uses the absolute API origin when the document is packaged under file://", () => {
+        expect(
+            resolvePublicFileURL(
+                "file/preview/sticker/u/x.png",
+                "https://im.deepminer.com.cn/v1/",
+                "file:///Applications/OCTO.app/Contents/Resources/app.asar/build/index.html",
+            ),
+        ).toBe("https://im.deepminer.com.cn/file/sticker/u/x.png")
+    })
+
+    it("does not generate a null/file URL for a packaged shell", () => {
+        const resolved = resolvePublicFileURL(
+            "file/preview/sticker/u/x.png",
+            "https://im.deepminer.com.cn/v1/",
+            "file:///Applications/OCTO.app/Contents/Resources/app.asar/build/index.html",
+        )
+        expect(resolved).not.toContain("null/file/")
+        expect(resolved).not.toContain("file:///file/")
     })
 })
 

--- a/packages/dmworkdatasource/src/datasource.ts
+++ b/packages/dmworkdatasource/src/datasource.ts
@@ -492,6 +492,39 @@ export function shouldAttachUploadToken(uploadURL: string, apiBaseURL: string, l
     }
 }
 
+/**
+ * Resolve public object-storage paths for both web and packaged desktop shells.
+ *
+ * Web uses a same-origin `/file/...` route, while a packaged Electron page is
+ * loaded from `file://` and therefore has no usable HTTP origin. In that case
+ * the API origin is the only valid base (the API URL is absolute in desktop
+ * production builds).
+ */
+export function resolvePublicFileURL(
+    path: string,
+    apiBaseURL: string,
+    locationHref: string,
+): string {
+    const cleanPath = path.replace(/^file\/preview\//, "file/")
+    const candidateOrigins = [apiBaseURL, locationHref]
+
+    for (const candidate of candidateOrigins) {
+        try {
+            const url = new URL(candidate, locationHref || undefined)
+            if (url.protocol === "http:" || url.protocol === "https:") {
+                return `${url.origin}/${cleanPath}`
+            }
+        } catch {
+            // Try the next candidate. The API client still handles other paths.
+        }
+    }
+
+    // Keep a deterministic fallback for non-browser callers. In a real
+    // Electron release apiBaseURL is absolute, so this branch is only for
+    // incomplete mocks or unusual embedding environments.
+    return `${apiBaseURL}${cleanPath}`
+}
+
 // Isolated axios instance carrying NONE of the project request interceptors. The
 // shared global axios has a request interceptor (APIClient) that injects the
 // session token into EVERY call with no origin scoping; an upload to a
@@ -635,8 +668,8 @@ export class CommonDataSource implements ICommonDataSource {
         }
         // file/preview/* paths use public MinIO URL (no auth needed)
         if (path.startsWith('file/preview/')) {
-            const origin = typeof window !== 'undefined' ? window.location.origin : ''
-            return `${origin}/${path.replace(/^file\/preview\//, "file/")}`
+            const locationHref = typeof window !== 'undefined' ? window.location.href : ''
+            return resolvePublicFileURL(path, WKApp.apiClient.config.apiURL, locationHref)
         }
         // All other paths go through API (e.g. users/xxx/avatar)
         const baseURL = WKApp.apiClient.config.apiURL
@@ -651,8 +684,8 @@ export class CommonDataSource implements ICommonDataSource {
             }
         }
         if (path.startsWith('file/preview/')) {
-            const origin = typeof window !== 'undefined' ? window.location.origin : ''
-            return `${origin}/${path.replace(/^file\/preview\//, "file/")}`
+            const locationHref = typeof window !== 'undefined' ? window.location.href : ''
+            return resolvePublicFileURL(path, WKApp.apiClient.config.apiURL, locationHref)
         }
         const baseURL = WKApp.apiClient.config.apiURL
         return `${baseURL}${path}`


### PR DESCRIPTION
## Summary

Backport of the closed-source fix (commit `08fddb44` by shixiaoze) — resolve public sticker/emoji URLs correctly in packaged desktop shells.

**Problem**: sticker/emoji files are exposed by the public object-storage route (`/file/preview/...`). A packaged Electron page has a `file://` origin, so resolving these against `window.location.origin` produces `null/file/...` (or a local file path) — stickers/emojis break on desktop.

**Fix**:
- New pure helper `resolvePublicFileURL(path, apiBaseURL, locationHref)` in `packages/dmworkdatasource/src/datasource.ts`: tries the API origin first (absolute in desktop production builds), then the document origin, and only falls back to non-browser callers deterministically. Handles both web (same-origin `/file/...`) and packaged shells.
- `CommonDataSource.fileURL` / `fileURLWithSize` use the helper.
- `EmojiService` resolves `/file/preview/` URLs against the API origin in the packaged shell.
- Tests: 3 new `resolvePublicFileURL` cases (web relative API, packaged `file://` shell, no-`null/file` guarantee) + 1 EmojiService packaged-shell case.

## Related Issue

Desktop-shell sticker/emoji URL resolution (closed-source repo; backported to OSS).

## Changes

- `packages/dmworkdatasource/src/datasource.ts` — `resolvePublicFileURL` helper + use in `CommonDataSource` (2 call sites)
- `packages/dmworkdatasource/src/datasource.test.ts` — 3 new helper tests
- `packages/dmworkbase/src/Service/EmojiService.ts` — `/file/preview/` resolution via API origin
- `packages/dmworkbase/src/Service/__tests__/EmojiService.test.ts` — 1 new packaged-shell case

## Testing

- [x] `EmojiService` suite 11/11 pass
- [x] `datasource` suite: new helper tests pass (3/3); one unrelated pre-existing failure (`threadDelete` — `@octo/base` mock missing `deleteImChannelInfo` export, present on closed-source branch, untouched by this PR)
- [x] `tsc` clean (both configs) for touched packages

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Ran relevant unit tests
- [x] Confirmed the change follows module ownership
