### PR TITLE
fix(chat): hide orphan separator in empty follow submenu

### DIFF
--- a/packages/dmworkbase/src/Components/ChatConversationList/__tests__/ChatConversationList.test.tsx
+++ b/packages/dmworkbase/src/Components/ChatConversationList/__tests__/ChatConversationList.test.tsx
@@ -1,3 +1,7 @@
+/**
+ * @vitest-environment jsdom
+ */
+
 import React from "react"
 import ReactDOM from "react-dom"
 import { act } from "react-dom/test-utils"
@@ -5,6 +9,8 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vite
 
 let ChatConversationList: typeof import("../index").default
 let container: HTMLDivElement
+let mockCategories: Array<any> = []
+let latestExtraContextMenus: ((conversation: any) => Array<any>) | undefined
 
 beforeAll(async () => {
     vi.doMock("wukongimjssdk", () => ({
@@ -36,7 +42,7 @@ beforeAll(async () => {
 
     vi.doMock("../../../Hooks/useCategoryList", () => ({
         useCategoryList: () => ({
-            categories: [],
+            categories: mockCategories,
             isLoading: false,
             error: null,
             reload: vi.fn(),
@@ -87,13 +93,22 @@ beforeAll(async () => {
     }))
 
     vi.doMock("../../ConversationList", () => ({
-        default: ({ conversations }: { conversations: Array<any> }) => (
-            <div data-testid="conversation-list">
-                {conversations.map((conv) => (
-                    <span key={conv.channel.channelID}>{conv.channel.channelID}</span>
-                ))}
-            </div>
-        ),
+        default: ({
+            conversations,
+            extraContextMenus,
+        }: {
+            conversations: Array<any>
+            extraContextMenus?: (conversation: any) => Array<any>
+        }) => {
+            latestExtraContextMenus = extraContextMenus
+            return (
+                <div data-testid="conversation-list">
+                    {conversations.map((conv) => (
+                        <span key={conv.channel.channelID}>{conv.channel.channelID}</span>
+                    ))}
+                </div>
+            )
+        },
     }))
 
     ChatConversationList = (await import("../index")).default
@@ -101,6 +116,8 @@ beforeAll(async () => {
 
 beforeEach(() => {
     vi.clearAllMocks()
+    mockCategories = []
+    latestExtraContextMenus = undefined
     container = document.createElement("div")
     document.body.appendChild(container)
 })
@@ -143,5 +160,83 @@ describe("ChatConversationList", () => {
 
         expect(container.textContent).toContain("stale-group")
         expect(container.textContent).toContain("recent-group")
+    })
+
+    it("does not add an orphan separator when no custom category exists", () => {
+        mockCategories = [{ category_id: "default", name: "默认分组", is_default: true }]
+        const conversation = makeGroupConversation("unfollowed-group", 1)
+
+        act(() => {
+            ReactDOM.render(
+                <ChatConversationList
+                    conversations={[conversation] as any}
+                    filter="all"
+                    onConversationClick={() => {}}
+                    onClearMessages={() => {}}
+                    onThreadOverflowClick={() => {}}
+                />,
+                container
+            )
+        })
+
+        const children = latestExtraContextMenus?.(conversation)?.[0]?.children
+        expect(children).toHaveLength(1)
+        expect(children?.[0]?.separator).not.toBe(true)
+        expect(children?.[0]?.title).toBe("base.chatSidebar.context.createCategory")
+    })
+
+    it("keeps one separator when at least one custom category exists", () => {
+        mockCategories = [
+            { category_id: "default", name: "默认分组", is_default: true },
+            { category_id: "engineering", name: "研发", is_default: false },
+        ]
+        const conversation = makeGroupConversation("unfollowed-group", 1)
+
+        act(() => {
+            ReactDOM.render(
+                <ChatConversationList
+                    conversations={[conversation] as any}
+                    filter="all"
+                    onConversationClick={() => {}}
+                    onClearMessages={() => {}}
+                    onThreadOverflowClick={() => {}}
+                />,
+                container
+            )
+        })
+
+        const children = latestExtraContextMenus?.(conversation)?.[0]?.children
+        expect(children?.map((item: any) => item.separator ? "separator" : item.title)).toEqual([
+            "研发",
+            "separator",
+            "base.chatSidebar.context.createCategory",
+        ])
+    })
+
+    it("applies the zero-category rule to a thread whose parent is not followed", () => {
+        const conversation = {
+            channel: { channelID: "thread-1", channelType: 5 },
+            channelInfo: { orgData: { parentGroupNo: "parent-group" } },
+            timestamp: 1,
+            unread: 0,
+        }
+
+        act(() => {
+            ReactDOM.render(
+                <ChatConversationList
+                    conversations={[conversation] as any}
+                    filter="all"
+                    onConversationClick={() => {}}
+                    onClearMessages={() => {}}
+                    onThreadOverflowClick={() => {}}
+                />,
+                container
+            )
+        })
+
+        const children = latestExtraContextMenus?.(conversation)?.[0]?.children
+        expect(children).toHaveLength(1)
+        expect(children?.[0]?.separator).not.toBe(true)
+        expect(children?.[0]?.title).toBe("base.chatSidebar.context.createCategory")
     })
 })

--- a/packages/dmworkbase/src/Components/ChatConversationList/index.tsx
+++ b/packages/dmworkbase/src/Components/ChatConversationList/index.tsx
@@ -321,7 +321,9 @@ const ChatConversationList: React.FC<ChatConversationListProps> = ({
                                     }
                                 }
                             }))
-                        categoryItems.push({ separator: true } as ContextMenusData)
+                        if (categoryItems.length > 0) {
+                            categoryItems.push({ separator: true } as ContextMenusData)
+                        }
                         categoryItems.push({
                             title: t("base.chatSidebar.context.createCategory"),
                             icon: FolderPlus,
@@ -352,7 +354,9 @@ const ChatConversationList: React.FC<ChatConversationListProps> = ({
                                 }
                             }
                         }))
-                    categoryItems.push({ separator: true } as ContextMenusData)
+                    if (categoryItems.length > 0) {
+                        categoryItems.push({ separator: true } as ContextMenusData)
+                    }
                     categoryItems.push({
                         title: t("base.chatSidebar.context.createCategory"),
                         icon: FolderPlus,


### PR DESCRIPTION
## Summary

Prevent the Add to follow submenu from rendering an orphan separator when no valid custom categories are available.

## Related Issue

None.

## Changes

- Add a separator only when the filtered custom-category list is non-empty.
- Apply the same rule to regular conversations and topics whose parent group is not followed.
- Add regression coverage for zero-category, populated-category, and topic paths.

## Architecture / Module Boundary

- Affected module(s): `@octo/base` chat conversation sidebar
- New or changed user-visible entry point: no; this corrects the existing Recent > Add to follow submenu
- Shared layer touched: `Components/ChatConversationList` only
- If shared code changed, impact scope: no shared primitive or API changed
- Duplicate entry point checked: not applicable

## Testing

- [x] Unit tests added/updated: `pnpm exec vitest run packages/dmworkbase/src/Components/ChatConversationList/__tests__/ChatConversationList.test.tsx` (4/4)
- [x] `pnpm --filter @octo/web build`
- [x] `pnpm i18n:check`
- [x] `git diff --check`
- [x] Manually verified the zero-category result and the populated-category regression at `http://localhost:3000/`

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Documentation checked; no repository documentation update is required for this bug fix
- [x] Ran `pnpm i18n:check`; no UI copy changed
- [x] Confirmed the change follows module ownership and does not add duplicate user-visible entry points
- [x] Described impact scope; no shared primitive, message renderer, bridge, or service changed
- [x] Followed commit message conventions (Conventional Commits)