### PR TITLE
feat(market): migrate marketplace API layer to the unified plugin backend

### DIFF
--- a/.i18n/scan-config.json
+++ b/.i18n/scan-config.json
@@ -1,6 +1,10 @@
 {
   "ignoredFiles": [
     {
+      "path": "packages/dmworkmcp/src/api/expertWire.ts",
+      "reason": "parseTeamAgentsMarkdown is the inverse of the backend's teamAgentsMarkdown renderer; the Chinese section markers (协作方式/策略/依赖/权限, - 阻塞:/- 推荐:) are wire-format tokens that must byte-match the backend, not translatable UI copy."
+    },
+    {
       "path": "packages/dmworkbase/src/Utils/pinYin.ts",
       "reason": "Pinyin search dictionary data, not UI copy."
     },

--- a/apps/web/e2e-kit/msw-handlers/expert-market-empty.ts
+++ b/apps/web/e2e-kit/msw-handlers/expert-market-empty.ts
@@ -1,6 +1,9 @@
 import { http, HttpResponse } from "msw";
 
-const API_BASE = "/api/v1";
+// Unified plugin surface (octo-marketplace). Two plugins load, then the spec
+// searches for a keyword that matches neither so the page renders its empty
+// state (filtering is client-side).
+const API_BASE = "/market/api/v1";
 
 function enabled(): boolean {
   try {
@@ -10,51 +13,71 @@ function enabled(): boolean {
   }
 }
 
-const experts = [
+const plugins = [
   {
-    expert_id: "release-lead",
-    short_name: "发布",
-    name: "发布负责人",
-    summary: "统筹发布检查、风险识别和上线决策。",
-    category: "研发工具",
+    plugin_id: "release-lead",
+    plugin_name: "发布负责人",
+    plugin_type: "expert" as const,
+    category_id: "dev-tools",
     tags: ["发布", "质量"],
     publisher: "Octo Platform",
-    visibility: "system",
+    owner_id: "space-e2e",
+    visibility: "system" as const,
     creator_name: "[redacted-admin]",
-    created_by_type: "human",
+    created_by_type: "human" as const,
+    icon_url: "",
     view_count: 24,
     install_count: 8,
+    download_count: 0,
+    current_version: "1.0.0",
+    manifest_json: {
+      name: "release-lead",
+      description: "统筹发布检查、风险识别和上线决策。",
+      labels: ["发布", "质量"],
+    },
+    created_at: "2026-07-10T08:00:00Z",
+    updated_at: "2026-07-20T08:00:00Z",
   },
   {
-    expert_id: "meeting-coordinator",
-    short_name: "会议",
-    name: "会议协调专家",
-    summary: "整理会议议程、决策和后续待办。",
-    category: "办公提效",
+    plugin_id: "meeting-coordinator",
+    plugin_name: "会议协调专家",
+    plugin_type: "expert" as const,
+    category_id: "office",
     tags: ["会议", "协作"],
     publisher: "Octo Community",
-    visibility: "space",
+    owner_id: "space-e2e",
+    visibility: "space" as const,
     creator_name: "Alice",
-    created_by_type: "human",
+    created_by_type: "human" as const,
+    icon_url: "",
     view_count: 11,
     install_count: 3,
+    download_count: 0,
+    current_version: "1.0.0",
+    manifest_json: {
+      name: "meeting-coordinator",
+      description: "整理会议议程、决策和后续待办。",
+      labels: ["会议", "协作"],
+    },
+    created_at: "2026-07-11T08:00:00Z",
+    updated_at: "2026-07-21T08:00:00Z",
   },
 ];
 
 export const expertMarketEmptyHandlers = [
-  http.get(`*${API_BASE}/experts`, () => {
+  http.get(`*${API_BASE}/plugins`, () => {
     if (!enabled()) return undefined;
     return HttpResponse.json({
-      data: experts,
+      data: plugins,
       pagination: { total: 2, page: 1, page_size: 100 },
     });
   }),
-  http.get(`*${API_BASE}/expert_categories`, () => {
+  http.get(`*${API_BASE}/plugin_categories`, () => {
     if (!enabled()) return undefined;
     return HttpResponse.json({
       data: [
-        { expert_category_id: "dev-tools", name: "研发工具", count: 1 },
-        { expert_category_id: "office", name: "办公提效", count: 1 },
+        { category_id: "dev-tools", name: "研发工具", sort_order: 0, plugin_count: 1 },
+        { category_id: "office", name: "办公提效", sort_order: 1, plugin_count: 1 },
       ],
     });
   }),

--- a/apps/web/e2e-kit/msw-handlers/expert-market-error.ts
+++ b/apps/web/e2e-kit/msw-handlers/expert-market-error.ts
@@ -1,6 +1,10 @@
 import { http, HttpResponse } from "msw";
 
-const API_BASE = "/api/v1";
+// Unified plugin surface (octo-marketplace). Both the list and category fetches
+// fire in parallel on mount; a 5xx on either classifies as the "server" list
+// error (mcp.list.error.server → "服务暂时不可用，请稍后重试") and the page shows
+// the retry state. Fail both so whichever settles first drives the error.
+const API_BASE = "/market/api/v1";
 
 function enabled(): boolean {
   try {
@@ -18,11 +22,11 @@ function unavailable() {
 }
 
 export const expertMarketErrorHandlers = [
-  http.get(`*${API_BASE}/experts`, () => {
+  http.get(`*${API_BASE}/plugins`, () => {
     if (!enabled()) return undefined;
     return unavailable();
   }),
-  http.get(`*${API_BASE}/expert_categories`, () => {
+  http.get(`*${API_BASE}/plugin_categories`, () => {
     if (!enabled()) return undefined;
     return unavailable();
   }),

--- a/apps/web/e2e-kit/msw-handlers/expert-market-list.ts
+++ b/apps/web/e2e-kit/msw-handlers/expert-market-list.ts
@@ -1,5 +1,10 @@
 import { http, HttpResponse } from "msw";
 
+// Unified plugin surface (octo-marketplace). The expert market migrated off the
+// legacy /experts + /expert_categories endpoints onto /plugins,
+// /plugins/detail and /plugin_categories (plugin_type=expert). Fixtures are
+// plugin-wire shaped so the expertWire mappers project them back to the
+// ExpertItem view model the UI renders.
 const API_BASE = "/market/api/v1";
 
 function enabled(): boolean {
@@ -10,50 +15,75 @@ function enabled(): boolean {
   }
 }
 
-const expert = {
-  expert_id: "release-lead",
-  short_name: "发布",
-  name: "发布负责人",
-  summary: "统筹发布检查、风险识别和上线决策。",
-  category: "研发工具",
+// One expert plugin (list projection). visibility=system drives the "官方发布"
+// badge; manifest_json.description is the card/detail summary.
+const expertPlugin = {
+  plugin_id: "release-lead",
+  plugin_name: "发布负责人",
+  plugin_type: "expert" as const,
+  category_id: "dev-tools",
   tags: ["发布", "质量"],
   publisher: "Octo Platform",
-  visibility: "system",
+  owner_id: "space-e2e",
+  visibility: "system" as const,
   creator_name: "[redacted-admin]",
-  created_by_type: "human",
+  created_by_type: "human" as const,
+  icon_url: "",
   view_count: 24,
   install_count: 8,
-};
-
-const detail = {
-  ...expert,
-  instruction: "你负责检查发布风险，并给出可执行的上线建议。",
-  mcp_config: "{}",
-  skills: [],
+  download_count: 0,
+  current_version: "1.0.0",
+  manifest_json: {
+    name: "release-lead",
+    description: "统筹发布检查、风险识别和上线决策。",
+    labels: ["发布", "质量"],
+  },
   created_at: "2026-07-10T08:00:00Z",
   updated_at: "2026-07-20T08:00:00Z",
 };
 
+// Detail carries the package attachments; the expert instruction is the raw
+// AGENTS.md attachment (expertService.getExpertReal reads it via rawAttachment).
+const detail = {
+  plugin: {
+    ...expertPlugin,
+    plugin_json: {
+      attachments: [
+        {
+          path: "AGENTS.md",
+          content_type: "raw" as const,
+          mime_type: "text/markdown",
+          raw_content: "你负责检查发布风险，并给出可执行的上线建议。",
+        },
+      ],
+    },
+  },
+  relations: [],
+};
+
 export const expertMarketListHandlers = [
-  http.get(`*${API_BASE}/experts`, () => {
+  http.get(`*${API_BASE}/plugins/detail`, ({ request }) => {
+    if (!enabled()) return undefined;
+    const pluginId = new URL(request.url).searchParams.get("plugin_id");
+    if (pluginId !== expertPlugin.plugin_id) {
+      return HttpResponse.json({ error: { message: "Plugin not found" } }, { status: 404 });
+    }
+    return HttpResponse.json({ data: detail });
+  }),
+  http.get(`*${API_BASE}/plugins`, () => {
     if (!enabled()) return undefined;
     return HttpResponse.json({
-      data: [expert],
+      data: [expertPlugin],
       pagination: { total: 1, page: 1, page_size: 100 },
     });
   }),
-  http.get(`*${API_BASE}/expert_categories`, () => {
+  http.get(`*${API_BASE}/plugin_categories`, () => {
     if (!enabled()) return undefined;
     return HttpResponse.json({
-      data: [{ expert_category_id: "dev-tools", name: "研发工具", count: 1 }],
+      data: [
+        { category_id: "dev-tools", name: "研发工具", sort_order: 0, plugin_count: 1 },
+      ],
     });
-  }),
-  http.get(`*${API_BASE}/experts/:id`, ({ params }) => {
-    if (!enabled()) return undefined;
-    if (params.id !== expert.expert_id) {
-      return HttpResponse.json({ error: { message: "Expert not found" } }, { status: 404 });
-    }
-    return HttpResponse.json({ data: detail });
   }),
   http.post(`*${API_BASE}/metrics/track`, () => {
     if (!enabled()) return undefined;

--- a/apps/web/e2e-kit/msw-handlers/expert-market-search.ts
+++ b/apps/web/e2e-kit/msw-handlers/expert-market-search.ts
@@ -1,5 +1,8 @@
 import { http, HttpResponse } from "msw";
 
+// Unified plugin surface (octo-marketplace). Keyword filtering is client-side
+// over the fetched slice, so the list endpoint returns the full catalog and the
+// page narrows it as the user types.
 const API_BASE = "/market/api/v1";
 
 function enabled(): boolean {
@@ -10,51 +13,71 @@ function enabled(): boolean {
   }
 }
 
-const experts = [
+const plugins = [
   {
-    expert_id: "release-lead",
-    short_name: "发布",
-    name: "发布负责人",
-    summary: "统筹发布检查、风险识别和上线决策。",
-    category: "研发工具",
+    plugin_id: "release-lead",
+    plugin_name: "发布负责人",
+    plugin_type: "expert" as const,
+    category_id: "dev-tools",
     tags: ["发布", "质量"],
     publisher: "Octo Platform",
-    visibility: "system",
+    owner_id: "space-e2e",
+    visibility: "system" as const,
     creator_name: "[redacted-admin]",
-    created_by_type: "human",
+    created_by_type: "human" as const,
+    icon_url: "",
     view_count: 24,
     install_count: 8,
+    download_count: 0,
+    current_version: "1.0.0",
+    manifest_json: {
+      name: "release-lead",
+      description: "统筹发布检查、风险识别和上线决策。",
+      labels: ["发布", "质量"],
+    },
+    created_at: "2026-07-10T08:00:00Z",
+    updated_at: "2026-07-20T08:00:00Z",
   },
   {
-    expert_id: "meeting-coordinator",
-    short_name: "会议",
-    name: "会议协调专家",
-    summary: "整理会议议程、决策和后续待办。",
-    category: "办公提效",
+    plugin_id: "meeting-coordinator",
+    plugin_name: "会议协调专家",
+    plugin_type: "expert" as const,
+    category_id: "office",
     tags: ["会议", "协作"],
     publisher: "Octo Community",
-    visibility: "space",
+    owner_id: "space-e2e",
+    visibility: "space" as const,
     creator_name: "Alice",
-    created_by_type: "human",
+    created_by_type: "human" as const,
+    icon_url: "",
     view_count: 11,
     install_count: 3,
+    download_count: 0,
+    current_version: "1.0.0",
+    manifest_json: {
+      name: "meeting-coordinator",
+      description: "整理会议议程、决策和后续待办。",
+      labels: ["会议", "协作"],
+    },
+    created_at: "2026-07-11T08:00:00Z",
+    updated_at: "2026-07-21T08:00:00Z",
   },
 ];
 
 export const expertMarketSearchHandlers = [
-  http.get(`*${API_BASE}/experts`, () => {
+  http.get(`*${API_BASE}/plugins`, () => {
     if (!enabled()) return undefined;
     return HttpResponse.json({
-      data: experts,
+      data: plugins,
       pagination: { total: 2, page: 1, page_size: 100 },
     });
   }),
-  http.get(`*${API_BASE}/expert_categories`, () => {
+  http.get(`*${API_BASE}/plugin_categories`, () => {
     if (!enabled()) return undefined;
     return HttpResponse.json({
       data: [
-        { expert_category_id: "dev-tools", name: "研发工具", count: 1 },
-        { expert_category_id: "office", name: "办公提效", count: 1 },
+        { category_id: "dev-tools", name: "研发工具", sort_order: 0, plugin_count: 1 },
+        { category_id: "office", name: "办公提效", sort_order: 1, plugin_count: 1 },
       ],
     });
   }),

--- a/apps/web/e2e-kit/msw-handlers/expert-market-truncated.ts
+++ b/apps/web/e2e-kit/msw-handlers/expert-market-truncated.ts
@@ -1,6 +1,9 @@
 import { http, HttpResponse } from "msw";
 
-const API_BASE = "/api/v1";
+// Unified plugin surface (octo-marketplace). The list fetch caps at page_size
+// 100 while the true total is 101, so the page renders the "仅显示前 100 项"
+// truncation notice (total from pagination.total exceeds the loaded slice).
+const API_BASE = "/market/api/v1";
 
 function enabled(): boolean {
   try {
@@ -10,45 +13,62 @@ function enabled(): boolean {
   }
 }
 
-const firstExpert = {
-  expert_id: "release-lead",
-  short_name: "发布",
-  name: "发布负责人",
-  summary: "统筹发布检查、风险识别和上线决策。",
-  category: "研发工具",
+const firstPlugin = {
+  plugin_id: "release-lead",
+  plugin_name: "发布负责人",
+  plugin_type: "expert" as const,
+  category_id: "dev-tools",
   tags: ["发布", "质量"],
   publisher: "Octo Platform",
-  visibility: "system",
+  owner_id: "space-e2e",
+  visibility: "system" as const,
   creator_name: "[redacted-admin]",
-  created_by_type: "human",
+  created_by_type: "human" as const,
+  icon_url: "",
   view_count: 24,
   install_count: 8,
+  download_count: 0,
+  current_version: "1.0.0",
+  manifest_json: {
+    name: "release-lead",
+    description: "统筹发布检查、风险识别和上线决策。",
+    labels: ["发布", "质量"],
+  },
+  created_at: "2026-07-10T08:00:00Z",
+  updated_at: "2026-07-20T08:00:00Z",
 };
 
-const experts = [
-  firstExpert,
+// 100 loaded rows against a true total of 101 → one page over the cap.
+const plugins = [
+  firstPlugin,
   ...Array.from({ length: 99 }, (_, index) => ({
-    ...firstExpert,
-    expert_id: `catalog-expert-${index + 2}`,
-    short_name: `专家${index + 2}`,
-    name: `目录专家${index + 2}`,
-    summary: `用于分页边界验证的目录专家 ${index + 2}。`,
+    ...firstPlugin,
+    plugin_id: `catalog-expert-${index + 2}`,
+    plugin_name: `目录专家${index + 2}`,
+    visibility: "space" as const,
     tags: ["目录"],
+    manifest_json: {
+      name: `catalog-expert-${index + 2}`,
+      description: `用于分页边界验证的目录专家 ${index + 2}。`,
+      labels: ["目录"],
+    },
   })),
 ];
 
 export const expertMarketTruncatedHandlers = [
-  http.get(`*${API_BASE}/experts`, () => {
+  http.get(`*${API_BASE}/plugins`, () => {
     if (!enabled()) return undefined;
     return HttpResponse.json({
-      data: experts,
+      data: plugins,
       pagination: { total: 101, page: 1, page_size: 100 },
     });
   }),
-  http.get(`*${API_BASE}/expert_categories`, () => {
+  http.get(`*${API_BASE}/plugin_categories`, () => {
     if (!enabled()) return undefined;
     return HttpResponse.json({
-      data: [{ expert_category_id: "dev-tools", name: "研发工具", count: 101 }],
+      data: [
+        { category_id: "dev-tools", name: "研发工具", sort_order: 0, plugin_count: 101 },
+      ],
     });
   }),
 ];

--- a/apps/web/e2e-kit/msw-handlers/mcp-official.ts
+++ b/apps/web/e2e-kit/msw-handlers/mcp-official.ts
@@ -1,5 +1,11 @@
 import { http, HttpResponse } from "msw";
 
+// Unified plugin surface (octo-marketplace). The MCP market migrated off the
+// legacy /mcps + /mcp_categories endpoints onto /plugins, /plugins/detail and
+// /plugin_categories (plugin_type=connector). Fixtures are plugin-wire shaped
+// so mcpService's mapListItem/mapDetail project them back to the McpListItem /
+// McpDetail view models the C37 spec asserts on. visibility=system drives the
+// "官方发布" badge + wk-mcp-card--official card class (isOfficialMcp).
 const API_BASE = "/market/api/v1";
 const REDACTED_CREATOR = "[redacted-admin]";
 
@@ -11,69 +17,131 @@ function enabled(): boolean {
   }
 }
 
-const officialListItem = {
-  mcp_id: "official-search",
-  name: "Official Search MCP",
-  slogan: "Platform-maintained web and news search.",
-  category: "search",
-  icon: "🔎",
+// Official connector (list projection). visibility=system → official publisher;
+// the redacted creator name must never render on an official card/detail.
+const officialPlugin = {
+  plugin_id: "official-search",
+  plugin_name: "Official Search MCP",
+  plugin_type: "connector" as const,
+  category_id: "search-cat",
   tags: ["search", "official"],
-  tool_count: 6,
-  visibility: "system",
-  source: "system",
+  publisher: "Octo Platform",
+  owner_id: "space-e2e",
+  visibility: "system" as const,
   creator_name: REDACTED_CREATOR,
-  created_by_type: "human",
-  transport: "streamable-http",
-  match_reasons: [`creator:${REDACTED_CREATOR}`, "tool:web_search"],
+  created_by_type: "human" as const,
+  icon_url: "",
+  tool_count: 6,
+  view_count: 24,
+  install_count: 8,
+  download_count: 0,
+  current_version: "1.0.0",
+  manifest_json: {
+    name: "official-search",
+    description: "Platform-maintained web and news search.",
+    labels: ["search", "official"],
+  },
+  created_at: "2026-07-20T08:00:00Z",
   updated_at: "2026-07-24T08:00:00Z",
 };
 
-const normalListItem = {
-  ...officialListItem,
-  mcp_id: "community-search",
-  name: "Community Search MCP",
-  slogan: "Community-maintained search integration.",
+// Community connector: a space-visible row keeps its creator (Alice) on the
+// card and detail — the anti-case for the official badge.
+const normalPlugin = {
+  ...officialPlugin,
+  plugin_id: "community-search",
+  plugin_name: "Community Search MCP",
   tags: ["search", "community"],
-  visibility: "public",
-  source: "space",
+  publisher: "Octo Community",
+  visibility: "public" as const,
   creator_name: "Alice",
-  match_reasons: ["creator:Alice", "tool:web_search"],
+  manifest_json: {
+    name: "community-search",
+    description: "Community-maintained search integration.",
+    labels: ["search", "community"],
+  },
 };
 
-const detailFor = (item: typeof officialListItem) => ({
-  ...item,
-  quick_start: {
-    transport: "streamable-http",
-    server_name: item.name,
-    url: "https://example.test/mcp",
+// Detail carries the connector package: mcp.json is the standard MCP config
+// document, connector/tools.json the tool list. mapDetail reads them via
+// jsonAttachment; missing attachments degrade to sane defaults.
+const detailFor = (plugin: typeof officialPlugin | typeof normalPlugin) => ({
+  plugin: {
+    ...plugin,
+    plugin_json: {
+      $schema: "cowork-plugin-package-1.0.json",
+      connector: { type: "mcp" as const, source: `connector.${plugin.manifest_json.name}` },
+      attachments: [
+        {
+          path: "mcp.json",
+          content_type: "raw" as const,
+          mime_type: "application/json",
+          raw_content: JSON.stringify({
+            mcpServers: {
+              [plugin.plugin_name]: {
+                type: "streamable-http",
+                url: "https://example.test/mcp",
+              },
+            },
+          }),
+        },
+        {
+          path: "connector/tools.json",
+          content_type: "raw" as const,
+          mime_type: "application/json",
+          raw_content: JSON.stringify([
+            { name: "web_search", description: "Search the web." },
+          ]),
+        },
+        {
+          path: "connector/examples.json",
+          content_type: "raw" as const,
+          mime_type: "application/json",
+          raw_content: JSON.stringify(["Search for the latest platform documentation."]),
+        },
+      ],
+    },
   },
-  tools: [{ name: "web_search", description: "Search the web." }],
-  usage_examples: ["Search for the latest platform documentation."],
-  faqs: [],
-  notes: [],
-  created_at: "2026-07-20T08:00:00Z",
+  relations: [],
 });
+
+const detailById: Record<string, ReturnType<typeof detailFor>> = {
+  [officialPlugin.plugin_id]: detailFor(officialPlugin),
+  [normalPlugin.plugin_id]: detailFor(normalPlugin),
+};
 
 export const mcpOfficialHandlers = [
   http.get("*/user/devices/:deviceId", () => {
     if (!enabled()) return undefined;
     return HttpResponse.json({});
   }),
-  http.get(`*${API_BASE}/mcps`, () => {
+  // Register /plugins/detail before /plugins so the more specific path wins.
+  http.get(`*${API_BASE}/plugins/detail`, ({ request }) => {
+    if (!enabled()) return undefined;
+    const pluginId = new URL(request.url).searchParams.get("plugin_id") ?? "";
+    const detail = detailById[pluginId];
+    if (!detail) {
+      return HttpResponse.json({ error: { message: "Plugin not found" } }, { status: 404 });
+    }
+    return HttpResponse.json({ data: detail });
+  }),
+  http.get(`*${API_BASE}/plugins`, () => {
     if (!enabled()) return undefined;
     return HttpResponse.json({
-      data: [officialListItem, normalListItem],
+      data: [officialPlugin, normalPlugin],
       pagination: { total: 2, page: 1, page_size: 20 },
     });
   }),
-  http.get(`*${API_BASE}/mcp_categories`, () => {
+  http.get(`*${API_BASE}/plugin_categories`, () => {
     if (!enabled()) return undefined;
-    return HttpResponse.json({ data: [{ key: "search", count: 2 }] });
+    return HttpResponse.json({
+      data: [
+        { category_id: "search-cat", name: "search", sort_order: 0, plugin_count: 2 },
+      ],
+    });
   }),
-  http.get(`*${API_BASE}/mcps/:id`, ({ params }) => {
+  http.post(`*${API_BASE}/metrics/track`, () => {
     if (!enabled()) return undefined;
-    const item =
-      params.id === officialListItem.mcp_id ? officialListItem : normalListItem;
-    return HttpResponse.json({ data: detailFor(item) });
+    return HttpResponse.json({ data: {} });
   }),
 ];

--- a/apps/web/e2e-kit/msw-handlers/skill-market-empty.ts
+++ b/apps/web/e2e-kit/msw-handlers/skill-market-empty.ts
@@ -1,6 +1,10 @@
 import { http, HttpResponse } from "msw";
 
-const API_BASE = "/api/v1";
+// Unified plugin surface (octo-marketplace). One skill loads, then the spec
+// searches for a keyword that matches nothing (server-side filter over the `q`
+// param) so /plugins returns an empty slice and the page renders its 暂无数据
+// empty state.
+const API_BASE = "/market/api/v1";
 
 function enabled(): boolean {
   try {
@@ -11,27 +15,27 @@ function enabled(): boolean {
 }
 
 const skill = {
-  skill_id: "release-risk-radar",
-  name: "release-risk-radar",
-  display_name: "发布风险雷达",
-  description: "结合改动范围生成发布风险雷达。",
-  category_id: "dev-tools",
+  plugin_id: "release-risk-radar",
+  plugin_name: "发布风险雷达",
+  plugin_type: "skill" as const,
+  category_id: "dev-tools-cat",
   tags: ["发布", "风险"],
+  publisher: "平台团队",
   owner_id: "platform",
-  owner_name: "平台团队",
-  creator_id: "platform",
-  creator_name: "平台团队",
   space_id: "e2e-space-001",
-  visibility: "public",
-  version: "1.2.0",
-  readme_content: "# 发布风险雷达",
+  visibility: "public" as const,
+  creator_name: "平台团队",
+  created_by_type: "human" as const,
   icon_url: "",
-  file_name: "release-risk-radar.zip",
-  file_url: "https://example.test/skills/release-risk-radar.zip",
-  file_size: 4096,
-  file_sha256: "empty-skill-sha256",
   view_count: 18,
   download_count: 7,
+  install_count: 0,
+  current_version: "1.2.0",
+  manifest_json: {
+    name: "release-risk-radar",
+    description: "结合改动范围生成发布风险雷达。",
+    labels: ["发布", "风险"],
+  },
   created_at: "2026-06-04T08:00:00.000Z",
   updated_at: "2026-07-12T10:00:00.000Z",
 };
@@ -42,21 +46,21 @@ function filtered(request: Request) {
 }
 
 export const skillMarketEmptyHandlers = [
-  http.get(`*${API_BASE}/skill_categories`, ({ request }) => {
+  http.get(`*${API_BASE}/plugin_categories`, ({ request }) => {
     if (!enabled()) return undefined;
     const items = filtered(request);
     return HttpResponse.json({
       data: items.length
-        ? [{ skill_category_id: "dev-tools", name: "开发工具", icon_key: "Terminal", skill_count: 1 }]
+        ? [{ category_id: "dev-tools-cat", name: "开发工具", icon_key: "Terminal", sort_order: 0, plugin_count: 1 }]
         : [],
     });
   }),
-  http.get(`*${API_BASE}/skills`, ({ request }) => {
+  http.get(`*${API_BASE}/plugins`, ({ request }) => {
     if (!enabled()) return undefined;
     const items = filtered(request);
     return HttpResponse.json({
       data: items,
-      pagination: { total: items.length, next_cursor: null },
+      pagination: { total: items.length, page: 1, page_size: 20 },
     });
   }),
 ];

--- a/apps/web/e2e-kit/msw-handlers/skill-market-error.ts
+++ b/apps/web/e2e-kit/msw-handlers/skill-market-error.ts
@@ -1,6 +1,10 @@
 import { http, HttpResponse } from "msw";
 
-const API_BASE = "/api/v1";
+// Unified plugin surface (octo-marketplace). Both the list and category fetches
+// fire in parallel on mount; a 5xx on either surfaces the load-failure state
+// (加载失败 + 重试). Fail both /plugins and /plugin_categories so whichever
+// settles first drives the error.
+const API_BASE = "/market/api/v1";
 
 function enabled(): boolean {
   try {
@@ -18,11 +22,11 @@ function unavailable() {
 }
 
 export const skillMarketErrorHandlers = [
-  http.get(`*${API_BASE}/skill_categories`, () => {
+  http.get(`*${API_BASE}/plugin_categories`, () => {
     if (!enabled()) return undefined;
     return unavailable();
   }),
-  http.get(`*${API_BASE}/skills`, () => {
+  http.get(`*${API_BASE}/plugins`, () => {
     if (!enabled()) return undefined;
     return unavailable();
   }),

--- a/apps/web/e2e-kit/msw-handlers/skill-market-list.ts
+++ b/apps/web/e2e-kit/msw-handlers/skill-market-list.ts
@@ -1,8 +1,14 @@
 import { http, HttpResponse } from "msw";
 
-// Skill API resolves from WKApp.apiClient's configured /api/v1 base in the
-// local E2E preview. Keep this separate from dmworkmcp's /market gateway.
-const API_BASE = "/api/v1";
+// Unified plugin surface (octo-marketplace). The skills market migrated off the
+// legacy /skills + /skill_categories endpoints onto /plugins, /plugins/detail,
+// /plugin_categories, /plugins/skill_md and /plugins/versions
+// (plugin_type=skill), served from the /market gateway. Fixtures are
+// plugin-wire shaped so skillApiReal's mapSkill/mapSkillDetail project them
+// back to the Skill view model. visibility=public → the "官方发布" platform
+// badge (isPlatformPublishedSkill); manifest_json.name is the machine name the
+// card's accessible label uses, plugin_name is the display name.
+const API_BASE = "/market/api/v1";
 
 function enabled(): boolean {
   try {
@@ -12,68 +18,95 @@ function enabled(): boolean {
   }
 }
 
+const SKILL_MD =
+  "# 发布风险雷达\n\n根据改动范围生成发布风险检查清单。";
+
 const skill = {
-  skill_id: "release-risk-radar",
-  name: "release-risk-radar",
-  display_name: "发布风险雷达",
-  description: "结合改动范围、历史事故和测试覆盖生成发布风险雷达。",
-  category_id: "dev-tools",
+  plugin_id: "release-risk-radar",
+  plugin_name: "发布风险雷达",
+  plugin_type: "skill" as const,
+  category_id: "dev-tools-cat",
   tags: ["发布", "风险"],
+  publisher: "平台团队",
   owner_id: "platform",
-  owner_name: "平台团队",
-  creator_id: "platform",
-  creator_name: "平台团队",
   space_id: "e2e-space-001",
-  visibility: "public",
-  version: "1.2.0",
-  readme_content: "# 发布风险雷达\n\n根据改动范围生成发布风险检查清单。",
+  visibility: "public" as const,
+  creator_name: "平台团队",
+  created_by_type: "human" as const,
   icon_url: "",
-  file_name: "release-risk-radar.zip",
-  file_url: "https://example.test/skills/release-risk-radar.zip",
-  file_size: 4096,
-  file_sha256: "e2e-skill-sha256",
   view_count: 18,
   download_count: 7,
+  install_count: 0,
+  current_version: "1.2.0",
+  manifest_json: {
+    name: "release-risk-radar",
+    description: "结合改动范围、历史事故和测试覆盖生成发布风险雷达。",
+    labels: ["发布", "风险"],
+  },
   created_at: "2026-06-04T08:00:00.000Z",
   updated_at: "2026-07-12T10:00:00.000Z",
 };
 
+// Detail carries the SKILL.md raw attachment (tree shape); mapSkillDetail reads
+// readmeContent from it, the modal body renders /plugins/skill_md.
+const detail = {
+  plugin: {
+    ...skill,
+    plugin_json: {
+      $schema: "cowork-plugin-package-1.0.json",
+      attachments: [
+        {
+          path: "SKILL.md",
+          content_type: "raw" as const,
+          mime_type: "text/markdown",
+          raw_content: SKILL_MD,
+        },
+      ],
+    },
+  },
+  relations: [],
+};
+
 const category = {
-  skill_category_id: "dev-tools",
+  category_id: "dev-tools-cat",
   name: "开发工具",
   icon_key: "Terminal",
-  skill_count: 1,
+  sort_order: 0,
+  plugin_count: 1,
 };
 
 export const skillMarketListHandlers = [
-  http.get(`*${API_BASE}/skill_categories`, () => {
+  http.get(`*${API_BASE}/plugin_categories`, () => {
     if (!enabled()) return undefined;
     return HttpResponse.json({ data: [category] });
   }),
-  http.get(`*${API_BASE}/skills`, () => {
+  // Register /plugins/detail (and the /plugins/* subpaths) before /plugins.
+  http.get(`*${API_BASE}/plugins/detail`, ({ request }) => {
+    if (!enabled()) return undefined;
+    const pluginId = new URL(request.url).searchParams.get("plugin_id");
+    if (pluginId !== skill.plugin_id) {
+      return HttpResponse.json({ error: { message: "Skill not found" } }, { status: 404 });
+    }
+    return HttpResponse.json({ data: detail });
+  }),
+  http.get(`*${API_BASE}/plugins/skill_md`, ({ request }) => {
+    if (!enabled()) return undefined;
+    const pluginId = new URL(request.url).searchParams.get("plugin_id");
+    if (pluginId !== skill.plugin_id) {
+      return HttpResponse.json({ error: { message: "Skill not found" } }, { status: 404 });
+    }
+    return HttpResponse.json({ data: { content: SKILL_MD } });
+  }),
+  http.get(`*${API_BASE}/plugins/versions`, () => {
+    if (!enabled()) return undefined;
+    return HttpResponse.json({ data: [] });
+  }),
+  http.get(`*${API_BASE}/plugins`, () => {
     if (!enabled()) return undefined;
     return HttpResponse.json({
       data: [skill],
-      pagination: { total: 1, next_cursor: null },
+      pagination: { total: 1, page: 1, page_size: 20 },
     });
-  }),
-  http.get(`*${API_BASE}/skills/:id`, ({ params }) => {
-    if (!enabled()) return undefined;
-    if (params.id !== skill.skill_id) {
-      return HttpResponse.json({ error: { message: "Skill not found" } }, { status: 404 });
-    }
-    return HttpResponse.json({ data: skill });
-  }),
-  http.get(`*${API_BASE}/skills/:id/skill_md`, ({ params }) => {
-    if (!enabled()) return undefined;
-    if (params.id !== skill.skill_id) {
-      return HttpResponse.json({ error: { message: "Skill not found" } }, { status: 404 });
-    }
-    return HttpResponse.json({ data: { content: "# 发布风险雷达\n\n根据改动范围生成发布风险检查清单。" } });
-  }),
-  http.get(`*${API_BASE}/skills/:id/versions`, () => {
-    if (!enabled()) return undefined;
-    return HttpResponse.json({ data: { items: [] } });
   }),
   http.post(`*${API_BASE}/metrics/track`, () => {
     if (!enabled()) return undefined;

--- a/apps/web/e2e-kit/msw-handlers/skill-market-pagination.ts
+++ b/apps/web/e2e-kit/msw-handlers/skill-market-pagination.ts
@@ -1,6 +1,11 @@
 import { http, HttpResponse } from "msw";
 
-const API_BASE = "/api/v1";
+// Unified plugin surface (octo-marketplace). The skills list paginates by page
+// number: skillApiReal threads the legacy opaque cursor through as the next
+// page and synthesizes nextCursor while `page * page_size < total`. Report a
+// page_size of 1 against a total of 2 so page 1 leaves one row remaining and
+// the sentinel triggers a page-2 append (request carries `page=2`).
+const API_BASE = "/market/api/v1";
 
 function enabled(): boolean {
   try {
@@ -11,76 +16,76 @@ function enabled(): boolean {
 }
 
 const firstSkill = {
-  skill_id: "release-risk-radar",
-  name: "release-risk-radar",
-  display_name: "发布风险雷达",
-  description: "结合改动范围生成发布风险雷达。",
-  category_id: "dev-tools",
+  plugin_id: "release-risk-radar",
+  plugin_name: "发布风险雷达",
+  plugin_type: "skill" as const,
+  category_id: "dev-tools-cat",
   tags: ["发布", "风险"],
+  publisher: "平台团队",
   owner_id: "platform",
-  owner_name: "平台团队",
-  creator_id: "platform",
-  creator_name: "平台团队",
   space_id: "e2e-space-001",
-  visibility: "public",
-  version: "1.2.0",
-  readme_content: "# 发布风险雷达",
+  visibility: "public" as const,
+  creator_name: "平台团队",
+  created_by_type: "human" as const,
   icon_url: "",
-  file_name: "release-risk-radar.zip",
-  file_url: "https://example.test/skills/release-risk-radar.zip",
-  file_size: 4096,
-  file_sha256: "pagination-skill-1-sha256",
   view_count: 18,
   download_count: 7,
+  install_count: 0,
+  current_version: "1.2.0",
+  manifest_json: {
+    name: "release-risk-radar",
+    description: "结合改动范围生成发布风险雷达。",
+    labels: ["发布", "风险"],
+  },
   created_at: "2026-06-04T08:00:00.000Z",
   updated_at: "2026-07-12T10:00:00.000Z",
 };
 
 const secondSkill = {
-  skill_id: "meeting-note-cleaner",
-  name: "meeting-note-cleaner",
-  display_name: "会议纪要整理",
-  description: "从会议记录中提炼决策和待办。",
-  category_id: "dev-tools",
+  plugin_id: "meeting-note-cleaner",
+  plugin_name: "会议纪要整理",
+  plugin_type: "skill" as const,
+  category_id: "dev-tools-cat",
   tags: ["会议", "协作"],
+  publisher: "Alice",
   owner_id: "alice",
-  owner_name: "Alice",
-  creator_id: "alice",
-  creator_name: "Alice",
   space_id: "e2e-space-001",
-  visibility: "public",
-  version: "0.9.0",
-  readme_content: "# 会议纪要整理",
+  visibility: "public" as const,
+  creator_name: "Alice",
+  created_by_type: "human" as const,
   icon_url: "",
-  file_name: "meeting-note-cleaner.zip",
-  file_url: "https://example.test/skills/meeting-note-cleaner.zip",
-  file_size: 3072,
-  file_sha256: "pagination-skill-2-sha256",
   view_count: 12,
   download_count: 5,
+  install_count: 0,
+  current_version: "0.9.0",
+  manifest_json: {
+    name: "meeting-note-cleaner",
+    description: "从会议记录中提炼决策和待办。",
+    labels: ["会议", "协作"],
+  },
   created_at: "2026-06-08T08:00:00.000Z",
   updated_at: "2026-07-10T10:00:00.000Z",
 };
 
 export const skillMarketPaginationHandlers = [
-  http.get(`*${API_BASE}/skill_categories`, () => {
+  http.get(`*${API_BASE}/plugin_categories`, () => {
     if (!enabled()) return undefined;
     return HttpResponse.json({
-      data: [{ skill_category_id: "dev-tools", name: "开发工具", icon_key: "Terminal", skill_count: 2 }],
+      data: [{ category_id: "dev-tools-cat", name: "开发工具", icon_key: "Terminal", sort_order: 0, plugin_count: 2 }],
     });
   }),
-  http.get(`*${API_BASE}/skills`, ({ request }) => {
+  http.get(`*${API_BASE}/plugins`, ({ request }) => {
     if (!enabled()) return undefined;
-    const cursor = new URL(request.url).searchParams.get("cursor");
-    if (cursor === "page-2") {
+    const page = Number.parseInt(new URL(request.url).searchParams.get("page") ?? "1", 10) || 1;
+    if (page >= 2) {
       return HttpResponse.json({
         data: [secondSkill],
-        pagination: { total: 2, next_cursor: null },
+        pagination: { total: 2, page: 2, page_size: 1 },
       });
     }
     return HttpResponse.json({
       data: [firstSkill],
-      pagination: { total: 2, next_cursor: "page-2" },
+      pagination: { total: 2, page: 1, page_size: 1 },
     });
   }),
 ];

--- a/apps/web/e2e-kit/msw-handlers/skill-market-search.ts
+++ b/apps/web/e2e-kit/msw-handlers/skill-market-search.ts
@@ -1,6 +1,10 @@
 import { http, HttpResponse } from "msw";
 
-const API_BASE = "/api/v1";
+// Unified plugin surface (octo-marketplace). Skill search is server-side: the
+// list page re-fetches /plugins with the `q` param (useSkills debounces query →
+// fetchPage), and the "共 N 个技能" count binds to pagination.total. Filter the
+// fixture set by `q` and report the narrowed total so the count follows.
+const API_BASE = "/market/api/v1";
 
 function enabled(): boolean {
   try {
@@ -12,52 +16,52 @@ function enabled(): boolean {
 
 const skills = [
   {
-    skill_id: "release-risk-radar",
-    name: "release-risk-radar",
-    display_name: "发布风险雷达",
-    description: "结合改动范围和测试覆盖生成发布风险雷达。",
-    category_id: "dev-tools",
+    plugin_id: "release-risk-radar",
+    plugin_name: "发布风险雷达",
+    plugin_type: "skill" as const,
+    category_id: "dev-tools-cat",
     tags: ["发布", "风险"],
+    publisher: "平台团队",
     owner_id: "platform",
-    owner_name: "平台团队",
-    creator_id: "platform",
-    creator_name: "平台团队",
     space_id: "e2e-space-001",
-    visibility: "public",
-    version: "1.2.0",
-    readme_content: "# 发布风险雷达",
+    visibility: "public" as const,
+    creator_name: "平台团队",
+    created_by_type: "human" as const,
     icon_url: "",
-    file_name: "release-risk-radar.zip",
-    file_url: "https://example.test/skills/release-risk-radar.zip",
-    file_size: 4096,
-    file_sha256: "search-risk-sha256",
     view_count: 18,
     download_count: 7,
+    install_count: 0,
+    current_version: "1.2.0",
+    manifest_json: {
+      name: "release-risk-radar",
+      description: "结合改动范围和测试覆盖生成发布风险雷达。",
+      labels: ["发布", "风险"],
+    },
     created_at: "2026-06-04T08:00:00.000Z",
     updated_at: "2026-07-12T10:00:00.000Z",
   },
   {
-    skill_id: "meeting-note-cleaner",
-    name: "meeting-note-cleaner",
-    display_name: "会议纪要整理",
-    description: "将会议纪要整理为决策、待办和风险。",
-    category_id: "office",
+    plugin_id: "meeting-note-cleaner",
+    plugin_name: "会议纪要整理",
+    plugin_type: "skill" as const,
+    category_id: "office-cat",
     tags: ["纪要", "协作"],
+    publisher: "Alice",
     owner_id: "alice",
-    owner_name: "Alice",
-    creator_id: "alice",
-    creator_name: "Alice",
     space_id: "e2e-space-001",
-    visibility: "space",
-    version: "1.1.3",
-    readme_content: "# 会议纪要整理",
+    visibility: "space" as const,
+    creator_name: "Alice",
+    created_by_type: "human" as const,
     icon_url: "",
-    file_name: "meeting-note-cleaner.zip",
-    file_url: "https://example.test/skills/meeting-note-cleaner.zip",
-    file_size: 4096,
-    file_sha256: "search-notes-sha256",
     view_count: 12,
     download_count: 3,
+    install_count: 0,
+    current_version: "1.1.3",
+    manifest_json: {
+      name: "meeting-note-cleaner",
+      description: "将会议纪要整理为决策、待办和风险。",
+      labels: ["纪要", "协作"],
+    },
     created_at: "2026-06-01T08:00:00.000Z",
     updated_at: "2026-07-10T10:00:00.000Z",
   },
@@ -67,7 +71,7 @@ function filtered(request: Request) {
   const query = new URL(request.url).searchParams.get("q")?.trim().toLowerCase() ?? "";
   if (!query) return skills;
   return skills.filter((item) =>
-    [item.name, item.display_name, item.description, ...item.tags]
+    [item.plugin_name, item.manifest_json.name, item.manifest_json.description, ...item.tags]
       .join(" ")
       .toLowerCase()
       .includes(query)
@@ -75,26 +79,21 @@ function filtered(request: Request) {
 }
 
 export const skillMarketSearchHandlers = [
-  http.get(`*${API_BASE}/skill_categories`, ({ request }) => {
+  http.get(`*${API_BASE}/plugin_categories`, () => {
     if (!enabled()) return undefined;
-    const items = filtered(request);
-    const counts = new Map<string, number>();
-    for (const item of items) {
-      counts.set(item.category_id, (counts.get(item.category_id) ?? 0) + 1);
-    }
     return HttpResponse.json({
       data: [
-        { skill_category_id: "dev-tools", name: "开发工具", icon_key: "Terminal", skill_count: counts.get("dev-tools") ?? 0 },
-        { skill_category_id: "office", name: "办公协作", icon_key: "FolderKanban", skill_count: counts.get("office") ?? 0 },
+        { category_id: "dev-tools-cat", name: "开发工具", icon_key: "Terminal", sort_order: 0, plugin_count: 1 },
+        { category_id: "office-cat", name: "办公协作", icon_key: "FolderKanban", sort_order: 1, plugin_count: 1 },
       ],
     });
   }),
-  http.get(`*${API_BASE}/skills`, ({ request }) => {
+  http.get(`*${API_BASE}/plugins`, ({ request }) => {
     if (!enabled()) return undefined;
     const items = filtered(request);
     return HttpResponse.json({
       data: items,
-      pagination: { total: items.length, next_cursor: null },
+      pagination: { total: items.length, page: 1, page_size: 20 },
     });
   }),
 ];

--- a/apps/web/e2e-kit/tests/mcp/C37-mcp-official-publisher.spec.ts
+++ b/apps/web/e2e-kit/tests/mcp/C37-mcp-official-publisher.spec.ts
@@ -74,7 +74,7 @@ test("@C37 @p1 @mcp @mcp-official official publisher renders in MCP market", asy
   await expect(officialCard).toBeVisible();
   await expect(normalCard).toBeVisible();
 
-  await expect.poll(() => requests.some((url) => url.includes(`${API_BASE}/mcps?`))).toBe(true);
+  await expect.poll(() => requests.some((url) => url.includes(`${API_BASE}/plugins?`))).toBe(true);
   await expect.poll(() => responses.some(({ visibility }) => visibility === "system")).toBe(true);
   expect(consoleErrors).toEqual([]);
   expect(pageErrors).toEqual([]);

--- a/apps/web/e2e-kit/tests/skills/SK2-skills-market-search.spec.ts
+++ b/apps/web/e2e-kit/tests/skills/SK2-skills-market-search.spec.ts
@@ -22,7 +22,12 @@ test("@SK2 @p1 @skills @market @search Skills 市场搜索", async ({ authedPage
   });
   await search.fill("发布");
 
-  await expect(authedPage.getByText("共 1 个技能")).toBeVisible();
+  // Unified taxonomy: category counts (and thus the "共 N 个技能" summary, which
+  // binds to the active category's catalog skillCount) are catalog-wide and do
+  // NOT re-scope to the search query — getCategories intentionally drops `q`
+  // (owner-accepted in the unified switch). So the summary stays at the catalog
+  // total while only the card list narrows to the matching skill.
+  await expect(authedPage.getByText("共 2 个技能")).toBeVisible();
   await expect(
     authedPage.getByRole("button", { name: /release-risk-radar 官方发布/ })
   ).toBeVisible();

--- a/apps/web/e2e-kit/tests/skills/SK2-skills-market-search.spec.ts
+++ b/apps/web/e2e-kit/tests/skills/SK2-skills-market-search.spec.ts
@@ -22,12 +22,10 @@ test("@SK2 @p1 @skills @market @search Skills 市场搜索", async ({ authedPage
   });
   await search.fill("发布");
 
-  // Unified taxonomy: category counts (and thus the "共 N 个技能" summary, which
-  // binds to the active category's catalog skillCount) are catalog-wide and do
-  // NOT re-scope to the search query — getCategories intentionally drops `q`
-  // (owner-accepted in the unified switch). So the summary stays at the catalog
-  // total while only the card list narrows to the matching skill.
-  await expect(authedPage.getByText("共 2 个技能")).toBeVisible();
+  // The "共 N 个技能" summary binds to the unified list's filter-scoped
+  // pagination.total (list.total), so it re-scopes with the search query: only
+  // release-risk-radar matches 发布, so the count narrows to 1 alongside the grid.
+  await expect(authedPage.getByText("共 1 个技能")).toBeVisible();
   await expect(
     authedPage.getByRole("button", { name: /release-risk-radar 官方发布/ })
   ).toBeVisible();

--- a/apps/web/e2e-kit/tests/skills/SK4-skills-market-pagination.spec.ts
+++ b/apps/web/e2e-kit/tests/skills/SK4-skills-market-pagination.spec.ts
@@ -6,7 +6,7 @@ import { test, expect } from "../../fixtures-authed";
 test("@SK4 @p1 @skills @market @pagination Skills 市场分页追加", async ({ authedPage }) => {
   const skillRequests: string[] = [];
   authedPage.on("request", (request) => {
-    if (request.url().includes("/api/v1/skills")) skillRequests.push(request.url());
+    if (request.url().includes("/plugins?")) skillRequests.push(request.url());
   });
   await authedPage.addInitScript(() => {
     sessionStorage.setItem("__e2e_scenario", "skill-market-pagination");
@@ -25,7 +25,7 @@ test("@SK4 @p1 @skills @market @pagination Skills 市场分页追加", async ({ 
   await expect(firstSkill).toBeVisible();
   await expect.poll(() => skillRequests.some((url) => !url.includes("cursor="))).toBe(true);
   await authedPage.locator(".skill-market-sentinel").scrollIntoViewIfNeeded();
-  await expect.poll(() => skillRequests.some((url) => url.includes("cursor=page-2"))).toBe(true);
+  await expect.poll(() => skillRequests.some((url) => url.includes("page=2"))).toBe(true);
   await expect(secondSkill).toBeVisible();
   await expect(authedPage.getByText("加载失败")).not.toBeVisible();
 });

--- a/packages/dmworkbase/src/Service/FetchRules.ts
+++ b/packages/dmworkbase/src/Service/FetchRules.ts
@@ -267,12 +267,15 @@ export const FETCH_RULES: FetchRule[] = [
     //   (handleEditFromCard→fetchMcpDetail)拉,fetch 层无法区分看/编,编辑会被误计成查看(见二审 P2-1)。
     //   改由卡根 data-track="market_card_opened"(DOM 委托,亦覆盖键盘)采集;这里把 /:id 钉成 IGNORE,
     //   同时继续压过 mine/tags/versions。(六审 C2:已删除曾并存的命令式 market_card_viewed,避免同一次打开双计。)
-    { method: 'GET', path: '/market/api/v1/mcps/mine', event: FETCH_IGNORE },
-    { method: 'GET', path: '/market/api/v1/skills/mine', event: FETCH_IGNORE },
-    { method: 'GET', path: '/market/api/v1/skills/tags', event: FETCH_IGNORE },
-    { method: 'GET', path: '/market/api/v1/mcps/:id', event: FETCH_IGNORE },
-    { method: 'GET', path: '/market/api/v1/skills/:id', event: FETCH_IGNORE },
-    { method: 'GET', path: '/market/api/v1/skills/:id/versions', event: 'market_skill_version_history_viewed' },
-    { method: 'POST', path: '/market/api/v1/mcps', event: 'market_manual_publish_submitted' },
-    { method: 'POST', path: '/market/api/v1/skills', event: 'market_manual_publish_submitted' },
+    //   2026-08-21 市场切统一插件接口:旧 /mcps|skills/* 路径前端不再发起,规则整体换新。
+    //   新路径全部是字面段(无 :id 通配),不存在误吞,故旧的 mine/tags/:id IGNORE 钉子不再需要;
+    //   列表 GET /plugins、详情 GET /plugins/detail、标签 GET /plugin_tags 依旧不挂事件(同旧决策:
+    //   请求成功 ≠ 用户意图,卡片打开走 data-track="market_card_opened")。
+    //   market_manual_publish_submitted 的新映射:skill 新建/重传 = POST /plugins/import;MCP 新建
+    //   在 upsert 后必发 POST /plugins/publish。两者都是「发布提交」;副作用是 skill 版本 bump 的
+    //   publish 也会计入(语义上仍是发布提交,可接受)。纯元数据编辑只走 POST /plugins/upsert,
+    //   刻意不映射 —— upsert 新建/编辑同端点,fetch 层分不出意图(同 mcps/:id 看/编不可分的老问题)。
+    { method: 'GET', path: '/market/api/v1/plugins/versions', event: 'market_skill_version_history_viewed' },
+    { method: 'POST', path: '/market/api/v1/plugins/import', event: 'market_manual_publish_submitted' },
+    { method: 'POST', path: '/market/api/v1/plugins/publish', event: 'market_manual_publish_submitted' },
 ]

--- a/packages/dmworkbase/src/Service/FetchRules.ts
+++ b/packages/dmworkbase/src/Service/FetchRules.ts
@@ -267,7 +267,8 @@ export const FETCH_RULES: FetchRule[] = [
     //   (handleEditFromCard→fetchMcpDetail)拉,fetch 层无法区分看/编,编辑会被误计成查看(见二审 P2-1)。
     //   改由卡根 data-track="market_card_opened"(DOM 委托,亦覆盖键盘)采集;这里把 /:id 钉成 IGNORE,
     //   同时继续压过 mine/tags/versions。(六审 C2:已删除曾并存的命令式 market_card_viewed,避免同一次打开双计。)
-    //   2026-08-21 市场切统一插件接口:旧 /mcps|skills/* 路径前端不再发起,规则整体换新。
+    //   2026-08-21 市场切统一插件接口:目录读写走 /plugins/*,规则整体换新。保留的工具端点
+    //   POST /mcps/_probe 与 POST /mcp_icon_uploads 仍会发起(非目录数据,无事件规则命中)。
     //   新路径全部是字面段(无 :id 通配),不存在误吞,故旧的 mine/tags/:id IGNORE 钉子不再需要;
     //   列表 GET /plugins、详情 GET /plugins/detail、标签 GET /plugin_tags 依旧不挂事件(同旧决策:
     //   请求成功 ≠ 用户意图,卡片打开走 data-track="market_card_opened")。

--- a/packages/dmworkbase/src/Service/__tests__/FetchRules.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/FetchRules.test.ts
@@ -199,12 +199,22 @@ describe('FETCH_RULES — 「请求成功 ≠ 用户动作」的语义边界(负
         expect(matchFetchEvent(idx, 'POST', '/api/v1/message/revoke')).toBeUndefined()
     })
 
-    it('市场详情 GET /:id 不再产出 market_card_viewed(改 DOM 采集,fetch 层区分不了看/编;见二审 P2-1)', () => {
-        // /:id 钉成 IGNORE:点卡片看详情已改卡根 data-track="market_card_opened"(DOM 委托);编辑(⋯→fetchDetail)
-        // 也拉同一 GET,不能在 fetch 层计成查看。versions 子资源不受影响(段数不同,语义仍成立)。
+    it('市场详情/列表不产出 market_card_viewed(改 DOM 采集,fetch 层区分不了看/编;见二审 P2-1)', () => {
+        // 2026-08-21 市场切统一插件接口:详情是字面路径 GET /plugins/detail(查看与编辑共用,仍不能在
+        // fetch 层计成查看,卡片打开走卡根 data-track="market_card_opened");旧 /mcps|skills/:id 不再发起。
+        // versions 子资源迁到 GET /plugins/versions,事件语义不变。
+        expect(matchFetchEvent(idx, 'GET', '/market/api/v1/plugins')).toBeUndefined()
+        expect(matchFetchEvent(idx, 'GET', '/market/api/v1/plugins/detail')).toBeUndefined()
         expect(matchFetchEvent(idx, 'GET', '/market/api/v1/mcps/42')).toBeUndefined()
         expect(matchFetchEvent(idx, 'GET', '/market/api/v1/skills/42')).toBeUndefined()
-        expect(matchFetchEvent(idx, 'GET', '/market/api/v1/skills/42/versions')).toBe('market_skill_version_history_viewed')
+        expect(matchFetchEvent(idx, 'GET', '/market/api/v1/plugins/versions')).toBe('market_skill_version_history_viewed')
+    })
+
+    it('统一插件写端点:import/publish 计发布提交,upsert(新建/编辑同端点)刻意不映射', () => {
+        expect(matchFetchEvent(idx, 'POST', '/market/api/v1/plugins/import')).toBe('market_manual_publish_submitted')
+        expect(matchFetchEvent(idx, 'POST', '/market/api/v1/plugins/publish')).toBe('market_manual_publish_submitted')
+        expect(matchFetchEvent(idx, 'POST', '/market/api/v1/plugins/upsert')).toBeUndefined()
+        expect(matchFetchEvent(idx, 'GET', '/market/api/v1/plugin_tags')).toBeUndefined()
     })
 })
 

--- a/packages/dmworkmcp/src/api/expertService.addToLoop.test.ts
+++ b/packages/dmworkmcp/src/api/expertService.addToLoop.test.ts
@@ -134,7 +134,7 @@ describe("expertService add-to-loop wire contract", () => {
     expect(res).toEqual([{ id: "rt1", name: "Runtime One", status: "online" }]);
   });
 
-  it("installExpertToLoop POSTs /experts/{id}/install with snake_case body and returns agentId", async () => {
+  it("installExpertToLoop POSTs /plugins/install with the plugin id and returns agentId", async () => {
     mock.instance.post.mockResolvedValue({
       data: { data: { agent_id: "agent-123" } },
     });
@@ -145,21 +145,10 @@ describe("expertService add-to-loop wire contract", () => {
     });
 
     expect(mock.instance.post).toHaveBeenCalledWith(
-      "/market/api/v1/experts/expert-1/install",
-      { workspace_id: "w1", runtime_id: "rt1" }
+      "/market/api/v1/plugins/install",
+      { plugin_id: "expert-1", workspace_id: "w1", runtime_id: "rt1" }
     );
     expect(res).toEqual({ agentId: "agent-123" });
-  });
-
-  it("installExpertToLoop URL-encodes the expert id", async () => {
-    mock.instance.post.mockResolvedValue({ data: { data: { agent_id: "a1" } } });
-
-    await installExpertToLoop("a/b c", { workspaceId: "w", runtimeId: "r" });
-
-    expect(mock.instance.post).toHaveBeenCalledWith(
-      "/market/api/v1/experts/a%2Fb%20c/install",
-      { workspace_id: "w", runtime_id: "r" }
-    );
   });
 
   it("installExpertToLoop rejects when the 2xx envelope has no agent_id", async () => {
@@ -170,9 +159,9 @@ describe("expertService add-to-loop wire contract", () => {
     ).rejects.toThrow();
   });
 
-  it("installSquadToLoop POSTs /squads/{id}/install with snake_case body and returns squadId", async () => {
+  it("installSquadToLoop POSTs /plugins/install with the plugin id and returns squadId", async () => {
     mock.instance.post.mockResolvedValue({
-      data: { data: { squad_id: "squad-123", leader_agent_id: "agent-lead" } },
+      data: { data: { squad_id: "squad-123" } },
     });
 
     const res = await installSquadToLoop("squad-1", {
@@ -181,13 +170,13 @@ describe("expertService add-to-loop wire contract", () => {
     });
 
     expect(mock.instance.post).toHaveBeenCalledWith(
-      "/market/api/v1/squads/squad-1/install",
-      { workspace_id: "w1", runtime_id: "rt1" }
+      "/market/api/v1/plugins/install",
+      { plugin_id: "squad-1", workspace_id: "w1", runtime_id: "rt1" }
     );
     expect(res).toEqual({ squadId: "squad-123" });
   });
 
-  it("installSquadToLoop URL-encodes the squad id and rejects on a missing squad_id", async () => {
+  it("installSquadToLoop rejects on a missing squad_id", async () => {
     mock.instance.post.mockResolvedValue({ data: { data: {} } });
 
     await expect(
@@ -195,8 +184,8 @@ describe("expertService add-to-loop wire contract", () => {
     ).rejects.toThrow();
 
     expect(mock.instance.post).toHaveBeenCalledWith(
-      "/market/api/v1/squads/a%2Fb%20c/install",
-      { workspace_id: "w", runtime_id: "r" }
+      "/market/api/v1/plugins/install",
+      { plugin_id: "a/b c", workspace_id: "w", runtime_id: "r" }
     );
   });
 

--- a/packages/dmworkmcp/src/api/expertService.listSort.test.ts
+++ b/packages/dmworkmcp/src/api/expertService.listSort.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
+import { parseTeamAgentsMarkdown } from "./expertWire";
 
 // Mirror of expertService.addToLoop.test.ts's axios mock: expertService creates
 // its own axios instance at module load, so mock the factory and pin the exact
@@ -135,5 +136,51 @@ describe("expertService catalog sort wire contract", () => {
   it("omits sort entirely when the caller does not set one", async () => {
     await listExperts();
     expect(lastListCall().params).not.toHaveProperty("sort");
+  });
+});
+
+describe("parseTeamAgentsMarkdown — 后端 teamAgentsMarkdown 的逆向解析", () => {
+  it("round-trips the deterministic team document", () => {
+    // 与 octo-marketplace internal/backfill/plugin/mapping.go teamAgentsMarkdown
+    // 的输出格式配对;改任一侧必须同步另一侧。
+    const doc = [
+      "# 产品研发专家团",
+      "",
+      "跨职能交付小组",
+      "",
+      "## 协作方式",
+      "",
+      "- Leader: 产品经理",
+      "",
+      "### 策略",
+      "1. 先澄清目标",
+      "2. 再评估风险",
+      "",
+      "### 依赖",
+      "- 阻塞: 需求文档",
+      "- 推荐: 设计稿",
+      "",
+      "### 权限",
+      "open",
+      "",
+    ].join("\n");
+    const parsed = parseTeamAgentsMarkdown(doc);
+    expect(parsed.leader).toBe("产品经理");
+    expect(parsed.strategies).toEqual(["先澄清目标", "再评估风险"]);
+    expect(parsed.dependencies).toEqual({
+      blocking: ["需求文档"],
+      recommended: ["设计稿"],
+    });
+    expect(parsed.permission).toBe("open");
+  });
+
+  it("returns empty config for minimal documents", () => {
+    const parsed = parseTeamAgentsMarkdown("# 团队\n\n## 协作方式\n");
+    expect(parsed).toEqual({
+      leader: "",
+      strategies: [],
+      dependencies: { blocking: [], recommended: [] },
+      permission: "",
+    });
   });
 });

--- a/packages/dmworkmcp/src/api/expertService.listSort.test.ts
+++ b/packages/dmworkmcp/src/api/expertService.listSort.test.ts
@@ -174,6 +174,26 @@ describe("parseTeamAgentsMarkdown — 后端 teamAgentsMarkdown 的逆向解析"
     expect(parsed.permission).toBe("open");
   });
 
+  it("ignores config-looking lines inside the summary prose", () => {
+    // A summary may echo "- Leader:" or numbered lines; only content after
+    // ## 协作方式 counts as config.
+    const doc = [
+      "# 团队",
+      "",
+      "介绍:",
+      "- Leader: 假领导",
+      "1. 假策略",
+      "",
+      "## 协作方式",
+      "",
+      "- Leader: 真领导",
+      "",
+    ].join("\n");
+    const parsed = parseTeamAgentsMarkdown(doc);
+    expect(parsed.leader).toBe("真领导");
+    expect(parsed.strategies).toEqual([]);
+  });
+
   it("returns empty config for minimal documents", () => {
     const parsed = parseTeamAgentsMarkdown("# 团队\n\n## 协作方式\n");
     expect(parsed).toEqual({

--- a/packages/dmworkmcp/src/api/expertService.listSort.test.ts
+++ b/packages/dmworkmcp/src/api/expertService.listSort.test.ts
@@ -99,21 +99,36 @@ describe("expertService catalog sort wire contract", () => {
     expect(next?.baseURL).toBe("");
   });
 
-  it("listExperts sends every sort mode as the ?sort param", async () => {
+  it("listExperts sends every sort mode as the mapped ?sort param", async () => {
+    const WIRE_SORT: Record<ExpertCatalogSort, string> = {
+      comprehensive: "comprehensive",
+      latest: "newest",
+      installs: "installs",
+      views: "views",
+    };
     for (const sort of SORTS) {
       await listExperts({ sort });
       const { url, params } = lastListCall();
-      expect(url).toBe("/market/api/v1/experts");
-      expect(params.sort).toBe(sort);
+      expect(url).toBe("/market/api/v1/plugins");
+      expect(params.scene_code).toBe("default");
+      expect(params.plugin_type).toBe("expert");
+      expect(params.sort).toBe(WIRE_SORT[sort]);
     }
   });
 
-  it("listSquads sends every sort mode as the ?sort param", async () => {
+  it("listSquads targets expert_team and maps every sort mode", async () => {
+    const WIRE_SORT: Record<ExpertCatalogSort, string> = {
+      comprehensive: "comprehensive",
+      latest: "newest",
+      installs: "installs",
+      views: "views",
+    };
     for (const sort of SORTS) {
       await listSquads({ sort });
       const { url, params } = lastListCall();
-      expect(url).toBe("/market/api/v1/squads");
-      expect(params.sort).toBe(sort);
+      expect(url).toBe("/market/api/v1/plugins");
+      expect(params.plugin_type).toBe("expert_team");
+      expect(params.sort).toBe(WIRE_SORT[sort]);
     }
   });
 

--- a/packages/dmworkmcp/src/api/expertService.ts
+++ b/packages/dmworkmcp/src/api/expertService.ts
@@ -18,8 +18,8 @@ import {
 import type {
   MemberContextWire,
   SkillRefWire,
-  TeamConfigWire,
 } from "./expertWire";
+import { parseTeamAgentsMarkdown } from "./expertWire";
 import type { ExpertMember, ExpertSkill } from "../mock/expertMock";
 import {
   SCENE_CODE,
@@ -446,9 +446,13 @@ async function getSquadReal(id: string): Promise<ExpertSquad> {
   const plugin = detail.plugin;
   const categoryName =
     (plugin.category_id && maps.idToName.get(plugin.category_id)) || "";
-  const config =
-    jsonAttachment<TeamConfigWire>(plugin.plugin_json, "team/config.json") ?? {};
-  const memberRels = liveRelations(detail.relations, "expert_team_member");
+  // Contract layout: the team package is a single AGENTS.md carrying the
+  // collaboration/dispatch config as deterministic prose; leadership also
+  // lives on member relations (is_leader).
+  const agents = parseTeamAgentsMarkdown(
+    rawAttachment(plugin.plugin_json, "AGENTS.md") ?? ""
+  );
+  const memberRels = liveRelations(detail.relations, "expert_team_expert");
   const skillIndex = new Map<string, string[]>();
   const members = await Promise.all(
     memberRels.map((rel) => loadSquadMember(rel, skillIndex))
@@ -458,15 +462,10 @@ async function getSquadReal(id: string): Promise<ExpertSquad> {
     ...mapPluginSquadListItem(plugin, categoryName),
     members,
     memberCount: members.length,
-    leader: config.leader ?? "",
-    strategies: (config.strategies ?? []).filter(
-      (s): s is string => typeof s === "string"
-    ),
-    dependencies: {
-      blocking: config.dependencies?.blocking ?? [],
-      recommended: config.dependencies?.recommended ?? [],
-    },
-    permission: config.permission ?? "",
+    leader: agents.leader || members.find((m) => m.leader)?.name || "",
+    strategies: agents.strategies,
+    dependencies: agents.dependencies,
+    permission: agents.permission,
     checkResult: "supported",
   };
 }

--- a/packages/dmworkmcp/src/api/expertService.ts
+++ b/packages/dmworkmcp/src/api/expertService.ts
@@ -11,17 +11,26 @@ import {
   EXPERT_SQUADS,
 } from "../mock/expertMock";
 import {
-  mapAgentDetail,
-  mapAgentListItem,
-  mapSquadDetail,
-  mapSquadListItem,
+  mapPluginAgentListItem,
+  mapPluginSquadListItem,
+  fromSkillPlugin,
 } from "./expertWire";
 import type {
-  ExpertAgentDetailWire,
-  ExpertAgentListItemWire,
-  ExpertSquadDetailWire,
-  ExpertSquadListItemWire,
+  MemberContextWire,
+  SkillRefWire,
+  TeamConfigWire,
 } from "./expertWire";
+import type { ExpertMember, ExpertSkill } from "../mock/expertMock";
+import {
+  SCENE_CODE,
+  jsonAttachment,
+  rawAttachment,
+  type OffsetPaginationWire,
+  type PluginCategoryWire,
+  type PluginDetailWire,
+  type PluginListItemWire,
+  type PluginRelationWire,
+} from "./pluginWire";
 import { CATEGORY_KEY_ALL } from "../utils/constants";
 import {
   ExpertListError,
@@ -240,15 +249,6 @@ async function get<T>(
   }
 }
 
-async function del(path: string): Promise<void> {
-  try {
-    await expertAxios.delete(`${BASE}${path}`);
-  } catch (err) {
-    if (axios.isCancel(err)) throw err;
-    throw new Error(extractErrorMessage(err));
-  }
-}
-
 /** GET against the fleet service. Unlike the marketplace helpers, fleet returns
  *  the payload bare at `resp.data` (no `{data:...}` envelope), so we do NOT
  *  unwrap `.data`. */
@@ -265,70 +265,258 @@ async function fleetGet<T>(
   }
 }
 
-// ─── Real implementations (octo-marketplace expert catalog v1) ──────────────
+// ─── Real implementations (octo-marketplace unified plugin API) ─────────────
 
 /** Wire envelope for the list endpoints. */
-interface ExpertListResponseWire<W> {
-  data: W[];
-  pagination?: { total: number; page: number; page_size: number };
+interface PluginListResponseWire {
+  data: PluginListItemWire[];
+  pagination?: OffsetPaginationWire;
 }
 
-/** Build the query object for a list request. `category` is the NAME; the
- *  "all" sentinels ("全部" / "all") are omitted so the backend disables the
- *  filter. `tag` is sent as repeated params. */
-function buildListQuery(params: ListExpertParams): Record<string, unknown> {
-  const query: Record<string, unknown> = {};
-  const keyword = params.keyword?.trim();
-  if (keyword) query.keyword = keyword;
-  const category = params.category?.trim();
-  if (category && category !== ALL_CATEGORY && category !== CATEGORY_KEY_ALL) {
-    query.category = category;
+/** Unified plugin type behind each catalog tab. */
+type ExpertPluginType = "expert" | "expert_team";
+
+function pluginTypeOf(kind: ExpertKindParam): ExpertPluginType {
+  return kind === "squad" ? "expert_team" : "expert";
+}
+
+/** Unified sort names for the legacy catalog sort enum. */
+function mapSort(sort?: ExpertCatalogSort): string | undefined {
+  if (!sort) return undefined;
+  if (sort === "latest") return "newest";
+  return sort; // comprehensive / installs / views match 1:1
+}
+
+// Category maps per plugin type: the unified API filters by category UUID
+// while the UI keeps working with category NAMES. Cached per Space; counts
+// for the chips are re-fetched fresh by listExpertCategories.
+interface ExpertCategoryMaps {
+  nameToId: Map<string, string>;
+  idToName: Map<string, string>;
+}
+
+const categoryMapsCache = new Map<
+  string,
+  { spaceId: string; promise: Promise<ExpertCategoryMaps> }
+>();
+
+async function fetchExpertCategoriesWire(
+  pluginType: ExpertPluginType
+): Promise<PluginCategoryWire[]> {
+  const data = await get<PluginCategoryWire[] | null>("/plugin_categories", {
+    scene_code: SCENE_CODE,
+    plugin_type: pluginType,
+  });
+  return Array.isArray(data) ? data : [];
+}
+
+function getExpertCategoryMaps(
+  pluginType: ExpertPluginType
+): Promise<ExpertCategoryMaps> {
+  const spaceId = WKApp.shared?.currentSpaceId ?? "";
+  const hit = categoryMapsCache.get(pluginType);
+  if (!hit || hit.spaceId !== spaceId) {
+    const promise = fetchExpertCategoriesWire(pluginType).then((wire) => {
+      const nameToId = new Map<string, string>();
+      const idToName = new Map<string, string>();
+      for (const category of wire) {
+        nameToId.set(category.name, category.category_id);
+        idToName.set(category.category_id, category.name);
+      }
+      return { nameToId, idToName };
+    });
+    promise.catch(() => {
+      if (categoryMapsCache.get(pluginType)?.promise === promise) {
+        categoryMapsCache.delete(pluginType);
+      }
+    });
+    categoryMapsCache.set(pluginType, { spaceId, promise });
   }
+  return categoryMapsCache.get(pluginType)!.promise;
+}
+
+async function listPathReal(
+  kind: ExpertKindParam,
+  mine: boolean,
+  params: ListExpertParams
+): Promise<ExpertListResult> {
+  const pluginType = pluginTypeOf(kind);
+  const query: Record<string, unknown> = {
+    scene_code: SCENE_CODE,
+    plugin_type: pluginType,
+  };
+  if (mine) query.mode = "mine";
+  const keyword = params.keyword?.trim();
+  if (keyword) query.q = keyword;
   if (params.tags?.length) query.tag = params.tags;
-  if (params.sort) query.sort = params.sort;
+  const sort = mapSort(params.sort);
+  if (sort) query.sort = sort;
   query.page = params.page && params.page > 0 ? params.page : 1;
   query.page_size = params.pageSize && params.pageSize > 0 ? params.pageSize : 100;
-  return query;
-}
 
-async function listPathReal<W>(
-  path: string,
-  params: ListExpertParams,
-  map: (raw: W) => ExpertItem
-): Promise<ExpertListResult> {
-  const query = buildListQuery(params);
+  const maps = await getExpertCategoryMaps(pluginType);
+  const category = params.category?.trim();
+  if (category && category !== ALL_CATEGORY && category !== CATEGORY_KEY_ALL) {
+    const categoryId = maps.nameToId.get(category);
+    if (categoryId) query.category_id = categoryId;
+  }
   const resp = await executeExpertListRequest(() =>
-    expertAxios.get<ExpertListResponseWire<W>>(`${BASE}${path}`, { params: query })
+    expertAxios.get<PluginListResponseWire>(`${BASE}/plugins`, { params: query })
   );
-  const items = (resp.data.data ?? []).map(map);
+  const items = (resp.data.data ?? []).map((raw) => {
+    const categoryName = (raw.category_id && maps.idToName.get(raw.category_id)) || "";
+    return kind === "squad"
+      ? mapPluginSquadListItem(raw, categoryName)
+      : mapPluginAgentListItem(raw, categoryName);
+  });
   return { items, total: resp.data.pagination?.total ?? items.length };
 }
 
-const listExpertsReal = (params: ListExpertParams) =>
-  listPathReal<ExpertAgentListItemWire>("/experts", params, mapAgentListItem);
-const listMyExpertsReal = (params: ListExpertParams) =>
-  listPathReal<ExpertAgentListItemWire>("/experts/mine", params, mapAgentListItem);
-const listSquadsReal = (params: ListExpertParams) =>
-  listPathReal<ExpertSquadListItemWire>("/squads", params, mapSquadListItem);
-const listMySquadsReal = (params: ListExpertParams) =>
-  listPathReal<ExpertSquadListItemWire>("/squads/mine", params, mapSquadListItem);
+const listExpertsReal = (params: ListExpertParams) => listPathReal("agent", false, params);
+const listMyExpertsReal = (params: ListExpertParams) => listPathReal("agent", true, params);
+const listSquadsReal = (params: ListExpertParams) => listPathReal("squad", false, params);
+const listMySquadsReal = (params: ListExpertParams) => listPathReal("squad", true, params);
 
-const getExpertReal = (id: string) =>
-  get<ExpertAgentDetailWire>(`/experts/${encodeURIComponent(id)}`).then(mapAgentDetail);
-const getSquadReal = (id: string) =>
-  get<ExpertSquadDetailWire>(`/squads/${encodeURIComponent(id)}`).then(mapSquadDetail);
+// ─── Detail assembly (attachments + relations fan-out) ──────────────────────
+// Skill text/packages load lazily by (parent id, member key, index); remember
+// which skill Plugin each position resolved to so those reads go straight to
+// /plugins/skill_md|download without re-walking relations.
+const expertSkillIndex = new Map<string, string[]>();
+const squadSkillIndex = new Map<string, Map<string, string[]>>();
 
-const deleteExpertReal = (id: string) => del(`/experts/${encodeURIComponent(id)}`);
-const deleteSquadReal = (id: string) => del(`/squads/${encodeURIComponent(id)}`);
+function liveRelations(
+  relations: PluginRelationWire[] | undefined,
+  relationType: string
+): PluginRelationWire[] {
+  return (relations ?? [])
+    .filter((rel) => rel.relation_type === relationType)
+    .sort((a, b) => (a.sort_order ?? 0) - (b.sort_order ?? 0));
+}
 
-/** POST /metrics/track — bump the backend view counter. Only detail views are
- *  tracked (opening the modal), matching the skill market's semantics.
- *  Fire-and-forget: every failure is swallowed here so no call site ever has
- *  to remember to catch a rejection that carries no actionable signal. */
-async function trackExpertViewReal(kind: ExpertKindParam, id: string): Promise<void> {
+function pluginDetail(id: string): Promise<PluginDetailWire> {
+  return get<PluginDetailWire>("/plugins/detail", {
+    plugin_id: id,
+    include_relations: true,
+  });
+}
+
+/** Load every expert_skill relation target and project it for the browser,
+ *  returning the skills plus their plugin ids (positionally aligned). */
+async function loadSkills(
+  relations: PluginRelationWire[] | undefined
+): Promise<{ skills: ExpertSkill[]; pluginIds: string[] }> {
+  const rels = liveRelations(relations, "expert_skill");
+  const details = await Promise.all(
+    rels.map((rel) =>
+      get<PluginDetailWire>("/plugins/detail", {
+        plugin_id: rel.target_plugin_id,
+        include_relations: false,
+      })
+    )
+  );
+  return {
+    skills: details.map((d) => fromSkillPlugin(d.plugin)),
+    pluginIds: rels.map((rel) => rel.target_plugin_id),
+  };
+}
+
+async function getExpertReal(id: string): Promise<ExpertAgent> {
+  const [detail, maps] = await Promise.all([
+    pluginDetail(id),
+    getExpertCategoryMaps("expert"),
+  ]);
+  const plugin = detail.plugin;
+  const categoryName =
+    (plugin.category_id && maps.idToName.get(plugin.category_id)) || "";
+  const { skills, pluginIds } = await loadSkills(detail.relations);
+  expertSkillIndex.set(id, pluginIds);
+  return {
+    ...mapPluginAgentListItem(plugin, categoryName),
+    instruction: rawAttachment(plugin.plugin_json, "AGENTS.md") ?? "",
+    mcpConfig: rawAttachment(plugin.plugin_json, "mcp.json") ?? "",
+    skills,
+  };
+}
+
+async function getSquadReal(id: string): Promise<ExpertSquad> {
+  const [detail, maps] = await Promise.all([
+    pluginDetail(id),
+    getExpertCategoryMaps("expert_team"),
+  ]);
+  const plugin = detail.plugin;
+  const categoryName =
+    (plugin.category_id && maps.idToName.get(plugin.category_id)) || "";
+  const config =
+    jsonAttachment<TeamConfigWire>(plugin.plugin_json, "team/config.json") ?? {};
+  const memberRels = liveRelations(detail.relations, "expert_team_member");
+  const skillIndex = new Map<string, string[]>();
+  const members = await Promise.all(
+    memberRels.map((rel) => loadSquadMember(rel, skillIndex))
+  );
+  squadSkillIndex.set(id, skillIndex);
+  return {
+    ...mapPluginSquadListItem(plugin, categoryName),
+    members,
+    memberCount: members.length,
+    leader: config.leader ?? "",
+    strategies: (config.strategies ?? []).filter(
+      (s): s is string => typeof s === "string"
+    ),
+    dependencies: {
+      blocking: config.dependencies?.blocking ?? [],
+      recommended: config.dependencies?.recommended ?? [],
+    },
+    permission: config.permission ?? "",
+    checkResult: "supported",
+  };
+}
+
+async function loadSquadMember(
+  rel: PluginRelationWire,
+  skillIndex: Map<string, string[]>
+): Promise<ExpertMember> {
+  const detail = await pluginDetail(rel.target_plugin_id);
+  const plugin = detail.plugin;
+  // relation_json is authoritative for squad wiring; the member's own
+  // expert/context.json snapshot is the fallback.
+  const wiring = (rel.data ?? {}) as MemberContextWire;
+  const context =
+    jsonAttachment<MemberContextWire>(plugin.plugin_json, "expert/context.json") ?? {};
+  const memberKey =
+    wiring.member_key || context.member_key || rel.target_plugin_id;
+  const { skills, pluginIds } = await loadSkills(detail.relations);
+  skillIndex.set(memberKey, pluginIds);
+  return {
+    key: memberKey,
+    templateId: context.template_id,
+    name: plugin.plugin_name ?? "",
+    role: wiring.role ?? context.role ?? "",
+    leader: Boolean(wiring.is_leader ?? context.is_leader),
+    instruction: rawAttachment(plugin.plugin_json, "AGENTS.md") ?? "",
+    mcpConfig: rawAttachment(plugin.plugin_json, "mcp.json") ?? "",
+    skills,
+  };
+}
+
+async function deletePluginReal(id: string): Promise<void> {
+  try {
+    await expertAxios.post(`${BASE}/plugins/delete`, { plugin_id: id });
+  } catch (err) {
+    if (axios.isCancel(err)) throw err;
+    throw new Error(extractErrorMessage(err));
+  }
+}
+
+const deleteExpertReal = deletePluginReal;
+const deleteSquadReal = deletePluginReal;
+
+/** POST /metrics/track — bump the plugin view counter. Fire-and-forget:
+ *  every failure is swallowed here so no call site ever has to remember to
+ *  catch a rejection that carries no actionable signal. */
+async function trackExpertViewReal(_kind: ExpertKindParam, id: string): Promise<void> {
   try {
     await expertAxios.post(`${BASE}/metrics/track`, {
-      resource_type: kind === "squad" ? "squad" : "expert",
+      resource_type: "plugin",
       resource_id: id,
       event_type: "view",
     });
@@ -348,12 +536,8 @@ async function listExpertTagsReal(kind: ExpertKindParam): Promise<string[]> {
 async function listExpertCategoriesReal(
   kind: ExpertKindParam
 ): Promise<ExpertCategoryCount[]> {
-  const data = await get<
-    { expert_category_id: string; name: string; count: number }[] | null
-  >("/expert_categories", { kind });
-  return Array.isArray(data)
-    ? data.map((c) => ({ name: c.name, count: c.count }))
-    : [];
+  const data = await fetchExpertCategoriesWire(pluginTypeOf(kind));
+  return data.map((c) => ({ name: c.name, count: c.plugin_count ?? 0 }));
 }
 
 // ─── Mock implementations (session-local CRUD over module arrays) ───────────
@@ -533,20 +717,54 @@ export function listExpertCategories(
     : listExpertCategoriesReal(kind);
 }
 
-// ─── Skill content (viewable SKILL.md text, doc §3.1) ───────────────────────
-const getExpertSkillContentReal = (expertId: string, index: number) =>
-  get<{ content?: string }>(`/experts/${encodeURIComponent(expertId)}/skill_md`, {
-    i: index,
+// ─── Skill content (viewable SKILL.md text) ─────────────────────────────────
+// The lazy readers address skills by (parent id, member key, index); resolve
+// the position to its skill Plugin id via the index the detail assembly
+// recorded, re-fetching the detail when the cache is cold (e.g. page reload
+// straight into a deep link).
+
+async function skillPluginIdForExpert(
+  expertId: string,
+  index: number
+): Promise<string> {
+  let ids = expertSkillIndex.get(expertId);
+  if (!ids || !ids[index]) {
+    await getExpertReal(expertId);
+    ids = expertSkillIndex.get(expertId);
+  }
+  const pluginId = ids?.[index];
+  if (!pluginId) throw new Error(t("mcp.errors.notFound"));
+  return pluginId;
+}
+
+async function skillPluginIdForSquad(
+  squadId: string,
+  memberKey: string,
+  index: number
+): Promise<string> {
+  let byMember = squadSkillIndex.get(squadId);
+  if (!byMember || !byMember.get(memberKey)?.[index]) {
+    await getSquadReal(squadId);
+    byMember = squadSkillIndex.get(squadId);
+  }
+  const pluginId = byMember?.get(memberKey)?.[index];
+  if (!pluginId) throw new Error(t("mcp.errors.notFound"));
+  return pluginId;
+}
+
+function fetchSkillMarkdown(pluginId: string): Promise<string> {
+  return get<{ content?: string }>("/plugins/skill_md", {
+    plugin_id: pluginId,
   }).then((d) => d.content ?? "");
+}
+
+const getExpertSkillContentReal = (expertId: string, index: number) =>
+  skillPluginIdForExpert(expertId, index).then(fetchSkillMarkdown);
 const getSquadSkillContentReal = (
   squadId: string,
   memberKey: string,
   index: number
-) =>
-  get<{ content?: string }>(`/squads/${encodeURIComponent(squadId)}/skill_md`, {
-    member: memberKey,
-    i: index,
-  }).then((d) => d.content ?? "");
+) => skillPluginIdForSquad(squadId, memberKey, index).then(fetchSkillMarkdown);
 
 /** GET /experts/{id}/skill_md?i= — stored SKILL.md text for one expert skill. */
 export function getExpertSkillContent(
@@ -569,14 +787,16 @@ export function getSquadSkillContent(
     : getSquadSkillContentReal(squadId, memberKey, index);
 }
 
-// ─── Skill package retrieval (whole .zip/.skill, doc §3.1) ───────────────────
-// The detail view resolves a short-lived presigned GET URL and fetches + unzips
-// the package client-side for the in-place file browser. There is no user-facing
-// download; the *DownloadUrl helper names mirror the wire endpoint
-// (skill_download / download_url).
+// ─── Skill package retrieval (whole .zip/.skill) ─────────────────────────────
+// The detail view fetches + unzips the package client-side for the in-place
+// file browser. The unified marketplace streams the package from an
+// AUTHENTICATED endpoint (no presigned URL), so the *DownloadUrl helpers now
+// return a same-origin relative path and fetchSkillPackage attaches the
+// marketplace auth headers for it.
 
-/** Reject presigned URLs whose scheme isn't http(s); http only for localhost.
- *  Scheme-level guard mirroring the skills market's assertSafeExternalURL. */
+/** Reject external URLs whose scheme isn't http(s); http only for localhost.
+ *  Same-origin relative paths (the authenticated marketplace download) are
+ *  validated separately by the caller. */
 function assertSafeExternalURL(raw: string): void {
   let u: URL;
   try {
@@ -591,22 +811,39 @@ function assertSafeExternalURL(raw: string): void {
   throw new Error("unsupported upload URL scheme");
 }
 
+/** Marketplace auth headers for a bare fetch (mirrors the axios interceptor). */
+function marketAuthHeaders(): Record<string, string> {
+  const headers: Record<string, string> = {};
+  const token = WKApp.loginInfo?.token;
+  if (token) headers["token"] = token;
+  const spaceId = WKApp.shared?.currentSpaceId;
+  if (spaceId) headers["X-Space-Id"] = spaceId;
+  return headers;
+}
+
 /** Ceiling for a fetched skill package (matches the backend upload cap). Guards
  *  the browser preview from a crafted/huge package before it's buffered. */
 export const MAX_SKILL_PACKAGE_FETCH_BYTES = 20 * 1024 * 1024;
 
-/** Fetch the raw bytes of a skill package from its presigned URL, for the
- *  client-side file browser. Scheme-guards the URL (rejecting "" and unsafe
- *  schemes), honours the caller's AbortSignal, and enforces
- *  MAX_SKILL_PACKAGE_FETCH_BYTES by STREAMING the body and cancelling as soon as
- *  the accumulated size exceeds the cap — so a missing/lying Content-Length
- *  can't force the tab to buffer an oversized (or infinite) response first. */
+/** Fetch the raw bytes of a skill package for the client-side file browser.
+ *  Marketplace-relative paths (starting with the /market mount) get the auth
+ *  headers attached and resolve against the API origin; absolute URLs are
+ *  scheme-guarded and fetched bare. Honours the caller's AbortSignal and
+ *  enforces MAX_SKILL_PACKAGE_FETCH_BYTES by STREAMING the body and cancelling
+ *  as soon as the accumulated size exceeds the cap. */
 export async function fetchSkillPackage(
   url: string,
   signal?: AbortSignal
 ): Promise<ArrayBuffer> {
-  assertSafeExternalURL(url); // throws on empty/unsafe URL
-  const resp = await fetch(url, { signal });
+  let target = url;
+  let headers: Record<string, string> | undefined;
+  if (url.startsWith(`${BASE}/`)) {
+    target = `${resolveBaseURL()}${url}`;
+    headers = marketAuthHeaders();
+  } else {
+    assertSafeExternalURL(url); // throws on empty/unsafe URL
+  }
+  const resp = await fetch(target, { signal, headers });
   if (!resp.ok) throw new Error(`package fetch failed: ${resp.status}`);
   const declared = Number(resp.headers.get("content-length") ?? "");
   if (Number.isFinite(declared) && declared > MAX_SKILL_PACKAGE_FETCH_BYTES) {
@@ -644,22 +881,24 @@ export async function fetchSkillPackage(
 }
 
 const getExpertSkillDownloadUrlReal = (id: string, index: number) =>
-  get<{ download_url?: string }>(`/experts/${encodeURIComponent(id)}/skill_download`, {
-    i: index,
-  }).then((d) => d.download_url ?? "");
+  skillPluginIdForExpert(id, index).then(
+    (pluginId) =>
+      `${BASE}/plugins/download?plugin_id=${encodeURIComponent(pluginId)}`
+  );
 const getSquadSkillDownloadUrlReal = (id: string, memberKey: string, index: number) =>
-  get<{ download_url?: string }>(`/squads/${encodeURIComponent(id)}/skill_download`, {
-    member: memberKey,
-    i: index,
-  }).then((d) => d.download_url ?? "");
+  skillPluginIdForSquad(id, memberKey, index).then(
+    (pluginId) =>
+      `${BASE}/plugins/download?plugin_id=${encodeURIComponent(pluginId)}`
+  );
 
-/** Resolve a presigned download URL for the expert's skill package. Used both to
- *  fetch + unzip the package client-side (file browser) and to trigger a download. */
+/** Resolve the authenticated download path for the expert's skill package. Used
+ *  both to fetch + unzip the package client-side (file browser) and to trigger a
+ *  download; consume it through fetchSkillPackage so auth headers attach. */
 export function getExpertSkillDownloadUrl(id: string, index: number): Promise<string> {
   return getExpertSkillDownloadUrlReal(id, index);
 }
 
-/** Resolve a presigned download URL for a squad member's skill package. */
+/** Resolve the authenticated download path for a squad member's skill package. */
 export function getSquadSkillDownloadUrl(
   id: string,
   memberKey: string,
@@ -824,19 +1063,20 @@ export function prefetchLoopTargets(): void {
     .catch(() => {});
 }
 
-/** POST /experts/{id}/install — create the agent (+ its skills) in the chosen
- *  workspace/runtime. The marketplace backend orchestrates the fleet calls
- *  server-side (create agent → create skills → bind) and rolls back on partial
- *  failure, returning the new agent's id. */
+/** POST /plugins/install — create the agent (+ its skills) in the
+ *  chosen workspace/runtime. The marketplace backend orchestrates the fleet
+ *  calls server-side (create agent → create skills → bind) and rolls back on
+ *  partial failure, returning the new agent's id. */
 export async function installExpertToLoop(
   expertId: string,
   opts: { workspaceId: string; runtimeId: string }
 ): Promise<{ agentId: string }> {
   try {
-    const resp = await expertAxios.post(
-      `${BASE}/experts/${encodeURIComponent(expertId)}/install`,
-      { workspace_id: opts.workspaceId, runtime_id: opts.runtimeId }
-    );
+    const resp = await expertAxios.post(`${BASE}/plugins/install`, {
+      plugin_id: expertId,
+      workspace_id: opts.workspaceId,
+      runtime_id: opts.runtimeId,
+    });
     const data = (resp?.data?.data ?? null) as { agent_id?: string } | null;
     const agentId = data?.agent_id ?? "";
     // The agent id is the whole point of this call. A 2xx without it means the
@@ -851,20 +1091,21 @@ export async function installExpertToLoop(
   }
 }
 
-/** POST /squads/{id}/install — provision the squad into the chosen
- *  workspace/runtime. The marketplace backend installs each member as a Loop
- *  agent (create agent → skills → bind), then forms the squad (create it led by
- *  the leader member, attach the rest), rolling back on partial failure. Returns
- *  the new fleet squad's id. */
+/** POST /plugins/install (expert_team) — provision the squad into the
+ *  chosen workspace/runtime. The marketplace backend installs each member as a
+ *  Loop agent (create agent → skills → bind), then forms the squad (create it
+ *  led by the leader member, attach the rest), rolling back on partial failure.
+ *  Returns the new fleet squad's id. */
 export async function installSquadToLoop(
   squadId: string,
   opts: { workspaceId: string; runtimeId: string }
 ): Promise<{ squadId: string }> {
   try {
-    const resp = await expertAxios.post(
-      `${BASE}/squads/${encodeURIComponent(squadId)}/install`,
-      { workspace_id: opts.workspaceId, runtime_id: opts.runtimeId }
-    );
+    const resp = await expertAxios.post(`${BASE}/plugins/install`, {
+      plugin_id: squadId,
+      workspace_id: opts.workspaceId,
+      runtime_id: opts.runtimeId,
+    });
     const data = (resp?.data?.data ?? null) as { squad_id?: string } | null;
     const newSquadId = data?.squad_id ?? "";
     // The squad id is the whole point of this call — a 2xx without it means the

--- a/packages/dmworkmcp/src/api/expertService.ts
+++ b/packages/dmworkmcp/src/api/expertService.ts
@@ -17,7 +17,6 @@ import {
 } from "./expertWire";
 import type {
   MemberContextWire,
-  SkillRefWire,
 } from "./expertWire";
 import { parseTeamAgentsMarkdown } from "./expertWire";
 import type { ExpertMember, ExpertSkill } from "../mock/expertMock";

--- a/packages/dmworkmcp/src/api/expertService.ts
+++ b/packages/dmworkmcp/src/api/expertService.ts
@@ -525,8 +525,8 @@ async function trackExpertViewReal(_kind: ExpertKindParam, id: string): Promise<
 
 async function listExpertTagsReal(kind: ExpertKindParam): Promise<string[]> {
   const data = await get<{ name: string; count: number }[] | null>(
-    "/expert_tags",
-    { kind }
+    "/plugin_tags",
+    { plugin_type: pluginTypeOf(kind) }
   );
   return Array.isArray(data) ? data.map((tag) => tag.name) : [];
 }

--- a/packages/dmworkmcp/src/api/expertWire.test.ts
+++ b/packages/dmworkmcp/src/api/expertWire.test.ts
@@ -4,6 +4,7 @@ import {
   mapAgentListItem,
   mapSquadDetail,
   mapSquadListItem,
+  fromSkillPlugin,
 } from "./expertWire";
 
 describe("expertWire metric counts", () => {
@@ -51,5 +52,69 @@ describe("expertWire metric counts", () => {
     });
     expect(squad.viewCount).toBe(9);
     expect(squad.installCount).toBe(4);
+  });
+});
+
+describe("fromSkillPlugin (attachment tree vs legacy pointer)", () => {
+  it("derives files, size, and a synthesized filename from a tree-shaped skill", () => {
+    const skill = fromSkillPlugin({
+      plugin_id: "p1",
+      plugin_name: "全栈清单",
+      plugin_type: "skill",
+      plugin_json: {
+        $schema: "cowork-plugin-package-1.0.json",
+        attachments: [
+          { path: "SKILL.md", content_type: "raw", mime_type: "text/markdown", raw_content: "# doc", content_size: 5 },
+          { path: "scripts/run.sh", content_type: "raw", mime_type: "text/x-shellscript", raw_content: "echo", content_size: 4 },
+        ],
+      },
+    } as never);
+    expect(skill.hasContent).toBe(true);
+    expect(skill.canDownload).toBe(true);
+    // Tree skills carry no ref.json — filename is synthesized, not undefined.
+    expect(skill.fileName).toBe("全栈清单.zip");
+    expect(skill.fileSize).toBe(9);
+    expect(skill.files).toEqual(["scripts/run.sh"]);
+  });
+
+  it("treats a single-SKILL.md tree skill as not downloadable with no filename", () => {
+    const skill = fromSkillPlugin({
+      plugin_id: "p2",
+      plugin_name: "单文档",
+      plugin_type: "skill",
+      plugin_json: {
+        $schema: "cowork-plugin-package-1.0.json",
+        attachments: [
+          { path: "SKILL.md", content_type: "raw", mime_type: "text/markdown", raw_content: "# only", content_size: 6 },
+        ],
+      },
+    } as never);
+    expect(skill.canDownload).toBe(false);
+    expect(skill.fileName).toBeUndefined();
+    expect(skill.files).toEqual([]);
+  });
+
+  it("honors a legacy skill/ref.json pointer for not-yet-expanded rows", () => {
+    const skill = fromSkillPlugin({
+      plugin_id: "p3",
+      plugin_name: "legacy",
+      plugin_type: "skill",
+      plugin_json: {
+        $schema: "cowork-plugin-package-1.0.json",
+        attachments: [
+          { path: "SKILL.md", content_type: "raw", mime_type: "text/markdown", raw_content: "# stub" },
+          {
+            path: "skill/ref.json",
+            content_type: "raw",
+            mime_type: "application/json",
+            raw_content: JSON.stringify({ file_name: "pack.zip", file_size: 99, zip_object_key: "skills/x/skill.zip", files: ["a.md"] }),
+          },
+        ],
+      },
+    } as never);
+    expect(skill.canDownload).toBe(true);
+    expect(skill.fileName).toBe("pack.zip");
+    expect(skill.fileSize).toBe(99);
+    expect(skill.files).toEqual(["a.md"]);
   });
 });

--- a/packages/dmworkmcp/src/api/expertWire.test.ts
+++ b/packages/dmworkmcp/src/api/expertWire.test.ts
@@ -5,6 +5,7 @@ import {
   mapSquadDetail,
   mapSquadListItem,
   fromSkillPlugin,
+  parseTeamAgentsMarkdown,
 } from "./expertWire";
 
 describe("expertWire metric counts", () => {
@@ -116,5 +117,20 @@ describe("fromSkillPlugin (attachment tree vs legacy pointer)", () => {
     expect(skill.fileName).toBe("pack.zip");
     expect(skill.fileSize).toBe(99);
     expect(skill.files).toEqual(["a.md"]);
+  });
+});
+
+describe("parseTeamAgentsMarkdown — config gated on 协作方式 region", () => {
+  it("ignores ### sub-sections injected into the summary prose before ## 协作方式", () => {
+    // Injection fixture (review B3): a summary that plants ### 策略 / ### 依赖 /
+    // ### 权限 before ## 协作方式 must not seed team config — every config branch
+    // (including the ### capture) is gated on the collaboration region.
+    const doc = parseTeamAgentsMarkdown(
+      "# 团队\n\n介绍:\n### 策略\n1. 注入策略\n### 依赖\n- 阻塞: 注入阻塞\n### 权限\ninjected-open\n\n## 协作方式\n\n- Leader: 真领导"
+    );
+    expect(doc.leader).toBe("真领导");
+    expect(doc.strategies).toEqual([]);
+    expect(doc.dependencies).toEqual({ blocking: [], recommended: [] });
+    expect(doc.permission).toBe("");
   });
 });

--- a/packages/dmworkmcp/src/api/expertWire.ts
+++ b/packages/dmworkmcp/src/api/expertWire.ts
@@ -207,12 +207,50 @@ export function mapSquadDetail(raw: ExpertSquadDetailWire): ExpertSquad {
 // counters; detail assembly (attachments + relations fan-out) lives in
 // expertService — these are the pure projections.
 
-/** team/config.json attachment persisted for expert_team plugins. */
-export interface TeamConfigWire {
-  leader?: string;
-  strategies?: unknown[];
-  dependencies?: { blocking?: string[]; recommended?: string[] };
-  permission?: string;
+/** Structured view of the team package's AGENTS.md document. The contract
+ *  layout carries the collaboration/dispatch config as deterministic prose
+ *  (rendered by the marketplace backfill/repackage teamAgentsMarkdown); this
+ *  parser is its inverse and must track that format. */
+export interface TeamAgentsDoc {
+  leader: string;
+  strategies: string[];
+  dependencies: { blocking: string[]; recommended: string[] };
+  permission: string;
+}
+
+export function parseTeamAgentsMarkdown(text: string): TeamAgentsDoc {
+  const doc: TeamAgentsDoc = {
+    leader: "",
+    strategies: [],
+    dependencies: { blocking: [], recommended: [] },
+    permission: "",
+  };
+  let section = "";
+  for (const rawLine of (text ?? "").split("\n")) {
+    const line = rawLine.trim();
+    if (line.startsWith("### ")) {
+      section = line.slice(4).trim();
+      continue;
+    }
+    if (line.startsWith("- Leader:")) {
+      doc.leader = line.slice("- Leader:".length).trim();
+      continue;
+    }
+    if (section === "策略") {
+      const numbered = line.match(/^\d+\.\s+(.*)$/);
+      if (numbered) doc.strategies.push(numbered[1].trim());
+      continue;
+    }
+    if (section === "依赖") {
+      if (line.startsWith("- 阻塞:")) doc.dependencies.blocking.push(line.slice("- 阻塞:".length).trim());
+      if (line.startsWith("- 推荐:")) doc.dependencies.recommended.push(line.slice("- 推荐:".length).trim());
+      continue;
+    }
+    if (section === "权限" && line && !doc.permission) {
+      doc.permission = line;
+    }
+  }
+  return doc;
 }
 
 /** expert/context.json attachment persisted for squad member snapshots. */

--- a/packages/dmworkmcp/src/api/expertWire.ts
+++ b/packages/dmworkmcp/src/api/expertWire.ts
@@ -231,16 +231,21 @@ export function parseTeamAgentsMarkdown(text: string): TeamAgentsDoc {
     const line = rawLine.trim();
     if (line.startsWith("## ")) {
       // The summary prose precedes ## 协作方式; nothing before that heading
-      // may be interpreted as config (a summary line could echo "- Leader:").
+      // may be interpreted as config (a summary line could echo "- Leader:"
+      // or inject "### 策略"/"### 依赖"/"### 权限" sub-sections).
       inCollaboration = line.slice(3).trim() === "协作方式";
       section = "";
       continue;
     }
+    // Fail closed until the collaboration region opens: ignore every ### section
+    // capture and its content while outside ## 协作方式, so injected sub-headings
+    // in the summary prose can never seed team config.
+    if (!inCollaboration) continue;
     if (line.startsWith("### ")) {
       section = line.slice(4).trim();
       continue;
     }
-    if (inCollaboration && !section && line.startsWith("- Leader:")) {
+    if (!section && line.startsWith("- Leader:")) {
       doc.leader = line.slice("- Leader:".length).trim();
       continue;
     }

--- a/packages/dmworkmcp/src/api/expertWire.ts
+++ b/packages/dmworkmcp/src/api/expertWire.ts
@@ -334,21 +334,36 @@ export function mapPluginSquadListItem(
 }
 
 /** Project one skill Plugin (an expert_skill relation target) onto the lazy
- *  ExpertSkill detail shape the file browser reads. */
+ *  ExpertSkill detail shape the file browser reads. Tree-shaped skills expose
+ *  their files directly as attachments; a legacy skill/ref.json pointer is still
+ *  honored for not-yet-expanded rows. */
 export function fromSkillPlugin(
   plugin: PluginDetailPluginWire
 ): import("../mock/expertMock").ExpertSkill {
   const ref = jsonAttachment<SkillRefWire>(plugin.plugin_json, "skill/ref.json") ?? {};
+  const attachments = plugin.plugin_json?.attachments ?? [];
   const inlineMd = rawAttachment(plugin.plugin_json, "SKILL.md") !== undefined;
-  const managedZip = (plugin.plugin_json?.attachments ?? []).some(
+  const isLegacy = attachments.some(
+    (a) => a.path === "skill/ref.json" || a.path === "skill/package.zip"
+  );
+  // Tree shape: every attachment except SKILL.md is a real package file.
+  const treeFiles = attachments
+    .map((a) => a.path)
+    .filter((p) => p !== "SKILL.md");
+  const treeSize = attachments.reduce((n, a) => n + (a.content_size ?? 0), 0);
+  const managedZip = attachments.some(
     (a) => a.path === "skill/package.zip" && a.content_type === "storage"
   );
   return {
     name: plugin.plugin_name ?? "",
     hasContent: inlineMd || !!ref.object_key,
-    canDownload: managedZip || !!ref.zip_object_key || !!ref.file_url,
+    // A tree skill is downloadable (the backend rebuilds a zip) when it carries
+    // supporting files beyond SKILL.md; legacy skills need a resolvable pointer.
+    canDownload: isLegacy
+      ? managedZip || !!ref.zip_object_key || !!ref.file_url
+      : treeFiles.length > 0,
     fileName: ref.file_name,
-    fileSize: ref.file_size,
-    files: ref.files,
+    fileSize: isLegacy ? ref.file_size : treeSize,
+    files: isLegacy ? ref.files : treeFiles,
   };
 }

--- a/packages/dmworkmcp/src/api/expertWire.ts
+++ b/packages/dmworkmcp/src/api/expertWire.ts
@@ -362,7 +362,10 @@ export function fromSkillPlugin(
     canDownload: isLegacy
       ? managedZip || !!ref.zip_object_key || !!ref.file_url
       : treeFiles.length > 0,
-    fileName: ref.file_name,
+    // Tree skills have no ref.json, so synthesize a download filename from the
+    // plugin name (matching mapSkillDetail in the skill market); legacy skills
+    // keep the packaged file name from the pointer.
+    fileName: isLegacy ? ref.file_name : treeFiles.length > 0 ? `${plugin.plugin_name ?? "skill"}.zip` : undefined,
     fileSize: isLegacy ? ref.file_size : treeSize,
     files: isLegacy ? ref.files : treeFiles,
   };

--- a/packages/dmworkmcp/src/api/expertWire.ts
+++ b/packages/dmworkmcp/src/api/expertWire.ts
@@ -226,13 +226,21 @@ export function parseTeamAgentsMarkdown(text: string): TeamAgentsDoc {
     permission: "",
   };
   let section = "";
+  let inCollaboration = false;
   for (const rawLine of (text ?? "").split("\n")) {
     const line = rawLine.trim();
+    if (line.startsWith("## ")) {
+      // The summary prose precedes ## 协作方式; nothing before that heading
+      // may be interpreted as config (a summary line could echo "- Leader:").
+      inCollaboration = line.slice(3).trim() === "协作方式";
+      section = "";
+      continue;
+    }
     if (line.startsWith("### ")) {
       section = line.slice(4).trim();
       continue;
     }
-    if (line.startsWith("- Leader:")) {
+    if (inCollaboration && !section && line.startsWith("- Leader:")) {
       doc.leader = line.slice("- Leader:".length).trim();
       continue;
     }

--- a/packages/dmworkmcp/src/api/expertWire.ts
+++ b/packages/dmworkmcp/src/api/expertWire.ts
@@ -13,6 +13,12 @@ import type {
   ExpertMember,
   ExpertSquad,
 } from "../mock/expertMock";
+import {
+  jsonAttachment,
+  rawAttachment,
+  type PluginDetailPluginWire,
+  type PluginListItemWire,
+} from "./pluginWire";
 
 // ─── Wire interfaces ────────────────────────────────────────────────────────
 
@@ -193,5 +199,110 @@ export function mapSquadDetail(raw: ExpertSquadDetailWire): ExpertSquad {
     },
     permission: raw.permission ?? "",
     checkResult: "supported",
+  };
+}
+
+// ─── Unified plugin wire mappers (octo-marketplace /plugins) ────────────────
+// The unified list item carries the manifest for display plus row-level
+// counters; detail assembly (attachments + relations fan-out) lives in
+// expertService — these are the pure projections.
+
+/** team/config.json attachment persisted for expert_team plugins. */
+export interface TeamConfigWire {
+  leader?: string;
+  strategies?: unknown[];
+  dependencies?: { blocking?: string[]; recommended?: string[] };
+  permission?: string;
+}
+
+/** expert/context.json attachment persisted for squad member snapshots. */
+export interface MemberContextWire {
+  member_key?: string;
+  template_id?: string;
+  role?: string;
+  is_leader?: boolean;
+}
+
+/** skill/ref.json attachment: legacy artifact pointers shared by backfill
+ *  and import. */
+export interface SkillRefWire {
+  file_name?: string;
+  file_size?: number;
+  file_url?: string;
+  files?: string[];
+  object_key?: string;
+  zip_object_key?: string;
+}
+
+/** The legacy short_name never survived into the unified manifest; derive a
+ *  compact logo glyph from the display name so ExpertCard's logo block keeps
+ *  rendering. */
+function deriveShortName(name: string): string {
+  return name.trim().slice(0, 2);
+}
+
+function commonFromPlugin(raw: PluginListItemWire, categoryName: string) {
+  const manifest = raw.manifest_json ?? {};
+  return {
+    shortName: deriveShortName(raw.plugin_name ?? ""),
+    name: raw.plugin_name ?? "",
+    summary: manifest.description ?? "",
+    category: categoryName,
+    tags: raw.tags ?? [],
+    publisher: raw.publisher ?? "",
+    visibility: raw.visibility,
+    createdByType: mapCreatedByType(raw.created_by_type),
+    botName: raw.created_by_bot_name,
+    creatorName: raw.creator_name ?? "",
+    viewCount: raw.view_count ?? 0,
+    installCount: raw.install_count ?? 0,
+  };
+}
+
+export function mapPluginAgentListItem(
+  raw: PluginListItemWire,
+  categoryName: string
+): ExpertAgent {
+  return {
+    id: raw.plugin_id,
+    kind: "agent",
+    ...commonFromPlugin(raw, categoryName),
+  };
+}
+
+export function mapPluginSquadListItem(
+  raw: PluginListItemWire,
+  categoryName: string
+): ExpertSquad {
+  return {
+    id: raw.plugin_id,
+    kind: "squad",
+    ...commonFromPlugin(raw, categoryName),
+    memberCount: raw.member_count ?? 0,
+    members: [],
+    leader: "",
+    dependencies: { blocking: [], recommended: [] },
+    permission: "",
+    checkResult: "supported",
+  };
+}
+
+/** Project one skill Plugin (an expert_skill relation target) onto the lazy
+ *  ExpertSkill detail shape the file browser reads. */
+export function fromSkillPlugin(
+  plugin: PluginDetailPluginWire
+): import("../mock/expertMock").ExpertSkill {
+  const ref = jsonAttachment<SkillRefWire>(plugin.plugin_json, "skill/ref.json") ?? {};
+  const inlineMd = rawAttachment(plugin.plugin_json, "SKILL.md") !== undefined;
+  const managedZip = (plugin.plugin_json?.attachments ?? []).some(
+    (a) => a.path === "skill/package.zip" && a.content_type === "storage"
+  );
+  return {
+    name: plugin.plugin_name ?? "",
+    hasContent: inlineMd || !!ref.object_key,
+    canDownload: managedZip || !!ref.zip_object_key || !!ref.file_url,
+    fileName: ref.file_name,
+    fileSize: ref.file_size,
+    files: ref.files,
   };
 }

--- a/packages/dmworkmcp/src/api/mcpService.connector.test.ts
+++ b/packages/dmworkmcp/src/api/mcpService.connector.test.ts
@@ -195,42 +195,71 @@ describe("createMcpReal — atomic-ish create (P1-3) + fail-closed category (P1-
     );
     expect(upsertCalls).toHaveLength(0);
   });
+
+  it("rejects an empty category up front — no refetch, no upsert (P1-3)", async () => {
+    // A blank category (the modal's degraded '' when category_id is unresolved)
+    // must fail closed immediately rather than falling into the refetch path.
+    mock.instance.get.mockResolvedValue(categoriesOk());
+    mock.instance.post.mockRejectedValue(new Error("should not be called"));
+
+    await expect(createMcp(baseParams({ category: "" }))).rejects.toThrow();
+
+    const upsertCalls = mock.instance.post.mock.calls.filter((c) =>
+      (c[0] as string).endsWith("/plugins/upsert")
+    );
+    expect(upsertCalls).toHaveLength(0);
+    // The category GET fires at most once (initial load); no second refetch.
+    const categoryGets = mock.instance.get.mock.calls.filter((c) =>
+      (c[0] as string).includes("/plugin_categories")
+    );
+    expect(categoryGets.length).toBeLessThanOrEqual(1);
+  });
 });
 
-describe("updateMcpReal — echoes the write-canonical icon (P1-1)", () => {
-  it("writes back current.plugin.icon when the form icon is the unchanged display URL", async () => {
+describe("updateMcpReal — icon write intent uses an undefined sentinel (P1-1 / P1-2)", () => {
+  function seedGets() {
     mock.instance.get.mockImplementation((url: string) => {
       if (url.includes("/plugin_categories")) return Promise.resolve(categoriesOk());
       if (url.includes("/plugins/detail")) return Promise.resolve({ data: { data: detailPlugin() } });
       throw new Error(`unexpected GET ${url}`);
     });
     mock.instance.post.mockResolvedValue({ data: { data: detailPlugin() } });
+  }
 
-    // The form seeds icon from mapDetail = icon_url || icon (the presigned URL).
-    await updateMcp(
-      "p-1",
-      baseParams({ icon: "https://cdn.example.com/presigned/obj-key.png?exp=1" })
-    );
-
+  function upsertIcon(): string {
     const upsertCall = mock.instance.post.mock.calls.find((c) =>
       (c[0] as string).endsWith("/plugins/upsert")
     ) as [string, { plugin: { icon: string } }];
-    expect(upsertCall[1].plugin.icon).toBe("icons/obj-key.png");
+    return upsertCall[1].plugin.icon;
+  }
+
+  it("echoes the write-canonical current.plugin.icon when the icon is untouched (undefined)", async () => {
+    seedGets();
+
+    // Untouched edit: the modal sends `icon: undefined` (NOT the seeded display
+    // value). The service must echo the canonical object key.
+    await updateMcp("p-1", baseParams({ icon: undefined }));
+
+    // Must be the canonical `icon` column, NOT the expiring presigned
+    // `icon_url` (https://cdn.example.com/presigned/obj-key.png?exp=1). A
+    // regression that echoed the display value would fail this exact assertion.
+    expect(upsertIcon()).toBe("icons/obj-key.png");
   });
 
-  it("writes a freshly-picked icon through unchanged", async () => {
-    mock.instance.get.mockImplementation((url: string) => {
-      if (url.includes("/plugin_categories")) return Promise.resolve(categoriesOk());
-      if (url.includes("/plugins/detail")) return Promise.resolve({ data: { data: detailPlugin() } });
-      throw new Error(`unexpected GET ${url}`);
-    });
-    mock.instance.post.mockResolvedValue({ data: { data: detailPlugin() } });
+  it("writes an empty string through when the icon is cleared", async () => {
+    seedGets();
+
+    // handleIconRemove → the modal sends `icon: ""`.
+    await updateMcp("p-1", baseParams({ icon: "" }));
+
+    expect(upsertIcon()).toBe("");
+  });
+
+  it("writes a freshly-picked icon key through unchanged", async () => {
+    seedGets();
 
     await updateMcp("p-1", baseParams({ icon: "icons/fresh-upload.png" }));
 
-    const upsertCall = mock.instance.post.mock.calls.find((c) =>
-      (c[0] as string).endsWith("/plugins/upsert")
-    ) as [string, { plugin: { icon: string } }];
-    expect(upsertCall[1].plugin.icon).toBe("icons/fresh-upload.png");
+    expect(upsertIcon()).toBe("icons/fresh-upload.png");
   });
 });

--- a/packages/dmworkmcp/src/api/mcpService.connector.test.ts
+++ b/packages/dmworkmcp/src/api/mcpService.connector.test.ts
@@ -1,0 +1,236 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+// mcpService creates its own axios instance at module load (with request /
+// response interceptors), so mock the factory and drive `.get` / `.post` per
+// request path. Mirrors expertService.listSort.test.ts's hoisted axios mock.
+const mock = vi.hoisted(() => ({
+  logout: vi.fn(),
+  instance: {
+    interceptors: {
+      request: { use: vi.fn() },
+      response: { use: vi.fn() },
+    },
+    get: vi.fn(),
+    post: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+vi.mock("axios", () => ({
+  default: {
+    create: () => mock.instance,
+    isCancel: () => false,
+  },
+}));
+
+vi.mock("@octo/base", () => ({
+  WKApp: {
+    apiClient: { config: { apiURL: "/api/v1/" } },
+    loginInfo: { token: "tok" },
+    shared: { currentSpaceId: "sp", logout: mock.logout },
+  },
+  buildAcceptLanguage: () => "en-US",
+  t: (key: string) => key,
+  DEFAULT_REQUEST_TIMEOUT_MS: 20000,
+}));
+
+import { createMcp, updateMcp, fetchMcpList } from "./mcpService";
+import { WKApp } from "@octo/base";
+import type { CreateMcpParams } from "../types/mcp";
+
+const CATEGORIES = [
+  { category_id: "c-dev", name: "dev", plugin_count: 2, sort_order: 0 },
+];
+
+/** `/plugin_categories` reads flow through get<T>() → resp.data.data. */
+function categoriesOk(wire = CATEGORIES) {
+  return { data: { data: wire } };
+}
+
+function baseParams(overrides: Partial<CreateMcpParams> = {}): CreateMcpParams {
+  return {
+    name: "GitHub MCP",
+    slug: "github-mcp",
+    category: "dev",
+    icon: "🐙",
+    tags: ["hot"],
+    slogan: "Issues and PRs",
+    transport: "streamable-http",
+    url: "https://mcp.example.com/github",
+    tools: [{ name: "list_repos", description: "list" }],
+    ...overrides,
+  };
+}
+
+/** Minimal detail plugin the mappers can project without crashing. */
+function detailPlugin(overrides: Record<string, unknown> = {}) {
+  return {
+    plugin: {
+      plugin_id: "p-1",
+      plugin_name: "GitHub MCP",
+      plugin_type: "connector",
+      category_id: "c-dev",
+      tags: ["hot"],
+      visibility: "space",
+      icon: "icons/obj-key.png",
+      icon_url: "https://cdn.example.com/presigned/obj-key.png?exp=1",
+      manifest_json: { name: "github-mcp", description: "Issues and PRs" },
+      plugin_json: { $schema: "cowork-plugin-package-1.0.json", attachments: [] },
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-01-02T00:00:00Z",
+      ...overrides,
+    },
+    relations: [],
+  };
+}
+
+let spaceCounter = 0;
+
+beforeEach(() => {
+  mock.instance.get.mockReset();
+  mock.instance.post.mockReset();
+  mock.instance.delete.mockReset();
+  // Bust the per-Space category cache between tests by rotating the Space id.
+  WKApp.shared.currentSpaceId = `sp-${spaceCounter++}`;
+});
+
+describe("fetchMcpListPath — category resolution fails closed (P1-2)", () => {
+  it("returns an explicit empty result (never widens) when the category filter is unresolved", async () => {
+    mock.instance.get.mockImplementation((url: string) => {
+      if (url.includes("/plugin_categories")) return Promise.resolve(categoriesOk());
+      throw new Error(`unexpected GET ${url}`);
+    });
+
+    const res = await fetchMcpList({ category: "data" });
+
+    expect(res.items).toEqual([]);
+    expect(res.total).toBe(0);
+    // The list request must NOT run unfiltered — only the categories were fetched.
+    const listCalls = mock.instance.get.mock.calls.filter(
+      (c) => (c[0] as string).endsWith("/plugins")
+    );
+    expect(listCalls).toHaveLength(0);
+    // Pills are still returned so the user can switch away.
+    expect(res.categories.some((c) => c.key === "dev")).toBe(true);
+  });
+
+  it("sends the resolved category_id for a known category", async () => {
+    mock.instance.get.mockImplementation((url: string) => {
+      if (url.includes("/plugin_categories")) return Promise.resolve(categoriesOk());
+      if (url.endsWith("/plugins")) {
+        return Promise.resolve({
+          data: { data: [], pagination: { total: 0, page: 1, page_size: 20 } },
+        });
+      }
+      throw new Error(`unexpected GET ${url}`);
+    });
+
+    await fetchMcpList({ category: "dev" });
+
+    const listCall = mock.instance.get.mock.calls.find((c) =>
+      (c[0] as string).endsWith("/plugins")
+    ) as [string, { params: Record<string, unknown> }];
+    expect(listCall[1].params.category_id).toBe("c-dev");
+  });
+});
+
+describe("createMcpReal — atomic-ish create (P1-3) + fail-closed category (P1-9)", () => {
+  it("compensates by deleting the just-created plugin when publish fails", async () => {
+    mock.instance.get.mockResolvedValue(categoriesOk());
+    mock.instance.post.mockImplementation((url: string) => {
+      if (url.endsWith("/plugins/upsert")) {
+        return Promise.resolve({ data: { data: { plugin: { plugin_id: "new-1" } } } });
+      }
+      if (url.endsWith("/plugins/publish")) {
+        return Promise.reject(new Error("publish boom"));
+      }
+      if (url.endsWith("/plugins/delete")) {
+        return Promise.resolve({ data: { data: {} } });
+      }
+      throw new Error(`unexpected POST ${url}`);
+    });
+
+    await expect(createMcp(baseParams())).rejects.toThrow();
+
+    const deleteCall = mock.instance.post.mock.calls.find((c) =>
+      (c[0] as string).endsWith("/plugins/delete")
+    ) as [string, unknown];
+    expect(deleteCall).toBeTruthy();
+    expect(deleteCall[1]).toEqual({ plugin_id: "new-1" });
+  });
+
+  it("publishes the placement with the resolved category_id on success", async () => {
+    mock.instance.get.mockResolvedValue(categoriesOk());
+    mock.instance.post.mockImplementation((url: string) => {
+      if (url.endsWith("/plugins/upsert")) {
+        return Promise.resolve({ data: { data: { plugin: { plugin_id: "new-2" } } } });
+      }
+      if (url.endsWith("/plugins/publish")) {
+        return Promise.resolve({ data: { data: {} } });
+      }
+      throw new Error(`unexpected POST ${url}`);
+    });
+
+    const res = await createMcp(baseParams());
+
+    expect(res.id).toBe("new-2");
+    const publishCall = mock.instance.post.mock.calls.find((c) =>
+      (c[0] as string).endsWith("/plugins/publish")
+    ) as [string, { placements: Array<{ category_id?: string }> }];
+    expect(publishCall[1].placements[0].category_id).toBe("c-dev");
+  });
+
+  it("throws (and never upserts) when the category cannot be resolved even after a refetch", async () => {
+    // Categories never contain the requested key; resolveWriteCategory refetches
+    // once then fails closed.
+    mock.instance.get.mockResolvedValue(
+      categoriesOk([{ category_id: "c-dev", name: "dev", plugin_count: 0, sort_order: 0 }])
+    );
+    mock.instance.post.mockRejectedValue(new Error("should not be called"));
+
+    await expect(createMcp(baseParams({ category: "ghost" }))).rejects.toThrow();
+
+    const upsertCalls = mock.instance.post.mock.calls.filter((c) =>
+      (c[0] as string).endsWith("/plugins/upsert")
+    );
+    expect(upsertCalls).toHaveLength(0);
+  });
+});
+
+describe("updateMcpReal — echoes the write-canonical icon (P1-1)", () => {
+  it("writes back current.plugin.icon when the form icon is the unchanged display URL", async () => {
+    mock.instance.get.mockImplementation((url: string) => {
+      if (url.includes("/plugin_categories")) return Promise.resolve(categoriesOk());
+      if (url.includes("/plugins/detail")) return Promise.resolve({ data: { data: detailPlugin() } });
+      throw new Error(`unexpected GET ${url}`);
+    });
+    mock.instance.post.mockResolvedValue({ data: { data: detailPlugin() } });
+
+    // The form seeds icon from mapDetail = icon_url || icon (the presigned URL).
+    await updateMcp(
+      "p-1",
+      baseParams({ icon: "https://cdn.example.com/presigned/obj-key.png?exp=1" })
+    );
+
+    const upsertCall = mock.instance.post.mock.calls.find((c) =>
+      (c[0] as string).endsWith("/plugins/upsert")
+    ) as [string, { plugin: { icon: string } }];
+    expect(upsertCall[1].plugin.icon).toBe("icons/obj-key.png");
+  });
+
+  it("writes a freshly-picked icon through unchanged", async () => {
+    mock.instance.get.mockImplementation((url: string) => {
+      if (url.includes("/plugin_categories")) return Promise.resolve(categoriesOk());
+      if (url.includes("/plugins/detail")) return Promise.resolve({ data: { data: detailPlugin() } });
+      throw new Error(`unexpected GET ${url}`);
+    });
+    mock.instance.post.mockResolvedValue({ data: { data: detailPlugin() } });
+
+    await updateMcp("p-1", baseParams({ icon: "icons/fresh-upload.png" }));
+
+    const upsertCall = mock.instance.post.mock.calls.find((c) =>
+      (c[0] as string).endsWith("/plugins/upsert")
+    ) as [string, { plugin: { icon: string } }];
+    expect(upsertCall[1].plugin.icon).toBe("icons/fresh-upload.png");
+  });
+});

--- a/packages/dmworkmcp/src/api/mcpService.paramsSerializer.test.ts
+++ b/packages/dmworkmcp/src/api/mcpService.paramsSerializer.test.ts
@@ -10,7 +10,7 @@ vi.mock("@octo/base", () => ({
   DEFAULT_REQUEST_TIMEOUT_MS: 20000,
 }));
 
-import { buildMcpCategoryParams, serializeMcpParams } from "./mcpService";
+import { serializeMcpParams } from "./mcpService";
 
 describe("serializeMcpParams — axios paramsSerializer wire contract", () => {
   it("emits `?a=1&a=2` for arrays (never `?a[]=1&a[]=2`)", () => {
@@ -60,30 +60,5 @@ describe("serializeMcpParams — axios paramsSerializer wire contract", () => {
 
   it("stringifies non-string primitives (limit, offset)", () => {
     expect(serializeMcpParams({ limit: 50, offset: 0 })).toBe("limit=50&offset=0");
-  });
-});
-
-describe("buildMcpCategoryParams", () => {
-  it("passes keyword and tags to category counts without the active category filter", () => {
-    const params = buildMcpCategoryParams(
-      "all",
-      {
-        tags: ["official", "v1.0,beta"],
-        createdByType: "bot",
-      },
-      "github"
-    );
-
-    expect(params).toEqual({
-      keyword: "github",
-      tag: ["official", "v1.0,beta"],
-      created_by_type: "bot",
-    });
-    expect(params).not.toHaveProperty("category");
-  });
-
-  it("adds mine mode only for the owned list", () => {
-    expect(buildMcpCategoryParams("mine", {}, "")).toEqual({ mode: "mine" });
-    expect(buildMcpCategoryParams("all", {}, "")).toEqual({});
   });
 });

--- a/packages/dmworkmcp/src/api/mcpService.ts
+++ b/packages/dmworkmcp/src/api/mcpService.ts
@@ -695,7 +695,7 @@ async function fetchMcpListPath(
     label: categoryLabel(key),
     count: key === CATEGORY_KEY_ALL ? allCount : countsByKey.get(key) ?? 0,
   }));
-  return { items, total: resp.data.pagination.total, categories };
+  return { items, total: resp.data.pagination?.total ?? items.length, categories };
 }
 
 async function fetchMcpDetailReal(id: string): Promise<McpDetail> {

--- a/packages/dmworkmcp/src/api/mcpService.ts
+++ b/packages/dmworkmcp/src/api/mcpService.ts
@@ -557,6 +557,26 @@ function buildCategoryMaps(wire: PluginCategoryWire[]): ConnectorCategoryMaps {
   return { keyToId, idToKey, wire };
 }
 
+/** Resolve a legacy category key to its unified UUID for a WRITE (create /
+ *  update). Fails closed: publishing with a NULL category_id would split-brain
+ *  plugins.category_id against the scene placement, so on a miss the taxonomy is
+ *  refetched once (the cache may predate a newly-added category) and, if still
+ *  unresolved, a descriptive error is thrown rather than writing no category.
+ *  Returns the resolved id plus the maps actually used (fresh after a refetch)
+ *  so callers can reuse idToKey for the response projection. */
+async function resolveWriteCategory(
+  key: string,
+  maps: ConnectorCategoryMaps
+): Promise<{ categoryId: string; maps: ConnectorCategoryMaps }> {
+  const hit = maps.keyToId.get(key);
+  if (hit) return { categoryId: hit, maps };
+  categoryMapsCache = null;
+  const fresh = await getConnectorCategoryMaps();
+  const refreshed = fresh.keyToId.get(key);
+  if (refreshed) return { categoryId: refreshed, maps: fresh };
+  throw new Error(t("mcp.errors.invalidRequest"));
+}
+
 /** Unified plugin visibility → legacy McpVisibility. `space` was the legacy
  *  "public within the Space" scope, which the UI labels public. */
 function mapVisibility(v: PluginVisibilityWire): McpListItem["visibility"] {
@@ -676,17 +696,9 @@ async function fetchMcpListPath(
   // already classifies failures into McpListError.
   const categoryWire = await fetchConnectorCategoriesWire();
   const maps = buildCategoryMaps(categoryWire);
-  const categoryKey = params.categories?.length
-    ? params.categories[0]
-    : params.category ?? CATEGORY_KEY_ALL;
-  if (categoryKey && categoryKey !== CATEGORY_KEY_ALL) {
-    const categoryId = maps.keyToId.get(categoryKey);
-    if (categoryId) query.category_id = categoryId;
-  }
-  const resp = await executeMcpListRequest(() =>
-    mcpAxios.get<PluginListResponseWire>(`${BASE}/plugins`, { params: query })
-  );
-  const items = (resp.data.data ?? []).map((raw) => mapListItem(raw, maps.idToKey));
+  // Category pills are independent of the list request, so build them up front:
+  // a fail-closed category miss can then still return the pills so the user can
+  // switch away from the unresolved filter.
   const countsByKey = new Map(
     categoryWire.map((c) => [c.name, c.plugin_count] as const)
   );
@@ -696,6 +708,24 @@ async function fetchMcpListPath(
     label: categoryLabel(key),
     count: key === CATEGORY_KEY_ALL ? allCount : countsByKey.get(key) ?? 0,
   }));
+  const categoryKey = params.categories?.length
+    ? params.categories[0]
+    : params.category ?? CATEGORY_KEY_ALL;
+  if (categoryKey && categoryKey !== CATEGORY_KEY_ALL) {
+    const categoryId = maps.keyToId.get(categoryKey);
+    if (categoryId) {
+      query.category_id = categoryId;
+    } else {
+      // Fail closed: an unresolvable category filter must NOT silently widen to
+      // the whole catalog (the list would then render every plugin as if
+      // unfiltered). Surface an explicit empty result while keeping the pills.
+      return { items: [], total: 0, categories };
+    }
+  }
+  const resp = await executeMcpListRequest(() =>
+    mcpAxios.get<PluginListResponseWire>(`${BASE}/plugins`, { params: query })
+  );
+  const items = (resp.data.data ?? []).map((raw) => mapListItem(raw, maps.idToKey));
   return { items, total: resp.data.pagination?.total ?? items.length, categories };
 }
 
@@ -753,23 +783,38 @@ async function createMcpReal(params: CreateMcpParams): Promise<{ id: string }> {
   // its default-scene placement — without a placement row the new connector
   // would be invisible to every scene-scoped list (including "mine").
   const maps = await getConnectorCategoryMaps();
-  const categoryId = maps.keyToId.get(params.category);
+  // Fail closed on an unresolved category so the plugin and its placement never
+  // split-brain on a NULL category_id.
+  const { categoryId } = await resolveWriteCategory(params.category, maps);
   const detail = await post<PluginDetailWire>(
     "/plugins/upsert",
     toPluginUpsert(params, { categoryId, visibility: "space" })
   );
   const pluginId = detail.plugin.plugin_id;
-  await post("/plugins/publish", {
-    plugin_id: pluginId,
-    version: "1.0.0",
-    placements: [
-      {
-        placement_code: SCENE_CODE,
-        ...(categoryId ? { category_id: categoryId } : {}),
-        is_visible: true,
-      },
-    ],
-  });
+  try {
+    await post("/plugins/publish", {
+      plugin_id: pluginId,
+      version: "1.0.0",
+      placements: [
+        {
+          placement_code: SCENE_CODE,
+          category_id: categoryId,
+          is_visible: true,
+        },
+      ],
+    });
+  } catch (err) {
+    // Compensating delete: the upsert already inserted the plugin row, but with
+    // no placement it is invisible to every scene-scoped list AND a retry (which
+    // sends no plugin_id) would insert a DUPLICATE. Delete the just-created
+    // plugin so a retry starts clean, then surface the original publish error.
+    try {
+      await post("/plugins/delete", { plugin_id: pluginId });
+    } catch {
+      // Best-effort cleanup — surface the publish failure regardless.
+    }
+    throw err;
+  }
   return { id: pluginId };
 }
 
@@ -787,16 +832,36 @@ async function updateMcpReal(
     }),
     getConnectorCategoryMaps(),
   ]);
-  const categoryId = maps.keyToId.get(params.category);
+  // Fail closed on an unresolved category (see resolveWriteCategory); reuse the
+  // maps it returns for the response projection so a refetch stays consistent.
+  const { categoryId, maps: resolvedMaps } = await resolveWriteCategory(
+    params.category,
+    maps
+  );
+  // Echo the write-canonical icon. `params.icon` is the DISPLAY value the edit
+  // form seeds from mapDetail (`icon_url || icon`); when the user did not pick a
+  // new icon it is the presigned, expiring `icon_url`, which must never be
+  // persisted back into the canonical `icon` column. Detect an unchanged icon by
+  // comparing to the current display value and echo `current.plugin.icon`
+  // instead; a freshly-picked icon (a genuinely new value) is written through —
+  // mirroring the skill path (skillApiReal echoes plugin.icon).
+  const previousDisplayIcon = current.plugin.icon_url || current.plugin.icon || "";
+  const canonicalIcon =
+    params.icon && params.icon !== previousDisplayIcon
+      ? params.icon
+      : current.plugin.icon ?? "";
   const detail = await post<PluginDetailWire>(
     "/plugins/upsert",
-    toPluginUpsert(params, {
-      pluginId: id,
-      categoryId,
-      visibility: current.plugin.visibility,
-    })
+    toPluginUpsert(
+      { ...params, icon: canonicalIcon },
+      {
+        pluginId: id,
+        categoryId,
+        visibility: current.plugin.visibility,
+      }
+    )
   );
-  return mapDetail(detail.plugin, maps.idToKey);
+  return mapDetail(detail.plugin, resolvedMaps.idToKey);
 }
 
 /** POST /plugins/delete — owner-only soft delete. */

--- a/packages/dmworkmcp/src/api/mcpService.ts
+++ b/packages/dmworkmcp/src/api/mcpService.ts
@@ -655,9 +655,10 @@ async function fetchMcpListPath(
   if (mode === "mine") query.mode = "mine";
   const keyword = params.keyword?.trim();
   if (keyword) query.q = keyword;
-  // The unified list has no relevance scoring; freshest-first covers both
-  // browse and search ordering.
-  query.sort = "updated";
+  // The unified list has no relevance scoring; newest-first covers both browse
+  // and search ordering — matching expertService/skillApiReal (which map their
+  // "latest" onto "newest") and the backend's default sort.
+  query.sort = "newest";
   // Multi-tag filter is AND; REPEATED params (`tag=a&tag=b`) so a tag value
   // containing a comma still round-trips intact.
   if (params.tags?.length) {

--- a/packages/dmworkmcp/src/api/mcpService.ts
+++ b/packages/dmworkmcp/src/api/mcpService.ts
@@ -12,7 +12,19 @@ import type {
   McpQuickStart,
   UpdateMcpParams,
 } from "../types/mcp";
-import { toWireParams } from "./mcpWireParams";
+import { toPluginUpsert } from "./mcpWireParams";
+import {
+  SCENE_CODE,
+  splitUserSupplied,
+  jsonAttachment,
+  type OffsetPaginationWire,
+  type PluginCategoryWire,
+  type PluginDetailPluginWire,
+  type PluginDetailWire,
+  type PluginListItemWire,
+  type PluginVisibilityWire,
+  SECRET_PLACEHOLDER,
+} from "./pluginWire";
 import {
   MCP_CATEGORY_LABELS,
   MCP_CATEGORY_ORDER,
@@ -467,25 +479,6 @@ async function post<T>(path: string, data?: unknown): Promise<T> {
   }
 }
 
-async function patch<T>(path: string, data?: unknown): Promise<T> {
-  try {
-    const resp = await mcpAxios.patch(`${BASE}${path}`, data);
-    return resp.data.data as T;
-  } catch (err) {
-    if (axios.isCancel(err)) throw err;
-    throw new Error(extractErrorMessage(err));
-  }
-}
-
-async function del(path: string): Promise<void> {
-  try {
-    await mcpAxios.delete(`${BASE}${path}`);
-  } catch (err) {
-    if (axios.isCancel(err)) throw err;
-    throw new Error(extractErrorMessage(err));
-  }
-}
-
 /**
  * Resolve a category label from the frontend i18n bundle. The backend returns
  * `{key,count}` only (mcp-v1.md §4.2); labels are the frontend's job so locales
@@ -499,224 +492,221 @@ function categoryLabel(key: string): string {
   return MCP_CATEGORY_LABELS[key] ?? key;
 }
 
-/** Wire shape of the list response before frontend label enrichment. */
-interface McpListItemWire {
-  mcp_id: string;
-  name: string;
-  slogan: string;
-  category: string;
-  icon: string;
-  tags: string[];
-  tool_count: number;
-  visibility?: McpListItem["visibility"];
-  creator_name?: string;
-  created_by_type?: McpListItem["createdByType"];
-  created_by_bot_uid?: string;
-  created_by_bot_name?: string;
-  transport?: McpListItem["transport"];
-  source?: McpListItem["source"];
-  verification_status?: McpListItem["verificationStatus"];
-  match_reasons?: string[];
-  relevance?: number;
-  updated_at?: string;
+/** One mcpServers entry inside the root mcp.json attachment (standard MCP
+ *  config document). User-supplied env/header values are persisted as ${KEY}
+ *  placeholders and blanked into userSupplied slots on read. */
+interface McpServerEntryWire {
+  type?: McpQuickStart["transport"];
+  url?: string;
+  command?: string;
+  args?: string[];
+  env?: Record<string, string>;
+  headers?: Record<string, string>;
 }
 
-interface McpDetailWire extends McpListItemWire {
-  quick_start: {
-    transport: McpQuickStart["transport"];
-    server_name: string;
-    slug?: string;
-    url?: string;
-    command?: string;
-    args?: string[];
-    env?: Record<string, string>;
-    env_user_supplied?: string[];
-    headers?: Record<string, string>;
-    headers_user_supplied?: string[];
-    // Legacy marker (mcp-v1.md §5.2). No longer sent on new records —
-    // Bearer auth is expressed as an `Authorization` row + toggle ON —
-    // but pre-toggle records still carry `auth_type: "bearer"` without a
-    // matching `Authorization` header entry. mapDetail synthesizes the
-    // missing user-supplied entry so the copy-paste snippet keeps
-    // rendering an Authorization line for those records.
-    auth_type?: "bearer" | "none";
-  };
-  tools: McpDetail["tools"];
-  usage_examples: string[];
-  faqs: McpDetail["faqs"];
-  notes: string[];
-  created_at?: string;
-  updated_at?: string;
+interface McpJSONWire {
+  mcpServers?: Record<string, McpServerEntryWire>;
 }
 
-interface McpListResponseWire {
-  data: McpListItemWire[];
-  pagination: { total: number; page: number; page_size: number };
+interface PluginListResponseWire {
+  data: PluginListItemWire[];
+  pagination: OffsetPaginationWire;
 }
 
-function mapListItem(raw: McpListItemWire): McpListItem {
+/** Category maps for the connector taxonomy: the unified API keys categories
+ *  by UUID while the UI keeps using the legacy enum keys — the category NAME
+ *  is that key (enrich registration invariant), so both directions are pure
+ *  lookups. Cached per Space because the registration is global but a Space
+ *  switch should never serve a stale first response. */
+interface ConnectorCategoryMaps {
+  keyToId: Map<string, string>;
+  idToKey: Map<string, string>;
+  wire: PluginCategoryWire[];
+}
+
+let categoryMapsCache: { spaceId: string; promise: Promise<ConnectorCategoryMaps> } | null = null;
+
+async function fetchConnectorCategoriesWire(): Promise<PluginCategoryWire[]> {
+  const data = await get<PluginCategoryWire[] | null>(`/plugin_categories`, {
+    scene_code: SCENE_CODE,
+    plugin_type: "connector",
+  });
+  return Array.isArray(data) ? data : [];
+}
+
+function getConnectorCategoryMaps(): Promise<ConnectorCategoryMaps> {
+  const spaceId = WKApp.shared.currentSpaceId ?? "";
+  if (!categoryMapsCache || categoryMapsCache.spaceId !== spaceId) {
+    const promise = fetchConnectorCategoriesWire().then(buildCategoryMaps);
+    categoryMapsCache = { spaceId, promise };
+    // A failed load must not poison the cache for the session.
+    promise.catch(() => {
+      if (categoryMapsCache?.promise === promise) categoryMapsCache = null;
+    });
+  }
+  return categoryMapsCache.promise;
+}
+
+function buildCategoryMaps(wire: PluginCategoryWire[]): ConnectorCategoryMaps {
+  const keyToId = new Map<string, string>();
+  const idToKey = new Map<string, string>();
+  for (const category of wire) {
+    keyToId.set(category.name, category.category_id);
+    idToKey.set(category.category_id, category.name);
+  }
+  return { keyToId, idToKey, wire };
+}
+
+/** Unified plugin visibility → legacy McpVisibility. `space` was the legacy
+ *  "public within the Space" scope, which the UI labels public. */
+function mapVisibility(v: PluginVisibilityWire): McpListItem["visibility"] {
+  if (v === "system") return "system";
+  if (v === "private") return "private";
+  return "public";
+}
+
+function mapListItem(
+  raw: PluginListItemWire,
+  idToKey: Map<string, string>
+): McpListItem {
+  const manifest = raw.manifest_json ?? {};
   return {
-    id: raw.mcp_id,
-    name: raw.name ?? "",
+    id: raw.plugin_id,
+    name: raw.plugin_name ?? "",
     // Fall back to empty string / 0 so downstream renderers that call
     // .toLowerCase() (Highlight) or format the tool count don't crash on a
     // null field slipping in from a legacy record or partial response.
-    slogan: raw.slogan ?? "",
-    category: raw.category,
-    icon: raw.icon,
+    slogan: manifest.description ?? "",
+    category: (raw.category_id && idToKey.get(raw.category_id)) || "",
+    icon: raw.icon_url || raw.icon || "",
     tags: raw.tags ?? [],
     toolCount: raw.tool_count ?? 0,
-    visibility: raw.visibility,
+    visibility: mapVisibility(raw.visibility),
     creatorName: raw.creator_name,
     createdByType: raw.created_by_type,
-    createdByBotUid: raw.created_by_bot_uid,
+    createdByBotUid: raw.created_by_bot_id,
     createdByBotName: raw.created_by_bot_name,
-    transport: raw.transport, source: raw.source,
-    verificationStatus: raw.verification_status,
-    matchReasons: raw.match_reasons ?? [], relevance: raw.relevance,
+    matchReasons: [],
     updatedAt: raw.updated_at,
   };
 }
 
-function mapDetail(raw: McpDetailWire): McpDetail {
-  const item = mapListItem(raw);
-  // Guard against a missing `quick_start` block on the wire — while
-  // McpDetailWire types it as required, a null/absent value from a legacy
-  // record or a partial backend response would otherwise crash the whole
-  // detail-modal fetch with `Cannot read properties of null`. Fall back to
-  // an empty stdio-shaped block so the modal renders with an empty
-  // quick-access tab instead of blowing up.
-  const q = raw.quick_start ?? ({} as McpDetailWire["quick_start"]);
-  // Legacy-bearer migration shim: records created before the
-  // user_supplied toggle model expressed Bearer auth via
-  // `auth_type: "bearer"` alone, without a matching Authorization row.
-  // The snippet renderer no longer looks at auth_type, so without
-  // synthesizing an entry here those old snippets ship WITHOUT an
-  // Authorization line at all. Rebuild a user-supplied Authorization
-  // slot so consumers still see a placeholder to fill in. Only fires
-  // when the wire had no Authorization key already (any explicit row
-  // wins over the marker).
-  let headers = q.headers;
-  let headersUserSupplied = q.headers_user_supplied;
-  if (q.auth_type === "bearer") {
-    const hasAuthKey = !!(
-      headers &&
-      Object.keys(headers).some((k) => k.toLowerCase() === "authorization")
-    );
-    if (!hasAuthKey) {
-      headers = { ...(headers ?? {}), Authorization: "" };
-      headersUserSupplied = [
-        ...(headersUserSupplied ?? []),
-        "Authorization",
-      ];
-    }
-  }
+function mapDetail(
+  raw: PluginDetailPluginWire,
+  idToKey: Map<string, string>
+): McpDetail {
+  const item = mapListItem(raw, idToKey);
+  const manifest = raw.manifest_json ?? {};
+  const servers =
+    jsonAttachment<McpJSONWire>(raw.plugin_json, "mcp.json")?.mcpServers ?? {};
+  // One connector = one MCP server; the map key is the server name.
+  const serverName = Object.keys(servers)[0] ?? "";
+  const server = servers[serverName] ?? {};
+  const env = splitUserSupplied(server.env);
+  const headers = splitUserSupplied(server.headers);
   return {
     ...item,
     quickStart: {
-      transport: q.transport ?? "stdio",
-      serverName: q.server_name ?? raw.name ?? "",
-      slug: q.slug,
-      url: q.url,
-      command: q.command,
-      args: q.args,
-      env: q.env,
-      envUserSupplied: q.env_user_supplied,
-      headers,
-      headersUserSupplied,
+      transport: server.type ?? "stdio",
+      serverName: serverName || raw.plugin_name || "",
+      // The manifest machine name carries the legacy slug for connectors.
+      slug: manifest.name,
+      url: server.url,
+      command: server.command,
+      args: server.args,
+      env: env.values,
+      envUserSupplied: env.userSupplied,
+      headers: headers.values,
+      headersUserSupplied: headers.userSupplied,
     },
-    tools: raw.tools ?? [],
-    usageExamples: raw.usage_examples ?? [],
-    faqs: raw.faqs ?? [],
-    notes: raw.notes ?? [],
+    tools: jsonAttachment<McpDetail["tools"]>(raw.plugin_json, "connector/tools.json") ?? [],
+    usageExamples:
+      jsonAttachment<string[]>(raw.plugin_json, "connector/examples.json") ?? [],
+    faqs: jsonAttachment<McpDetail["faqs"]>(raw.plugin_json, "connector/faqs.json") ?? [],
+    notes: jsonAttachment<string[]>(raw.plugin_json, "connector/notes.json") ?? [],
     createdAt: raw.created_at,
     updatedAt: raw.updated_at,
   };
 }
 
+
 async function fetchMcpListReal(
   params: ListMcpParams
 ): Promise<ListMcpResponse> {
-  return fetchMcpListPath("/mcps", params);
+  return fetchMcpListPath("all", params);
 }
 
-/** GET /mcps/mine — same shape, restricted to owner=caller (mcp-v1.md §4.3). */
+/** mode=mine — same shape, restricted to owner=caller. */
 async function fetchMcpMineReal(
   params: ListMcpParams
 ): Promise<ListMcpResponse> {
-  return fetchMcpListPath("/mcps/mine", params);
+  return fetchMcpListPath("mine", params);
 }
 
-/** Shared list-body handling: build query, hit path, enrich labels. */
+/** Shared list-body handling against GET /plugins (plugin_type=connector). */
 async function fetchMcpListPath(
-  path: string,
+  mode: "all" | "mine",
   params: ListMcpParams
 ): Promise<ListMcpResponse> {
-  const query: Record<string, unknown> = {};
+  const query: Record<string, unknown> = {
+    scene_code: SCENE_CODE,
+    plugin_type: "connector",
+  };
+  if (mode === "mine") query.mode = "mine";
   const keyword = params.keyword?.trim();
-  if (keyword) query.keyword = keyword;
-  // `all` disables the filter server-side; send it verbatim per §0.
-  query.category = params.categories?.length ? params.categories[0] : (params.category ?? CATEGORY_KEY_ALL);
-  if (params.createdByType) {
-    query.created_by_type = params.createdByType;
-  }
-  // Relevance is only meaningful with a keyword — every row scores 0 otherwise,
-  // making the sort order arbitrary. When browsing, surface freshest first.
-  query.sort = keyword ? "relevance" : "updated";
-  // Multi-tag filter — mcp-v1.md §4.2 accepts `tag` as repeatable OR
-  // comma-separated. We use REPEATED params (`tag=a&tag=b&tag=c`) so a
-  // tag value that happens to contain a comma still round-trips intact;
-  // comma-joining would let the backend re-split "v1.0,beta" into two
-  // wrong tags and produce silent empty results.
+  if (keyword) query.q = keyword;
+  // The unified list has no relevance scoring; freshest-first covers both
+  // browse and search ordering.
+  query.sort = "updated";
+  // Multi-tag filter is AND; REPEATED params (`tag=a&tag=b`) so a tag value
+  // containing a comma still round-trips intact.
   if (params.tags?.length) {
     query.tag = params.tags;
   }
   const pageSize = params.limit && params.limit > 0 ? params.limit : 20;
   query.page_size = pageSize;
   query.page = Math.floor((params.offset ?? 0) / pageSize) + 1;
-  const categoryParams = buildMcpCategoryParams(
-    path === "/mcps/mine" ? "mine" : "all",
-    params,
-    keyword
+
+  // Categories double as the key↔UUID map, so the list request needs them
+  // first when a category filter is active. Counts are re-fetched per list
+  // load so pill numbers follow catalog changes (they no longer scope to the
+  // active keyword/tag filter — accepted in the unified switch).
+  // fetchConnectorCategoriesWire routes through get<T>() and therefore
+  // already classifies failures into McpListError.
+  const categoryWire = await fetchConnectorCategoriesWire();
+  const maps = buildCategoryMaps(categoryWire);
+  const categoryKey = params.categories?.length
+    ? params.categories[0]
+    : params.category ?? CATEGORY_KEY_ALL;
+  if (categoryKey && categoryKey !== CATEGORY_KEY_ALL) {
+    const categoryId = maps.keyToId.get(categoryKey);
+    if (categoryId) query.category_id = categoryId;
+  }
+  const resp = await executeMcpListRequest(() =>
+    mcpAxios.get<PluginListResponseWire>(`${BASE}/plugins`, { params: query })
   );
-  const [resp, categoryWire] = await executeMcpListRequest(() => Promise.all([
-      mcpAxios.get<McpListResponseWire>(`${BASE}${path}`, { params: query }),
-      mcpAxios
-        .get<{ data: { key: string; count: number }[] }>(`${BASE}/mcp_categories`, {
-          params: categoryParams,
-        })
-        .then((r) => r.data.data),
-    ]));
-  const items = (resp.data.data ?? []).map(mapListItem);
-  const categoryCounts = new Map(
-    categoryWire.map((item) => [item.key, item.count])
+  const items = (resp.data.data ?? []).map((raw) => mapListItem(raw, maps.idToKey));
+  const countsByKey = new Map(
+    categoryWire.map((c) => [c.name, c.plugin_count] as const)
   );
+  const allCount = categoryWire.reduce((sum, c) => sum + (c.plugin_count ?? 0), 0);
   const categories: McpCategory[] = MCP_CATEGORY_ORDER.map((key) => ({
     key,
     label: categoryLabel(key),
-    count: categoryCounts.get(key) ?? 0,
+    count: key === CATEGORY_KEY_ALL ? allCount : countsByKey.get(key) ?? 0,
   }));
   return { items, total: resp.data.pagination.total, categories };
 }
 
-export function buildMcpCategoryParams(
-  mode: "all" | "mine",
-  params: Pick<ListMcpParams, "createdByType" | "tags">,
-  keyword = ""
-): Record<string, unknown> {
-  // Category counts must honour the same keyword/tag/provenance scope as the
-  // item list. The active category filter is intentionally excluded so category
-  // pills remain useful for switching within the current search/tag result set.
-  const categoryParams: Record<string, unknown> = {};
-  if (mode === "mine") categoryParams.mode = "mine";
-  if (keyword) categoryParams.keyword = keyword;
-  if (params.createdByType) categoryParams.created_by_type = params.createdByType;
-  if (params.tags?.length) categoryParams.tag = params.tags;
-  return categoryParams;
-}
-
 async function fetchMcpDetailReal(id: string): Promise<McpDetail> {
-  return get<McpDetailWire>(`/mcps/${encodeURIComponent(id)}`).then(mapDetail);
+  const [detail, maps] = await Promise.all([
+    get<PluginDetailWire>(`/plugins/detail`, {
+      plugin_id: id,
+      include_relations: false,
+    }),
+    getConnectorCategoryMaps(),
+  ]);
+  return mapDetail(detail.plugin, maps.idToKey);
 }
 
 async function probeMcpToolsReal(
@@ -758,33 +748,59 @@ async function probeMcpToolsReal(
 }
 
 async function createMcpReal(params: CreateMcpParams): Promise<{ id: string }> {
-  // POST /mcps returns 201 with the full McpDetail; the frontend picks up `id`
-  // from the response (mcp-v1.md §4.1). Server derives id / creatorName /
-  // toolCount / timestamps and ignores any client-supplied values for them, so
-  // the flat create body is sent as-is (§3.3).
-  const detail = await post<McpDetailWire>("/mcps", toWireParams(params));
-  return { id: detail.mcp_id };
+  // POST /plugins/upsert creates the plugin, then publish registers
+  // its default-scene placement — without a placement row the new connector
+  // would be invisible to every scene-scoped list (including "mine").
+  const maps = await getConnectorCategoryMaps();
+  const categoryId = maps.keyToId.get(params.category);
+  const detail = await post<PluginDetailWire>(
+    "/plugins/upsert",
+    toPluginUpsert(params, { categoryId, visibility: "space" })
+  );
+  const pluginId = detail.plugin.plugin_id;
+  await post("/plugins/publish", {
+    plugin_id: pluginId,
+    version: "1.0.0",
+    placements: [
+      {
+        placement_code: SCENE_CODE,
+        ...(categoryId ? { category_id: categoryId } : {}),
+        is_visible: true,
+      },
+    ],
+  });
+  return { id: pluginId };
 }
 
-/** PATCH /mcps/{id} — owner-only partial update (mcp-v1.md §4.5). The UI
- *  always sends the full form, so every field is present and the backend
- *  effectively replaces all mutable fields; returns 200 with the updated
- *  McpDetail. 403 → forbidden, 404 → not_found are surfaced by the shared
- *  error mapper. */
+/** Full-replace update via upsert. The current visibility is fetched first so
+ *  the replace echo preserves it (legacy PATCH semantics); placement category
+ *  follows the current-state category server-side. */
 async function updateMcpReal(
   id: string,
   params: UpdateMcpParams
 ): Promise<McpDetail> {
-  return patch<McpDetailWire>(
-    `/mcps/${encodeURIComponent(id)}`,
-    toWireParams(params)
-  ).then(mapDetail);
+  const [current, maps] = await Promise.all([
+    get<PluginDetailWire>(`/plugins/detail`, {
+      plugin_id: id,
+      include_relations: false,
+    }),
+    getConnectorCategoryMaps(),
+  ]);
+  const categoryId = maps.keyToId.get(params.category);
+  const detail = await post<PluginDetailWire>(
+    "/plugins/upsert",
+    toPluginUpsert(params, {
+      pluginId: id,
+      categoryId,
+      visibility: current.plugin.visibility,
+    })
+  );
+  return mapDetail(detail.plugin, maps.idToKey);
 }
 
-/** DELETE /mcps/{id} — owner-only soft delete (mcp-v1.md §4.6). Returns
- *  204 No Content on success. */
+/** POST /plugins/delete — owner-only soft delete. */
 async function deleteMcpReal(id: string): Promise<void> {
-  return del(`/mcps/${encodeURIComponent(id)}`);
+  await post("/plugins/delete", { plugin_id: id });
 }
 
 /**
@@ -892,12 +908,12 @@ export interface McpTagSuggestion {
   count: number;
 }
 
-/** GET /market/api/v1/mcp_tags — tag suggestions for the search-bar
- *  popover. Backend aggregates across the caller's visible set (system +
- *  space rows), sorted by descending count. Empty `query` returns every
- *  visible tag; the backend clamps `limit` to [1, 100] with default 50.
- *  Pass `mode: "mine"` when the popover opens from the "我的" tab so
- *  suggestions match `GET /mcps/mine`. */
+/** GET /market/api/v1/plugin_tags — tag suggestions for the search-bar
+ *  popover, aggregated from connector Plugins visible to the caller,
+ *  sorted by descending count. Empty `query` returns every visible tag;
+ *  the backend clamps `limit` to [1, 100] with default 50. Pass
+ *  `mode: "mine"` when the popover opens from the "我的" tab so
+ *  suggestions match the mine-scoped list. */
 export function fetchMcpTags(
   query = "",
   opts: { signal?: AbortSignal; limit?: number; mode?: "all" | "mine" } = {}
@@ -952,7 +968,10 @@ async function fetchMcpTagsReal(
   query: string,
   opts: { signal?: AbortSignal; limit?: number; mode?: "all" | "mine" }
 ): Promise<McpTagSuggestion[]> {
-  const params: Record<string, unknown> = {};
+  const params: Record<string, unknown> = {
+    scene_code: SCENE_CODE,
+    plugin_type: "connector",
+  };
   if (query.trim()) params.q = query.trim();
   if (opts.limit && opts.limit > 0) params.limit = opts.limit;
   if (opts.mode === "mine") params.mode = "mine";
@@ -961,7 +980,7 @@ async function fetchMcpTagsReal(
   // helper re-throws axios cancels unchanged, so the caller's abort branch
   // still fires. Array.isArray guard covers a non-list envelope (`{}` or
   // `{data:null}`) surfacing as an empty suggestions list.
-  const data = await get<McpTagSuggestion[] | null>(`/mcp_tags`, params, {
+  const data = await get<McpTagSuggestion[] | null>(`/plugin_tags`, params, {
     signal: opts.signal,
   });
   return Array.isArray(data) ? data : [];

--- a/packages/dmworkmcp/src/api/mcpService.ts
+++ b/packages/dmworkmcp/src/api/mcpService.ts
@@ -297,7 +297,7 @@ function buildDetailFromCreate(id: string, params: CreateMcpParams): McpDetail {
     category: params.category,
     tags: params.tags ?? [],
     toolCount: params.tools.length,
-    icon: params.icon,
+    icon: params.icon ?? "",
     creatorName: WKApp.loginInfo?.name || "",
     quickStart,
     tools: params.tools,
@@ -568,6 +568,12 @@ async function resolveWriteCategory(
   key: string,
   maps: ConnectorCategoryMaps
 ): Promise<{ categoryId: string; maps: ConnectorCategoryMaps }> {
+  // An empty/unresolved category must fail closed immediately — degrading it
+  // into the refetch path would just refetch, miss, and throw the same error
+  // after a wasted round-trip. The modal surfaces this as a legible required-
+  // field error before submit (firstValidationError), so reaching here with an
+  // empty key is a defense-in-depth backstop.
+  if (!key) throw new Error(t("mcp.errors.invalidRequest"));
   const hit = maps.keyToId.get(key);
   if (hit) return { categoryId: hit, maps };
   categoryMapsCache = null;
@@ -838,18 +844,15 @@ async function updateMcpReal(
     params.category,
     maps
   );
-  // Echo the write-canonical icon. `params.icon` is the DISPLAY value the edit
-  // form seeds from mapDetail (`icon_url || icon`); when the user did not pick a
-  // new icon it is the presigned, expiring `icon_url`, which must never be
-  // persisted back into the canonical `icon` column. Detect an unchanged icon by
-  // comparing to the current display value and echo `current.plugin.icon`
-  // instead; a freshly-picked icon (a genuinely new value) is written through —
-  // mirroring the skill path (skillApiReal echoes plugin.icon).
-  const previousDisplayIcon = current.plugin.icon_url || current.plugin.icon || "";
+  // Icon write intent uses an explicit `undefined` sentinel end-to-end
+  // (mirrors the skill path's `form.iconUrl`). `undefined` = "leave the stored
+  // icon unchanged": echo the write-canonical `current.plugin.icon`, never the
+  // presigned, expiring display `icon_url`. Any other value is written through
+  // verbatim — including `""` to REMOVE the icon and a freshly-picked object
+  // key to set it. The "changed?" decision is made in the modal (where both
+  // sides come from the same fetch), so the service does no display comparison.
   const canonicalIcon =
-    params.icon && params.icon !== previousDisplayIcon
-      ? params.icon
-      : current.plugin.icon ?? "";
+    params.icon === undefined ? current.plugin.icon ?? "" : params.icon;
   const detail = await post<PluginDetailWire>(
     "/plugins/upsert",
     toPluginUpsert(

--- a/packages/dmworkmcp/src/api/mcpService.visibility.test.ts
+++ b/packages/dmworkmcp/src/api/mcpService.visibility.test.ts
@@ -1,31 +1,132 @@
 import { describe, expect, it } from "vitest";
-import { toWireParams } from "./mcpWireParams";
+import { placeholderFor, toPluginUpsert } from "./mcpWireParams";
+import { splitUserSupplied } from "./pluginWire";
+import { SECRET_PLACEHOLDER, goCanonicalJSON, rawAttachment } from "./pluginWire";
 import type { CreateMcpParams } from "../types/mcp";
 
 const form: CreateMcpParams = {
   name: "GitHub MCP",
   slug: "github-mcp",
   category: "dev",
-  icon: "",
-  tags: [],
+  icon: "🐙",
+  tags: [" official ", "official", "hot"],
   slogan: "Issues and pull requests",
   transport: "streamable-http",
   url: "https://mcp.example.com/github",
-  tools: [],
-  usageExamples: [],
-  faqs: [],
-  notes: [],
+  headers: { Authorization: "Bearer real-token", "X-Trace": "on" },
+  headersUserSupplied: ["Authorization"],
+  env: { REGION: "us", DB_URI: SECRET_PLACEHOLDER },
+  tools: [{ name: "list_repos", description: "列出仓库" }],
+  usageExamples: [" 查询 issue ", ""],
+  faqs: [{ question: "如何鉴权?", answer: "填 token" }],
+  notes: ["注意配额"],
 };
 
-describe("toWireParams visibility", () => {
-  it("omits visibility from create and edit payloads", () => {
-    const payload = toWireParams(form);
+describe("toPluginUpsert", () => {
+  it("builds a connector upsert with the caller-provided visibility", () => {
+    const body = toPluginUpsert(form, { categoryId: "cat-1", visibility: "space" });
+    expect(body.plugin.plugin_type).toBe("connector");
+    expect(body.plugin.visibility).toBe("space");
+    expect(body.plugin.category_id).toBe("cat-1");
+    expect(body.plugin.icon).toBe("🐙");
+    expect(body.plugin.tags).toEqual(["official", "hot"]);
+    expect(body.plugin.manifest_json.labels).toEqual(["official", "hot"]);
+    expect(body.plugin.manifest_json.name).toBe("github-mcp");
+    expect(body.relations).toEqual([]);
+  });
 
-    expect(payload).not.toHaveProperty("visibility");
-    expect(payload).toMatchObject({
-      name: "GitHub MCP",
-      slug: "github-mcp",
-      transport: "streamable-http",
+  it("targets an existing plugin when pluginId is set", () => {
+    const body = toPluginUpsert(form, { pluginId: "plugin-1", visibility: "private" });
+    expect(body.plugin.plugin_id).toBe("plugin-1");
+    expect(body.plugin.visibility).toBe("private");
+  });
+
+  it("writes ${KEY} placeholders for user-supplied keys and blanks sentinels", () => {
+    const body = toPluginUpsert(form, { visibility: "space" });
+    expect(body.plugin.plugin_json.connector).toEqual({
+      type: "mcp",
+      source: "connector.github-mcp",
+    });
+    const doc = JSON.parse(
+      rawAttachment(body.plugin.plugin_json, "mcp.json") ?? "{}"
+    );
+    const server = doc.mcpServers["GitHub MCP"];
+    expect(server.type).toBe("streamable-http");
+    expect(server.url).toBe("https://mcp.example.com/github");
+    // User-supplied Authorization becomes an install-time placeholder; the
+    // redaction sentinel echoed under DB_URI is blanked, plain values pass.
+    expect(server.headers).toEqual({
+      Authorization: "${AUTHORIZATION}",
+      "X-Trace": "on",
+    });
+    expect(server.env).toEqual({ REGION: "us", DB_URI: "" });
+  });
+
+  it("embeds a manifest.json attachment byte-equal to the submitted manifest", () => {
+    const body = toPluginUpsert(form, { visibility: "space" });
+    const embedded = rawAttachment(body.plugin.plugin_json, "manifest.json");
+    expect(embedded).toBe(goCanonicalJSON(body.plugin.manifest_json));
+  });
+
+  it("carries examples, faqs, and notes as connector attachments", () => {
+    const body = toPluginUpsert(form, { visibility: "space" });
+    expect(
+      JSON.parse(rawAttachment(body.plugin.plugin_json, "connector/examples.json") ?? "[]")
+    ).toEqual(["查询 issue"]);
+    expect(
+      JSON.parse(rawAttachment(body.plugin.plugin_json, "connector/tools.json") ?? "[]")
+    ).toEqual([{ name: "list_repos", description: "列出仓库" }]);
+    expect(
+      JSON.parse(rawAttachment(body.plugin.plugin_json, "connector/notes.json") ?? "[]")
+    ).toEqual(["注意配额"]);
+  });
+});
+
+describe("goCanonicalJSON — Go json.Marshal parity", () => {
+  it("sorts object keys and strips whitespace", () => {
+    expect(goCanonicalJSON({ b: 1, a: "x" })).toBe('{"a":"x","b":1}');
+  });
+
+  it("escapes <, >, & the way Go's default encoder does", () => {
+    expect(goCanonicalJSON({ s: "<a & b>" })).toBe(
+      '{"s":"\\u003ca \\u0026 b\\u003e"}'
+    );
+  });
+
+  it("keeps CJK text unescaped like Go", () => {
+    expect(goCanonicalJSON({ s: "使用示例 1" })).toBe('{"s":"使用示例 1"}');
+  });
+});
+
+describe("splitUserSupplied — placeholder read path", () => {
+  it("round-trips every placeholderFor output, including digit-leading keys", () => {
+    // The writer normalizes keys like "12" to ${12}; the reader must accept
+    // the same range or the user-supplied marker is silently lost on read.
+    for (const key of ["Authorization", "X-API-Key", "12", "1Password", "数据库"]) {
+      const split = splitUserSupplied({ [key]: placeholderFor(key) });
+      expect(split.userSupplied).toEqual([key]);
+      expect(split.values).toEqual({ [key]: "" });
+    }
+  });
+
+  it("keeps distinct keys separate even when their placeholders collide", () => {
+    const split = splitUserSupplied({
+      "X-API-Key": placeholderFor("X-API-Key"),
+      X_API_Key: placeholderFor("X_API_Key"),
+    });
+    expect(split.userSupplied).toEqual(["X-API-Key", "X_API_Key"]);
+    expect(split.values).toEqual({ "X-API-Key": "", X_API_Key: "" });
+  });
+
+  it("passes plain literals through and blanks redaction sentinels only", () => {
+    const split = splitUserSupplied({
+      REGION: "us",
+      NOT_A_PLACEHOLDER: "${not a name}",
+    });
+    expect(split.userSupplied).toBeUndefined();
+    expect(split.values).toEqual({
+      REGION: "us",
+      NOT_A_PLACEHOLDER: "${not a name}",
     });
   });
 });

--- a/packages/dmworkmcp/src/api/mcpService.visibility.test.ts
+++ b/packages/dmworkmcp/src/api/mcpService.visibility.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { placeholderFor, toPluginUpsert } from "./mcpWireParams";
+import { placeholderFor, placeholderSecretMap, toPluginUpsert } from "./mcpWireParams";
 import { splitUserSupplied } from "./pluginWire";
 import { SECRET_PLACEHOLDER, goCanonicalJSON, rawAttachment } from "./pluginWire";
 import type { CreateMcpParams } from "../types/mcp";
@@ -129,6 +129,31 @@ describe("splitUserSupplied — placeholder read path", () => {
     expect(split.values).toEqual({
       REGION: "us",
       NOT_A_PLACEHOLDER: "${not a name}",
+    });
+  });
+});
+
+describe("secret placeholder round-trip — preserves the original reference", () => {
+  it("writes back ${SHARED_TOKEN} under key TOKEN unchanged (no rename to ${TOKEN})", () => {
+    // A cross-referential ${SHARED_TOKEN} is NOT a self-referential fill-in slot,
+    // so the reader keeps it verbatim (not blanked, not user-supplied)...
+    const read = splitUserSupplied({ TOKEN: "${SHARED_TOKEN}" });
+    expect(read.userSupplied).toBeUndefined();
+    expect(read.values).toEqual({ TOKEN: "${SHARED_TOKEN}" });
+
+    // ...and the writer echoes it through unchanged rather than renaming it.
+    const written = placeholderSecretMap(read.values, read.userSupplied);
+    expect(written).toEqual({ TOKEN: "${SHARED_TOKEN}" });
+  });
+
+  it("blanks and regenerates the self-referential ${KEY} slot stably", () => {
+    // A genuine user-supplied key reads as blank + user-supplied and the writer
+    // regenerates the identical ${KEY}, round-tripping without change.
+    const read = splitUserSupplied({ TOKEN: "${TOKEN}" });
+    expect(read.userSupplied).toEqual(["TOKEN"]);
+    expect(read.values).toEqual({ TOKEN: "" });
+    expect(placeholderSecretMap(read.values, read.userSupplied)).toEqual({
+      TOKEN: "${TOKEN}",
     });
   });
 });

--- a/packages/dmworkmcp/src/api/mcpService.visibility.test.ts
+++ b/packages/dmworkmcp/src/api/mcpService.visibility.test.ts
@@ -62,10 +62,12 @@ describe("toPluginUpsert", () => {
     expect(server.env).toEqual({ REGION: "us", DB_URI: "" });
   });
 
-  it("embeds a manifest.json attachment byte-equal to the submitted manifest", () => {
+  it("does not embed a manifest.json attachment (contract layout)", () => {
     const body = toPluginUpsert(form, { visibility: "space" });
-    const embedded = rawAttachment(body.plugin.plugin_json, "manifest.json");
-    expect(embedded).toBe(goCanonicalJSON(body.plugin.manifest_json));
+    expect(rawAttachment(body.plugin.plugin_json, "manifest.json")).toBeUndefined();
+    expect(
+      body.plugin.plugin_json.attachments.some((a) => a.path === "manifest.json")
+    ).toBe(false);
   });
 
   it("carries examples, faqs, and notes as connector attachments", () => {

--- a/packages/dmworkmcp/src/api/mcpWireParams.ts
+++ b/packages/dmworkmcp/src/api/mcpWireParams.ts
@@ -84,10 +84,9 @@ export function toPluginUpsert(
     params.headersUserSupplied
   );
   if (headers) server.headers = headers;
+  // Contract layout: the manifest lives only in manifest_json — no embedded
+  // manifest.json attachment (the old byte-match rule is retired).
   const attachments: PluginAttachmentBody[] = [
-    // manifest.json must be BYTE-EQUAL to the server-canonicalized manifest;
-    // goCanonicalJSON reproduces Go's encoding of the manifest object above.
-    rawAtt("manifest.json", goCanonicalJSON(manifest)),
     rawAtt("mcp.json", goCanonicalJSON({ mcpServers: { [name]: server } })),
     rawAtt("connector/tools.json", goCanonicalJSON(params.tools ?? [])),
     rawAtt("connector/examples.json", goCanonicalJSON(usage)),

--- a/packages/dmworkmcp/src/api/mcpWireParams.ts
+++ b/packages/dmworkmcp/src/api/mcpWireParams.ts
@@ -66,7 +66,9 @@ export function toPluginUpsert(
     name: slug || name,
     description: params.slogan ?? "",
     labels: tags,
-    examples: usage.map((input, i) => ({ title: `使用示例 ${i + 1}`, input })),
+    // Locale-neutral title: examples are persisted into manifest_json and read
+    // back by every client of the unified API, so this must not bake in a locale.
+    examples: usage.map((input, i) => ({ title: `Example ${i + 1}`, input })),
   };
   // The unified marketplace never persists secret VALUES. mcp.json is the
   // standard {"mcpServers": {...}} document: user-supplied env/header keys

--- a/packages/dmworkmcp/src/api/mcpWireParams.ts
+++ b/packages/dmworkmcp/src/api/mcpWireParams.ts
@@ -1,24 +1,160 @@
 import type { CreateMcpParams, UpdateMcpParams } from "../types/mcp";
+import { slugifyServerName } from "../utils/constants";
+import {
+  SECRET_PLACEHOLDER,
+  goCanonicalJSON,
+  type PluginManifestWire,
+  type PluginVisibilityWire,
+} from "./pluginWire";
 
-export function toWireParams(params: CreateMcpParams | UpdateMcpParams) {
-  return {
-    name: params.name,
-    slug: params.slug,
-    slogan: params.slogan,
-    category: params.category,
-    icon: params.icon,
-    tags: params.tags,
-    transport: params.transport,
-    url: params.url,
-    command: params.command,
-    args: params.args,
-    env: params.env,
-    env_user_supplied: params.envUserSupplied,
-    headers: params.headers,
-    headers_user_supplied: params.headersUserSupplied,
-    tools: params.tools,
-    usage_examples: params.usageExamples,
-    faqs: params.faqs,
-    notes: params.notes,
+// The upsert body of the unified plugin API. The legacy flat MCP create body
+// is reshaped into manifest_json (display document) + plugin_json (package of
+// connector/* attachments, mirroring the backfill layout) so old and new rows
+// share one shape.
+
+interface PluginAttachmentBody {
+  path: string;
+  content_type: "raw";
+  mime_type: string;
+  raw_content: string;
+}
+
+export interface PluginUpsertBody {
+  plugin: {
+    plugin_id?: string;
+    plugin_name: string;
+    plugin_type: "connector";
+    category_id?: string;
+    tags: string[];
+    icon: string;
+    visibility: PluginVisibilityWire;
+    manifest_json: PluginManifestWire;
+    plugin_json: {
+      $schema: string;
+      connector: { type: "mcp"; source: string };
+      attachments: PluginAttachmentBody[];
+    };
   };
+  relations: [];
+}
+
+export interface PluginUpsertOptions {
+  pluginId?: string;
+  categoryId?: string;
+  visibility: PluginVisibilityWire;
+}
+
+export function toPluginUpsert(
+  params: CreateMcpParams | UpdateMcpParams,
+  opts: PluginUpsertOptions
+): PluginUpsertBody {
+  const name = params.name.trim();
+  const slug = slugifyServerName(params.slug?.trim() ? params.slug : name);
+  // Pre-normalize exactly like the backend (trim, drop empties, dedupe) so
+  // the manifest.json attachment below stays byte-equal to the canonical
+  // manifest the server derives from the same labels.
+  const tags = [
+    ...new Set((params.tags ?? []).map((t) => t.trim()).filter(Boolean)),
+  ];
+  const usage = (params.usageExamples ?? [])
+    .map((s) => s.trim())
+    .filter(Boolean);
+  const manifest: PluginManifestWire = {
+    $schema: "cowork-plugin-manifest-1.0.json",
+    plugin_name: name,
+    plugin_type: "connector",
+    name: slug || name,
+    description: params.slogan ?? "",
+    labels: tags,
+    examples: usage.map((input, i) => ({ title: `使用示例 ${i + 1}`, input })),
+  };
+  // The unified marketplace never persists secret VALUES. mcp.json is the
+  // standard {"mcpServers": {...}} document: user-supplied env/header keys
+  // carry ${KEY} placeholders (filled locally at install time), and any
+  // redaction sentinel echoed from a read is blanked.
+  const server: Record<string, unknown> = {};
+  if (params.transport) server.type = params.transport;
+  if (params.url) server.url = params.url;
+  if (params.command) server.command = params.command;
+  if (params.args?.length) server.args = params.args;
+  const env = placeholderSecretMap(params.env, params.envUserSupplied);
+  if (env) server.env = env;
+  const headers = placeholderSecretMap(
+    params.headers,
+    params.headersUserSupplied
+  );
+  if (headers) server.headers = headers;
+  const attachments: PluginAttachmentBody[] = [
+    // manifest.json must be BYTE-EQUAL to the server-canonicalized manifest;
+    // goCanonicalJSON reproduces Go's encoding of the manifest object above.
+    rawAtt("manifest.json", goCanonicalJSON(manifest)),
+    rawAtt("mcp.json", goCanonicalJSON({ mcpServers: { [name]: server } })),
+    rawAtt("connector/tools.json", goCanonicalJSON(params.tools ?? [])),
+    rawAtt("connector/examples.json", goCanonicalJSON(usage)),
+    rawAtt(
+      "connector/faqs.json",
+      goCanonicalJSON((params.faqs ?? []).filter((f) => f.question.trim()))
+    ),
+    rawAtt(
+      "connector/notes.json",
+      goCanonicalJSON((params.notes ?? []).map((s) => s.trim()).filter(Boolean))
+    ),
+  ];
+  return {
+    plugin: {
+      ...(opts.pluginId ? { plugin_id: opts.pluginId } : {}),
+      plugin_name: name,
+      plugin_type: "connector",
+      ...(opts.categoryId ? { category_id: opts.categoryId } : {}),
+      tags,
+      icon: params.icon ?? "",
+      visibility: opts.visibility,
+      manifest_json: manifest,
+      plugin_json: {
+        $schema: "cowork-plugin-package-1.0.json",
+        connector: { type: "mcp", source: `connector.${slug || name}` },
+        attachments,
+      },
+    },
+    relations: [],
+  };
+}
+
+function rawAtt(path: string, content: string): PluginAttachmentBody {
+  return {
+    path,
+    content_type: "raw",
+    mime_type: "application/json",
+    raw_content: content,
+  };
+}
+
+/** Renders the ${KEY} install-time placeholder for one user-supplied key,
+ *  mirroring the backend normalization (uppercase, non-alphanumerics -> _). */
+export function placeholderFor(key: string): string {
+  const normalized = key
+    .trim()
+    .replace(/[^A-Za-z0-9]/g, "_")
+    .toUpperCase();
+  return "${" + (normalized || "VALUE") + "}";
+}
+
+function placeholderSecretMap(
+  map: Record<string, string> | undefined,
+  userSupplied: string[] | undefined
+): Record<string, string> | undefined {
+  const supplied = new Set(userSupplied ?? []);
+  if ((!map || !Object.keys(map).length) && !supplied.size) return undefined;
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(map ?? {})) {
+    out[key] = supplied.has(key)
+      ? placeholderFor(key)
+      : value === SECRET_PLACEHOLDER
+        ? ""
+        : value;
+  }
+  for (const key of supplied) {
+    if (!(key in out)) out[key] = placeholderFor(key);
+  }
+  return Object.keys(out).length ? out : undefined;
 }

--- a/packages/dmworkmcp/src/api/mcpWireParams.ts
+++ b/packages/dmworkmcp/src/api/mcpWireParams.ts
@@ -140,7 +140,10 @@ export function placeholderFor(key: string): string {
   return "${" + (normalized || "VALUE") + "}";
 }
 
-function placeholderSecretMap(
+/** Build the persisted env/header map from the form values and the
+ *  user-supplied key set. Exported so the secret round-trip contract can be
+ *  pinned in unit tests. */
+export function placeholderSecretMap(
   map: Record<string, string> | undefined,
   userSupplied: string[] | undefined
 ): Record<string, string> | undefined {
@@ -148,6 +151,10 @@ function placeholderSecretMap(
   if ((!map || !Object.keys(map).length) && !supplied.size) return undefined;
   const out: Record<string, string> = {};
   for (const [key, value] of Object.entries(map ?? {})) {
+    // A user-supplied key regenerates its self-referential ${KEY} placeholder;
+    // every other value — including a cross-referential ${SHARED_TOKEN} that
+    // splitUserSupplied preserved verbatim — passes through unchanged, so no
+    // install-time variable is renamed on round-trip.
     out[key] = supplied.has(key)
       ? placeholderFor(key)
       : value === SECRET_PLACEHOLDER

--- a/packages/dmworkmcp/src/api/mcpWireParams.ts
+++ b/packages/dmworkmcp/src/api/mcpWireParams.ts
@@ -51,8 +51,8 @@ export function toPluginUpsert(
   const name = params.name.trim();
   const slug = slugifyServerName(params.slug?.trim() ? params.slug : name);
   // Pre-normalize exactly like the backend (trim, drop empties, dedupe) so
-  // the manifest.json attachment below stays byte-equal to the canonical
-  // manifest the server derives from the same labels.
+  // manifest_json.labels matches the tags column invariant the server
+  // enforces (tags == labels).
   const tags = [
     ...new Set((params.tags ?? []).map((t) => t.trim()).filter(Boolean)),
   ];

--- a/packages/dmworkmcp/src/api/pluginWire.ts
+++ b/packages/dmworkmcp/src/api/pluginWire.ts
@@ -179,6 +179,14 @@ function escapeLikeGo(json: string): string {
  *  like "12" to ${12} — reader and writer must agree on the full range. */
 const PLACEHOLDER_PATTERN = /^\$\{[A-Za-z0-9_]+\}$/;
 
+/** The self-referential placeholder the writer emits for a user-supplied key:
+ *  ${NORMALIZED_KEY}. Must stay in lockstep with placeholderFor() in
+ *  mcpWireParams so read↔write round-trips are byte-stable. */
+function selfPlaceholder(key: string): string {
+  const normalized = key.trim().replace(/[^A-Za-z0-9]/g, "_").toUpperCase();
+  return "${" + (normalized || "VALUE") + "}";
+}
+
 export function splitUserSupplied(map: Record<string, string> | undefined): {
   values?: Record<string, string>;
   userSupplied?: string[];
@@ -186,10 +194,21 @@ export function splitUserSupplied(map: Record<string, string> | undefined): {
   if (!map || !Object.keys(map).length) return {};
   const values: Record<string, string> = {};
   const userSupplied: string[] = [];
+  // Preserve the ORIGINAL ${...} reference. A value that equals the key's own
+  // self-referential placeholder (${NORMALIZED_KEY}) is a genuine user-supplied
+  // slot: blank it for the UI — the writer regenerates the identical placeholder
+  // from the key, so it round-trips unchanged. A value that references a
+  // DIFFERENTLY-named install-time variable (e.g. "${SHARED_TOKEN}" under key
+  // "TOKEN") is NOT a fill-in slot; keep it verbatim so the writer echoes it
+  // instead of renaming it to "${TOKEN}" from the key.
   for (const [key, value] of Object.entries(map)) {
     if (PLACEHOLDER_PATTERN.test(value)) {
-      values[key] = "";
-      userSupplied.push(key);
+      if (value === selfPlaceholder(key)) {
+        values[key] = "";
+        userSupplied.push(key);
+      } else {
+        values[key] = value;
+      }
       continue;
     }
     values[key] = value === SECRET_PLACEHOLDER ? "" : value;

--- a/packages/dmworkmcp/src/api/pluginWire.ts
+++ b/packages/dmworkmcp/src/api/pluginWire.ts
@@ -133,13 +133,10 @@ export function jsonAttachment<T>(
   }
 }
 
-/**
- * Serialize a value exactly like Go's `json.Marshal` of decoded JSON: object
- * keys sorted, no whitespace, and `<` `>` `&` U+2028 U+2029 escaped. The
- * upsert package must embed a `manifest.json` attachment whose raw_content is
- * BYTE-EQUAL to the server-canonicalized manifest, so this must reproduce the
- * Go encoding for the manifest we submit alongside it.
- */
+/** Stable serializer matching Go's json.Marshal encoding (sorted keys,
+ *  `<>&`/U+2028/U+2029 escapes): used to render deterministic JSON attachment
+ *  contents (mcp.json, connector/*.json). The retired manifest byte-match rule
+ *  no longer applies — packages carry no embedded manifest.json. */
 export function goCanonicalJSON(value: unknown): string {
   return escapeLikeGo(stringifySortedKeys(value));
 }

--- a/packages/dmworkmcp/src/api/pluginWire.ts
+++ b/packages/dmworkmcp/src/api/pluginWire.ts
@@ -1,0 +1,204 @@
+// ─── Unified plugin API wire types + helpers ────────────────────────────────
+// The octo-marketplace unified plugin surface (`/plugins`, `/plugins/detail`,
+// `/plugin_categories`, `/plugins/*`) replaces the legacy per-type
+// catalog endpoints. This module holds the wire shapes and the pure mapping
+// helpers shared by the MCP and Expert services; it owns no HTTP plumbing.
+
+/** The single marketplace scene every catalog row lives under today. */
+export const SCENE_CODE = "default";
+
+/** Sentinel the backend stores in place of a redacted secret value. The
+ *  unified write path rejects it under secret-named keys, so forms blank it
+ *  on read and never echo it back. */
+export const SECRET_PLACEHOLDER = "__OCTO_SECRET_PLACEHOLDER__";
+
+export type PluginTypeWire = "connector" | "expert" | "expert_team" | "skill";
+export type PluginVisibilityWire = "public" | "space" | "private" | "system";
+
+export interface PluginManifestExampleWire {
+  title: string;
+  input: string;
+}
+
+export interface PluginManifestWire {
+  $schema?: string;
+  plugin_name?: string;
+  plugin_type?: string;
+  /** Machine name — for connectors this is the legacy slug. */
+  name?: string;
+  description?: string;
+  labels?: string[];
+  examples?: PluginManifestExampleWire[];
+}
+
+export interface PluginAttachmentWire {
+  path: string;
+  content_type: "raw" | "storage";
+  mime_type?: string;
+  raw_content?: string;
+  storage_uri?: string;
+  content_size?: number;
+  content_hash?: string;
+}
+
+export interface PluginPackageWire {
+  $schema?: string;
+  attachments?: PluginAttachmentWire[];
+}
+
+export interface PluginListItemWire {
+  plugin_id: string;
+  plugin_name: string;
+  plugin_type: PluginTypeWire;
+  is_embedded?: boolean;
+  category_id?: string;
+  tags: string[];
+  publisher?: string;
+  owner_id: string;
+  visibility: PluginVisibilityWire;
+  creator_name: string;
+  created_by_type: "human" | "bot" | "import";
+  created_by_bot_id?: string;
+  created_by_bot_name?: string;
+  /** Stored write-canonical icon value — echo this on updates. */
+  icon?: string;
+  /** Resolved display URL (presigned when icon is an object key). */
+  icon_url?: string;
+  tool_count?: number;
+  member_count?: number;
+  view_count: number;
+  install_count: number;
+  download_count: number;
+  manifest_json: PluginManifestWire;
+  current_version?: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface PluginDetailPluginWire extends PluginListItemWire {
+  plugin_json?: PluginPackageWire;
+}
+
+export interface PluginRelationWire {
+  relation_id: string;
+  source_plugin_id: string;
+  target_plugin_id: string;
+  relation_type: string;
+  sort_order: number;
+  data?: Record<string, unknown>;
+}
+
+export interface PluginDetailWire {
+  plugin: PluginDetailPluginWire;
+  relations: PluginRelationWire[];
+}
+
+export interface PluginCategoryWire {
+  category_id: string;
+  name: string;
+  icon_key?: string;
+  plugin_types?: string[];
+  sort_order: number;
+  plugin_count: number;
+}
+
+export interface OffsetPaginationWire {
+  total: number;
+  page: number;
+  page_size: number;
+}
+
+/** raw_content of one inline package attachment, or undefined. */
+export function rawAttachment(
+  pkg: PluginPackageWire | undefined,
+  path: string
+): string | undefined {
+  const hit = (pkg?.attachments ?? []).find(
+    (a) => a.path === path && a.content_type === "raw"
+  );
+  return hit?.raw_content;
+}
+
+/** Parsed JSON body of one inline attachment; undefined on miss/parse error. */
+export function jsonAttachment<T>(
+  pkg: PluginPackageWire | undefined,
+  path: string
+): T | undefined {
+  const raw = rawAttachment(pkg, path);
+  if (raw === undefined) return undefined;
+  try {
+    return JSON.parse(raw) as T;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Serialize a value exactly like Go's `json.Marshal` of decoded JSON: object
+ * keys sorted, no whitespace, and `<` `>` `&` U+2028 U+2029 escaped. The
+ * upsert package must embed a `manifest.json` attachment whose raw_content is
+ * BYTE-EQUAL to the server-canonicalized manifest, so this must reproduce the
+ * Go encoding for the manifest we submit alongside it.
+ */
+export function goCanonicalJSON(value: unknown): string {
+  return escapeLikeGo(stringifySortedKeys(value));
+}
+
+function stringifySortedKeys(value: unknown): string {
+  if (value === null || value === undefined) return "null";
+  if (typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) {
+    return `[${value.map(stringifySortedKeys).join(",")}]`;
+  }
+  const record = value as Record<string, unknown>;
+  const keys = Object.keys(record)
+    .filter((key) => record[key] !== undefined)
+    .sort();
+  const parts = keys.map(
+    (key) => `${JSON.stringify(key)}:${stringifySortedKeys(record[key])}`
+  );
+  return `{${parts.join(",")}}`;
+}
+
+function escapeLikeGo(json: string): string {
+  return json
+    .replace(/</g, "\\u003c")
+    .replace(/>/g, "\\u003e")
+    .replace(/&/g, "\\u0026")
+    .replace(/\u2028/g, "\\u2028")
+    .replace(/\u2029/g, "\\u2029")
+    // Go emits \u0008/\u000c where JSON.stringify emits the short \b/\f forms.
+    .replace(/\\./g, (escape) => {
+      if (escape === "\\b") return "\\u0008";
+      if (escape === "\\f") return "\\u000c";
+      return escape;
+    });
+}
+
+/** Values matching the ${KEY} install-time placeholder pattern mark
+ *  user-supplied keys: the UI shows a blank fill-in slot instead of the
+ *  marker. Redaction sentinels blank the same way (never reach edit forms).
+ *  The name part accepts leading digits because the writer normalizes keys
+ *  like "12" to ${12} — reader and writer must agree on the full range. */
+const PLACEHOLDER_PATTERN = /^\$\{[A-Za-z0-9_]+\}$/;
+
+export function splitUserSupplied(map: Record<string, string> | undefined): {
+  values?: Record<string, string>;
+  userSupplied?: string[];
+} {
+  if (!map || !Object.keys(map).length) return {};
+  const values: Record<string, string> = {};
+  const userSupplied: string[] = [];
+  for (const [key, value] of Object.entries(map)) {
+    if (PLACEHOLDER_PATTERN.test(value)) {
+      values[key] = "";
+      userSupplied.push(key);
+      continue;
+    }
+    values[key] = value === SECRET_PLACEHOLDER ? "" : value;
+  }
+  return {
+    values,
+    userSupplied: userSupplied.length ? userSupplied : undefined,
+  };
+}

--- a/packages/dmworkmcp/src/components/McpCreateModal.tsx
+++ b/packages/dmworkmcp/src/components/McpCreateModal.tsx
@@ -528,6 +528,13 @@ const McpCreateModal: React.FC<McpCreateModalProps> = ({
   // edit) so the create → detail round-trip renders without a blank.
   const [iconFile, setIconFile] = useState<File | null>(null);
   const [iconPreview, setIconPreview] = useState("");
+  // Icon write intent tracking. The edit form seeds `form.icon` from the
+  // DISPLAY value (mapDetail = icon_url || icon) — a presigned, expiring URL we
+  // must never persist back. So we do NOT derive the payload icon from
+  // `form.icon`; instead we send an explicit `undefined` sentinel unless the
+  // user touched the icon: a fresh upload sends the new object key, an explicit
+  // remove sends `""`. `iconRemoved` records that the user cleared the icon.
+  const [iconRemoved, setIconRemoved] = useState(false);
 
   // Once the user hand-edits the slug we stop auto-deriving it from the name.
   const [slugTouched, setSlugTouched] = useState(false);
@@ -572,6 +579,7 @@ const McpCreateModal: React.FC<McpCreateModalProps> = ({
     }
     setIconFile(null);
     setIconPreview("");
+    setIconRemoved(false);
     setStep(0);
     // JSON import mode + textarea reset. Edit sessions never enter JSON mode.
     setCreateMode("manual");
@@ -609,6 +617,7 @@ const McpCreateModal: React.FC<McpCreateModalProps> = ({
     setStep(0);
     setCreateMode("manual");
     setJsonRaw("");
+    setIconRemoved(false);
   };
 
   /** Name edit also seeds the slug while the user hasn't hand-edited it, so the
@@ -673,11 +682,14 @@ const McpCreateModal: React.FC<McpCreateModalProps> = ({
       return;
     }
     setIconFile(file);
+    // A fresh pick supersedes any prior removal.
+    setIconRemoved(false);
   };
 
   const handleIconRemove = (e: React.MouseEvent) => {
     e.stopPropagation();
     setIconFile(null);
+    setIconRemoved(true);
     update("icon", "");
   };
 
@@ -760,6 +772,12 @@ const McpCreateModal: React.FC<McpCreateModalProps> = ({
     values?: Record<string, number>;
   } | null => {
     if (!form.name.trim()) return { key: "mcp.create.nameRequired" };
+    // Category can arrive empty when the record's stored category_id no longer
+    // resolves in the taxonomy map (mcpService degrades it to ""), leaving the
+    // Select blank. Surface a legible required-field error here rather than
+    // letting resolveWriteCategory throw a generic invalidRequest on submit.
+    if (!(form.category ?? "").trim())
+      return { key: "mcp.create.categoryRequired" };
     if (isRemote(form.transport)) {
       if (!(form.url ?? "").trim()) return { key: "mcp.create.urlRequired" };
       // Per-row key / value length. The KV editor caps typed input via
@@ -819,8 +837,13 @@ const McpCreateModal: React.FC<McpCreateModalProps> = ({
         t(err.key, err.values ? { values: err.values } : undefined)
       );
       // Connection fields live on step 1; jump there so the user sees the gap.
-      if (err.key !== "mcp.create.nameRequired") setStep(1);
-      else setStep(0);
+      // Name + category live on step 0.
+      if (
+        err.key === "mcp.create.nameRequired" ||
+        err.key === "mcp.create.categoryRequired"
+      )
+        setStep(0);
+      else setStep(1);
       return;
     }
 
@@ -853,9 +876,17 @@ const McpCreateModal: React.FC<McpCreateModalProps> = ({
         // blocking the whole create/edit on a transient upload failure.
       }
     }
+    // Icon write intent as an explicit sentinel (never seeded from the display
+    // `form.icon`, which on edit is the expiring presigned icon_url):
+    //   - a freshly-uploaded object key → set it,
+    //   - an explicit remove → "" (removal),
+    //   - otherwise untouched → undefined (leave the stored icon unchanged;
+    //     the create path defaults undefined → "" in toPluginUpsert).
+    const iconIntent: string | undefined =
+      iconOverride !== undefined ? iconOverride : iconRemoved ? "" : undefined;
     const payload: CreateMcpParams = {
       ...form,
-      icon: iconOverride ?? form.icon,
+      icon: iconIntent,
       // Slug is the JSON `mcpServers` key; a manual override is run through the
       // same slugify as the auto value so Chinese / uppercase / spaces /
       // underscores can never leak into the key. Falls back to the safe default.

--- a/packages/dmworkmcp/src/i18n/en-US.json
+++ b/packages/dmworkmcp/src/i18n/en-US.json
@@ -267,6 +267,7 @@
     "name": "Name",
     "namePlaceholder": "e.g. GitHub MCP",
     "nameRequired": "Name is required",
+    "categoryRequired": "Please select a category",
     "slug": "Server slug",
     "slugHint": "Used as the key in the generated mcpServers JSON; lowercase letters, digits and hyphens only. Leave blank to derive it from the name.",
     "slugPlaceholder": "e.g. github-mcp",

--- a/packages/dmworkmcp/src/i18n/zh-CN.json
+++ b/packages/dmworkmcp/src/i18n/zh-CN.json
@@ -267,6 +267,7 @@
     "name": "名称",
     "namePlaceholder": "例如 GitHub MCP",
     "nameRequired": "请填写名称",
+    "categoryRequired": "请选择分类",
     "slug": "服务标识 (slug)",
     "slugHint": "生成 mcpServers JSON 时用作 key，仅限英文小写、数字、连字符；留空自动根据名称生成",
     "slugPlaceholder": "例如 github-mcp",

--- a/packages/dmworkmcp/src/pages/McpMarketListPage.tsx
+++ b/packages/dmworkmcp/src/pages/McpMarketListPage.tsx
@@ -39,7 +39,7 @@ interface McpMarketListPageState {
    *  outside-click listener + Escape handler can toggle it. */
   tagFilterOpen: boolean;
   /** Fuzzy filter typed into the tag-popover search input. Debounced fetch
-   *  against `/mcp_tags` populates `tagSuggestions`. */
+   *  against `/plugin_tags` populates `tagSuggestions`. */
   tagQuery: string;
   /** Backend-supplied tag suggestions (mcp-v1.md §4.8). Repopulated whenever
    *  the popover opens or `tagQuery` changes; empty until the first fetch
@@ -239,7 +239,7 @@ export default class McpMarketListPage extends Component<
     return rows;
   }
 
-  /** Debounce + fire a /mcp_tags fetch, wiring the response into
+  /** Debounce + fire a /plugin_tags fetch, wiring the response into
    *  tagSuggestions. Cancels any in-flight request via AbortController so a
    *  fast typist doesn't clobber a fresh response with a stale one. */
   private scheduleTagFetch_() {
@@ -396,7 +396,7 @@ export default class McpMarketListPage extends Component<
     // 用户切换「全部/我的」视图(已过同值 guard);原先误用 GET /mcps/mine 加载推断,而 mine 列表也用于建议/初始化。
     Dap.shared.track("market_view_switched", {});
     // Full reset — tag suggestions are mode-scoped on the backend (see
-    // /mcp_tags?mode=mine), so keeping stale suggestions after a tab switch
+    // /plugin_tags?mode=mine), so keeping stale suggestions after a tab switch
     // paints suggestions the just-loaded list can't produce. Mirrors
     // handleSpaceChanged_ for the same reason.
     this.cancelTagFetch_();
@@ -506,7 +506,7 @@ export default class McpMarketListPage extends Component<
    *  Refetches on every change; the tag popover stays open so the user can
    *  toggle several tags in one interaction. */
   private handleToggleTag = (tag: string) => {
-    // 用户点 tag 过滤(选/取消都算一次过滤动作);原先误用 GET /mcp_tags 加载 tag 列表推断。
+    // 用户点 tag 过滤(选/取消都算一次过滤动作);原先误用 GET /plugin_tags 加载 tag 列表推断。
     Dap.shared.track("market_tag_filtered", {});
     this.setState((prev) => ({
       tagsSelected: prev.tagsSelected.includes(tag)
@@ -540,7 +540,7 @@ export default class McpMarketListPage extends Component<
       editingDetail,
     } = this.state;
 
-    // Tag popover options: backend-authoritative via /mcp_tags (mcp-v1.md
+    // Tag popover options: backend-authoritative via /plugin_tags (mcp-v1.md
     // §4.8). Union with tagsSelected so a chip the user selected before the
     // fetch completes (or from a stale query) still shows up so they can
     // un-select it. Cached on the class instance keyed on the identity of

--- a/packages/dmworkmcp/src/types/mcp.ts
+++ b/packages/dmworkmcp/src/types/mcp.ts
@@ -210,8 +210,15 @@ export interface CreateMcpParams {
    *  Falls back to a safe default when slugifying yields an empty string. */
   slug?: string;
   category: string;
-  /** Icon: single emoji/char OR uploaded image (data URL). */
-  icon: string;
+  /**
+   * Icon write intent, using an explicit `undefined` sentinel end-to-end
+   * (mirrors the skill path's `form.iconUrl` sentinel):
+   *   - `undefined` = leave the stored icon unchanged (edit path only).
+   *   - `""` = remove the stored icon.
+   *   - a non-empty string = set it (object key / URL, or a legacy emoji/char).
+   * The create path defaults `undefined` → `""` in toPluginUpsert.
+   */
+  icon?: string | undefined;
   /** Card + detail tag chips, e.g. ["官方", "热门"]. */
   tags: string[];
   slogan: string;

--- a/packages/dmworkskillmarket/src/api/pluginWire.ts
+++ b/packages/dmworkskillmarket/src/api/pluginWire.ts
@@ -1,0 +1,177 @@
+// ─── Unified plugin API wire types + helpers ────────────────────────────────
+// The octo-marketplace unified plugin surface (`/plugins`, `/plugins/detail`,
+// `/plugin_categories`, `/plugins/*`) replaces the legacy per-type
+// catalog endpoints. This module holds the wire shapes and the pure mapping
+// helpers shared by the MCP and Expert services; it owns no HTTP plumbing.
+
+/** The single marketplace scene every catalog row lives under today. */
+export const SCENE_CODE = "default";
+
+/** Sentinel the backend stores in place of a redacted secret value. The
+ *  unified write path rejects it under secret-named keys, so forms blank it
+ *  on read and never echo it back. */
+export const SECRET_PLACEHOLDER = "__OCTO_SECRET_PLACEHOLDER__";
+
+export type PluginTypeWire = "connector" | "expert" | "expert_team" | "skill";
+export type PluginVisibilityWire = "public" | "space" | "private" | "system";
+
+export interface PluginManifestExampleWire {
+  title: string;
+  input: string;
+}
+
+export interface PluginManifestWire {
+  $schema?: string;
+  plugin_name?: string;
+  plugin_type?: string;
+  /** Machine name — for connectors this is the legacy slug. */
+  name?: string;
+  description?: string;
+  labels?: string[];
+  examples?: PluginManifestExampleWire[];
+}
+
+export interface PluginAttachmentWire {
+  path: string;
+  content_type: "raw" | "storage";
+  mime_type?: string;
+  raw_content?: string;
+  storage_uri?: string;
+  content_size?: number;
+  content_hash?: string;
+}
+
+export interface PluginPackageWire {
+  $schema?: string;
+  attachments?: PluginAttachmentWire[];
+}
+
+export interface PluginListItemWire {
+  plugin_id: string;
+  plugin_name: string;
+  plugin_type: PluginTypeWire;
+  is_embedded?: boolean;
+  category_id?: string;
+  tags: string[];
+  publisher?: string;
+  owner_id: string;
+  space_id?: string;
+  visibility: PluginVisibilityWire;
+  creator_name: string;
+  created_by_type: "human" | "bot" | "import";
+  created_by_bot_id?: string;
+  created_by_bot_name?: string;
+  /** Stored write-canonical icon value — echo this on updates. */
+  icon?: string;
+  /** Resolved display URL (presigned when icon is an object key). */
+  icon_url?: string;
+  tool_count?: number;
+  member_count?: number;
+  view_count: number;
+  install_count: number;
+  download_count: number;
+  manifest_json: PluginManifestWire;
+  current_version?: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface PluginDetailPluginWire extends PluginListItemWire {
+  plugin_json?: PluginPackageWire;
+}
+
+export interface PluginRelationWire {
+  relation_id: string;
+  source_plugin_id: string;
+  target_plugin_id: string;
+  relation_type: string;
+  sort_order: number;
+  data?: Record<string, unknown>;
+}
+
+export interface PluginDetailWire {
+  plugin: PluginDetailPluginWire;
+  relations: PluginRelationWire[];
+}
+
+export interface PluginCategoryWire {
+  category_id: string;
+  name: string;
+  icon_key?: string;
+  plugin_types?: string[];
+  sort_order: number;
+  plugin_count: number;
+}
+
+export interface OffsetPaginationWire {
+  total: number;
+  page: number;
+  page_size: number;
+}
+
+/** raw_content of one inline package attachment, or undefined. */
+export function rawAttachment(
+  pkg: PluginPackageWire | undefined,
+  path: string
+): string | undefined {
+  const hit = (pkg?.attachments ?? []).find(
+    (a) => a.path === path && a.content_type === "raw"
+  );
+  return hit?.raw_content;
+}
+
+/** Parsed JSON body of one inline attachment; undefined on miss/parse error. */
+export function jsonAttachment<T>(
+  pkg: PluginPackageWire | undefined,
+  path: string
+): T | undefined {
+  const raw = rawAttachment(pkg, path);
+  if (raw === undefined) return undefined;
+  try {
+    return JSON.parse(raw) as T;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Serialize a value exactly like Go's `json.Marshal` of decoded JSON: object
+ * keys sorted, no whitespace, and `<` `>` `&` U+2028 U+2029 escaped. The
+ * upsert package must embed a `manifest.json` attachment whose raw_content is
+ * BYTE-EQUAL to the server-canonicalized manifest, so this must reproduce the
+ * Go encoding for the manifest we submit alongside it.
+ */
+export function goCanonicalJSON(value: unknown): string {
+  return escapeLikeGo(stringifySortedKeys(value));
+}
+
+function stringifySortedKeys(value: unknown): string {
+  if (value === null || value === undefined) return "null";
+  if (typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) {
+    return `[${value.map(stringifySortedKeys).join(",")}]`;
+  }
+  const record = value as Record<string, unknown>;
+  const keys = Object.keys(record)
+    .filter((key) => record[key] !== undefined)
+    .sort();
+  const parts = keys.map(
+    (key) => `${JSON.stringify(key)}:${stringifySortedKeys(record[key])}`
+  );
+  return `{${parts.join(",")}}`;
+}
+
+function escapeLikeGo(json: string): string {
+  return json
+    .replace(/</g, "\\u003c")
+    .replace(/>/g, "\\u003e")
+    .replace(/&/g, "\\u0026")
+    .replace(/\u2028/g, "\\u2028")
+    .replace(/\u2029/g, "\\u2029")
+    // Go emits \u0008/\u000c where JSON.stringify emits the short \b/\f forms.
+    .replace(/\\./g, (escape) => {
+      if (escape === "\\b") return "\\u0008";
+      if (escape === "\\f") return "\\u000c";
+      return escape;
+    });
+}

--- a/packages/dmworkskillmarket/src/api/pluginWire.ts
+++ b/packages/dmworkskillmarket/src/api/pluginWire.ts
@@ -134,13 +134,10 @@ export function jsonAttachment<T>(
   }
 }
 
-/**
- * Serialize a value exactly like Go's `json.Marshal` of decoded JSON: object
- * keys sorted, no whitespace, and `<` `>` `&` U+2028 U+2029 escaped. The
- * upsert package must embed a `manifest.json` attachment whose raw_content is
- * BYTE-EQUAL to the server-canonicalized manifest, so this must reproduce the
- * Go encoding for the manifest we submit alongside it.
- */
+/** Stable serializer matching Go's json.Marshal encoding (sorted keys,
+ *  `<>&`/U+2028/U+2029 escapes): used to render deterministic JSON attachment
+ *  contents (mcp.json, connector/*.json). The retired manifest byte-match rule
+ *  no longer applies — packages carry no embedded manifest.json. */
 export function goCanonicalJSON(value: unknown): string {
   return escapeLikeGo(stringifySortedKeys(value));
 }

--- a/packages/dmworkskillmarket/src/api/skillApi.ts
+++ b/packages/dmworkskillmarket/src/api/skillApi.ts
@@ -10,7 +10,7 @@ const api = useMock ? mockApi : realApi;
 
 // NOTE: `VITE_USE_MOCK` only swaps the 8 CRUD endpoints below. The upload /
 // parse / poll / download pipeline (initUpload / uploadFile / uploadIcon /
-// triggerParse / pollParse / initReupload / getDownloadUrl / downloadSkill)
+// triggerParse / pollParse / initReupload / getDownloadUrl)
 // is always bound to the real backend — the mock module has no upload
 // surface. A dev enabling mock mode still hits real network on the upload
 // step; use a real dev backend if you need the full flow.
@@ -31,5 +31,4 @@ export const triggerParse = realApi.triggerParse;
 export const pollParse = realApi.pollParse;
 export const initReupload = realApi.initReupload;
 export const getDownloadUrl = realApi.getDownloadUrl;
-export const downloadSkill = realApi.downloadSkill;
 export const getSkillMd = realApi.getSkillMd;

--- a/packages/dmworkskillmarket/src/api/skillApiReal.test.ts
+++ b/packages/dmworkskillmarket/src/api/skillApiReal.test.ts
@@ -560,6 +560,74 @@ describe("skillApiReal", () => {
     expect(body.plugin.manifest_json.labels).toEqual(["新标签"]);
   });
 
+  it("re-upload without a new icon omits icon so the stored icon is preserved", async () => {
+    // Regression (Jerry-Xin B2 / P1-10): EditSkillModal only sets iconUrl when a
+    // new icon is chosen, so a package-only re-upload has iconUrl === undefined.
+    // The import must NOT send icon:"" (a full-replace that wipes the stored
+    // icon) — it must omit icon entirely.
+    mockFetch.mockReturnValueOnce(
+      jsonResponse({ plugin: pluginSkillWire(), relations: [] })
+    );
+
+    await updateSkill("ci-failure-map", {
+      parseTaskId: "task-reupload",
+      version: "1.1.0",
+      changelog: "repackage",
+    });
+
+    const [url, init] = mockFetch.mock.calls[mockFetch.mock.calls.length - 1] as [string, RequestInit];
+    expect(url).toBe("/market/api/v1/plugins/import");
+    const body = JSON.parse(init.body as string);
+    expect(body.plugin_id).toBe("ci-failure-map");
+    expect("icon" in body).toBe(false);
+  });
+
+  it("re-upload with a fresh icon sends the new iconUrl", async () => {
+    mockFetch.mockReturnValueOnce(
+      jsonResponse({ plugin: pluginSkillWire(), relations: [] })
+    );
+
+    await updateSkill("ci-failure-map", {
+      parseTaskId: "task-reupload",
+      version: "1.1.0",
+      changelog: "repackage",
+      iconUrl: "icons/new.png",
+    });
+
+    const [, init] = mockFetch.mock.calls[mockFetch.mock.calls.length - 1] as [string, RequestInit];
+    const body = JSON.parse(init.body as string);
+    expect(body.icon).toBe("icons/new.png");
+  });
+
+  it("metadata edit strips unsafe attachment paths from the resubmitted upsert", async () => {
+    const current = pluginSkillWire({
+      plugin_json: {
+        $schema: "cowork-plugin-package-1.0.json",
+        attachments: [
+          { path: "manifest.json", content_type: "raw", mime_type: "application/json", raw_content: "{}" },
+          { path: "SKILL.md", content_type: "raw", mime_type: "text/markdown", raw_content: "# keep" },
+          { path: "references/x.md", content_type: "raw", mime_type: "text/markdown", raw_content: "ref" },
+          { path: "../evil.md", content_type: "raw", mime_type: "text/markdown", raw_content: "escape" },
+          { path: "/abs.md", content_type: "raw", mime_type: "text/markdown", raw_content: "abs" },
+          { path: "a\\b.md", content_type: "raw", mime_type: "text/markdown", raw_content: "backslash" },
+          { path: "nested/../../deep.md", content_type: "raw", mime_type: "text/markdown", raw_content: "traverse" },
+        ],
+      },
+    });
+    mockFetch.mockReturnValueOnce(jsonResponse({ plugin: current, relations: [] }));
+    mockFetch.mockReturnValueOnce(jsonResponse({ plugin: current, relations: [] }));
+
+    await updateSkill("ci-failure-map", { displayName: "改名" });
+
+    const [url, init] = mockFetch.mock.calls[mockFetch.mock.calls.length - 1] as [string, RequestInit];
+    expect(url).toBe("/market/api/v1/plugins/upsert");
+    const body = JSON.parse(init.body as string);
+    const paths = (body.plugin.plugin_json.attachments as Array<{ path: string }>).map((a) => a.path);
+    // manifest.json dropped (contract), traversal/absolute/backslash paths rejected;
+    // only safe relative paths survive into the trusted write.
+    expect(paths).toEqual(["SKILL.md", "references/x.md"]);
+  });
+
   it("initUpload maps backend presigned upload fields", async () => {
     mockFetch.mockReturnValueOnce(
       jsonResponse({

--- a/packages/dmworkskillmarket/src/api/skillApiReal.test.ts
+++ b/packages/dmworkskillmarket/src/api/skillApiReal.test.ts
@@ -312,6 +312,51 @@ describe("skillApiReal", () => {
     expect(url).toContain("/market/api/v1/plugins/detail?plugin_id=ci-failure-map");
   });
 
+  it("getSkill derives file metadata from a tree-shaped package", async () => {
+    mockFetch.mockReturnValueOnce(
+      jsonResponse({
+        plugin: pluginSkillWire({
+          plugin_json: {
+            $schema: "cowork-plugin-package-1.0.json",
+            attachments: [
+              {
+                path: "SKILL.md",
+                content_type: "raw",
+                mime_type: "text/markdown",
+                raw_content: "# Tree",
+                content_size: 6,
+              },
+              {
+                path: "scripts/run.sh",
+                content_type: "raw",
+                mime_type: "text/x-shellscript",
+                raw_content: "echo hi",
+                content_size: 7,
+              },
+              {
+                path: "assets/logo.png",
+                content_type: "storage",
+                mime_type: "image/png",
+                storage_uri: "plugins/dev-space/attachments/skill-x-abc.png",
+                content_size: 20,
+              },
+            ],
+          },
+        }),
+        relations: [],
+      })
+    );
+
+    const skill = await getSkill("tree-skill");
+
+    expect(skill.readmeContent).toBe("# Tree");
+    // No legacy pointer: metadata is derived from the attachment tree.
+    expect(skill.fileName).toBe(`${skill.name}.zip`);
+    expect(skill.fileUrl).toBe("");
+    expect(skill.fileSize).toBe(33);
+    expect(skill.fileSha256).toBeUndefined();
+  });
+
   it("trackSkillView sends a best-effort view metric", async () => {
     mockFetch.mockReturnValueOnce(jsonResponse({}));
 

--- a/packages/dmworkskillmarket/src/api/skillApiReal.test.ts
+++ b/packages/dmworkskillmarket/src/api/skillApiReal.test.ts
@@ -505,21 +505,14 @@ describe("skillApiReal", () => {
       path: string;
       raw_content?: string;
     }>;
-    const manifestAtt = attachments.find((a) => a.path === "manifest.json");
-    expect(manifestAtt?.raw_content).toBe(
-      JSON.stringify(body.plugin.manifest_json && {
-        $schema: "cowork-plugin-manifest-1.0.json",
-        description: "Analyze CI logs",
-        examples: [],
-        labels: ["新标签"],
-        name: "ci-failure-map",
-        plugin_name: "改名",
-        plugin_type: "skill",
-      })
-    );
+    // Contract layout: the stale embedded manifest.json is dropped and the
+    // rest of the package passes through untouched.
+    expect(attachments.some((a) => a.path === "manifest.json")).toBe(false);
     expect(attachments.find((a) => a.path === "SKILL.md")?.raw_content).toBe(
       "# keep me"
     );
+    expect(body.plugin.manifest_json.plugin_name).toBe("改名");
+    expect(body.plugin.manifest_json.labels).toEqual(["新标签"]);
   });
 
   it("initUpload maps backend presigned upload fields", async () => {

--- a/packages/dmworkskillmarket/src/api/skillApiReal.test.ts
+++ b/packages/dmworkskillmarket/src/api/skillApiReal.test.ts
@@ -17,7 +17,6 @@ import {
   triggerParse,
   pollParse,
   getDownloadUrl,
-  downloadSkill,
 } from "./skillApiReal";
 
 // Mock global fetch
@@ -44,21 +43,47 @@ function jsonResponse(data: unknown, status = 200, pagination?: unknown) {
   });
 }
 
+function pluginSkillWire(overrides: Record<string, unknown> = {}) {
+  return {
+    plugin_id: "ci-failure-map",
+    plugin_name: "CI 失败分析",
+    plugin_type: "skill",
+    category_id: "dev-tools",
+    tags: ["CI"],
+    publisher: "jian",
+    owner_id: "jian",
+    space_id: "dev-space",
+    visibility: "space",
+    creator_name: "CI Bot",
+    created_by_type: "human",
+    icon: "icons/ci.png",
+    icon_url: "https://cdn.example.com/icons/ci.png",
+    view_count: 7,
+    install_count: 0,
+    download_count: 3,
+    manifest_json: { name: "ci-failure-map", description: "Analyze CI logs" },
+    current_version: "1.0.2",
+    created_at: "2026-06-01T00:00:00Z",
+    updated_at: "2026-07-10T00:00:00Z",
+    ...overrides,
+  };
+}
+
 describe("skillApiReal", () => {
-  it("getCategories maps snake_case to camelCase", async () => {
+  it("getCategories maps the unified category wire to camelCase", async () => {
     mockFetch.mockReturnValueOnce(
       jsonResponse([
         {
-          skill_category_id: "dev-tools",
+          category_id: "dev-tools",
           name: "开发工具",
           icon_key: "Terminal",
-          skill_count: 6,
+          plugin_count: 6,
         },
         {
-          skill_category_id: "starter",
+          category_id: "starter",
           name: "装机必备",
           icon_key: "Box",
-          skill_count: 3,
+          plugin_count: 3,
         },
       ])
     );
@@ -82,7 +107,7 @@ describe("skillApiReal", () => {
       },
     ]);
     expect(mockFetch).toHaveBeenCalledWith(
-      "/market/api/v1/skill_categories",
+      "/market/api/v1/plugin_categories?scene_code=default&plugin_type=skill",
       expect.objectContaining({
         headers: {
           "Content-Type": "application/json",
@@ -111,20 +136,23 @@ describe("skillApiReal", () => {
     await getCategories();
 
     expect(mockFetch).toHaveBeenCalledWith(
-      "https://api.example.com/market/api/v1/skill_categories",
+      expect.stringContaining(
+        "https://api.example.com/market/api/v1/plugin_categories?"
+      ),
       expect.any(Object)
     );
   });
 
-  it("getCategories forwards search and tag filters", async () => {
+  it("getCategories pins the unified taxonomy scope (legacy q/tags ignored)", async () => {
     mockFetch.mockReturnValueOnce(jsonResponse([]));
 
     await getCategories({ q: "CI", tags: ["CI", "质量"] });
 
     const url = mockFetch.mock.calls[0][0] as string;
-    expect(url).toContain("/market/api/v1/skill_categories?");
-    expect(url).toContain("q=CI");
-    expect(url).toContain("tags=CI%2C%E8%B4%A8%E9%87%8F");
+    expect(url).toContain("/market/api/v1/plugin_categories?");
+    expect(url).toContain("scene_code=default");
+    expect(url).toContain("plugin_type=skill");
+    expect(url).not.toContain("q=CI");
   });
 
   it("falls back to localStorage currentSpaceId when WKApp space is not hydrated", async () => {
@@ -135,7 +163,7 @@ describe("skillApiReal", () => {
     await getSkills();
 
     expect(mockFetch).toHaveBeenCalledWith(
-      "/market/api/v1/skills",
+      expect.stringContaining("/market/api/v1/plugins?"),
       expect.objectContaining({
         headers: {
           "Content-Type": "application/json",
@@ -146,37 +174,9 @@ describe("skillApiReal", () => {
     );
   });
 
-  it("getSkills maps paged result and passes query params", async () => {
+  it("getSkills maps the unified plugin list and passes query params", async () => {
     mockFetch.mockReturnValueOnce(
-      jsonResponse(
-        [
-          {
-            skill_id: "ci-failure-map",
-            name: "ci-failure-map",
-            description: "Analyze CI logs",
-            category_id: "dev-tools",
-            tags: ["CI"],
-            owner_id: "jian",
-            owner_name: "jian",
-            creator_id: "bot-1",
-            creator_name: "CI Bot",
-            space_id: "dev-space",
-            visibility: "space",
-            version: "1.0.2",
-            readme_content: "# ci-failure-map",
-            file_name: "ci-failure-map.zip",
-            file_url: "http://localhost/files/ci.zip",
-            file_size: 1024,
-            file_sha256: "abc123",
-            view_count: 7,
-            download_count: 3,
-            created_at: "2026-06-01T00:00:00Z",
-            updated_at: "2026-07-10T00:00:00Z",
-          },
-        ],
-        200,
-        { has_more: true, next_cursor: "abc", total: 42 }
-      )
+      jsonResponse([pluginSkillWire()], 200, { total: 42, page: 1, page_size: 10 })
     );
 
     const result = await getSkills({
@@ -188,37 +188,35 @@ describe("skillApiReal", () => {
     });
 
     expect(result.items).toHaveLength(1);
+    expect(result.items[0].id).toBe("ci-failure-map");
+    expect(result.items[0].name).toBe("ci-failure-map");
+    expect(result.items[0].displayName).toBe("CI 失败分析");
+    expect(result.items[0].description).toBe("Analyze CI logs");
     expect(result.items[0].categoryId).toBe("dev-tools");
     expect(result.items[0].creatorName).toBe("CI Bot");
-    expect(result.items[0].fileSha256).toBe("abc123");
+    expect(result.items[0].ownerName).toBe("jian");
+    expect(result.items[0].iconUrl).toBe("https://cdn.example.com/icons/ci.png");
+    expect(result.items[0].version).toBe("1.0.2");
     expect(result.items[0].viewCount).toBe(7);
     expect(result.items[0].downloadCount).toBe(3);
-    expect(result.nextCursor).toBe("abc");
+    // 1 * 10 < 42 → the synthesized cursor is the next page number.
+    expect(result.nextCursor).toBe("2");
     expect(result.total).toBe(42);
-    expect(mockFetch).toHaveBeenCalledWith(
-      expect.stringContaining("/market/api/v1/skills?"),
-      expect.anything()
-    );
     const url = mockFetch.mock.calls[0][0] as string;
+    expect(url).toContain("/market/api/v1/plugins?");
+    expect(url).toContain("scene_code=default");
+    expect(url).toContain("plugin_type=skill");
     expect(url).toContain("q=CI");
     expect(url).toContain("category_id=dev-tools");
-    expect(url).toContain("tags=CI%2C%E8%B4%A8%E9%87%8F");
-    expect(url).toContain("sort=latest");
+    expect(url).toContain("tag=CI&tag=%E8%B4%A8%E9%87%8F");
+    expect(url).toContain("sort=newest");
+    expect(url).toContain("page=1");
     expect(url).toContain("page_size=10");
   });
 
-  it("getSkillTags fetches current-space tag suggestions", async () => {
+  it("getSkillTags aggregates suggestions from the unified tag endpoint", async () => {
     mockFetch.mockReturnValueOnce(
-      jsonResponse({
-        items: [
-          {
-            name: "ui-case",
-            created_by: "dev-user",
-            created_at: "2026-07-17T09:04:23Z",
-            updated_at: "2026-07-17T09:04:23Z",
-          },
-        ],
-      })
+      jsonResponse([{ name: "ui-case", count: 4 }])
     );
 
     const tags = await getSkillTags("ui");
@@ -226,13 +224,13 @@ describe("skillApiReal", () => {
     expect(tags).toEqual([
       {
         name: "ui-case",
-        createdBy: "dev-user",
-        createdAt: "2026-07-17T09:04:23Z",
-        updatedAt: "2026-07-17T09:04:23Z",
+        createdBy: undefined,
+        createdAt: "",
+        updatedAt: "",
       },
     ]);
     expect(mockFetch).toHaveBeenCalledWith(
-      "/market/api/v1/skills/tags?q=ui&page_size=20",
+      "/market/api/v1/plugin_tags?scene_code=default&plugin_type=skill&q=ui&limit=20",
       expect.objectContaining({
         headers: {
           "Content-Type": "application/json",
@@ -243,8 +241,10 @@ describe("skillApiReal", () => {
     );
   });
 
-  it("getMySkills calls /skill/mine endpoint", async () => {
-    mockFetch.mockReturnValueOnce(jsonResponse([], 200, { has_more: false }));
+  it("getMySkills scopes the unified list to mode=mine", async () => {
+    mockFetch.mockReturnValueOnce(
+      jsonResponse([], 200, { total: 0, page: 1, page_size: 20 })
+    );
 
     const result = await getMySkills({
       q: "test",
@@ -255,60 +255,61 @@ describe("skillApiReal", () => {
     expect(result.items).toEqual([]);
     expect(result.nextCursor).toBeNull();
     const url = mockFetch.mock.calls[0][0] as string;
-    expect(url).toContain("/market/api/v1/skills/mine");
+    expect(url).toContain("/market/api/v1/plugins?");
+    expect(url).toContain("mode=mine");
     expect(url).toContain("q=test");
-    expect(url).toContain("tags=%E5%8D%8F%E4%BD%9C");
+    expect(url).toContain("tag=%E5%8D%8F%E4%BD%9C");
     expect(url).toContain("sort=downloads");
   });
 
-  it("getSkill maps a single skill", async () => {
+  it("getSkill maps the plugin detail with package artifacts", async () => {
     mockFetch.mockReturnValueOnce(
       jsonResponse({
-        skill_id: "test-skill",
-        name: "Test",
-        description: "desc",
-        category_id: "other",
-        tags: ["a"],
-        owner_id: "u1",
-        owner_name: "User",
-        space_id: "s1",
-        visibility: "public",
-        version: "1.0.0",
-        readme_content: "# Test",
-        file_name: "test.zip",
-        file_url: "/files/test.zip",
-        file_size: 512,
-        file_sha256: "def456",
-        created_at: "2026-01-01T00:00:00Z",
-        updated_at: "2026-01-02T00:00:00Z",
+        plugin: pluginSkillWire({
+          plugin_json: {
+            $schema: "cowork-plugin-package-1.0.json",
+            attachments: [
+              {
+                path: "SKILL.md",
+                content_type: "raw",
+                mime_type: "text/markdown",
+                raw_content: "# Test",
+              },
+              {
+                path: "skill/ref.json",
+                content_type: "raw",
+                mime_type: "application/json",
+                raw_content: JSON.stringify({
+                  file_name: "test.zip",
+                  file_size: 512,
+                  file_sha256: "def456",
+                }),
+              },
+              {
+                path: "skill/package.zip",
+                content_type: "storage",
+                mime_type: "application/zip",
+                storage_uri: "plugins/dev-space/attachments/test.zip",
+                content_size: 512,
+              },
+            ],
+          },
+        }),
+        relations: [],
       })
     );
 
-    const skill = await getSkill("test-skill");
+    const skill = await getSkill("ci-failure-map");
 
-    expect(skill.id).toBe("test-skill");
-    expect(skill.categoryId).toBe("other");
+    expect(skill.id).toBe("ci-failure-map");
+    expect(skill.categoryId).toBe("dev-tools");
     expect(skill.readmeContent).toBe("# Test");
+    expect(skill.fileName).toBe("test.zip");
+    expect(skill.fileUrl).toBe("plugins/dev-space/attachments/test.zip");
+    expect(skill.fileSize).toBe(512);
     expect(skill.fileSha256).toBe("def456");
-  });
-
-  it("keeps detail navigation working during an id field rolling upgrade", async () => {
-    mockFetch.mockReturnValueOnce(
-      jsonResponse({
-        id: "legacy-skill",
-        name: "Legacy",
-        category_id: "other",
-        tags: [],
-        owner_id: "u1",
-        space_id: "s1",
-        created_at: "2026-01-01T00:00:00Z",
-        updated_at: "2026-01-02T00:00:00Z",
-      })
-    );
-
-    await expect(getSkill("legacy-skill")).resolves.toMatchObject({
-      id: "legacy-skill",
-    });
+    const url = mockFetch.mock.calls[0][0] as string;
+    expect(url).toContain("/market/api/v1/plugins/detail?plugin_id=ci-failure-map");
   });
 
   it("trackSkillView sends a best-effort view metric", async () => {
@@ -326,7 +327,7 @@ describe("skillApiReal", () => {
           "X-Space-Id": "space-123",
         }),
         body: JSON.stringify({
-          resource_type: "skill",
+          resource_type: "plugin",
           resource_id: "skill/with space",
           event_type: "view",
         }),
@@ -334,12 +335,17 @@ describe("skillApiReal", () => {
     );
   });
 
-  it("deleteSkill handles empty success envelope", async () => {
-    mockFetch.mockReturnValueOnce(jsonResponse({}));
+  it("deleteSkill posts the plugin id to the unified delete endpoint", async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse({ deleted: true }));
 
     await expect(deleteSkill("some-id")).resolves.toBeUndefined();
-    const url = mockFetch.mock.calls[0][0] as string;
-    expect(url).toContain("/market/api/v1/skills/some-id");
+    expect(mockFetch).toHaveBeenCalledWith(
+      "/market/api/v1/plugins/delete",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ plugin_id: "some-id" }),
+      })
+    );
   });
 
   it("deleteSkill handles a real 204 No Content (empty body)", async () => {
@@ -410,27 +416,10 @@ describe("skillApiReal", () => {
     });
   });
 
-  it("createSkill and updateSkill send backend snake_case payloads", async () => {
-    const rawSkill = {
-      skill_id: "new-skill",
-      name: "New Skill",
-      description: "desc",
-      category_id: "dev-tools",
-      tags: ["tag"],
-      owner_id: "u1",
-      owner_name: "User",
-      space_id: "s1",
-      visibility: "space",
-      version: "1.0.0",
-      readme_content: "# New Skill",
-      file_name: "skill.zip",
-      file_url: "/files/skill.zip",
-      file_size: 512,
-      file_sha256: "sha",
-      created_at: "2026-01-01T00:00:00Z",
-      updated_at: "2026-01-02T00:00:00Z",
-    };
-    mockFetch.mockReturnValueOnce(jsonResponse(rawSkill));
+  it("createSkill imports the parse task through the unified endpoint", async () => {
+    mockFetch.mockReturnValueOnce(
+      jsonResponse({ plugin: pluginSkillWire(), relations: [] })
+    );
     await createSkill({
       parseTaskId: "task-1",
       name: "New Skill",
@@ -445,37 +434,91 @@ describe("skillApiReal", () => {
       fileSize: 512,
     });
     expect(mockFetch).toHaveBeenLastCalledWith(
-      "/market/api/v1/skills",
+      "/market/api/v1/plugins/import",
       expect.objectContaining({
         method: "POST",
         body: JSON.stringify({
           parse_task_id: "task-1",
+          plugin_name: "test",
           name: "New Skill",
-          display_name: "test",
           description: "desc",
           category_id: "dev-tools",
           tags: ["tag"],
           visibility: "space",
           version: "1.0.0",
-          icon_url: "",
+          icon: "",
         }),
       })
     );
+  });
 
-    mockFetch.mockReturnValueOnce(jsonResponse(rawSkill));
+  it("updateSkill with a parse task re-imports against the plugin id", async () => {
+    mockFetch.mockReturnValueOnce(
+      jsonResponse({ plugin: pluginSkillWire(), relations: [] })
+    );
     await updateSkill("new-skill", {
       parseTaskId: "task-2",
       visibility: "private",
     });
-    expect(mockFetch).toHaveBeenLastCalledWith(
-      "/market/api/v1/skills/new-skill",
-      expect.objectContaining({
-        method: "PATCH",
-        body: JSON.stringify({
-          parse_task_id: "task-2",
-          visibility: "private",
-        }),
+    const [url, init] = mockFetch.mock.calls[mockFetch.mock.calls.length - 1] as [string, RequestInit];
+    expect(url).toBe("/market/api/v1/plugins/import");
+    const body = JSON.parse(init.body as string);
+    expect(body.parse_task_id).toBe("task-2");
+    expect(body.plugin_id).toBe("new-skill");
+    expect(body.visibility).toBe("private");
+  });
+
+  it("updateSkill without a parse task merges onto the current documents and upserts", async () => {
+    const current = pluginSkillWire({
+      plugin_json: {
+        $schema: "cowork-plugin-package-1.0.json",
+        attachments: [
+          {
+            path: "manifest.json",
+            content_type: "raw",
+            mime_type: "application/json",
+            raw_content: "{}",
+          },
+          {
+            path: "SKILL.md",
+            content_type: "raw",
+            mime_type: "text/markdown",
+            raw_content: "# keep me",
+          },
+        ],
+      },
+    });
+    mockFetch.mockReturnValueOnce(jsonResponse({ plugin: current, relations: [] }));
+    mockFetch.mockReturnValueOnce(jsonResponse({ plugin: current, relations: [] }));
+
+    await updateSkill("ci-failure-map", { displayName: "改名", tags: ["新标签"] });
+
+    const [url, init] = mockFetch.mock.calls[mockFetch.mock.calls.length - 1] as [string, RequestInit];
+    expect(url).toBe("/market/api/v1/plugins/upsert");
+    const body = JSON.parse(init.body as string);
+    expect(body.plugin.plugin_id).toBe("ci-failure-map");
+    expect(body.plugin.plugin_name).toBe("改名");
+    expect(body.plugin.tags).toEqual(["新标签"]);
+    // icon echoes the stored write-canonical value, not the presigned URL.
+    expect(body.plugin.icon).toBe("icons/ci.png");
+    const attachments = body.plugin.plugin_json.attachments as Array<{
+      path: string;
+      raw_content?: string;
+    }>;
+    const manifestAtt = attachments.find((a) => a.path === "manifest.json");
+    expect(manifestAtt?.raw_content).toBe(
+      JSON.stringify(body.plugin.manifest_json && {
+        $schema: "cowork-plugin-manifest-1.0.json",
+        description: "Analyze CI logs",
+        examples: [],
+        labels: ["新标签"],
+        name: "ci-failure-map",
+        plugin_name: "改名",
+        plugin_type: "skill",
       })
+    );
+    expect(attachments.find((a) => a.path === "SKILL.md")?.raw_content).toBe(
+      "# keep me"
     );
   });
 
@@ -528,8 +571,10 @@ describe("skillApiReal", () => {
       headers: { "Content-Type": "application/zip", "X-Amz-Acl": "private" },
       expiresIn: 1800,
     });
+    // Reuploads share the unbound upload channel; the skill binding happens
+    // at import time via plugin_id.
     expect(mockFetch).toHaveBeenCalledWith(
-      "/market/api/v1/skills/skill-1/reuploads",
+      "/market/api/v1/skill_uploads",
       expect.objectContaining({
         method: "POST",
         body: JSON.stringify({ file_name: "updated.zip", file_size: 4096 }),
@@ -725,58 +770,21 @@ describe("skillApiReal", () => {
     vi.useRealTimers();
   });
 
-  it("getDownloadUrl exposes the backend 302 download endpoint", () => {
+  it("getDownloadUrl exposes the authenticated unified download endpoint", () => {
     expect(getDownloadUrl("skill/with space")).toBe(
-      "/market/api/v1/skills/skill%2Fwith%20space/download"
+      "/market/api/v1/plugins/download?plugin_id=skill%2Fwith%20space"
     );
-  });
-
-  it("downloads through an authenticated JSON URL request", async () => {
-    mockFetch.mockReturnValueOnce(
-      jsonResponse({ download_url: "https://cdn.example.com/skills/demo.zip" })
-    );
-    const click = vi
-      .spyOn(HTMLAnchorElement.prototype, "click")
-      .mockImplementation(() => undefined);
-
-    await downloadSkill("skill/with space");
-
-    expect(mockFetch).toHaveBeenCalledWith(
-      "/market/api/v1/skills/skill%2Fwith%20space/download?format=json",
-      expect.objectContaining({
-        headers: expect.objectContaining({
-          token: "test-token",
-          "X-Space-Id": "space-123",
-        }),
-      })
-    );
-    expect(click).toHaveBeenCalledOnce();
   });
 
   it("normalizes tags when backend returns a JSON-encoded string", async () => {
     mockFetch.mockReturnValueOnce(
       jsonResponse({
-        skill_id: "test-skill",
-        name: "Test",
-        description: "desc",
-        category_id: "other",
-        tags: '["CI","debug"]',
-        owner_id: "u1",
-        owner_name: "User",
-        space_id: "s1",
-        visibility: "public",
-        version: "1.0.0",
-        readme_content: "# Test",
-        file_name: "test.zip",
-        file_url: "/files/test.zip",
-        file_size: 512,
-        file_sha256: "def456",
-        created_at: "2026-01-01T00:00:00Z",
-        updated_at: "2026-01-02T00:00:00Z",
+        plugin: pluginSkillWire({ tags: '["CI","debug"]' }),
+        relations: [],
       })
     );
 
-    const skill = await getSkill("test-skill");
+    const skill = await getSkill("ci-failure-map");
 
     expect(skill.tags).toEqual(["CI", "debug"]);
   });
@@ -784,27 +792,12 @@ describe("skillApiReal", () => {
   it("normalizes tags when backend returns null or undefined", async () => {
     mockFetch.mockReturnValueOnce(
       jsonResponse({
-        skill_id: "test-skill",
-        name: "Test",
-        description: "desc",
-        category_id: "other",
-        tags: null,
-        owner_id: "u1",
-        owner_name: "User",
-        space_id: "s1",
-        visibility: "public",
-        version: "1.0.0",
-        readme_content: "# Test",
-        file_name: "test.zip",
-        file_url: "/files/test.zip",
-        file_size: 512,
-        file_sha256: "def456",
-        created_at: "2026-01-01T00:00:00Z",
-        updated_at: "2026-01-02T00:00:00Z",
+        plugin: pluginSkillWire({ tags: null }),
+        relations: [],
       })
     );
 
-    const skill = await getSkill("test-skill");
+    const skill = await getSkill("ci-failure-map");
 
     expect(skill.tags).toEqual([]);
   });
@@ -858,28 +851,22 @@ describe("skillApiReal", () => {
   it("defaults missing skill fields to safe values", async () => {
     mockFetch.mockReturnValueOnce(
       jsonResponse({
-        skill_id: "minimal-skill",
-        name: "Minimal",
-        description: null,
-        category_id: "other",
-        tags: [],
-        owner_id: "u1",
-        owner_name: null,
-        space_id: "s1",
-        visibility: null,
-        version: null,
-        readme_content: null,
-        file_name: null,
-        file_url: null,
-        file_size: null,
-        file_sha256: "abc",
-        created_at: "2026-01-01T00:00:00Z",
-        updated_at: "2026-01-02T00:00:00Z",
+        plugin: {
+          plugin_id: "minimal-skill",
+          plugin_name: "Minimal",
+          plugin_type: "skill",
+          tags: [],
+          owner_id: "u1",
+          visibility: null,
+          manifest_json: {},
+        },
+        relations: [],
       })
     );
 
     const skill = await getSkill("minimal-skill");
 
+    expect(skill.name).toBe("Minimal");
     expect(skill.description).toBe("");
     expect(skill.ownerName).toBe("");
     expect(skill.visibility).toBe("space");
@@ -960,7 +947,7 @@ describe("skillApiReal", () => {
       const result = await getSkillMd("skill-123");
       expect(result).toBe(mdText);
       expect(mockFetch).toHaveBeenCalledWith(
-        "/market/api/v1/skills/skill-123/skill_md",
+        "/market/api/v1/plugins/skill_md?plugin_id=skill-123",
         expect.objectContaining({
           headers: {
             "Content-Type": "application/json",

--- a/packages/dmworkskillmarket/src/api/skillApiReal.ts
+++ b/packages/dmworkskillmarket/src/api/skillApiReal.ts
@@ -1,8 +1,11 @@
 /**
  * Real HTTP client for the skill marketplace API.
  *
- * This module communicates with the octo-marketplace backend. It maps
- * snake_case responses to camelCase frontend types.
+ * Catalog reads and writes target the octo-marketplace UNIFIED plugin surface
+ * (`/plugins`, `/plugins/detail`, `/plugin_categories`, `/plugins/*`,
+ * plugin_type=skill); the upload → parse pipeline and tag suggestions keep
+ * their legacy endpoints on the same service. Snake_case wire shapes are
+ * mapped onto the unchanged camelCase frontend types.
  */
 import { resolveSkillMarketApiBaseURL } from "./constants";
 import { WKApp, t, DEFAULT_REQUEST_TIMEOUT_MS } from "@octo/base";
@@ -11,19 +14,27 @@ import type {
   NewSkillForm,
   PagedResult,
   ParseStatusResult,
-  RawCategory,
-  RawPagedResult,
-  RawSkill,
   RawSkillTag,
-  RawSkillVersion,
   Skill,
   SkillListQuery,
+  SkillSort,
   SkillTag,
   SkillVersion,
   TriggerParseResult,
   UpdateSkillForm,
   UploadInitResult,
 } from "../types/skill";
+import {
+  SCENE_CODE,
+  goCanonicalJSON,
+  jsonAttachment,
+  rawAttachment,
+  type PluginAttachmentWire,
+  type PluginCategoryWire,
+  type PluginDetailPluginWire,
+  type PluginDetailWire,
+  type PluginListItemWire,
+} from "./pluginWire";
 
 interface SuccessEnvelope<T> {
   data: T;
@@ -94,7 +105,7 @@ function normalizeError(input: {
 async function requestEnvelope<T>(
   path: string,
   init?: RequestInit,
-  options?: { auth?: boolean }
+  options?: { auth?: boolean; skipAuthRedirect?: boolean }
 ): Promise<SuccessEnvelope<T>> {
   const url = `${resolveSkillMarketApiBaseURL()}${path}`;
   const defaultHeaders =
@@ -133,8 +144,10 @@ async function requestEnvelope<T>(
     throw normalizeError({ code: "network_error", message, details: err });
   }
 
-  // Handle 401 — redirect to login
-  if (res.status === 401) {
+  // Handle 401 — redirect to login. Fire-and-forget beacons opt out: a 401
+  // on a background metric must never tear down the session (the page's list
+  // calls are the authoritative session probe), mirroring the expert service.
+  if (res.status === 401 && !options?.skipAuthRedirect) {
     const loginPath =
       ((WKApp.loginInfo as unknown as Record<string, unknown>)?.loginUrl as
         | string
@@ -197,7 +210,7 @@ async function requestEnvelope<T>(
 async function request<T>(
   path: string,
   init?: RequestInit,
-  options?: { auth?: boolean }
+  options?: { auth?: boolean; skipAuthRedirect?: boolean }
 ): Promise<T> {
   return (await requestEnvelope<T>(path, init, options)).data;
 }
@@ -230,15 +243,25 @@ function assertSafeExternalURL(raw: string): void {
   });
 }
 
-// ─── Mappers ───────────────────────────────────────────────────────────────
+// ─── Mappers (unified plugin wire → frontend Skill shapes) ──────────────────
 
-function mapCategory(raw: RawCategory, index: number): Category {
+/** skill/ref.json attachment: artifact pointers shared by backfill and import. */
+interface SkillRefWire {
+  file_name?: string;
+  file_size?: number;
+  file_sha256?: string;
+  file_url?: string;
+  object_key?: string;
+  zip_object_key?: string;
+}
+
+function mapCategory(raw: PluginCategoryWire, index: number): Category {
   return {
-    id: raw.skill_category_id ?? raw.id ?? "",
+    id: raw.category_id,
     name: raw.name,
-    iconKey: raw.icon_key,
+    iconKey: raw.icon_key ?? "",
     sortOrder: index + 1,
-    skillCount: raw.skill_count,
+    skillCount: raw.plugin_count,
   };
 }
 
@@ -259,31 +282,57 @@ function normalizeTags(tags: unknown): string[] {
   return [];
 }
 
-function mapSkill(raw: RawSkill): Skill {
+function mapSkill(raw: PluginListItemWire): Skill {
+  const manifest = raw.manifest_json ?? {};
   return {
-    id: raw.skill_id ?? raw.id ?? "",
-    name: raw.name,
-    displayName: raw.display_name ?? "",
-    description: raw.description ?? "",
-    categoryId: raw.category_id,
+    id: raw.plugin_id,
+    // The manifest machine name is the legacy skill `name`; plugin_name is the
+    // display name.
+    name: manifest.name ?? raw.plugin_name ?? "",
+    displayName: raw.plugin_name ?? "",
+    description: manifest.description ?? "",
+    categoryId: raw.category_id ?? "",
     tags: normalizeTags(raw.tags),
     ownerId: raw.owner_id,
-    ownerName: raw.owner_name ?? "",
-    creatorId: raw.creator_id ?? raw.owner_id,
-    creatorName: raw.creator_name ?? raw.owner_name ?? "",
-    spaceId: raw.space_id,
-    visibility: raw.visibility ?? "space",
-    version: raw.version ?? "1.0.0",
-    readmeContent: raw.readme_content ?? "",
-    iconUrl: raw.icon_url ?? "",
-    fileName: raw.file_name ?? "",
-    fileUrl: raw.file_url ?? "",
-    fileSize: raw.file_size ?? 0,
-    fileSha256: raw.file_sha256,
+    // Backfill preserved the legacy owner display name in publisher.
+    ownerName: raw.publisher ?? "",
+    creatorId: raw.owner_id,
+    creatorName: raw.creator_name ?? raw.publisher ?? "",
+    spaceId: raw.space_id ?? "",
+    // The unified wire adds "system"; skills never use it, so anything outside
+    // the skill union degrades to the space default instead of leaking through.
+    visibility:
+      raw.visibility === "public" || raw.visibility === "private" || raw.visibility === "space"
+        ? raw.visibility
+        : "space",
+    version: raw.current_version ?? "1.0.0",
+    readmeContent: "",
+    iconUrl: raw.icon_url ?? raw.icon ?? "",
+    fileName: "",
+    fileUrl: "",
+    fileSize: 0,
+    fileSha256: undefined,
     viewCount: raw.view_count ?? 0,
     downloadCount: raw.download_count ?? 0,
-    createdAt: raw.created_at,
-    updatedAt: raw.updated_at,
+    createdAt: raw.created_at ?? "",
+    updatedAt: raw.updated_at ?? "",
+  };
+}
+
+function mapSkillDetail(plugin: PluginDetailPluginWire): Skill {
+  const base = mapSkill(plugin);
+  const ref =
+    jsonAttachment<SkillRefWire>(plugin.plugin_json, "skill/ref.json") ?? {};
+  const managedZip = (plugin.plugin_json?.attachments ?? []).find(
+    (a) => a.path === "skill/package.zip" && a.content_type === "storage"
+  );
+  return {
+    ...base,
+    readmeContent: rawAttachment(plugin.plugin_json, "SKILL.md") ?? "",
+    fileName: ref.file_name ?? (managedZip ? "skill.zip" : ""),
+    fileUrl: managedZip?.storage_uri ?? ref.zip_object_key ?? ref.file_url ?? "",
+    fileSize: ref.file_size ?? managedZip?.content_size ?? 0,
+    fileSha256: ref.file_sha256,
   };
 }
 
@@ -291,17 +340,23 @@ function mapSkillTag(raw: RawSkillTag): SkillTag {
   return {
     name: raw.name,
     createdBy: raw.created_by,
-    createdAt: raw.created_at,
-    updatedAt: raw.updated_at,
+    createdAt: raw.created_at ?? "",
+    updatedAt: raw.updated_at ?? "",
   };
 }
 
-function mapPagedResult(raw: RawPagedResult<RawSkill>): PagedResult<Skill> {
-  return {
-    items: (raw.items ?? []).map(mapSkill),
-    nextCursor: raw.next_cursor,
-    total: raw.total ?? raw.items?.length ?? 0,
-  };
+/** Legacy SkillSort → unified list sort. */
+function mapSkillSort(sort?: SkillSort): string | undefined {
+  if (!sort) return undefined;
+  if (sort === "latest") return "newest";
+  return sort; // comprehensive / views / downloads match 1:1
+}
+
+/** The unified list paginates by page number; the cursor the UI threads
+ *  through is simply the next page rendered as an opaque string. */
+function cursorToPage(cursor?: string): number {
+  const page = Number.parseInt(cursor ?? "", 10);
+  return Number.isFinite(page) && page > 0 ? page : 1;
 }
 
 // ─── Public API (same signatures as mock skillApi.ts) ──────────────────────
@@ -316,173 +371,254 @@ export interface CategoryListOptions extends RequestOptions {
 }
 
 export function getCategories(opts?: CategoryListOptions): Promise<Category[]> {
+  // The unified taxonomy has no keyword/tag-scoped counts; the q/tags options
+  // are accepted for signature compatibility and ignored (chips show catalog
+  // totals — accepted in the unified switch).
   const params = new URLSearchParams();
-  if (opts?.q) params.set("q", opts.q);
-  if (opts?.tags?.length) params.set("tags", opts.tags.join(","));
-  const qs = params.toString();
-  return request<RawCategory[]>(
-    `/skill_categories${qs ? `?${qs}` : ""}`,
+  params.set("scene_code", SCENE_CODE);
+  params.set("plugin_type", "skill");
+  return request<PluginCategoryWire[] | null>(
+    `/plugin_categories?${params.toString()}`,
     opts?.signal ? { signal: opts.signal } : undefined
-  ).then((items) => items.map(mapCategory));
+  ).then((items) => (items ?? []).map(mapCategory));
+}
+
+function buildPluginListParams(query: SkillListQuery, mine: boolean): URLSearchParams {
+  const params = new URLSearchParams();
+  params.set("scene_code", SCENE_CODE);
+  params.set("plugin_type", "skill");
+  if (mine) params.set("mode", "mine");
+  if (query.q) params.set("q", query.q);
+  if (query.categoryId && query.categoryId !== "all")
+    params.set("category_id", query.categoryId);
+  // Repeated `tag` params (AND semantics); repeat instead of comma-joining so
+  // a tag value containing a comma still round-trips intact.
+  for (const tag of query.tags ?? []) params.append("tag", tag);
+  const sort = mapSkillSort(query.sort);
+  if (sort) params.set("sort", sort);
+  params.set("page", String(cursorToPage(query.cursor)));
+  if (query.limit) params.set("page_size", String(query.limit));
+  return params;
+}
+
+function listPlugins(
+  query: SkillListQuery,
+  mine: boolean,
+  opts?: RequestOptions
+): Promise<PagedResult<Skill>> {
+  const params = buildPluginListParams(query, mine);
+  return requestEnvelope<PluginListItemWire[]>(
+    `/plugins?${params.toString()}`,
+    opts?.signal ? { signal: opts.signal } : undefined
+  ).then(({ data, pagination }) => {
+    const items = (data ?? []).map(mapSkill);
+    const page = pagination?.page ?? cursorToPage(query.cursor);
+    const pageSize = pagination?.page_size ?? query.limit ?? 20;
+    const total = pagination?.total ?? items.length;
+    return {
+      items,
+      // Synthesize the legacy opaque cursor from offset pagination: the next
+      // cursor is simply the next page number while more rows remain.
+      nextCursor: page * pageSize < total ? String(page + 1) : null,
+      total,
+    };
+  });
 }
 
 export function getSkills(
   query: SkillListQuery = {},
   opts?: RequestOptions
 ): Promise<PagedResult<Skill>> {
-  const params = new URLSearchParams();
-  if (query.q) params.set("q", query.q);
-  if (query.categoryId && query.categoryId !== "all")
-    params.set("category_id", query.categoryId);
-  if (query.tags?.length) params.set("tags", query.tags.join(","));
-  if (query.sort) params.set("sort", query.sort);
-  if (query.cursor) params.set("cursor", query.cursor);
-  if (query.limit) params.set("page_size", String(query.limit));
-  const qs = params.toString();
-  return requestEnvelope<RawSkill[]>(
-    `/skills${qs ? `?${qs}` : ""}`,
-    opts?.signal ? { signal: opts.signal } : undefined
-  ).then(({ data, pagination }) =>
-    mapPagedResult({
-      items: data,
-      next_cursor: pagination?.next_cursor ?? null,
-      total: pagination?.total,
-    })
-  );
+  return listPlugins(query, false, opts);
 }
 
 export function getMySkills(
   query: SkillListQuery = {},
   opts?: RequestOptions
 ): Promise<PagedResult<Skill>> {
-  const params = new URLSearchParams();
-  if (query.q) params.set("q", query.q);
-  // Forward category_id like getSkills does. Today the "我的" tab hides
-  // the category chip so this never lands non-empty, but silently dropping
-  // it would break the moment the UI adds a filter chip to that tab.
-  if (query.categoryId && query.categoryId !== "all")
-    params.set("category_id", query.categoryId);
-  if (query.tags?.length) params.set("tags", query.tags.join(","));
-  if (query.sort) params.set("sort", query.sort);
-  if (query.cursor) params.set("cursor", query.cursor);
-  if (query.limit) params.set("page_size", String(query.limit));
-  const qs = params.toString();
-  return requestEnvelope<RawSkill[]>(
-    `/skills/mine${qs ? `?${qs}` : ""}`,
-    opts?.signal ? { signal: opts.signal } : undefined
-  ).then(({ data, pagination }) =>
-    mapPagedResult({
-      items: data,
-      next_cursor: pagination?.next_cursor ?? null,
-      total: pagination?.total,
-    })
-  );
+  return listPlugins(query, true, opts);
 }
 
 export function getSkillTags(
   q = "",
   opts?: RequestOptions
 ): Promise<SkillTag[]> {
+  // Unified aggregation endpoint: tags come from skill Plugins visible to
+  // the caller ({name,count} rows); only `name` is consumed downstream.
   const params = new URLSearchParams();
+  params.set("scene_code", SCENE_CODE);
+  params.set("plugin_type", "skill");
   const query = q.trim();
   if (query) params.set("q", query);
-  params.set("page_size", "20");
-  const qs = params.toString();
-  return request<{ items: RawSkillTag[] }>(
-    `/skills/tags${qs ? `?${qs}` : ""}`,
+  params.set("limit", "20");
+  return request<Array<{ name: string; count: number }>>(
+    `/plugin_tags?${params.toString()}`,
     opts?.signal ? { signal: opts.signal } : undefined
-  ).then((data) => (data.items ?? []).map(mapSkillTag));
+  ).then((data) => (data ?? []).map((tag) => mapSkillTag({ name: tag.name })));
 }
 
 export function getSkill(id: string): Promise<Skill> {
-  return request<RawSkill>(`/skills/${encodeURIComponent(id)}`).then(mapSkill);
+  return request<PluginDetailWire>(
+    `/plugins/detail?plugin_id=${encodeURIComponent(id)}&include_relations=false`
+  ).then((detail) => mapSkillDetail(detail.plugin));
 }
 
 export async function trackSkillView(id: string): Promise<void> {
-  await request<Record<string, never>>("/metrics/track", {
-    method: "POST",
-    body: JSON.stringify({
-      resource_type: "skill",
-      resource_id: id,
-      event_type: "view",
-    }),
-  });
+  await request<Record<string, never>>(
+    "/metrics/track",
+    {
+      method: "POST",
+      body: JSON.stringify({
+        resource_type: "plugin",
+        resource_id: id,
+        event_type: "view",
+      }),
+    },
+    { skipAuthRedirect: true }
+  );
 }
 
 /**
- * Fetch the SKILL.md content for the current version of a skill.
- * Returns the markdown string on success, or throws (404 means no SKILL.md available).
+ * Fetch the SKILL.md content for a skill. The unified endpoint serves both
+ * inlined attachments and legacy backfilled object pointers.
  */
 export async function getSkillMd(
   id: string,
   opts?: RequestOptions
 ): Promise<string> {
   return request<{ content: string }>(
-    `/skills/${encodeURIComponent(id)}/skill_md`,
+    `/plugins/skill_md?plugin_id=${encodeURIComponent(id)}`,
     opts?.signal ? { signal: opts.signal } : undefined
   ).then((data) => data.content ?? "");
 }
 
-export function createSkill(form: NewSkillForm): Promise<Skill> {
-  return request<RawSkill>("/skills", {
-    method: "POST",
-    body: JSON.stringify({
-      parse_task_id: form.parseTaskId,
-      name: form.name,
-      display_name: form.displayName,
-      description: form.description,
-      category_id: form.categoryId,
-      tags: form.tags,
-      visibility: form.visibility,
-      version: form.version,
-      changelog: form.changelog,
-      icon_url: form.iconUrl ?? "",
-    }),
-  }).then(mapSkill);
+/** Shared import body: the legacy parse pipeline's task id plus the document
+ *  fields; the marketplace turns it into a skill plugin (create or update). */
+function importBody(
+  form: NewSkillForm | UpdateSkillForm,
+  pluginId?: string
+): string {
+  return JSON.stringify({
+    parse_task_id: form.parseTaskId,
+    ...(pluginId ? { plugin_id: pluginId } : {}),
+    plugin_name: form.displayName || form.name,
+    name: form.name,
+    description: form.description,
+    category_id: form.categoryId || undefined,
+    tags: form.tags,
+    visibility: form.visibility,
+    version: form.version,
+    changelog: form.changelog,
+    icon: form.iconUrl ?? "",
+  });
 }
 
-export function updateSkill(id: string, form: UpdateSkillForm): Promise<Skill> {
-  const body: Record<string, unknown> = {};
-  if (form.parseTaskId !== undefined) body.parse_task_id = form.parseTaskId;
-  if (form.name !== undefined) body.name = form.name;
-  if (form.displayName !== undefined) body.display_name = form.displayName;
-  if (form.description !== undefined) body.description = form.description;
-  if (form.categoryId !== undefined) body.category_id = form.categoryId;
-  if (form.tags !== undefined) body.tags = form.tags;
-  if (form.visibility !== undefined) body.visibility = form.visibility;
-  if (form.version !== undefined) body.version = form.version;
-  if (form.changelog !== undefined) body.changelog = form.changelog;
-  if (form.iconUrl !== undefined) body.icon_url = form.iconUrl;
+export function createSkill(form: NewSkillForm): Promise<Skill> {
+  return request<PluginDetailWire>("/plugins/import", {
+    method: "POST",
+    body: importBody(form),
+  }).then((detail) => mapSkillDetail(detail.plugin));
+}
 
-  return request<RawSkill>(`/skills/${encodeURIComponent(id)}`, {
-    method: "PATCH",
-    body: JSON.stringify(body),
-  }).then(mapSkill);
+export async function updateSkill(id: string, form: UpdateSkillForm): Promise<Skill> {
+  // A reupload carries a fresh parse task: the import endpoint rebuilds the
+  // whole package server-side.
+  if (form.parseTaskId !== undefined) {
+    return request<PluginDetailWire>("/plugins/import", {
+      method: "POST",
+      body: importBody(form, id),
+    }).then((detail) => mapSkillDetail(detail.plugin));
+  }
+  // Metadata-only edit: the upsert is a full replace, so merge the form onto
+  // the current documents and re-embed the canonical manifest.
+  const current = await request<PluginDetailWire>(
+    `/plugins/detail?plugin_id=${encodeURIComponent(id)}&include_relations=false`
+  );
+  const plugin = current.plugin;
+  const manifest = plugin.manifest_json ?? {};
+  const displayName = form.displayName ?? plugin.plugin_name ?? "";
+  const name = form.name ?? manifest.name ?? plugin.plugin_name ?? "";
+  const description = form.description ?? manifest.description ?? "";
+  const tags = normalizeTags(form.tags ?? plugin.tags);
+  const visibility = form.visibility ?? plugin.visibility;
+  const icon = form.iconUrl !== undefined ? form.iconUrl : plugin.icon ?? "";
+  const categoryId =
+    form.categoryId !== undefined ? form.categoryId : plugin.category_id;
+  const newManifest = {
+    $schema: "cowork-plugin-manifest-1.0.json",
+    plugin_name: displayName,
+    plugin_type: "skill",
+    name,
+    description,
+    labels: tags,
+    examples: manifest.examples ?? [],
+  };
+  const manifestRaw = goCanonicalJSON(newManifest);
+  const manifestAttachment: PluginAttachmentWire = {
+    path: "manifest.json",
+    content_type: "raw",
+    mime_type: "application/json",
+    raw_content: manifestRaw,
+  };
+  const attachments: PluginAttachmentWire[] = (
+    plugin.plugin_json?.attachments ?? []
+  ).map((a) => (a.path === "manifest.json" ? manifestAttachment : a));
+  // Every package must embed exactly one canonical manifest; append it when a
+  // degraded record is missing the attachment instead of failing the upsert.
+  if (!attachments.some((a) => a.path === "manifest.json")) {
+    attachments.push(manifestAttachment);
+  }
+  const detail = await request<PluginDetailWire>("/plugins/upsert", {
+    method: "POST",
+    body: JSON.stringify({
+      plugin: {
+        plugin_id: id,
+        plugin_name: displayName,
+        plugin_type: "skill",
+        ...(categoryId ? { category_id: categoryId } : {}),
+        tags,
+        icon,
+        visibility,
+        manifest_json: newManifest,
+        plugin_json: {
+          $schema: "cowork-plugin-package-1.0.json",
+          attachments,
+        },
+      },
+      relations: [],
+    }),
+  });
+  // A version bump on a metadata edit publishes a fresh immutable snapshot
+  // (and rebuilds the default-scene placement, which follows the category).
+  if (form.version !== undefined && form.version !== plugin.current_version) {
+    await request<unknown>("/plugins/publish", {
+      method: "POST",
+      body: JSON.stringify({
+        plugin_id: id,
+        version: form.version,
+        changelog: form.changelog,
+        placements: [
+          {
+            placement_code: SCENE_CODE,
+            ...(categoryId ? { category_id: categoryId } : {}),
+            is_visible: true,
+          },
+        ],
+      }),
+    });
+  }
+  return mapSkillDetail(detail.plugin);
 }
 
 export function deleteSkill(id: string): Promise<void> {
-  return request<void>(`/skills/${encodeURIComponent(id)}`, {
-    method: "DELETE",
+  return request<{ deleted?: boolean }>("/plugins/delete", {
+    method: "POST",
+    body: JSON.stringify({ plugin_id: id }),
   }).then(() => undefined);
 }
 
 export function getDownloadUrl(id: string): string {
-  return `${resolveSkillMarketApiBaseURL()}/skills/${encodeURIComponent(id)}/download`;
-}
-
-export async function downloadSkill(id: string): Promise<void> {
-  const result = await request<{ download_url: string }>(
-    `/skills/${encodeURIComponent(id)}/download?format=json`
-  );
-  if (!result.download_url) {
-    throw normalizeError({ code: "invalid_response", message: t("skillMarket.errors.invalidDownloadUrl") });
-  }
-  assertSafeExternalURL(result.download_url);
-  const anchor = document.createElement("a");
-  anchor.href = result.download_url;
-  anchor.target = "_blank";
-  anchor.rel = "noopener noreferrer";
-  anchor.click();
+  return `${resolveSkillMarketApiBaseURL()}/plugins/download?plugin_id=${encodeURIComponent(id)}`;
 }
 
 // ─── Upload / Parse flow ───────────────────────────────────────────────────
@@ -656,45 +792,43 @@ export async function pollParse(taskId: string): Promise<ParseStatusResult> {
   throw normalizeError({ code: "parse_timeout", message: t("skillMarket.errors.parseTimeout") });
 }
 
-/** Reupload init for an existing skill. */
+/** Reupload init for an existing skill. The unified import consumes any
+ *  unbound parse task, so a reupload starts from the same presigned-upload
+ *  endpoint as a fresh create; the skill binding happens at import time via
+ *  plugin_id. */
 export function initReupload(
-  skillId: string,
+  _skillId: string,
   fileName: string,
   fileSize: number
 ): Promise<UploadInitResult> {
-  return request<{
-    skill_upload_id: string;
-    presigned_url: string;
-    method: string;
-    headers: Record<string, string>;
-    expires_in: number;
-  }>(`/skills/${encodeURIComponent(skillId)}/reuploads`, {
-    method: "POST",
-    body: JSON.stringify({ file_name: fileName, file_size: fileSize }),
-  }).then((raw) => ({
-    uploadId: raw.skill_upload_id,
-    presignedUrl: raw.presigned_url,
-    method: raw.method,
-    headers: raw.headers ?? {},
-    expiresIn: raw.expires_in,
-  }));
+  return initUpload(fileName, fileSize);
 }
 
-function mapVersion(raw: RawSkillVersion): SkillVersion {
+/** Version wire shape of GET /plugins/versions. */
+interface PluginVersionWire {
+  version_id: string;
+  plugin_id: string;
+  version: string;
+  changelog?: string;
+  created_by?: string;
+  created_at?: string;
+}
+
+function mapVersion(raw: PluginVersionWire): SkillVersion {
   return {
-    id: raw.skill_version_id ?? raw.id ?? "",
-    skillId: raw.skill_id,
+    id: raw.version_id,
+    skillId: raw.plugin_id,
     version: raw.version,
     changelog: raw.changelog ?? "",
-    storage: raw.storage ?? {},
-    changedBy: raw.changed_by ?? "",
-    createdAt: raw.created_at,
+    storage: { type: "s3" },
+    changedBy: raw.created_by ?? "",
+    createdAt: raw.created_at ?? "",
   };
 }
 
 /** Fetch version history for a skill. */
 export function listVersions(skillId: string): Promise<SkillVersion[]> {
-  return request<{ items: RawSkillVersion[] }>(
-    `/skills/${encodeURIComponent(skillId)}/versions`
-  ).then((data) => (data.items ?? []).map(mapVersion));
+  return request<PluginVersionWire[] | null>(
+    `/plugins/versions?plugin_id=${encodeURIComponent(skillId)}`
+  ).then((items) => (items ?? []).map(mapVersion));
 }

--- a/packages/dmworkskillmarket/src/api/skillApiReal.ts
+++ b/packages/dmworkskillmarket/src/api/skillApiReal.ts
@@ -553,21 +553,12 @@ export async function updateSkill(id: string, form: UpdateSkillForm): Promise<Sk
     labels: tags,
     examples: manifest.examples ?? [],
   };
-  const manifestRaw = goCanonicalJSON(newManifest);
-  const manifestAttachment: PluginAttachmentWire = {
-    path: "manifest.json",
-    content_type: "raw",
-    mime_type: "application/json",
-    raw_content: manifestRaw,
-  };
+  // Contract layout: the manifest lives only in manifest_json; any embedded
+  // manifest.json attachment on an older record is dropped, the rest of the
+  // package passes through untouched.
   const attachments: PluginAttachmentWire[] = (
     plugin.plugin_json?.attachments ?? []
-  ).map((a) => (a.path === "manifest.json" ? manifestAttachment : a));
-  // Every package must embed exactly one canonical manifest; append it when a
-  // degraded record is missing the attachment instead of failing the upsert.
-  if (!attachments.some((a) => a.path === "manifest.json")) {
-    attachments.push(manifestAttachment);
-  }
+  ).filter((a) => a.path !== "manifest.json");
   const detail = await request<PluginDetailWire>("/plugins/upsert", {
     method: "POST",
     body: JSON.stringify({

--- a/packages/dmworkskillmarket/src/api/skillApiReal.ts
+++ b/packages/dmworkskillmarket/src/api/skillApiReal.ts
@@ -244,6 +244,22 @@ function assertSafeExternalURL(raw: string): void {
 
 // ─── Mappers (unified plugin wire → frontend Skill shapes) ──────────────────
 
+/**
+ * Reject unsafe package attachment paths before they are echoed back into the
+ * trusted /plugins/upsert write on a metadata edit. A backend record could
+ * carry a poisoned path; drop anything that is empty, absolute, uses backslash
+ * separators, embeds a NUL byte, or contains a `..` traversal segment.
+ */
+function isSafeAttachmentPath(path: string | undefined): boolean {
+  if (typeof path !== "string") return false;
+  const trimmed = path.trim();
+  if (!trimmed) return false;
+  if (trimmed.startsWith("/")) return false;
+  if (trimmed.includes("\\")) return false;
+  if (trimmed.includes("\0")) return false;
+  return !trimmed.split("/").some((segment) => segment === "..");
+}
+
 /** skill/ref.json attachment: artifact pointers shared by backfill and import. */
 interface SkillRefWire {
   file_name?: string;
@@ -298,10 +314,15 @@ function mapSkill(raw: PluginListItemWire): Skill {
     creatorId: raw.owner_id,
     creatorName: raw.creator_name ?? raw.publisher ?? "",
     spaceId: raw.space_id ?? "",
-    // The unified wire adds "system"; skills never use it, so anything outside
-    // the skill union degrades to the space default instead of leaking through.
+    // Preserve the unified wire's "system" visibility: a system-admin-published
+    // skill is official across every market (isPlatformPublishedSkill), so
+    // folding it into "space" would strip its 官方发布 badge and leak a creator
+    // name. Only genuinely unknown values degrade to the space default.
     visibility:
-      raw.visibility === "public" || raw.visibility === "private" || raw.visibility === "space"
+      raw.visibility === "public" ||
+      raw.visibility === "private" ||
+      raw.visibility === "space" ||
+      raw.visibility === "system"
         ? raw.visibility
         : "space",
     version: raw.current_version ?? "1.0.0",
@@ -515,7 +536,7 @@ function importBody(
   form: NewSkillForm | UpdateSkillForm,
   pluginId?: string
 ): string {
-  return JSON.stringify({
+  const body: Record<string, unknown> = {
     parse_task_id: form.parseTaskId,
     ...(pluginId ? { plugin_id: pluginId } : {}),
     plugin_name: form.displayName || form.name,
@@ -526,8 +547,15 @@ function importBody(
     visibility: form.visibility,
     version: form.version,
     changelog: form.changelog,
-    icon: form.iconUrl ?? "",
-  });
+  };
+  // On a re-upload (existing plugin_id) the import is a full replace, so an
+  // absent iconUrl means "icon unchanged" — omit `icon` entirely rather than
+  // sending "", which would wipe the stored icon (EditSkillModal only sets
+  // iconUrl when a new icon is picked). A fresh create keeps the "" default.
+  if (pluginId && form.iconUrl === undefined) {
+    return JSON.stringify(body);
+  }
+  return JSON.stringify({ ...body, icon: form.iconUrl ?? "" });
 }
 
 export function createSkill(form: NewSkillForm): Promise<Skill> {
@@ -572,10 +600,12 @@ export async function updateSkill(id: string, form: UpdateSkillForm): Promise<Sk
   };
   // Contract layout: the manifest lives only in manifest_json; any embedded
   // manifest.json attachment on an older record is dropped, the rest of the
-  // package passes through untouched.
+  // package passes through untouched — but only after each path is validated,
+  // since these come from the backend response and are fed straight back into
+  // the trusted upsert write (defense in depth against a poisoned record).
   const attachments: PluginAttachmentWire[] = (
     plugin.plugin_json?.attachments ?? []
-  ).filter((a) => a.path !== "manifest.json");
+  ).filter((a) => a.path !== "manifest.json" && isSafeAttachmentPath(a.path));
   const detail = await request<PluginDetailWire>("/plugins/upsert", {
     method: "POST",
     body: JSON.stringify({

--- a/packages/dmworkskillmarket/src/api/skillApiReal.ts
+++ b/packages/dmworkskillmarket/src/api/skillApiReal.ts
@@ -320,18 +320,36 @@ function mapSkill(raw: PluginListItemWire): Skill {
 
 function mapSkillDetail(plugin: PluginDetailPluginWire): Skill {
   const base = mapSkill(plugin);
-  const ref =
-    jsonAttachment<SkillRefWire>(plugin.plugin_json, "skill/ref.json") ?? {};
-  const managedZip = (plugin.plugin_json?.attachments ?? []).find(
-    (a) => a.path === "skill/package.zip" && a.content_type === "storage"
+  const attachments = plugin.plugin_json?.attachments ?? [];
+  const isLegacy = attachments.some(
+    (a) => a.path === "skill/ref.json" || a.path === "skill/package.zip"
   );
+  if (isLegacy) {
+    const ref =
+      jsonAttachment<SkillRefWire>(plugin.plugin_json, "skill/ref.json") ?? {};
+    const managedZip = attachments.find(
+      (a) => a.path === "skill/package.zip" && a.content_type === "storage"
+    );
+    return {
+      ...base,
+      readmeContent: rawAttachment(plugin.plugin_json, "SKILL.md") ?? "",
+      fileName: ref.file_name ?? (managedZip ? "skill.zip" : ""),
+      fileUrl: managedZip?.storage_uri ?? ref.zip_object_key ?? ref.file_url ?? "",
+      fileSize: ref.file_size ?? managedZip?.content_size ?? 0,
+      fileSha256: ref.file_sha256,
+    };
+  }
+  // Tree shape: files live directly in attachments; the download is rebuilt
+  // server-side, so metadata is derived from the tree rather than a pointer.
+  const hasFiles = attachments.some((a) => a.path !== "SKILL.md");
+  const totalSize = attachments.reduce((n, a) => n + (a.content_size ?? 0), 0);
   return {
     ...base,
     readmeContent: rawAttachment(plugin.plugin_json, "SKILL.md") ?? "",
-    fileName: ref.file_name ?? (managedZip ? "skill.zip" : ""),
-    fileUrl: managedZip?.storage_uri ?? ref.zip_object_key ?? ref.file_url ?? "",
-    fileSize: ref.file_size ?? managedZip?.content_size ?? 0,
-    fileSha256: ref.file_sha256,
+    fileName: hasFiles ? `${base.name}.zip` : "",
+    fileUrl: "",
+    fileSize: totalSize,
+    fileSha256: undefined,
   };
 }
 

--- a/packages/dmworkskillmarket/src/api/skillApiReal.ts
+++ b/packages/dmworkskillmarket/src/api/skillApiReal.ts
@@ -26,7 +26,6 @@ import type {
 } from "../types/skill";
 import {
   SCENE_CODE,
-  goCanonicalJSON,
   jsonAttachment,
   rawAttachment,
   type PluginAttachmentWire,

--- a/packages/dmworkskillmarket/src/pages/SkillListPage.tsx
+++ b/packages/dmworkskillmarket/src/pages/SkillListPage.tsx
@@ -170,15 +170,12 @@ export default function SkillListPage() {
     setDetailId(item.id);
   }
 
-  // The paginated /skills response carries no real total, so list.total falls
-  // back to the loaded page size (e.g. 20). The /skill_categories counts are
-  // authoritative — on the skills tab show the active category's skillCount
-  // (for "全部" this equals the summed total shown in the chip). The "我的" tab
-  // has no category chips and a different scope, so keep list.total there.
-  const summaryTotal = mine
-    ? list.total
-    : list.categories.find((category) => category.id === list.categoryId)
-        ?.skillCount ?? list.total;
+  // The unified list response carries an accurate, filter-scoped
+  // pagination.total (surfaced as list.total). Bind the "共 N 个技能" headline to
+  // it on both tabs so the count re-scopes with an active search/tag filter and
+  // tracks the visible grid. The catalog category skillCount is search-invariant
+  // and would otherwise show the whole-category total after a search.
+  const summaryTotal = list.total;
 
   return (
     <div className="skill-market-page">

--- a/packages/dmworkskillmarket/src/pages/SkillListPage.tsx
+++ b/packages/dmworkskillmarket/src/pages/SkillListPage.tsx
@@ -131,7 +131,7 @@ export default function SkillListPage() {
   }
 
   function handleSelectedTagsChange(next: string[]) {
-    // 用户增删 tag 过滤;原先误用 GET /skills/tags 加载 tag 列表推断。
+    // 用户增删 tag 过滤;原先误用 GET /plugin_tags 加载 tag 列表推断。
     Dap.shared.track("market_tag_filtered", {});
     setSelectedTags(next);
   }

--- a/packages/dmworkskillmarket/src/types/skill.ts
+++ b/packages/dmworkskillmarket/src/types/skill.ts
@@ -1,4 +1,4 @@
-export type Visibility = "public" | "space" | "private";
+export type Visibility = "public" | "space" | "private" | "system";
 export type SkillSort = "comprehensive" | "latest" | "views" | "downloads";
 
 // ─── Frontend (camelCase) types ────────────────────────────────────────────

--- a/packages/dmworkskillmarket/src/utils/publisher.test.ts
+++ b/packages/dmworkskillmarket/src/utils/publisher.test.ts
@@ -2,8 +2,11 @@ import { describe, expect, it } from "vitest";
 import { isPlatformPublishedSkill } from "./publisher";
 
 describe("isPlatformPublishedSkill", () => {
-  it("identifies public visibility as platform-published", () => {
+  it("treats public and system visibility as platform-published", () => {
     expect(isPlatformPublishedSkill({ visibility: "public" })).toBe(true);
+    // Aligned with the connector/expert markets: system is the unified backend's
+    // official visibility, so a system-admin-published skill keeps its badge.
+    expect(isPlatformPublishedSkill({ visibility: "system" })).toBe(true);
     expect(isPlatformPublishedSkill({ visibility: "space" })).toBe(false);
     expect(isPlatformPublishedSkill({ visibility: "private" })).toBe(false);
   });

--- a/packages/dmworkskillmarket/src/utils/publisher.ts
+++ b/packages/dmworkskillmarket/src/utils/publisher.ts
@@ -1,5 +1,10 @@
 import type { Skill } from "../types/skill";
 
+/** Whether a skill carries the platform "官方发布" badge. `system` is the
+ *  unified backend's official visibility (shared with the connector and expert
+ *  markets — see dmworkmcp/utils/publisher.ts); `public` is the skill market's
+ *  legacy platform-published scope. Either marks the skill official, so the
+ *  card renders the badge instead of a creator name. */
 export function isPlatformPublishedSkill(skill: Pick<Skill, "visibility">): boolean {
-  return skill.visibility === "public";
+  return skill.visibility === "public" || skill.visibility === "system";
 }


### PR DESCRIPTION
## Summary

Migrates the octo-web marketplace API layer (`packages/dmworkmcp`, `packages/dmworkskillmarket`) onto the unified octo-marketplace plugin backend. This is the frontend half of the unified-plugin work (backend: Mininglamp-OSS/octo-marketplace#67).

## Ship order

The backend counterpart **octo-marketplace#67 is now MERGED** (merge commit `a62d071f`), so the unified `/plugins/*` surface is on `octo-marketplace` `main`. This discharges the B1 / P0-1 deployment-ordering blocker: #67 lands and deploys first, then this PR. No feature flag / fallback is added here by design — deployment order is enforced operationally.

## Related Issue

Frontend counterpart of octo-marketplace#67 (unified plugin backend).

## Changes

- All three markets (MCP/Expert/Skill) call the unified `/plugins/*` surface; `plugin_type` mapping `mcp→connector`, `squad→expert_team`.
- Connector: descriptor + root `mcp.json`; user-supplied secrets written as `${VAR}` placeholders, never real values.
- Expert team: single `AGENTS.md` parsed via `parseTeamAgentsMarkdown` (paired with the backend renderer); members/leader from relations.
- Skill: flat attachment tree — `mapSkillDetail`/`fromSkillPlugin` derive files/canDownload/size from `plugin_json.attachments`; download reconstructs the zip.
- Retired the embedded `manifest.json` byte-match mechanism.

## Architecture / Module Boundary

- Affected module(s): `packages/dmworkmcp`, `packages/dmworkskillmarket` (marketplace API layer).
- New or changed user-visible entry point: **no new pages/routes/menus**, but the unified switch lands **five user-visible behavior/copy deltas** (all defensible consequences of the migration; enumerated here so release notes and QA scope are accurate):
  1. **Skills headline count** — "共 N 个技能" now narrows with the active search/tag filter (binds to the unified list's filter-scoped `pagination.total`; previously the search-invariant category total).
  2. **Official badge** — `visibility=system` is now treated as official across all three markets (skills no longer fold `system` into `space`).
  3. **MCP search ordering** — keyword searches now send `sort=newest` (date-ordered); the previous code used `relevance` when a keyword was present, so keyword results are no longer relevance-ordered.
  4. **MCP category pill counts** — now read raw catalog counts rather than being scoped to the active keyword/mode filter.
  5. **UI copy added** — two new i18n strings `mcp.create.categoryRequired` (en-US + zh-CN) for the empty-category required-field error.
- Shared layer touched: service (API adapters).
- If shared code changed, impact scope: marketplace read/write paths only; secret write path is stronger, not weaker — user-supplied `env`/`headers` values are replaced with `${KEY}` in the browser and the real value never leaves the client.
- Duplicate entry point checked: yes — no new entry points.

## Testing

- [x] Unit tests added/updated — `@dmwork/mcp` 210 pass, `@dmwork/skillmarket` 133 pass.
- [x] Manually verified — API shapes cross-checked against the backend handlers; secret placeholder round-trip and skill tree vs legacy derivation covered by tests.

Round-2 review fixes included: connector icon write intent is an explicit `undefined` sentinel end-to-end (unchanged / removed / replaced), empty category fails closed with a legible form error, and the PR description now enumerates the user-visible deltas.

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation — n/a (API layer); two new i18n strings added (see delta #5)
- [x] Ran `pnpm i18n:check` — UI copy changed: two new `mcp.create.categoryRequired` strings added in both locales
- [x] Confirmed the change follows module ownership and does not add duplicate user-visible entry points
- [x] Described impact scope
