### PR TITLE
fix(context-menu): keep submenus within viewport

### DIFF
--- a/packages/dmworkbase/src/Components/ContextMenus/__tests__/ContextMenus.test.tsx
+++ b/packages/dmworkbase/src/Components/ContextMenus/__tests__/ContextMenus.test.tsx
@@ -187,8 +187,46 @@ describe("ContextMenus rounded hover boundaries", () => {
 
         expect(rootList.querySelector(":scope > li:first-of-type")?.textContent).toContain("Move to")
         expect(rootList.querySelector(":scope > li:last-of-type")?.textContent).toBe("Delete")
-        expect(submenu.querySelector(":scope > li:first-of-type")?.textContent).toBe("First group")
-        expect(submenu.querySelector(":scope > li:last-of-type")?.textContent).toBe("Last group")
+        expect(submenu.querySelector(":scope > .wk-ctx-submenu-list > li:first-of-type")?.textContent).toBe("First group")
+        expect(submenu.querySelector(":scope > .wk-ctx-submenu-list > li:last-of-type")?.textContent).toBe("Last group")
+    })
+
+    it("keeps a long submenu inside the viewport and makes its list scrollable", () => {
+        act(() => {
+            ReactDOM.render(
+                <ContextMenus
+                    onContext={() => undefined}
+                    menus={[{
+                        title: "Add to favorites",
+                        children: Array.from({ length: 30 }, (_, index) => ({ title: `Group ${index + 1}` })),
+                    }]}
+                />,
+                container
+            )
+        })
+
+        const parentItem = container.querySelector<HTMLElement>(".wk-contextmenus > ul > li")!
+        const submenu = container.querySelector<HTMLElement>(".wk-ctx-submenu")!
+        const submenuList = container.querySelector<HTMLElement>(".wk-ctx-submenu-list")!
+        Object.defineProperty(submenuList, "scrollHeight", { configurable: true, value: 1200 })
+        vi.spyOn(parentItem, "getBoundingClientRect").mockReturnValue({
+            top: 740,
+            bottom: 780,
+            left: 0,
+            right: 160,
+            width: 160,
+            height: 40,
+            x: 0,
+            y: 740,
+            toJSON: () => ({}),
+        })
+
+        act(() => {
+            parentItem.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }))
+        })
+
+        expect(submenu.style.top).toBe("-732px")
+        expect(submenuList.querySelectorAll(":scope > li")).toHaveLength(30)
     })
 })
 

--- a/packages/dmworkbase/src/Components/ContextMenus/__tests__/ContextMenus.test.tsx
+++ b/packages/dmworkbase/src/Components/ContextMenus/__tests__/ContextMenus.test.tsx
@@ -84,7 +84,10 @@ function dispatchContextMenu(element: Element) {
     return event
 }
 
-function renderContextMenus(onHide = vi.fn()) {
+function renderContextMenus(
+    onHide = vi.fn(),
+    menus: ContextMenusData[] = [{ title: "Copy", onClick: vi.fn() }],
+) {
     let context: ContextMenusContext | null = null
 
     act(() => {
@@ -102,7 +105,7 @@ function renderContextMenus(onHide = vi.fn()) {
                         context = nextContext
                     }}
                     onHide={onHide}
-                    menus={[{ title: "Copy", onClick: vi.fn() }]}
+                    menus={menus}
                 />
             </div>,
             container
@@ -158,6 +161,23 @@ describe("ContextMenus native contextmenu suppression", () => {
 })
 
 describe("ContextMenus rounded hover boundaries", () => {
+    it("clears a previous submenu offset before each open cycle", () => {
+        const { context } = renderContextMenus(vi.fn(), [{
+            title: "Add to favorites",
+            children: [{ title: "Group 1" }],
+        }])
+        const trigger = container.querySelector(".trigger")!
+        const submenu = container.querySelector<HTMLElement>(".wk-ctx-submenu")!
+        submenu.style.top = "-320px"
+
+        act(() => {
+            context?.hide()
+        })
+        dispatchContextMenu(trigger)
+
+        expect(submenu.style.top).toBe("")
+    })
+
     it("keeps the first and last menu items selectable around separators at every level", () => {
         act(() => {
             ReactDOM.render(

--- a/packages/dmworkbase/src/Components/ContextMenus/index.css
+++ b/packages/dmworkbase/src/Components/ContextMenus/index.css
@@ -123,6 +123,12 @@ body[theme-mode=dark] .wk-contextmenus li:hover {
     display: none;
 }
 
+.wk-ctx-submenu-list {
+    max-height: calc(100vh - var(--wk-sp-4) - 2px);
+    overflow-y: auto;
+    overscroll-behavior: contain;
+}
+
 body[theme-mode=dark] .wk-ctx-submenu {
     background: var(--wk-bg-surface);
     box-shadow: var(--wk-shadow-lg), var(--wk-shadow-sm);

--- a/packages/dmworkbase/src/Components/ContextMenus/index.tsx
+++ b/packages/dmworkbase/src/Components/ContextMenus/index.tsx
@@ -133,6 +133,10 @@ export default class ContextMenus extends Component<ContextMenusProps, ContextMe
             if (instance !== this && instance.isShow()) instance.hide()
         })
 
+        this.contextMenusRef
+            .querySelectorAll<HTMLElement>(".wk-ctx-submenu")
+            .forEach((submenu) => { submenu.style.top = "" })
+
         const clickX = event.clientX;
         const clickY = event.clientY;
 

--- a/packages/dmworkbase/src/Components/ContextMenus/index.tsx
+++ b/packages/dmworkbase/src/Components/ContextMenus/index.tsx
@@ -199,6 +199,24 @@ export default class ContextMenus extends Component<ContextMenusProps, ContextMe
         ContextMenus.hideAll()
     }
 
+    _positionSubmenu(event: React.MouseEvent<HTMLLIElement>) {
+        const submenu = event.currentTarget.querySelector<HTMLElement>(":scope > .wk-ctx-submenu")
+        const submenuList = submenu?.querySelector<HTMLElement>(":scope > .wk-ctx-submenu-list")
+        if (!submenu || !submenuList) return
+
+        const VIEWPORT_MARGIN = 8
+        const SUBMENU_BORDER_HEIGHT = 2
+        const parentTop = event.currentTarget.getBoundingClientRect().top
+        const submenuHeight = Math.min(
+            submenuList.scrollHeight + SUBMENU_BORDER_HEIGHT,
+            window.innerHeight - VIEWPORT_MARGIN * 2,
+        )
+        const lowestTop = VIEWPORT_MARGIN - parentTop
+        const highestTop = window.innerHeight - VIEWPORT_MARGIN - parentTop - submenuHeight
+
+        submenu.style.top = `${Math.max(lowestTop, Math.min(0, highestTop))}px`
+    }
+
     _renderItem(m: ContextMenusData, i: number): ReactNode {
         if (m.separator) {
             return <div key={i} className="wk-ctx-sep" />
@@ -211,6 +229,7 @@ export default class ContextMenus extends Component<ContextMenusProps, ContextMe
                 key={i}
                 data-testid={m.testid}
                 className={classNames(m.danger && "wk-ctx-danger")}
+                onMouseEnter={hasChildren ? (event) => this._positionSubmenu(event) : undefined}
                 onClick={(e) => {
                     if (hasChildren) {
                         e.stopPropagation()
@@ -225,35 +244,37 @@ export default class ContextMenus extends Component<ContextMenusProps, ContextMe
                 {hasChildren && (
                     <>
                         <ArrowIcon />
-                        <ul className="wk-ctx-submenu">
-                            {m.children!.map((child, ci) => {
-                                if (child.separator) {
-                                    return <div key={ci} className="wk-ctx-sep" />
-                                }
-                                return (
-                                    <li
-                                        key={ci}
-                                        onClick={(e) => {
-                                            e.stopPropagation()
-                                            this.hide()
-                                            if (child.onClick) child.onClick()
-                                        }}
-                                    >
-                                        {child.icon && <CtxIcon icon={child.icon} />}
-                                        <span style={{ flex: 1 }}>{child.title}</span>
-                                        {child.checked && (
-                                            <span style={{
-                                                color: 'var(--wk-brand-primary, #1C1C23)',
-                                                fontSize: 13,
-                                                fontWeight: 600,
-                                                flexShrink: 0,
-                                                marginLeft: 4,
-                                            }}>✓</span>
-                                        )}
-                                    </li>
-                                )
-                            })}
-                        </ul>
+                        <div className="wk-ctx-submenu">
+                            <ul className="wk-ctx-submenu-list">
+                                {m.children!.map((child, ci) => {
+                                    if (child.separator) {
+                                        return <div key={ci} className="wk-ctx-sep" />
+                                    }
+                                    return (
+                                        <li
+                                            key={ci}
+                                            onClick={(e) => {
+                                                e.stopPropagation()
+                                                this.hide()
+                                                if (child.onClick) child.onClick()
+                                            }}
+                                        >
+                                            {child.icon && <CtxIcon icon={child.icon} />}
+                                            <span style={{ flex: 1 }}>{child.title}</span>
+                                            {child.checked && (
+                                                <span style={{
+                                                    color: 'var(--wk-brand-primary, #1C1C23)',
+                                                    fontSize: 13,
+                                                    fontWeight: 600,
+                                                    flexShrink: 0,
+                                                    marginLeft: 4,
+                                                }}>✓</span>
+                                            )}
+                                        </li>
+                                    )
+                                })}
+                            </ul>
+                        </div>
                     </>
                 )}
             </li>


### PR DESCRIPTION
## Summary

Keep long context submenus fully operable near the bottom of the viewport by shifting them upward when needed and scrolling the submenu list internally.

## Related Issue

Fixes #1527

## Changes

- Clamp submenu placement to an 8px viewport margin when it would overflow vertically.
- Limit long submenu lists to the viewport height and enable internal vertical scrolling while preserving the existing hover bridge and horizontal flip behavior.
- Add regression coverage for a long submenu opened from a bottom-positioned conversation.

## Architecture / Module Boundary

- Affected module(s): `@octo/base` ContextMenus
- New or changed user-visible entry point: no
- Shared layer touched: Components
- If shared code changed, impact scope: nested context menus used by Add to Favorites and Move to Group; leaf-only context menus keep their existing behavior
- Duplicate entry point checked: not applicable

## Testing

- [x] Unit tests added/updated
- [x] Manually verified

Commands and evidence:

- `pnpm --dir packages/dmworkbase exec vitest run src/Components/ContextMenus/__tests__/ContextMenus.test.tsx src/Components/ChatConversationList/__tests__/ChatConversationList.test.tsx src/Components/ConversationListGrouped/__tests__/ConversationListGrouped.archived.test.tsx` (13 tests passed)
- `pnpm --dir apps/web build`
- `pnpm exec stylelint packages/dmworkbase/src/Components/ContextMenus/index.css --config stylelint.config.mjs` (0 errors; pre-existing color warnings only)
- `git diff --check`
- Manually verified the bottom-of-list Add to Favorites flow with many groups at `http://localhost:3000/`
- Screenshot and reproduction context: #1527

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation (not applicable; no documentation contract changed)
- [x] Ran `pnpm i18n:check` or confirmed the change does not affect UI copy
- [x] Confirmed the change follows module ownership and does not add duplicate user-visible entry points
- [x] Described impact scope when shared components, messages, bridge, or services are changed
- [x] Followed commit message conventions (Conventional Commits)