### PR TITLE
feat(summary): emit group completion tip as WK_TIP(2000) system message (iterates #1379)

### DIFF
--- a/.i18n/scan-config.json
+++ b/.i18n/scan-config.json
@@ -97,8 +97,8 @@
       "reason": "Error message template with interpolation placeholder; already covered by runtime error handling with proper i18n."
     },
     {
-      "path": "packages/dmworkbase/src/Messages/SummaryNotify/index.tsx",
-      "reason": "SummaryTipContent send-side WK_TIP(2000) payload template ('{0}总结了群聊内容'). Cross-platform wire-format system-tip string consumed by SDK SystemContent {0}+extra placeholder replacement on Web and native; product decision locks copy to zh-CN (see #1379 iteration). Not translatable UI copy. Historical type-21 renderer strings in the same file use i18n keys."
+      "path": "packages/dmworkbase/src/Messages/SummaryNotify/protocol.ts",
+      "reason": "SummaryTipContent send-side WK_TIP(2000) payload template ('{0}总结了群聊内容'). Cross-platform wire-format system-tip string consumed by SDK SystemContent {0}+extra placeholder replacement on Web and native; product decision locks copy to zh-CN (see #1379 iteration). Not translatable UI copy."
     },
     {
       "path": "packages/dmworksummary/src/__mocks__/dmworkBase.ts",

--- a/.i18n/scan-config.json
+++ b/.i18n/scan-config.json
@@ -95,6 +95,14 @@
     {
       "path": "packages/dmworksummary/src/utils/channelType.ts",
       "reason": "Error message template with interpolation placeholder; already covered by runtime error handling with proper i18n."
+    },
+    {
+      "path": "packages/dmworkbase/src/Messages/SummaryNotify/index.tsx",
+      "reason": "SummaryTipContent send-side WK_TIP(2000) payload template ('{0}总结了群聊内容'). Cross-platform wire-format system-tip string consumed by SDK SystemContent {0}+extra placeholder replacement on Web and native; product decision locks copy to zh-CN (see #1379 iteration). Not translatable UI copy. Historical type-21 renderer strings in the same file use i18n keys."
+    },
+    {
+      "path": "packages/dmworksummary/src/__mocks__/dmworkBase.ts",
+      "reason": "Vitest mock mirroring the SummaryTipContent wire-format template; test fixture, not UI copy."
     }
   ]
 }

--- a/packages/dmworkbase/src/Components/Conversation/__tests__/messageOrder.test.ts
+++ b/packages/dmworkbase/src/Components/Conversation/__tests__/messageOrder.test.ts
@@ -163,6 +163,7 @@ vi.mock("../../../i18n", () => ({
 
 import ConversationVM from "../vm"
 import { Channel, MessageStatus } from "wukongimjssdk"
+import { SUMMARY_TIP_TEMPLATE } from "../../../Messages/SummaryNotify/protocol"
 
 const channel = new Channel("g1", 2)
 
@@ -248,6 +249,38 @@ describe("ConversationVM message ordering", () => {
         expect(first.messageContainerId).toMatch(/^viewport-\d+$/)
         expect(second.messageContainerId).toMatch(/^viewport-\d+$/)
         expect(first.messageContainerId).not.toBe(second.messageContainerId)
+    })
+
+    it("keeps separate summary-completion tips inside the generic system-tip dedup window", () => {
+        const vm = new ConversationVM(channel)
+        const summaryContent = {
+            contentType: 2000,
+            displayText: "Alice总结了群聊内容",
+            content: {
+                content: SUMMARY_TIP_TEMPLATE,
+                extra: [{ uid: "alice", name: "Alice" }],
+            },
+        }
+        const first = wrap({ clientMsgNo: "summary-1", timestamp: 100, content: summaryContent })
+        const second = wrap({ clientMsgNo: "summary-2", timestamp: 200, content: { ...summaryContent } })
+
+        expect(vm.deduplicateSystemTips([first, second])).toEqual([first, second])
+    })
+
+    it("still deduplicates other identical system tips inside five minutes", () => {
+        const vm = new ConversationVM(channel)
+        const first = wrap({
+            clientMsgNo: "system-1",
+            timestamp: 100,
+            content: { contentType: 1001, displayText: "安全提示", content: { content: "安全提示" } },
+        })
+        const second = wrap({
+            clientMsgNo: "system-2",
+            timestamp: 200,
+            content: { contentType: 1001, displayText: "安全提示", content: { content: "安全提示" } },
+        })
+
+        expect(vm.deduplicateSystemTips([first, second])).toEqual([first])
     })
 
     it("keeps a fully unread conversation unread until the visible-message gate advances browseTo", async () => {

--- a/packages/dmworkbase/src/Components/Conversation/vm.ts
+++ b/packages/dmworkbase/src/Components/Conversation/vm.ts
@@ -53,6 +53,7 @@ import {
 } from "../../im-runtime/channelRuntime";
 import { getBrowserUnreadConversationSync } from "../../features/documentTitle";
 import { isOwnedConversationSingleton } from "../../features/notifications/messageAttention";
+import { isSummaryTipContent } from "../../Messages/SummaryNotify/protocol";
 
 export interface FoldSessionParticipant {
     uid: string
@@ -2069,6 +2070,10 @@ export default class ConversationVM extends ProviderListener {
         return messages.filter((m) => {
             // Only process system messages (content_type 1000-2000)
             if (m.contentType < 1000 || m.contentType > 2000) return true
+            // Summary-completion tips represent distinct tasks. Their visible
+            // text can be identical within five minutes, so the generic
+            // security-warning dedup must not collapse them.
+            if (isSummaryTipContent(m.content)) return true
             const content = m.content as SystemContent
             const text = content?.displayText
             if (!text) return true

--- a/packages/dmworkbase/src/Messages/SummaryNotify/__tests__/SummaryNotifyContent.test.ts
+++ b/packages/dmworkbase/src/Messages/SummaryNotify/__tests__/SummaryNotifyContent.test.ts
@@ -36,7 +36,7 @@ vi.mock("../../../i18n", () => ({
 }));
 
 import { MessageContentTypeConst } from "../../../Service/Const";
-import { SummaryNotifyCell, SummaryNotifyContent } from "../index";
+import { SummaryNotifyCell, SummaryNotifyContent, SummaryTipContent } from "../index";
 
 describe("SummaryNotifyContent", () => {
   beforeEach(() => {
@@ -92,5 +92,38 @@ describe("SummaryNotifyContent", () => {
     const content = new SummaryNotifyContent();
     expect(content.tipForSender("me")).toBe("你总结了群聊内容");
     expect(content.conversationDigest).toBe("总结了群聊内容");
+  });
+});
+
+describe("SummaryTipContent (WK_TIP 2000 send-side)", () => {
+  it("uses content type 2000", () => {
+    const content = new SummaryTipContent();
+    expect(content.contentType).toBe(MessageContentTypeConst.summaryTip);
+    expect(MessageContentTypeConst.summaryTip).toBe(2000);
+  });
+
+  it("encodes the SystemContent placeholder payload with a locked zh-CN template", () => {
+    const content = new SummaryTipContent().setSender(" alice ", " Alice ");
+    expect(content.fromUID).toBe("alice");
+    expect(content.fromName).toBe("Alice");
+    expect(content.encodeJSON()).toEqual({
+      content: "{0}总结了群聊内容",
+      extra: [{ uid: "alice", name: "Alice" }],
+    });
+  });
+
+  it("decodes back from the SystemContent payload shape", () => {
+    const content = new SummaryTipContent();
+    content.decodeJSON({
+      content: "{0}总结了群聊内容",
+      extra: [{ uid: " bob ", name: " Bob " }],
+    });
+    expect(content.fromUID).toBe("bob");
+    expect(content.fromName).toBe("Bob");
+  });
+
+  it("exposes a readable conversation digest", () => {
+    const content = new SummaryTipContent().setSender("alice", "Alice");
+    expect(content.conversationDigest).toBe("Alice总结了群聊内容");
   });
 });

--- a/packages/dmworkbase/src/Messages/SummaryNotify/__tests__/SummaryNotifyContent.test.ts
+++ b/packages/dmworkbase/src/Messages/SummaryNotify/__tests__/SummaryNotifyContent.test.ts
@@ -8,10 +8,12 @@ vi.mock("wukongimjssdk", () => {
     constructor(public channelID: string, public channelType: number) {}
   }
   class MessageContent {}
+  class SystemContent extends MessageContent {}
   return {
     Channel,
     ChannelTypePerson: 1,
     MessageContent,
+    SystemContent,
     WKSDK: { shared: () => ({}) },
   };
 });
@@ -36,7 +38,7 @@ vi.mock("../../../i18n", () => ({
 }));
 
 import { MessageContentTypeConst } from "../../../Service/Const";
-import { SummaryNotifyCell, SummaryNotifyContent, SummaryTipContent } from "../index";
+import { SummaryNotifyCell, SummaryNotifyContent } from "../index";
 
 describe("SummaryNotifyContent", () => {
   beforeEach(() => {
@@ -92,38 +94,5 @@ describe("SummaryNotifyContent", () => {
     const content = new SummaryNotifyContent();
     expect(content.tipForSender("me")).toBe("你总结了群聊内容");
     expect(content.conversationDigest).toBe("总结了群聊内容");
-  });
-});
-
-describe("SummaryTipContent (WK_TIP 2000 send-side)", () => {
-  it("uses content type 2000", () => {
-    const content = new SummaryTipContent();
-    expect(content.contentType).toBe(MessageContentTypeConst.summaryTip);
-    expect(MessageContentTypeConst.summaryTip).toBe(2000);
-  });
-
-  it("encodes the SystemContent placeholder payload with a locked zh-CN template", () => {
-    const content = new SummaryTipContent().setSender(" alice ", " Alice ");
-    expect(content.fromUID).toBe("alice");
-    expect(content.fromName).toBe("Alice");
-    expect(content.encodeJSON()).toEqual({
-      content: "{0}总结了群聊内容",
-      extra: [{ uid: "alice", name: "Alice" }],
-    });
-  });
-
-  it("decodes back from the SystemContent payload shape", () => {
-    const content = new SummaryTipContent();
-    content.decodeJSON({
-      content: "{0}总结了群聊内容",
-      extra: [{ uid: " bob ", name: " Bob " }],
-    });
-    expect(content.fromUID).toBe("bob");
-    expect(content.fromName).toBe("Bob");
-  });
-
-  it("exposes a readable conversation digest", () => {
-    const content = new SummaryTipContent().setSender("alice", "Alice");
-    expect(content.conversationDigest).toBe("Alice总结了群聊内容");
   });
 });

--- a/packages/dmworkbase/src/Messages/SummaryNotify/__tests__/SummaryTipContent.test.ts
+++ b/packages/dmworkbase/src/Messages/SummaryNotify/__tests__/SummaryTipContent.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { SystemContent } from "wukongimjssdk";
+import { MessageContentTypeConst } from "../../../Service/Const";
+import {
+  isSummaryTipContent,
+  SummaryTipContent,
+} from "../tip";
+
+describe("SummaryTipContent (WK_TIP 2000 send-side)", () => {
+  it("uses the generic system content contract for the sender local echo", () => {
+    const content = new SummaryTipContent().setSender(" alice ", " Alice ");
+
+    expect(content).toBeInstanceOf(SystemContent);
+    expect(content.contentType).toBe(MessageContentTypeConst.summaryTip);
+    expect(content.displayText).toBe("Alice总结了群聊内容");
+    expect(content.conversationDigest).toBe("Alice总结了群聊内容");
+  });
+
+  it("encodes the locked zh-CN SystemContent placeholder payload", () => {
+    const content = new SummaryTipContent().setSender(" alice ", " Alice ");
+
+    expect(content.encodeJSON()).toEqual({
+      content: "{0}总结了群聊内容",
+      extra: [{ uid: "alice", name: "Alice" }],
+    });
+    expect(isSummaryTipContent(content)).toBe(true);
+  });
+
+  it("inherits receive-side decoding and placeholder substitution", () => {
+    const content = new SummaryTipContent();
+    content.decodeJSON({
+      content: "{0}总结了群聊内容",
+      extra: [{ uid: "bob", name: "Bob" }],
+    });
+
+    expect(content.displayText).toBe("Bob总结了群聊内容");
+    expect(isSummaryTipContent(content)).toBe(true);
+  });
+
+  it("does not classify unrelated generic WK_TIP payloads as summary tips", () => {
+    const content = new SystemContent();
+    content.decodeJSON({
+      content: "{0}加入了群聊",
+      extra: [{ uid: "bob", name: "Bob" }],
+    });
+
+    expect(isSummaryTipContent(content)).toBe(false);
+  });
+});

--- a/packages/dmworkbase/src/Messages/SummaryNotify/index.tsx
+++ b/packages/dmworkbase/src/Messages/SummaryNotify/index.tsx
@@ -14,6 +14,8 @@ import { t } from "../../i18n";
 import { MessageContentTypeConst } from "../../Service/Const";
 import { MessageCell } from "../MessageCell";
 
+export * from "./tip";
+
 export class SummaryNotifyContent extends MessageContent {
   fromUID = "";
   fromName = "";
@@ -70,57 +72,5 @@ export class SummaryNotifyCell extends MessageCell {
         {content.tipForSender(message.fromUID)}
       </div>
     );
-  }
-}
-
-/**
- * Send-side content for the group summary completion tip.
- *
- * Iterates #1379: instead of the custom type-21 message (which needs a
- * dedicated renderer on every client), we emit a WK_TIP (2000) system-range
- * message. Both Web (`SystemCell`) and native clients (`WKSystemContent` /
- * `WKSystemMessageCell`) already render the 1000–2000 system range out of the
- * box, so App needs no adaptation.
- *
- * The payload uses the SDK SystemContent placeholder convention:
- *   { content: "{0}总结了群聊内容", extra: [{ uid, name }] }
- * The SDK replaces `{0}` with `extra[0].name`. Copy is locked to Chinese on
- * the send side (product decision), so no i18n lookup here. Note: native
- * SystemContent additionally renders the tip as "你..." when the viewer's uid
- * matches `extra[0].uid` (accepted per plan option A).
- */
-export class SummaryTipContent extends MessageContent {
-  fromUID = "";
-  fromName = "";
-
-  setSender(uid: string, name: string): this {
-    this.fromUID = typeof uid === "string" ? uid.trim() : "";
-    this.fromName = typeof name === "string" ? name.trim() : "";
-    return this;
-  }
-
-  decodeJSON(content: any): void {
-    // Receive-side decoding is handled by the SDK SystemContent for the
-    // 1000–2000 range; this method exists only so the class is a valid
-    // MessageContent for the send path.
-    const extra = Array.isArray(content?.extra) ? content.extra[0] : undefined;
-    this.fromUID = typeof extra?.uid === "string" ? extra.uid.trim() : "";
-    this.fromName = typeof extra?.name === "string" ? extra.name.trim() : "";
-  }
-
-  encodeJSON(): any {
-    return {
-      content: "{0}总结了群聊内容",
-      extra: [{ uid: this.fromUID, name: this.fromName }],
-    };
-  }
-
-  get contentType() {
-    return MessageContentTypeConst.summaryTip;
-  }
-
-  get conversationDigest() {
-    const name = this.fromName || "";
-    return `${name}总结了群聊内容`;
   }
 }

--- a/packages/dmworkbase/src/Messages/SummaryNotify/index.tsx
+++ b/packages/dmworkbase/src/Messages/SummaryNotify/index.tsx
@@ -72,3 +72,55 @@ export class SummaryNotifyCell extends MessageCell {
     );
   }
 }
+
+/**
+ * Send-side content for the group summary completion tip.
+ *
+ * Iterates #1379: instead of the custom type-21 message (which needs a
+ * dedicated renderer on every client), we emit a WK_TIP (2000) system-range
+ * message. Both Web (`SystemCell`) and native clients (`WKSystemContent` /
+ * `WKSystemMessageCell`) already render the 1000–2000 system range out of the
+ * box, so App needs no adaptation.
+ *
+ * The payload uses the SDK SystemContent placeholder convention:
+ *   { content: "{0}总结了群聊内容", extra: [{ uid, name }] }
+ * The SDK replaces `{0}` with `extra[0].name`. Copy is locked to Chinese on
+ * the send side (product decision), so no i18n lookup here. Note: native
+ * SystemContent additionally renders the tip as "你..." when the viewer's uid
+ * matches `extra[0].uid` (accepted per plan option A).
+ */
+export class SummaryTipContent extends MessageContent {
+  fromUID = "";
+  fromName = "";
+
+  setSender(uid: string, name: string): this {
+    this.fromUID = typeof uid === "string" ? uid.trim() : "";
+    this.fromName = typeof name === "string" ? name.trim() : "";
+    return this;
+  }
+
+  decodeJSON(content: any): void {
+    // Receive-side decoding is handled by the SDK SystemContent for the
+    // 1000–2000 range; this method exists only so the class is a valid
+    // MessageContent for the send path.
+    const extra = Array.isArray(content?.extra) ? content.extra[0] : undefined;
+    this.fromUID = typeof extra?.uid === "string" ? extra.uid.trim() : "";
+    this.fromName = typeof extra?.name === "string" ? extra.name.trim() : "";
+  }
+
+  encodeJSON(): any {
+    return {
+      content: "{0}总结了群聊内容",
+      extra: [{ uid: this.fromUID, name: this.fromName }],
+    };
+  }
+
+  get contentType() {
+    return MessageContentTypeConst.summaryTip;
+  }
+
+  get conversationDigest() {
+    const name = this.fromName || "";
+    return `${name}总结了群聊内容`;
+  }
+}

--- a/packages/dmworkbase/src/Messages/SummaryNotify/protocol.ts
+++ b/packages/dmworkbase/src/Messages/SummaryNotify/protocol.ts
@@ -1,0 +1,43 @@
+export const SUMMARY_TIP_TEMPLATE = "{0}总结了群聊内容";
+
+interface SummaryTipExtra {
+  uid: string;
+  name: string;
+}
+
+export interface SummaryTipPayload {
+  content: typeof SUMMARY_TIP_TEMPLATE;
+  extra: [SummaryTipExtra];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function createSummaryTipPayload(
+  uid: string,
+  name: string
+): SummaryTipPayload {
+  return {
+    content: SUMMARY_TIP_TEMPLATE,
+    extra: [{ uid, name }],
+  };
+}
+
+/** Identifies only this feature's WK_TIP payload, not every generic type-2000 tip. */
+export function isSummaryTipContent(value: unknown): boolean {
+  const payload =
+    isRecord(value) && isRecord(value.content) ? value.content : value;
+  if (!isRecord(payload) || payload.content !== SUMMARY_TIP_TEMPLATE) {
+    return false;
+  }
+  if (!Array.isArray(payload.extra) || payload.extra.length !== 1) {
+    return false;
+  }
+  const sender = payload.extra[0];
+  return (
+    isRecord(sender) &&
+    typeof sender.uid === "string" &&
+    typeof sender.name === "string"
+  );
+}

--- a/packages/dmworkbase/src/Messages/SummaryNotify/tip.ts
+++ b/packages/dmworkbase/src/Messages/SummaryNotify/tip.ts
@@ -1,0 +1,39 @@
+import { SystemContent } from "wukongimjssdk";
+import { MessageContentTypeConst } from "../../Service/Const";
+import { createSummaryTipPayload } from "./protocol";
+import type { SummaryTipPayload } from "./protocol";
+
+export * from "./protocol";
+
+/**
+ * Send-side WK_TIP (2000) content for group-summary completion.
+ *
+ * Extending SystemContent is important: the SDK keeps this exact instance for
+ * the sender's local echo, while SystemCell reads `displayText`. Initializing
+ * `content` gives the local echo the same placeholder rendering contract as a
+ * remote message decoded by the SDK.
+ */
+export class SummaryTipContent extends SystemContent {
+  declare content: SummaryTipPayload;
+
+  constructor() {
+    super();
+    this.content = createSummaryTipPayload("", "");
+  }
+
+  setSender(uid: string, name: string): this {
+    this.content = createSummaryTipPayload(
+      typeof uid === "string" ? uid.trim() : "",
+      typeof name === "string" ? name.trim() : ""
+    );
+    return this;
+  }
+
+  encodeJSON(): SummaryTipPayload {
+    return this.content;
+  }
+
+  get contentType() {
+    return MessageContentTypeConst.summaryTip;
+  }
+}

--- a/packages/dmworkbase/src/Service/Const.ts
+++ b/packages/dmworkbase/src/Service/Const.ts
@@ -68,7 +68,8 @@ export class MessageContentTypeConst {
   static newGroupOwner: number = 1008 // 新的管理员
   static approveGroupMember: number = 1009 // 审批群成员
   static screenshot:number = 20 // 截屏消息
-  static summaryNotify:number = 21 // 群内总结完成提示
+  static summaryNotify:number = 21 // [已废弃] 群内总结完成提示（自定义 type-21，App 需单独适配）。仅保留用于渲染历史消息；新消息改用 summaryTip(2000) 系统 tip。
+  static summaryTip:number = 2000 // 群内总结完成提示（复用 WK_TIP 系统号段，Web/App 靠 SystemContent 兜底渲染，App 免适配）
 
   // 音频通话消息号段 9900 - 9999
   static rtcResult:number = 9989 // 音视频通话结果

--- a/packages/dmworkbase/src/Service/__tests__/messageContinuity.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/messageContinuity.test.ts
@@ -73,4 +73,16 @@ describe("isMessageContinuation", () => {
             msg("u1", 1_030, { contentType: MessageContentTypeConst.summaryNotify }),
         )).toBe(false)
     })
+
+    it("breaks on the WK_TIP (2000) summary completion tip", () => {
+        expect(isMessageContinuation(
+            msg("u1", 1_000, { contentType: MessageContentTypeConst.summaryTip }),
+            msg("u1", 1_030),
+        )).toBe(false)
+
+        expect(isMessageContinuation(
+            msg("u1", 1_000),
+            msg("u1", 1_030, { contentType: MessageContentTypeConst.summaryTip }),
+        )).toBe(false)
+    })
 })

--- a/packages/dmworkbase/src/Service/__tests__/messageNotification.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/messageNotification.test.ts
@@ -7,6 +7,9 @@ describe("isNotificationSuppressedContentType", () => {
     expect(
       isNotificationSuppressedContentType(MessageContentTypeConst.summaryNotify)
     ).toBe(true);
+    expect(
+      isNotificationSuppressedContentType(MessageContentTypeConst.summaryTip)
+    ).toBe(true);
   });
 
   it("does not change existing screenshot or text notification behavior", () => {

--- a/packages/dmworkbase/src/Service/messageContinuity.ts
+++ b/packages/dmworkbase/src/Service/messageContinuity.ts
@@ -23,6 +23,7 @@ function isBoundaryMessage(message: ContinuityMessage): boolean {
         || contentType === MessageContentTypeConst.typing
         || contentType === MessageContentTypeConst.screenshot
         || contentType === MessageContentTypeConst.summaryNotify
+        || contentType === MessageContentTypeConst.summaryTip
         || !!message.revoke
 }
 

--- a/packages/dmworkbase/src/Service/messageNotification.ts
+++ b/packages/dmworkbase/src/Service/messageNotification.ts
@@ -4,5 +4,8 @@ import { MessageContentTypeConst } from "./Const";
 export function isNotificationSuppressedContentType(
   contentType: number
 ): boolean {
-  return contentType === MessageContentTypeConst.summaryNotify;
+  return (
+    contentType === MessageContentTypeConst.summaryNotify ||
+    contentType === MessageContentTypeConst.summaryTip
+  );
 }

--- a/packages/dmworksummary/src/__mocks__/dmworkBase.ts
+++ b/packages/dmworksummary/src/__mocks__/dmworkBase.ts
@@ -105,4 +105,23 @@ export class SummaryNotifyContent {
   fromName = '';
 }
 
+export class SummaryTipContent {
+  fromUID = '';
+  fromName = '';
+  setSender(uid: string, name: string) {
+    this.fromUID = typeof uid === 'string' ? uid.trim() : '';
+    this.fromName = typeof name === 'string' ? name.trim() : '';
+    return this;
+  }
+  encodeJSON() {
+    return {
+      content: '{0}总结了群聊内容',
+      extra: [{ uid: this.fromUID, name: this.fromName }],
+    };
+  }
+  get contentType() {
+    return 2000;
+  }
+}
+
 export const isConversationDisbanded = () => false;

--- a/packages/dmworksummary/src/pages/SummaryDetailPage.tsx
+++ b/packages/dmworksummary/src/pages/SummaryDetailPage.tsx
@@ -19,7 +19,7 @@ import {
   ForwardService,
   interpretForwardResult,
   titleContextStore,
-  SummaryNotifyContent,
+  SummaryTipContent,
   isConversationDisbanded,
   Dap,
 } from "@octo/base";
@@ -1182,11 +1182,13 @@ export default class SummaryDetailPage extends Component<SummaryDetailPageProps,
             ChannelTypeGroup,
             {
                 sendToChannel: async (channel, currentUserId) => {
-                    const content = new SummaryNotifyContent();
-                    content.fromUID = currentUserId;
-                    content.fromName = WKApp.loginInfo.selfDisplayName?.()
+                    const name = WKApp.loginInfo.selfDisplayName?.()
                         || WKApp.loginInfo.name
                         || currentUserId;
+                    // Iterate #1379: emit a WK_TIP (2000) system-range tip so
+                    // Web and native clients render it via their built-in
+                    // SystemContent path with no per-type adaptation.
+                    const content = new SummaryTipContent().setSender(currentUserId, name);
                     await WKSDK.shared().chatManager.send(content, channel);
                 },
                 isDisbanded: isConversationDisbanded,


### PR DESCRIPTION
## Summary

Iterates #1379. On the send side, replaces the custom type-21 group-summary completion tip with a WK_TIP (2000) system-range message. Web and iOS render it through their built-in `SystemContent` system-message path, while type 21 remains registered for historical messages.

Product decision: the wire copy is locked to Chinese. Web shows the sender's snapshotted display name; iOS maps the sender to `你` for the sender's own view. English-locale Web users therefore also see the locked Chinese tip, and later profile/group-nickname changes do not rewrite historical tips.

### Why 2000

- Web SDK and iOS both classify `1000 <= contentType <= 2000` as system messages.
- Web uses `SystemCell`; iOS uses `WKSystemContent` + `WKSystemMessageCell`.
- Both understand `{ content: "{0}总结了群聊内容", extra: [{ uid, name }] }`.
- iOS already defines `WK_TIP = 2000`; 1010 is already occupied by `WK_GROUP_MEMBERREFUND`.

Android source/runtime behavior has not been independently verified in this task, so an Android smoke test remains required before relying on zero-adaptation behavior there.

## Changes

- Add `MessageContentTypeConst.summaryTip = 2000`; keep `summaryNotify = 21` for history compatibility.
- Add a send-side `SummaryTipContent` that extends SDK `SystemContent`, so the sender's local echo exposes the same `displayText` consumed by `SystemCell`.
- Move the locked wire payload and exact-shape predicate into a small protocol module.
- Send `SummaryTipContent` when group-summary completion notifications are emitted.
- Treat 2000 as a message-continuity boundary.
- Explicitly suppress desktop notification/sound for both historical type 21 and new type 2000.
- Exempt only the exact summary-completion WK_TIP payload from generic five-minute system-tip deduplication, so distinct summary tasks remain visible.
- Limit the i18n scanner exception to the protocol-only file; the historical renderer remains scanned.
- Add local-echo, payload classification, notification, continuity, and dedup regression coverage.

## Backward compatibility

The type-21 content factory and renderer remain in place, so historical messages continue to display normally.

## Verification

- `pnpm --filter @octo/base exec vitest run` — 382 files, 3410 tests passed.
- `pnpm --filter @dmwork/summary exec vitest run src/utils/groupSummaryNotify.test.ts src/pages/__tests__/SummaryDetailPage.schedule.test.tsx` — 2 files, 167 tests passed.
- `pnpm i18n:check` — passed.
- `git diff --check` — passed.

## Runtime follow-ups

- Send one real type-2000 tip in iOS and Android test environments.
- If a backend later emits or relays this tip, preserve the `{ content, extra: [{ uid, name }] }` payload shape.

Product decision reference: #289
