### PR TITLE
docs: verify e2e-p0 skipped check does not block docs-only merges

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,3 +162,5 @@ See [NOTICE](NOTICE) for the full attribution list and third-party component lic
 <p align="center">
   <sub>Made with 🐙 by <b>OCTO Contributors</b> · <a href="https://github.com/Mininglamp-OSS">Mininglamp-OSS</a></sub>
 </p>
+
+<!-- e2e-p0 required-check verification: docs-only change, e2e-p0 should be SKIPPED and not block merge (GH#1539) -->


### PR DESCRIPTION
Docs-only change to verify the newly-required `e2e-p0` status check (ruleset 16278105) is satisfied by the skip-path of the `changes` preflight (#1546) and does not block docs-only PRs. Part of #1539. Will be merged as verification then the issue closes.