### PR TITLE
fix(web): restore last organization after login

### DIFF
--- a/apps/web/src/Components/InviteLanding/index.tsx
+++ b/apps/web/src/Components/InviteLanding/index.tsx
@@ -3,6 +3,7 @@ import { I18nContext, WKApp, apiFetchJson, computeAndSaveJoinSuccess, setSession
 import type { JoinSpaceStatus } from "@octo/base";
 import { Button, Spin, Toast } from "@douyinfe/semi-ui";
 import { buildPostLoginRedirectUrl } from "../../Layout/postLoginRedirect";
+import { persistActiveSpace, readLastSpaceId } from "../../features/spacePreference";
 import "./index.css";
 
 interface InviteLandingProps {
@@ -232,7 +233,7 @@ export default class InviteLanding extends Component<InviteLandingProps, InviteL
             // dmwork-web#1065: 在调用 /space/join 前先记住用户「当前 Space」。
             // 多 Space 用户在非归属 Space 点邀请链接时，不应自动切换 currentSpaceId —
             // 必须由用户显式点 toast 里的「切换过去」才切。这里在改动前快照下来。
-            const prevCurrentSpaceId = localStorage.getItem("currentSpaceId") || "";
+            const prevCurrentSpaceId = WKApp.shared.currentSpaceId || readLastSpaceId(WKApp.loginInfo.uid) || "";
             const apiUrl = WKApp.apiClient.config.apiURL?.replace(/\/+$/, '');
             const result = await apiFetchJson<any>(`${apiUrl}/space/join`, {
                 method: 'POST',
@@ -277,7 +278,7 @@ export default class InviteLanding extends Component<InviteLandingProps, InviteL
 
             // 硬约束：不自动切换 currentSpace。只有非跨 Space（或无历史 Space）时才更新。
             if (!crossSpace && joinedSpaceId) {
-                localStorage.setItem('currentSpaceId', joinedSpaceId);
+                persistActiveSpace(WKApp.loginInfo.uid, joinedSpaceId);
             }
             // 跳转回主界面（sid-clean 派：先把 sid 存到 SessionScope
             // sessionStorage，跳转 URL 就不再挂 `?sid=` 了。RouteManager 的

--- a/apps/web/src/Components/JoinSpacePage/index.tsx
+++ b/apps/web/src/Components/JoinSpacePage/index.tsx
@@ -3,6 +3,7 @@ import { SpaceCreate, WKApp, toJoinApprovalStatus, useI18n } from "@octo/base";
 import { SpaceService } from "@octo/base";
 import { Button, Input, Toast } from "@douyinfe/semi-ui";
 import { LogOut } from "lucide-react";
+import { persistActiveSpace } from "../../features/spacePreference";
 import "./index.css";
 
 type View = "home" | "join" | "join-confirm";
@@ -25,7 +26,7 @@ const ACCENT = "var(--wk-color-primary, #1C1C23)";
 const setCurrentSpace = (spaceId: string) => {
     if (!spaceId) return;
     WKApp.shared.currentSpaceId = spaceId;
-    localStorage.setItem("currentSpaceId", spaceId);
+    persistActiveSpace(WKApp.loginInfo.uid, spaceId);
 };
 
 export default function JoinSpacePage({ onSuccess }: JoinSpacePageProps) {

--- a/apps/web/src/Components/SpaceGate/index.tsx
+++ b/apps/web/src/Components/SpaceGate/index.tsx
@@ -4,6 +4,10 @@ import { SpaceService } from "@octo/base";
 import { Input, Button, Toast, Spin } from "@douyinfe/semi-ui";
 import { SpaceCreate } from "@octo/base";
 import { LogOut } from "lucide-react";
+import {
+    persistActiveSpace,
+    resolveInitialSpaceForUser,
+} from "../../features/spacePreference";
 import "./index.css";
 
 interface SpaceGateState {
@@ -43,11 +47,6 @@ export default class SpaceGate extends Component<{}, SpaceGateState> {
             }
             this.forceUpdate();
         });
-        const cached = localStorage.getItem("currentSpaceId");
-        if (cached) {
-            this.enterSpace(cached);
-            return;
-        }
         this.checkSpaces();
     }
 
@@ -71,7 +70,7 @@ export default class SpaceGate extends Component<{}, SpaceGateState> {
 
         WKApp.shared.currentSpaceId = spaceId;
         WKApp.shared.spaceChecked = true;
-        localStorage.setItem("currentSpaceId", spaceId);
+        persistActiveSpace(WKApp.loginInfo.uid, spaceId);
         try { WKApp.shared.notifyListener(); } catch (_) {}
 
         if (this._isMounted) {
@@ -89,8 +88,13 @@ export default class SpaceGate extends Component<{}, SpaceGateState> {
     checkSpaces = async () => {
         try {
             const spaces = await SpaceService.shared.getMySpaces();
-            if (spaces.length >= 1) {
-                this.enterSpace(spaces[0].space_id);
+            const selectedSpace = resolveInitialSpaceForUser(
+                spaces,
+                WKApp.loginInfo.uid,
+                WKApp.shared.currentSpaceId,
+            );
+            if (selectedSpace) {
+                this.enterSpace(selectedSpace.space_id);
             } else {
                 this.setState({ loading: false, noSpace: true });
             }

--- a/apps/web/src/Layout/index.tsx
+++ b/apps/web/src/Layout/index.tsx
@@ -30,6 +30,7 @@ import {
     resolveMailAuthorizeSearch,
 } from "@octo/mail";
 import { consumeStandaloneReturn, persistStandaloneReturn, clearStandaloneReturn } from "./standaloneReturn";
+import { persistActiveSpace, readLastSpaceId } from "../features/spacePreference";
 
 interface AppLayoutState {
     showJoinSpace: boolean;
@@ -246,7 +247,7 @@ export default class AppLayout extends Component<{}, AppLayoutState> {
                 // dmwork-web#1068 Round 2：
                 // 登录+邀请路径也要弹 join-success toast（与 InviteLanding 直连加入走同一 helper）。
                 // 在调用 /space/join 前先快照 prevCurrentSpaceId，并预取 invite 信息拿 space_name。
-                const prevCurrentSpaceId = localStorage.getItem("currentSpaceId") || "";
+                const prevCurrentSpaceId = WKApp.shared.currentSpaceId || readLastSpaceId(WKApp.loginInfo.uid) || "";
                 // 预取邀请信息以便 toast 显示「位于 xxx 空间」。失败时降级为空 spaceName
                 // （toast 也能显示常规「已加入」），不阻塞 auto-join 流程。
                 const fetchInviteInfo = WKApp.apiClient
@@ -276,7 +277,7 @@ export default class AppLayout extends Component<{}, AppLayoutState> {
                             // 与 InviteLanding 一致：跨 Space 时不自动切换 currentSpaceId —
                             // 等用户点 toast 里的「切换过去」按钮。
                             if (!notice.crossSpace && spaceId) {
-                                localStorage.setItem('currentSpaceId', spaceId);
+                                persistActiveSpace(WKApp.loginInfo.uid, spaceId);
                             }
                             // 十二审 🔴 P1-4:space_join_new 命令式,仅真加入时计(审批态已在上方 early-return)。
                             //   此为 auto-join(登录时用 pendingInviteCode 直发 POST /space/join)的成功分支。
@@ -290,7 +291,8 @@ export default class AppLayout extends Component<{}, AppLayoutState> {
                                 import('@douyinfe/semi-ui').then(({ Toast }) => Toast.error(t("app.invite.spaceFullCannotJoin")));
                             } else if (msg.includes(t("app.joinSpace.serverTerms.alreadyMember", { locale: "zh-CN" })) || msg.includes('already')) {
                                 localStorage.removeItem("pendingInviteCode");
-                                if (e?.space_id) localStorage.setItem('currentSpaceId', e.space_id);
+                                const targetSpaceId = e?.space_id || inviteInfo?.space_id || "";
+                                if (targetSpaceId) persistActiveSpace(WKApp.loginInfo.uid, targetSpaceId);
                             } else {
                                 localStorage.removeItem("pendingInviteCode");
                                 console.warn('Auto-join space failed:', msg);
@@ -451,7 +453,7 @@ export default class AppLayout extends Component<{}, AppLayoutState> {
             if (!WKApp.loginInfo.token) recoverOctoSessionFromStorage(true);
             if (WKApp.loginInfo.token) {
                 if (!WKApp.shared.currentSpaceId) {
-                    const cachedSpaceId = localStorage.getItem("currentSpaceId") || "";
+                    const cachedSpaceId = readLastSpaceId(WKApp.loginInfo.uid) || "";
                     if (cachedSpaceId) WKApp.shared.currentSpaceId = cachedSpaceId;
                 }
                 const mailAuthorizeComponent = WKApp.route.get(MAIL_AUTHORIZE_PATH, {
@@ -474,7 +476,7 @@ export default class AppLayout extends Component<{}, AppLayoutState> {
             if (!WKApp.loginInfo.token) recoverOctoSessionFromStorage(true);
             if (WKApp.loginInfo.token) {
                 if (!WKApp.shared.currentSpaceId) {
-                    const cachedSpaceId = localStorage.getItem("currentSpaceId") || "";
+                    const cachedSpaceId = readLastSpaceId(WKApp.loginInfo.uid) || "";
                     if (cachedSpaceId) WKApp.shared.currentSpaceId = cachedSpaceId;
                 }
                 const enterpriseStandalonePage = enterpriseStandaloneHandler.render({
@@ -557,8 +559,8 @@ export default class AppLayout extends Component<{}, AppLayoutState> {
             }
             // Space 模式：检查用户是否属于至少一个 Space
             if (!WKApp.shared.currentSpaceId) {
-                // 尝试从 localStorage 恢复
-                const cached = localStorage.getItem("currentSpaceId");
+                // 仅恢复当前账号的设备偏好，避免全局 currentSpaceId 串号。
+                const cached = readLastSpaceId(WKApp.loginInfo.uid);
                 if (cached) {
                     WKApp.shared.currentSpaceId = cached;
                     WKApp.shared.spaceChecked = true;

--- a/apps/web/src/Pages/Main/index.tsx
+++ b/apps/web/src/Pages/Main/index.tsx
@@ -15,8 +15,11 @@ import { Toast } from "@douyinfe/semi-ui";
 import {
     requestGuardedSpaceChange,
     publishInitialSpaceResolution,
-    resolveInitialSpace,
 } from "./spaceChange";
+import {
+    persistActiveSpace,
+    resolveInitialSpaceForUser,
+} from "../../features/spacePreference";
 import { requestGuardedMenuChange, requestProgrammaticMenuChange } from "./menuChange";
 import { requestMailWorkspaceSwitch } from "@octo/mail";
 
@@ -99,11 +102,14 @@ export class MainPage extends Component<{}, MainPageState> {
         SpaceService.shared.getMySpaces().then(spaces => {
             this.setState({ allSpaces: spaces });
             const previousSpaceId = WKApp.shared.currentSpaceId || "";
-            const savedSpaceId = localStorage.getItem("currentSpaceId");
-            const selectedSpace = resolveInitialSpace(spaces, savedSpaceId);
+            const selectedSpace = resolveInitialSpaceForUser(
+                spaces,
+                WKApp.loginInfo.uid,
+                previousSpaceId,
+            );
             if (selectedSpace) {
                 WKApp.shared.currentSpaceId = selectedSpace.space_id;
-                localStorage.setItem("currentSpaceId", selectedSpace.space_id);
+                persistActiveSpace(WKApp.loginInfo.uid, selectedSpace.space_id);
             } else {
                 WKApp.shared.currentSpaceId = '';
                 WKApp.shared.spaceChecked = false;
@@ -172,7 +178,7 @@ export class MainPage extends Component<{}, MainPageState> {
         // 避免随后用户立即触发的"合并转发"等动作读到旧的 spaceId
         // （此前这些更新都放在 getMySpaces().then 内，存在网络 race）。
         WKApp.shared.currentSpaceId = spaceId;
-        localStorage.setItem("currentSpaceId", spaceId);
+        persistActiveSpace(WKApp.loginInfo.uid, spaceId);
         const existing = this.state.allSpaces.find(s => s.space_id === spaceId);
         if (existing) {
             WKApp.mittBus.emit("space-changed", existing);

--- a/apps/web/src/Pages/Main/index.tsx
+++ b/apps/web/src/Pages/Main/index.tsx
@@ -17,6 +17,7 @@ import {
     publishInitialSpaceResolution,
 } from "./spaceChange";
 import {
+    clearLastSpaceId,
     persistActiveSpace,
     resolveInitialSpaceForUser,
 } from "../../features/spacePreference";
@@ -113,6 +114,7 @@ export class MainPage extends Component<{}, MainPageState> {
             } else {
                 WKApp.shared.currentSpaceId = '';
                 WKApp.shared.spaceChecked = false;
+                clearLastSpaceId(WKApp.loginInfo.uid);
                 localStorage.removeItem("currentSpaceId");
             }
             publishInitialSpaceResolution(

--- a/apps/web/src/Pages/Main/spaceChange.ts
+++ b/apps/web/src/Pages/Main/spaceChange.ts
@@ -34,14 +34,3 @@ export function requestGuardedSpaceChange(
   }
   return requestSwitch(() => apply(nextSpaceId));
 }
-
-export function resolveInitialSpace<T extends { space_id: string }>(
-  spaces: T[],
-  savedSpaceId: string | null
-): T | undefined {
-  return (
-    (savedSpaceId
-      ? spaces.find((space) => space.space_id === savedSpaceId)
-      : undefined) ?? spaces[0]
-  );
-}

--- a/apps/web/src/__tests__/inviteLandingCrossSpaceToast.test.ts
+++ b/apps/web/src/__tests__/inviteLandingCrossSpaceToast.test.ts
@@ -7,7 +7,7 @@ import * as path from 'path';
  * 这组 grep 断言锁定 InviteLanding、MainPage、helper、toast 组件的关键行为：
  * 1. InviteLanding 在 /space/join 前快照 prevCurrentSpaceId
  * 2. 根据 groupSpaceId !== currentSpaceId 判定 crossSpace
- * 3. 跨 Space 时不写 localStorage.currentSpaceId（不自动切换）
+ * 3. 跨 Space 时不持久化当前组织（不自动切换）
  * 4. 把 notice 写入 sessionStorage，MainPage 挂载时消费
  * 5. 切换按钮调用 handleSpaceSelected 显式切
  */
@@ -31,10 +31,10 @@ describe('InviteLanding + MainPage — dmwork-web#1065 cross-space toast', () =>
     });
 
     it('InviteLanding snapshots prevCurrentSpaceId before /space/join', () => {
-        expect(inviteLanding).toMatch(/prevCurrentSpaceId\s*=\s*localStorage\.getItem\(\s*["']currentSpaceId["']/);
+        expect(inviteLanding).toMatch(/prevCurrentSpaceId\s*=\s*WKApp\.shared\.currentSpaceId\s*\|\|\s*readLastSpaceId/);
         // The snapshot line must precede the actual fetch — prevent regression that reads
         // localStorage AFTER join (which wouldn't reflect the user's "pre-join" space).
-        const snapIdx = inviteLanding.search(/prevCurrentSpaceId\s*=\s*localStorage/);
+        const snapIdx = inviteLanding.search(/prevCurrentSpaceId\s*=\s*WKApp\.shared\.currentSpaceId/);
         const joinIdx = inviteLanding.search(/apiFetchJson<any>\(\s*`\$\{apiUrl\}\/space\/join`/);
         expect(snapIdx).toBeGreaterThan(0);
         expect(joinIdx).toBeGreaterThan(snapIdx);
@@ -53,8 +53,9 @@ describe('InviteLanding + MainPage — dmwork-web#1065 cross-space toast', () =>
     });
 
     it('InviteLanding does NOT auto-switch currentSpaceId when crossSpace is true', () => {
-        // Only set localStorage.currentSpaceId when !crossSpace
+        // Only persist the active organization when !crossSpace
         expect(inviteLanding).toMatch(/if\s*\(\s*!crossSpace\s*&&\s*joinedSpaceId\s*\)/);
+        expect(inviteLanding).toMatch(/persistActiveSpace\(WKApp\.loginInfo\.uid,\s*joinedSpaceId\)/);
     });
 
     it('InviteLanding no longer calls Toast.success directly (toast now lives on main page)', () => {

--- a/apps/web/src/__tests__/layoutPendingInviteToast.test.ts
+++ b/apps/web/src/__tests__/layoutPendingInviteToast.test.ts
@@ -9,9 +9,9 @@
  *
  * 本测试通过 grep 锁定 Layout.tsx 在 pendingInviteCode 分支中：
  * 1. 共用 computeAndSaveJoinSuccess helper（与 InviteLanding 行为一致）
- * 2. 在 /space/join 之前快照 prevCurrentSpaceId
+ * 2. 在 /space/join 之前按当前 UID 快照 prevCurrentSpaceId
  * 3. 预取 invite 信息以带上 space_name
- * 4. 只有 !crossSpace 时才写 localStorage.currentSpaceId（不自动切换）
+ * 4. 只有 !crossSpace 时才持久化当前组织（不自动切换）
  */
 import * as fs from 'fs';
 import * as path from 'path';
@@ -30,8 +30,8 @@ describe('Layout.onLogin — pendingInviteCode path shares joinSuccessNotice', (
     });
 
     it('snapshots prevCurrentSpaceId before calling /space/join', () => {
-        expect(layout).toMatch(/prevCurrentSpaceId\s*=\s*localStorage\.getItem\(\s*["']currentSpaceId["']/);
-        const snapIdx = layout.search(/prevCurrentSpaceId\s*=\s*localStorage/);
+        expect(layout).toMatch(/prevCurrentSpaceId\s*=\s*WKApp\.shared\.currentSpaceId\s*\|\|\s*readLastSpaceId/);
+        const snapIdx = layout.search(/prevCurrentSpaceId\s*=\s*WKApp\.shared\.currentSpaceId/);
         const joinIdx = layout.search(/post\(\s*`\/space\/join`/);
         expect(snapIdx).toBeGreaterThan(0);
         expect(joinIdx).toBeGreaterThan(snapIdx);
@@ -47,8 +47,13 @@ describe('Layout.onLogin — pendingInviteCode path shares joinSuccessNotice', (
     });
 
     it('does NOT auto-switch currentSpaceId when crossSpace is true', () => {
-        // Only set localStorage.currentSpaceId when !notice.crossSpace
+        // Only persist the active organization when !notice.crossSpace
         expect(layout).toMatch(/if\s*\(\s*!notice\.crossSpace\s*&&\s*spaceId\s*\)/);
+        expect(layout).toMatch(/persistActiveSpace\(WKApp\.loginInfo\.uid,\s*spaceId\)/);
+    });
+
+    it('uses prefetched invite info when the already-member error omits space_id', () => {
+        expect(layout).toMatch(/e\?\.space_id\s*\|\|\s*inviteInfo\?\.space_id/);
     });
 
     it('still removes pendingInviteCode on success so we do not loop', () => {

--- a/apps/web/src/__tests__/mainInitialSpaceResolution.test.ts
+++ b/apps/web/src/__tests__/mainInitialSpaceResolution.test.ts
@@ -42,7 +42,7 @@ describe("MainPage initial Space resolution", () => {
     ).toEqual(spaces[2]);
   });
 
-  it("uses one user-scoped resolution path for session, current, and historical choices", () => {
+  it("uses one user-scoped resolution path and ignores the global legacy key", () => {
     const spaces = [
       { space_id: "space-a" },
       { space_id: "space-b" },
@@ -52,19 +52,19 @@ describe("MainPage initial Space resolution", () => {
       ["currentSpaceId", "space-b"],
       ["octo:last-space:user-a", "space-c"],
     ]);
-    const storage = {
+    const store = {
       getItem: (key: string) => values.get(key) ?? null,
     };
 
     expect(
-      resolveInitialSpaceForUser(spaces, "user-a", "space-a", storage)
+      resolveInitialSpaceForUser(spaces, "user-a", "space-a", store)
     ).toEqual(spaces[0]);
-    expect(resolveInitialSpaceForUser(spaces, "user-a", null, storage)).toEqual(
-      spaces[1]
-    );
-    values.delete("currentSpaceId");
-    expect(resolveInitialSpaceForUser(spaces, "user-a", null, storage)).toEqual(
+    expect(resolveInitialSpaceForUser(spaces, "user-a", null, store)).toEqual(
       spaces[2]
+    );
+    values.delete("octo:last-space:user-a");
+    expect(resolveInitialSpaceForUser(spaces, "user-a", null, store)).toEqual(
+      spaces[0]
     );
   });
 
@@ -112,17 +112,17 @@ describe("MainPage initial Space resolution", () => {
 describe("per-user last Space persistence", () => {
   it("isolates the last Space by uid while keeping currentSpaceId compatible", () => {
     const values = new Map<string, string>();
-    const storage = {
+    const store = {
       getItem: (key: string) => values.get(key) ?? null,
       setItem: (key: string, value: string) => values.set(key, value),
     };
 
-    persistActiveSpace("user-a", "space-a", storage);
-    persistActiveSpace("user-b", "space-b", storage);
+    persistActiveSpace("user-a", "space-a", store);
+    persistActiveSpace("user-b", "space-b", store);
 
     expect(values.get("currentSpaceId")).toBe("space-b");
-    expect(readLastSpaceId("user-a", storage)).toBe("space-a");
-    expect(readLastSpaceId("user-b", storage)).toBe("space-b");
+    expect(readLastSpaceId("user-a", store)).toBe("space-a");
+    expect(readLastSpaceId("user-b", store)).toBe("space-b");
   });
 
   it("does not persist an account preference without a uid", () => {
@@ -133,6 +133,23 @@ describe("per-user last Space persistence", () => {
     expect(setItem).toHaveBeenCalledOnce();
     expect(setItem).toHaveBeenCalledWith("currentSpaceId", "space-a");
     expect(getLastSpaceStorageKey("  ")).toBeUndefined();
+    expect(getLastSpaceStorageKey(undefined)).toBeUndefined();
+  });
+
+  it("restores the same user's last Space after logout clears currentSpaceId", () => {
+    const values = new Map<string, string>();
+    const store = {
+      getItem: (key: string) => values.get(key) ?? null,
+      setItem: (key: string, value: string) => values.set(key, value),
+    };
+    const spaces = [{ space_id: "space-a" }, { space_id: "space-b" }];
+
+    persistActiveSpace("user-a", "space-b", store);
+    values.delete("currentSpaceId");
+
+    expect(resolveInitialSpaceForUser(spaces, "user-a", null, store)).toEqual(
+      spaces[1]
+    );
   });
 
   it("degrades safely when browser storage is unavailable", () => {

--- a/apps/web/src/__tests__/mainInitialSpaceResolution.test.ts
+++ b/apps/web/src/__tests__/mainInitialSpaceResolution.test.ts
@@ -42,7 +42,7 @@ describe("MainPage initial Space resolution", () => {
     ).toEqual(spaces[2]);
   });
 
-  it("uses one user-scoped resolution path and ignores the global legacy key", () => {
+  it("uses one user-scoped resolution path after legacy migration", () => {
     const spaces = [
       { space_id: "space-a" },
       { space_id: "space-b" },
@@ -54,6 +54,7 @@ describe("MainPage initial Space resolution", () => {
     ]);
     const store = {
       getItem: (key: string) => values.get(key) ?? null,
+      setItem: (key: string, value: string) => values.set(key, value),
     };
 
     expect(
@@ -110,6 +111,28 @@ describe("MainPage initial Space resolution", () => {
 });
 
 describe("per-user last Space persistence", () => {
+  it("migrates a legacy-only currentSpaceId to the current uid once", () => {
+    const values = new Map<string, string>([
+      ["currentSpaceId", "space-b"],
+    ]);
+    const store = {
+      getItem: (key: string) => values.get(key) ?? null,
+      setItem: (key: string, value: string) => values.set(key, value),
+    };
+    const spaces = [{ space_id: "space-a" }, { space_id: "space-b" }];
+
+    expect(resolveInitialSpaceForUser(spaces, "user-a", null, store)).toEqual(
+      spaces[1]
+    );
+    expect(values.get("octo:last-space:user-a")).toBe("space-b");
+    expect(values.get("octo:last-space-legacy-migration:v1")).toBe("1");
+
+    expect(resolveInitialSpaceForUser(spaces, "user-b", null, store)).toEqual(
+      spaces[0]
+    );
+    expect(values.has("octo:last-space:user-b")).toBe(false);
+  });
+
   it("isolates the last Space by uid while keeping currentSpaceId compatible", () => {
     const values = new Map<string, string>();
     const store = {

--- a/apps/web/src/__tests__/mainInitialSpaceResolution.test.ts
+++ b/apps/web/src/__tests__/mainInitialSpaceResolution.test.ts
@@ -2,9 +2,15 @@ import { describe, expect, it, vi } from "vitest";
 import {
   publishInitialSpaceResolution,
   requestGuardedSpaceChange,
-  resolveInitialSpace,
   shouldPublishInitialSpaceChange,
 } from "../Pages/Main/spaceChange";
+import {
+  getLastSpaceStorageKey,
+  persistActiveSpace,
+  readLastSpaceId,
+  resolveInitialSpace,
+  resolveInitialSpaceForUser,
+} from "../features/spacePreference";
 import {
   requestGuardedBrowserRouteChange,
   requestGuardedMenuChange,
@@ -16,6 +22,58 @@ describe("MainPage initial Space resolution", () => {
     const spaces = [{ space_id: "space-a" }, { space_id: "space-b" }];
     expect(resolveInitialSpace(spaces, "stale-space")).toEqual(spaces[0]);
     expect(resolveInitialSpace(spaces, "space-b")).toEqual(spaces[1]);
+  });
+
+  it("restores the current user's last accessible Space", () => {
+    const spaces = [{ space_id: "space-a" }, { space_id: "space-b" }];
+
+    expect(resolveInitialSpace(spaces, null, "space-b")).toEqual(spaces[1]);
+  });
+
+  it("keeps explicit and current-session choices ahead of device history", () => {
+    const spaces = [
+      { space_id: "space-a" },
+      { space_id: "space-b" },
+      { space_id: "space-c" },
+    ];
+
+    expect(
+      resolveInitialSpace(spaces, "space-c", "space-b", "space-a")
+    ).toEqual(spaces[2]);
+  });
+
+  it("uses one user-scoped resolution path for session, current, and historical choices", () => {
+    const spaces = [
+      { space_id: "space-a" },
+      { space_id: "space-b" },
+      { space_id: "space-c" },
+    ];
+    const values = new Map<string, string>([
+      ["currentSpaceId", "space-b"],
+      ["octo:last-space:user-a", "space-c"],
+    ]);
+    const storage = {
+      getItem: (key: string) => values.get(key) ?? null,
+    };
+
+    expect(
+      resolveInitialSpaceForUser(spaces, "user-a", "space-a", storage)
+    ).toEqual(spaces[0]);
+    expect(resolveInitialSpaceForUser(spaces, "user-a", null, storage)).toEqual(
+      spaces[1]
+    );
+    values.delete("currentSpaceId");
+    expect(resolveInitialSpaceForUser(spaces, "user-a", null, storage)).toEqual(
+      spaces[2]
+    );
+  });
+
+  it("ignores an inaccessible historical Space and uses the first accessible Space", () => {
+    const spaces = [{ space_id: "space-a" }, { space_id: "space-b" }];
+
+    expect(resolveInitialSpace(spaces, null, "removed-space")).toEqual(
+      spaces[0]
+    );
   });
 
   it("publishes the resolved Space only when startup changes the active Space", () => {
@@ -48,6 +106,49 @@ describe("MainPage initial Space resolution", () => {
   it("clears a stale Space when the user has no accessible Spaces", () => {
     expect(resolveInitialSpace([], "stale-space")).toBeUndefined();
     expect(shouldPublishInitialSpaceChange("stale-space", "")).toBe(false);
+  });
+});
+
+describe("per-user last Space persistence", () => {
+  it("isolates the last Space by uid while keeping currentSpaceId compatible", () => {
+    const values = new Map<string, string>();
+    const storage = {
+      getItem: (key: string) => values.get(key) ?? null,
+      setItem: (key: string, value: string) => values.set(key, value),
+    };
+
+    persistActiveSpace("user-a", "space-a", storage);
+    persistActiveSpace("user-b", "space-b", storage);
+
+    expect(values.get("currentSpaceId")).toBe("space-b");
+    expect(readLastSpaceId("user-a", storage)).toBe("space-a");
+    expect(readLastSpaceId("user-b", storage)).toBe("space-b");
+  });
+
+  it("does not persist an account preference without a uid", () => {
+    const setItem = vi.fn();
+
+    persistActiveSpace("", "space-a", { setItem });
+
+    expect(setItem).toHaveBeenCalledOnce();
+    expect(setItem).toHaveBeenCalledWith("currentSpaceId", "space-a");
+    expect(getLastSpaceStorageKey("  ")).toBeUndefined();
+  });
+
+  it("degrades safely when browser storage is unavailable", () => {
+    const unavailableStorage = {
+      getItem: () => {
+        throw new Error("unavailable");
+      },
+      setItem: () => {
+        throw new Error("unavailable");
+      },
+    };
+
+    expect(() =>
+      persistActiveSpace("user-a", "space-a", unavailableStorage)
+    ).not.toThrow();
+    expect(readLastSpaceId("user-a", unavailableStorage)).toBeNull();
   });
 });
 

--- a/apps/web/src/__tests__/mainInitialSpaceResolution.test.ts
+++ b/apps/web/src/__tests__/mainInitialSpaceResolution.test.ts
@@ -5,6 +5,7 @@ import {
   shouldPublishInitialSpaceChange,
 } from "../Pages/Main/spaceChange";
 import {
+  clearLastSpaceId,
   getLastSpaceStorageKey,
   persistActiveSpace,
   readLastSpaceId,
@@ -173,6 +174,26 @@ describe("per-user last Space persistence", () => {
     expect(resolveInitialSpaceForUser(spaces, "user-a", null, store)).toEqual(
       spaces[1]
     );
+  });
+
+  it("does not resurrect the last Space after an empty membership result", () => {
+    const values = new Map<string, string>();
+    const store = {
+      getItem: (key: string) => values.get(key) ?? null,
+      setItem: (key: string, value: string) => values.set(key, value),
+      removeItem: (key: string) => values.delete(key),
+    };
+
+    persistActiveSpace("user-a", "space-a", store);
+    expect(resolveInitialSpaceForUser([], "user-a", "space-a", store)).toBe(
+      undefined
+    );
+
+    clearLastSpaceId("user-a", store);
+    store.removeItem("currentSpaceId");
+
+    expect(readLastSpaceId("user-a", store)).toBeNull();
+    expect(values.has("octo:last-space:user-a")).toBe(false);
   });
 
   it("degrades safely when browser storage is unavailable", () => {

--- a/apps/web/src/__tests__/oidcLogoutWiring.test.ts
+++ b/apps/web/src/__tests__/oidcLogoutWiring.test.ts
@@ -29,6 +29,16 @@ describe("OIDC logout wiring", () => {
     expect(cleanupIdx).toBeLessThan(loadIdx);
   });
 
+  it("clears active organization state during forced device migration logout", () => {
+    const source = readRepoFile("packages/dmworkbase/src/App.tsx");
+    const mismatchBranch = source.match(
+      /if \(!this\._deviceFlagMigrationHandled[\s\S]*?} else if \(!hasDeviceFlagMismatch/
+    )?.[0];
+
+    expect(mismatchBranch).toContain("void this.clearLocalLoginState()");
+    expect(mismatchBranch).not.toContain("WKApp.loginInfo.logout()");
+  });
+
   it("delegates user-initiated OIDC logout to the extracted helper", () => {
     const appSource = readRepoFile("packages/dmworkbase/src/App.tsx");
     const navSource = readRepoFile("packages/dmworkbase/src/Components/NavRail/NavSettingsPanel.tsx");

--- a/apps/web/src/__tests__/spaceGateLastSpaceRestore.test.tsx
+++ b/apps/web/src/__tests__/spaceGateLastSpaceRestore.test.tsx
@@ -1,0 +1,72 @@
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getMySpaces: vi.fn(),
+  notifyListener: vi.fn(),
+  addConfigChangeListener: vi.fn(() => vi.fn()),
+  app: {
+    loginInfo: { uid: "user-a" },
+    shared: {
+      currentSpaceId: "",
+      spaceChecked: false,
+      notifyListener: vi.fn(),
+      logoutUserInitiated: vi.fn(),
+    },
+    remoteConfig: {
+      disableUserCreateSpace: false,
+      addConfigChangeListener: vi.fn(() => vi.fn()),
+    },
+  },
+}));
+
+vi.mock("@octo/base", () => ({
+  I18nContext: React.createContext({}),
+  WKApp: mocks.app,
+  SpaceService: { shared: { getMySpaces: mocks.getMySpaces } },
+  SpaceCreate: () => null,
+  t: (key: string) => key,
+}));
+
+vi.mock("@douyinfe/semi-ui", () => ({
+  Button: () => null,
+  Input: () => null,
+  Spin: () => null,
+  Toast: { success: vi.fn(), warning: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock("lucide-react", () => ({ LogOut: () => null }));
+
+import SpaceGate from "../Components/SpaceGate";
+
+describe("SpaceGate last organization restore", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    mocks.app.loginInfo.uid = "user-a";
+    mocks.app.shared.currentSpaceId = "";
+    mocks.app.shared.spaceChecked = false;
+    mocks.getMySpaces.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("restores the current UID preference after currentSpaceId was cleared", async () => {
+    localStorage.setItem("octo:last-space:user-a", "space-b");
+    mocks.getMySpaces.mockResolvedValue([
+      { space_id: "space-a" },
+      { space_id: "space-b" },
+    ]);
+    const gate = new SpaceGate({});
+    gate.forceUpdate = vi.fn();
+
+    gate.componentDidMount();
+    await vi.waitFor(() => {
+      expect(mocks.app.shared.currentSpaceId).toBe("space-b");
+    });
+
+    expect(localStorage.getItem("currentSpaceId")).toBe("space-b");
+    gate.componentWillUnmount();
+  });
+});

--- a/apps/web/src/__tests__/spaceGateLastSpaceRestore.test.tsx
+++ b/apps/web/src/__tests__/spaceGateLastSpaceRestore.test.tsx
@@ -69,4 +69,25 @@ describe("SpaceGate last organization restore", () => {
     expect(localStorage.getItem("currentSpaceId")).toBe("space-b");
     gate.componentWillUnmount();
   });
+
+  it("migrates and restores a legacy-only currentSpaceId on first load", async () => {
+    localStorage.setItem("currentSpaceId", "space-b");
+    mocks.getMySpaces.mockResolvedValue([
+      { space_id: "space-a" },
+      { space_id: "space-b" },
+    ]);
+    const gate = new SpaceGate({});
+    gate.forceUpdate = vi.fn();
+
+    gate.componentDidMount();
+    await vi.waitFor(() => {
+      expect(mocks.app.shared.currentSpaceId).toBe("space-b");
+    });
+
+    expect(localStorage.getItem("octo:last-space:user-a")).toBe("space-b");
+    expect(localStorage.getItem("octo:last-space-legacy-migration:v1")).toBe(
+      "1"
+    );
+    gate.componentWillUnmount();
+  });
 });

--- a/apps/web/src/features/spacePreference.ts
+++ b/apps/web/src/features/spacePreference.ts
@@ -1,0 +1,72 @@
+const CURRENT_SPACE_STORAGE_KEY = "currentSpaceId";
+const LAST_SPACE_STORAGE_PREFIX = "octo:last-space:";
+
+export function getLastSpaceStorageKey(uid: string): string | undefined {
+  const normalizedUid = uid.trim();
+  if (!normalizedUid) return undefined;
+  return `${LAST_SPACE_STORAGE_PREFIX}${encodeURIComponent(normalizedUid)}`;
+}
+
+export function readLastSpaceId(
+  uid: string,
+  storage: Pick<Storage, "getItem"> = localStorage
+): string | null {
+  const key = getLastSpaceStorageKey(uid);
+  if (!key) return null;
+
+  try {
+    return storage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+export function persistActiveSpace(
+  uid: string,
+  spaceId: string,
+  storage: Pick<Storage, "setItem"> = localStorage
+): void {
+  if (!spaceId) return;
+
+  try {
+    storage.setItem(CURRENT_SPACE_STORAGE_KEY, spaceId);
+    const lastSpaceKey = getLastSpaceStorageKey(uid);
+    if (lastSpaceKey) storage.setItem(lastSpaceKey, spaceId);
+  } catch {
+    // Storage can be unavailable in privacy-restricted browser contexts.
+  }
+}
+
+export function resolveInitialSpace<T extends { space_id: string }>(
+  spaces: T[],
+  ...preferredSpaceIds: Array<string | null | undefined>
+): T | undefined {
+  for (const spaceId of preferredSpaceIds) {
+    if (!spaceId) continue;
+    const preferredSpace = spaces.find((space) => space.space_id === spaceId);
+    if (preferredSpace) return preferredSpace;
+  }
+
+  return spaces[0];
+}
+
+export function resolveInitialSpaceForUser<T extends { space_id: string }>(
+  spaces: T[],
+  uid: string,
+  activeSpaceId: string | null | undefined,
+  storage: Pick<Storage, "getItem"> = localStorage
+): T | undefined {
+  let savedSpaceId: string | null = null;
+  try {
+    savedSpaceId = storage.getItem(CURRENT_SPACE_STORAGE_KEY);
+  } catch {
+    // The in-memory and fallback candidates still work without storage.
+  }
+
+  return resolveInitialSpace(
+    spaces,
+    activeSpaceId,
+    savedSpaceId,
+    readLastSpaceId(uid, storage)
+  );
+}

--- a/apps/web/src/features/spacePreference.ts
+++ b/apps/web/src/features/spacePreference.ts
@@ -1,5 +1,9 @@
 const CURRENT_SPACE_STORAGE_KEY = "currentSpaceId";
 const LAST_SPACE_STORAGE_PREFIX = "octo:last-space:";
+const LEGACY_SPACE_MIGRATION_KEY = "octo:last-space-legacy-migration:v1";
+
+type SpacePreferenceReader = Pick<Storage, "getItem"> &
+  Partial<Pick<Storage, "setItem">>;
 
 export function getLastSpaceStorageKey(
   uid: string | null | undefined
@@ -11,13 +15,47 @@ export function getLastSpaceStorageKey(
 
 export function readLastSpaceId(
   uid: string | null | undefined,
-  store: Pick<Storage, "getItem"> = localStorage
+  store: SpacePreferenceReader = localStorage
 ): string | null {
   const key = getLastSpaceStorageKey(uid);
   if (!key) return null;
 
   try {
-    return store.getItem(key);
+    const lastSpaceId = store.getItem(key);
+    if (lastSpaceId) {
+      // Once UID-scoped data exists, the legacy global key must never be
+      // adopted by another account on this device.
+      try {
+        store.setItem?.(LEGACY_SPACE_MIGRATION_KEY, "1");
+      } catch {
+        // The UID-scoped value is still safe to read when storage is read-only.
+      }
+      return lastSpaceId;
+    }
+
+    if (
+      store.getItem(LEGACY_SPACE_MIGRATION_KEY) !== null ||
+      !store.setItem
+    ) {
+      return null;
+    }
+
+    const legacySpaceId = store.getItem(CURRENT_SPACE_STORAGE_KEY);
+
+    // Mark first so an interrupted migration cannot let a later account
+    // inherit the same global value. The selected Space is still validated
+    // against /space/my before it is entered.
+    store.setItem(LEGACY_SPACE_MIGRATION_KEY, "1");
+    if (legacySpaceId) {
+      try {
+        store.setItem(key, legacySpaceId);
+      } catch {
+        // The legacy value remains valid for this session. The marker prevents
+        // it from being adopted by a different uid later.
+      }
+    }
+
+    return legacySpaceId;
   } catch {
     return null;
   }

--- a/apps/web/src/features/spacePreference.ts
+++ b/apps/web/src/features/spacePreference.ts
@@ -77,6 +77,20 @@ export function persistActiveSpace(
   }
 }
 
+export function clearLastSpaceId(
+  uid: string | null | undefined,
+  store: Pick<Storage, "removeItem"> = localStorage
+): void {
+  const lastSpaceKey = getLastSpaceStorageKey(uid);
+  if (!lastSpaceKey) return;
+
+  try {
+    store.removeItem(lastSpaceKey);
+  } catch {
+    // Storage can be unavailable in privacy-restricted browser contexts.
+  }
+}
+
 export function resolveInitialSpace<T extends { space_id: string }>(
   spaces: T[],
   ...preferredSpaceIds: Array<string | null | undefined>

--- a/apps/web/src/features/spacePreference.ts
+++ b/apps/web/src/features/spacePreference.ts
@@ -1,37 +1,39 @@
 const CURRENT_SPACE_STORAGE_KEY = "currentSpaceId";
 const LAST_SPACE_STORAGE_PREFIX = "octo:last-space:";
 
-export function getLastSpaceStorageKey(uid: string): string | undefined {
-  const normalizedUid = uid.trim();
+export function getLastSpaceStorageKey(
+  uid: string | null | undefined
+): string | undefined {
+  const normalizedUid = typeof uid === "string" ? uid.trim() : "";
   if (!normalizedUid) return undefined;
   return `${LAST_SPACE_STORAGE_PREFIX}${encodeURIComponent(normalizedUid)}`;
 }
 
 export function readLastSpaceId(
-  uid: string,
-  storage: Pick<Storage, "getItem"> = localStorage
+  uid: string | null | undefined,
+  store: Pick<Storage, "getItem"> = localStorage
 ): string | null {
   const key = getLastSpaceStorageKey(uid);
   if (!key) return null;
 
   try {
-    return storage.getItem(key);
+    return store.getItem(key);
   } catch {
     return null;
   }
 }
 
 export function persistActiveSpace(
-  uid: string,
+  uid: string | null | undefined,
   spaceId: string,
-  storage: Pick<Storage, "setItem"> = localStorage
+  store: Pick<Storage, "setItem"> = localStorage
 ): void {
   if (!spaceId) return;
 
   try {
-    storage.setItem(CURRENT_SPACE_STORAGE_KEY, spaceId);
+    store.setItem(CURRENT_SPACE_STORAGE_KEY, spaceId);
     const lastSpaceKey = getLastSpaceStorageKey(uid);
-    if (lastSpaceKey) storage.setItem(lastSpaceKey, spaceId);
+    if (lastSpaceKey) store.setItem(lastSpaceKey, spaceId);
   } catch {
     // Storage can be unavailable in privacy-restricted browser contexts.
   }
@@ -52,21 +54,13 @@ export function resolveInitialSpace<T extends { space_id: string }>(
 
 export function resolveInitialSpaceForUser<T extends { space_id: string }>(
   spaces: T[],
-  uid: string,
+  uid: string | null | undefined,
   activeSpaceId: string | null | undefined,
-  storage: Pick<Storage, "getItem"> = localStorage
+  store: Pick<Storage, "getItem"> = localStorage
 ): T | undefined {
-  let savedSpaceId: string | null = null;
-  try {
-    savedSpaceId = storage.getItem(CURRENT_SPACE_STORAGE_KEY);
-  } catch {
-    // The in-memory and fallback candidates still work without storage.
-  }
-
   return resolveInitialSpace(
     spaces,
     activeSpaceId,
-    savedSpaceId,
-    readLastSpaceId(uid, storage)
+    readLastSpaceId(uid, store)
   );
 }

--- a/packages/dmworkbase/src/App.tsx
+++ b/packages/dmworkbase/src/App.tsx
@@ -1052,7 +1052,7 @@ export default class WKApp extends ProviderListener {
       );
       this._deviceFlagMigrationHandled = true;
       markDeviceFlagMigration(migrationSid);
-      WKApp.loginInfo.logout();
+      void this.clearLocalLoginState();
     } else if (!hasDeviceFlagMismatch && WKApp.loginInfo.isLogined()) {
       // A matching session supersedes any marker left by an interrupted boot.
       clearDeviceFlagMigration(migrationSid);

--- a/packages/dmworkbase/src/Service/__tests__/oidcLogout.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/oidcLogout.test.ts
@@ -212,6 +212,7 @@ describe("oidcLogout helpers", () => {
     sessionStorage.setItem("theme-mode", "dark");
     localStorage.setItem("tokenabc", "t");
     localStorage.setItem("currentSpaceId", "s1");
+    localStorage.setItem("octo:last-space:user-a", "s1");
     localStorage.setItem("i18n_lang", "zh-CN");
 
     clearAuthStorage();
@@ -227,6 +228,7 @@ describe("oidcLogout helpers", () => {
     expect(sessionStorage.getItem("octo.docs.standaloneReturn")).toBeNull();
     expect(localStorage.getItem("tokenabc")).toBeNull();
     expect(localStorage.getItem("currentSpaceId")).toBeNull();
+    expect(localStorage.getItem("octo:last-space:user-a")).toBe("s1");
     expect(sessionStorage.getItem("theme-mode")).toBe("dark");
     expect(localStorage.getItem("i18n_lang")).toBe("zh-CN");
   });

--- a/packages/dmworkbase/src/Service/oidcLogout.ts
+++ b/packages/dmworkbase/src/Service/oidcLogout.ts
@@ -18,6 +18,8 @@ const AUTH_STORAGE_PREFIXES = [
 
 const AUTH_STORAGE_KEYS = [
   "currentSpaceId",
+  // `octo:last-space:<uid>` is intentionally not cleared: it is a device
+  // preference used to restore the same account's last active organization.
   "pending_oidc_login",
   // One-time standalone authorization targets are owned by the account that
   // opened them and must not be replayed after another account signs in.


### PR DESCRIPTION
## Summary

- persist the last active organization in a UID-scoped local preference while keeping `currentSpaceId` as logout-cleared compatibility state
- migrate an existing legacy-only `currentSpaceId` to the current UID exactly once, with a global marker preventing another account from inheriting it
- make the UID-scoped preference authoritative on reload and validate every candidate against the current `/space/my` result
- route Main, SpaceGate, JoinSpacePage, InviteLanding, and post-login invite writes through one persistence helper
- preserve explicit in-memory/deep-link targets, handle already-member invite targets, and tolerate missing UID or unavailable browser storage
- clear active organization state during forced device-migration logout while retaining per-user history

## Behavior

Resolution order is: validated explicit/in-memory target, current UID last-used organization, then the first accessible organization. On the first load after upgrading, an existing legacy `currentSpaceId` is adopted by the current UID once and remains membership-validated. The global key continues to be written for existing consumers but is not reused by later accounts.

This remains device-local; it does not add a server-side default organization or cross-device synchronization.

## Testing

- `cd apps/web && pnpm exec vitest run src/__tests__/mainInitialSpaceResolution.test.ts src/__tests__/spaceGateLastSpaceRestore.test.tsx src/__tests__/layoutPendingInviteToast.test.ts src/__tests__/inviteLandingCrossSpaceToast.test.ts src/__tests__/oidcLogoutWiring.test.ts` (54 passed)
- `cd packages/dmworkbase && pnpm exec vitest run src/Service/__tests__/oidcLogout.test.ts` (23 passed)
- `pnpm build` (full monorepo build, including the WXT extension)

Fixes #1212
