### PR TITLE
fix(chat): persist pinned child threads

### DIFF
--- a/apps/web/e2e-kit/msw-handlers/chat-baseline.ts
+++ b/apps/web/e2e-kit/msw-handlers/chat-baseline.ts
@@ -156,6 +156,7 @@ export const chatBaselineHandlers = [
       server_time: new Date().toISOString(),
     })
   ),
+  http.get("*/api/v1/user/pinned", () => HttpResponse.json([])),
   http.put("*/user/language", () => HttpResponse.json({})),
 
   // === Contacts / friends ===

--- a/packages/dmworkbase/src/Components/ConversationList/__tests__/layout.test.tsx
+++ b/packages/dmworkbase/src/Components/ConversationList/__tests__/layout.test.tsx
@@ -19,6 +19,8 @@ let ConversationList: typeof import("../index").default;
 let container: HTMLDivElement;
 const apiPut = vi.fn();
 const toastError = vi.fn();
+const notifyConversationListeners = vi.fn();
+const topChannelSetting = vi.fn(() => Promise.resolve());
 
 class MockChannel {
   channelID: string;
@@ -51,6 +53,9 @@ beforeAll(async () => {
           fetchChannelInfo: vi.fn(),
           getChannelInfo: vi.fn(),
         },
+        conversationManager: {
+          notifyConversationListeners,
+        },
       }),
     };
 
@@ -60,6 +65,7 @@ beforeAll(async () => {
       Channel: MockChannel,
       ChannelTypePerson: 1,
       ChannelTypeGroup: 2,
+      ConversationAction: { update: "update" },
       ReminderType: {
         ReminderTypeMentionMe: 1,
       },
@@ -154,6 +160,11 @@ beforeAll(async () => {
         mute: vi.fn(() => Promise.resolve()),
       },
     },
+  }));
+
+  vi.doMock("../../../bridge/channelSetting/channelSettingActions", () => ({
+    muteChannelSetting: vi.fn(() => Promise.resolve()),
+    topChannelSetting,
   }));
 
   vi.doMock("../../../Service/Model", () => ({
@@ -569,6 +580,60 @@ describe("ConversationList context-menu matrix", () => {
       "base.chatSidebar.context.unfollow",
       "base.conversationList.context.mute",
     ]);
+  });
+
+  it("updates a Recent child thread immediately after the persisted pin succeeds", async () => {
+    const thread = makeCompactConversation(
+      "group-a____thread-a",
+      3,
+      "group-a"
+    ) as any;
+    thread.conversation = {
+      channel: thread.channel,
+      extra: { top: 0 },
+    };
+    thread.extra = thread.conversation.extra;
+
+    act(() => {
+      ReactDOM.render(
+        <ConversationList conversations={[thread]} />,
+        container
+      );
+    });
+    openContextMenu(".wk-conversationlist-item");
+
+    expect(currentMenuOrder()[0]).toBe("base.conversationList.context.pin");
+    await act(async () => {
+      (container.querySelector(
+        '[data-menu-title="base.conversationList.context.pin"]'
+      ) as HTMLElement).click();
+      await Promise.resolve();
+    });
+
+    expect(topChannelSetting).toHaveBeenCalledWith({
+      channel: thread.channel,
+      top: true,
+    });
+    expect(thread.conversation.extra.top).toBe(1);
+    expect(notifyConversationListeners).toHaveBeenCalledWith(
+      thread.conversation,
+      expect.anything()
+    );
+    expect(currentMenuOrder()[0]).toBe("base.conversationList.context.unpin");
+
+    await act(async () => {
+      (container.querySelector(
+        '[data-menu-title="base.conversationList.context.unpin"]'
+      ) as HTMLElement).click();
+      await Promise.resolve();
+    });
+
+    expect(topChannelSetting).toHaveBeenLastCalledWith({
+      channel: thread.channel,
+      top: false,
+    });
+    expect(thread.conversation.extra.top).toBe(0);
+    expect(currentMenuOrder()[0]).toBe("base.conversationList.context.pin");
   });
 
   it("keeps unread state and reports an error when clear-unread fails", async () => {

--- a/packages/dmworkbase/src/Components/ConversationList/index.tsx
+++ b/packages/dmworkbase/src/Components/ConversationList/index.tsx
@@ -65,6 +65,15 @@ import { getBrowserUnreadConversationSync } from "../../features/documentTitle";
 import { hideConversation } from "./hideConversation";
 export type ConvFilter = "all" | "human" | "ai" | "group" | "dm";
 
+export function isConversationPinned(conversationWrap: ConversationWrap): boolean {
+  if (
+    conversationWrap.channel.channelType === ChannelTypeCommunityTopic
+  ) {
+    return conversationWrap.extra?.top === 1;
+  }
+  return !!conversationWrap.channelInfo?.top;
+}
+
 // ── 在线态判定/渲染 helper ──────────────────────────────────────────────
 // 最近列表（非 compact）与关注/收藏列表（compact 的 CompactGroupItem）共用同一份
 // 判定与 tip 文案，保证两处在线圆点的数据源、阈值、文案完全一致，避免逻辑复制漂移。
@@ -786,7 +795,9 @@ export default class ConversationList extends Component<
         className={classNames(
           "wk-conversationlist-item",
           selected ? "wk-conversationlist-item-selected" : undefined,
-          channelInfo?.top ? "wk-conversationlist-item-top" : undefined,
+          isConversationPinned(conversationWrap)
+            ? "wk-conversationlist-item-top"
+            : undefined,
           totalUnread > 0
             ? "wk-conversationlist-item-unread"
             : undefined,
@@ -939,13 +950,30 @@ export default class ConversationList extends Component<
     );
   }
 
-  onTop(channelInfo: ChannelInfo) {
+  onTop(conversationWrap: ConversationWrap) {
+    const channelInfo = conversationWrap.channelInfo;
+    const isThread =
+      conversationWrap.channel.channelType === ChannelTypeCommunityTopic;
+    if (!isThread && !channelInfo) return;
+    const top = !isConversationPinned(conversationWrap);
     // 置顶埋点(conversation_pinned)已收口到 topChannelSetting 内部,这里不再本地派生 willPin
     // 供埋点使用;仅按当前状态取反传入(#1452 review P2-7)。
     topChannelSetting({
-      channel: channelInfo.channel,
-      top: !channelInfo.top,
+      channel: conversationWrap.channel,
+      top,
     })
+      .then(() => {
+        if (!isThread) return;
+        conversationWrap.conversation.extra =
+          conversationWrap.conversation.extra || {};
+        conversationWrap.conversation.extra.top = top ? 1 : 0;
+        if (channelInfo) channelInfo.top = top;
+        this.setState({});
+        WKSDK.shared().conversationManager.notifyConversationListeners(
+          conversationWrap.conversation,
+          ConversationAction.update
+        );
+      })
       .catch((err) => {
         Toast.error(err?.msg);
       });
@@ -1222,7 +1250,7 @@ export default class ConversationList extends Component<
     }
     const groupedPinned = grouped.filter((item) => {
       if ("type" in item) return false;
-      return (item as ConversationWrap).channelInfo?.top;
+      return isConversationPinned(item as ConversationWrap);
     });
 
     // 子区和溢出提示跟随父群组：如果父群组被置顶，把它的子区也移到置顶区
@@ -1251,7 +1279,7 @@ export default class ConversationList extends Component<
         }
       } else {
         const conv = item as ConversationWrap;
-        if (conv.channelInfo?.top) {
+        if (isConversationPinned(conv)) {
           finalPinned.push(item);
         } else if (compact && conv.channel.channelType === ChannelTypeCommunityTopic) {
           // compact 嵌套语义：子区跟随父群组
@@ -1364,16 +1392,17 @@ export default class ConversationList extends Component<
               : [];
 
             const menus: ContextMenusData[] = [];
+            const isPinned = conv ? isConversationPinned(conv) : false;
 
             // 1. 置顶 / 取消置顶（最近页个人、群聊和活跃子区）
             if (!this.props.hidePin) {
               menus.push({
-                title: channelInfo?.top
+                title: isPinned
                   ? t("base.conversationList.context.unpin")
                   : t("base.conversationList.context.pin"),
-                icon: channelInfo?.top ? PinOff : Pin,
+                icon: isPinned ? PinOff : Pin,
                 onClick: () => {
-                  if (channelInfo) this.onTop(channelInfo);
+                  if (conv) this.onTop(conv);
                 },
               });
             }

--- a/packages/dmworkbase/src/Pages/Chat/__tests__/vm.channelListener.test.ts
+++ b/packages/dmworkbase/src/Pages/Chat/__tests__/vm.channelListener.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest"
 // 捕获 ChatVM.channelListener（didMount 里通过 channelManager.addListener 注册）。
 const hoisted = vi.hoisted(() => ({
     channelListener: undefined as undefined | ((channelInfo: any) => void),
+    conversationListener: undefined as undefined | ((conversation: any, action: string) => void),
     spaceChangedHandler: undefined as undefined | ((space: any) => void),
     activeMenuHandlers: new Set<(payload: { menuId?: string }) => void>(),
     removeChannelListener: vi.fn(),
@@ -15,7 +16,9 @@ vi.mock("wukongimjssdk", () => ({
         shared: () => ({
             conversationManager: {
                 conversations: [],
-                addConversationListener: () => {},
+                addConversationListener: (listener: (conversation: any, action: string) => void) => {
+                    hoisted.conversationListener = listener
+                },
                 removeConversationListener: () => {},
                 findConversation: () => undefined,
                 sync: () => Promise.resolve([]),
@@ -56,7 +59,7 @@ vi.mock("wukongimjssdk", () => ({
     ChannelTypeGroup: 2,
     ChannelTypePerson: 1,
     Conversation: class {},
-    ConversationAction: {},
+    ConversationAction: { add: "add", update: "update", remove: "remove" },
     ConnectStatus: { Connected: 1, Disconnect: 0 },
     Message: class {},
     MessageContent: class {},
@@ -192,7 +195,7 @@ describe("ChatVM.channelListener — CommunityTopic 子区同步 (issue #345)", 
         expect(notifySpy).toHaveBeenCalledTimes(1)
     })
 
-    it("子区在 conversations 中时也 notifyListener（既有 top 分支）", () => {
+    it("子区 channelInfo 更新不会覆盖 pinned 快照中的置顶状态", () => {
         const vm = mountVM()
         const threadChannel = {
             channelID: "g1____t2",
@@ -203,7 +206,7 @@ describe("ChatVM.channelListener — CommunityTopic 子区同步 (issue #345)", 
         vm.conversations = [
             {
                 channel: threadChannel,
-                extra: {},
+                extra: { top: 1 },
             } as any,
         ]
         const notifySpy = vi.spyOn(vm, "notifyListener")
@@ -214,6 +217,7 @@ describe("ChatVM.channelListener — CommunityTopic 子区同步 (issue #345)", 
         })
 
         expect(notifySpy).toHaveBeenCalledTimes(1)
+        expect(vm.conversations[0].extra.top).toBe(1)
     })
 
     it("非子区且不在 conversations 的群 channelInfo 不会走子区分支", () => {
@@ -253,6 +257,34 @@ describe("ChatVM.channelListener — CommunityTopic 子区同步 (issue #345)", 
 
         expect(hoisted.removeChannelListener).toHaveBeenCalledTimes(1)
         expect(hoisted.removeChannelListener).toHaveBeenCalledWith(hoisted.channelListener)
+    })
+})
+
+describe("ChatVM.conversationListener — child-thread pin state", () => {
+    it("keeps the persisted pin when an ordinary conversation update lacks pinned data", () => {
+        const vm = mountVM()
+        const channel = {
+            channelID: "g1____t4",
+            channelType: ChannelTypeCommunityTopic,
+            isEqual: (other: any) =>
+                other?.channelID === "g1____t4" && other?.channelType === ChannelTypeCommunityTopic,
+        }
+        vm.conversations = [
+            {
+                channel,
+                conversation: { channel, timestamp: 1, extra: { top: 1 } },
+                extra: { top: 1 },
+                timestamp: 1,
+            } as any,
+        ]
+        vi.spyOn(vm, "currentConversationListY").mockReturnValue(undefined)
+
+        hoisted.conversationListener!(
+            { channel, timestamp: 2, extra: { top: 0 } },
+            "update"
+        )
+
+        expect(vm.conversations[0].extra.top).toBe(1)
     })
 })
 

--- a/packages/dmworkbase/src/Pages/Chat/__tests__/vm.channelListener.test.ts
+++ b/packages/dmworkbase/src/Pages/Chat/__tests__/vm.channelListener.test.ts
@@ -155,6 +155,7 @@ vi.mock("../../../Utils/download", () => ({
 
 import { ChatVM } from "../vm"
 import WKApp from "../../../App"
+import { ConversationWrap } from "../../../Service/Model"
 import { chatPageTitleController } from "../chatPageTitleController"
 
 // 真实 Const 值：子区频道 channelType = 5
@@ -270,12 +271,11 @@ describe("ChatVM.conversationListener — child-thread pin state", () => {
                 other?.channelID === "g1____t4" && other?.channelType === ChannelTypeCommunityTopic,
         }
         vm.conversations = [
-            {
+            new ConversationWrap({
                 channel,
-                conversation: { channel, timestamp: 1, extra: { top: 1 } },
                 extra: { top: 1 },
                 timestamp: 1,
-            } as any,
+            } as any),
         ]
         vi.spyOn(vm, "currentConversationListY").mockReturnValue(undefined)
 

--- a/packages/dmworkbase/src/Pages/Chat/__tests__/vm.sortConversations.test.ts
+++ b/packages/dmworkbase/src/Pages/Chat/__tests__/vm.sortConversations.test.ts
@@ -160,6 +160,14 @@ function makeConversation(id: string, timestamp: number, top = 0): ConversationW
     } as any)
 }
 
+function deferred<T>() {
+    let resolve!: (value: T) => void
+    const promise = new Promise<T>((resolvePromise) => {
+        resolve = resolvePromise
+    })
+    return { promise, resolve }
+}
+
 describe("ChatVM.sortConversations", () => {
     it("replaces vm.conversations with a newly sorted array so memoized recent lists recalculate", () => {
         const vm = new ChatVM()
@@ -214,6 +222,64 @@ describe("ChatVM.reloadRequestConversationList", () => {
 
         expect(vm.loading).toBe(false)
         expect(notifyListener).toHaveBeenCalled()
+    })
+
+    it("does not let a stale Space sync overwrite the active Space", async () => {
+        const vm = new ChatVM()
+        const spaceASync = deferred<any[]>()
+        const spaceAPins = deferred<any[]>()
+        const spaceAConversation = makeConversation("space-a", 100)
+        const spaceBConversation = makeConversation("space-b", 200)
+        ;(WKApp.shared as any).currentSpaceId = "space-a"
+        hoisted.sync
+            .mockReturnValueOnce(spaceASync.promise)
+            .mockResolvedValueOnce([spaceBConversation.conversation])
+        hoisted.pinnedList
+            .mockReturnValueOnce(spaceAPins.promise)
+            .mockResolvedValueOnce([])
+
+        const spaceARequest = vm.reloadRequestConversationList()
+        let spaceARequestSettled = false
+        void spaceARequest.then(() => {
+            spaceARequestSettled = true
+        })
+        ;(WKApp.shared as any).currentSpaceId = "space-b"
+        await vm.reloadRequestConversationList()
+
+        expect(vm.conversations.map((item) => item.channel.channelID)).toEqual(["space-b"])
+
+        spaceASync.resolve([spaceAConversation.conversation])
+        await Promise.resolve()
+        await Promise.resolve()
+
+        expect(spaceARequestSettled).toBe(true)
+        expect(vm.conversations.map((item) => item.channel.channelID)).toEqual(["space-b"])
+    })
+
+    it("does not let a stale Space pinned snapshot overwrite the active Space", async () => {
+        const vm = new ChatVM()
+        const spaceAPins = deferred<any[]>()
+        const spaceAConversation = makeConversation("space-a", 100)
+        const spaceBConversation = makeConversation("space-b", 200)
+        ;(WKApp.shared as any).currentSpaceId = "space-a"
+        hoisted.sync
+            .mockResolvedValueOnce([spaceAConversation.conversation])
+            .mockResolvedValueOnce([spaceBConversation.conversation])
+        hoisted.pinnedList
+            .mockReturnValueOnce(spaceAPins.promise)
+            .mockResolvedValueOnce([])
+
+        const spaceARequest = vm.reloadRequestConversationList()
+        await Promise.resolve()
+        ;(WKApp.shared as any).currentSpaceId = "space-b"
+        await vm.reloadRequestConversationList()
+
+        expect(vm.conversations.map((item) => item.channel.channelID)).toEqual(["space-b"])
+
+        spaceAPins.resolve([])
+        await spaceARequest
+
+        expect(vm.conversations.map((item) => item.channel.channelID)).toEqual(["space-b"])
     })
 })
 

--- a/packages/dmworkbase/src/Pages/Chat/__tests__/vm.sortConversations.test.ts
+++ b/packages/dmworkbase/src/Pages/Chat/__tests__/vm.sortConversations.test.ts
@@ -1,7 +1,8 @@
-import { describe, expect, it, vi } from "vitest"
+import { beforeEach, describe, expect, it, vi } from "vitest"
 
 const hoisted = vi.hoisted(() => ({
     emit: vi.fn(),
+    pinnedList: vi.fn(() => Promise.resolve([])),
     sync: vi.fn(() => Promise.resolve([])),
 }))
 
@@ -108,6 +109,10 @@ vi.mock("../../../Service/ProhibitwordsService", () => ({
     ProhibitwordsService: { shared: { filter: (text: string) => text } },
 }))
 
+vi.mock("../../../Service/PinnedService", () => ({
+    default: { list: hoisted.pinnedList },
+}))
+
 vi.mock("../../../Service/SpaceService", () => ({
     SpaceService: { shared: { getMembers: () => Promise.resolve([]) } },
     shouldSkipChannelForSpace: () => false,
@@ -133,6 +138,14 @@ vi.mock("../../../Utils/download", () => ({
 
 import { ChatVM } from "../vm"
 import { ConversationWrap } from "../../../Service/Model"
+import WKApp from "../../../App"
+
+beforeEach(() => {
+    vi.clearAllMocks()
+    hoisted.sync.mockResolvedValue([])
+    hoisted.pinnedList.mockResolvedValue([])
+    ;(WKApp.shared as any).currentSpaceId = ""
+})
 
 function makeConversation(id: string, timestamp: number, top = 0): ConversationWrap {
     return new ConversationWrap({
@@ -220,5 +233,65 @@ describe("ChatVM.requestConversationList", () => {
             expect.any(Error)
         )
         consoleError.mockRestore()
+    })
+
+    it("restores persisted child-thread pin state before sorting the recent list", async () => {
+        const vm = new ChatVM()
+        const thread = {
+            channel: {
+                channelID: "group-1____thread-1",
+                channelType: 5,
+                getChannelKey: () => "group-1____thread-1-5",
+            },
+            timestamp: 100,
+            extra: { top: 0 },
+        }
+        const newer = {
+            channel: {
+                channelID: "alice",
+                channelType: 1,
+                getChannelKey: () => "alice-1",
+            },
+            timestamp: 300,
+            extra: { top: 0 },
+        }
+        ;(WKApp.shared as any).currentSpaceId = "space-1"
+        hoisted.sync.mockResolvedValueOnce([newer, thread] as any)
+        hoisted.pinnedList.mockResolvedValueOnce([
+            {
+                channel_id: "group-1____thread-1",
+                channel_type: 5,
+                sort_order: 1,
+            },
+        ])
+
+        await vm.requestConversationList()
+
+        expect(hoisted.pinnedList).toHaveBeenCalledTimes(1)
+        expect(thread.extra.top).toBe(1)
+        expect(vm.conversations.map((item) => item.channel.channelID)).toEqual([
+            "group-1____thread-1",
+            "alice",
+        ])
+    })
+
+    it("clears stale child-thread pin state when the persisted snapshot is empty", async () => {
+        const vm = new ChatVM()
+        const thread = {
+            channel: {
+                channelID: "group-1____thread-1",
+                channelType: 5,
+                getChannelKey: () => "group-1____thread-1-5",
+            },
+            timestamp: 100,
+            extra: { top: 1 },
+        }
+        ;(WKApp.shared as any).currentSpaceId = "space-1"
+        hoisted.sync.mockResolvedValueOnce([thread] as any)
+        hoisted.pinnedList.mockResolvedValueOnce([])
+
+        await vm.requestConversationList()
+
+        expect(thread.extra.top).toBe(0)
     })
 })

--- a/packages/dmworkbase/src/Pages/Chat/vm.ts
+++ b/packages/dmworkbase/src/Pages/Chat/vm.ts
@@ -31,9 +31,29 @@ import {
 } from "../../features/documentTitle";
 import { chatPageTitleController } from "./chatPageTitleController";
 import { Dap } from "../../Service/Dap";
+import PinnedService, { PinnedChannelItem } from "../../Service/PinnedService";
 
 
 const TOP_CONVERSATION_SCORE_BOOST = 1000000000000;
+
+export function applyPinnedThreadSnapshot(
+    conversations: Conversation[],
+    pinnedChannels: PinnedChannelItem[] | undefined,
+) {
+    if (!pinnedChannels) return
+
+    const pinnedThreadIds = new Set(
+        pinnedChannels
+            .filter((item) => item.channel_type === ChannelTypeCommunityTopic)
+            .map((item) => item.channel_id)
+    )
+    for (const conversation of conversations) {
+        if (conversation.channel.channelType !== ChannelTypeCommunityTopic) continue
+        conversation.extra = conversation.extra || {}
+        conversation.extra.top = pinnedThreadIds.has(conversation.channel.channelID) ? 1 : 0
+    }
+}
+
 export class ChatVM extends ProviderListener {
   conversations: ConversationWrap[] = new Array();
   // 首次权威 conversation sync 完成前保持加载态，避免用未完成快照计算 Tab 未读角标。
@@ -300,6 +320,15 @@ export class ChatVM extends ProviderListener {
                 if (shouldSkipPersonConversationForSpace(conversation)) return
                 const existConversation = this.findConversation(conversation.channel)
                 if (existConversation) {
+                    if (
+                        conversation.channel.channelType === ChannelTypeCommunityTopic &&
+                        existConversation.extra?.top === 1
+                    ) {
+                        // 普通会话实时更新不携带 /user/pinned 的子区置顶状态，保留当前
+                        // 已从 pinned 快照恢复的值，避免一条新消息把子区重新打回未置顶。
+                        conversation.extra = conversation.extra || {}
+                        conversation.extra.top = 1
+                    }
                     existConversation.conversation = conversation
                     // WS 更新后有条件清除 spaceLastMessage (#783)
                     // 只在新消息属于当前 Space 时清除（有更新的实时消息可用）
@@ -343,7 +372,11 @@ export class ChatVM extends ProviderListener {
             }
             const conversation = this.findConversation(channelInfo.channel)
             if (conversation) {
-                conversation.extra.top = channelInfo.top ? 1 : 0
+                // 子区置顶由 /user/pinned 持久化；子区 channelInfo 的 setting 响应只含
+                // mute，不得用缺省的 channelInfo.top=false 覆盖已加载的置顶快照。
+                if (channelInfo.channel.channelType !== ChannelTypeCommunityTopic) {
+                    conversation.extra.top = channelInfo.top ? 1 : 0
+                }
                 this.sortConversations()
                 this.notifyListener()
             } else if (channelInfo.channel.channelType === ChannelTypeCommunityTopic) {
@@ -610,6 +643,12 @@ export class ChatVM extends ProviderListener {
         // B 的回包可能晚于 C 的回包到达;如果直接写入会把 C 的 cache 覆盖成 B 的
         // (甚至空数组,见 dmworkdatasource/module.ts 的 stale guard)。
         const requestSpaceId = WKApp.shared.currentSpaceId
+        const pinnedChannelsPromise = requestSpaceId
+            ? PinnedService.list().catch((error) => {
+                console.warn('[ChatVM] failed to load pinned channels', error)
+                return undefined
+            })
+            : Promise.resolve(undefined)
 
         // 先拉取数据，避免清空列表导致 UI 闪烁（fix #266）
         let conversations: Conversation[] | undefined
@@ -631,6 +670,10 @@ export class ChatVM extends ProviderListener {
         if (WKApp.shared.currentSpaceId !== requestSpaceId) {
             return
         }
+        const pinnedChannels = await pinnedChannelsPromise
+        if (WKApp.shared.currentSpaceId !== requestSpaceId) {
+            return
+        }
 
         // _pendingSpaceConversations 是 ChatVM 自己的延迟队列,跟 SDK cache 无关,
         // 切 Space 时清掉避免旧 Space 排队中的 incoming 落入新 Space 视图。
@@ -640,6 +683,7 @@ export class ChatVM extends ProviderListener {
         // 写入缓存。这样 shouldSkipChannelForSpace 命中率最大化，下游实时消息
         // 也能立即用到，避免 fail-open 误展示其他 Space 的群。
         if (conversations && conversations.length > 0) {
+            applyPinnedThreadSnapshot(conversations, pinnedChannels)
             this.prefillSpaceMapsFromSync(conversations)
         }
 
@@ -675,6 +719,12 @@ export class ChatVM extends ProviderListener {
     async reloadRequestConversationList() {
         const conversationWraps = new Array<ConversationWrap>()
         let conversations: Conversation[] | undefined
+        const pinnedChannelsPromise = WKApp.shared.currentSpaceId
+            ? PinnedService.list().catch((error) => {
+                console.warn('[ChatVM] failed to load pinned channels', error)
+                return undefined
+            })
+            : Promise.resolve(undefined)
         try {
             conversations = await WKSDK.shared().conversationManager.sync({})
         } catch (error) {
@@ -683,9 +733,11 @@ export class ChatVM extends ProviderListener {
             this.notifyListener()
             throw error
         }
+        const pinnedChannels = await pinnedChannelsPromise
         // 先按 sync 响应预填 channelSpaceMap / channelMySourceSpaceMap
         // 再做 Space 过滤，避免老缓存缺失时落到 fail-closed 默认值。
         if (conversations && conversations.length > 0) {
+            applyPinnedThreadSnapshot(conversations, pinnedChannels)
             this.prefillSpaceMapsFromSync(conversations)
         }
         if (conversations && conversations.length > 0) {

--- a/packages/dmworkbase/src/Pages/Chat/vm.ts
+++ b/packages/dmworkbase/src/Pages/Chat/vm.ts
@@ -719,7 +719,8 @@ export class ChatVM extends ProviderListener {
     async reloadRequestConversationList() {
         const conversationWraps = new Array<ConversationWrap>()
         let conversations: Conversation[] | undefined
-        const pinnedChannelsPromise = WKApp.shared.currentSpaceId
+        const requestSpaceId = WKApp.shared.currentSpaceId
+        const pinnedChannelsPromise = requestSpaceId
             ? PinnedService.list().catch((error) => {
                 console.warn('[ChatVM] failed to load pinned channels', error)
                 return undefined
@@ -733,7 +734,13 @@ export class ChatVM extends ProviderListener {
             this.notifyListener()
             throw error
         }
+        if (WKApp.shared.currentSpaceId !== requestSpaceId) {
+            return
+        }
         const pinnedChannels = await pinnedChannelsPromise
+        if (WKApp.shared.currentSpaceId !== requestSpaceId) {
+            return
+        }
         // 先按 sync 响应预填 channelSpaceMap / channelMySourceSpaceMap
         // 再做 Space 过滤，避免老缓存缺失时落到 fail-closed 默认值。
         if (conversations && conversations.length > 0) {

--- a/packages/dmworkbase/src/Service/PinnedService.ts
+++ b/packages/dmworkbase/src/Service/PinnedService.ts
@@ -1,0 +1,33 @@
+import type { Channel } from "wukongimjssdk";
+
+import APIClient from "./APIClient";
+
+export interface PinnedChannelItem {
+  channel_id: string;
+  channel_type: number;
+  sort_order: number;
+}
+
+const PinnedService = {
+  add(channel: Channel): Promise<void> {
+    return APIClient.shared.post("/user/pinned", {
+      channel_id: channel.channelID,
+      channel_type: channel.channelType,
+    });
+  },
+
+  remove(channel: Channel): Promise<void> {
+    return APIClient.shared.delete("/user/pinned", {
+      param: {
+        channel_id: channel.channelID,
+        channel_type: channel.channelType,
+      },
+    });
+  },
+
+  list(): Promise<PinnedChannelItem[]> {
+    return APIClient.shared.get("/user/pinned") as Promise<PinnedChannelItem[]>;
+  },
+};
+
+export default PinnedService;

--- a/packages/dmworkbase/src/Service/__tests__/PinnedService.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/PinnedService.test.ts
@@ -1,0 +1,64 @@
+import { Channel } from "wukongimjssdk";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import APIClient from "../APIClient";
+import { ChannelTypeCommunityTopic } from "../Const";
+import PinnedService from "../PinnedService";
+
+vi.mock("../APIClient", () => ({
+  default: {
+    shared: {
+      delete: vi.fn(() => Promise.resolve()),
+      get: vi.fn(() => Promise.resolve([])),
+      post: vi.fn(() => Promise.resolve()),
+    },
+  },
+}));
+
+const apiDelete = APIClient.shared.delete as unknown as ReturnType<
+  typeof vi.fn
+>;
+const apiGet = APIClient.shared.get as unknown as ReturnType<typeof vi.fn>;
+const apiPost = APIClient.shared.post as unknown as ReturnType<typeof vi.fn>;
+
+describe("PinnedService", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("pins a child thread through the dedicated pinned endpoint", async () => {
+    const channel = new Channel(
+      "group-1____thread-1",
+      ChannelTypeCommunityTopic
+    );
+
+    await PinnedService.add(channel);
+
+    expect(apiPost).toHaveBeenCalledWith("/user/pinned", {
+      channel_id: "group-1____thread-1",
+      channel_type: ChannelTypeCommunityTopic,
+    });
+  });
+
+  it("unpins a child thread through the dedicated pinned endpoint", async () => {
+    const channel = new Channel(
+      "group-1____thread-1",
+      ChannelTypeCommunityTopic
+    );
+
+    await PinnedService.remove(channel);
+
+    expect(apiDelete).toHaveBeenCalledWith("/user/pinned", {
+      param: {
+        channel_id: "group-1____thread-1",
+        channel_type: ChannelTypeCommunityTopic,
+      },
+    });
+  });
+
+  it("loads the persisted pinned-channel snapshot", async () => {
+    await PinnedService.list();
+
+    expect(apiGet).toHaveBeenCalledWith("/user/pinned");
+  });
+});

--- a/packages/dmworkbase/src/bridge/channelSetting/__tests__/channelSettingActions.test.ts
+++ b/packages/dmworkbase/src/bridge/channelSetting/__tests__/channelSettingActions.test.ts
@@ -80,6 +80,7 @@ function createRuntime(
     markRemovedChannelSubscribers: vi.fn(),
     notifyCurrentChannelSubscribers: vi.fn(),
     notifyCurrentChannelInfo: vi.fn(),
+    setPinnedChannel: vi.fn(() => Promise.resolve()),
     setCurrentChannelSubscribers: vi.fn(),
     setCurrentChannelInfo: vi.fn(),
     syncCurrentChannelSubscribers: vi.fn(() => Promise.resolve()),
@@ -451,6 +452,21 @@ describe("channel setting actions", () => {
     expect(runtime.topChannel).toHaveBeenCalledWith(channel, true);
     expect(runtime.saveChannel).toHaveBeenCalledWith(channel, false);
     expect(runtime.remarkChannel).toHaveBeenCalledWith(channel, "remark");
+  });
+
+  it("uses the dedicated pinned contract for child threads", async () => {
+    const runtime = createRuntime();
+    const channel = new Channel(
+      "group-1____thread-1",
+      ChannelTypeCommunityTopic
+    );
+
+    await topChannelSetting({ channel, top: true, runtime });
+    await topChannelSetting({ channel, top: false, runtime });
+
+    expect(runtime.setPinnedChannel).toHaveBeenNthCalledWith(1, channel, true);
+    expect(runtime.setPinnedChannel).toHaveBeenNthCalledWith(2, channel, false);
+    expect(runtime.topChannel).not.toHaveBeenCalled();
   });
 
   it("emits imperative conversation_muted/pinned with the direction action (M3 收口点)", async () => {

--- a/packages/dmworkbase/src/bridge/channelSetting/channelSettingActions.ts
+++ b/packages/dmworkbase/src/bridge/channelSetting/channelSettingActions.ts
@@ -37,6 +37,7 @@ import {
 import { patchImChannelInfoOrgData } from "../../im-runtime/channelRuntime";
 import { Dap } from "../../Service/Dap";
 import { stripSpacePrefix } from "../../Service/SpacePrefix";
+import PinnedService from "../../Service/PinnedService";
 import {
   findCurrentImConversation,
   removeCurrentImConversation,
@@ -74,6 +75,7 @@ export interface ChannelSettingActionRuntime {
   markRemovedChannelSubscribers(channel: Channel, uids: string[]): void;
   notifyCurrentChannelSubscribers(channel: Channel): void;
   notifyCurrentChannelInfo(channelInfo: ChannelInfo): void;
+  setPinnedChannel(channel: Channel, top: boolean): Promise<void>;
   setCurrentChannelInfo(channelInfo: ChannelInfo): void;
   setCurrentChannelSubscribers(
     channel: Channel,
@@ -194,6 +196,9 @@ function defaultRuntime(): ChannelSettingActionRuntime {
     },
     notifyCurrentChannelInfo(channelInfo) {
       notifyCurrentImChannelInfoListeners(channelInfo);
+    },
+    setPinnedChannel(channel, top) {
+      return top ? PinnedService.add(channel) : PinnedService.remove(channel);
     },
     setCurrentChannelSubscribers(channel, subscribers) {
       setCurrentImChannelSubscribersCache(channel, subscribers);
@@ -519,7 +524,12 @@ export async function topChannelSetting(params: {
   top: boolean;
   runtime?: ChannelSettingActionRuntime;
 }) {
-  await runtimeOrDefault(params.runtime).topChannel(params.channel, params.top);
+  const runtime = runtimeOrDefault(params.runtime);
+  if (params.channel.channelType === ChannelTypeCommunityTopic) {
+    await runtime.setPinnedChannel(params.channel, params.top);
+  } else {
+    await runtime.topChannel(params.channel, params.top);
+  }
   // conversation_pinned 收口点:同 conversation_muted,覆盖列表右键 + 设置面板置顶开关,
   // await 成功后单发,携带方向 action(pin/unpin)(见 M3)。门控同上(见 #1452 review P2)。
   if (channelSettingRequestIssued(params.channel)) {


### PR DESCRIPTION
## Summary

Fix child-thread pinning in the Recent conversation list. Child threads now use the dedicated per-user pinned-channel contract, move into the pinned section immediately, and restore their pinned state after reload.

## Related Issue

N/A

## Changes

- Route child-thread pin and unpin actions through `/v1/user/pinned` while preserving the existing group and DM setting paths.
- Apply optimistic child-thread pin state after a successful write and notify the conversation list so it re-sorts immediately.
- Restore persisted child-thread pins during conversation synchronization and preserve them across ordinary channel/conversation updates.
- Add focused service, action, VM sorting/listener, and conversation-list interaction coverage.

## Architecture / Module Boundary

- Affected module(s): `@octo/base` chat conversation list, chat VM, channel-setting bridge, and service layer.
- New or changed user-visible entry point: no; the existing Recent-tab context-menu action is retained.
- Shared layer touched: Components / bridge / service.
- If shared code changed, impact scope: `topChannelSetting` now selects the pinned-channel API only for `ChannelTypeCommunityTopic`; existing person/group callers are unchanged.
- Duplicate entry point checked: yes.

## Testing

- [x] Unit tests added/updated: 5 files, 58 tests passed.
- [x] Production Web build passed (`pnpm --filter @octo/web build`).
- [x] Manually verified on `http://localhost:3000/`: pin/unpin placement, menu state, and reload behavior.
- Focused ESLint was unavailable because the repository ESLint parser rejects TypeScript imports before parsing; Vitest and Vite compilation passed.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation (inline contract comments and tests; no standalone documentation change required)
- [x] Confirmed the change does not affect UI copy
- [x] Confirmed the change follows module ownership and does not add duplicate user-visible entry points
- [x] Described impact scope when shared components, messages, bridge, or services are changed
- [x] Followed commit message conventions (Conventional Commits)