### PR TITLE
fix(base): render forwarded HTML docs instead of a red preview error

### DIFF
--- a/packages/dmworkbase/src/Messages/DocumentShareCard/DocumentShareCardContent.ts
+++ b/packages/dmworkbase/src/Messages/DocumentShareCard/DocumentShareCardContent.ts
@@ -3,13 +3,15 @@ import { MessageContentTypeConst } from "../../Service/Const";
 import { t } from "../../i18n";
 import { asDocIdentifier } from "./docIdentity";
 
-/** 转发的资源类型。与 docs 后端 /d/:docId 的三条内容线对应。 */
-export type DocShareKind = "doc" | "board" | "sheet";
+/** 转发的资源类型。与 docs 后端 /d/:docId 的内容线对应（html = HTML 文档，无首屏预览）。 */
+export type DocShareKind = "doc" | "board" | "sheet" | "html";
 
 /** 转发时授予接收者的权限（forwardGrant 的结果，只承载展示语义）。 */
 export type DocSharePermission = "reader" | "commenter" | "writer";
 
-const KINDS: DocShareKind[] = ["doc", "board", "sheet"];
+// html 必须入白名单：否则 asKind() 会把 wire 里的 "html" 静默降级回 "doc"，
+// 发送侧传了 kind 也无效，接收端拿不到真实类型。
+const KINDS: DocShareKind[] = ["doc", "board", "sheet", "html"];
 const PERMISSIONS: DocSharePermission[] = ["reader", "commenter", "writer"];
 
 /** 从 unknown 安全取字符串（SDK decodeJSON 签名为 any，一律按 unknown 收窄）。 */
@@ -45,7 +47,7 @@ export class DocumentShareCardContent extends MessageContent {
   docId = "";
   /** 文档所属 space id（仍用于 ACL-safe 首屏预览；deep-link 不再携带）。 */
   spaceId = "";
-  /** 资源类型：doc/board/sheet。 */
+  /** 资源类型：doc/board/sheet/html。 */
   kind: DocShareKind = "doc";
   /** 转发时的文档标题快照（已由发送侧转义/截断）。 */
   title = "";

--- a/packages/dmworkbase/src/Messages/DocumentShareCard/__tests__/DocumentShareCardContent.test.ts
+++ b/packages/dmworkbase/src/Messages/DocumentShareCard/__tests__/DocumentShareCardContent.test.ts
@@ -77,4 +77,11 @@ describe("permissionState — only live ACL controls the effective badge", () =>
   it("error → error (preview failure may be transient)", () => {
     expect(permissionState("error")).toBe("error");
   });
+
+  // empty 只来自 docs-backend 的 409 unsupported_doc_type，而 409 只能在
+  // requireDocRole(reader) **通过之后**才抛——所以 empty 在 ACL 上确证了 reader，
+  // 标绿「可查看」是准确结论，不是乐观猜测。
+  it("empty (409 unsupported_doc_type, raised only after the reader check passed) → reader", () => {
+    expect(permissionState("empty")).toBe("reader");
+  });
 });

--- a/packages/dmworkbase/src/Messages/DocumentShareCard/__tests__/contentCodec.test.ts
+++ b/packages/dmworkbase/src/Messages/DocumentShareCard/__tests__/contentCodec.test.ts
@@ -54,6 +54,28 @@ describe("DocumentShareCardContent.decodeJSON — untrusted-wire narrowing", () 
     expect(c.permission).toBe("reader");
   });
 
+  // html 必须在 KINDS 白名单里：否则 asKind 会把 wire 里的 html **静默降级**回 doc，
+  // 发送侧就算传了 kind 也白传，接收端依旧当普通文档处理。
+  it("keeps kind='html' (must NOT silently downgrade to 'doc')", () => {
+    const c = new DocumentShareCardContent();
+    c.decodeJSON({ doc_id: "d_1", kind: "html", title: "T" });
+    expect(c.kind).toBe("html");
+  });
+
+  it("round-trips kind='html' through encodeJSON → decodeJSON", () => {
+    const src = new DocumentShareCardContent();
+    src.docId = "d_1";
+    src.kind = "html";
+    src.title = "周报.html";
+
+    const wire = src.encodeJSON();
+    expect(wire.kind).toBe("html");
+
+    const dst = new DocumentShareCardContent();
+    dst.decodeJSON(wire);
+    expect(dst.kind).toBe("html");
+  });
+
   it("tolerates non-string / missing fields without throwing", () => {
     const c = new DocumentShareCardContent();
     expect(() => c.decodeJSON({ doc_id: 123, title: null })).not.toThrow();

--- a/packages/dmworkbase/src/Messages/DocumentShareCard/__tests__/preview.test.ts
+++ b/packages/dmworkbase/src/Messages/DocumentShareCard/__tests__/preview.test.ts
@@ -25,6 +25,25 @@ import { fetchDocPreview, resetDocPreviewCache } from "../preview";
 
 const apiGet = APIClient.shared.get as unknown as ReturnType<typeof vi.fn>;
 
+/**
+ * 构造一个和 APIClient 拦截器真实 reject 形状一致的错误对象。
+ * 见 Service/APIClient.ts 的 `const rejected: APIClientRejectedError = { error, msg,
+ * status, code, ... }`：`error` 字段就是**原始 axios error**，wire 错误体在
+ * `error.response.data`。docs-backend 这批 GET 预览接口回的是 `{ error: "<code>" }`
+ * （error 是**字符串**），所以它走不进 apiError.ts 的 v2 envelope 分支
+ * （`isV2ErrorEnvelope` 要求 data.error 是**对象**），`normalized.code`/`rejected.code`
+ * 一律 undefined —— 判别码只能从原始 axios error 里取。
+ */
+function wireReject(status: number, errorCode?: string) {
+  return {
+    error: errorCode === undefined ? {} : { response: { data: { error: errorCode } } },
+    msg: "",
+    status,
+    code: undefined,
+    normalized: { httpStatus: status, message: "", raw: {} },
+  };
+}
+
 beforeEach(() => {
   apiGet.mockReset();
   currentUid = "u_self";
@@ -38,6 +57,9 @@ describe("fetchDocPreview — kind → endpoint mapping (blocker #2 regression)"
     ["doc", "content"],
     ["board", "scene"],
     ["sheet", "sheet"],
+    // html 没有专属预览端点，故意复用 /content 当 ACL 探针
+    // （预期 409 unsupported_doc_type，见下面的 empty 用例）。
+    ["html", "content"],
   ] as const)("kind=%s → GET docs/:id/%s", async (kind, endpoint) => {
     apiGet.mockResolvedValueOnce({});
     await fetchDocPreview(kind, "d_1", "sp_1");
@@ -73,6 +95,70 @@ describe("fetchDocPreview — ACL-safe status mapping (blocker #3 / ACL design)"
     expect(res.status).toBe("error");
   });
 
+  // docs-backend 的 409 unsupported_doc_type 只可能在 requireDocRole(reader) **通过之后**
+  // 才抛出（docContent.ts:151 / docSheet.ts:55 / docScene.ts:48），所以它证明了「有权限、
+  // 但这个 doc_type 没有预览」——是正常降级（empty），不是错误（error）。掉进 error 会让
+  // html 文档卡片必现红色「预览不可用」。
+  it("409 unsupported_doc_type → empty (has access, type has no preview — NOT an error)", async () => {
+    apiGet.mockRejectedValueOnce(wireReject(409, "unsupported_doc_type"));
+    const res = await fetchDocPreview("html", "d_1", "sp_1");
+    expect(res.status).toBe("empty");
+    expect(res.preview).toBeUndefined();
+  });
+
+  // 同一批 GET 预览接口的 409 **不止一种**。guard.ts:104 的 requireDocRole 在鉴权
+  // **通过之后**发现 meta.status === 2（文档已归档）时也抛 409，错误码是 "conflict"。
+  // 把它当 empty 会把「已归档」渲染成绿色「可查看 + 暂无预览」——错的。它语义上等同
+  // 404/410：文案 docShareCard.placeholder.unavailable.desc 正是「可能已被删除或归档」。
+  it("409 conflict (archived doc) → unavailable, NOT empty", async () => {
+    apiGet.mockRejectedValueOnce(wireReject(409, "conflict"));
+    const res = await fetchDocPreview("doc", "d_1", "sp_1");
+    expect(res.status).toBe("unavailable");
+    expect(res.preview).toBeUndefined();
+  });
+
+  // 🔴 最关键的一条：snapshot_invalid 是后端明确 fail-closed 的**数据损坏/契约违例**
+  // （docSheet.ts:165 / docScene.ts:94 的 GET 路径）。绝不能被吞成绿色「可查看」，
+  // 必须保持红色 error，否则用户会以为文档没事。
+  it.each([
+    ["sheet" as const, "sheet_snapshot_invalid"],
+    ["board" as const, "board_snapshot_invalid"],
+  ])("409 %s snapshot_invalid → error (data corruption must stay fail-closed)", async (kind, code) => {
+    apiGet.mockRejectedValueOnce(wireReject(409, code));
+    const res = await fetchDocPreview(kind, "d_1", "sp_1");
+    expect(res.status).toBe("error");
+    expect(res.preview).toBeUndefined();
+  });
+
+  // fail-closed 兜底：拿不到错误码（响应体缺失 / 形状意外 / 未知新码）的 409 一律 error。
+  // 宁可多显示一次红色，也不能把**未知**状态标成绿色「可查看」。
+  it.each([
+    ["missing response body", undefined],
+    ["unknown error code", "some_future_code"],
+  ])("409 with %s → error (fail-closed default)", async (_label, code) => {
+    apiGet.mockRejectedValueOnce(wireReject(409, code));
+    const res = await fetchDocPreview("doc", "d_1", "sp_1");
+    expect(res.status).toBe("error");
+  });
+
+  // 缓存约定回归：error 不缓存（可能瞬时故障，允许重试）、unavailable 缓存（稳定结论）。
+  it("does NOT cache a 409 error result (retry allowed on next call)", async () => {
+    apiGet.mockRejectedValueOnce(wireReject(409, "sheet_snapshot_invalid"));
+    expect((await fetchDocPreview("sheet", "d_err", "sp_1")).status).toBe("error");
+    expect(apiGet).toHaveBeenCalledTimes(1);
+    apiGet.mockRejectedValueOnce(wireReject(409, "sheet_snapshot_invalid"));
+    expect((await fetchDocPreview("sheet", "d_err", "sp_1")).status).toBe("error");
+    expect(apiGet).toHaveBeenCalledTimes(2);
+  });
+
+  it("caches a 409 unavailable result (second call within TTL does not re-request)", async () => {
+    apiGet.mockRejectedValueOnce(wireReject(409, "conflict"));
+    expect((await fetchDocPreview("doc", "d_arch", "sp_1")).status).toBe("unavailable");
+    expect(apiGet).toHaveBeenCalledTimes(1);
+    expect((await fetchDocPreview("doc", "d_arch", "sp_1")).status).toBe("unavailable");
+    expect(apiGet).toHaveBeenCalledTimes(1);
+  });
+
   it("empty docId short-circuits to error without a request", async () => {
     const res = await fetchDocPreview("doc", "", "sp_1");
     expect(res.status).toBe("error");
@@ -106,6 +192,32 @@ describe("fetchDocPreview — doc ProseMirror parsing", () => {
     const res = await fetchDocPreview("doc", "d_1", "sp_1");
     expect(res.status).toBe("ready");
     expect(res.preview).toBeUndefined();
+  });
+});
+
+describe("fetchDocPreview — html kind (unsupported_doc_type degrade)", () => {
+  // 防御性：今天 backend 对 html 必回 409，走不到这里。但哪天它给 html 开了 200，
+  // body 形状也不是 ProseMirror doc——绝不能拿去 parseDocPreview 解析/崩溃，直接 empty。
+  it("html + HTTP 200 → empty (never parses a non-ProseMirror body)", async () => {
+    apiGet.mockResolvedValueOnce({
+      doc: { type: "doc", content: [{ type: "heading", content: [{ type: "text", text: "X" }] }] },
+    });
+    const res = await fetchDocPreview("html", "d_1", "sp_1");
+    expect(res.status).toBe("empty");
+    expect(res.preview).toBeUndefined();
+  });
+
+  // empty 是**稳定结论**（doc_type 不会在 TTL 内变），必须和 ready/denied 一样进缓存，
+  // 否则每个 cell 挂载/每次 focus 都对同一个 html 文档白打一枪 409。
+  it("caches the empty result (second call within TTL does not re-request)", async () => {
+    apiGet.mockRejectedValueOnce(wireReject(409, "unsupported_doc_type"));
+    const first = await fetchDocPreview("html", "d_1", "sp_1");
+    expect(first.status).toBe("empty");
+    expect(apiGet).toHaveBeenCalledTimes(1);
+
+    const again = await fetchDocPreview("html", "d_1", "sp_1");
+    expect(again.status).toBe("empty");
+    expect(apiGet).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/packages/dmworkbase/src/Messages/DocumentShareCard/docIdentity.ts
+++ b/packages/dmworkbase/src/Messages/DocumentShareCard/docIdentity.ts
@@ -42,5 +42,12 @@ export function permissionState(status: DocSharePreviewStatus): DocSharePermissi
   if (status === "unavailable") return "unavailable";
   if (status === "error") return "error";
   if (status === "ready") return "reader";
+  // empty 只来自 docs-backend 的 409 `unsupported_doc_type`（**已收窄**：其它 409 —— 归档的
+  // `conflict` 走 unavailable、snapshot_invalid 等走 error —— 都到不了这里）。而那道 doc_type
+  // 闸在 requireDocRole(reader) **之后**才跑，换言之，能拿到这个码就意味着调用者已通过
+  // reader 校验；后端也没有任何「无权限却返回 409」的路径。所以 empty 在 ACL 上**确证**了
+  // reader 权限，标绿「可查看」是准确结论，不是乐观猜测；卡片随后自然落到「暂无预览」
+  // 占位，而不是红色错误态。
+  if (status === "empty") return "reader";
   return "checking";
 }

--- a/packages/dmworkbase/src/Messages/DocumentShareCard/preview.ts
+++ b/packages/dmworkbase/src/Messages/DocumentShareCard/preview.ts
@@ -135,7 +135,36 @@ const ENDPOINT: Record<DocShareKind, string> = {
   doc: "content",
   board: "scene",
   sheet: "sheet",
+  // html **故意**打 /content，虽然它没有专属预览端点。docs-backend 的 docContent 是
+  // 先跑 requireDocRole(reader)、通过后才撞 doc_type 闸抛 409 `unsupported_doc_type`，
+  // 所以这一枪被当作纯粹的 **ACL 探针**：409 `unsupported_doc_type` 就是“有 reader 权限、
+  // 但此类型无预览”（→ empty），403/404 依旧是无权限/失效。注意 409 **不止这一种**
+  // （见 requestPreview 的错误码分派），只有这个码能推出 reader。零新端点、ACL 语义不丢，
+  // 且未来任何新 doc_type 自动兜住。
+  html: "content",
 };
+
+/**
+ * 从 APIClient reject 出来的错误里取 docs-backend 的 **wire 错误码**。
+ *
+ * 为什么不能读 `rejected.code` / `normalized.code`：docs-backend 这批 GET 预览接口返回的是
+ * `{ error: "unsupported_doc_type" }`，`error` 是**字符串**；而 apiError.ts 的
+ * `isV2ErrorEnvelope` 要求 `data.error` 是**对象**才认作 v2 信封，所以这个响应走 legacy
+ * 分支，两个 `code` 字段恒为 undefined。判别码只能从原始 axios error 上取
+ * （`APIClientRejectedError.error` 即原始 axios error，见 Service/APIClient.ts 拦截器）。
+ * 同款先例：dmworkmcp/src/api/mcpService.ts、expertService.ts 的 extractErrorMessage。
+ */
+function wireErrorCode(e: unknown): string | undefined {
+  if (!e || typeof e !== "object") return undefined;
+  const raw = (e as { error?: unknown }).error;
+  if (!raw || typeof raw !== "object") return undefined;
+  const response = (raw as { response?: unknown }).response;
+  if (!response || typeof response !== "object") return undefined;
+  const data = (response as { data?: unknown }).data;
+  if (!data || typeof data !== "object") return undefined;
+  const code = (data as { error?: unknown }).error;
+  return typeof code === "string" && code !== "" ? code : undefined;
+}
 
 async function requestPreview(
   kind: DocShareKind,
@@ -150,6 +179,10 @@ async function requestPreview(
         param: spaceId ? { sp: spaceId } : undefined,
       } as any,
     );
+    // html 没有可渲染的首屏预览，body 形状也不是 ProseMirror doc——绝不能拿去
+    // parseDocPreview 解析。防御性分支：今天 backend 必回 409、走不到这里，但哪天
+    // 它给 html 开了 200，也只能得出 empty（有权限无预览），不能崩也不能乱渲染。
+    if (kind === "html") return { status: "empty" };
     const preview =
       kind === "doc"
         ? parseDocPreview(body)
@@ -161,6 +194,23 @@ async function requestPreview(
     const status = (e as { status?: number })?.status;
     if (status === 403) return { status: "denied" };
     if (status === 404 || status === 410) return { status: "unavailable" };
+    // 409 **不是单一语义**，同一批 GET 预览接口至少吐三类，必须按 wire 错误码分派，
+    // 否则会把「已归档」和「数据损坏」一起吞成绿色「可查看」（fail-open 状态误判）：
+    //   • unsupported_doc_type（docContent.ts / docSheet.ts / docScene.ts）——doc_type 闸在
+    //     requireDocRole(reader) **通过之后**才跑，故它确证「有 reader 权限、只是此类型无
+    //     预览」，是正常降级 → empty（卡片标绿 + 「暂无预览」占位）。
+    //   • conflict（guard.ts 的 requireDocRole，鉴权通过后发现 meta.status === 2）——文档
+    //     **已归档** → unavailable，与 404/410 同类（文案「可能已被删除或归档」正好吻合）。
+    //   • sheet_snapshot_invalid / board_snapshot_invalid（GET 路径）——真实的数据损坏/契约
+    //     违例，后端明确 fail-closed → 必须保持 error（红色），不能被吞成绿色。
+    // 兜底方向是 **fail-closed**：任何其它 409、以及**取不到错误码**的 409，一律 error。
+    // 宁可多显示一次红色，也不能把未知状态标成「可查看」。
+    if (status === 409) {
+      const code = wireErrorCode(e);
+      if (code === "unsupported_doc_type") return { status: "empty" };
+      if (code === "conflict") return { status: "unavailable" };
+      return { status: "error" };
+    }
     return { status: "error" };
   }
 }
@@ -201,12 +251,15 @@ function cacheKey(
 
 /**
  * 拉取一份 ACL-safe 首屏预览。信任边界由 **docs 后端 reader 接口**把守（requireDocRole）：
- * 无权限 → 403 → denied；文档删/锁/归档 → 404/410 → unavailable；其余错误 → error。
+ * 无权限 → 403 → denied；文档删/锁 → 404/410 → unavailable；有 reader 权限但该类型无预览 →
+ * 409 `unsupported_doc_type` → empty；文档已归档 → 409 `conflict` → unavailable；
+ * 其余错误（含**其它 409**，如 snapshot_invalid 这类后端 fail-closed 的数据损坏）→ error。
  * space 用显式 X-Space-Id 头传文档自身 space（文档可能不在当前 space）。
  *
- * 去重 + 缓存（P2-4）：并发同 key 共享一个在飞请求；成功/无权限/失效结果缓存 30s，
- * error 不缓存（可能是瞬时故障，允许下次重试）。`signal` 保留以兼容调用方，但共享请求
- * 不按单个调用方 abort（Cell 侧已用自身 aborted 标志守 setState，卸载后不写状态）。
+ * 去重 + 缓存（P2-4）：并发同 key 共享一个在飞请求；成功/无权限/失效/无预览结果缓存 30s
+ * （empty 和 ready 一样是**稳定结论**，doc_type 不会在 TTL 内变），error 不缓存（可能是瞬时
+ * 故障，允许下次重试）。`signal` 保留以兼容调用方，但共享请求不按单个调用方 abort
+ * （Cell 侧已用自身 aborted 标志守 setState，卸载后不写状态）。
  */
 export async function fetchDocPreview(
   kind: DocShareKind,

--- a/packages/dmworkbase/src/ui/DocumentShareCard/__tests__/DocumentShareCard.test.tsx
+++ b/packages/dmworkbase/src/ui/DocumentShareCard/__tests__/DocumentShareCard.test.tsx
@@ -97,3 +97,63 @@ describe("DocumentShareCard — 预览区主操作 disabled 门控", () => {
     expect(html).toContain("需要访问权限");
   });
 });
+
+/** 提取类型图标的 svg markup（用于区分不同 kind 的图形）。 */
+function typeIconMarkup(html: string): string {
+  const m = html.match(/<span class="document-forward-type-icon"[^>]*>([\s\S]*?)<\/span>/);
+  return m ? m[1] : "";
+}
+
+describe("DocumentShareCard — kind=html", () => {
+  // html 文档转发：有 reader 权限但该类型无预览（409 → empty → reader + 「暂无预览」占位）。
+  // 卡片必须能渲染、不能因未知 kind 崩溃，且类型图标仍在。
+  it("kind='html' 渲染不崩，类型图标存在", () => {
+    const html = renderToStaticMarkup(
+      <DocumentShareCard
+        {...baseProps({
+          kind: "html",
+          title: "周报.html",
+          state: "reader",
+          preview: undefined,
+          strings: strings({ permissionLabel: "可查看" }),
+          placeholder: { icon: "info", title: "暂无预览" },
+        })}
+      />,
+    );
+    expect(html).toContain("document-forward-type-icon");
+    expect(html).toContain("<svg");
+    expect(html).toContain("周报.html");
+    // empty → reader → 绿色基调，绝不能是红色 error 基调。
+    expect(html).toContain("document-forward-card is-success");
+    expect(html).toContain("暂无预览");
+  });
+
+  // html 有自己的图标，不能 fall-through 到默认 doc 图标（否则用户分不出这是 HTML 文档）。
+  it("kind='html' 的类型图标与 doc 不同", () => {
+    const render = (kind: DocumentShareCardProps["kind"]): string =>
+      renderToStaticMarkup(
+        <DocumentShareCard
+          {...baseProps({ kind, preview: undefined, placeholder: { icon: "info", title: "暂无预览" } })}
+        />,
+      );
+    const htmlIcon = typeIconMarkup(render("html"));
+    expect(htmlIcon).not.toBe("");
+    expect(htmlIcon).not.toBe(typeIconMarkup(render("doc")));
+    expect(htmlIcon).not.toBe(typeIconMarkup(render("board")));
+    expect(htmlIcon).not.toBe(typeIconMarkup(render("sheet")));
+  });
+
+  it("kind='html' 预览区仍可点（可打开文档）", () => {
+    const html = renderToStaticMarkup(
+      <DocumentShareCard
+        {...baseProps({
+          kind: "html",
+          state: "reader",
+          preview: undefined,
+          placeholder: { icon: "info", title: "暂无预览" },
+        })}
+      />,
+    );
+    expect(previewButtonDisabled(html)).toBe(false);
+  });
+});

--- a/packages/dmworkbase/src/ui/DocumentShareCard/index.tsx
+++ b/packages/dmworkbase/src/ui/DocumentShareCard/index.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import "./index.css";
 
-export type DocShareKind = "doc" | "board" | "sheet";
+export type DocShareKind = "doc" | "board" | "sheet" | "html";
 
 /** viewer 视角的权限态（由 Cell 依据实时 ACL 取数结果给出）。 */
 export type DocSharePermissionState =
@@ -13,8 +13,18 @@ export type DocSharePermissionState =
   | "error"
   | "checking";
 
-/** 首屏预览取数状态。 */
-export type DocSharePreviewStatus = "loading" | "ready" | "denied" | "unavailable" | "error";
+/**
+ * 首屏预览取数状态。
+ * `empty` = 有访问权限、但该 doc_type 没有可渲染的预览（如 html 文档）——
+ * 是**正常降级**，与 error（取数失败）严格区分：前者标绿显「暂无预览」，后者标红。
+ */
+export type DocSharePreviewStatus =
+  | "loading"
+  | "ready"
+  | "denied"
+  | "unavailable"
+  | "error"
+  | "empty";
 
 /** ACL 校验后的首屏预览数据，按 kind 区分。 */
 export type DocSharePreview =
@@ -76,6 +86,14 @@ function KindIcon({ kind }: { kind: DocShareKind }): JSX.Element {
       <svg className="icon" viewBox="0 0 24 24" aria-hidden="true">
         <rect x="4" y="4" width="16" height="16" rx="2" />
         <path d="M4 10h16M4 15h16M10 4v16" />
+      </svg>
+    );
+  }
+  if (kind === "html") {
+    return (
+      <svg className="icon" viewBox="0 0 24 24" aria-hidden="true">
+        <rect x="3" y="4" width="18" height="16" rx="2" />
+        <path d="M9 10l-2.5 2L9 14M15 10l2.5 2L15 14M13 9l-2 6" />
       </svg>
     );
   }


### PR DESCRIPTION
## Summary

Forwarding an HTML doc as a type-18 `DocumentShareCard` always rendered the red 「预览不可用」 state, even for a user with full access.

The card fetches its ACL-safe first-screen preview from docs-backend `GET /docs/:id/content`. That handler runs `requireDocRole(reader)` **first**, and only then rejects a non-`'doc'` doc_type with `409 unsupported_doc_type`. The client mapped 403/404/410 and let everything else fall through to `error` — so a perfectly accessible HTML doc surfaced as a failure.

This PR adds `html` as a first-class kind and introduces a distinct `empty` preview status meaning *"authorized, but this doc_type has no renderable preview"*.

**html deliberately keeps hitting `/content`.** The request doubles as the ACL probe, so no new endpoint is needed and the permission semantics stay intact.

### 409 is dispatched on the wire error code, not the status

`409` is not single-valued on these endpoints, so mapping it wholesale would be wrong:

| wire `error` | source | → status | UI |
|---|---|---|---|
| `unsupported_doc_type` | docContent / docSheet / docScene | `empty` | green 可查看 + 「暂无预览」 |
| `conflict` | `guard.ts`, `meta.status === 2` (archived) | `unavailable` | 文档不可用 |
| `sheet_snapshot_invalid` / `board_snapshot_invalid` | GET paths | `error` | red |
| unknown code / unreadable body | — | `error` | red (fail-closed) |

Treating all 409s as `empty` would have painted **archived documents and genuine snapshot corruption green**. That is why the default direction is `error`: better one spurious red than one wrong 可查看.

> The code must be read off the raw axios error. docs-backend replies `{ error: "<code>" }` with a **string** payload, which `isV2ErrorEnvelope` rejects, so `normalized.code` is always `undefined` on this path — reading it would silently match nothing.

### Works standalone

Existing cards keep working without the paired sender change: a legacy `kind='doc'` card pointing at an HTML doc still hits the same 409 and degrades the same way. Recognition is driven by the **response**, not by `kind`.

### Changes

- `ui/DocumentShareCard` — `html` kind + icon, `empty` preview status
- `DocumentShareCardContent` — accept `html` in `KINDS` so `asKind` stops downgrading it
- `preview` — `html` endpoint mapping, `wireErrorCode` helper, 409 dispatch
- `docIdentity` — `empty` → `reader` (409 implies the reader check already passed)

## Linked Spec

None — bug fix, no spec change.

## How verified

- Every new assertion checked **fail-before / pass-after**. Reverting the 409 dispatch to the broad mapping turns 7 of them red (`expected 'empty' to be 'error'` / `'unavailable'`) — the two branches that would otherwise turn archived and corrupted docs green.
- Targeted: **4 files / 67 tests** pass
- Full package regression: **387 files / 3499 tests** pass
- Backend claims verified against `octo-docs-backend` `gitlab/main`: `docContent.ts`, `docSheet.ts`, `docScene.ts`, `guard.ts`

## COMPREHENSION

**(a) What it does to the load-bearing path**

The load-bearing path is the card's ACL-safe preview fetch. *Before:* its error mapping was status-only and terminal — any unmapped status meant `error`, so an authorized HTML doc looked broken. *After:* the same fetch also carries a "no preview for this type" outcome, decided by the **response body** rather than the status code. Authorization still comes solely from the backend; the client only classifies the answer.

**(b) What could break**

Every `DocumentShareCard` consumer, since `DocSharePreviewStatus` gained a member. `permissionState`, `buildPreviewOrPlaceholder` and `toneOf` were each checked to route `empty` correctly (green + 「暂无预览」 placeholder, still clickable). The real risk was **fail-open** — mislabelling an inaccessible or corrupt doc as viewable — which the narrowed dispatch plus the `error` default rules out. Board/sheet/doc behaviour is untouched; no backend or wire format change.

**(c) How I know it works**

The fail-before runs above pin each branch individually, including the two dangerous ones. Cache behaviour is asserted too (`error` not cached, `unavailable`/`empty` cached), matching the existing `status !== "error"` contract.

## Paired change

Sender-side counterpart lands in **octo-docs-module** (`fix/doc-share-html-kind`), which makes the two forward entry points emit `kind: 'html'`.

**Merge order:** this PR **first or together** — the receiver must know `html` before any sender emits it, otherwise `asKind()` downgrades it back to `'doc'`. This PR alone is safe and already fixes the red state for existing cards; that MR alone is a no-op.

## Deployment prerequisites

**No new environment variables.** No backend, config, or wire-format change — frontend only.
