### PR TITLE
fix(desktop): restore window on tray primary click

### DIFF
--- a/apps/web/src-election/main/__tests__/trayBehavior.test.ts
+++ b/apps/web/src-election/main/__tests__/trayBehavior.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from "vitest";
+import { attachTrayPrimaryClick } from "../trayBehavior";
+
+describe("tray primary click behavior", () => {
+  it("restores the main window on primary click", () => {
+    let onClick: (() => void) | undefined;
+    const tray = {
+      on: vi.fn((event: "click", listener: () => void) => {
+        if (event === "click") onClick = listener;
+      }),
+    };
+    const mainWindow = {
+      isDestroyed: vi.fn(() => false),
+      show: vi.fn(),
+      focus: vi.fn(),
+    };
+
+    attachTrayPrimaryClick(tray, () => mainWindow);
+    onClick?.();
+
+    expect(tray.on).toHaveBeenCalledWith("click", expect.any(Function));
+    expect(mainWindow.show).toHaveBeenCalledOnce();
+    expect(mainWindow.focus).toHaveBeenCalledOnce();
+  });
+
+  it("does nothing when the main window has been destroyed", () => {
+    let onClick: (() => void) | undefined;
+    const tray = {
+      on: vi.fn((_event: "click", listener: () => void) => {
+        onClick = listener;
+      }),
+    };
+    const mainWindow = {
+      isDestroyed: vi.fn(() => true),
+      show: vi.fn(),
+      focus: vi.fn(),
+    };
+
+    attachTrayPrimaryClick(tray, () => mainWindow);
+    onClick?.();
+
+    expect(mainWindow.show).not.toHaveBeenCalled();
+    expect(mainWindow.focus).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src-election/main/__tests__/trayBehavior.test.ts
+++ b/apps/web/src-election/main/__tests__/trayBehavior.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { attachTrayPrimaryClick } from "../trayBehavior";
+import { attachTrayPrimaryClick, attachTraySecondaryMenu } from "../trayBehavior";
 
 describe("tray primary click behavior", () => {
   it("restores the main window on primary click", () => {
@@ -11,6 +11,8 @@ describe("tray primary click behavior", () => {
     };
     const mainWindow = {
       isDestroyed: vi.fn(() => false),
+      isMinimized: vi.fn(() => false),
+      restore: vi.fn(),
       show: vi.fn(),
       focus: vi.fn(),
     };
@@ -19,6 +21,29 @@ describe("tray primary click behavior", () => {
     onClick?.();
 
     expect(tray.on).toHaveBeenCalledWith("click", expect.any(Function));
+    expect(mainWindow.show).toHaveBeenCalledOnce();
+    expect(mainWindow.focus).toHaveBeenCalledOnce();
+  });
+
+  it("restores a minimized main window before focusing it", () => {
+    let onClick: (() => void) | undefined;
+    const tray = {
+      on: vi.fn((_event: "click", listener: () => void) => {
+        onClick = listener;
+      }),
+    };
+    const mainWindow = {
+      isDestroyed: vi.fn(() => false),
+      isMinimized: vi.fn(() => true),
+      restore: vi.fn(),
+      show: vi.fn(),
+      focus: vi.fn(),
+    };
+
+    attachTrayPrimaryClick(tray, () => mainWindow);
+    onClick?.();
+
+    expect(mainWindow.restore).toHaveBeenCalledOnce();
     expect(mainWindow.show).toHaveBeenCalledOnce();
     expect(mainWindow.focus).toHaveBeenCalledOnce();
   });
@@ -32,6 +57,8 @@ describe("tray primary click behavior", () => {
     };
     const mainWindow = {
       isDestroyed: vi.fn(() => true),
+      isMinimized: vi.fn(),
+      restore: vi.fn(),
       show: vi.fn(),
       focus: vi.fn(),
     };
@@ -41,5 +68,22 @@ describe("tray primary click behavior", () => {
 
     expect(mainWindow.show).not.toHaveBeenCalled();
     expect(mainWindow.focus).not.toHaveBeenCalled();
+  });
+
+  it("opens the context menu on secondary click", () => {
+    let onRightClick: (() => void) | undefined;
+    const tray = {
+      on: vi.fn((_event: "right-click", listener: () => void) => {
+        onRightClick = listener;
+      }),
+      popUpContextMenu: vi.fn(),
+    };
+    const menu = {};
+
+    attachTraySecondaryMenu(tray, menu);
+    onRightClick?.();
+
+    expect(tray.popUpContextMenu).toHaveBeenCalledOnce();
+    expect(tray.popUpContextMenu).toHaveBeenCalledWith(menu);
   });
 });

--- a/apps/web/src-election/main/index.ts
+++ b/apps/web/src-election/main/index.ts
@@ -73,7 +73,7 @@ import { attachLogoutWindowNavigationListeners, classifyOidcNavigation, extractE
 import { createTrustedShellDocumentTracker } from "./trustedShell";
 import { clearAuthSessionCookies } from "./clearAuthSession";
 import { DOWNLOAD_SETTINGS_VERSION, normalizeDownloadSettings, sanitizeDownloadFilename, type DownloadSettings } from "./downloadSettings";
-import { attachTrayPrimaryClick } from "./trayBehavior";
+import { attachTrayPrimaryClick, attachTraySecondaryMenu } from "./trayBehavior";
 
 let forceQuit = false;
 let mainWindow: any;
@@ -1539,8 +1539,10 @@ function updateTray(unread?: number, isFlash = false): any {
         // Init tray icon
         tray = new Tray(trayIcon);
         // A primary click on the tray icon always restores the main window.
-        // Windows still exposes this menu on right-click via setContextMenu.
+        // Windows exposes this menu on right-click via setContextMenu. On
+        // macOS, keep primary click for restoring and open it on right-click.
         if (!isOsx) tray.setContextMenu(contextmenu);
+        else attachTraySecondaryMenu(tray, contextmenu);
         tray.setToolTip(OCTO_CONFIG.name);
 
         attachTrayPrimaryClick(tray, () => mainWindow);

--- a/apps/web/src-election/main/index.ts
+++ b/apps/web/src-election/main/index.ts
@@ -73,6 +73,7 @@ import { attachLogoutWindowNavigationListeners, classifyOidcNavigation, extractE
 import { createTrustedShellDocumentTracker } from "./trustedShell";
 import { clearAuthSessionCookies } from "./clearAuthSession";
 import { DOWNLOAD_SETTINGS_VERSION, normalizeDownloadSettings, sanitizeDownloadFilename, type DownloadSettings } from "./downloadSettings";
+import { attachTrayPrimaryClick } from "./trayBehavior";
 
 let forceQuit = false;
 let mainWindow: any;
@@ -1537,20 +1538,12 @@ function updateTray(unread?: number, isFlash = false): any {
       if (!tray) {
         // Init tray icon
         tray = new Tray(trayIcon);
-        // macOS uses the status-item click for its menu; Windows shows this
-        // menu on right-click automatically. Keep the explicit window restore
-        // click only on Windows to avoid two actions on one macOS click.
+        // A primary click on the tray icon always restores the main window.
+        // Windows still exposes this menu on right-click via setContextMenu.
         if (!isOsx) tray.setContextMenu(contextmenu);
         tray.setToolTip(OCTO_CONFIG.name);
 
-        tray.on("click", () => {
-          if (isOsx) {
-            tray.popUpContextMenu(contextmenu);
-          } else if (mainWindow && !mainWindow.isDestroyed()) {
-            mainWindow.show();
-            mainWindow.focus();
-          }
-        });
+        attachTrayPrimaryClick(tray, () => mainWindow);
       }
 
       if (isOsx) {

--- a/apps/web/src-election/main/trayBehavior.ts
+++ b/apps/web/src-election/main/trayBehavior.ts
@@ -1,14 +1,16 @@
 export interface TrayWindow {
   isDestroyed(): boolean;
+  isMinimized(): boolean;
+  restore(): void;
   show(): void;
   focus(): void;
 }
 
 export function restoreMainWindow(mainWindow: TrayWindow | null | undefined): void {
-  if (mainWindow && !mainWindow.isDestroyed()) {
-    mainWindow.show();
-    mainWindow.focus();
-  }
+  if (!mainWindow || mainWindow.isDestroyed()) return;
+  if (mainWindow.isMinimized()) mainWindow.restore();
+  mainWindow.show();
+  mainWindow.focus();
 }
 
 export function attachTrayPrimaryClick(
@@ -16,4 +18,11 @@ export function attachTrayPrimaryClick(
   getMainWindow: () => TrayWindow | null | undefined,
 ): void {
   tray.on("click", () => restoreMainWindow(getMainWindow()));
+}
+
+export function attachTraySecondaryMenu(
+  tray: { on(event: "right-click", listener: () => void): void; popUpContextMenu(menu: unknown): void },
+  menu: unknown,
+): void {
+  tray.on("right-click", () => tray.popUpContextMenu(menu));
 }

--- a/apps/web/src-election/main/trayBehavior.ts
+++ b/apps/web/src-election/main/trayBehavior.ts
@@ -1,0 +1,19 @@
+export interface TrayWindow {
+  isDestroyed(): boolean;
+  show(): void;
+  focus(): void;
+}
+
+export function restoreMainWindow(mainWindow: TrayWindow | null | undefined): void {
+  if (mainWindow && !mainWindow.isDestroyed()) {
+    mainWindow.show();
+    mainWindow.focus();
+  }
+}
+
+export function attachTrayPrimaryClick(
+  tray: { on(event: "click", listener: () => void): void },
+  getMainWindow: () => TrayWindow | null | undefined,
+): void {
+  tray.on("click", () => restoreMainWindow(getMainWindow()));
+}


### PR DESCRIPTION
## Summary
- restore and focus the main window when the tray icon is clicked
- restore minimized windows before focusing them
- keep the tray menu available on secondary click (including macOS)
- add behavior-focused tests for primary click, minimized-window restore, destroyed windows, and secondary-click menus

## Validation
- `pnpm --dir apps/web exec tsc -p tsconfig.e.tests.json --noEmit`
- `pnpm --dir apps/web exec vitest run src-election/main/__tests__/trayBehavior.test.ts --config vitest.config.ts --pool=threads --maxWorkers=1`
- `pnpm --dir apps/web exec tsc -p tsconfig.e.json --noEmit`

The branch is based on `main`.