### PR TITLE
fix(login): preserve form state across tab restores

### DIFF
--- a/packages/dmworkbase/src/Service/Route.tsx
+++ b/packages/dmworkbase/src/Service/Route.tsx
@@ -31,7 +31,6 @@ export default class RouteManager {
   // Absent path → path is not shell-scoped → renderCurrentPath falls back to
   // the pre-fix behaviour (restContent(handlerResult)).
   private hostShells: Map<string, () => JSX.Element> = new Map();
-
   private handlePopState = () => {
     RouteManager.shared.renderCurrentPath(window.location.pathname)
   }

--- a/packages/dmworkbase/src/module.tsx
+++ b/packages/dmworkbase/src/module.tsx
@@ -272,7 +272,13 @@ export default class BaseModule implements IModule {
 
     // 账号级快捷静音复用 WuKongIM CMD；回前台、网络恢复和重连时用 GET
     // 校准，CMD 只作为低延迟更新，不承担最终一致性。
-    const refreshQuickMute = () => { void quickMuteStore.refresh().catch(() => undefined); };
+    const refreshQuickMute = () => {
+      // The login page also receives foreground events. Do not call an
+      // authenticated endpoint without a session: its 401 is interpreted by
+      // APIClient as an expired login and reloads /login, discarding form input.
+      if (window.location.pathname.endsWith('/login') || !WKApp.loginInfo.isLogined()) return;
+      void quickMuteStore.refresh().catch(() => undefined);
+    };
     voiceSettingsStore.setUserId(WKApp.loginInfo.uid || "");
     quickMuteStore.setUserId(WKApp.loginInfo.uid || "");
     WKApp.mittBus.on("wk:app-foreground", refreshQuickMute);


### PR DESCRIPTION
## Summary

- Skip the authenticated quick-mute refresh when the current page is `/login` or there is no logged-in session.
- Prevent the resulting unauthenticated 401 from entering the global logout/reload path and discarding login form input during tab restore.

This is the load-bearing fix. On `/login`, the foreground event previously requested `/user/notification-pause` without a valid session; the resulting 401 called `WKApp.logout()` and reloaded `/login`. No route-rendering behavior was changed.

## Verification

- Reproduced the issue in the dev environment on port 3012.
- Verified the fix manually in the dev environment.
- `pnpm --filter @octo/web build`
- `git diff --check`

## Scope

This PR is limited to the login-page tab-restore/input-loss issue.