### PR TITLE
feat(dmworkbase): fetch html doc share preview from its own endpoint

### DIFF
--- a/packages/dmworkbase/src/Messages/DocumentShareCard/__tests__/DocumentShareCardContent.test.ts
+++ b/packages/dmworkbase/src/Messages/DocumentShareCard/__tests__/DocumentShareCardContent.test.ts
@@ -78,10 +78,11 @@ describe("permissionState — only live ACL controls the effective badge", () =>
     expect(permissionState("error")).toBe("error");
   });
 
-  // empty 只来自 docs-backend 的 409 unsupported_doc_type，而 409 只能在
-  // requireDocRole(reader) **通过之后**才抛——所以 empty 在 ACL 上确证了 reader，
+  // empty = reader-protected 接口确认了访问权、但无可渲染内容。两条来源（409
+  // unsupported_doc_type；/html-preview 的 200 + 空 preview）都只能在
+  // requireDocRole(reader) **通过之后**发生——所以 empty 在 ACL 上确证了 reader，
   // 标绿「可查看」是准确结论，不是乐观猜测。
-  it("empty (409 unsupported_doc_type, raised only after the reader check passed) → reader", () => {
+  it("empty (both sources arise only after the reader check passed) → reader", () => {
     expect(permissionState("empty")).toBe("reader");
   });
 });

--- a/packages/dmworkbase/src/Messages/DocumentShareCard/__tests__/preview.test.ts
+++ b/packages/dmworkbase/src/Messages/DocumentShareCard/__tests__/preview.test.ts
@@ -57,9 +57,10 @@ describe("fetchDocPreview — kind → endpoint mapping (blocker #2 regression)"
     ["doc", "content"],
     ["board", "scene"],
     ["sheet", "sheet"],
-    // html 没有专属预览端点，故意复用 /content 当 ACL 探针
-    // （预期 409 unsupported_doc_type，见下面的 empty 用例）。
-    ["html", "content"],
+    // html 有专属预览端点 docs/:id/html-preview（docs-backend docHtmlPreview.ts）。
+    // 曾经它被故意打到 /content 当 ACL 探针（必回 409 → empty），端点上线后必须改打
+    // html-preview，否则 html 卡片永远只有灰色「暂无预览」。
+    ["html", "html-preview"],
   ] as const)("kind=%s → GET docs/:id/%s", async (kind, endpoint) => {
     apiGet.mockResolvedValueOnce({});
     await fetchDocPreview(kind, "d_1", "sp_1");
@@ -195,20 +196,116 @@ describe("fetchDocPreview — doc ProseMirror parsing", () => {
   });
 });
 
-describe("fetchDocPreview — html kind (unsupported_doc_type degrade)", () => {
-  // 防御性：今天 backend 对 html 必回 409，走不到这里。但哪天它给 html 开了 200，
-  // body 形状也不是 ProseMirror doc——绝不能拿去 parseDocPreview 解析/崩溃，直接 empty。
-  it("html + HTTP 200 → empty (never parses a non-ProseMirror body)", async () => {
-    apiGet.mockResolvedValueOnce({
-      doc: { type: "doc", content: [{ type: "heading", content: [{ type: "text", text: "X" }] }] },
+describe("fetchDocPreview — html kind (dedicated /html-preview endpoint)", () => {
+  const htmlBody = (preview: unknown) => ({ docId: "d_1", preview });
+
+  it("adopts body.preview (normalised, NOT fed to parseDocPreview) → ready", async () => {
+    apiGet.mockResolvedValueOnce(
+      htmlBody({ type: "doc", heading: "季度复盘", paragraphs: ["第一段。", "第二段。"] }),
+    );
+    const res = await fetchDocPreview("html", "d_1", "sp_1");
+    expect(apiGet.mock.calls[0][0]).toBe("docs/d_1/html-preview");
+    expect(res.status).toBe("ready");
+    expect(res.preview).toEqual({
+      type: "doc",
+      heading: "季度复盘",
+      paragraphs: ["第一段。", "第二段。"],
     });
+  });
+
+  // 后端 body 是**已经抽好的纯文本结果**，不是 ProseMirror 树。喂给 parseDocPreview
+  // （读 body.doc.content）只会得出 undefined —— 锁死「不走 parseDocPreview」这条契约：
+  // 即使 body 里同时带了一棵 ProseMirror 树，采用的也必须是 preview 字段。
+  it("ignores a ProseMirror-shaped body.doc and uses body.preview", async () => {
+    apiGet.mockResolvedValueOnce({
+      docId: "d_1",
+      doc: {
+        type: "doc",
+        content: [{ type: "heading", content: [{ type: "text", text: "不该被采用" }] }],
+      },
+      preview: { type: "doc", paragraphs: ["真正的预览"] },
+    });
+    const res = await fetchDocPreview("html", "d_1", "sp_1");
+    expect(res.preview).toEqual({ type: "doc", heading: undefined, paragraphs: ["真正的预览"] });
+  });
+
+  it("heading-only preview (no paragraphs) → ready", async () => {
+    apiGet.mockResolvedValueOnce(htmlBody({ type: "doc", heading: "只有标题", paragraphs: [] }));
+    const res = await fetchDocPreview("html", "d_1", "sp_1");
+    expect(res.status).toBe("ready");
+    expect(res.preview).toEqual({ type: "doc", heading: "只有标题", paragraphs: [] });
+  });
+
+  // 🔴 后端对「无 slug / 上游取不到 / 解析不出内容」一律回 **200 + 空预览**（绝不 5xx），
+  // 因为预览失败让卡片变红比没有预览严重得多。前端必须把它落成 empty（灰色「暂无预览」），
+  // 既不能变 error（红色），也不能是 ready-with-undefined。
+  it.each([
+    ["empty paragraphs, no heading", { type: "doc", paragraphs: [] }],
+    ["blank-only strings", { type: "doc", heading: "   ", paragraphs: ["", "  "] }],
+    ["missing preview field", undefined],
+  ])("200 with %s → empty (normal degrade, NOT error)", async (_label, preview) => {
+    apiGet.mockResolvedValueOnce(htmlBody(preview));
     const res = await fetchDocPreview("html", "d_1", "sp_1");
     expect(res.status).toBe("empty");
     expect(res.preview).toBeUndefined();
   });
 
-  // empty 是**稳定结论**（doc_type 不会在 TTL 内变），必须和 ready/denied 一样进缓存，
-  // 否则每个 cell 挂载/每次 focus 都对同一个 html 文档白打一枪 409。
+  // wire 数据不可信：非字符串段落丢弃，段数按前端自身预算收敛，别让后端上限成为唯一上限。
+  it("sanitises untrusted wire content (drops non-strings, caps to 3 paragraphs)", async () => {
+    apiGet.mockResolvedValueOnce(
+      htmlBody({ type: "doc", paragraphs: ["p1", 42, null, "p2", "p3", "p4"] }),
+    );
+    const res = await fetchDocPreview("html", "d_1", "sp_1");
+    expect(res.preview?.type).toBe("doc");
+    expect((res.preview as { paragraphs: string[] }).paragraphs).toEqual(["p1", "p2", "p3"]);
+  });
+
+  // P0 安全：文本来自攻击者可控的 HTML 文档，可能含 `<` `>` `&`。这里只确认**原样保留**
+  // （渲染层 JSX 插值负责转义），绝不能在这一层做任何 HTML 拼接/解码。
+  it("keeps markup-looking plain text verbatim (render layer must escape, not this layer)", async () => {
+    apiGet.mockResolvedValueOnce(
+      htmlBody({ type: "doc", heading: "<script>alert(1)</script>", paragraphs: ["5 < 10 && ok"] }),
+    );
+    const res = await fetchDocPreview("html", "d_1", "sp_1");
+    expect(res.preview).toEqual({
+      type: "doc",
+      heading: "<script>alert(1)</script>",
+      paragraphs: ["5 < 10 && ok"],
+    });
+  });
+
+  it("carries the doc's own space via X-Space-Id header + sp param (same as other kinds)", async () => {
+    apiGet.mockResolvedValueOnce(htmlBody({ type: "doc", paragraphs: ["p"] }));
+    await fetchDocPreview("html", "d_1", "sp_other");
+    const cfg = apiGet.mock.calls[0][1] as {
+      headers?: Record<string, string>;
+      param?: Record<string, string>;
+    };
+    expect(cfg.headers?.["X-Space-Id"]).toBe("sp_other");
+    expect(cfg.param?.sp).toBe("sp_other");
+  });
+
+  // 错误码语义与其它 kind 完全一致（后端复用同一套 guard + 409 body）。
+  it.each([
+    [403, undefined, "denied"],
+    [404, undefined, "unavailable"],
+    [410, undefined, "unavailable"],
+    [409, "unsupported_doc_type", "empty"],
+    [409, "conflict", "unavailable"],
+    [409, "some_future_code", "error"],
+    [500, undefined, "error"],
+  ] as const)("html %d %s → %s", async (status, code, expected) => {
+    apiGet.mockRejectedValueOnce(
+      code === undefined ? { status } : wireReject(status, code),
+    );
+    const res = await fetchDocPreview("html", "d_1", "sp_1");
+    expect(res.status).toBe(expected);
+    expect(res.preview).toBeUndefined();
+  });
+
+  // empty 必须和 ready/denied 一样进缓存，否则每个 cell 挂载/每次 focus 都对同一个 html
+  // 文档白打一枪。注意 409 `unsupported_doc_type` 这条来源确实稳定（doc_type 不会在 TTL 内
+  // 变），下面那条 200 + 空预览的来源则**不稳定** —— 见后一个用例。
   it("caches the empty result (second call within TTL does not re-request)", async () => {
     apiGet.mockRejectedValueOnce(wireReject(409, "unsupported_doc_type"));
     const first = await fetchDocPreview("html", "d_1", "sp_1");
@@ -218,6 +315,45 @@ describe("fetchDocPreview — html kind (unsupported_doc_type degrade)", () => {
     const again = await fetchDocPreview("html", "d_1", "sp_1");
     expect(again.status).toBe("empty");
     expect(apiGet).toHaveBeenCalledTimes(1);
+  });
+
+  // ★ 完整走一遍「上游临时故障 → 自愈」这条链路。
+  //
+  // 背景：html 的 empty **不是稳定结论**。docs-backend 的 htmlPreviewFetch.ts 在上游超时 /
+  // 非 2xx / 无 slug 时一律降级成 200 + 空 preview（绝不 5xx），所以一次上游抖动就会产出
+  // empty，而它可能在几秒内自愈。缓存这种 empty 是有意的权衡（避免每次挂载重打上游），
+  // 但**必须**留一条主动破除的路：force=true 的焦点/可见性重查。
+  //
+  // 三段断言对应三个真实行为：
+  //   1. 200 + 空 preview → empty（不是 error、不是 ready-with-undefined）
+  //   2. TTL 内复用缓存，不重打请求
+  //   3. force=true 绕过缓存重打 —— 上游恢复后用户切回窗口能刷出真预览
+  it("html 200-with-empty-preview → empty is cached, but force:true bypasses the cache so a recovered upstream can refresh it", async () => {
+    // 1. 上游抖动：后端降级回 200 + 空 preview。
+    apiGet.mockResolvedValueOnce(htmlBody({ type: "doc", heading: "", paragraphs: [] }));
+    const first = await fetchDocPreview("html", "d_1", "sp_1");
+    expect(first.status).toBe("empty");
+    expect(first.preview).toBeUndefined();
+    expect(apiGet).toHaveBeenCalledTimes(1);
+
+    // 2. TTL 内再挂载一个 cell：命中缓存，不重打。
+    const cached = await fetchDocPreview("html", "d_1", "sp_1");
+    expect(cached.status).toBe("empty");
+    expect(apiGet).toHaveBeenCalledTimes(1);
+
+    // 3. 上游恢复，用户切回窗口触发 force 重查：必须绕过那条 empty 缓存重新发请求，
+    //    并把真预览刷出来。若 force 被忽略，这里会读回上面的 empty 且请求数停在 1。
+    apiGet.mockResolvedValueOnce(
+      htmlBody({ type: "doc", heading: "季度复盘", paragraphs: ["第一段。"] }),
+    );
+    const refreshed = await fetchDocPreview("html", "d_1", "sp_1", { force: true });
+    expect(apiGet).toHaveBeenCalledTimes(2);
+    expect(refreshed.status).toBe("ready");
+    expect(refreshed.preview).toEqual({
+      type: "doc",
+      heading: "季度复盘",
+      paragraphs: ["第一段。"],
+    });
   });
 });
 

--- a/packages/dmworkbase/src/Messages/DocumentShareCard/docIdentity.ts
+++ b/packages/dmworkbase/src/Messages/DocumentShareCard/docIdentity.ts
@@ -42,12 +42,22 @@ export function permissionState(status: DocSharePreviewStatus): DocSharePermissi
   if (status === "unavailable") return "unavailable";
   if (status === "error") return "error";
   if (status === "ready") return "reader";
-  // empty 只来自 docs-backend 的 409 `unsupported_doc_type`（**已收窄**：其它 409 —— 归档的
-  // `conflict` 走 unavailable、snapshot_invalid 等走 error —— 都到不了这里）。而那道 doc_type
-  // 闸在 requireDocRole(reader) **之后**才跑，换言之，能拿到这个码就意味着调用者已通过
-  // reader 校验；后端也没有任何「无权限却返回 409」的路径。所以 empty 在 ACL 上**确证**了
-  // reader 权限，标绿「可查看」是准确结论，不是乐观猜测；卡片随后自然落到「暂无预览」
-  // 占位，而不是红色错误态。
+  // empty = **reader-protected 接口确认了访问权，但没有可渲染内容**。它有两条来源，
+  // 两条都在 requireDocRole(reader) **通过之后**才可能发生：
+  //   • 409 `unsupported_doc_type`——doc_type 闸排在鉴权之后，拿到这个码即证明已过 reader
+  //     校验（其它 409 到不了这里：归档的 `conflict` 走 unavailable、snapshot_invalid 等走
+  //     error）。doc/sheet/board 端点会对 html 目标回它；/html-preview 自己也会对非 html
+  //     目标回它——四个端点同一套语义，不用区分。
+  //   • 200 + 空 preview（html 的 /html-preview 端点）——路由本身挂在 requireDocRole(reader)
+  //     上，能返回 200 就说明鉴权已过；空内容是后端刻意的降级出口（无 slug / 上游超时 /
+  //     抽不出正文时宁可回空也不回 5xx，见 htmlPreviewFetch.ts）。
+  // 后端没有任何「无权限却返回 409 或 200」的路径，所以无论走哪条，empty 在 ACL 上都
+  // **确证**了 reader 权限，标绿「可查看」是准确结论，不是乐观猜测；卡片随后自然落到
+  // 「暂无预览」占位，而不是红色错误态。
+  //
+  // ⚠️ 注意区分：empty 对**权限**是稳定结论，但对**内容**不是——html 那条来源可能只是
+  // 上游一次抖动，内容随时可能自愈（缓存语义见 preview.ts 的 fetchDocPreview）。
+  // 这里只关心权限维度，所以两条来源殊途同归。
   if (status === "empty") return "reader";
   return "checking";
 }

--- a/packages/dmworkbase/src/Messages/DocumentShareCard/preview.ts
+++ b/packages/dmworkbase/src/Messages/DocumentShareCard/preview.ts
@@ -131,17 +131,55 @@ function parseSheetPreview(body: unknown): DocSharePreview | undefined {
   return { type: "sheet", headers, rows: dataRows };
 }
 
+/**
+ * 采用并**规范化** GET /docs/:id/html-preview 的 `body.preview`。
+ *
+ * ⚠️ 这个 body **不是** ProseMirror 树，是后端已经抽好的纯文本结果，喂给
+ * parseDocPreview 只会读到 `body.doc.content === undefined` → 恒 undefined。
+ * 所以 html 分支只认 `body.preview`、**绝不解析 `body.doc`**（后端
+ * docHtmlPreview.ts 文件头明确写了这条契约）。
+ *
+ * 但“不解析”不等于“逐字照收”：wire 数据仍不可信，这里会 trim、丢弃非字符串与空串、
+ * 按本文件既有预算截断长度与段数（MAX_TEXT_CHARS / MAX_PARAGRAPHS）——别让后端的上限
+ * 成为前端唯一的上限。
+ *
+ * ⚠️ heading/paragraphs 是从**攻击者可控**的 HTML 文档里抽出来的纯文本，可能含
+ * `<` `>` `&`（`&lt;script&gt;` 解码后就是字面量 `<script>`）。消费端必须**当文本渲染**
+ * ——ui/DocumentShareCard 的 JSX 插值天然转义，符合要求；任何 innerHTML /
+ * dangerouslySetInnerHTML 都会把文本变回 markup，重新造出这个端点本来要消灭的 XSS。
+ */
+function adoptHtmlPreview(body: unknown): DocSharePreview | undefined {
+  const preview = (body as { preview?: unknown })?.preview;
+  if (!preview || typeof preview !== "object") return undefined;
+  const p = preview as { heading?: unknown; paragraphs?: unknown };
+  const rawHeading = typeof p.heading === "string" ? p.heading.trim() : "";
+  const heading = rawHeading ? rawHeading.slice(0, MAX_TEXT_CHARS) : undefined;
+  const paragraphs: string[] = [];
+  if (Array.isArray(p.paragraphs)) {
+    for (const item of p.paragraphs as unknown[]) {
+      if (typeof item !== "string") continue;
+      const text = item.trim();
+      if (!text) continue;
+      paragraphs.push(text.slice(0, MAX_TEXT_CHARS));
+      if (paragraphs.length >= MAX_PARAGRAPHS) break;
+    }
+  }
+  // 空 paragraphs + 无 heading 是后端的**正常降级**（无 slug / 上游取不到 / 解析不出
+  // 内容时它回 200 + 空预览，绝不 5xx）→ undefined，交给 requestPreview 判成 empty
+  // （灰色「暂无预览」），**不能**变成红色 error。
+  if (!heading && paragraphs.length === 0) return undefined;
+  return { type: "doc", heading, paragraphs };
+}
+
 const ENDPOINT: Record<DocShareKind, string> = {
   doc: "content",
   board: "scene",
   sheet: "sheet",
-  // html **故意**打 /content，虽然它没有专属预览端点。docs-backend 的 docContent 是
-  // 先跑 requireDocRole(reader)、通过后才撞 doc_type 闸抛 409 `unsupported_doc_type`，
-  // 所以这一枪被当作纯粹的 **ACL 探针**：409 `unsupported_doc_type` 就是“有 reader 权限、
-  // 但此类型无预览”（→ empty），403/404 依旧是无权限/失效。注意 409 **不止这一种**
-  // （见 requestPreview 的错误码分派），只有这个码能推出 reader。零新端点、ACL 语义不丢，
-  // 且未来任何新 doc_type 自动兜住。
-  html: "content",
+  // html 有了专属预览端点（docs-backend docHtmlPreview.ts，reader / requireDocRole）：
+  // 服务端抓上游 HTML、抽出 heading + 前几段**纯文本**返回，原始 markup 永不过界。
+  // 它复用 doc 的三段式错误码语义（403 无权限 / 404·410 失效 / 409
+  // `unsupported_doc_type` 该类型无预览 / 409 `conflict` 已归档），所以下面的分派不变。
+  html: "html-preview",
 };
 
 /**
@@ -179,16 +217,17 @@ async function requestPreview(
         param: spaceId ? { sp: spaceId } : undefined,
       } as any,
     );
-    // html 没有可渲染的首屏预览，body 形状也不是 ProseMirror doc——绝不能拿去
-    // parseDocPreview 解析。防御性分支：今天 backend 必回 409、走不到这里，但哪天
-    // 它给 html 开了 200，也只能得出 empty（有权限无预览），不能崩也不能乱渲染。
-    if (kind === "html") return { status: "empty" };
     const preview =
       kind === "doc"
         ? parseDocPreview(body)
         : kind === "board"
           ? parseBoardPreview(body)
-          : parseSheetPreview(body);
+          : kind === "sheet"
+            ? parseSheetPreview(body)
+            : adoptHtmlPreview(body);
+    // html-preview 的 200 + 空预览是后端**刻意**的降级出口（宁可无预览也不让卡片变红），
+    // 前端必须把它落成 empty（灰色「暂无预览」），而不是 ready-with-undefined。
+    if (kind === "html" && !preview) return { status: "empty" };
     return { status: "ready", preview };
   } catch (e) {
     const status = (e as { status?: number })?.status;
@@ -253,12 +292,31 @@ function cacheKey(
  * 拉取一份 ACL-safe 首屏预览。信任边界由 **docs 后端 reader 接口**把守（requireDocRole）：
  * 无权限 → 403 → denied；文档删/锁 → 404/410 → unavailable；有 reader 权限但该类型无预览 →
  * 409 `unsupported_doc_type` → empty；文档已归档 → 409 `conflict` → unavailable；
+ * html 另有一条：/html-preview 回 **200 + 空 preview** → empty（后端刻意的降级出口）；
  * 其余错误（含**其它 409**，如 snapshot_invalid 这类后端 fail-closed 的数据损坏）→ error。
- * space 用显式 X-Space-Id 头传文档自身 space（文档可能不在当前 space）。
+ * space 用显式 X-Space-Id 头传文档自身的 space（文档可能不在当前 space）。
  *
- * 去重 + 缓存（P2-4）：并发同 key 共享一个在飞请求；成功/无权限/失效/无预览结果缓存 30s
- * （empty 和 ready 一样是**稳定结论**，doc_type 不会在 TTL 内变），error 不缓存（可能是瞬时
- * 故障，允许下次重试）。`signal` 保留以兼容调用方，但共享请求不按单个调用方 abort
+ * 去重 + 缓存（P2-4）：并发同 key 共享一个在飞请求；成功/无权限/失效/无预览结果缓存 30s，
+ * error 不缓存（可能是瞬时故障，允许下次重试）。
+ *
+ * ⚠️ empty **不是稳定结论**，它仍然进缓存是一个权衡，不是推论：
+ *   • 409 `unsupported_doc_type` 这条确实稳定（doc_type 不会在 TTL 内变）；
+ *   • 但 html 的 200 + 空 preview 可能源于**上游超时 / 临时故障 / 无 slug**
+ *     （见 docs-backend htmlPreviewFetch.ts：任何失败都降级成空预览，绝不 5xx）——
+ *     这类 empty **30s 内完全可能自愈**。
+ * 仍然缓存它的理由：（1）不缓存就变成每个 cell 挂载都对同一文档重打一枪，而 html 那一枪
+ * 还会穿透到上游取源，成本远高于一次 409；（2）降级态本身是中性的「暂无预览」，多撑一会
+ * 不会误导用户（不会把有预览说成没权限，也不会把正常说成出错）。
+ *
+ * ⚠️ 但**没有定时重查**：能拿到新结果的只有两种情况——缓存**已过期**后的 Cell 挂载（挂载走
+ * `force: false`，TTL 内重新挂载会直接命中旧 empty，**不**会重取），或 `force: true`（Cell 侧绑的
+ * window focus / visibilitychange，见 Messages/DocumentShareCard/index.tsx）。注意 `force: true`
+ * 只绕过**结果缓存**，不绕过在飞去重：同 key 请求正在路上时它复用那一枪、不另发。用户若一直
+ * 停在同一个可见窗口盯着这张卡，上游恢复了它也不会自己变出预览——陈旧态**不是有界的**，
+ * 需要用户切走再切回（force），或等 TTL 过期后再挂载。缩短 html empty 的 TTL 或加定时重试
+ * 可以改善这一点，属于后续优化，不在本次改动范围内。
+ *
+ * `signal` 保留以兼容调用方，但共享请求不按单个调用方 abort
  * （Cell 侧已用自身 aborted 标志守 setState，卸载后不写状态）。
  */
 export async function fetchDocPreview(

--- a/packages/dmworkbase/src/ui/DocumentShareCard/index.tsx
+++ b/packages/dmworkbase/src/ui/DocumentShareCard/index.tsx
@@ -15,7 +15,9 @@ export type DocSharePermissionState =
 
 /**
  * 首屏预览取数状态。
- * `empty` = 有访问权限、但该 doc_type 没有可渲染的预览（如 html 文档）——
+ * `empty` = **鉴权已通过**（reader 接口确认了访问权），但**没有可渲染的内容**——不绑定具体
+ * doc_type，既覆盖「该类型本来就没有预览」（409 `unsupported_doc_type`），也覆盖「有预览
+ * 能力但这次没抽到内容」（专属预览接口 200 + 空内容）。
  * 是**正常降级**，与 error（取数失败）严格区分：前者标绿显「暂无预览」，后者标红。
  */
 export type DocSharePreviewStatus =


### PR DESCRIPTION
## Summary

转发 HTML 文档产生的 type-18 DocumentShareCard 一直停在灰色「暂无预览」。原因是前端把 `/content` 当纯 ACL 探针用——docs-backend 的 `docContent` 只接受 `doc` 类型，html 目标必然撞 409 `unsupported_doc_type`，前端据此得出 `empty`。这是当时没有专属端点的权宜之计。

docs-backend 现已上线专属端点（`GET /docs/:docId/html-preview`，reader 权限）：服务端抓取上游 HTML、抽出 heading + 前几段**纯文本**返回，原始 markup 永不过界。本 PR 把前端接上去。

- `ENDPOINT.html`: `content` → `html-preview`
- 新增 `adoptHtmlPreview()`：采用并规范化 `body.preview`，**绕开 `parseDocPreview`**（后者读 `body.doc.content`，对该端点恒得 `undefined`）
- `200 + 空预览` 是后端刻意的降级出口 → `empty`（灰色占位），**不是** `error`（红卡）
- 403 / 404 / 410 / 409 的分派语义保持不变

同步修正了三处因本次改动而失准的注释：`empty` 不再只来自 409，新增「200 + 空预览」这条来源，且它**对权限稳定、对内容不稳定**。

## Linked Spec

- 后端端点：octo-docs-backend MR !97（`src/api/routes/docHtmlPreview.ts`），已部署验证
- 发送侧 kind 透传：octo-docs-module MR !40（已合入 main）

本 PR 是这条链路的第三块，也是最后一块：卡片去取摘要并渲染。

## COMPREHENSION

**(a) 对 load-bearing 路径做了什么（before/after）**

`fetchDocPreview` 是所有分享卡片首屏预览的唯一取数入口，四种 kind 共用它的缓存、去重、账号隔离与错误码分派。

- Before：`kind=html` → `GET docs/:id/content` → 后端 `requireDocRole(reader)` 通过后撞 doc_type 闸 → 409 `unsupported_doc_type` → `status:"empty"` → 灰色「暂无预览」。预览内容**永远拿不到**。
- After：`kind=html` → `GET docs/:id/html-preview` → 200 + `{preview:{type:"doc",heading?,paragraphs}}` → 规范化后 `status:"ready"` → 走**现有** `document-preview-page` 渲染器。取不到内容时后端回 200 + 空预览 → `status:"empty"` → 仍是灰色占位。

关键设计约束：本端点返回的是**已抽取的结果**，不是 ProseMirror 树，所以 html 分支必须绕开 `parseDocPreview`。这是后端 `docHtmlPreview.ts` 文件头写死的契约——服务端抽取正是为了让攻击者可控的 HTML 永不到达客户端，让前端重新解析会重造出该端点要消灭的问题。

**(b) 什么可能坏（依赖方 + 失败模式）**

- `Messages/DocumentShareCard/index.tsx`（Cell）：唯一调用方，`componentDidMount` 走 `force:false`、focus/visibilitychange 走 `force:true`。本 PR 未改其行为。
- `docIdentity.ts permissionState()`：把 `empty` 映射为 `reader`（标绿「可查看」）。这个结论在新来源下**仍然成立**——`/html-preview` 路由挂在 `requireDocRole(reader)` 上，能返回 200 即证明鉴权已过。若此处误判，会把无权限文档标绿。
- `ui/DocumentShareCard/index.tsx` doc 分支渲染器：被四种 kind 共用，本 PR 复用它渲染 html 预览（只改注释，未改逻辑）。
- 最主要的失败模式：若把 `200 + 空预览` 误落成 `error`，卡片会变红「预览不可用」——比没有预览严重得多，测试专门锁了这条。
- 未触碰：跨账号缓存隔离（cache key 嵌 uid）、TTL、inflight 去重、`force` 语义。

**(c) 怎么知道它能用**

- `packages/dmworkbase/src/Messages/DocumentShareCard/`：**71 passed**（3 文件），其中 `preview.test.ts` 40 例。
- **fail-before 实证**：退回旧实现（html 打 `/content`）后 6 例立即变红，典型断言 `expected 'docs/d_1/content' to be 'docs/d_1/html-preview'`、`expected 'empty' to be 'ready'`。
- **force-bypass 的独立 fail-before**：把 `if (!opts.force)` 改成 `if (true)`（即忽略 force）后**只有新增的那一条**变红：`expected "vi.fn()" to be called 2 times, but got 1 times` —— 证明此前无任何测试守着这条路径。
- typecheck：`tsc --noEmit` 错误数 before/after 均为 2812（全部是既存的 `.stories.tsx` / `@storybook/react` moduleResolution 问题），**无新增**。
- 新增覆盖：端点断言、heading+paragraphs → ready、空数组/纯空白/缺 `preview` 字段 → empty、忽略 ProseMirror 形状的 `body.doc`、非字符串过滤 + 段数截断、markup 样文本原样保留、403/404/410/409×3/500 全套、`X-Space-Id` 头 + `sp` 参数、empty 进缓存且 `force` 可绕过。

## How verified

1. 上述测试与 typecheck，由我（orchestrator）**独立复跑**，非采信实现者报告；fail-before 两次注入均为我亲手执行并恢复（`grep` 确认注入痕迹已清零）。
2. 独立 reviewer 四轮对抗审查。逻辑面无 P0/P1，7 项裁决全部确认正确（含 html 单独返回 `empty` 的语义决策、前端二次截断、409 fail-closed 分派、跨账号缓存回归）。前三轮的 CHANGES-REQUESTED **全部是注释精度问题**，已逐条修正。
3. 安全红线（P0）复查通过：`heading`/`paragraphs` 全链路经 JSX 文本插值渲染，grep 确认无 `innerHTML` / `dangerouslySetInnerHTML` / `insertAdjacentHTML`。

## 已知限制

这些是当前实现的真实行为，不是本 PR 引入的回归，但应知悉：

- HTML 空预览会**缓存 30 秒**，期间普通重新挂载仍显示旧的「暂无预览」。
- **没有定时刷新**；恢复依赖窗口 focus、页面重新可见，或 TTL 过期后的再次挂载。用户若一直停在同一个可见窗口盯着卡片，上游恢复后它**不会自愈**。
- `force:true` 只绕过**结果缓存**，不绕过在飞去重；同 key 请求仍在路上时会复用该请求。
- 上游超时 / 非 2xx / 无 slug / 解析失败在后端统一降级为 `200 + 空预览`，前端**无法区分**具体原因（这是后端刻意的设计：预览失败让卡片变红比没有预览更糟）。
- 前端会 trim 文本，并将标题/单段限制为 500 字符、段落限制为 3 段（后端已有更严的限制，此处是独立的防御边界）。
- 共享请求不会因单个 Cell 卸载而取消；卸载只阻止后续状态写入。

改善「持续停留不自愈」可以缩短 html `empty` 的 TTL 或加定时重试。reviewer 裁决为**可后续单开、不阻塞本 PR**，故未纳入范围。

## 部署前提

无新增环境变量。**唯一前提**：docs-backend 需已部署包含 MR !97 的版本，否则 `/html-preview` 返回 404 → 前端落到 `error`（红卡）。后端未上线的环境请勿合入本 PR。
