### PR TITLE
feat(mail): allow repeated rule condition fields

### DIFF
--- a/packages/mail/src/ui/MailRuleManagementView/MailRuleManagementView.test.tsx
+++ b/packages/mail/src/ui/MailRuleManagementView/MailRuleManagementView.test.tsx
@@ -113,6 +113,20 @@ describe("MailRuleManagementView editor", () => {
     expect(
       screen.getByText("已添加 2 / 5 个条件；至少添加并填写一个条件。")
     ).toBeTruthy();
+    const secondConditionType = screen.getByRole("combobox", {
+      name: "条件类型 2",
+    }) as HTMLSelectElement;
+    expect(
+      Array.from(secondConditionType.options)
+        .filter((option) => option.value)
+        .map((option) => [option.value, option.disabled])
+    ).toEqual([
+      ["subject", false],
+      ["body", false],
+      ["subject_or_body", false],
+      ["from", false],
+      ["to", false],
+    ]);
     const deleteConditions = screen.getAllByRole("button", {
       name: /^删除条件 \d+$/,
     });
@@ -259,6 +273,73 @@ describe("MailRuleManagementView editor", () => {
     );
   });
 
+  it("creates repeated field conditions through the editor", () => {
+    const onSave = vi.fn().mockResolvedValue(true);
+    render(
+      <MailRuleManagementView
+        mailbox={{
+          id: "mailbox-1",
+          address: "agent@example.com",
+          connectState: "connected",
+          outboundMode: "manual_confirmation",
+        }}
+        rules={[]}
+        loading={false}
+        error=""
+        actionError=""
+        saving={false}
+        deletingId=""
+        t={(key) => labels[key] ?? key}
+        onBack={vi.fn()}
+        onRefresh={vi.fn()}
+        onSave={onSave}
+        onSetEnabled={vi.fn()}
+        onDelete={vi.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getAllByRole("button", { name: "新建规则" })[0]!);
+    fireEvent.change(screen.getByRole("textbox", { name: "名称" }), {
+      target: { value: "正文组合规则" },
+    });
+    fireEvent.change(screen.getByRole("combobox", { name: "条件类型 1" }), {
+      target: { value: "body" },
+    });
+    fireEvent.change(screen.getByRole("textbox", { name: "正文 1" }), {
+      target: { value: "alpha" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "添加条件" }));
+    fireEvent.change(screen.getByRole("combobox", { name: "条件类型 2" }), {
+      target: { value: "body" },
+    });
+    fireEvent.change(screen.getByRole("textbox", { name: "正文 2" }), {
+      target: { value: "beta" },
+    });
+    fireEvent.change(
+      screen.getByRole("textbox", { name: "转发至固定地址 1" }),
+      { target: { value: "owner@example.com" } }
+    );
+    fireEvent.click(
+      screen.getAllByRole("button", { name: "新建规则" }).at(-1)!
+    );
+
+    expect(onSave).toHaveBeenCalledWith(
+      {
+        name: "正文组合规则",
+        enabled: true,
+        priority: 0,
+        matchMode: "all",
+        conditions: [
+          { field: "body", operator: "contains", value: "alpha" },
+          { field: "body", operator: "contains", value: "beta" },
+        ],
+        forwardTargets: ["owner@example.com"],
+      },
+      undefined
+    );
+  });
+
   it("does not save an API rule with more than five conditions", () => {
     render(
       <MailRuleManagementView
@@ -317,7 +398,15 @@ describe("MailRuleManagementView editor", () => {
     ).toBe(true);
   });
 
-  it("does not save an API rule with duplicate condition fields", () => {
+  it("saves five conditions that repeat the same field", () => {
+    const onSave = vi.fn().mockResolvedValue(true);
+    const conditions = ["alpha", "beta", "gamma", "delta", "epsilon"].map(
+      (value) => ({
+        field: "body" as const,
+        operator: "contains" as const,
+        value,
+      })
+    );
     render(
       <MailRuleManagementView
         mailbox={{
@@ -333,10 +422,7 @@ describe("MailRuleManagementView editor", () => {
             enabled: true,
             priority: 0,
             matchMode: "all",
-            conditions: [
-              { field: "from", operator: "contains", value: "a" },
-              { field: "from", operator: "not_contains", value: "b" },
-            ],
+            conditions,
             forwardTargets: ["owner@example.com"],
             createdAt: "2026-08-17T00:00:00Z",
             updatedAt: "2026-08-17T00:00:00Z",
@@ -350,7 +436,7 @@ describe("MailRuleManagementView editor", () => {
         t={(key) => labels[key] ?? key}
         onBack={vi.fn()}
         onRefresh={vi.fn()}
-        onSave={vi.fn()}
+        onSave={onSave}
         onSetEnabled={vi.fn()}
         onDelete={vi.fn()}
       />
@@ -358,9 +444,29 @@ describe("MailRuleManagementView editor", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "编辑规则" }));
     expect(
+      (
+        screen.getByRole("button", {
+          name: "添加条件",
+        }) as HTMLButtonElement
+      ).disabled
+    ).toBe(true);
+    expect(
       (screen.getByRole("button", { name: "保存" }) as HTMLButtonElement)
         .disabled
-    ).toBe(true);
+    ).toBe(false);
+
+    fireEvent.click(screen.getByRole("button", { name: "保存" }));
+    expect(onSave).toHaveBeenCalledWith(
+      {
+        name: "重复条件规则",
+        enabled: true,
+        priority: 0,
+        matchMode: "all",
+        conditions,
+        forwardTargets: ["owner@example.com"],
+      },
+      "duplicate-rule"
+    );
   });
 
   it("uses the centered product confirmation before deleting a rule", () => {

--- a/packages/mail/src/ui/MailRuleManagementView/index.tsx
+++ b/packages/mail/src/ui/MailRuleManagementView/index.tsx
@@ -88,6 +88,7 @@ const conditionFields: MailRuleConditionField[] = [
   "from",
   "to",
 ];
+const maxConditions = 5;
 
 function effectiveConditions(rule: MailRule): MailRuleCondition[] {
   if (rule.conditions?.length) return rule.conditions;
@@ -146,9 +147,7 @@ export default function MailRuleManagementView(
   const conditionsValid = Boolean(
     editor &&
       editor.conditions.length > 0 &&
-      editor.conditions.length <= conditionFields.length &&
-      new Set(editor.conditions.map((condition) => condition.field)).size ===
-        editor.conditions.length &&
+      editor.conditions.length <= maxConditions &&
       editor.conditions.every((condition) => condition.value.trim())
   );
   const targetRowsValid = Boolean(
@@ -456,9 +455,7 @@ export default function MailRuleManagementView(
                   </select>
                   <button
                     type="button"
-                    disabled={
-                      editor.conditions.length >= conditionFields.length
-                    }
+                    disabled={editor.conditions.length >= maxConditions}
                     onClick={() => {
                       const next = conditionFields.find(
                         (field) =>
@@ -516,16 +513,7 @@ export default function MailRuleManagementView(
                       <optgroup label={t("mail.rules.conditionGroupContent")}>
                         {(["subject", "body", "subject_or_body"] as const).map(
                           (field) => (
-                            <option
-                              value={field}
-                              key={field}
-                              disabled={
-                                field !== condition.field &&
-                                editor.conditions.some(
-                                  (item) => item.field === field
-                                )
-                              }
-                            >
+                            <option value={field} key={field}>
                               {t(`mail.rules.${field}`)}
                             </option>
                           )
@@ -533,16 +521,7 @@ export default function MailRuleManagementView(
                       </optgroup>
                       <optgroup label={t("mail.rules.conditionGroupPeople")}>
                         {(["from", "to"] as const).map((field) => (
-                          <option
-                            value={field}
-                            key={field}
-                            disabled={
-                              field !== condition.field &&
-                              editor.conditions.some(
-                                (item) => item.field === field
-                              )
-                            }
-                          >
+                          <option value={field} key={field}>
                             {t(`mail.rules.${field}`)}
                           </option>
                         ))}
@@ -618,7 +597,7 @@ export default function MailRuleManagementView(
                   {t("mail.rules.conditionsHint", {
                     values: {
                       count: editor.conditions.length,
-                      limit: conditionFields.length,
+                      limit: maxConditions,
                     },
                   })}
                 </p>


### PR DESCRIPTION
## Summary

Allow users to select the same field in multiple conditions within one mail rule.

## Related Issue

Closes #1573

Related backend: Mininglamp-OSS/octo-mail#77 — merged on 2026-08-26. The backend change will be deployed before this Web change.

## Changes

- Allow every condition row to select any supported field, including a field already used by another row.
- Keep the existing maximum of five conditions and non-empty value validation.
- Add component coverage for authoring repeated fields and saving five body conditions.

## Architecture / Module Boundary

- Affected module(s): `packages/mail`
- New or changed user-visible entry point: no; the existing mail rule editor accepts repeated fields
- Shared layer touched: ui
- If shared code changed, impact scope: mail rule management only
- Duplicate entry point checked: not applicable

## Testing

- [x] Unit tests added/updated
- [x] Manually verified
- `pnpm --filter @octo/mail test` — 205 tests passed
- `pnpm --filter @octo/mail typecheck` — passed
- `pnpm i18n:check` — passed
- `pnpm build` — passed

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation
- [x] Ran `pnpm i18n:check` or confirmed the change does not affect UI copy
- [x] Confirmed the change follows module ownership and does not add duplicate user-visible entry points
- [x] Described impact scope when shared components, messages, bridge, or services are changed
- [x] Followed commit message conventions (Conventional Commits)
