### PR TITLE
fix(chat): keep channel settings above floating controls

### DIFF
--- a/apps/web/e2e-kit/_kit/mock-im-runtime/fake-provider.ts
+++ b/apps/web/e2e-kit/_kit/mock-im-runtime/fake-provider.ts
@@ -125,6 +125,7 @@ function toSubscriber(s: MockSubscriberSeed): Subscriber {
   sub.uid = s.uid;
   (sub as any).name = s.name ?? s.uid;
   (sub as any).role = s.role ?? 0;
+  (sub as any).status = s.status ?? 0;
   (sub as any).version = 1; // 增量 sync 需要,SDK 内部读 lastMember.version
   (sub as any).orgData = { ...s.orgData, robot: s.robot ?? 0 };
   return sub;

--- a/apps/web/e2e-kit/_kit/mock-im-runtime/seed-types.ts
+++ b/apps/web/e2e-kit/_kit/mock-im-runtime/seed-types.ts
@@ -58,6 +58,7 @@ export interface MockSubscriberSeed {
   channelId: string;
   channelType: number;
   role?: number;
+  status?: 0 | 1 | 2;
   robot?: 0 | 1;
   orgData?: Record<string, unknown>;
 }

--- a/apps/web/e2e-kit/tests/chat/chat-layout-coverage.spec.ts
+++ b/apps/web/e2e-kit/tests/chat/chat-layout-coverage.spec.ts
@@ -175,32 +175,62 @@ test(
       .last();
     await expect(scrollButton).toHaveClass(/wk-reveale/);
 
-    await authedPage.getByTestId("chat-channel-setting-entry").click();
+    const channelSettingEntry = authedPage.getByTestId(
+      "chat-channel-setting-entry",
+    );
+    await channelSettingEntry.click();
     const mask = authedPage.getByTestId("chat-channel-setting-mask");
     const panel = authedPage.locator(".wk-chat-channelsetting");
     await expect(mask).toBeVisible();
     await expect(panel).toBeVisible();
+    await expect(panel).toBeFocused();
+    await expect(panel).toHaveAttribute("aria-modal", "true");
+    await expect(authedPage.locator(".wk-chat-content-chat")).toHaveAttribute(
+      "inert",
+      "",
+    );
+    await authedPage.keyboard.press("Shift+Tab");
+    await expect
+      .poll(() =>
+        panel.evaluate((element) => element.contains(document.activeElement)),
+      )
+      .toBe(true);
+    await authedPage.keyboard.press("Tab");
+    await expect
+      .poll(() =>
+        panel.evaluate((element) => element.contains(document.activeElement)),
+      )
+      .toBe(true);
 
-    const [scrollZIndex, maskZIndex, panelZIndex] = await Promise.all([
-      scrollPositionView.evaluate((element) =>
-        Number(getComputedStyle(element).zIndex),
-      ),
-      mask.evaluate((element) => Number(getComputedStyle(element).zIndex)),
-      panel.evaluate((element) => Number(getComputedStyle(element).zIndex)),
-    ]);
-    expect(scrollZIndex).toBeLessThan(maskZIndex);
-    expect(maskZIndex).toBeLessThan(panelZIndex);
+    const scrollButtonBox = await scrollButton.boundingBox();
+    if (!scrollButtonBox) throw new Error("滚动到底部按钮没有可验证的布局位置");
+    const panelCoversScrollButton = await panel.evaluate(
+      (element, point) =>
+        element.contains(document.elementFromPoint(point.x, point.y)),
+      {
+        x: scrollButtonBox.x + scrollButtonBox.width / 2,
+        y: scrollButtonBox.y + scrollButtonBox.height / 2,
+      },
+    );
+    expect(panelCoversScrollButton).toBe(true);
 
+    await authedPage.keyboard.press("Escape");
+    await expect(mask).toHaveCount(0);
+    await expect(channelSettingEntry).toBeFocused();
+
+    await channelSettingEntry.click();
     await mask.click({ position: { x: 8, y: 8 } });
     await expect(mask).toHaveCount(0);
     await expect(
       authedPage.locator(".wk-chat-content-right"),
     ).not.toHaveClass(/wk-chat-channelsetting-open/);
 
-    await authedPage.getByTestId("chat-thread-panel-entry").click();
+    await channelSettingEntry.click();
+    await authedPage.getByTestId("chat-thread-panel-entry").dispatchEvent("click");
     await expect(
       authedPage.getByTestId("chat-channel-setting-mask"),
     ).toHaveCount(0);
+    await expect(authedPage.getByText("子区", { exact: true })).toBeVisible();
   },
 );
 

--- a/apps/web/e2e-kit/tests/chat/chat-layout-coverage.spec.ts
+++ b/apps/web/e2e-kit/tests/chat/chat-layout-coverage.spec.ts
@@ -146,6 +146,64 @@ test("@CH23 @p1 @chat @conversation 详情顶部显示标题并打开群详情",
   await expect(authedPage.locator(".wk-chat-content-right")).toHaveClass(/wk-chat-channelsetting-open/);
 });
 
+test(
+  "@CH43 @p1 @chat @conversation 群详情遮罩覆盖聊天浮动按钮",
+  async ({ authedPage }) => {
+    await installMockImRuntime(authedPage, seed());
+    await openChat(authedPage);
+    await authedPage
+      .getByRole("button", { name: "最近", exact: true })
+      .click();
+    await authedPage.getByText(GROUP_NAME, { exact: true }).click();
+
+    const messages = authedPage.locator(".wk-conversation-messages");
+    await expect(messages).toBeVisible({ timeout: 15_000 });
+    await messages.evaluate((element) => {
+      Object.defineProperties(element, {
+        scrollHeight: { configurable: true, value: 2_000 },
+        clientHeight: { configurable: true, value: 600 },
+      });
+      element.scrollTop = 0;
+      element.dispatchEvent(new Event("scroll", { bubbles: true }));
+    });
+
+    const scrollPositionView = authedPage.locator(
+      ".wk-conversationpositionview",
+    );
+    const scrollButton = scrollPositionView
+      .locator(".wk-conversationpositionview-item")
+      .last();
+    await expect(scrollButton).toHaveClass(/wk-reveale/);
+
+    await authedPage.getByTestId("chat-channel-setting-entry").click();
+    const mask = authedPage.getByTestId("chat-channel-setting-mask");
+    const panel = authedPage.locator(".wk-chat-channelsetting");
+    await expect(mask).toBeVisible();
+    await expect(panel).toBeVisible();
+
+    const [scrollZIndex, maskZIndex, panelZIndex] = await Promise.all([
+      scrollPositionView.evaluate((element) =>
+        Number(getComputedStyle(element).zIndex),
+      ),
+      mask.evaluate((element) => Number(getComputedStyle(element).zIndex)),
+      panel.evaluate((element) => Number(getComputedStyle(element).zIndex)),
+    ]);
+    expect(scrollZIndex).toBeLessThan(maskZIndex);
+    expect(maskZIndex).toBeLessThan(panelZIndex);
+
+    await mask.click({ position: { x: 8, y: 8 } });
+    await expect(mask).toHaveCount(0);
+    await expect(
+      authedPage.locator(".wk-chat-content-right"),
+    ).not.toHaveClass(/wk-chat-channelsetting-open/);
+
+    await authedPage.getByTestId("chat-thread-panel-entry").click();
+    await expect(
+      authedPage.getByTestId("chat-channel-setting-mask"),
+    ).toHaveCount(0);
+  },
+);
+
 test("@CH24 @p1 @chat @thread 群详情顶部打开子区列表", async ({ authedPage }) => {
   await openConversation(authedPage); await authedPage.getByTestId("chat-thread-panel-entry").click();
   await expect(authedPage.getByText("子区", { exact: true })).toBeVisible({ timeout: 15_000 });

--- a/apps/web/e2e-kit/tests/chat/chat-layout-coverage.spec.ts
+++ b/apps/web/e2e-kit/tests/chat/chat-layout-coverage.spec.ts
@@ -49,6 +49,31 @@ async function openConversation(page: Parameters<typeof installMockImRuntime>[0]
   await expect(page.locator('[contenteditable="true"]')).toBeVisible({ timeout: 15_000 });
 }
 
+async function registerChannelSettingUserInfo(
+  page: Parameters<typeof installMockImRuntime>[0],
+) {
+  await page.evaluate(() => {
+    type Msw = {
+      worker: { use: (...handlers: unknown[]) => void };
+      http: { get: (path: string, resolver: () => unknown) => unknown };
+      HttpResponse: { json: (body: unknown) => unknown };
+    };
+    const msw = (window as unknown as { __msw?: Msw }).__msw;
+    if (!msw) throw new Error("[chat-layout] MSW worker 未就绪");
+    msw.worker.use(
+      msw.http.get("*/users/e2e-user-2", () =>
+        msw.HttpResponse.json({
+          uid: "e2e-user-2",
+          name: "E2E Sender",
+          short_no: "e2e-2001",
+          robot: 0,
+          extra: {},
+        }),
+      ),
+    );
+  });
+}
+
 
 test("@CH21 @p1 @chat @sidebar 顶部搜索和添加入口打开面板", async ({ authedPage }) => {
   await openChat(authedPage);
@@ -149,7 +174,27 @@ test("@CH23 @p1 @chat @conversation 详情顶部显示标题并打开群详情",
 test(
   "@CH43 @p1 @chat @conversation 群详情遮罩覆盖聊天浮动按钮",
   async ({ authedPage }) => {
-    await installMockImRuntime(authedPage, seed());
+    await installMockImRuntime(authedPage, {
+      ...seed(),
+      subscribers: [
+        {
+          uid: "e2e-user-1",
+          name: "E2E Tester",
+          channelId: GROUP_ID,
+          channelType: 2,
+          role: 1,
+          status: 1,
+        },
+        {
+          uid: "e2e-user-2",
+          name: "E2E Sender",
+          channelId: GROUP_ID,
+          channelType: 2,
+          status: 1,
+        },
+      ],
+    });
+    await registerChannelSettingUserInfo(authedPage);
     await openChat(authedPage);
     await authedPage
       .getByRole("button", { name: "最近", exact: true })
@@ -214,6 +259,31 @@ test(
     );
     expect(panelCoversScrollButton).toBe(true);
 
+    const member = panel
+      .locator(".wk-subscribers-item")
+      .filter({ hasText: "E2E Sender" });
+    await expect(member).toBeVisible();
+    await member.click();
+    const userInfoModal = authedPage
+      .locator(".semi-modal-content.wk-modal-content")
+      .filter({ hasText: "E2E Sender" });
+    await expect(userInfoModal).toBeVisible();
+    const userInfoAction = userInfoModal.locator("button").first();
+    await expect(userInfoAction).toBeVisible();
+    await userInfoAction.focus();
+    await authedPage.keyboard.press("Tab");
+    await expect
+      .poll(() =>
+        userInfoModal.evaluate((element) =>
+          element.contains(document.activeElement),
+        ),
+      )
+      .toBe(true);
+    await authedPage.keyboard.press("Escape");
+    await expect(userInfoModal).toBeHidden();
+    await expect(mask).toBeVisible();
+
+    await panel.focus();
     await authedPage.keyboard.press("Escape");
     await expect(mask).toHaveCount(0);
     await expect(channelSettingEntry).toBeFocused();
@@ -225,11 +295,7 @@ test(
       authedPage.locator(".wk-chat-content-right"),
     ).not.toHaveClass(/wk-chat-channelsetting-open/);
 
-    await channelSettingEntry.click();
-    await authedPage.getByTestId("chat-thread-panel-entry").dispatchEvent("click");
-    await expect(
-      authedPage.getByTestId("chat-channel-setting-mask"),
-    ).toHaveCount(0);
+    await authedPage.getByTestId("chat-thread-panel-entry").click();
     await expect(authedPage.getByText("子区", { exact: true })).toBeVisible();
   },
 );

--- a/packages/dmworkbase/src/Pages/Chat/index.css
+++ b/packages/dmworkbase/src/Pages/Chat/index.css
@@ -548,13 +548,34 @@
   align-items: center;
 }
 
+.wk-chat-channelsetting-mask {
+  position: fixed;
+  inset: 0;
+  z-index: 300;
+  padding: 0;
+  border: 0;
+  background: var(--wk-overlay-scrim);
+  cursor: default;
+  animation: wk-chat-channelsetting-mask-in 150ms ease-out;
+}
+
+@keyframes wk-chat-channelsetting-mask-in {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
+}
+
 .wk-chat-channelsetting {
   pointer-events: auto;
   width: var(--wk-wdith-chat-channelsetting);
   height: 100%;
   transition: margin-right 150ms ease-in-out 0s;
   position: absolute;
-  z-index: 99;
+  z-index: 301;
   top: 0;
   right: 0;
   border-left: var(--wk-line);

--- a/packages/dmworkbase/src/Pages/Chat/index.css
+++ b/packages/dmworkbase/src/Pages/Chat/index.css
@@ -551,22 +551,9 @@
 .wk-chat-channelsetting-mask {
   position: fixed;
   inset: 0;
-  z-index: 300;
-  padding: 0;
-  border: 0;
+  z-index: calc(var(--wk-z-modal) + 10);
   background: var(--wk-overlay-scrim);
   cursor: default;
-  animation: wk-chat-channelsetting-mask-in 150ms ease-out;
-}
-
-@keyframes wk-chat-channelsetting-mask-in {
-  from {
-    opacity: 0;
-  }
-
-  to {
-    opacity: 1;
-  }
 }
 
 .wk-chat-channelsetting {
@@ -575,7 +562,7 @@
   height: 100%;
   transition: margin-right 150ms ease-in-out 0s;
   position: absolute;
-  z-index: 301;
+  z-index: calc(var(--wk-z-modal) + 11);
   top: 0;
   right: 0;
   border-left: var(--wk-line);

--- a/packages/dmworkbase/src/Pages/Chat/index.tsx
+++ b/packages/dmworkbase/src/Pages/Chat/index.tsx
@@ -396,6 +396,53 @@ export class ChatContentPage extends Component<
   private _unsubscribeChannelInfoListener?: () => void;
   private _unsubscribeChannelSearchConfig?: () => void;
   private readonly titlePageOwner = Symbol("chat-content-page");
+  private readonly channelSettingPanelRef = React.createRef<HTMLDivElement>();
+  private channelSettingReturnFocusElement?: HTMLElement;
+
+  private _closeChannelSetting = () => {
+    this.setState({ showChannelSetting: false });
+  };
+
+  private _onChannelSettingKeyDown = (event: KeyboardEvent) => {
+    if (!this.state.showChannelSetting) return;
+
+    if (event.key === "Escape") {
+      event.preventDefault();
+      event.stopPropagation();
+      this._closeChannelSetting();
+      return;
+    }
+
+    if (event.key !== "Tab") return;
+
+    const panel = this.channelSettingPanelRef.current;
+    if (!panel) return;
+
+    const focusableElements = Array.from(
+      panel.querySelectorAll<HTMLElement>(
+        'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"]), [contenteditable="true"]'
+      )
+    ).filter((element) => element.getAttribute("aria-hidden") !== "true");
+
+    if (focusableElements.length === 0) {
+      event.preventDefault();
+      panel.focus();
+      return;
+    }
+
+    const first = focusableElements[0];
+    const last = focusableElements[focusableElements.length - 1];
+    const activeElement = document.activeElement;
+    if (
+      !panel.contains(activeElement) ||
+      activeElement === panel ||
+      (event.shiftKey && activeElement === first) ||
+      (!event.shiftKey && activeElement === last)
+    ) {
+      event.preventDefault();
+      (event.shiftKey ? last : first).focus();
+    }
+  };
 
   constructor(props: any) {
     super(props);
@@ -618,6 +665,8 @@ export class ChatContentPage extends Component<
   componentDidMount() {
     const { channel } = this.props;
 
+    document.addEventListener("keydown", this._onChannelSettingKeyDown, true);
+
     chatPageTitleController.activate(channel, this.titlePageOwner);
 
     // 监听文件预览事件
@@ -798,6 +847,16 @@ export class ChatContentPage extends Component<
     prevProps: ChatContentPageProps,
     prevState: ChatContentPageState
   ) {
+    if (!prevState.showChannelSetting && this.state.showChannelSetting) {
+      this.channelSettingPanelRef.current?.focus();
+    } else if (
+      prevState.showChannelSetting &&
+      !this.state.showChannelSetting
+    ) {
+      this.channelSettingReturnFocusElement?.focus();
+      this.channelSettingReturnFocusElement = undefined;
+    }
+
     // 子区打开(入口二:页内子区选择)——本页 channel 为父群、activeThread 身份(channel_id)变化即一次
     // subchannel_opened,覆盖 onOpenThreadPanel / onThreadSelect 这类不 remount 只改 state 的页内入口。
     // 与挂载入口(入口一)的去重由 subchannelOpenFromMount 的 sentinel 负责:本支照发,若用户随后把该
@@ -915,6 +974,11 @@ export class ChatContentPage extends Component<
   }) => void;
 
   componentWillUnmount() {
+    document.removeEventListener(
+      "keydown",
+      this._onChannelSettingKeyDown,
+      true
+    );
     chatPageTitleController.deactivate(this.titlePageOwner);
     WKApp.mittBus.off("wk:file-preview", this._onFilePreview);
     if (this._onPendingThread) {
@@ -1062,6 +1126,8 @@ export class ChatContentPage extends Component<
             "wk-chat-content-chat",
             selectionMode ? "wk-chat-content-chat-selection" : undefined
           )}
+          aria-hidden={showChannelSetting || undefined}
+          {...(showChannelSetting ? { inert: "" } : {})}
         >
           <div
             className={classNames(
@@ -1243,8 +1309,17 @@ export class ChatContentPage extends Component<
                     <div
                       data-testid="chat-channel-setting-entry"
                       className="wk-chat-conversation-header-right-item"
+                      role="button"
+                      tabIndex={0}
+                      aria-controls="chat-channel-setting-panel"
+                      aria-expanded={showChannelSetting}
+                      aria-label={t("base.chatPage.channelSettings")}
                       onClick={(e) => {
                         e.stopPropagation();
+                        if (!this.state.showChannelSetting) {
+                          this.channelSettingReturnFocusElement =
+                            e.currentTarget;
+                        }
                         // group_info_panel_opened:仅开面板(opening)且为群频道时发,props 恒空
                         if (
                           !this.state.showChannelSetting &&
@@ -1258,6 +1333,12 @@ export class ChatContentPage extends Component<
                             ? openChatRightPanel("channelSetting")
                             : { showChannelSetting: false };
                         });
+                      }}
+                      onKeyDown={(event) => {
+                        if (event.key === "Enter" || event.key === " ") {
+                          event.preventDefault();
+                          event.currentTarget.click();
+                        }
                       }}
                     >
                       <svg
@@ -1333,27 +1414,31 @@ export class ChatContentPage extends Component<
         </div>
 
         {showChannelSetting && (
-          <button
-            type="button"
+          <div
             className="wk-chat-channelsetting-mask"
             data-testid="chat-channel-setting-mask"
-            aria-label={t("base.common.close")}
-            onClick={() => {
-              this.setState({ showChannelSetting: false });
-            }}
+            onClick={this._closeChannelSetting}
           />
         )}
 
-        <div className={classNames("wk-chat-channelsetting")}>
+        <div
+          id="chat-channel-setting-panel"
+          ref={this.channelSettingPanelRef}
+          className={classNames("wk-chat-channelsetting")}
+          role="dialog"
+          aria-modal={showChannelSetting || undefined}
+          aria-hidden={showChannelSetting ? undefined : true}
+          aria-label={t("base.chatPage.channelSettings")}
+          tabIndex={-1}
+          {...(!showChannelSetting ? { inert: "" } : {})}
+        >
           <ErrorBoundary moduleName={t("base.chatPage.channelSettings")}>
             <ChannelSetting
               conversationContext={this.conversationContext}
               key={channel.getChannelKey()}
               channel={channel}
               onClose={() => {
-                this.setState({
-                  showChannelSetting: false,
-                });
+                this._closeChannelSetting();
               }}
             ></ChannelSetting>
           </ErrorBoundary>

--- a/packages/dmworkbase/src/Pages/Chat/index.tsx
+++ b/packages/dmworkbase/src/Pages/Chat/index.tsx
@@ -1313,7 +1313,7 @@ export class ChatContentPage extends Component<
                       tabIndex={0}
                       aria-controls="chat-channel-setting-panel"
                       aria-expanded={showChannelSetting}
-                      aria-label={t("base.chatPage.channelSettings")}
+                      aria-label={t("base.channelSetting.title")}
                       onClick={(e) => {
                         e.stopPropagation();
                         if (!this.state.showChannelSetting) {

--- a/packages/dmworkbase/src/Pages/Chat/index.tsx
+++ b/packages/dmworkbase/src/Pages/Chat/index.tsx
@@ -1332,6 +1332,18 @@ export class ChatContentPage extends Component<
           </div>
         </div>
 
+        {showChannelSetting && (
+          <button
+            type="button"
+            className="wk-chat-channelsetting-mask"
+            data-testid="chat-channel-setting-mask"
+            aria-label={t("base.common.close")}
+            onClick={() => {
+              this.setState({ showChannelSetting: false });
+            }}
+          />
+        )}
+
         <div className={classNames("wk-chat-channelsetting")}>
           <ErrorBoundary moduleName={t("base.chatPage.channelSettings")}>
             <ChannelSetting

--- a/packages/dmworkbase/src/Pages/Chat/index.tsx
+++ b/packages/dmworkbase/src/Pages/Chat/index.tsx
@@ -397,32 +397,58 @@ export class ChatContentPage extends Component<
   private _unsubscribeChannelSearchConfig?: () => void;
   private readonly titlePageOwner = Symbol("chat-content-page");
   private readonly channelSettingPanelRef = React.createRef<HTMLDivElement>();
+  private readonly chatContentRef = React.createRef<HTMLDivElement>();
   private channelSettingReturnFocusElement?: HTMLElement;
+  private shouldRestoreChannelSettingFocus = false;
 
   private _closeChannelSetting = () => {
+    this.shouldRestoreChannelSettingFocus = true;
     this.setState({ showChannelSetting: false });
   };
 
   private _onChannelSettingKeyDown = (event: KeyboardEvent) => {
     if (!this.state.showChannelSetting) return;
 
+    const panel = this.channelSettingPanelRef.current;
+    const chatContent = this.chatContentRef.current;
+    const eventTarget = event.target;
+    if (
+      !panel ||
+      !(eventTarget instanceof Node) ||
+      (!panel.contains(eventTarget) && !chatContent?.contains(eventTarget))
+    ) {
+      return;
+    }
+
     if (event.key === "Escape") {
       event.preventDefault();
-      event.stopPropagation();
       this._closeChannelSetting();
       return;
     }
 
     if (event.key !== "Tab") return;
 
-    const panel = this.channelSettingPanelRef.current;
-    if (!panel) return;
-
     const focusableElements = Array.from(
       panel.querySelectorAll<HTMLElement>(
         'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"]), [contenteditable="true"]'
       )
-    ).filter((element) => element.getAttribute("aria-hidden") !== "true");
+    ).filter((element) => {
+      if (
+        element.closest('[aria-hidden="true"]') ||
+        element.getClientRects().length === 0
+      ) {
+        return false;
+      }
+
+      const routeView = element.closest<HTMLElement>(".wk-viewqueue-view");
+      if (!routeView) return true;
+
+      const route = routeView.parentElement;
+      const activeRouteView =
+        route?.querySelector<HTMLElement>(":scope > #wk-viewqueue-view-last") ||
+        route?.querySelector<HTMLElement>(":scope > .wk-viewqueue-view");
+      return routeView === activeRouteView;
+    });
 
     if (focusableElements.length === 0) {
       event.preventDefault();
@@ -665,8 +691,6 @@ export class ChatContentPage extends Component<
   componentDidMount() {
     const { channel } = this.props;
 
-    document.addEventListener("keydown", this._onChannelSettingKeyDown, true);
-
     chatPageTitleController.activate(channel, this.titlePageOwner);
 
     // 监听文件预览事件
@@ -848,12 +872,23 @@ export class ChatContentPage extends Component<
     prevState: ChatContentPageState
   ) {
     if (!prevState.showChannelSetting && this.state.showChannelSetting) {
+      document.addEventListener(
+        "keydown",
+        this._onChannelSettingKeyDown,
+        true
+      );
+      this.shouldRestoreChannelSettingFocus = false;
       this.channelSettingPanelRef.current?.focus();
-    } else if (
-      prevState.showChannelSetting &&
-      !this.state.showChannelSetting
-    ) {
-      this.channelSettingReturnFocusElement?.focus();
+    } else if (prevState.showChannelSetting && !this.state.showChannelSetting) {
+      document.removeEventListener(
+        "keydown",
+        this._onChannelSettingKeyDown,
+        true
+      );
+      if (this.shouldRestoreChannelSettingFocus) {
+        this.channelSettingReturnFocusElement?.focus();
+      }
+      this.shouldRestoreChannelSettingFocus = false;
       this.channelSettingReturnFocusElement = undefined;
     }
 
@@ -1122,6 +1157,7 @@ export class ChatContentPage extends Component<
         )}
       >
         <div
+          ref={this.chatContentRef}
           className={classNames(
             "wk-chat-content-chat",
             selectionMode ? "wk-chat-content-chat-selection" : undefined
@@ -1316,23 +1352,16 @@ export class ChatContentPage extends Component<
                       aria-label={t("base.channelSetting.title")}
                       onClick={(e) => {
                         e.stopPropagation();
-                        if (!this.state.showChannelSetting) {
-                          this.channelSettingReturnFocusElement =
-                            e.currentTarget;
+                        if (this.state.showChannelSetting) {
+                          this._closeChannelSetting();
+                          return;
                         }
+                        this.channelSettingReturnFocusElement = e.currentTarget;
                         // group_info_panel_opened:仅开面板(opening)且为群频道时发,props 恒空
-                        if (
-                          !this.state.showChannelSetting &&
-                          channel.channelType === ChannelTypeGroup
-                        ) {
+                        if (channel.channelType === ChannelTypeGroup) {
                           Dap.shared.track("group_info_panel_opened", {});
                         }
-                        this.setState((prevState) => {
-                          const opening = !prevState.showChannelSetting;
-                          return opening
-                            ? openChatRightPanel("channelSetting")
-                            : { showChannelSetting: false };
-                        });
+                        this.setState(openChatRightPanel("channelSetting"));
                       }}
                       onKeyDown={(event) => {
                         if (event.key === "Enter" || event.key === " ") {
@@ -1428,7 +1457,7 @@ export class ChatContentPage extends Component<
           role="dialog"
           aria-modal={showChannelSetting || undefined}
           aria-hidden={showChannelSetting ? undefined : true}
-          aria-label={t("base.chatPage.channelSettings")}
+          aria-label={t("base.channelSetting.title")}
           tabIndex={-1}
           {...(!showChannelSetting ? { inert: "" } : {})}
         >


### PR DESCRIPTION
Supersedes #1571 to clear stale review state while preserving the same verified code head.

## Summary

Keep the group channel settings drawer above the chat scroll-to-bottom control and preserve the user-approved full-viewport Web2-style scrim.

## Related Issue

Closes #1558

## Changes

- Render a full-viewport, theme-aware scrim only while group channel settings are open.
- Place the scrim and drawer at `calc(var(--wk-z-modal) + 10)` and `calc(var(--wk-z-modal) + 11)`.
- Complete modal keyboard behavior with dialog semantics, Escape-to-close, focus entry/restoration, and Tab containment.
- Keep nested profile and confirmation dialogs in control of their own Escape and Tab events.
- Restrict the drawer focus cycle to the visible `WKViewQueue` route and align its accessible name with the visible heading.
- Remove the asymmetric scrim enter animation.
- Strengthen CH43 with real paint-order hit testing, nested profile keyboard coverage, Escape/mask close paths, and reachable thread-panel navigation.

## Architecture / Module Boundary

- Affected modules: `packages/dmworkbase` Chat page and `apps/web` E2E coverage
- New or changed user-visible entry point: no; the existing group channel settings entry is unchanged
- Shared layer touched: test-only mock IM subscriber seed status support
- Data, API, route, permission, and cache behavior changed: no
- Duplicate entry point checked: yes

## Testing

- [x] User manually accepted the full-viewport Web2 visual behavior
- [x] Production build: `pnpm --filter @octo/web build`
- [x] Base unit tests: 391 files / 3634 tests
- [x] Focused CH43: 1/1, including nested profile Tab/Escape ownership
- [x] i18n check
- [x] `git diff --check`
- [ ] Exact-head CI and code review are running after this push

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] PR description is in English
- [x] Added E2E coverage for my changes
- [x] Documentation is not required for this scoped bug fix
- [x] Confirmed the change does not add or modify user-visible copy
- [x] Confirmed the change follows module ownership and does not add duplicate user-visible entry points
- [x] Described impact scope; no shared production component, message, bridge, or service API was changed
- [x] Followed commit message conventions (Conventional Commits)