### PR TITLE
feat: global search — Drive tab with standalone preview

### DIFF
--- a/packages/dmworkbase/src/Components/GlobalSearch/DriveSearchPanel.stories.tsx
+++ b/packages/dmworkbase/src/Components/GlobalSearch/DriveSearchPanel.stories.tsx
@@ -1,0 +1,193 @@
+import React from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fireEvent, waitFor } from "@storybook/test";
+import DriveSearchPanel from "./DriveSearchPanel";
+import type {
+  DriveSearchHit,
+  DriveSearchResponse,
+  GlobalSearchDataSource,
+} from "../../Service/SearchTypes";
+
+// Build `count` drive hits with unique ids (offset keeps ids distinct across
+// pages). Rotates through the three renderable types so the icon variants show.
+function makeHits(count: number, offset = 0): DriveSearchHit[] {
+  const types: DriveSearchHit["type"][] = ["folder", "doc", "blob"];
+  return Array.from({ length: count }, (_, i) => {
+    const n = offset + i;
+    const type = types[n % types.length];
+    return {
+      file_id: 1000 + n,
+      space_id: "space-1",
+      space_name: "产研共享",
+      parent_id: 0,
+      path: ["设计稿", "2026"],
+      name: `需求评审纪要-${n}.${type === "folder" ? "" : "md"}`.replace(
+        /\.$/,
+        ""
+      ),
+      type,
+      ext: type === "folder" ? undefined : "md",
+      size: type === "folder" ? undefined : 24_576 + n * 1024,
+      owner_uid: "u-alex",
+      owner_name: "Alex Chen",
+      updater_uid: "u-alex",
+      updater_name: "Alex Chen",
+      created_at: "2026-08-20T10:00:00.000Z",
+      updated_at: "2026-08-24T09:30:00.000Z",
+    };
+  });
+}
+
+// Minimal data source: the panel only ever calls searchDrive. Cast through
+// unknown so the story doesn't have to stub the whole GlobalSearchDataSource.
+function makeDataSource(
+  searchDrive: GlobalSearchDataSource["searchDrive"]
+): GlobalSearchDataSource {
+  return { searchDrive } as unknown as GlobalSearchDataSource;
+}
+
+const meta = {
+  title: "Base/GlobalSearch/DriveSearchPanel",
+  component: DriveSearchPanel,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "网盘搜索面板:offset(page_index) 滚动加载 + 世代保护 + AbortController,全态覆盖(empty / loading / hits / highlight / loadingMore / hasNoMore / truncated)。",
+      },
+    },
+  },
+  decorators: [
+    (Story: React.FC) => (
+      <div
+        style={{
+          width: "min(100%, 720px)",
+          height: "480px",
+          margin: "0 auto",
+          background: "var(--wk-bg-surface)",
+        }}
+      >
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof DriveSearchPanel>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// 1. 未输入关键词 → 空提示
+export const Empty: Story = {
+  args: {
+    keyword: "",
+    isActive: true,
+    dataSource: makeDataSource(async () => ({
+      total: 0,
+      truncated: false,
+      items: [],
+    })),
+  },
+};
+
+// 2. 首页加载中(请求永不 resolve)
+export const Loading: Story = {
+  args: {
+    keyword: "评审",
+    isActive: true,
+    dataSource: makeDataSource(
+      () => new Promise<DriveSearchResponse>(() => undefined)
+    ),
+  },
+};
+
+// 3. 命中列表(还有下一页,不显示底部提示)
+export const Hits: Story = {
+  args: {
+    keyword: "评审",
+    isActive: true,
+    dataSource: makeDataSource(async () => ({
+      total: 40,
+      truncated: false,
+      items: makeHits(6),
+    })),
+  },
+};
+
+// 4. 命中 + name/body 高亮(<mark>)
+export const HitsWithHighlight: Story = {
+  args: {
+    keyword: "评审",
+    isActive: true,
+    dataSource: makeDataSource(async () => ({
+      total: 40,
+      truncated: false,
+      items: makeHits(4).map((hit, i) => ({
+        ...hit,
+        highlights: {
+          name: [`需求<mark>评审</mark>纪要-${i}`],
+          body: [`本次<mark>评审</mark>通过了排期,请各位在周五前确认。`],
+        },
+      })),
+    })),
+  },
+};
+
+// 5. 追加下一页加载中:首页返回满页(total>已加载),滚动触发 loadNextPage,
+//    第二页请求挂起 → 底部 spinner「加载中…」。
+export const LoadingMore: Story = {
+  args: {
+    keyword: "评审",
+    isActive: true,
+    dataSource: makeDataSource(async (query) => {
+      if (query.page_index === 0) {
+        return { total: 40, truncated: false, items: makeHits(20, 0) };
+      }
+      // 第二页永不 resolve,停在 loadingMore 态
+      return new Promise<DriveSearchResponse>(() => undefined);
+    }),
+  },
+  play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+    const list = await waitFor(() => {
+      const el = canvasElement.querySelector<HTMLElement>(
+        ".wk-drive-search__list"
+      );
+      if (!el || !el.querySelector(".wk-drive-search__item")) {
+        throw new Error("first page not rendered yet");
+      }
+      return el;
+    });
+    list.scrollTop = list.scrollHeight;
+    fireEvent.scroll(list);
+    await waitFor(() => {
+      if (!canvasElement.querySelector(".wk-drive-search__footer")) {
+        throw new Error("loadingMore footer not shown yet");
+      }
+    });
+  },
+};
+
+// 6. 已加载全部(total===已加载)→ 底部「已显示全部 N 条」
+export const HasNoMore: Story = {
+  args: {
+    keyword: "评审",
+    isActive: true,
+    dataSource: makeDataSource(async () => ({
+      total: 6,
+      truncated: false,
+      items: makeHits(6),
+    })),
+  },
+};
+
+// 7. 结果不完整(truncated=true)→ 底部软提示,不阻塞翻页
+export const Truncated: Story = {
+  args: {
+    keyword: "评审",
+    isActive: true,
+    dataSource: makeDataSource(async () => ({
+      total: 8,
+      truncated: true,
+      items: makeHits(8),
+    })),
+  },
+};

--- a/packages/dmworkbase/src/Components/GlobalSearch/DriveSearchPanel.tsx
+++ b/packages/dmworkbase/src/Components/GlobalSearch/DriveSearchPanel.tsx
@@ -149,7 +149,14 @@ const DriveSearchPanel: React.FC<DriveSearchPanelProps> = ({
     const timer = window.setTimeout(() => {
       dataSource
         .searchDrive!(
-          { q: trimmed, scope: "all", page_index: 0, page_size: PAGE_SIZE },
+          {
+            q: trimmed,
+            scope: "all",
+            // Exclude folder hits — this panel only opens file previews.
+            filters: { types: ["blob", "doc"] },
+            page_index: 0,
+            page_size: PAGE_SIZE,
+          },
           controller.signal
         )
         .then((resp) => {
@@ -191,6 +198,8 @@ const DriveSearchPanel: React.FC<DriveSearchPanelProps> = ({
         {
           q: trimmed,
           scope: "all",
+          // Keep the folder-exclusion filter consistent across pages.
+          filters: { types: ["blob", "doc"] },
           page_index: nextIndex,
           page_size: PAGE_SIZE,
         },

--- a/packages/dmworkbase/src/Components/GlobalSearch/DriveSearchPanel.tsx
+++ b/packages/dmworkbase/src/Components/GlobalSearch/DriveSearchPanel.tsx
@@ -1,0 +1,313 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { File, FileText, FolderOpen } from "lucide-react";
+import { useI18n } from "../../i18n";
+import type {
+  DriveFileType,
+  DriveSearchHit,
+  GlobalSearchDataSource,
+} from "../../Service/SearchTypes";
+import { formatFileSize } from "../../Utils/fileIcon";
+import "./drive-search-panel.css";
+
+const PAGE_SIZE = 20;
+// Debounce keystrokes so a fast typist fires one search per pause, not one per
+// character. Matches the drive module's own search box.
+const DEBOUNCE_MS = 250;
+// Trigger the next page while this many px from the bottom (same as the
+// cursor-paged panels feed useSearchPagination).
+const SCROLL_THRESHOLD_PX = 100;
+// Upper bound on the highlight fragment we scan/render (see renderHighlight).
+const HIGHLIGHT_MAX_LEN = 2000;
+// Show at most this many body snippets per hit; the backend may return more.
+const BODY_SNIPPET_MAX = 2;
+
+interface DriveSearchPanelProps {
+  keyword: string;
+  dataSource: GlobalSearchDataSource;
+  // Mounted alongside the other tab panels and toggled via display:none, so a
+  // hidden panel must not run its search. Gate on isActive (same contract as
+  // DocSearchPanel / GlobalContentSearchPanel).
+  isActive?: boolean;
+  // Integration point: open the clicked hit. Wired by the host (Chat) to
+  // /drive?fileId=..&spaceId=.. -> window.open in a new tab; the search modal
+  // is kept open so several results can be opened in turn. No-op default keeps
+  // this panel self-contained when the prop is unwired.
+  onOpenDriveHit?: (hit: DriveSearchHit) => void;
+}
+
+// Backend highlight fragments already wrap hits in <mark></mark>. Render them
+// into React text nodes with a <mark>-only allowlist: everything between/around
+// the tags becomes a plain React string (auto-escaped by React), and only the
+// marked spans are wrapped in <mark>. This never uses dangerouslySetInnerHTML,
+// so injected markup in the fragment cannot execute. (Same logic as
+// DocSearchPanel.renderHighlight, with <em> swapped for <mark>.)
+function renderHighlight(rawFragment: string): React.ReactNode {
+  const fragment =
+    rawFragment.length > HIGHLIGHT_MAX_LEN
+      ? rawFragment.slice(0, HIGHLIGHT_MAX_LEN)
+      : rawFragment;
+  const pattern = /<mark>([\s\S]*?)<\/mark>/gi;
+  const nodes: React.ReactNode[] = [];
+  let cursor = 0;
+  let match: RegExpExecArray | null;
+  let key = 0;
+  while ((match = pattern.exec(fragment))) {
+    if (match.index > cursor) nodes.push(fragment.slice(cursor, match.index));
+    nodes.push(<mark key={key++}>{match[1]}</mark>);
+    cursor = pattern.lastIndex;
+  }
+  if (cursor < fragment.length) nodes.push(fragment.slice(cursor));
+  return nodes.length > 0 ? nodes : fragment;
+}
+
+function renderFileIcon(type: DriveFileType): React.ReactNode {
+  if (type === "folder") return <FolderOpen size={20} aria-hidden />;
+  if (type === "doc") return <FileText size={20} aria-hidden />;
+  return <File size={20} aria-hidden />;
+}
+
+function formatUpdatedAt(iso: string, locale: string): string {
+  if (!iso) return "";
+  try {
+    return new Date(iso).toLocaleDateString(locale);
+  } catch {
+    return "";
+  }
+}
+
+// space_name + root-first folder chain (path excludes the hit itself).
+function breadcrumb(hit: DriveSearchHit): string {
+  return [hit.space_name, ...(hit.path ?? [])].filter(Boolean).join(" / ");
+}
+
+const DriveSearchPanel: React.FC<DriveSearchPanelProps> = ({
+  keyword,
+  dataSource,
+  isActive = true,
+  onOpenDriveHit,
+}) => {
+  const { t, locale } = useI18n();
+  const trimmed = keyword.trim();
+  const canSearch = !!trimmed && isActive && !!dataSource.searchDrive;
+
+  const [items, setItems] = useState<DriveSearchHit[]>([]);
+  const [total, setTotal] = useState(0);
+  const [truncated, setTruncated] = useState(false);
+  const [pageIndex, setPageIndex] = useState(0); // current loaded page (0-based)
+  const [loading, setLoading] = useState(false); // first page in flight
+  const [loadingMore, setLoadingMore] = useState(false); // next page in flight
+  const [error, setError] = useState<string | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+  // Generation guard: only the latest generation may write state. Bumped when
+  // the first page resets, so a stale in-flight response (first page OR next
+  // page) is silently dropped — dual protection with AbortController.
+  const seqRef = useRef(0);
+
+  // Derived: more pages exist while we hold fewer hits than the reported total.
+  // The backend has no has_more / nextCursor field, so this is the sole gate.
+  const hasMore = items.length < total;
+
+  // First page: reset + fetch page_index=0 whenever the query / active / source
+  // changes. Debounced so a fast typist fires one search per pause.
+  useEffect(() => {
+    abortRef.current?.abort();
+    setItems([]);
+    setTotal(0);
+    setTruncated(false);
+    setPageIndex(0);
+    setError(null);
+    if (!canSearch) {
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    const seq = ++seqRef.current;
+    const controller = new AbortController();
+    abortRef.current = controller;
+    const timer = window.setTimeout(() => {
+      dataSource
+        .searchDrive!(
+          { q: trimmed, scope: "all", page_index: 0, page_size: PAGE_SIZE },
+          controller.signal
+        )
+        .then((resp) => {
+          if (seq !== seqRef.current) return;
+          setItems(resp.items);
+          setTotal(resp.total);
+          setTruncated(resp.truncated);
+        })
+        .catch(() => {
+          // A superseded generation (keyword changed / abort) is dropped by the
+          // seq guard before it can surface a spurious error.
+          if (seq !== seqRef.current) return;
+          setError(t("base.globalSearch.drive.searchFailed"));
+        })
+        .finally(() => {
+          if (seq === seqRef.current) setLoading(false);
+        });
+    }, DEBOUNCE_MS);
+    return () => {
+      window.clearTimeout(timer);
+      controller.abort();
+    };
+    // t is referentially stable (from I18n context); listing it keeps
+    // exhaustive-deps happy without causing a refetch.
+  }, [canSearch, trimmed, dataSource, t]);
+
+  // Next page: appended on scroll-to-bottom. Shares the generation number with
+  // the first-page effect, so a first-page reset invalidates an in-flight
+  // loadNextPage (its captured seq goes stale and its result is dropped).
+  const loadNextPage = useCallback(async () => {
+    if (loading || loadingMore || !hasMore || !canSearch) return;
+    setLoadingMore(true);
+    const seq = seqRef.current;
+    const nextIndex = pageIndex + 1;
+    try {
+      const resp = await dataSource.searchDrive!({
+        q: trimmed,
+        scope: "all",
+        page_index: nextIndex,
+        page_size: PAGE_SIZE,
+      });
+      if (seq !== seqRef.current) return;
+      setItems((prev) => [...prev, ...resp.items]);
+      setPageIndex(nextIndex);
+      setTotal(resp.total); // total normally stable; follow backend if it moves
+      setTruncated(resp.truncated);
+    } catch {
+      if (seq !== seqRef.current) return;
+      setError(t("base.globalSearch.drive.searchFailed"));
+    } finally {
+      if (seq === seqRef.current) setLoadingMore(false);
+    }
+  }, [
+    loading,
+    loadingMore,
+    hasMore,
+    canSearch,
+    pageIndex,
+    trimmed,
+    dataSource,
+    t,
+  ]);
+
+  const handleScroll = useCallback(
+    (e: React.UIEvent<HTMLDivElement>) => {
+      const el = e.currentTarget;
+      if (
+        el.scrollHeight - el.scrollTop - el.clientHeight <
+        SCROLL_THRESHOLD_PX
+      ) {
+        void loadNextPage();
+      }
+    },
+    [loadNextPage]
+  );
+
+  const emptyState = useMemo(() => {
+    if (loading) {
+      return (
+        <div className="wk-drive-search__hint">
+          {t("base.globalSearch.drive.loading")}
+        </div>
+      );
+    }
+    if (error) {
+      return <div className="wk-drive-search__hint">{error}</div>;
+    }
+    return (
+      <div className="wk-drive-search__empty">
+        {!trimmed
+          ? t("base.globalSearch.drive.emptyHint")
+          : t("base.globalSearch.drive.noResults")}
+      </div>
+    );
+  }, [error, loading, t, trimmed]);
+
+  return (
+    <div className="wk-drive-search">
+      <div className="wk-drive-search__list" onScroll={handleScroll}>
+        {items.length === 0
+          ? emptyState
+          : items.map((hit) => {
+              const bodySnippets = (hit.highlights?.body ?? []).slice(
+                0,
+                BODY_SNIPPET_MAX
+              );
+              const crumb = breadcrumb(hit);
+              return (
+                <button
+                  type="button"
+                  key={`${hit.space_id}:${hit.file_id}`}
+                  className="wk-drive-search__item"
+                  onClick={() => onOpenDriveHit?.(hit)}
+                >
+                  <span
+                    className={`wk-drive-search__icon wk-drive-search__icon--${hit.type}`}
+                  >
+                    {renderFileIcon(hit.type)}
+                  </span>
+                  <span className="wk-drive-search__meta">
+                    <span className="wk-drive-search__title">
+                      {hit.highlights?.name?.[0]
+                        ? renderHighlight(hit.highlights.name[0])
+                        : hit.name}
+                    </span>
+                    {crumb && (
+                      <span className="wk-drive-search__crumb">{crumb}</span>
+                    )}
+                    {bodySnippets.length > 0 ? (
+                      bodySnippets.map((frag, i) => (
+                        <span key={i} className="wk-drive-search__snippet">
+                          {renderHighlight(frag)}
+                        </span>
+                      ))
+                    ) : (
+                      <span className="wk-drive-search__sub">
+                        {[
+                          hit.owner_name,
+                          formatUpdatedAt(hit.updated_at, locale),
+                          typeof hit.size === "number"
+                            ? formatFileSize(hit.size)
+                            : "",
+                        ]
+                          .filter(Boolean)
+                          .join(" · ")}
+                      </span>
+                    )}
+                  </span>
+                </button>
+              );
+            })}
+        {/* Bottom hints (only once the first page has results). Priority:
+            loadingMore spinner > paging error > truncated note > all-loaded. */}
+        {items.length > 0 && loadingMore && (
+          <div className="wk-drive-search__footer" role="status">
+            {t("base.globalSearch.drive.loading")}
+          </div>
+        )}
+        {items.length > 0 && !loadingMore && error && (
+          <div className="wk-drive-search__footer">{error}</div>
+        )}
+        {items.length > 0 && !loadingMore && !error && truncated && (
+          <div className="wk-drive-search__footer" role="status">
+            {t("base.globalSearch.drive.truncated")}
+          </div>
+        )}
+        {items.length > 0 &&
+          !loadingMore &&
+          !error &&
+          !truncated &&
+          !hasMore && (
+            <div className="wk-drive-search__footer" role="status">
+              {t("base.globalSearch.drive.allLoaded", {
+                values: { count: total },
+              })}
+            </div>
+          )}
+      </div>
+    </div>
+  );
+};
+
+export default DriveSearchPanel;

--- a/packages/dmworkbase/src/Components/GlobalSearch/DriveSearchPanel.tsx
+++ b/packages/dmworkbase/src/Components/GlobalSearch/DriveSearchPanel.tsx
@@ -21,6 +21,17 @@ const HIGHLIGHT_MAX_LEN = 2000;
 // Show at most this many body snippets per hit; the backend may return more.
 const BODY_SNIPPET_MAX = 2;
 
+// Abort rejections (keyword change / unmount cleanup calling controller.abort())
+// are expected control flow, never a real search failure — filter them so a
+// request we cancelled ourselves never flashes an error banner.
+function isAbortError(err: unknown): boolean {
+  return (
+    !!err &&
+    typeof err === "object" &&
+    (err as { name?: unknown }).name === "AbortError"
+  );
+}
+
 interface DriveSearchPanelProps {
   keyword: string;
   dataSource: GlobalSearchDataSource;
@@ -111,17 +122,28 @@ const DriveSearchPanel: React.FC<DriveSearchPanelProps> = ({
   // changes. Debounced so a fast typist fires one search per pause.
   useEffect(() => {
     abortRef.current?.abort();
+    // Bump the generation on EVERY run — INCLUDING the !canSearch early return
+    // below — so any in-flight response (first page or next page) from the prior
+    // generation fails its `seq === seqRef.current` guard and cannot write stale
+    // items/error back after we reset to the empty state. abort() alone races: a
+    // resolve/reject already queued before the abort still lands, and without a
+    // seq bump it would pass the guard and pollute the empty state (QA 🔴).
+    const seq = ++seqRef.current;
     setItems([]);
     setTotal(0);
     setTruncated(false);
     setPageIndex(0);
     setError(null);
+    // Reset loadingMore too: an in-flight next page whose finally() is now gated
+    // out by the seq bump would otherwise leave loadingMore stuck true forever —
+    // footer frozen on "loading" and loadNextPage's opening guard blocking every
+    // later page. Mirrors the cursor-paged panels' reset (高研 必修🟠).
+    setLoadingMore(false);
     if (!canSearch) {
       setLoading(false);
       return;
     }
     setLoading(true);
-    const seq = ++seqRef.current;
     const controller = new AbortController();
     abortRef.current = controller;
     const timer = window.setTimeout(() => {
@@ -136,10 +158,10 @@ const DriveSearchPanel: React.FC<DriveSearchPanelProps> = ({
           setTotal(resp.total);
           setTruncated(resp.truncated);
         })
-        .catch(() => {
-          // A superseded generation (keyword changed / abort) is dropped by the
-          // seq guard before it can surface a spurious error.
-          if (seq !== seqRef.current) return;
+        .catch((err) => {
+          // A cancelled request (AbortError) or a superseded generation is not a
+          // failure — drop it silently instead of surfacing a spurious error.
+          if (isAbortError(err) || seq !== seqRef.current) return;
           setError(t("base.globalSearch.drive.searchFailed"));
         })
         .finally(() => {
@@ -163,19 +185,25 @@ const DriveSearchPanel: React.FC<DriveSearchPanelProps> = ({
     const seq = seqRef.current;
     const nextIndex = pageIndex + 1;
     try {
-      const resp = await dataSource.searchDrive!({
-        q: trimmed,
-        scope: "all",
-        page_index: nextIndex,
-        page_size: PAGE_SIZE,
-      });
+      // Share the current generation's controller so a keyword switch mid-page
+      // cancels this request too (the first-page effect already called abort()).
+      const resp = await dataSource.searchDrive!(
+        {
+          q: trimmed,
+          scope: "all",
+          page_index: nextIndex,
+          page_size: PAGE_SIZE,
+        },
+        abortRef.current?.signal
+      );
       if (seq !== seqRef.current) return;
       setItems((prev) => [...prev, ...resp.items]);
       setPageIndex(nextIndex);
       setTotal(resp.total); // total normally stable; follow backend if it moves
       setTruncated(resp.truncated);
-    } catch {
-      if (seq !== seqRef.current) return;
+    } catch (err) {
+      // Cancelled request or superseded generation: drop it, never show an error.
+      if (isAbortError(err) || seq !== seqRef.current) return;
       setError(t("base.globalSearch.drive.searchFailed"));
     } finally {
       if (seq === seqRef.current) setLoadingMore(false);

--- a/packages/dmworkbase/src/Components/GlobalSearch/__tests__/driveSearch.test.tsx
+++ b/packages/dmworkbase/src/Components/GlobalSearch/__tests__/driveSearch.test.tsx
@@ -351,10 +351,16 @@ describe("DriveSearchPanel — folder exclusion (filters.types)", () => {
       types: ["blob", "doc"],
     });
 
-    await waitFor(() => {
-      fireEvent.scroll(listEl(container));
-      expect(searchDrive.mock.calls.length).toBe(2);
-    });
+    // Generous timeout: the scroll→debounce→next-page settle is CPU-timing
+    // sensitive and can exceed the 1s default when the whole monorepo suite runs
+    // in parallel (turbo). Package-level runs settle in well under this.
+    await waitFor(
+      () => {
+        fireEvent.scroll(listEl(container));
+        expect(searchDrive.mock.calls.length).toBe(2);
+      },
+      { timeout: 15000 }
+    );
     // The next-page request must carry the same filter, or folders would leak
     // back in as the user scrolls.
     expect(searchDrive.mock.calls[1]![0].filters).toEqual({

--- a/packages/dmworkbase/src/Components/GlobalSearch/__tests__/driveSearch.test.tsx
+++ b/packages/dmworkbase/src/Components/GlobalSearch/__tests__/driveSearch.test.tsx
@@ -211,6 +211,106 @@ describe("DriveSearchPanel — offset pagination", () => {
 
     expect(screen.queryByText("old-more-20")).toBeNull();
     expect(screen.getByText("new-0")).toBeInTheDocument();
+    // loadingMore must be reset on the keyword switch — the stale page-2's
+    // finally() is seq-gated out, so without the first-page reset it would leave
+    // loadingMore stuck true: footer frozen on "loading" and loadNextPage's guard
+    // blocking every later page forever (必修🟠).
+    expect(
+      screen.queryByText("base.globalSearch.drive.loading")
+    ).toBeNull();
+  });
+
+  it("世代保护: 切到空关键词后滞后的旧首页响应不得污染空态", async () => {
+    let releaseOld!: () => void;
+    const oldGate = new Promise<void>((resolve) => {
+      releaseOld = resolve;
+    });
+    const { ds, searchDrive } = makeDataSource(async (query) => {
+      if (query.q === "old") {
+        await oldGate; // first page hangs until released (after clearing keyword)
+        return { total: 20, truncated: false, items: makeHits(20, 0, "old") };
+      }
+      return { total: 0, truncated: false, items: [] };
+    });
+
+    const { rerender } = render(
+      <DriveSearchPanel keyword="old" dataSource={ds} isActive />
+    );
+    // Wait for the debounced first-page request to fire (still hanging).
+    await waitFor(() => expect(searchDrive).toHaveBeenCalledTimes(1));
+
+    // Clear the keyword -> canSearch false -> the effect resets to the empty
+    // state AND (with the fix) bumps the generation so the pending "old" first
+    // page can no longer write back.
+    rerender(<DriveSearchPanel keyword="" dataSource={ds} isActive />);
+    expect(
+      screen.getByText("base.globalSearch.drive.emptyHint")
+    ).toBeInTheDocument();
+
+    releaseOld();
+    await oldGate;
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(screen.queryByText("old-0")).toBeNull();
+    expect(
+      screen.getByText("base.globalSearch.drive.emptyHint")
+    ).toBeInTheDocument();
+  });
+
+  it("世代保护: 切到 inactive 后滞后的旧首页响应不得污染", async () => {
+    let releaseOld!: () => void;
+    const oldGate = new Promise<void>((resolve) => {
+      releaseOld = resolve;
+    });
+    const { ds, searchDrive } = makeDataSource(async () => {
+      await oldGate;
+      return { total: 20, truncated: false, items: makeHits(20, 0, "old") };
+    });
+
+    const { rerender } = render(
+      <DriveSearchPanel keyword="old" dataSource={ds} isActive />
+    );
+    await waitFor(() => expect(searchDrive).toHaveBeenCalledTimes(1));
+
+    // Panel goes inactive (hidden) -> canSearch false -> reset + generation bump.
+    rerender(<DriveSearchPanel keyword="old" dataSource={ds} isActive={false} />);
+
+    releaseOld();
+    await oldGate;
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(screen.queryByText("old-0")).toBeNull();
+  });
+
+  it("abort 拒绝不置错: 被取消的旧首页请求 reject 不得触发错误态", async () => {
+    let rejectOld!: (err: unknown) => void;
+    const oldGate = new Promise<DriveSearchResponse>((_, reject) => {
+      rejectOld = reject;
+    });
+    const { ds, searchDrive } = makeDataSource(async (query) => {
+      if (query.q === "old") return oldGate; // hangs, then rejected as if aborted
+      return { total: 1, truncated: false, items: makeHits(1, 0, "new") };
+    });
+
+    const { rerender } = render(
+      <DriveSearchPanel keyword="old" dataSource={ds} isActive />
+    );
+    await waitFor(() => expect(searchDrive).toHaveBeenCalledTimes(1));
+
+    rerender(<DriveSearchPanel keyword="new" dataSource={ds} isActive />);
+    await screen.findByText("new-0");
+
+    // The cancelled "old" request now rejects with an AbortError — it must be
+    // swallowed (superseded generation + isAbortError), never shown as a failure.
+    const abortErr = new Error("aborted");
+    abortErr.name = "AbortError";
+    rejectOld(abortErr);
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(
+      screen.queryByText("base.globalSearch.drive.searchFailed")
+    ).toBeNull();
+    expect(screen.getByText("new-0")).toBeInTheDocument();
   });
 
   it("truncated: shows the soft hint and still allows paging", async () => {

--- a/packages/dmworkbase/src/Components/GlobalSearch/__tests__/driveSearch.test.tsx
+++ b/packages/dmworkbase/src/Components/GlobalSearch/__tests__/driveSearch.test.tsx
@@ -335,3 +335,30 @@ describe("DriveSearchPanel — offset pagination", () => {
     expect(searchDrive.mock.calls[1]![0].page_index).toBe(1);
   });
 });
+
+describe("DriveSearchPanel — folder exclusion (filters.types)", () => {
+  it("requests only blob+doc so folder hits never reach the panel — on every page", async () => {
+    const { ds, searchDrive } = makeDataSource(async (query) => ({
+      total: 40,
+      truncated: false,
+      items: makeHits(20, query.page_index === 0 ? 0 : 20),
+    }));
+    const { container } = render(
+      <DriveSearchPanel keyword="评审" dataSource={ds} isActive />
+    );
+    await screen.findByText("file-0");
+    expect(searchDrive.mock.calls[0]![0].filters).toEqual({
+      types: ["blob", "doc"],
+    });
+
+    await waitFor(() => {
+      fireEvent.scroll(listEl(container));
+      expect(searchDrive.mock.calls.length).toBe(2);
+    });
+    // The next-page request must carry the same filter, or folders would leak
+    // back in as the user scrolls.
+    expect(searchDrive.mock.calls[1]![0].filters).toEqual({
+      types: ["blob", "doc"],
+    });
+  });
+});

--- a/packages/dmworkbase/src/Components/GlobalSearch/__tests__/driveSearch.test.tsx
+++ b/packages/dmworkbase/src/Components/GlobalSearch/__tests__/driveSearch.test.tsx
@@ -1,0 +1,237 @@
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+// i18n: identity translator so the panel renders without a provider (keys are
+// asserted verbatim). Return a STABLE value/`t` reference (like the real
+// useMemo-backed provider) — the panel's first-page effect lists `t` in its
+// deps, so a fresh `t` per render would re-fire it every render (infinite loop).
+vi.mock("../../../i18n", () => {
+  const value = { t: (k: string) => k, locale: "en-US" };
+  return { useI18n: () => value };
+});
+
+import type {
+  DriveSearchHit,
+  DriveSearchResponse,
+  GlobalSearchDataSource,
+} from "../../../Service/SearchTypes";
+import DriveSearchPanel from "../DriveSearchPanel";
+
+function makeHits(count: number, offset = 0, prefix = "file"): DriveSearchHit[] {
+  return Array.from({ length: count }, (_, i) => {
+    const n = offset + i;
+    return {
+      file_id: 1000 + n,
+      space_id: "space-1",
+      space_name: "共享空间",
+      parent_id: 0,
+      path: ["设计稿"],
+      name: `${prefix}-${n}`,
+      type: "doc" as const,
+      ext: "md",
+      size: 2048,
+      owner_uid: "u1",
+      owner_name: "Alex",
+      updater_uid: "u1",
+      updater_name: "Alex",
+      created_at: "2026-08-20T10:00:00.000Z",
+      updated_at: "2026-08-24T09:30:00.000Z",
+    };
+  });
+}
+
+function makeDataSource(
+  impl: (
+    query: Parameters<NonNullable<GlobalSearchDataSource["searchDrive"]>>[0]
+  ) => Promise<DriveSearchResponse>
+): { ds: GlobalSearchDataSource; searchDrive: ReturnType<typeof vi.fn> } {
+  const searchDrive = vi.fn(impl);
+  return {
+    ds: { searchDrive } as unknown as GlobalSearchDataSource,
+    searchDrive,
+  };
+}
+
+function listEl(container: HTMLElement): HTMLElement {
+  const el = container.querySelector<HTMLElement>(".wk-drive-search__list");
+  if (!el) throw new Error("list not rendered");
+  return el;
+}
+
+describe("DriveSearchPanel — states & interaction", () => {
+  it("shows the empty hint and does not search when the keyword is blank", async () => {
+    const { ds, searchDrive } = makeDataSource(async () => ({
+      total: 0,
+      truncated: false,
+      items: [],
+    }));
+    render(<DriveSearchPanel keyword="" dataSource={ds} isActive />);
+    expect(
+      screen.getByText("base.globalSearch.drive.emptyHint")
+    ).toBeInTheDocument();
+    await new Promise((r) => setTimeout(r, 300));
+    expect(searchDrive).not.toHaveBeenCalled();
+  });
+
+  it("does not search while inactive (hidden panel stays idle)", async () => {
+    const { ds, searchDrive } = makeDataSource(async () => ({
+      total: 1,
+      truncated: false,
+      items: makeHits(1),
+    }));
+    render(<DriveSearchPanel keyword="评审" dataSource={ds} isActive={false} />);
+    await new Promise((r) => setTimeout(r, 300));
+    expect(searchDrive).not.toHaveBeenCalled();
+  });
+
+  it("shows the loading hint while the first page is in flight", async () => {
+    const { ds } = makeDataSource(
+      () => new Promise<DriveSearchResponse>(() => undefined)
+    );
+    render(<DriveSearchPanel keyword="评审" dataSource={ds} isActive />);
+    expect(
+      await screen.findByText("base.globalSearch.drive.loading")
+    ).toBeInTheDocument();
+  });
+
+  it("renders hits and opens the clicked one via onOpenDriveHit", async () => {
+    const hits = makeHits(3);
+    const { ds } = makeDataSource(async () => ({
+      total: 3,
+      truncated: false,
+      items: hits,
+    }));
+    const onOpenDriveHit = vi.fn();
+    const { container } = render(
+      <DriveSearchPanel
+        keyword="评审"
+        dataSource={ds}
+        isActive
+        onOpenDriveHit={onOpenDriveHit}
+      />
+    );
+    await screen.findByText("file-0");
+    const first = container.querySelector<HTMLElement>(".wk-drive-search__item");
+    fireEvent.click(first!);
+    expect(onOpenDriveHit).toHaveBeenCalledWith(hits[0]);
+  });
+
+  it("renders backend <mark> highlights as inert <mark> elements (no innerHTML)", async () => {
+    const { ds } = makeDataSource(async () => ({
+      total: 1,
+      truncated: false,
+      items: makeHits(1).map((hit) => ({
+        ...hit,
+        highlights: {
+          name: ["需求<mark>评审</mark>纪要"],
+          body: ["本次<mark>评审</mark>通过 <script>alert(1)</script>"],
+        },
+      })),
+    }));
+    const { container } = render(
+      <DriveSearchPanel keyword="评审" dataSource={ds} isActive />
+    );
+    // Two matches (name + body), so use the findAll variant.
+    const marks = await screen.findAllByText("评审", { selector: "mark" });
+    expect(marks.length).toBeGreaterThanOrEqual(2);
+    // The injected <script> survives as escaped text, never a live element.
+    expect(container.querySelector("script")).toBeNull();
+    expect(container.textContent).toContain("<script>alert(1)</script>");
+  });
+});
+
+describe("DriveSearchPanel — offset pagination", () => {
+  it("翻页语义: scroll-to-bottom loads page_index+1 and appends the results", async () => {
+    const { ds, searchDrive } = makeDataSource(async (query) => ({
+      total: 40,
+      truncated: false,
+      items: makeHits(20, query.page_index === 0 ? 0 : 20),
+    }));
+    const { container } = render(
+      <DriveSearchPanel keyword="评审" dataSource={ds} isActive />
+    );
+    await screen.findByText("file-0");
+    expect(searchDrive.mock.calls[0]![0].page_index).toBe(0);
+
+    // jsdom reports 0 scroll metrics, so any scroll event reads "near bottom".
+    // Re-fire until the first page has settled (loading=false) so loadNextPage
+    // passes its guard — a real user likewise keeps scrolling once it loads.
+    await waitFor(() => {
+      fireEvent.scroll(listEl(container));
+      expect(searchDrive.mock.calls.length).toBe(2);
+    });
+    expect(searchDrive.mock.calls[1]![0].page_index).toBe(1);
+
+    // Page 2's hits are appended, not replaced (20 -> 40).
+    await waitFor(() =>
+      expect(container.querySelectorAll(".wk-drive-search__item").length).toBe(
+        40
+      )
+    );
+    expect(screen.getByText("file-20")).toBeInTheDocument();
+  });
+
+  it("世代保护: a slow loadNextPage from the previous keyword is discarded after switching", async () => {
+    let releaseOld!: () => void;
+    const oldGate = new Promise<void>((resolve) => {
+      releaseOld = resolve;
+    });
+    const { ds } = makeDataSource(async (query) => {
+      if (query.q === "old") {
+        if (query.page_index === 0) {
+          return { total: 40, truncated: false, items: makeHits(20, 0, "old") };
+        }
+        await oldGate; // page 1 hangs until we release it (after switching)
+        return {
+          total: 40,
+          truncated: false,
+          items: makeHits(20, 20, "old-more"),
+        };
+      }
+      return { total: 4, truncated: false, items: makeHits(4, 0, "new") };
+    });
+
+    const { container, rerender } = render(
+      <DriveSearchPanel keyword="old" dataSource={ds} isActive />
+    );
+    await screen.findByText("old-0");
+    // Kick off the (hanging) page-2 fetch for "old".
+    fireEvent.scroll(listEl(container));
+
+    // Switch keyword while page 2 is still in flight — this bumps the generation.
+    rerender(<DriveSearchPanel keyword="new" dataSource={ds} isActive />);
+    await screen.findByText("new-0");
+
+    // Now let the stale page-2 resolve; its generation is expired -> dropped.
+    releaseOld();
+    await oldGate;
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(screen.queryByText("old-more-20")).toBeNull();
+    expect(screen.getByText("new-0")).toBeInTheDocument();
+  });
+
+  it("truncated: shows the soft hint and still allows paging", async () => {
+    const { ds, searchDrive } = makeDataSource(async (query) => ({
+      total: 40,
+      truncated: true,
+      items: makeHits(20, query.page_index === 0 ? 0 : 20),
+    }));
+    const { container } = render(
+      <DriveSearchPanel keyword="评审" dataSource={ds} isActive />
+    );
+    await screen.findByText("file-0");
+    expect(
+      await screen.findByText("base.globalSearch.drive.truncated")
+    ).toBeInTheDocument();
+
+    // truncated must NOT gate loadNextPage (hasMore is still true here).
+    await waitFor(() => {
+      fireEvent.scroll(listEl(container));
+      expect(searchDrive.mock.calls.length).toBe(2);
+    });
+    expect(searchDrive.mock.calls[1]![0].page_index).toBe(1);
+  });
+});

--- a/packages/dmworkbase/src/Components/GlobalSearch/drive-search-panel.css
+++ b/packages/dmworkbase/src/Components/GlobalSearch/drive-search-panel.css
@@ -1,0 +1,110 @@
+/* Drive search tab. Mirrors the chrome of the cloud-docs panel
+   (doc-search-panel.css) using the shared theme tokens from theme/semantic.css.
+   Kept token-only (no literal fallbacks / no hardcoded colours) so it inherits
+   light/dark theming automatically via body[theme-mode=dark]. Sizes/spacing/
+   radii deliberately match doc-search-panel.css 1:1 (spec §2.4 视觉铁律). */
+.wk-drive-search {
+  height: 100%;
+  min-height: 0;
+}
+.wk-drive-search__list {
+  height: var(--wk-global-search-content-height, min(58vh, 640px));
+  overflow: auto;
+  padding: var(--wk-sp-1) var(--wk-sp-2);
+}
+.wk-drive-search__item {
+  display: flex;
+  gap: var(--wk-sp-3);
+  width: 100%;
+  padding: var(--wk-sp-2) var(--wk-sp-3);
+  border: 0;
+  border-radius: var(--wk-r-md);
+  background: transparent;
+  text-align: left;
+  cursor: pointer;
+  align-items: flex-start;
+}
+.wk-drive-search__item:hover {
+  background: var(--wk-bg-item-hover);
+}
+/* Icon badge: same 38x38 / radius / glyph colour as .wk-doc-search__icon.
+   Folder + generic files fall back to the accent fill (doc panel's default
+   icon background); the doc type overrides to the shared doc accent. The
+   lucide glyph paints with currentColor = --wk-text-inverse. */
+.wk-drive-search__icon {
+  flex: none;
+  width: 38px;
+  height: 38px;
+  border-radius: var(--wk-r-sm);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--wk-text-inverse);
+  background: var(--wk-text-accent);
+}
+.wk-drive-search__icon--doc {
+  background: var(--wk-doc-accent-doc);
+}
+.wk-drive-search__meta {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+}
+.wk-drive-search__title {
+  font-size: 14px;
+  line-height: 20px;
+  color: var(--wk-text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+/* <mark> highlight: identical to .wk-doc-search__snippet em. background:transparent
+   neutralises the UA yellow default so it matches the <em> treatment exactly. */
+.wk-drive-search__title mark,
+.wk-drive-search__snippet mark {
+  background: transparent;
+  font-style: normal;
+  color: var(--wk-text-accent);
+  font-weight: 600;
+}
+.wk-drive-search__crumb {
+  font-size: 12px;
+  line-height: 18px;
+  color: var(--wk-text-tertiary);
+  margin-top: 2px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.wk-drive-search__snippet {
+  font-size: 12px;
+  line-height: 18px;
+  color: var(--wk-text-secondary);
+  margin-top: 2px;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+.wk-drive-search__sub {
+  font-size: 12px;
+  color: var(--wk-text-tertiary);
+  margin-top: 4px;
+}
+.wk-drive-search__hint,
+.wk-drive-search__empty {
+  padding: var(--wk-sp-6) var(--wk-sp-4);
+  text-align: center;
+  color: var(--wk-text-tertiary);
+  font-size: 13px;
+}
+/* loadingMore / truncated / all-loaded bottom hints share one container. */
+.wk-drive-search__footer {
+  padding: var(--wk-sp-3) var(--wk-sp-4);
+  text-align: center;
+  color: var(--wk-text-tertiary);
+  font-size: 12px;
+}

--- a/packages/dmworkbase/src/Pages/Chat/__tests__/onOpenDriveHit.test.ts
+++ b/packages/dmworkbase/src/Pages/Chat/__tests__/onOpenDriveHit.test.ts
@@ -1,17 +1,17 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import fs from "node:fs";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { DriveSearchHit } from "../../../Service/SearchTypes";
+import {
+  buildDriveFileHitUrl,
+  openDriveFileHit,
+  type OpenedTab,
+} from "../openDriveFileHit";
 
-// onOpenDriveHit routes a clicked global-search drive hit to the standalone
-// file-preview tab (`/drive/f/<fileId>?name=&size=&spaceId=`) and drops folder
-// hits (they have no preview; the panel already filters them server-side, this
-// is the client-side backstop).
-//
-// Why a behavioral mirror + source guard, not a full render: the handler is
-// inline in Pages/Chat/index.tsx, whose class component pulls the whole chat
-// stack (WKApp, wukongimjssdk, react-virtuoso) into vitest. §A mirrors the
-// handler against a mocked window.open; §B locks the production edit in place.
+// Tests the REAL production routing (openDriveFileHit / buildDriveFileHitUrl),
+// not a mirror — so folder-skip, URL shape, opener=null, and popup handling
+// cannot drift from what Chat's handler actually calls. Chat/index.tsx only
+// wires window.open + Toast into these functions (verified by the source guard).
 
 function baseHit(overrides: Partial<DriveSearchHit> = {}): DriveSearchHit {
   return {
@@ -34,106 +34,86 @@ function baseHit(overrides: Partial<DriveSearchHit> = {}): DriveSearchHit {
   };
 }
 
-// Mirror of Chat#onOpenDriveHit. If production diverges from this shape, the §B
-// source guard below fails.
-function simulateOnOpenDriveHit(
-  hit: DriveSearchHit,
-  deps: {
-    open: (url: string, target: string) => { opener: unknown; location: { href: string } } | null;
-    warn: () => void;
-  }
-): void {
-  if (hit.type === "folder") {
-    // production console.warns and skips
-    return;
-  }
-  const params = new URLSearchParams({
-    name: hit.name || "",
-    size: hit.size != null ? String(hit.size) : "",
-    spaceId: hit.space_id,
-  });
-  const url = `/drive/f/${encodeURIComponent(String(hit.file_id))}?${params.toString()}`;
-  const opened = deps.open("about:blank", "_blank");
-  if (!opened) {
-    deps.warn();
-    return;
-  }
-  try {
-    opened.opener = null;
-  } catch {
-    /* swallow */
-  }
-  opened.location.href = url;
-}
-
-describe("onOpenDriveHit — §A behavior", () => {
-  let win: { opener: unknown; location: { href: string } };
-  let open: ReturnType<typeof vi.fn>;
-  let warn: ReturnType<typeof vi.fn>;
-
-  beforeEach(() => {
-    win = { opener: {}, location: { href: "about:blank" } };
-    open = vi.fn(() => win);
-    warn = vi.fn();
-  });
-  afterEach(() => vi.clearAllMocks());
-
-  it("file hit: opens /drive/f/<id> with name, size and spaceId in the query", () => {
-    simulateOnOpenDriveHit(baseHit(), { open, warn });
-    expect(open).toHaveBeenCalledWith("about:blank", "_blank");
-    expect(win.opener).toBeNull();
-    const u = new URL(win.location.href, "https://x.example.com");
+describe("buildDriveFileHitUrl", () => {
+  it("file hit: /drive/f/<id> with name, size and spaceId in the query", () => {
+    const u = new URL(buildDriveFileHitUrl(baseHit())!, "https://x.example.com");
     expect(u.pathname).toBe("/drive/f/1234");
     expect(u.searchParams.get("name")).toBe("spec.pdf");
     expect(u.searchParams.get("size")).toBe("2048");
     expect(u.searchParams.get("spaceId")).toBe("space-9");
   });
 
-  it("folder hit: never opens a tab (client-side backstop)", () => {
-    simulateOnOpenDriveHit(baseHit({ type: "folder", name: "设计稿" }), {
-      open,
-      warn,
-    });
-    expect(open).not.toHaveBeenCalled();
+  it("folder hit: returns null (no preview URL)", () => {
+    expect(buildDriveFileHitUrl(baseHit({ type: "folder", name: "设计稿" }))).toBeNull();
   });
 
   it("missing size: leaves the size param empty rather than 'undefined'", () => {
-    simulateOnOpenDriveHit(baseHit({ size: undefined }), { open, warn });
-    const u = new URL(win.location.href, "https://x.example.com");
+    const u = new URL(
+      buildDriveFileHitUrl(baseHit({ size: undefined }))!,
+      "https://x.example.com"
+    );
     expect(u.searchParams.get("size")).toBe("");
-  });
-
-  it("popup blocked: warns and does not navigate", () => {
-    open.mockReturnValueOnce(null);
-    simulateOnOpenDriveHit(baseHit(), { open, warn });
-    expect(warn).toHaveBeenCalledTimes(1);
   });
 });
 
-describe("onOpenDriveHit — §B source guard", () => {
-  const src = fs.readFileSync(
-    path.resolve(__dirname, "../index.tsx"),
-    "utf8"
-  );
-  const block = (() => {
+describe("openDriveFileHit", () => {
+  let tab: OpenedTab;
+  let open: ReturnType<typeof vi.fn>;
+  let onBlocked: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    tab = { opener: {}, location: { href: "about:blank" } };
+    open = vi.fn(() => tab);
+    onBlocked = vi.fn();
+  });
+  afterEach(() => vi.clearAllMocks());
+
+  it("file hit: opens about:blank, clears opener, then navigates to the preview URL", () => {
+    openDriveFileHit(baseHit(), { open, onBlocked });
+    expect(open).toHaveBeenCalledWith("about:blank", "_blank");
+    expect(tab.opener).toBeNull();
+    const u = new URL(tab.location.href, "https://x.example.com");
+    expect(u.pathname).toBe("/drive/f/1234");
+    expect(u.searchParams.get("spaceId")).toBe("space-9");
+    expect(onBlocked).not.toHaveBeenCalled();
+  });
+
+  it("folder hit: never opens a tab (client-side backstop)", () => {
+    openDriveFileHit(baseHit({ type: "folder", name: "设计稿" }), { open, onBlocked });
+    expect(open).not.toHaveBeenCalled();
+    expect(onBlocked).not.toHaveBeenCalled();
+  });
+
+  it("popup blocked: calls onBlocked and does not navigate", () => {
+    open.mockReturnValueOnce(null);
+    openDriveFileHit(baseHit(), { open, onBlocked });
+    expect(onBlocked).toHaveBeenCalledTimes(1);
+  });
+
+  it("frozen opener setter: swallows and still navigates", () => {
+    Object.defineProperty(tab, "opener", {
+      get: () => ({}),
+      set: () => {
+        throw new Error("frozen");
+      },
+    });
+    expect(() => openDriveFileHit(baseHit(), { open, onBlocked })).not.toThrow();
+    expect(tab.location.href).toContain("/drive/f/1234");
+  });
+});
+
+describe("Chat handler delegates to openDriveFileHit (source guard)", () => {
+  // Behavior above tests the real function; this only guards that the handler
+  // keeps calling it (no re-inlined copy that could drift) and wires the popup
+  // warning in, without importing the heavy Chat class into vitest.
+  const src = fs.readFileSync(path.resolve(__dirname, "../index.tsx"), "utf8");
+
+  it("onOpenDriveHit calls openDriveFileHit with a popup-blocked Toast", () => {
     const start = src.indexOf("onOpenDriveHit={(hit)");
     expect(start, "onOpenDriveHit handler should exist").toBeGreaterThan(-1);
-    return src.slice(start, start + 3200);
-  })();
-
-  it("skips folder hits before opening a tab", () => {
-    const folderIdx = block.indexOf('hit.type === "folder"');
-    const openIdx = block.indexOf("window.open");
-    expect(folderIdx).toBeGreaterThan(-1);
-    expect(openIdx).toBeGreaterThan(folderIdx);
-  });
-
-  it("routes to the /drive/f/<fileId> standalone preview path", () => {
-    expect(block).toMatch(/\/drive\/f\/\$\{encodeURIComponent/);
-  });
-
-  it("keeps the about:blank + opener=null new-tab pattern", () => {
-    expect(block).toMatch(/window\.open\("about:blank", "_blank"\)/);
-    expect(block).toMatch(/opened\.opener = null/);
+    const block = src.slice(start, start + 600);
+    expect(block).toMatch(/openDriveFileHit\(hit,/);
+    expect(block).toMatch(/popupBlocked/);
+    expect(src).toMatch(/import \{ openDriveFileHit \} from "\.\/openDriveFileHit"/);
   });
 });

--- a/packages/dmworkbase/src/Pages/Chat/__tests__/onOpenDriveHit.test.ts
+++ b/packages/dmworkbase/src/Pages/Chat/__tests__/onOpenDriveHit.test.ts
@@ -1,0 +1,139 @@
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { DriveSearchHit } from "../../../Service/SearchTypes";
+
+// onOpenDriveHit routes a clicked global-search drive hit to the standalone
+// file-preview tab (`/drive/f/<fileId>?name=&size=&spaceId=`) and drops folder
+// hits (they have no preview; the panel already filters them server-side, this
+// is the client-side backstop).
+//
+// Why a behavioral mirror + source guard, not a full render: the handler is
+// inline in Pages/Chat/index.tsx, whose class component pulls the whole chat
+// stack (WKApp, wukongimjssdk, react-virtuoso) into vitest. §A mirrors the
+// handler against a mocked window.open; §B locks the production edit in place.
+
+function baseHit(overrides: Partial<DriveSearchHit> = {}): DriveSearchHit {
+  return {
+    file_id: 1234,
+    space_id: "space-9",
+    space_name: "共享空间",
+    parent_id: 0,
+    path: ["设计稿"],
+    name: "spec.pdf",
+    type: "blob",
+    ext: "pdf",
+    size: 2048,
+    owner_uid: "u1",
+    owner_name: "Alex",
+    updater_uid: "u1",
+    updater_name: "Alex",
+    created_at: "2026-08-20T10:00:00.000Z",
+    updated_at: "2026-08-24T09:30:00.000Z",
+    ...overrides,
+  };
+}
+
+// Mirror of Chat#onOpenDriveHit. If production diverges from this shape, the §B
+// source guard below fails.
+function simulateOnOpenDriveHit(
+  hit: DriveSearchHit,
+  deps: {
+    open: (url: string, target: string) => { opener: unknown; location: { href: string } } | null;
+    warn: () => void;
+  }
+): void {
+  if (hit.type === "folder") {
+    // production console.warns and skips
+    return;
+  }
+  const params = new URLSearchParams({
+    name: hit.name || "",
+    size: hit.size != null ? String(hit.size) : "",
+    spaceId: hit.space_id,
+  });
+  const url = `/drive/f/${encodeURIComponent(String(hit.file_id))}?${params.toString()}`;
+  const opened = deps.open("about:blank", "_blank");
+  if (!opened) {
+    deps.warn();
+    return;
+  }
+  try {
+    opened.opener = null;
+  } catch {
+    /* swallow */
+  }
+  opened.location.href = url;
+}
+
+describe("onOpenDriveHit — §A behavior", () => {
+  let win: { opener: unknown; location: { href: string } };
+  let open: ReturnType<typeof vi.fn>;
+  let warn: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    win = { opener: {}, location: { href: "about:blank" } };
+    open = vi.fn(() => win);
+    warn = vi.fn();
+  });
+  afterEach(() => vi.clearAllMocks());
+
+  it("file hit: opens /drive/f/<id> with name, size and spaceId in the query", () => {
+    simulateOnOpenDriveHit(baseHit(), { open, warn });
+    expect(open).toHaveBeenCalledWith("about:blank", "_blank");
+    expect(win.opener).toBeNull();
+    const u = new URL(win.location.href, "https://x.example.com");
+    expect(u.pathname).toBe("/drive/f/1234");
+    expect(u.searchParams.get("name")).toBe("spec.pdf");
+    expect(u.searchParams.get("size")).toBe("2048");
+    expect(u.searchParams.get("spaceId")).toBe("space-9");
+  });
+
+  it("folder hit: never opens a tab (client-side backstop)", () => {
+    simulateOnOpenDriveHit(baseHit({ type: "folder", name: "设计稿" }), {
+      open,
+      warn,
+    });
+    expect(open).not.toHaveBeenCalled();
+  });
+
+  it("missing size: leaves the size param empty rather than 'undefined'", () => {
+    simulateOnOpenDriveHit(baseHit({ size: undefined }), { open, warn });
+    const u = new URL(win.location.href, "https://x.example.com");
+    expect(u.searchParams.get("size")).toBe("");
+  });
+
+  it("popup blocked: warns and does not navigate", () => {
+    open.mockReturnValueOnce(null);
+    simulateOnOpenDriveHit(baseHit(), { open, warn });
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("onOpenDriveHit — §B source guard", () => {
+  const src = fs.readFileSync(
+    path.resolve(__dirname, "../index.tsx"),
+    "utf8"
+  );
+  const block = (() => {
+    const start = src.indexOf("onOpenDriveHit={(hit)");
+    expect(start, "onOpenDriveHit handler should exist").toBeGreaterThan(-1);
+    return src.slice(start, start + 3200);
+  })();
+
+  it("skips folder hits before opening a tab", () => {
+    const folderIdx = block.indexOf('hit.type === "folder"');
+    const openIdx = block.indexOf("window.open");
+    expect(folderIdx).toBeGreaterThan(-1);
+    expect(openIdx).toBeGreaterThan(folderIdx);
+  });
+
+  it("routes to the /drive/f/<fileId> standalone preview path", () => {
+    expect(block).toMatch(/\/drive\/f\/\$\{encodeURIComponent/);
+  });
+
+  it("keeps the about:blank + opener=null new-tab pattern", () => {
+    expect(block).toMatch(/window\.open\("about:blank", "_blank"\)/);
+    expect(block).toMatch(/opened\.opener = null/);
+  });
+});

--- a/packages/dmworkbase/src/Pages/Chat/__tests__/onOpenDriveHit.test.ts
+++ b/packages/dmworkbase/src/Pages/Chat/__tests__/onOpenDriveHit.test.ts
@@ -47,6 +47,19 @@ describe("buildDriveFileHitUrl", () => {
     expect(buildDriveFileHitUrl(baseHit({ type: "folder", name: "设计稿" }))).toBeNull();
   });
 
+  it("doc hit with ref_id: routes to the /d/<ref_id> standalone reader, not /drive/f/*", () => {
+    const u = new URL(
+      buildDriveFileHitUrl(baseHit({ type: "doc", ref_id: "doc-abc", name: "设计文档" }))!,
+      "https://x.example.com"
+    );
+    expect(u.pathname).toBe("/d/doc-abc");
+    expect(u.pathname).not.toContain("/drive/f/");
+  });
+
+  it("doc hit without ref_id: returns null (no reader link, must not fall through to /drive/f/*)", () => {
+    expect(buildDriveFileHitUrl(baseHit({ type: "doc", ref_id: undefined }))).toBeNull();
+  });
+
   it("missing size: leaves the size param empty rather than 'undefined'", () => {
     const u = new URL(
       buildDriveFileHitUrl(baseHit({ size: undefined }))!,
@@ -82,6 +95,30 @@ describe("openDriveFileHit", () => {
     openDriveFileHit(baseHit({ type: "folder", name: "设计稿" }), { open, onBlocked });
     expect(open).not.toHaveBeenCalled();
     expect(onBlocked).not.toHaveBeenCalled();
+  });
+
+  it("doc hit with ref_id: navigates to /d/<ref_id> (docs reader), not the blob preview", () => {
+    openDriveFileHit(baseHit({ type: "doc", ref_id: "doc-abc", name: "设计文档" }), {
+      open,
+      onBlocked,
+    });
+    expect(open).toHaveBeenCalledWith("about:blank", "_blank");
+    const u = new URL(tab.location.href, "https://x.example.com");
+    expect(u.pathname).toBe("/d/doc-abc");
+    expect(tab.location.href).not.toContain("/drive/f/");
+    expect(onBlocked).not.toHaveBeenCalled();
+  });
+
+  it("doc hit without ref_id: warns and never opens a tab", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    openDriveFileHit(baseHit({ type: "doc", ref_id: undefined }), { open, onBlocked });
+    expect(open).not.toHaveBeenCalled();
+    expect(onBlocked).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("doc hit missing ref_id"),
+      expect.anything()
+    );
+    warn.mockRestore();
   });
 
   it("popup blocked: calls onBlocked and does not navigate", () => {

--- a/packages/dmworkbase/src/Pages/Chat/index.tsx
+++ b/packages/dmworkbase/src/Pages/Chat/index.tsx
@@ -1764,6 +1764,35 @@ export default class ChatPage extends Component<any, ChatPageState> {
                       }
                       opened.location.href = url;
                     }}
+                    onOpenDriveHit={(hit) => {
+                      // Open the clicked drive hit in the standalone `/drive`
+                      // page, which the drive module locates via the fileId /
+                      // spaceId query params (see drive-module patch). Same new-tab
+                      // pattern as onOpenDoc: `/drive` is intercepted by apps/web
+                      // Layout outside the app shell, so it can't be reached by an
+                      // in-shell soft push. The about:blank-first dance avoids the
+                      // noopener null-return popup-blocker false positive. The
+                      // search modal stays open so several results can be opened
+                      // in a row.
+                      const url = `/drive?fileId=${hit.file_id}&spaceId=${encodeURIComponent(
+                        hit.space_id
+                      )}`;
+                      const opened = window.open("about:blank", "_blank");
+                      if (!opened) {
+                        Toast.warning(
+                          t("base.globalSearch.drive.popupBlocked")
+                        );
+                        return;
+                      }
+                      try {
+                        opened.opener = null;
+                      } catch {
+                        // Some sandboxes freeze the opener setter; continue
+                        // navigating. about:blank is same-origin so the residual
+                        // risk is already contained.
+                      }
+                      opened.location.href = url;
+                    }}
                     hideModal={() => {
                       vm.showGlobalSearch = false;
                     }}

--- a/packages/dmworkbase/src/Pages/Chat/index.tsx
+++ b/packages/dmworkbase/src/Pages/Chat/index.tsx
@@ -29,6 +29,7 @@ import ChannelSetting from "../../Components/ChannelSetting";
 import ChannelSearchPanel from "../../features/channelSearch/ChannelSearchPanel";
 import { createChannelSearchApiDataSource } from "../../bridge/channelSearch/createChannelSearchDataSource";
 import { isChannelSearchEnabled } from "../../features/channelSearch/feature";
+import { openDriveFileHit } from "./openDriveFileHit";
 import type {
   ChannelSearchDataSource,
   ChannelSearchItem,
@@ -1765,50 +1766,17 @@ export default class ChatPage extends Component<any, ChatPageState> {
                       opened.location.href = url;
                     }}
                     onOpenDriveHit={(hit) => {
-                      // Folders have no preview — the panel already filters them
-                      // out server-side (filters.types), so a folder hit here
-                      // means a stale/loosened filter; warn and skip rather than
-                      // open a broken preview.
-                      if (hit.type === "folder") {
-                        console.warn(
-                          "[GlobalSearch] folder hit should be filtered out server-side; skipping"
-                        );
-                        return;
-                      }
-                      // Open the clicked file in the standalone preview page
-                      // `/drive/f/<fileId>`, which enterprise-modules routes to
-                      // StandalonePreview. name/size ride in the query so the
-                      // panel can label the file before the presigned URL
-                      // resolves; spaceId is kept for parity with the old link.
-                      // Same new-tab pattern as onOpenDoc: `/drive/f/...` is
-                      // intercepted by apps/web Layout outside the app shell, so
-                      // it can't be reached by an in-shell soft push. The
-                      // about:blank-first dance avoids the noopener null-return
-                      // popup-blocker false positive. The search modal stays open
-                      // so several results can be opened in a row.
-                      const params = new URLSearchParams({
-                        name: hit.name || "",
-                        size: hit.size != null ? String(hit.size) : "",
-                        spaceId: hit.space_id,
+                      // Routing lives in openDriveFileHit (unit-tested directly)
+                      // so folder-skip / URL shape / popup handling can't drift
+                      // from a test mirror. The search modal stays open so
+                      // several results can be opened in a row.
+                      openDriveFileHit(hit, {
+                        open: (u, target) => window.open(u, target),
+                        onBlocked: () =>
+                          Toast.warning(
+                            t("base.globalSearch.drive.popupBlocked")
+                          ),
                       });
-                      const url = `/drive/f/${encodeURIComponent(
-                        String(hit.file_id)
-                      )}?${params.toString()}`;
-                      const opened = window.open("about:blank", "_blank");
-                      if (!opened) {
-                        Toast.warning(
-                          t("base.globalSearch.drive.popupBlocked")
-                        );
-                        return;
-                      }
-                      try {
-                        opened.opener = null;
-                      } catch {
-                        // Some sandboxes freeze the opener setter; continue
-                        // navigating. about:blank is same-origin so the residual
-                        // risk is already contained.
-                      }
-                      opened.location.href = url;
                     }}
                     hideModal={() => {
                       vm.showGlobalSearch = false;

--- a/packages/dmworkbase/src/Pages/Chat/index.tsx
+++ b/packages/dmworkbase/src/Pages/Chat/index.tsx
@@ -1765,18 +1765,35 @@ export default class ChatPage extends Component<any, ChatPageState> {
                       opened.location.href = url;
                     }}
                     onOpenDriveHit={(hit) => {
-                      // Open the clicked drive hit in the standalone `/drive`
-                      // page, which the drive module locates via the fileId /
-                      // spaceId query params (see drive-module patch). Same new-tab
-                      // pattern as onOpenDoc: `/drive` is intercepted by apps/web
-                      // Layout outside the app shell, so it can't be reached by an
-                      // in-shell soft push. The about:blank-first dance avoids the
-                      // noopener null-return popup-blocker false positive. The
-                      // search modal stays open so several results can be opened
-                      // in a row.
-                      const url = `/drive?fileId=${hit.file_id}&spaceId=${encodeURIComponent(
-                        hit.space_id
-                      )}`;
+                      // Folders have no preview — the panel already filters them
+                      // out server-side (filters.types), so a folder hit here
+                      // means a stale/loosened filter; warn and skip rather than
+                      // open a broken preview.
+                      if (hit.type === "folder") {
+                        console.warn(
+                          "[GlobalSearch] folder hit should be filtered out server-side; skipping"
+                        );
+                        return;
+                      }
+                      // Open the clicked file in the standalone preview page
+                      // `/drive/f/<fileId>`, which enterprise-modules routes to
+                      // StandalonePreview. name/size ride in the query so the
+                      // panel can label the file before the presigned URL
+                      // resolves; spaceId is kept for parity with the old link.
+                      // Same new-tab pattern as onOpenDoc: `/drive/f/...` is
+                      // intercepted by apps/web Layout outside the app shell, so
+                      // it can't be reached by an in-shell soft push. The
+                      // about:blank-first dance avoids the noopener null-return
+                      // popup-blocker false positive. The search modal stays open
+                      // so several results can be opened in a row.
+                      const params = new URLSearchParams({
+                        name: hit.name || "",
+                        size: hit.size != null ? String(hit.size) : "",
+                        spaceId: hit.space_id,
+                      });
+                      const url = `/drive/f/${encodeURIComponent(
+                        String(hit.file_id)
+                      )}?${params.toString()}`;
                       const opened = window.open("about:blank", "_blank");
                       if (!opened) {
                         Toast.warning(

--- a/packages/dmworkbase/src/Pages/Chat/openDriveFileHit.ts
+++ b/packages/dmworkbase/src/Pages/Chat/openDriveFileHit.ts
@@ -1,0 +1,61 @@
+import type { DriveSearchHit } from "../../Service/SearchTypes";
+
+// Routing for a clicked global-search drive hit, extracted from Chat's
+// onOpenDriveHit so the contract is unit-tested against the real code rather
+// than a mirror: folder hits have no preview and must never open a tab; file
+// hits open the standalone preview page `/drive/f/<fileId>?name=&size=&spaceId=`
+// (intercepted by apps/web Layout outside the app shell). name/size ride in the
+// query so the panel can label the file before the presigned URL resolves.
+
+/** Minimal shape of the window the opener returns — kept structural so tests
+ *  can supply a plain object and production can pass a real `Window`. */
+export interface OpenedTab {
+  opener: unknown;
+  location: { href: string };
+}
+
+export interface OpenDriveFileHitDeps {
+  /** Opens a blank tab (production: `window.open`). Returns null when blocked. */
+  open: (url: string, target: string) => OpenedTab | null;
+  /** Called when the popup was blocked (production: a Toast warning). */
+  onBlocked: () => void;
+}
+
+/** The standalone-preview URL for a file hit, or null for a folder (no preview). */
+export function buildDriveFileHitUrl(hit: DriveSearchHit): string | null {
+  if (hit.type === "folder") return null;
+  const params = new URLSearchParams({
+    name: hit.name || "",
+    size: hit.size != null ? String(hit.size) : "",
+    spaceId: hit.space_id,
+  });
+  return `/drive/f/${encodeURIComponent(String(hit.file_id))}?${params.toString()}`;
+}
+
+/**
+ * Open a clicked file hit in a new standalone-preview tab. Folder hits are
+ * skipped (client-side backstop: the panel already excludes them server-side
+ * via filters.types). Uses the about:blank-first + opener=null pattern to dodge
+ * the noopener null-return popup-blocker false positive.
+ */
+export function openDriveFileHit(hit: DriveSearchHit, deps: OpenDriveFileHitDeps): void {
+  const url = buildDriveFileHitUrl(hit);
+  if (url === null) {
+    console.warn(
+      "[GlobalSearch] folder hit should be filtered out server-side; skipping"
+    );
+    return;
+  }
+  const opened = deps.open("about:blank", "_blank");
+  if (!opened) {
+    deps.onBlocked();
+    return;
+  }
+  try {
+    opened.opener = null;
+  } catch {
+    // Some sandboxes freeze the opener setter; continue navigating. about:blank
+    // is same-origin so the residual risk is already contained.
+  }
+  opened.location.href = url;
+}

--- a/packages/dmworkbase/src/Pages/Chat/openDriveFileHit.ts
+++ b/packages/dmworkbase/src/Pages/Chat/openDriveFileHit.ts
@@ -1,9 +1,12 @@
 import type { DriveSearchHit } from "../../Service/SearchTypes";
+import { buildDocLink } from "../../Utils/docLink";
 
 // Routing for a clicked global-search drive hit, extracted from Chat's
 // onOpenDriveHit so the contract is unit-tested against the real code rather
-// than a mirror: folder hits have no preview and must never open a tab; file
-// hits open the standalone preview page `/drive/f/<fileId>?name=&size=&spaceId=`
+// than a mirror: folder hits have no preview and must never open a tab; doc
+// hits open the docs standalone reader `/d/<ref_id>` via buildDocLink (a doc
+// file_id would 400 on the blob-download preview); blob hits open the
+// standalone preview page `/drive/f/<fileId>?name=&size=&spaceId=`
 // (intercepted by apps/web Layout outside the app shell). name/size ride in the
 // query so the panel can label the file before the presigned URL resolves.
 
@@ -21,9 +24,19 @@ export interface OpenDriveFileHitDeps {
   onBlocked: () => void;
 }
 
-/** The standalone-preview URL for a file hit, or null for a folder (no preview). */
+/** The preview URL for a hit, or null when there is nothing to open (a folder,
+ *  or a doc hit missing its ref_id). Doc hits route to the /d/:docId standalone
+ *  reader via buildDocLink; blob hits route to the /drive/f/:fileId preview. */
 export function buildDriveFileHitUrl(hit: DriveSearchHit): string | null {
   if (hit.type === "folder") return null;
+  if (hit.type === "doc") {
+    // A doc hit is a cloud document, not a blob: route it to the docs
+    // standalone reader (same target as a cloud-doc tab hit), never to the
+    // blob-download preview which 400s on a doc file_id. ref_id is the docId;
+    // absent it we cannot build a link, so skip (return null).
+    if (!hit.ref_id) return null;
+    return buildDocLink({ docId: hit.ref_id });
+  }
   const params = new URLSearchParams({
     name: hit.name || "",
     size: hit.size != null ? String(hit.size) : "",
@@ -33,17 +46,24 @@ export function buildDriveFileHitUrl(hit: DriveSearchHit): string | null {
 }
 
 /**
- * Open a clicked file hit in a new standalone-preview tab. Folder hits are
- * skipped (client-side backstop: the panel already excludes them server-side
- * via filters.types). Uses the about:blank-first + opener=null pattern to dodge
- * the noopener null-return popup-blocker false positive.
+ * Open a clicked hit in a new tab. Folder hits, and doc hits missing a ref_id,
+ * are skipped (folders are a client-side backstop — the panel already excludes
+ * them server-side via filters.types; a doc without ref_id has no reader link).
+ * Uses the about:blank-first + opener=null pattern to dodge the noopener
+ * null-return popup-blocker false positive.
  */
 export function openDriveFileHit(hit: DriveSearchHit, deps: OpenDriveFileHitDeps): void {
   const url = buildDriveFileHitUrl(hit);
   if (url === null) {
-    console.warn(
-      "[GlobalSearch] folder hit should be filtered out server-side; skipping"
-    );
+    if (hit.type === "doc") {
+      console.warn("[GlobalSearch] doc hit missing ref_id; skipping", {
+        file_id: hit.file_id,
+      });
+    } else {
+      console.warn(
+        "[GlobalSearch] folder hit should be filtered out server-side; skipping"
+      );
+    }
     return;
   }
   const opened = deps.open("about:blank", "_blank");

--- a/packages/dmworkbase/src/Service/APIClient.ts
+++ b/packages/dmworkbase/src/Service/APIClient.ts
@@ -173,6 +173,7 @@ export default class APIClient {
     }
     post(path: string, data?: any, config?: RequestConfig) {
         return this.wrapResult(axios.post(path, data, {
+            baseURL: config?.baseURL,
             headers: config?.headers,
             responseType: config?.responseType,
             timeout: config?.timeout,
@@ -285,6 +286,14 @@ export class RequestConfig {
      * yujiawei.
      */
     signal?: AbortSignal
+    /**
+     * Per-request axios baseURL override. When set, axios uses it INSTEAD of the
+     * shared `axios.defaults.baseURL` (`/api/v1/`) and combines it with `path`.
+     * Used by the drive full-text search, which is proxied under `/api/drive/`
+     * (a distinct nginx location from the `/api/v1/` gateway), not the v1 API.
+     * Omitting it fully preserves the existing default-baseURL behavior.
+     */
+    baseURL?: string
 }
 
 export interface APIResp {

--- a/packages/dmworkbase/src/Service/APIClient.ts
+++ b/packages/dmworkbase/src/Service/APIClient.ts
@@ -289,9 +289,9 @@ export class RequestConfig {
     /**
      * Per-request axios baseURL override. When set, axios uses it INSTEAD of the
      * shared `axios.defaults.baseURL` (`/api/v1/`) and combines it with `path`.
-     * Used by the drive full-text search, which is proxied under `/api/drive/`
-     * (a distinct nginx location from the `/api/v1/` gateway), not the v1 API.
-     * Omitting it fully preserves the existing default-baseURL behavior.
+     * Used by the drive full-text search, which is proxied under `/v1/drive/`
+     * (a distinct nginx location from the `/api/v1/` gateway), matching the exact
+     * route drive-module uses. Omitting it fully preserves the default behavior.
      */
     baseURL?: string
 }

--- a/packages/dmworkbase/src/Service/SearchService.ts
+++ b/packages/dmworkbase/src/Service/SearchService.ts
@@ -76,6 +76,13 @@ export function toChannelSearchRequestBody(query: ChannelSearchQuery) {
 // CN-tz day formatter for GlobalSearch. See §11.
 const CN_TZ = "Asia/Shanghai";
 
+// Drive full-text search is proxied under a dedicated nginx location
+// (`^~ /api/drive` -> octo-drive backend), NOT the `/api/v1/` gateway that is
+// APIClient's default baseURL. Pass this as a per-request baseURL override so
+// the request resolves to `/api/drive/search`, per the spec route contract —
+// axios combines this baseURL with the `"search"` path (no leading slash).
+const DRIVE_API_PREFIX = "/api/drive/";
+
 // Split a Date into CN-tz Y/M/D (numeric). Extracted so both the wire
 // serializer and the datePreset boundary math share one code path.
 function cnCalendarParts(
@@ -518,7 +525,8 @@ const SearchService = {
     };
   },
 
-  // Drive full-text search: octo-drive backend `POST drive/search`. uid is
+  // Drive full-text search: octo-drive backend, proxied at `POST /api/drive/search`
+  // (see DRIVE_API_PREFIX). uid is
   // injected by the gateway (not sent from the client); the backend applies
   // permission down-push server-side, so the client renders items verbatim.
   //
@@ -548,7 +556,10 @@ const SearchService = {
     };
     if (query.space_id) body.space_id = query.space_id;
     if (query.filters) body.filters = query.filters;
-    const resp = await APIClient.shared.post("drive/search", body, { signal });
+    const resp = await APIClient.shared.post("search", body, {
+      signal,
+      baseURL: DRIVE_API_PREFIX,
+    });
     const items = Array.isArray(resp?.items) ? resp.items : [];
     const validItems = items.filter(
       (it: unknown): it is DriveSearchHit =>

--- a/packages/dmworkbase/src/Service/SearchService.ts
+++ b/packages/dmworkbase/src/Service/SearchService.ts
@@ -76,12 +76,12 @@ export function toChannelSearchRequestBody(query: ChannelSearchQuery) {
 // CN-tz day formatter for GlobalSearch. See §11.
 const CN_TZ = "Asia/Shanghai";
 
-// Drive full-text search is proxied under a dedicated nginx location
-// (`^~ /api/drive` -> octo-drive backend), NOT the `/api/v1/` gateway that is
-// APIClient's default baseURL. Pass this as a per-request baseURL override so
-// the request resolves to `/api/drive/search`, per the spec route contract —
-// axios combines this baseURL with the `"search"` path (no leading slash).
-const DRIVE_API_PREFIX = "/api/drive/";
+// Drive full-text search shares drive-module's exact route: `POST /v1/drive/search`
+// (dmwork-prod nginx: `location ^~ /v1/drive/` -> octo-drive backend, already live).
+// APIClient's default baseURL is the `/api/v1/` gateway, so we still pass `/v1/drive/`
+// as a per-request baseURL override — axios combines it with the `"search"` path (no
+// leading slash) to resolve `/v1/drive/search`.
+const DRIVE_API_PREFIX = "/v1/drive/";
 
 // Split a Date into CN-tz Y/M/D (numeric). Extracted so both the wire
 // serializer and the datePreset boundary math share one code path.
@@ -525,7 +525,7 @@ const SearchService = {
     };
   },
 
-  // Drive full-text search: octo-drive backend, proxied at `POST /api/drive/search`
+  // Drive full-text search: octo-drive backend, proxied at `POST /v1/drive/search`
   // (see DRIVE_API_PREFIX). uid is
   // injected by the gateway (not sent from the client); the backend applies
   // permission down-push server-side, so the client renders items verbatim.

--- a/packages/dmworkbase/src/Service/SearchService.ts
+++ b/packages/dmworkbase/src/Service/SearchService.ts
@@ -23,6 +23,9 @@ import type {
   DocSearchItem,
   DocSearchQuery,
   DocSearchResponse,
+  DriveSearchHit,
+  DriveSearchQuery,
+  DriveSearchResponse,
   GlobalContentTab,
   GlobalSearchFileTypeCategory,
   GlobalSearchFilters,
@@ -512,6 +515,52 @@ const SearchService = {
       total: typeof resp?.total === "number" ? resp.total : validItems.length,
       items: validItems,
       nextCursor,
+    };
+  },
+
+  // Drive full-text search: octo-drive backend `POST drive/search`. uid is
+  // injected by the gateway (not sent from the client); the backend applies
+  // permission down-push server-side, so the client renders items verbatim.
+  //
+  // Contract mirrors octo-drive-module src/bridge/types.ts (SearchParams /
+  // SearchResult). Request/response shape:
+  //   req:  { q, scope, space_id?, filters?, page_index, page_size }
+  //   resp: { total, truncated, items: SearchHit[] }
+  //   1. Pagination is OFFSET-based (page_index / page_size), NOT keyset. The
+  //      global-search drive tab only ever fetches the first page (page_index
+  //      0, page_size 20), so there is no pager arithmetic here.
+  //   2. `truncated` — true when the OpenSearch response was capped; the panel
+  //      renders a "results may be partial" note.
+  //   3. Highlight fragments already wrap hits in <mark> (name[]/body[]); the
+  //      panel renders them through a <mark>-only allowlist, never raw HTML.
+  // Boundary guard: drop items missing a usable numeric file_id / string
+  // space_id (both feed React key= and the /drive open URL), so a malformed
+  // row can't forge a key collision or a /drive?fileId=undefined jump.
+  async searchDrive(
+    query: DriveSearchQuery,
+    signal?: AbortSignal
+  ): Promise<DriveSearchResponse> {
+    const body: Record<string, unknown> = {
+      q: query.q,
+      scope: query.scope ?? "all",
+      page_index: query.page_index ?? 0,
+      page_size: query.page_size ?? 20,
+    };
+    if (query.space_id) body.space_id = query.space_id;
+    if (query.filters) body.filters = query.filters;
+    const resp = await APIClient.shared.post("drive/search", body, { signal });
+    const items = Array.isArray(resp?.items) ? resp.items : [];
+    const validItems = items.filter(
+      (it: unknown): it is DriveSearchHit =>
+        !!it &&
+        typeof (it as DriveSearchHit).file_id === "number" &&
+        typeof (it as DriveSearchHit).space_id === "string" &&
+        (it as DriveSearchHit).space_id !== ""
+    );
+    return {
+      total: typeof resp?.total === "number" ? resp.total : validItems.length,
+      truncated: resp?.truncated === true,
+      items: validItems,
     };
   },
 

--- a/packages/dmworkbase/src/Service/SearchTypes.ts
+++ b/packages/dmworkbase/src/Service/SearchTypes.ts
@@ -271,10 +271,9 @@ export type DriveSearchOwnerScope = "me" | "others";
 export type DriveFileType = "doc" | "blob" | "folder";
 
 export interface DriveSearchFilters {
-  type?: DriveFileType;
-  /** Multi-value include (TES-70 wire contract); excludes folder hits by
-   * requesting only ['blob','doc']. Kept alongside single `type` for
-   * back-compat — backend treats the two as an OR. */
+  /** Multi-value include (TES-70/TES-72 wire contract); excludes folder hits by
+   * requesting only ['blob','doc']. The single-value `type` field was removed to
+   * match the TES-72 backend, which keeps only the `Types` array. */
   types?: DriveFileType[];
   owner_scope?: DriveSearchOwnerScope;
   /** RFC3339. Include hits whose `updated_at >= updated_after`. */

--- a/packages/dmworkbase/src/Service/SearchTypes.ts
+++ b/packages/dmworkbase/src/Service/SearchTypes.ts
@@ -306,6 +306,12 @@ export interface DriveSearchContentMeta {
 
 export interface DriveSearchHit {
   file_id: number;
+  /** Present only when type='doc'. Value = drive_file.ref_id = the cloud-doc
+   *  docId. The host dispatches a doc hit to buildDocLink({docId: ref_id}) →
+   *  /d/:docId (docs standalone reader), avoiding the blob-download 400 that a
+   *  doc file_id triggers. Backend contract: drive-search merge.go doc-hit
+   *  branch (omitempty — absent on blob/folder hits). */
+  ref_id?: string;
   space_id: string;
   space_name: string;
   parent_id: number;

--- a/packages/dmworkbase/src/Service/SearchTypes.ts
+++ b/packages/dmworkbase/src/Service/SearchTypes.ts
@@ -200,6 +200,15 @@ export interface GlobalSearchDataSource {
   // Optional so existing DataSource fakes/tests stay valid; the docs tab is
   // only rendered where a real API data source provides it.
   searchDocs?: (query: DocSearchQuery) => Promise<DocSearchResponse>;
+  // Drive full-text search (octo-drive backend POST drive/search). Optional so
+  // existing DataSource fakes/tests stay valid; the drive tab is only rendered
+  // where a real API data source provides it and remoteConfig.driveOn is set.
+  // Accepts an AbortSignal so the panel can cancel a stale in-flight request
+  // when the keyword changes (mirrors the APIClient search-abort convention).
+  searchDrive?: (
+    query: DriveSearchQuery,
+    signal?: AbortSignal
+  ) => Promise<DriveSearchResponse>;
 }
 
 // --- Cloud-docs search (octo-docs-backend) -------------------------------
@@ -246,6 +255,78 @@ export interface DocSearchResponse {
   // while a further page exists; absent => no more results, so the pager stops
   // on `!nextCursor` rather than any offset/total arithmetic.
   nextCursor?: string;
+}
+
+// --- Drive search (octo-drive backend, POST drive/search) ----------------
+// Host-owned types symmetric to the octo-drive wire contract
+// (octo-drive-module src/bridge/types.ts). Duplicated here on purpose: host
+// must not import the drive module. Keep field names/types 1:1 with the wire.
+//   - file_id / parent_id are Go uint64 -> number; space_id is a string.
+//   - parent_id === 0 means "space root".
+//   - Pagination is offset-based (page_index / page_size), NOT cursor.
+//   - Highlight fragments already wrap hits in <mark> (rendered via an
+//     allowlist, never dangerouslySetInnerHTML).
+export type DriveSearchScope = "all" | "space";
+export type DriveSearchOwnerScope = "me" | "others";
+export type DriveFileType = "doc" | "blob" | "folder";
+
+export interface DriveSearchFilters {
+  type?: DriveFileType;
+  owner_scope?: DriveSearchOwnerScope;
+  /** RFC3339. Include hits whose `updated_at >= updated_after`. */
+  updated_after?: string;
+  /** Byte range, blob-only. Inclusive on both ends. */
+  size_min?: number;
+  size_max?: number;
+}
+
+export interface DriveSearchQuery {
+  q: string;
+  scope?: DriveSearchScope;
+  /** Required when scope === 'space'. */
+  space_id?: string;
+  filters?: DriveSearchFilters;
+  page_index?: number;
+  page_size?: number;
+}
+
+/** Per-field highlight fragments; each fragment already wraps hits in <mark>. */
+export interface DriveSearchHighlights {
+  name?: string[];
+  body?: string[];
+}
+
+export interface DriveSearchContentMeta {
+  extractor: string;
+  truncated: boolean;
+}
+
+export interface DriveSearchHit {
+  file_id: number;
+  space_id: string;
+  space_name: string;
+  parent_id: number;
+  /** Root-first folder-name chain, does NOT include the hit itself. */
+  path: string[];
+  name: string;
+  type: DriveFileType;
+  ext?: string;
+  size?: number;
+  owner_uid: string;
+  owner_name: string;
+  updater_uid: string;
+  updater_name: string;
+  created_at: string;
+  updated_at: string;
+  highlights?: DriveSearchHighlights;
+  content_meta?: DriveSearchContentMeta;
+}
+
+export interface DriveSearchResponse {
+  total: number;
+  /** True when the OS response was capped; UI shows a "results may be partial" note. */
+  truncated: boolean;
+  items: DriveSearchHit[];
 }
 
 export interface GlobalSearchChannelOption {

--- a/packages/dmworkbase/src/Service/SearchTypes.ts
+++ b/packages/dmworkbase/src/Service/SearchTypes.ts
@@ -272,6 +272,10 @@ export type DriveFileType = "doc" | "blob" | "folder";
 
 export interface DriveSearchFilters {
   type?: DriveFileType;
+  /** Multi-value include (TES-70 wire contract); excludes folder hits by
+   * requesting only ['blob','doc']. Kept alongside single `type` for
+   * back-compat — backend treats the two as an OR. */
+  types?: DriveFileType[];
   owner_scope?: DriveSearchOwnerScope;
   /** RFC3339. Include hits whose `updated_at >= updated_after`. */
   updated_after?: string;

--- a/packages/dmworkbase/src/Service/__tests__/SearchService.drive.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/SearchService.drive.test.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { postMock } = vi.hoisted(() => ({
+  postMock: vi.fn(),
+}));
+
+vi.mock("../APIClient", () => ({
+  default: {
+    shared: {
+      post: postMock,
+    },
+  },
+}));
+
+import SearchService from "../SearchService";
+import type { DriveSearchHit } from "../SearchTypes";
+
+function hit(overrides: Partial<DriveSearchHit> = {}): DriveSearchHit {
+  return {
+    file_id: 1,
+    space_id: "space-1",
+    space_name: "共享空间",
+    parent_id: 0,
+    path: [],
+    name: "file.md",
+    type: "doc",
+    owner_uid: "u1",
+    owner_name: "Alex",
+    updater_uid: "u1",
+    updater_name: "Alex",
+    created_at: "2026-08-20T10:00:00.000Z",
+    updated_at: "2026-08-24T09:30:00.000Z",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  postMock.mockReset();
+});
+
+describe("SearchService.searchDrive", () => {
+  it("posts drive/search with the default offset body (page_index 0) and forwards the abort signal", async () => {
+    postMock.mockResolvedValue({ total: 1, truncated: false, items: [hit()] });
+    const controller = new AbortController();
+
+    await SearchService.searchDrive({ q: "评审" }, controller.signal);
+
+    expect(postMock).toHaveBeenCalledWith(
+      "drive/search",
+      { q: "评审", scope: "all", page_index: 0, page_size: 20 },
+      { signal: controller.signal }
+    );
+  });
+
+  it("passes page_index / page_size / space_id / filters through when provided", async () => {
+    postMock.mockResolvedValue({ total: 0, truncated: false, items: [] });
+
+    await SearchService.searchDrive({
+      q: "spec",
+      scope: "space",
+      space_id: "space-9",
+      page_index: 2,
+      page_size: 50,
+      filters: { type: "doc" },
+    });
+
+    expect(postMock).toHaveBeenCalledWith(
+      "drive/search",
+      {
+        q: "spec",
+        scope: "space",
+        page_index: 2,
+        page_size: 50,
+        space_id: "space-9",
+        filters: { type: "doc" },
+      },
+      { signal: undefined }
+    );
+  });
+
+  it("drops hits without a numeric file_id or a non-empty string space_id", async () => {
+    postMock.mockResolvedValue({
+      total: 4,
+      truncated: false,
+      items: [
+        hit({ file_id: 1 }),
+        hit({ file_id: "2" as unknown as number }), // non-number -> dropped
+        hit({ space_id: "" }), // empty space_id -> dropped
+        null, // falsy -> dropped
+      ],
+    });
+
+    const result = await SearchService.searchDrive({ q: "x" });
+    expect(result.items.map((it) => it.file_id)).toEqual([1]);
+    // total is passed through verbatim (display-only), not the filtered count.
+    expect(result.total).toBe(4);
+  });
+
+  it("normalizes total (falls back to valid item count) and truncated (strict true)", async () => {
+    postMock.mockResolvedValue({ items: [hit()], truncated: "yes" });
+    const noTotal = await SearchService.searchDrive({ q: "x" });
+    expect(noTotal.total).toBe(1); // no numeric total -> valid item count
+    expect(noTotal.truncated).toBe(false); // only === true counts as truncated
+
+    postMock.mockResolvedValue({ total: 8, truncated: true, items: [] });
+    const truncated = await SearchService.searchDrive({ q: "x" });
+    expect(truncated).toEqual({ total: 8, truncated: true, items: [] });
+  });
+});

--- a/packages/dmworkbase/src/Service/__tests__/SearchService.drive.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/SearchService.drive.test.ts
@@ -39,17 +39,30 @@ beforeEach(() => {
 });
 
 describe("SearchService.searchDrive", () => {
-  it("posts drive/search with the default offset body (page_index 0) and forwards the abort signal", async () => {
+  it("posts search under the /api/drive/ prefix with the default offset body (page_index 0) and forwards the abort signal", async () => {
     postMock.mockResolvedValue({ total: 1, truncated: false, items: [hit()] });
     const controller = new AbortController();
 
     await SearchService.searchDrive({ q: "评审" }, controller.signal);
 
     expect(postMock).toHaveBeenCalledWith(
-      "drive/search",
+      "search",
       { q: "评审", scope: "all", page_index: 0, page_size: 20 },
-      { signal: controller.signal }
+      { signal: controller.signal, baseURL: "/api/drive/" }
     );
+  });
+
+  it("routes drive search to /api/drive/search (baseURL override + path combine)", async () => {
+    postMock.mockResolvedValue({ total: 0, truncated: false, items: [] });
+
+    await SearchService.searchDrive({ q: "x" });
+
+    const [path, , config] = postMock.mock.calls[0];
+    expect(path).toBe("search");
+    expect(config.baseURL).toBe("/api/drive/");
+    // The drive tab must resolve to the dedicated /api/drive proxy, NOT the
+    // /api/v1 gateway; axios combines baseURL + path exactly like this.
+    expect(`${config.baseURL}${path}`).toBe("/api/drive/search");
   });
 
   it("passes page_index / page_size / space_id / filters through when provided", async () => {
@@ -65,7 +78,7 @@ describe("SearchService.searchDrive", () => {
     });
 
     expect(postMock).toHaveBeenCalledWith(
-      "drive/search",
+      "search",
       {
         q: "spec",
         scope: "space",
@@ -74,7 +87,7 @@ describe("SearchService.searchDrive", () => {
         space_id: "space-9",
         filters: { type: "doc" },
       },
-      { signal: undefined }
+      { signal: undefined, baseURL: "/api/drive/" }
     );
   });
 

--- a/packages/dmworkbase/src/Service/__tests__/SearchService.drive.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/SearchService.drive.test.ts
@@ -39,7 +39,7 @@ beforeEach(() => {
 });
 
 describe("SearchService.searchDrive", () => {
-  it("posts search under the /api/drive/ prefix with the default offset body (page_index 0) and forwards the abort signal", async () => {
+  it("posts search under the /v1/drive/ prefix with the default offset body (page_index 0) and forwards the abort signal", async () => {
     postMock.mockResolvedValue({ total: 1, truncated: false, items: [hit()] });
     const controller = new AbortController();
 
@@ -48,21 +48,22 @@ describe("SearchService.searchDrive", () => {
     expect(postMock).toHaveBeenCalledWith(
       "search",
       { q: "评审", scope: "all", page_index: 0, page_size: 20 },
-      { signal: controller.signal, baseURL: "/api/drive/" }
+      { signal: controller.signal, baseURL: "/v1/drive/" }
     );
   });
 
-  it("routes drive search to /api/drive/search (baseURL override + path combine)", async () => {
+  it("routes drive search to /v1/drive/search (baseURL override + path combine)", async () => {
     postMock.mockResolvedValue({ total: 0, truncated: false, items: [] });
 
     await SearchService.searchDrive({ q: "x" });
 
     const [path, , config] = postMock.mock.calls[0];
     expect(path).toBe("search");
-    expect(config.baseURL).toBe("/api/drive/");
-    // The drive tab must resolve to the dedicated /api/drive proxy, NOT the
-    // /api/v1 gateway; axios combines baseURL + path exactly like this.
-    expect(`${config.baseURL}${path}`).toBe("/api/drive/search");
+    expect(config.baseURL).toBe("/v1/drive/");
+    // The drive tab shares drive-module's exact route: the dedicated
+    // `/v1/drive/` nginx location, NOT the `/api/v1` gateway default. axios
+    // combines baseURL + path exactly like this.
+    expect(`${config.baseURL}${path}`).toBe("/v1/drive/search");
   });
 
   it("passes page_index / page_size / space_id / filters through when provided", async () => {
@@ -74,7 +75,7 @@ describe("SearchService.searchDrive", () => {
       space_id: "space-9",
       page_index: 2,
       page_size: 50,
-      filters: { type: "doc" },
+      filters: { types: ["doc"] },
     });
 
     expect(postMock).toHaveBeenCalledWith(
@@ -85,9 +86,9 @@ describe("SearchService.searchDrive", () => {
         page_index: 2,
         page_size: 50,
         space_id: "space-9",
-        filters: { type: "doc" },
+        filters: { types: ["doc"] },
       },
-      { signal: undefined, baseURL: "/api/drive/" }
+      { signal: undefined, baseURL: "/v1/drive/" }
     );
   });
 

--- a/packages/dmworkbase/src/bridge/globalSearch/GlobalSearchVM.ts
+++ b/packages/dmworkbase/src/bridge/globalSearch/GlobalSearchVM.ts
@@ -58,6 +58,15 @@ export default class GlobalSearchVM extends ProviderListener {
     if (WKApp.remoteConfig.docsOn && WKApp.remoteConfig.docsSearchOn) {
       tabs.push({ tab: t("base.globalSearch.tab.docs"), itemKey: "docs" });
     }
+    // Drive search hits the octo-drive backend (POST drive/search). Single-flag
+    // gate: driveOn means the drive module is deployed AND its search endpoint is
+    // available (unlike docs, drive search ships in the same backend as the
+    // module, so there is no separate search switch). The drive panel fetches
+    // lazily on first activation, so an enabled-but-empty backend never 404s
+    // until the user actually opens the tab.
+    if (WKApp.remoteConfig.driveOn) {
+      tabs.push({ tab: t("base.globalSearch.tab.drive"), itemKey: "drive" });
+    }
     return tabs;
   }
 

--- a/packages/dmworkbase/src/bridge/globalSearch/__tests__/driveTabList.test.ts
+++ b/packages/dmworkbase/src/bridge/globalSearch/__tests__/driveTabList.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock the App singleton so we can flip remoteConfig flags; the VM only reads
+// WKApp.remoteConfig in the tabList getter under test.
+const mockState = vi.hoisted(() => ({
+  remoteConfig: {
+    docsOn: false as boolean,
+    docsSearchOn: false as boolean,
+    driveOn: false as boolean,
+  },
+}));
+
+vi.mock("../../../App", () => ({
+  default: { remoteConfig: mockState.remoteConfig },
+}));
+
+// Identity translator so tab itemKeys are what we assert on (labels are keys).
+vi.mock("../../../i18n", () => ({
+  t: (k: string) => k,
+}));
+
+import GlobalSearchVM from "../GlobalSearchVM";
+
+beforeEach(() => {
+  mockState.remoteConfig.docsOn = false;
+  mockState.remoteConfig.docsSearchOn = false;
+  mockState.remoteConfig.driveOn = false;
+});
+
+describe("GlobalSearchVM tabList — drive tab gating", () => {
+  const keys = (vm: GlobalSearchVM) => vm.tabList.map((t) => t.itemKey);
+
+  it("omits the drive tab when driveOn is false", () => {
+    const vm = new GlobalSearchVM();
+    expect(keys(vm)).not.toContain("drive");
+  });
+
+  it("appends the drive tab when driveOn is true", () => {
+    mockState.remoteConfig.driveOn = true;
+    const vm = new GlobalSearchVM();
+    const list = keys(vm);
+    expect(list).toContain("drive");
+    // drive is peer to (and ordered after) the base tabs — last when docs is off.
+    expect(list[list.length - 1]).toBe("drive");
+  });
+
+  it("gates independently of the docs flags", () => {
+    mockState.remoteConfig.driveOn = true;
+    mockState.remoteConfig.docsOn = true;
+    mockState.remoteConfig.docsSearchOn = true;
+    const list = keys(new GlobalSearchVM());
+    expect(list).toContain("docs");
+    expect(list).toContain("drive");
+  });
+});

--- a/packages/dmworkbase/src/bridge/globalSearch/createGlobalSearchDataSource.ts
+++ b/packages/dmworkbase/src/bridge/globalSearch/createGlobalSearchDataSource.ts
@@ -9,6 +9,7 @@ import { createSearchAssetResolver } from "../search/createSearchAssetResolver";
 import { activeGlobalSearchFilterCount } from "./filterState";
 import type {
   DocSearchQuery,
+  DriveSearchQuery,
   GlobalSearchChannelOption,
   GlobalSearchDataSource,
   GlobalSearchFileTypeCategory,
@@ -260,6 +261,8 @@ export function createGlobalSearchApiDataSource(
       return result;
     },
     searchDocs: (query: DocSearchQuery) => SearchService.searchDocs(query),
+    searchDrive: (query: DriveSearchQuery, signal?: AbortSignal) =>
+      SearchService.searchDrive(query, signal),
   };
 }
 

--- a/packages/dmworkbase/src/features/globalSearch/GlobalSearchPanel.tsx
+++ b/packages/dmworkbase/src/features/globalSearch/GlobalSearchPanel.tsx
@@ -10,6 +10,7 @@ import TabFile from "../../Components/GlobalSearch/tab-file";
 import { Channel } from "wukongimjssdk";
 import GlobalContentSearchPanel from "../../Components/GlobalSearch/GlobalContentSearchPanel";
 import DocSearchPanel from "../../Components/GlobalSearch/DocSearchPanel";
+import DriveSearchPanel from "../../Components/GlobalSearch/DriveSearchPanel";
 import GlobalSearchFilterPanel, {
   type GlobalSearchFilterApplyMeta,
 } from "../../Components/GlobalSearch/GlobalSearchFilterPanel";
@@ -25,6 +26,7 @@ import {
 import type {
   ChannelSearchItem,
   DocSearchItem,
+  DriveSearchHit,
 } from "../../Service/SearchTypes";
 import { canLocateChannelSearchItem } from "../../bridge/channelSearch/locate";
 import WKApp from "../../App";
@@ -56,6 +58,10 @@ export interface GlobalSearchProps {
   // is a deployment concern; when omitted the docs tab still searches but the
   // click is a no-op (see handleOpenDoc).
   onOpenDoc?: (item: DocSearchItem) => void;
+  // Host-provided opener for a drive search hit (drive tab). Route/endpoint is a
+  // deployment concern; when omitted the drive tab still searches but the click
+  // is a no-op (see handleOpenDriveHit).
+  onOpenDriveHit?: (hit: DriveSearchHit) => void;
   initialState?: Partial<GlobalSearchState>;
 }
 
@@ -207,6 +213,24 @@ export default class GlobalSearch extends Component<
     }
   };
 
+  // Drive tab: open the clicked hit via the host `onOpenDriveHit`, which the
+  // Chat host wires to a /drive?fileId=..&spaceId=.. -> window.open in a new
+  // browser tab. Same contract as handleOpenDoc: keep this modal open, and a
+  // no-op + dev hint when unwired rather than a bogus navigation.
+  handleOpenDriveHit = (hit: DriveSearchHit) => {
+    if (this.props.onOpenDriveHit) {
+      this.props.onOpenDriveHit(hit);
+      return;
+    }
+    if (process.env.NODE_ENV !== "production") {
+      // eslint-disable-next-line no-console
+      console.warn(
+        "[GlobalSearch] onOpenDriveHit not wired; cannot open drive file",
+        hit.file_id
+      );
+    }
+  };
+
   // 同时挂载所有 tab 组件，通过 display 切换可见性。
   // 避免切 tab 时 unmount 导致 <img>/VisibilityTrigger 全部重建，进而重新
   // 触发头像请求（浏览器 HTTP cache 不一定命中，网络面板会看到"全量重拉"）。
@@ -326,6 +350,20 @@ export default class GlobalSearch extends Component<
             onOpenDoc={this.handleOpenDoc}
           />
         </div>
+        {/* Drive tab. Conditionally mounted so a driveOn=false deployment never
+            renders the panel at all (the tab LIST is gated in GlobalSearchVM;
+            this mirror-gates the panel). isActive gates the actual search so a
+            hidden-but-mounted panel stays idle. */}
+        {WKApp.remoteConfig.driveOn && (
+          <div className="wk-search-tabs__panel" style={panelStyle("drive")}>
+            <DriveSearchPanel
+              keyword={vm.keyword}
+              dataSource={this.globalDataSource}
+              isActive={currentKey === "drive" && !!WKApp.remoteConfig.driveOn}
+              onOpenDriveHit={this.handleOpenDriveHit}
+            />
+          </div>
+        )}
         {showSharedFilter && (
           <aside className="wk-search-tabs__shared-filter">
             <GlobalSearchFilterPanel

--- a/packages/dmworkbase/src/i18n/locales/en-US.json
+++ b/packages/dmworkbase/src/i18n/locales/en-US.json
@@ -1455,5 +1455,13 @@
   "globalSearch.docs.loading": "Searching…",
   "globalSearch.docs.searchFailed": "Search failed, please try again",
   "globalSearch.docs.loadMore": "Load more",
-  "globalSearch.docs.popupBlocked": "Your browser blocked the new tab. Allow pop-ups for this site, then click the document again."
+  "globalSearch.docs.popupBlocked": "Your browser blocked the new tab. Allow pop-ups for this site, then click the document again.",
+  "globalSearch.tab.drive": "Drive",
+  "globalSearch.drive.emptyHint": "Type a keyword to search drive files",
+  "globalSearch.drive.noResults": "No matching drive files found",
+  "globalSearch.drive.loading": "Searching…",
+  "globalSearch.drive.searchFailed": "Search failed, please try again",
+  "globalSearch.drive.popupBlocked": "Your browser blocked the new tab. Allow pop-ups for this site, then click the file again.",
+  "globalSearch.drive.truncated": "Results may be incomplete. Try a more specific keyword.",
+  "globalSearch.drive.allLoaded": "All {{count}} results shown"
 }

--- a/packages/dmworkbase/src/i18n/locales/zh-CN.json
+++ b/packages/dmworkbase/src/i18n/locales/zh-CN.json
@@ -1455,5 +1455,13 @@
   "globalSearch.docs.loading": "搜索中…",
   "globalSearch.docs.searchFailed": "搜索失败，请稍后重试",
   "globalSearch.docs.loadMore": "加载更多",
-  "globalSearch.docs.popupBlocked": "浏览器拦截了新标签页，请允许本站弹窗后重新点击该文档。"
+  "globalSearch.docs.popupBlocked": "浏览器拦截了新标签页，请允许本站弹窗后重新点击该文档。",
+  "globalSearch.tab.drive": "网盘",
+  "globalSearch.drive.emptyHint": "输入关键词搜索网盘文件",
+  "globalSearch.drive.noResults": "未找到匹配的网盘文件",
+  "globalSearch.drive.loading": "搜索中…",
+  "globalSearch.drive.searchFailed": "搜索失败，请稍后重试",
+  "globalSearch.drive.popupBlocked": "浏览器拦截了新标签页，请允许本站弹窗后重新点击该文件。",
+  "globalSearch.drive.truncated": "结果可能不完整，请缩小关键词",
+  "globalSearch.drive.allLoaded": "已显示全部 {{count}} 条"
 }


### PR DESCRIPTION
## Summary

Add a **Drive** tab to the global search modal (Cmd+K), alongside contacts, groups, messages, files, and docs. Users can search Drive files/documents from anywhere in the app; hits open in a new tab (StandalonePreview for blobs, `/d/:docId` StandaloneDocPage for cloud docs).

## Changes

**Global search Drive tab (12 commits):**
- `feat(global-search): 网盘搜索 types 与 service 数据层` — `DriveSearchQuery` / `DriveSearchHit` / `DriveSearchFilters` types + `SearchService.searchDrive`
- `feat(global-search): DriveSearchPanel 面板组件与样式` — new panel component with light/dark stories, `--wk-*` tokens only
- `feat(global-search): 全局搜索接入「网盘」tab` — tab wiring, lazy-load pattern matches Docs tab (fetch on active + keyword, 250ms debounce, AbortController, generation guard)
- `feat(chat): 打开网盘搜索结果深链` — `onOpenDriveHit` → new-tab open
- `feat(global-search): 网盘 tab i18n 文案 (en-US/zh-CN)`
- `docs(global-search): DriveSearchPanel Storybook 全态` — 7-state coverage (empty / loading / hits / hits+highlight / loadingMore / hasNoMore / truncated)
- `fix(global-search): 修复 drive 搜索世代保护/loadingMore 卡死与路由前缀` — `++seqRef` before every invalidation path, `loadingMore` reset guard, path contract lockdown

**Hit dispatch refinement:**
- `feat(dmworkbase): add filters.types to DriveSearchQuery type` — array type filter (matches backend `Filters.Types`), replaces single-value `type`, folder excluded server-side
- `feat(dmworkbase): route file search hits to StandalonePreview + drop folder hits` — `openDriveFileHit` pure fn: blob → `/drive/f/<id>?name=&size=&spaceId=`, doc → `buildDocLink({docId})` → `/d/:docId`, folder → warn skip
- `refactor(dmworkbase): extract openDriveFileHit pure fn + test real code` — QA-hardened factoring for testability
- `refactor(dmworkbase): global search drive path uses /v1/drive/search (match drive-module)` — align with drive-module in-page search route
- `feat(dmworkbase): dispatch doc hits to /d/:docId via buildDocLink (TES-78)` — doc hit → docs standalone reader (using `ref_id` from backend), avoids blob-download 400 on doc-typed drive_file rows

## Testing

- `pnpm --dir packages/dmworkbase test` — **329 files / 2909 tests passed**
- Backend contract compatibility already verified against `octo-drive`'s `feat/drive-search-multi-type` (`Filters.Types` array + doc `RefID` fields, `/v1/drive/search` route)

## Deployment Coordination

This PR is one of four coordinated changes that need to land together for a full rollout:

| Repo | Branch | Notes |
|---|---|---|
| **octo-drive** (drive-search backend) | `feat/drive-search-multi-type` | `Filters.Types []string` array contract, doc hit `RefID` field |
| **octo-drive-module** (in-page search) | `feat/drive-header-refactor` | `SearchFilters.types` array in `FilterDrawer`, matches backend |
| **octo-enterprise-modules** (route dispatch) | `feat/drive-standalone-preview` | `drive.preview` standalone handler for `/drive/f/<id>` |
| **octo-web** (this PR) | `feat/global-search-drive-tab` | Global search Drive tab |

Merging this PR alone will surface the Drive tab in the UI, but hit clicks require the other three changes to be deployed together (otherwise: folder shows up in results, doc hits skip silently, blob hits get 404 in the new window).

## Screenshots / Verified

Deployed to internal hero stack (HTTPS :28448) with all four repos rebuilt from these branches. Verified end-to-end: keyword input → Drive tab hits → click blob → StandalonePreview opens with FilePreviewPanel; click doc → `/d/:docId` StandaloneDocPage opens; folder never appears in results.
