### PR TITLE
fix(summary): 修复 Firefox 下 agent 对话面板按钮不显示

### DIFF
--- a/packages/dmworksummary/src/components/AgentChatPanel.css
+++ b/packages/dmworksummary/src/components/AgentChatPanel.css
@@ -72,6 +72,13 @@
 
 .agent-chat-textarea {
     flex: 1;
+    /* flex item 默认 min-width:auto，不能小于自身 min-content。
+       <textarea> 的 intrinsic min-content 在 Firefox/WebKit 上远大于 Blink，
+       不覆盖会把同行的「发送/保存为总结」按钮推出 .agent-chat-panel-input
+       可视区，再被 .agent-chat-panel{overflow:hidden} 裁掉，表现为按钮消失。
+       显式置 0 让 flex:1 的收缩生效；Chrome 上行为不变（其 intrinsic size
+       本来就极小）。 */
+    min-width: 0;
     resize: none;
     max-height: 120px;
     padding: var(--wk-sp-2, 8px);


### PR DESCRIPTION
## Summary
agent 对话面板底部输入区（`.agent-chat-panel-input`，flex 容器）里的 `<textarea>` 缺少 `min-width: 0`。flex item 默认 `min-width: auto`（即 intrinsic min-content）；在已复现的 Firefox 环境中，native `<textarea>` 的 intrinsic 最小宽度达到约 2750px，导致 `flex: 1` 无法正常收缩，同行的「发送」和「保存为总结」按钮被推到 flex 行右外，再被 `.agent-chat-panel { overflow: hidden }` 裁掉。

修复：给 `.agent-chat-textarea` 加一行 `min-width: 0;`，让 `flex: 1` 的收缩生效。Chrome/Blink 在当前正常宽度下最终布局不变。

WebKit/Safari 存在同类 automatic minimum size 风险，但本 PR 尚未在真实 Safari 设备上完成验证，因此不把 Safari 写成已验证结论。

## Linked Spec
用户线上反馈 + DevTools 实测定位。`im-test` 复现现场：

- textarea rect `width=2750px`，`flex=1 1 0%`，`min-width=auto`
- save button rect `x=3309.5px`，位于可视区外
- `.agent-chat-panel-input` 的 `scrollWidth=2936px`，远大于 `clientWidth=1102px`

## How verified
- 在 `https://im-test.deepminer.com.cn/summary` 的 Firefox 154 / Linux 上复现：DOM 中 `summary-agent-send-btn` 和 `summary-agent-save-btn` 均存在，且 `display:flex`、`visibility:visible`，但位置落在面板外。
- 在 DevTools 临时应用 `min-width: 0` 后，textarea 可正常收缩，两个按钮回到输入框右侧。
- 静态 CSS diff 仅增加一个属性和说明注释，无 JS/TS 行为变更。
- Chrome/Blink 原本的 intrinsic 最小宽度未成为约束，覆盖为 `0` 不改变当前正常宽度下的 flex 分配结果。

## Scope and follow-ups
本 PR 保持单点修复，不混入未复现或会改变交互布局的额外调整：

1. **窄侧栏行为**：`AgentChatPanel` 还会挂载在约 360px、可拖窄的聊天侧栏中。`min-width: 0` 修复后 textarea 会承担收缩压力；当前约 120px 的可用输入宽度仍可使用。若产品需要支持更窄面板，后续应基于实际最小宽度选择 `flex-wrap` 或响应式按钮布局，而不是在本 PR 中未经视觉验证直接换行。
2. **跨浏览器回归测试**：现有 Playwright 配置只跑 Chromium，普通 `toBeVisible()` 也抓不到“DOM 存在但被推出面板”的问题。后续应增加 Firefox/WebKit 的窄布局用例，或至少断言发送/保存按钮的 bounding box 位于 panel client rect 内。
3. **同类样式排查**：`ChatSummaryNewModal.css` 的 `.chat-summary-modal-input` 也是 flex item 且缺少 `min-width: 0`，但当前没有兄弟按钮、也未在 Firefox 复现，因此单独排查，不扩大本 PR 范围。
4. **既有间距**：Save 按钮已有 `marginLeft: 8`，同时容器使用 `gap: 8px`，实际 Send↔Save 间距为 16px。该问题存在于 base，后续可删除冗余 margin，为窄侧栏回收 8px；不影响本次缺陷修复。
