### PR TITLE
fix(group-management): use checkboxes for multi-select pickers

### DIFF
--- a/packages/dmworkbase/src/Components/GroupManagement/MemberPicker.css
+++ b/packages/dmworkbase/src/Components/GroupManagement/MemberPicker.css
@@ -85,29 +85,12 @@
   background: var(--wk-bg-hover);
 }
 
-.wk-group-member-picker-check {
-  display: inline-flex;
-  width: var(--wk-sp-4);
-  height: var(--wk-sp-4);
-  flex: 0 0 auto;
+.wk-group-member-picker-item .wk-checkbox__label {
+  display: flex;
+  min-width: 0;
+  flex: 1;
   align-items: center;
-  justify-content: center;
-  border: 1px solid var(--wk-border-default);
-  border-radius: var(--wk-r-full);
-  background: var(--wk-bg-surface);
-  box-sizing: border-box;
-}
-
-.wk-group-member-picker-check--selected {
-  border-color: var(--wk-brand-primary);
-  background: var(--wk-brand-primary);
-}
-
-.wk-group-member-picker-check-dot {
-  width: var(--wk-sp-2);
-  height: var(--wk-sp-2);
-  border-radius: var(--wk-r-full);
-  background: var(--wk-text-inverse);
+  gap: var(--wk-sp-3);
 }
 
 .wk-group-member-picker-avatar {

--- a/packages/dmworkbase/src/Components/GroupManagement/MemberPicker.tsx
+++ b/packages/dmworkbase/src/Components/GroupManagement/MemberPicker.tsx
@@ -4,6 +4,7 @@ import { Channel, Subscriber } from "wukongimjssdk";
 import Provider from "../../Service/Provider";
 import { SubscriberListVM } from "../Subscribers/list_vm";
 import WKAvatar from "../WKAvatar";
+import Checkbox from "../Checkbox";
 import { debounce, throttle } from "../../Utils/rateLimit";
 import "./MemberPicker.css";
 
@@ -160,25 +161,14 @@ export class GroupManagementMemberPicker extends Component<
                     const selected = this.isSelected(subscriber.uid);
                     const name = this.displayName(subscriber);
                     return (
-                      <button
+                      <Checkbox
                         key={subscriber.uid}
-                        type="button"
                         className="wk-group-member-picker-item"
-                        onClick={() => this.toggleSelect(subscriber)}
+                        checked={selected}
+                        disabled={this.isDisabled(subscriber.uid)}
+                        ariaLabel={name}
+                        onChange={() => this.toggleSelect(subscriber)}
                       >
-                        <span
-                          className={`wk-group-member-picker-check${
-                            selected
-                              ? " wk-group-member-picker-check--selected"
-                              : ""
-                          }`}
-                          role="checkbox"
-                          aria-checked={selected}
-                        >
-                          {selected && (
-                            <span className="wk-group-member-picker-check-dot" />
-                          )}
-                        </span>
                         <span className="wk-group-member-picker-avatar">
                           <WKAvatar src={subscriber.avatar} />
                         </span>
@@ -188,7 +178,7 @@ export class GroupManagementMemberPicker extends Component<
                         >
                           {name}
                         </span>
-                      </button>
+                      </Checkbox>
                     );
                   })
                 )}

--- a/packages/dmworkbase/src/Components/GroupManagement/__tests__/MemberPicker.test.tsx
+++ b/packages/dmworkbase/src/Components/GroupManagement/__tests__/MemberPicker.test.tsx
@@ -1,0 +1,86 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Channel } from "wukongimjssdk";
+
+const hoisted = vi.hoisted(() => ({
+  subscribers: [
+    { uid: "user-1", name: "Alice", avatar: "alice.png" },
+    { uid: "user-2", name: "Bob", avatar: "bob.png" },
+  ],
+  search: vi.fn(),
+  loadMoreSubscribersIfNeed: vi.fn(),
+}));
+
+vi.mock("../../../Service/Provider", () => ({
+  default: ({
+    render: renderView,
+  }: {
+    render: (vm: unknown) => React.ReactNode;
+  }) =>
+    renderView({
+      subscribers: hoisted.subscribers,
+      search: hoisted.search,
+      loadMoreSubscribersIfNeed: hoisted.loadMoreSubscribersIfNeed,
+    }),
+  ProviderListener: class {},
+}));
+
+vi.mock("../../WKAvatar", () => ({
+  default: ({ src }: { src?: string }) => <img src={src} alt="" />,
+}));
+
+vi.mock("../../Subscribers/list_vm", () => ({
+  SubscriberListVM: class {},
+}));
+
+import { GroupManagementMemberPicker } from "../MemberPicker";
+
+describe("GroupManagementMemberPicker", () => {
+  beforeEach(() => {
+    hoisted.search.mockReset();
+    hoisted.loadMoreSubscribersIfNeed.mockReset();
+  });
+
+  it("uses square checkboxes and keeps independent multi-selection", () => {
+    const onSelect = vi.fn();
+    const { container } = render(
+      <GroupManagementMemberPicker
+        channel={new Channel("group-1", 2)}
+        filter={() => true}
+        labels={{
+          searchPlaceholder: "搜索成员",
+          empty: "暂无成员",
+          emptySearch: "没有匹配成员",
+        }}
+        onSelect={onSelect}
+      />
+    );
+
+    const alice = screen.getByRole("checkbox", { name: "Alice" });
+    const bob = screen.getByRole("checkbox", { name: "Bob" });
+
+    expect(alice).toHaveAttribute("aria-checked", "false");
+    expect(bob).toHaveAttribute("aria-checked", "false");
+    expect(container.querySelector(".wk-group-member-picker-check")).toBeNull();
+
+    fireEvent.click(alice);
+    expect(alice).toHaveAttribute("aria-checked", "true");
+    expect(onSelect).toHaveBeenLastCalledWith([hoisted.subscribers[0]]);
+
+    fireEvent.click(bob);
+    expect(alice).toHaveAttribute("aria-checked", "true");
+    expect(bob).toHaveAttribute("aria-checked", "true");
+    expect(onSelect).toHaveBeenLastCalledWith([
+      hoisted.subscribers[1],
+      hoisted.subscribers[0],
+    ]);
+
+    fireEvent.keyDown(alice, { key: " " });
+    expect(alice).toHaveAttribute("aria-checked", "false");
+    expect(bob).toHaveAttribute("aria-checked", "true");
+    expect(onSelect).toHaveBeenCalledTimes(3);
+  });
+});


### PR DESCRIPTION
## Summary

Fix the group-management member pickers whose multi-select controls looked like radio buttons. The picker now reuses the existing square checkbox component so the visual affordance matches its multi-selection behavior.

## Related Issue

Fixes #1615

## Changes

- Replace the custom circular selection indicator with the existing `Checkbox` component.
- Keep the full member row as one keyboard-accessible selection target without changing filtering, pagination, permissions, or submission behavior.
- Add regression coverage for independent multi-selection, deselection, keyboard interaction, and removal of the old radio-like marker.

## Architecture / Module Boundary

- Affected module(s): `packages/dmworkbase/src/Components/GroupManagement`
- New or changed user-visible entry point: no; the existing Add Manager and Add Bot Admin flows are unchanged.
- Shared layer touched: Components; the existing shared Checkbox is consumed but not modified.
- If shared code changed, impact scope: no shared implementation changed. Both group-management picker callers receive the corrected control; other Checkbox consumers are unaffected.
- Duplicate entry point checked: not applicable

## Testing

- [x] Unit tests added/updated: `pnpm --filter @octo/base exec vitest run src/Components/GroupManagement/__tests__` (5 files, 21 tests passed)
- [x] Manually verified: both Add Manager and Add Bot Admin use square checkboxes and support selecting multiple entries.
- [x] Production build: `pnpm --filter @octo/web build`
- [x] Formatting and diff checks: Prettier and `git diff --check`

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Documentation is not required because no public API or documented workflow changed
- [x] Confirmed the change does not affect UI copy
- [x] Confirmed the change follows module ownership and does not add duplicate user-visible entry points
- [x] Described impact scope when shared components, messages, bridge, or services are changed
- [x] Followed commit message conventions (Conventional Commits)
