### PR TITLE
feat(chat): add reusable embedded communication capability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ playwright-report
 out/
 build
 build-e2e
+apps/web/build-client-communication/
 *.tsbuildinfo
 
 # misc

--- a/apps/web/client-communication.html
+++ b/apps/web/client-communication.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width,initial-scale=1.0,maximum-scale=1.0,user-scalable=no"
+    />
+    <meta name="theme-color" content="#ffffff" />
+    <meta name="description" content="Octo Communication" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; media-src 'self' blob: https:; connect-src 'self' https: wss:; worker-src 'self' blob:; object-src 'none'; frame-src 'none'; base-uri 'none'; form-action 'none'"
+    />
+    <link rel="icon" href="./favicon.ico?v=2" />
+    <title>Octo Communication</title>
+    <script src="./owt.js" type="text/javascript"></script>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/client-communication/index.tsx"></script>
+  </body>
+</html>

--- a/apps/web/client-communication.html
+++ b/apps/web/client-communication.html
@@ -10,7 +10,7 @@
     <meta name="description" content="Octo Communication" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; media-src 'self' blob: https:; connect-src 'self' https: wss:; worker-src 'self' blob:; object-src 'none'; frame-src 'none'; base-uri 'none'; form-action 'none'"
+      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https: http:; font-src 'self' data:; media-src 'self' blob: https: http:; connect-src 'self' https: http: wss: ws:; worker-src 'self' blob:; object-src 'none'; frame-src 'self' blob: https: http:; base-uri 'none'; form-action 'none'"
     />
     <link rel="icon" href="./favicon.ico?v=2" />
     <title>Octo Communication</title>

--- a/apps/web/e2e-kit/_kit/mock-im-runtime/communication-seed.ts
+++ b/apps/web/e2e-kit/_kit/mock-im-runtime/communication-seed.ts
@@ -1,0 +1,30 @@
+import type { MockSeed } from "./seed-types";
+
+export const communicationDefaultSeed: MockSeed = {
+  currentUid: "e2e-user",
+  spaceId: "e2e-space",
+  users: [
+    {
+      uid: "e2e-contact-human",
+      name: "E2E 联系人",
+      robot: 0,
+      extra: { follow: 1 },
+    },
+    {
+      uid: "e2e-contact-bot",
+      name: "E2E 助手",
+      robot: 1,
+      extra: { follow: 1, robot: 1 },
+    },
+  ],
+  groups: [
+    {
+      group_no: "e2e-contact-group",
+      name: "E2E 项目群",
+      extra: { member_count: 3 },
+    },
+  ],
+  conversations: [],
+  messages: [],
+  subscribers: [],
+};

--- a/apps/web/e2e-kit/msw-handlers/chat-baseline.ts
+++ b/apps/web/e2e-kit/msw-handlers/chat-baseline.ts
@@ -193,12 +193,67 @@ export const chatBaselineHandlers = [
     })
   ),
   http.get("*/api/v1/user/pinned", () => HttpResponse.json([])),
+  http.get("*/user/pinned", () => HttpResponse.json([])),
+  http.get("*/robot/my_bots", () => HttpResponse.json([
+    {
+      uid: "e2e-contact-bot",
+      name: "E2E 助手",
+      status: "added",
+      description: "用于验证通讯录 Bot 发起会话",
+    },
+  ])),
+  http.get("*/robot/space_bots", () => HttpResponse.json([
+    {
+      uid: "e2e-contact-bot",
+      name: "E2E 助手",
+      status: "added",
+      description: "用于验证通讯录 Bot 发起会话",
+    },
+  ])),
   http.put("*/user/language", () => HttpResponse.json({})),
 
   // === Contacts / friends ===
   http.get("*/friend/sync", () => HttpResponse.json([])),
-  http.get("*/group/my", () => HttpResponse.json([])),
-  http.get("*/space/:spaceId/members", () => HttpResponse.json([])),
+  http.get("*/group/my", () => HttpResponse.json([
+    {
+      group_no: "e2e-contact-group",
+      name: "E2E 项目群",
+      member_count: 3,
+    },
+  ])),
+  http.get("*/space/:spaceId/members", () => HttpResponse.json([
+    {
+      uid: "e2e-contact-human",
+      name: "E2E 联系人",
+      avatar: "",
+      role: 0,
+      robot: 0,
+    },
+    {
+      uid: "e2e-contact-bot",
+      name: "E2E 助手",
+      avatar: "",
+      role: 0,
+      robot: 1,
+    },
+  ])),
+  http.get("*/users/e2e-contact-human", () => HttpResponse.json({
+    uid: "e2e-contact-human",
+    name: "E2E 联系人",
+    follow: 1,
+    robot: 0,
+    role: 0,
+  })),
+  http.get("*/users/e2e-contact-bot", () => HttpResponse.json({
+    uid: "e2e-contact-bot",
+    name: "E2E 助手",
+    username: "e2e-contact-bot",
+    follow: 1,
+    robot: 1,
+    bot_description: "用于验证通讯录 Bot 发起会话",
+    bot_creator_uid: "e2e-owner",
+    bot_creator_name: "E2E Owner",
+  })),
   http.delete("*/user/reddot/friendApply", () => HttpResponse.json({})),
 
   // === Sidebar ===

--- a/apps/web/e2e-kit/tests/chat/chat-layout-coverage.spec.ts
+++ b/apps/web/e2e-kit/tests/chat/chat-layout-coverage.spec.ts
@@ -171,6 +171,40 @@ test("@CH23 @p1 @chat @conversation 详情顶部显示标题并打开群详情",
   await expect(authedPage.locator(".wk-chat-content-right")).toHaveClass(/wk-chat-channelsetting-open/);
 });
 
+test("@CH46 @p1 @chat @conversation 输入区始终贴住会话底部", async ({ authedPage }) => {
+  await openConversation(authedPage);
+
+  const geometry = await authedPage.evaluate(() => {
+    const conversationRegion = document.querySelector(".wk-chat-conversation");
+    const surface = document.querySelector(".wk-chat-conversation-surface");
+    const conversation = document.querySelector(".wk-conversation");
+    const footer = document.querySelector(".wk-conversation-footer");
+    if (!conversationRegion || !surface || !conversation || !footer) {
+      throw new Error("聊天窗口布局节点不完整");
+    }
+    const regionRect = conversationRegion.getBoundingClientRect();
+    const surfaceRect = surface.getBoundingClientRect();
+    const conversationRect = conversation.getBoundingClientRect();
+    const footerRect = footer.getBoundingClientRect();
+    return {
+      regionHeight: regionRect.height,
+      surfaceHeight: surfaceRect.height,
+      conversationHeight: conversationRect.height,
+      regionBottom: regionRect.bottom,
+      surfaceBottom: surfaceRect.bottom,
+      conversationBottom: conversationRect.bottom,
+      footerBottom: footerRect.bottom,
+    };
+  });
+
+  expect(geometry.regionHeight).toBeGreaterThan(200);
+  expect(Math.abs(geometry.surfaceHeight - geometry.regionHeight)).toBeLessThanOrEqual(1);
+  expect(Math.abs(geometry.conversationHeight - geometry.regionHeight)).toBeLessThanOrEqual(1);
+  expect(Math.abs(geometry.surfaceBottom - geometry.regionBottom)).toBeLessThanOrEqual(1);
+  expect(Math.abs(geometry.conversationBottom - geometry.regionBottom)).toBeLessThanOrEqual(1);
+  expect(Math.abs(geometry.footerBottom - geometry.regionBottom)).toBeLessThanOrEqual(2);
+});
+
 test(
   "@CH43 @p1 @chat @conversation 群详情遮罩覆盖聊天浮动按钮",
   async ({ authedPage }) => {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,6 +12,7 @@
     "start:electron": "cross-env NODE_ENV=development electron .",
     "build": "vite build",
     "build:electron": "node scripts/build-electron-renderer.mjs",
+    "build:client-communication": "node scripts/build-client-communication.mjs",
     "build:analyzer": "cross-env ANALYZER=true vite build",
     "build:e2e": "VITE_E2E_MOCK=1 VITE_E2E_MOCK_IM=1 VITE_API_URL=http://mock.e2e.local vite build --outDir build-e2e",
     "preview:e2e": "vite preview --outDir build-e2e --port ${PW_PREVIEW_PORT:-5173} --strictPort",

--- a/apps/web/scripts/build-client-communication.mjs
+++ b/apps/web/scripts/build-client-communication.mjs
@@ -68,7 +68,9 @@ child.on("exit", (code, signal) => {
     commit,
     entry: "index.html",
     hostBridgeMajor: 1,
-    e2eMock: process.env.VITE_E2E_MOCK === "1",
+    e2eMock:
+      process.env.VITE_E2E_MOCK === "1" ||
+      process.env.VITE_E2E_MOCK_IM === "1",
   }, null, 2)}\n`);
 
   process.exit(0);

--- a/apps/web/scripts/build-client-communication.mjs
+++ b/apps/web/scripts/build-client-communication.mjs
@@ -4,13 +4,15 @@ import path from "node:path";
 import { createRequire } from "node:module";
 import { fileURLToPath } from "node:url";
 import { loadEnv } from "vite";
+import { resolveCommunicationBuildEnv } from "./client-communication-build-env.mjs";
 
 const require = createRequire(import.meta.url);
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const appDir = path.resolve(scriptDir, "..");
 const outputDir = path.join(appDir, "build-client-communication");
 const viteEnv = loadEnv("production", appDir, "VITE_");
-const apiURL = process.env.VITE_API_URL || viteEnv.VITE_API_URL;
+const buildEnv = resolveCommunicationBuildEnv(process.env, viteEnv);
+const apiURL = buildEnv.apiURL;
 const viteBin = path.join(path.dirname(require.resolve("vite/package.json")), "bin", "vite.js");
 
 if (!apiURL) {
@@ -28,7 +30,7 @@ const child = childProcess.spawn(process.execPath, [
   env: {
     ...process.env,
     VITE_ELECTRON_BUILD: "true",
-    VITE_API_URL: apiURL,
+    ...buildEnv.viteEnv,
   },
   stdio: "inherit",
 });
@@ -52,15 +54,23 @@ child.on("exit", (code, signal) => {
   }
   fs.renameSync(sourceEntry, entry);
 
-  if (process.env.VITE_E2E_MOCK !== "1") {
+  if (!buildEnv.e2eMock) {
     fs.rmSync(path.join(outputDir, "mockServiceWorker.js"), { force: true });
   }
 
   const packageJson = JSON.parse(fs.readFileSync(path.join(appDir, "package.json"), "utf8"));
-  const commit = childProcess.spawnSync("git", ["rev-parse", "--short", "HEAD"], {
+  const gitResult = childProcess.spawnSync("git", ["rev-parse", "--short", "HEAD"], {
     cwd: appDir,
     encoding: "utf8",
-  }).stdout.trim();
+  });
+  if (gitResult.error || gitResult.status !== 0 || !gitResult.stdout?.trim()) {
+    console.error(
+      `[build-client-communication] failed to resolve git commit: ${gitResult.error?.message || gitResult.stderr?.trim() || `exit ${gitResult.status}`}`,
+    );
+    process.exit(1);
+    return;
+  }
+  const commit = gitResult.stdout.trim();
   fs.writeFileSync(path.join(outputDir, "renderer-manifest.json"), `${JSON.stringify({
     schemaVersion: 1,
     name: "octo-web-client-communication",
@@ -68,9 +78,11 @@ child.on("exit", (code, signal) => {
     commit,
     entry: "index.html",
     hostBridgeMajor: 1,
-    e2eMock:
-      process.env.VITE_E2E_MOCK === "1" ||
-      process.env.VITE_E2E_MOCK_IM === "1",
+    e2eMock: buildEnv.e2eMock || buildEnv.e2eMockIm,
+    mockFlags: {
+      api: buildEnv.viteEnv.VITE_E2E_MOCK,
+      im: buildEnv.viteEnv.VITE_E2E_MOCK_IM,
+    },
   }, null, 2)}\n`);
 
   process.exit(0);

--- a/apps/web/scripts/build-client-communication.mjs
+++ b/apps/web/scripts/build-client-communication.mjs
@@ -1,0 +1,80 @@
+import childProcess from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
+import { loadEnv } from "vite";
+
+const require = createRequire(import.meta.url);
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const appDir = path.resolve(scriptDir, "..");
+const outputDir = path.join(appDir, "build-client-communication");
+const viteEnv = loadEnv("production", appDir, "VITE_");
+const apiURL = process.env.VITE_API_URL || viteEnv.VITE_API_URL;
+const viteBin = path.join(path.dirname(require.resolve("vite/package.json")), "bin", "vite.js");
+
+if (!apiURL) {
+  console.error("[build-client-communication] VITE_API_URL is required");
+  process.exit(1);
+}
+
+const child = childProcess.spawn(process.execPath, [
+  viteBin,
+  "build",
+  "--config",
+  "vite.client-communication.config.ts",
+], {
+  cwd: appDir,
+  env: {
+    ...process.env,
+    VITE_ELECTRON_BUILD: "true",
+    VITE_API_URL: apiURL,
+  },
+  stdio: "inherit",
+});
+
+child.on("exit", (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal);
+    return;
+  }
+  if (code !== 0) {
+    process.exit(code ?? 1);
+    return;
+  }
+
+  const sourceEntry = path.join(outputDir, "client-communication.html");
+  const entry = path.join(outputDir, "index.html");
+  if (!fs.existsSync(sourceEntry)) {
+    console.error("[build-client-communication] missing generated HTML entry");
+    process.exit(1);
+    return;
+  }
+  fs.renameSync(sourceEntry, entry);
+
+  if (process.env.VITE_E2E_MOCK !== "1") {
+    fs.rmSync(path.join(outputDir, "mockServiceWorker.js"), { force: true });
+  }
+
+  const packageJson = JSON.parse(fs.readFileSync(path.join(appDir, "package.json"), "utf8"));
+  const commit = childProcess.spawnSync("git", ["rev-parse", "--short", "HEAD"], {
+    cwd: appDir,
+    encoding: "utf8",
+  }).stdout.trim();
+  fs.writeFileSync(path.join(outputDir, "renderer-manifest.json"), `${JSON.stringify({
+    schemaVersion: 1,
+    name: "octo-web-client-communication",
+    version: packageJson.version,
+    commit,
+    entry: "index.html",
+    hostBridgeMajor: 1,
+    e2eMock: process.env.VITE_E2E_MOCK === "1",
+  }, null, 2)}\n`);
+
+  process.exit(0);
+});
+
+child.on("error", (error) => {
+  console.error(`[build-client-communication] failed: ${error.message}`);
+  process.exit(1);
+});

--- a/apps/web/scripts/client-communication-build-env.mjs
+++ b/apps/web/scripts/client-communication-build-env.mjs
@@ -1,0 +1,17 @@
+export function resolveCommunicationBuildEnv(processEnv, viteEnv) {
+  const resolveValue = (key) => processEnv[key] ?? viteEnv[key] ?? "";
+  const apiURL = resolveValue("VITE_API_URL");
+  const e2eMock = resolveValue("VITE_E2E_MOCK") === "1";
+  const e2eMockIm = resolveValue("VITE_E2E_MOCK_IM") === "1";
+
+  return {
+    apiURL,
+    e2eMock,
+    e2eMockIm,
+    viteEnv: {
+      VITE_API_URL: apiURL,
+      VITE_E2E_MOCK: e2eMock ? "1" : "0",
+      VITE_E2E_MOCK_IM: e2eMockIm ? "1" : "0",
+    },
+  };
+}

--- a/apps/web/src/client-communication/CommunicationShell.test.tsx
+++ b/apps/web/src/client-communication/CommunicationShell.test.tsx
@@ -121,6 +121,7 @@ describe("CommunicationShell", () => {
         <CommunicationShell
           bridge={mocks.bridge as any}
           initialPage="chat"
+          initialSpaceId="space-a"
           initialPresentation="workspace"
           onReady={onReady}
         />
@@ -130,6 +131,32 @@ describe("CommunicationShell", () => {
     await waitFor(() => expect(onReady).toHaveBeenCalledTimes(1));
     await Promise.resolve();
     expect(onReady).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports the latest page and space when commands arrive before ready runs", async () => {
+    const onReady = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <CommunicationShell
+        bridge={mocks.bridge as any}
+        initialPage="chat"
+        initialSpaceId="space-a"
+        initialPresentation="workspace"
+        onReady={onReady}
+      />,
+    );
+
+    expect(mocks.command.listener).toBeTypeOf("function");
+    mocks.command.listener?.({ type: "navigate", page: "contacts" });
+    mocks.command.listener?.({
+      type: "spaceChanged",
+      space: { id: "space-b", name: "Space B" },
+    });
+
+    await waitFor(() => expect(onReady).toHaveBeenCalledWith({
+      page: "contacts",
+      spaceId: "space-b",
+    }));
   });
 
   it("isolates synchronous and asynchronous navigation reporting failures", async () => {
@@ -146,6 +173,7 @@ describe("CommunicationShell", () => {
       <CommunicationShell
         bridge={mocks.bridge as any}
         initialPage="chat"
+        initialSpaceId="space-a"
         initialPresentation="workspace"
         onReady={vi.fn(async () => {})}
       />,
@@ -176,6 +204,7 @@ describe("CommunicationShell", () => {
       <CommunicationShell
         bridge={mocks.bridge as any}
         initialPage="chat"
+        initialSpaceId="space-a"
         initialPresentation="workspace"
         onReady={vi.fn(async () => {})}
       />,
@@ -192,6 +221,7 @@ describe("CommunicationShell", () => {
       <CommunicationShell
         bridge={mocks.bridge as any}
         initialPage="chat"
+        initialSpaceId="space-a"
         initialPresentation="workspace"
         onReady={vi.fn(async () => {})}
       />,

--- a/apps/web/src/client-communication/CommunicationShell.test.tsx
+++ b/apps/web/src/client-communication/CommunicationShell.test.tsx
@@ -1,0 +1,171 @@
+import React, { useEffect } from "react";
+import { render, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  bridge: {
+    reportNavigation: vi.fn(async () => {}),
+    reportUnread: vi.fn(),
+    onCommand: vi.fn(() => () => {}),
+  },
+  conversationManager: {
+    addConversationListener: vi.fn(),
+    removeConversationListener: vi.fn(),
+  },
+}));
+
+vi.mock("./hostBridge", () => ({
+  requireHostBridge: () => mocks.bridge,
+}));
+
+vi.mock("../App/electronUnreadCount", () => ({
+  getElectronUnreadMessageCount: () => 0,
+}));
+
+vi.mock("@octo/contacts", () => ({
+  ContactsList: () => <div>contacts</div>,
+}));
+
+vi.mock("wukongimjssdk", () => ({
+  Channel: class Channel {
+    constructor(
+      public channelID: string,
+      public channelType: number,
+    ) {}
+  },
+  WKSDK: {
+    shared: () => ({ conversationManager: mocks.conversationManager }),
+  },
+}));
+
+vi.mock("@octo/base", () => {
+  const route = {
+    setPush: vi.fn(),
+    setReplaceToRoot: vi.fn(),
+    setPop: vi.fn(),
+    setPopToRoot: vi.fn(),
+    popToRoot: vi.fn(),
+  };
+  const mittBus = {
+    emit: vi.fn(),
+    on: vi.fn(),
+    off: vi.fn(),
+  };
+  return {
+    ChatPage: () => <div>chat</div>,
+    ThemeMode: { light: "light", dark: "dark" },
+    WKApp: {
+      routeLeft: { ...route },
+      routeRight: { ...route },
+      currentMenuId: "chat",
+      switchToMenuById: undefined,
+      config: {},
+      endpoints: { showConversation: vi.fn() },
+      mittBus,
+      shared: {
+        openChannel: null,
+        currentSpaceId: "space-a",
+        addListener: vi.fn(() => () => {}),
+        notifyListener: vi.fn(),
+      },
+    },
+    WKBase: ({ children, onContext }: any) => {
+      useEffect(() => onContext?.({}), [onContext]);
+      return children;
+    },
+    WKLayout: ({ contentLeft, contentRight, onLeftContext, onRightContext }: any) => {
+      useEffect(() => {
+        const context = {
+          push: vi.fn(),
+          replaceToRoot: vi.fn(),
+          pop: vi.fn(),
+          popToRoot: vi.fn(),
+        };
+        onLeftContext?.(context);
+        onRightContext?.(context);
+      }, [onLeftContext, onRightContext]);
+      return <>{contentLeft}{contentRight}</>;
+    },
+    i18n: { setLocale: vi.fn() },
+  };
+});
+
+import { CommunicationShell } from "./CommunicationShell";
+import { WKApp } from "@octo/base";
+
+describe("CommunicationShell", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("reports ready once during the React StrictMode effect cycle", async () => {
+    const onReady = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
+
+    render(
+      <React.StrictMode>
+        <CommunicationShell
+          initialPage="chat"
+          initialPresentation="workspace"
+          onReady={onReady}
+        />
+      </React.StrictMode>,
+    );
+
+    await waitFor(() => expect(onReady).toHaveBeenCalledTimes(1));
+    await Promise.resolve();
+    expect(onReady).toHaveBeenCalledTimes(1);
+  });
+
+  it("isolates synchronous and asynchronous navigation reporting failures", async () => {
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const syncError = new Error("synchronous navigation failure");
+    const asyncError = new Error("asynchronous navigation failure");
+    mocks.bridge.reportNavigation
+      .mockImplementationOnce(() => {
+        throw syncError;
+      })
+      .mockRejectedValueOnce(asyncError);
+
+    render(
+      <CommunicationShell
+        initialPage="chat"
+        initialPresentation="workspace"
+        onReady={vi.fn(async () => {})}
+      />,
+    );
+
+    expect(() => WKApp.switchToMenuById?.("contacts")).not.toThrow();
+    await waitFor(() => expect(consoleSpy).toHaveBeenCalledWith(
+      "[client-communication] failed to report navigation",
+      syncError,
+    ));
+
+    expect(() => WKApp.switchToMenuById?.("chat")).not.toThrow();
+    await waitFor(() => expect(consoleSpy).toHaveBeenCalledWith(
+      "[client-communication] failed to report navigation",
+      asyncError,
+    ));
+    consoleSpy.mockRestore();
+  });
+
+  it("isolates unread reporting failures from renderer startup", () => {
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const error = new Error("unread IPC failure");
+    mocks.bridge.reportUnread.mockImplementationOnce(() => {
+      throw error;
+    });
+
+    expect(() => render(
+      <CommunicationShell
+        initialPage="chat"
+        initialPresentation="workspace"
+        onReady={vi.fn(async () => {})}
+      />,
+    )).not.toThrow();
+    expect(consoleSpy).toHaveBeenCalledWith(
+      "[client-communication] failed to report unread count",
+      error,
+    );
+    consoleSpy.mockRestore();
+  });
+});

--- a/apps/web/src/client-communication/CommunicationShell.test.tsx
+++ b/apps/web/src/client-communication/CommunicationShell.test.tsx
@@ -2,21 +2,34 @@ import React, { useEffect } from "react";
 import { render, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const mocks = vi.hoisted(() => ({
-  bridge: {
-    reportNavigation: vi.fn(async () => {}),
-    reportUnread: vi.fn(),
-    onCommand: vi.fn(() => () => {}),
-  },
-  conversationManager: {
-    addConversationListener: vi.fn(),
-    removeConversationListener: vi.fn(),
-  },
-}));
-
-vi.mock("./hostBridge", () => ({
-  requireHostBridge: () => mocks.bridge,
-}));
+const mocks = vi.hoisted(() => {
+  const command = {
+    listener: undefined as ((command: any) => void) | undefined,
+  };
+  return {
+    command,
+    bridge: {
+      getBootstrap: vi.fn(),
+      reportReady: vi.fn(async () => {}),
+      reportNavigation: vi.fn(async () => {}),
+      reportUnread: vi.fn(),
+      reportAuthExpired: vi.fn(),
+      reportFatalError: vi.fn(),
+      onCommand: vi.fn((listener: (command: any) => void) => {
+        command.listener = listener;
+        return () => {
+          if (command.listener === listener) {
+            command.listener = undefined;
+          }
+        };
+      }),
+    },
+    conversationManager: {
+      addConversationListener: vi.fn(),
+      removeConversationListener: vi.fn(),
+    },
+  };
+});
 
 vi.mock("../App/electronUnreadCount", () => ({
   getElectronUnreadMessageCount: () => 0,
@@ -60,6 +73,7 @@ vi.mock("@octo/base", () => {
       currentMenuId: "chat",
       switchToMenuById: undefined,
       config: {},
+      loginInfo: { logout: vi.fn() },
       endpoints: { showConversation: vi.fn() },
       mittBus,
       shared: {
@@ -91,11 +105,12 @@ vi.mock("@octo/base", () => {
 });
 
 import { CommunicationShell } from "./CommunicationShell";
-import { WKApp } from "@octo/base";
+import { WKApp, i18n } from "@octo/base";
 
 describe("CommunicationShell", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.command.listener = undefined;
   });
 
   it("reports ready once during the React StrictMode effect cycle", async () => {
@@ -104,6 +119,7 @@ describe("CommunicationShell", () => {
     render(
       <React.StrictMode>
         <CommunicationShell
+          bridge={mocks.bridge as any}
           initialPage="chat"
           initialPresentation="workspace"
           onReady={onReady}
@@ -128,6 +144,7 @@ describe("CommunicationShell", () => {
 
     render(
       <CommunicationShell
+        bridge={mocks.bridge as any}
         initialPage="chat"
         initialPresentation="workspace"
         onReady={vi.fn(async () => {})}
@@ -157,6 +174,7 @@ describe("CommunicationShell", () => {
 
     expect(() => render(
       <CommunicationShell
+        bridge={mocks.bridge as any}
         initialPage="chat"
         initialPresentation="workspace"
         onReady={vi.fn(async () => {})}
@@ -167,5 +185,27 @@ describe("CommunicationShell", () => {
       error,
     );
     consoleSpy.mockRestore();
+  });
+
+  it("updates the document language when the host appearance changes", async () => {
+    render(
+      <CommunicationShell
+        bridge={mocks.bridge as any}
+        initialPage="chat"
+        initialPresentation="workspace"
+        onReady={vi.fn(async () => {})}
+      />,
+    );
+
+    await waitFor(() => expect(mocks.command.listener).toBeTypeOf("function"));
+    mocks.command.listener?.({
+      type: "appearanceChanged",
+      theme: "dark",
+      locale: "en-US",
+    });
+
+    expect(document.documentElement.lang).toBe("en-US");
+    expect(document.documentElement.dataset.theme).toBe("dark");
+    expect(i18n.setLocale).toHaveBeenCalledWith("en-US", { persist: false });
   });
 });

--- a/apps/web/src/client-communication/CommunicationShell.tsx
+++ b/apps/web/src/client-communication/CommunicationShell.tsx
@@ -19,6 +19,7 @@ import {
   type HostCommand,
   type NavigationReport,
 } from "./hostBridge";
+import { createReadyReporter } from "./readyReporter";
 import "./index.css";
 
 const bridge = requireHostBridge();
@@ -38,7 +39,19 @@ function bindRightRoute(context: WKViewQueueContext) {
 }
 
 function reportNavigation(report: NavigationReport) {
-  void bridge.reportNavigation(report);
+  void Promise.resolve()
+    .then(() => bridge.reportNavigation(report))
+    .catch((error: unknown) => {
+      console.error("[client-communication] failed to report navigation", error);
+    });
+}
+
+function reportUnread(count: number) {
+  try {
+    bridge.reportUnread(count);
+  } catch (error) {
+    console.error("[client-communication] failed to report unread count", error);
+  }
 }
 
 function openTarget(target: ConversationTarget) {
@@ -65,19 +78,19 @@ export function CommunicationShell({
   const activePageRef = useRef(activePage);
   const routeReadyRef = useRef({ left: false, right: false });
   const commandListenerReadyRef = useRef(false);
-  const readyReportedRef = useRef(false);
   const pendingTargetRef = useRef<ConversationTarget | undefined>();
+  const onReadyRef = useRef(onReady);
+  onReadyRef.current = onReady;
+  const readyReporterRef = useRef<ReturnType<typeof createReadyReporter>>();
 
   const reportReadyWhenPrepared = useCallback(() => {
     if (
-      readyReportedRef.current ||
       !commandListenerReadyRef.current ||
       !routeReadyRef.current.left ||
       !routeReadyRef.current.right
     ) return;
-    readyReportedRef.current = true;
-    void onReady();
-  }, [onReady]);
+    readyReporterRef.current?.request();
+  }, []);
 
   const markRouteReady = useCallback((side: "left" | "right") => {
     routeReadyRef.current[side] = true;
@@ -96,6 +109,26 @@ export function CommunicationShell({
     reportNavigation({ page, source });
     requestAnimationFrame(() => requestAnimationFrame(() => afterSwitch?.()));
   }, []);
+
+  useEffect(() => {
+    const reporter = createReadyReporter(
+      () => onReadyRef.current(),
+      {
+        onExhausted: (error) => {
+          console.error("[client-communication] failed to report ready", error);
+        },
+      },
+    );
+    readyReporterRef.current = reporter;
+    reportReadyWhenPrepared();
+
+    return () => {
+      reporter.dispose();
+      if (readyReporterRef.current === reporter) {
+        readyReporterRef.current = undefined;
+      }
+    };
+  }, [reportReadyWhenPrepared]);
 
   useEffect(() => {
     WKApp.currentMenuId = initialPage;
@@ -163,7 +196,7 @@ export function CommunicationShell({
   }, [activatePage, initialPage, reportReadyWhenPrepared]);
 
   useEffect(() => {
-    const syncUnread = () => bridge.reportUnread(getElectronUnreadMessageCount());
+    const syncUnread = () => reportUnread(getElectronUnreadMessageCount());
     const conversationManager = WKSDK.shared().conversationManager;
     conversationManager.addConversationListener(syncUnread);
     WKApp.mittBus.on("conversation-list-refreshed", syncUnread);

--- a/apps/web/src/client-communication/CommunicationShell.tsx
+++ b/apps/web/src/client-communication/CommunicationShell.tsx
@@ -68,17 +68,20 @@ function openTarget(target: ConversationTarget) {
 export function CommunicationShell({
   bridge,
   initialPage,
+  initialSpaceId,
   initialPresentation,
   onReady,
 }: {
   bridge: OctoBuddyCommunicationBridge;
   initialPage: CommunicationPage;
+  initialSpaceId: string;
   initialPresentation: CommunicationPresentation;
-  onReady: () => Promise<void>;
+  onReady: (state: { page: CommunicationPage; spaceId: string }) => Promise<void>;
 }) {
   const [activePage, setActivePage] = useState<CommunicationPage>(initialPage);
   const [presentation, setPresentation] = useState<CommunicationPresentation>(initialPresentation);
   const activePageRef = useRef(activePage);
+  const spaceIdRef = useRef(initialSpaceId);
   const routeReadyRef = useRef({ left: false, right: false });
   const commandListenerReadyRef = useRef(false);
   const pendingTargetRef = useRef<ConversationTarget | undefined>();
@@ -115,7 +118,10 @@ export function CommunicationShell({
 
   useEffect(() => {
     const reporter = createReadyReporter(
-      () => onReadyRef.current(),
+      () => onReadyRef.current({
+        page: activePageRef.current,
+        spaceId: spaceIdRef.current,
+      }),
       {
         onExhausted: (error) => {
           console.error("[client-communication] failed to report ready", error);
@@ -159,6 +165,7 @@ export function CommunicationShell({
       }
 
       if (command.type === "spaceChanged") {
+        spaceIdRef.current = command.space.id;
         WKApp.shared.currentSpaceId = command.space.id;
         document.documentElement.dataset.spaceId = command.space.id;
         WKApp.mittBus.emit("space-changed", {

--- a/apps/web/src/client-communication/CommunicationShell.tsx
+++ b/apps/web/src/client-communication/CommunicationShell.tsx
@@ -14,6 +14,7 @@ import { getElectronUnreadMessageCount } from "../App/electronUnreadCount";
 import {
   requireHostBridge,
   type CommunicationPage,
+  type CommunicationPresentation,
   type ConversationTarget,
   type HostCommand,
   type NavigationReport,
@@ -52,12 +53,15 @@ function openTarget(target: ConversationTarget) {
 
 export function CommunicationShell({
   initialPage,
+  initialPresentation,
   onReady,
 }: {
   initialPage: CommunicationPage;
+  initialPresentation: CommunicationPresentation;
   onReady: () => Promise<void>;
 }) {
   const [activePage, setActivePage] = useState<CommunicationPage>(initialPage);
+  const [presentation, setPresentation] = useState<CommunicationPresentation>(initialPresentation);
   const activePageRef = useRef(activePage);
   const routeReadyRef = useRef({ left: false, right: false });
   const commandListenerReadyRef = useRef(false);
@@ -102,6 +106,7 @@ export function CommunicationShell({
 
     const dispose = bridge.onCommand((command: HostCommand) => {
       if (command.type === "navigate") {
+        if (command.presentation) setPresentation(command.presentation);
         if (command.page !== activePageRef.current) {
           WKApp.routeLeft.popToRoot();
           if (command.page === "contacts") WKApp.routeRight.popToRoot();
@@ -169,6 +174,25 @@ export function CommunicationShell({
     };
   }, []);
 
+  useEffect(() => {
+    let previousChannel = "";
+    const reportOpenChannel = () => {
+      const channel = WKApp.shared.openChannel;
+      if (!channel) return;
+      const key = `${channel.channelID}:${channel.channelType}`;
+      if (key === previousChannel) return;
+      previousChannel = key;
+      reportNavigation({
+        page: "chat",
+        source: "internal",
+        channel: { id: channel.channelID, type: channel.channelType },
+      });
+    };
+    const unsubscribe = WKApp.shared.addListener(reportOpenChannel);
+    reportOpenChannel();
+    return unsubscribe;
+  }, []);
+
   const leftContent = useMemo(() => (
     <div className="communication-page-stack">
       <div className="communication-page" style={{ display: activePage === "chat" ? "block" : "none" }}>
@@ -184,24 +208,26 @@ export function CommunicationShell({
     <WKBase onContext={(context) => {
       WKApp.shared.baseContext = context;
     }}>
-      <WKLayout
-        embedded
-        contentLeft={leftContent}
-        contentRight={<div className="communication-empty-state" />}
-        onLeftContext={(context) => {
-          bindLeftRoute(context);
-          markRouteReady("left");
-        }}
-        onRightContext={(context) => {
-          bindRightRoute(context);
-          markRouteReady("right");
-          const target = pendingTargetRef.current;
-          if (target) {
-            pendingTargetRef.current = undefined;
-            openTarget(target);
-          }
-        }}
-      />
+      <div className={`communication-shell communication-shell--${presentation}`}>
+        <WKLayout
+          embedded
+          contentLeft={leftContent}
+          contentRight={<div className="communication-empty-state" />}
+          onLeftContext={(context) => {
+            bindLeftRoute(context);
+            markRouteReady("left");
+          }}
+          onRightContext={(context) => {
+            bindRightRoute(context);
+            markRouteReady("right");
+            const target = pendingTargetRef.current;
+            if (target) {
+              pendingTargetRef.current = undefined;
+              openTarget(target);
+            }
+          }}
+        />
+      </div>
     </WKBase>
   );
 }

--- a/apps/web/src/client-communication/CommunicationShell.tsx
+++ b/apps/web/src/client-communication/CommunicationShell.tsx
@@ -1,0 +1,193 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  ChatPage,
+  ThemeMode,
+  WKApp,
+  WKBase,
+  WKLayout,
+  i18n,
+} from "@octo/base";
+import type { WKViewQueueContext } from "@octo/base/src/Components/WKViewQueue";
+import { ContactsList } from "@octo/contacts";
+import { Channel, WKSDK } from "wukongimjssdk";
+import { getElectronUnreadMessageCount } from "../App/electronUnreadCount";
+import {
+  requireHostBridge,
+  type CommunicationPage,
+  type ConversationTarget,
+  type HostCommand,
+  type NavigationReport,
+} from "./hostBridge";
+import "./index.css";
+
+const bridge = requireHostBridge();
+
+function bindLeftRoute(context: WKViewQueueContext) {
+  WKApp.routeLeft.setPush = (view) => context.push(view);
+  WKApp.routeLeft.setReplaceToRoot = (view) => context.replaceToRoot(view);
+  WKApp.routeLeft.setPop = () => context.pop();
+  WKApp.routeLeft.setPopToRoot = () => context.popToRoot();
+}
+
+function bindRightRoute(context: WKViewQueueContext) {
+  WKApp.routeRight.setPush = (view) => context.push(view);
+  WKApp.routeRight.setReplaceToRoot = (view) => context.replaceToRoot(view);
+  WKApp.routeRight.setPop = () => context.pop();
+  WKApp.routeRight.setPopToRoot = () => context.popToRoot();
+}
+
+function reportNavigation(report: NavigationReport) {
+  void bridge.reportNavigation(report);
+}
+
+function openTarget(target: ConversationTarget) {
+  WKApp.endpoints.showConversation(
+    new Channel(target.channelId, target.channelType),
+    {
+      initLocateMessageSeq: target.messageSeq,
+      openChannelSearch: target.openChannelSearch,
+    },
+  );
+}
+
+export function CommunicationShell({
+  initialPage,
+  onReady,
+}: {
+  initialPage: CommunicationPage;
+  onReady: () => Promise<void>;
+}) {
+  const [activePage, setActivePage] = useState<CommunicationPage>(initialPage);
+  const activePageRef = useRef(activePage);
+  const routeReadyRef = useRef({ left: false, right: false });
+  const readyReportedRef = useRef(false);
+  const pendingTargetRef = useRef<ConversationTarget | undefined>();
+
+  const markRouteReady = useCallback((side: "left" | "right") => {
+    routeReadyRef.current[side] = true;
+    if (readyReportedRef.current || !routeReadyRef.current.left || !routeReadyRef.current.right) return;
+    readyReportedRef.current = true;
+    void onReady();
+  }, [onReady]);
+
+  const activatePage = useCallback((
+    page: CommunicationPage,
+    source: NavigationReport["source"],
+    afterSwitch?: () => void,
+  ) => {
+    activePageRef.current = page;
+    WKApp.currentMenuId = page;
+    setActivePage(page);
+    reportNavigation({ page, source });
+    requestAnimationFrame(() => requestAnimationFrame(() => afterSwitch?.()));
+  }, []);
+
+  useEffect(() => {
+    WKApp.currentMenuId = initialPage;
+    WKApp.switchToMenuById = (menuId, afterSwitch) => {
+      if (menuId !== "chat" && menuId !== "contacts") return;
+      activatePage(menuId, "internal", afterSwitch);
+    };
+
+    const dispose = bridge.onCommand((command: HostCommand) => {
+      if (command.type === "navigate") {
+        if (command.page !== activePageRef.current) {
+          WKApp.routeLeft.popToRoot();
+          if (command.page === "contacts") WKApp.routeRight.popToRoot();
+        }
+        pendingTargetRef.current = command.target;
+        activatePage(command.page, "host", () => {
+          if (pendingTargetRef.current && routeReadyRef.current.right) {
+            const target = pendingTargetRef.current;
+            pendingTargetRef.current = undefined;
+            openTarget(target);
+          }
+        });
+        return;
+      }
+
+      if (command.type === "spaceChanged") {
+        WKApp.shared.currentSpaceId = command.space.id;
+        document.documentElement.dataset.spaceId = command.space.id;
+        WKApp.mittBus.emit("space-changed", {
+          space_id: command.space.id,
+          name: command.space.name,
+        });
+        WKApp.shared.notifyListener();
+        return;
+      }
+
+      if (command.type === "appearanceChanged") {
+        WKApp.config.themeMode = command.theme === "dark" ? ThemeMode.dark : ThemeMode.light;
+        WKApp.config.locale = command.locale;
+        i18n.setLocale(command.locale, { persist: false });
+        document.documentElement.dataset.theme = command.theme;
+        WKApp.shared.notifyListener();
+        return;
+      }
+
+      if (command.type === "sessionRevoked") {
+        window.location.reload();
+        return;
+      }
+
+      if (command.type === "suspend" || command.type === "resume") {
+        document.documentElement.dataset.hostVisibility = command.type === "suspend" ? "hidden" : "visible";
+        window.dispatchEvent(new CustomEvent(`octobuddy:${command.type}`));
+      }
+    });
+
+    return () => {
+      dispose();
+      WKApp.switchToMenuById = undefined;
+    };
+  }, [activatePage, initialPage]);
+
+  useEffect(() => {
+    const syncUnread = () => bridge.reportUnread(getElectronUnreadMessageCount());
+    const conversationManager = WKSDK.shared().conversationManager;
+    conversationManager.addConversationListener(syncUnread);
+    WKApp.mittBus.on("conversation-list-refreshed", syncUnread);
+    syncUnread();
+    return () => {
+      conversationManager.removeConversationListener(syncUnread);
+      WKApp.mittBus.off("conversation-list-refreshed", syncUnread);
+    };
+  }, []);
+
+  const leftContent = useMemo(() => (
+    <div className="communication-page-stack">
+      <div className="communication-page" style={{ display: activePage === "chat" ? "block" : "none" }}>
+        <ChatPage />
+      </div>
+      <div className="communication-page" style={{ display: activePage === "contacts" ? "block" : "none" }}>
+        <ContactsList />
+      </div>
+    </div>
+  ), [activePage]);
+
+  return (
+    <WKBase onContext={(context) => {
+      WKApp.shared.baseContext = context;
+    }}>
+      <WKLayout
+        embedded
+        contentLeft={leftContent}
+        contentRight={<div className="communication-empty-state" />}
+        onLeftContext={(context) => {
+          bindLeftRoute(context);
+          markRouteReady("left");
+        }}
+        onRightContext={(context) => {
+          bindRightRoute(context);
+          markRouteReady("right");
+          const target = pendingTargetRef.current;
+          if (target) {
+            pendingTargetRef.current = undefined;
+            openTarget(target);
+          }
+        }}
+      />
+    </WKBase>
+  );
+}

--- a/apps/web/src/client-communication/CommunicationShell.tsx
+++ b/apps/web/src/client-communication/CommunicationShell.tsx
@@ -60,15 +60,25 @@ export function CommunicationShell({
   const [activePage, setActivePage] = useState<CommunicationPage>(initialPage);
   const activePageRef = useRef(activePage);
   const routeReadyRef = useRef({ left: false, right: false });
+  const commandListenerReadyRef = useRef(false);
   const readyReportedRef = useRef(false);
   const pendingTargetRef = useRef<ConversationTarget | undefined>();
 
-  const markRouteReady = useCallback((side: "left" | "right") => {
-    routeReadyRef.current[side] = true;
-    if (readyReportedRef.current || !routeReadyRef.current.left || !routeReadyRef.current.right) return;
+  const reportReadyWhenPrepared = useCallback(() => {
+    if (
+      readyReportedRef.current ||
+      !commandListenerReadyRef.current ||
+      !routeReadyRef.current.left ||
+      !routeReadyRef.current.right
+    ) return;
     readyReportedRef.current = true;
     void onReady();
   }, [onReady]);
+
+  const markRouteReady = useCallback((side: "left" | "right") => {
+    routeReadyRef.current[side] = true;
+    reportReadyWhenPrepared();
+  }, [reportReadyWhenPrepared]);
 
   const activatePage = useCallback((
     page: CommunicationPage,
@@ -77,6 +87,7 @@ export function CommunicationShell({
   ) => {
     activePageRef.current = page;
     WKApp.currentMenuId = page;
+    WKApp.mittBus.emit("wk:active-menu-changed", { menuId: page });
     setActivePage(page);
     reportNavigation({ page, source });
     requestAnimationFrame(() => requestAnimationFrame(() => afterSwitch?.()));
@@ -136,12 +147,15 @@ export function CommunicationShell({
         window.dispatchEvent(new CustomEvent(`octobuddy:${command.type}`));
       }
     });
+    commandListenerReadyRef.current = true;
+    reportReadyWhenPrepared();
 
     return () => {
+      commandListenerReadyRef.current = false;
       dispose();
       WKApp.switchToMenuById = undefined;
     };
-  }, [activatePage, initialPage]);
+  }, [activatePage, initialPage, reportReadyWhenPrepared]);
 
   useEffect(() => {
     const syncUnread = () => bridge.reportUnread(getElectronUnreadMessageCount());

--- a/apps/web/src/client-communication/CommunicationShell.tsx
+++ b/apps/web/src/client-communication/CommunicationShell.tsx
@@ -12,17 +12,15 @@ import { ContactsList } from "@octo/contacts";
 import { Channel, WKSDK } from "wukongimjssdk";
 import { getElectronUnreadMessageCount } from "../App/electronUnreadCount";
 import {
-  requireHostBridge,
   type CommunicationPage,
   type CommunicationPresentation,
   type ConversationTarget,
   type HostCommand,
   type NavigationReport,
+  type OctoBuddyCommunicationBridge,
 } from "./hostBridge";
 import { createReadyReporter } from "./readyReporter";
 import "./index.css";
-
-const bridge = requireHostBridge();
 
 function bindLeftRoute(context: WKViewQueueContext) {
   WKApp.routeLeft.setPush = (view) => context.push(view);
@@ -38,7 +36,10 @@ function bindRightRoute(context: WKViewQueueContext) {
   WKApp.routeRight.setPopToRoot = () => context.popToRoot();
 }
 
-function reportNavigation(report: NavigationReport) {
+function reportNavigation(
+  bridge: OctoBuddyCommunicationBridge,
+  report: NavigationReport,
+) {
   void Promise.resolve()
     .then(() => bridge.reportNavigation(report))
     .catch((error: unknown) => {
@@ -46,7 +47,7 @@ function reportNavigation(report: NavigationReport) {
     });
 }
 
-function reportUnread(count: number) {
+function reportUnread(bridge: OctoBuddyCommunicationBridge, count: number) {
   try {
     bridge.reportUnread(count);
   } catch (error) {
@@ -65,10 +66,12 @@ function openTarget(target: ConversationTarget) {
 }
 
 export function CommunicationShell({
+  bridge,
   initialPage,
   initialPresentation,
   onReady,
 }: {
+  bridge: OctoBuddyCommunicationBridge;
   initialPage: CommunicationPage;
   initialPresentation: CommunicationPresentation;
   onReady: () => Promise<void>;
@@ -106,9 +109,9 @@ export function CommunicationShell({
     WKApp.currentMenuId = page;
     WKApp.mittBus.emit("wk:active-menu-changed", { menuId: page });
     setActivePage(page);
-    reportNavigation({ page, source });
-    requestAnimationFrame(() => requestAnimationFrame(() => afterSwitch?.()));
-  }, []);
+    reportNavigation(bridge, { page, source });
+    if (afterSwitch) window.setTimeout(afterSwitch, 0);
+  }, [bridge]);
 
   useEffect(() => {
     const reporter = createReadyReporter(
@@ -171,11 +174,13 @@ export function CommunicationShell({
         WKApp.config.locale = command.locale;
         i18n.setLocale(command.locale, { persist: false });
         document.documentElement.dataset.theme = command.theme;
+        document.documentElement.lang = command.locale;
         WKApp.shared.notifyListener();
         return;
       }
 
       if (command.type === "sessionRevoked") {
+        WKApp.loginInfo.logout();
         window.location.reload();
         return;
       }
@@ -196,7 +201,7 @@ export function CommunicationShell({
   }, [activatePage, initialPage, reportReadyWhenPrepared]);
 
   useEffect(() => {
-    const syncUnread = () => reportUnread(getElectronUnreadMessageCount());
+    const syncUnread = () => reportUnread(bridge, getElectronUnreadMessageCount());
     const conversationManager = WKSDK.shared().conversationManager;
     conversationManager.addConversationListener(syncUnread);
     WKApp.mittBus.on("conversation-list-refreshed", syncUnread);
@@ -205,7 +210,7 @@ export function CommunicationShell({
       conversationManager.removeConversationListener(syncUnread);
       WKApp.mittBus.off("conversation-list-refreshed", syncUnread);
     };
-  }, []);
+  }, [bridge]);
 
   useEffect(() => {
     let previousChannel = "";
@@ -215,7 +220,7 @@ export function CommunicationShell({
       const key = `${channel.channelID}:${channel.channelType}`;
       if (key === previousChannel) return;
       previousChannel = key;
-      reportNavigation({
+      reportNavigation(bridge, {
         page: "chat",
         source: "internal",
         channel: { id: channel.channelID, type: channel.channelType },
@@ -224,7 +229,7 @@ export function CommunicationShell({
     const unsubscribe = WKApp.shared.addListener(reportOpenChannel);
     reportOpenChannel();
     return unsubscribe;
-  }, []);
+  }, [bridge]);
 
   const leftContent = useMemo(() => (
     <div className="communication-page-stack">

--- a/apps/web/src/client-communication/authLifecycle.test.ts
+++ b/apps/web/src/client-communication/authLifecycle.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from "vitest";
+import { installCommunicationAuthExpiryHandler } from "./authLifecycle";
+
+describe("installCommunicationAuthExpiryHandler", () => {
+  it("clears the renderer session and reports expiration once", () => {
+    const apiClient: { logoutCallback?: () => void } = {};
+    const loginInfo = { logout: vi.fn() };
+    const bridge = { reportAuthExpired: vi.fn() };
+
+    installCommunicationAuthExpiryHandler(
+      apiClient,
+      loginInfo,
+      bridge as never
+    );
+
+    apiClient.logoutCallback?.();
+    apiClient.logoutCallback?.();
+
+    expect(loginInfo.logout).toHaveBeenCalledTimes(1);
+    expect(bridge.reportAuthExpired).toHaveBeenCalledWith(
+      "Communication session expired"
+    );
+  });
+
+  it("isolates host reporting failures", () => {
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const apiClient: { logoutCallback?: () => void } = {};
+    const loginInfo = { logout: vi.fn() };
+    const error = new Error("ipc unavailable");
+    const bridge = {
+      reportAuthExpired: vi.fn(() => {
+        throw error;
+      }),
+    };
+
+    installCommunicationAuthExpiryHandler(
+      apiClient,
+      loginInfo,
+      bridge as never
+    );
+
+    expect(() => apiClient.logoutCallback?.()).not.toThrow();
+    expect(consoleSpy).toHaveBeenCalledWith(
+      "[client-communication] failed to report expired session",
+      error
+    );
+    consoleSpy.mockRestore();
+  });
+});

--- a/apps/web/src/client-communication/authLifecycle.ts
+++ b/apps/web/src/client-communication/authLifecycle.ts
@@ -1,0 +1,30 @@
+import type { OctoBuddyCommunicationBridge } from "./hostBridge";
+
+interface AuthExpiryClient {
+  logoutCallback?: () => void;
+}
+
+interface EphemeralLoginInfo {
+  logout(): void;
+}
+
+export function installCommunicationAuthExpiryHandler(
+  apiClient: AuthExpiryClient,
+  loginInfo: EphemeralLoginInfo,
+  bridge: OctoBuddyCommunicationBridge
+): void {
+  let reported = false;
+  apiClient.logoutCallback = () => {
+    if (reported) return;
+    reported = true;
+    loginInfo.logout();
+    try {
+      bridge.reportAuthExpired("Communication session expired");
+    } catch (error) {
+      console.error(
+        "[client-communication] failed to report expired session",
+        error
+      );
+    }
+  };
+}

--- a/apps/web/src/client-communication/buildEnvironment.test.mjs
+++ b/apps/web/src/client-communication/buildEnvironment.test.mjs
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { resolveCommunicationBuildEnv } from "../../scripts/client-communication-build-env.mjs";
+
+describe("resolveCommunicationBuildEnv", () => {
+  it("uses Vite-loaded mock flags when process env is unset", () => {
+    const result = resolveCommunicationBuildEnv(
+      {},
+      {
+        VITE_API_URL: "https://im.example.test",
+        VITE_E2E_MOCK_IM: "1",
+      }
+    );
+
+    expect(result).toEqual({
+      apiURL: "https://im.example.test",
+      e2eMock: false,
+      e2eMockIm: true,
+      viteEnv: {
+        VITE_API_URL: "https://im.example.test",
+        VITE_E2E_MOCK: "0",
+        VITE_E2E_MOCK_IM: "1",
+      },
+    });
+  });
+
+  it("uses process env as the explicit override", () => {
+    const result = resolveCommunicationBuildEnv(
+      {
+        VITE_API_URL: "https://override.example.test",
+        VITE_E2E_MOCK: "0",
+        VITE_E2E_MOCK_IM: "0",
+      },
+      {
+        VITE_API_URL: "https://file.example.test",
+        VITE_E2E_MOCK: "1",
+        VITE_E2E_MOCK_IM: "1",
+      }
+    );
+
+    expect(result.e2eMock).toBe(false);
+    expect(result.e2eMockIm).toBe(false);
+    expect(result.viteEnv).toEqual({
+      VITE_API_URL: "https://override.example.test",
+      VITE_E2E_MOCK: "0",
+      VITE_E2E_MOCK_IM: "0",
+    });
+  });
+});

--- a/apps/web/src/client-communication/hostBridge.ts
+++ b/apps/web/src/client-communication/hostBridge.ts
@@ -1,4 +1,5 @@
 export type CommunicationPage = "chat" | "contacts";
+export type CommunicationPresentation = "workspace" | "conversation";
 
 export interface ConversationTarget {
   channelId: string;
@@ -26,10 +27,16 @@ export interface CommunicationBootstrap {
     locale: "zh-CN" | "en-US";
   };
   initialPage: CommunicationPage;
+  initialPresentation: CommunicationPresentation;
 }
 
 export type HostCommand =
-  | { type: "navigate"; page: CommunicationPage; target?: ConversationTarget }
+  | {
+      type: "navigate";
+      page: CommunicationPage;
+      presentation?: CommunicationPresentation;
+      target?: ConversationTarget;
+    }
   | { type: "spaceChanged"; space: { id: string; name: string } }
   | { type: "appearanceChanged"; theme: "light" | "dark"; locale: "zh-CN" | "en-US" }
   | { type: "suspend" }

--- a/apps/web/src/client-communication/hostBridge.ts
+++ b/apps/web/src/client-communication/hostBridge.ts
@@ -1,0 +1,70 @@
+export type CommunicationPage = "chat" | "contacts";
+
+export interface ConversationTarget {
+  channelId: string;
+  channelType: number;
+  messageSeq?: number;
+  openChannelSearch?: boolean;
+}
+
+export interface CommunicationBootstrap {
+  bridgeVersion: 1;
+  session: {
+    uid: string;
+    token: string;
+    name: string;
+    email?: string;
+    provider: string;
+    apiOrigin: string;
+  };
+  space: {
+    id: string;
+    name: string;
+  };
+  appearance: {
+    theme: "light" | "dark";
+    locale: "zh-CN" | "en-US";
+  };
+  initialPage: CommunicationPage;
+}
+
+export type HostCommand =
+  | { type: "navigate"; page: CommunicationPage; target?: ConversationTarget }
+  | { type: "spaceChanged"; space: { id: string; name: string } }
+  | { type: "appearanceChanged"; theme: "light" | "dark"; locale: "zh-CN" | "en-US" }
+  | { type: "suspend" }
+  | { type: "resume" }
+  | { type: "sessionRevoked" };
+
+export interface NavigationReport {
+  page: CommunicationPage;
+  source: "host" | "contact-card" | "group-card" | "notification" | "internal";
+  channel?: { id: string; type: number };
+}
+
+export interface OctoBuddyCommunicationBridge {
+  getBootstrap(): Promise<CommunicationBootstrap>;
+  reportReady(state: {
+    bridgeVersion: 1;
+    page: CommunicationPage;
+    spaceId: string;
+    rendererVersion: string;
+  }): Promise<void>;
+  reportNavigation(state: NavigationReport): Promise<void>;
+  reportUnread(count: number): void;
+  reportAuthExpired(reason: string): void;
+  reportFatalError(error: { message: string; stack?: string }): void;
+  onCommand(callback: (command: HostCommand) => void): () => void;
+}
+
+declare global {
+  interface Window {
+    octoBuddyCommunication?: OctoBuddyCommunicationBridge;
+  }
+}
+
+export function requireHostBridge(): OctoBuddyCommunicationBridge {
+  const bridge = window.octoBuddyCommunication;
+  if (!bridge) throw new Error("octoBuddy communication bridge is unavailable");
+  return bridge;
+}

--- a/apps/web/src/client-communication/hostBridge.ts
+++ b/apps/web/src/client-communication/hostBridge.ts
@@ -51,6 +51,7 @@ export interface NavigationReport {
 
 export interface OctoBuddyCommunicationBridge {
   getBootstrap(): Promise<CommunicationBootstrap>;
+  /** May be retried after a timeout; hosts must handle duplicate reports. */
   reportReady(state: {
     bridgeVersion: 1;
     page: CommunicationPage;

--- a/apps/web/src/client-communication/index.css
+++ b/apps/web/src/client-communication/index.css
@@ -1,0 +1,23 @@
+html,
+body,
+#root {
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  overflow: hidden;
+}
+
+.communication-page-stack,
+.communication-page {
+  width: 100%;
+  height: 100%;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.communication-empty-state {
+  width: 100%;
+  height: 100%;
+  background: var(--wk-bg-base, #fff);
+}

--- a/apps/web/src/client-communication/index.css
+++ b/apps/web/src/client-communication/index.css
@@ -16,6 +16,24 @@ body,
   overflow: hidden;
 }
 
+.communication-shell {
+  width: 100%;
+  height: 100%;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.communication-shell--conversation .wk-layout-content-left,
+.communication-shell--conversation .wk-layout-splitter {
+  display: none;
+}
+
+.communication-shell--conversation .wk-layout-content-right {
+  width: 100%;
+  flex: 1 1 auto;
+}
+
 .communication-empty-state {
   width: 100%;
   height: 100%;

--- a/apps/web/src/client-communication/index.tsx
+++ b/apps/web/src/client-communication/index.tsx
@@ -77,6 +77,7 @@ async function main() {
       <I18nProvider>
         <CommunicationShell
           initialPage={bootstrap.initialPage}
+          initialPresentation={bootstrap.initialPresentation}
           onReady={() => host.reportReady({
             bridgeVersion: 1,
             page: bootstrap.initialPage,

--- a/apps/web/src/client-communication/index.tsx
+++ b/apps/web/src/client-communication/index.tsx
@@ -1,0 +1,161 @@
+import React from "react";
+import { createRoot } from "react-dom/client";
+import "@octo/base/src/theme/tokens.css";
+import "../index.css";
+import {
+  BaseModule,
+  Dap,
+  I18nProvider,
+  IM_DEVICE_FLAG_PC,
+  ThemeMode,
+  WKApp,
+  i18n,
+} from "@octo/base";
+import { ContactsModule } from "@octo/contacts";
+import { DataSourceModule } from "@octo/datasource";
+import { SummaryModule } from "@dmwork/summary";
+import { registerEnterpriseModules } from "virtual:octo-enterprise-modules";
+import { version as pkgVersion } from "../../package.json";
+import { resolveApiURL } from "../apiURL";
+import appEnUS from "../i18n/en-US.json";
+import appZhCN from "../i18n/zh-CN.json";
+import { CommunicationShell } from "./CommunicationShell";
+import { requireHostBridge } from "./hostBridge";
+
+async function main() {
+  const host = requireHostBridge();
+  const bootstrap = await host.getBootstrap();
+  if (bootstrap.bridgeVersion !== 1) {
+    throw new Error(`Unsupported communication bridge version: ${bootstrap.bridgeVersion}`);
+  }
+
+  WKApp.apiClient.config.apiURL = resolveApiURL({
+    isDesktop: true,
+    isDev: false,
+    rawApiURL: bootstrap.session.apiOrigin,
+  });
+  WKApp.apiClient.config.tokenCallback = () => WKApp.loginInfo.token;
+  WKApp.apiClient.config.spaceIdCallback = () => WKApp.shared.currentSpaceId;
+  Dap.shared.setTokenProvider(() => WKApp.loginInfo.token);
+  WKApp.config.appVersion = import.meta.env.VITE_VERSION || pkgVersion;
+  WKApp.config.appName = "Octo";
+
+  WKApp.loginInfo.applySession({
+    uid: bootstrap.session.uid,
+    token: bootstrap.session.token,
+    name: bootstrap.session.name,
+    loginProvider: bootstrap.session.provider,
+    deviceFlag: IM_DEVICE_FLAG_PC,
+  });
+  WKApp.shared.currentSpaceId = bootstrap.space.id;
+  document.documentElement.dataset.spaceId = bootstrap.space.id;
+
+  i18n.registerNamespace("app", {
+    "zh-CN": appZhCN,
+    "en-US": appEnUS,
+  });
+  WKApp.config.locale = bootstrap.appearance.locale;
+  i18n.init({ locale: bootstrap.appearance.locale });
+
+  WKApp.shared.registerModule(new BaseModule());
+  WKApp.shared.registerModule(new DataSourceModule());
+  WKApp.shared.registerModule(new ContactsModule());
+  WKApp.shared.registerModule(new SummaryModule());
+  registerEnterpriseModules({
+    registerModule: (module) => WKApp.shared.registerModule(module),
+  });
+
+  await enableMocksIfE2E();
+  await enableMockImIfE2E();
+  WKApp.shared.startup({ loadLoginInfo: false });
+  WKApp.config.themeMode = bootstrap.appearance.theme === "dark" ? ThemeMode.dark : ThemeMode.light;
+  document.documentElement.dataset.theme = bootstrap.appearance.theme;
+  Dap.shared.init();
+
+  createRoot(document.getElementById("root")!).render(
+    <React.StrictMode>
+      <I18nProvider>
+        <CommunicationShell
+          initialPage={bootstrap.initialPage}
+          onReady={() => host.reportReady({
+            bridgeVersion: 1,
+            page: bootstrap.initialPage,
+            spaceId: bootstrap.space.id,
+            rendererVersion: WKApp.config.appVersion,
+          })}
+        />
+      </I18nProvider>
+    </React.StrictMode>,
+  );
+}
+
+async function enableMocksIfE2E(): Promise<void> {
+  if (import.meta.env.VITE_E2E_MOCK !== "1") return;
+  try {
+    const { worker } = await import("../mocks/browser");
+    await worker.start({ onUnhandledRequest: "bypass" });
+  } catch (error) {
+    console.warn("[communication-e2e] MSW disabled:", error);
+  }
+}
+
+async function enableMockImIfE2E(): Promise<void> {
+  if (import.meta.env.VITE_E2E_MOCK_IM !== "1") return;
+  try {
+    const mod = await import("../../e2e-kit/_kit/mock-im-runtime/fake-provider");
+    const wksdk = await import("wukongimjssdk");
+    const defaultSeed = {
+      currentUid: "e2e-user",
+      spaceId: "e2e-space",
+      users: [
+        {
+          uid: "e2e-contact-human",
+          name: "E2E 联系人",
+          robot: 0,
+          extra: { follow: 1 },
+        },
+        {
+          uid: "e2e-contact-bot",
+          name: "E2E 助手",
+          robot: 1,
+          extra: { follow: 1, robot: 1 },
+        },
+      ],
+      groups: [
+        {
+          group_no: "e2e-contact-group",
+          name: "E2E 项目群",
+          extra: { member_count: 3 },
+        },
+      ],
+      conversations: [],
+      messages: [],
+      subscribers: [],
+    };
+    (window as unknown as {
+      __installMockImRuntime__: (seed: unknown) => void;
+      WKSDK: typeof wksdk.WKSDK;
+    }).__installMockImRuntime__ = mod.installFakeProvider as (seed: unknown) => void;
+    (window as unknown as { WKSDK: typeof wksdk.WKSDK }).WKSDK = wksdk.WKSDK;
+    mod.installFakeProvider(defaultSeed);
+    (window as unknown as {
+      __octoCommunicationE2E__?: {
+        getOpenChannel: () => { channelID?: string; channelType?: number } | null;
+      };
+    }).__octoCommunicationE2E__ = {
+      getOpenChannel: () => WKApp.shared.openChannel || null,
+    };
+  } catch (error) {
+    console.warn("[communication-e2e] mock IM disabled:", error);
+  }
+}
+
+void main().catch((error) => {
+  const normalized = error instanceof Error ? error : new Error(String(error));
+  window.octoBuddyCommunication?.reportFatalError({
+    message: normalized.message,
+    stack: normalized.stack,
+  });
+  const root = document.getElementById("root");
+  if (root) root.textContent = `通信模块启动失败：${normalized.message}`;
+});

--- a/apps/web/src/client-communication/index.tsx
+++ b/apps/web/src/client-communication/index.tsx
@@ -15,10 +15,12 @@ import { ContactsModule } from "@octo/contacts";
 import { DataSourceModule } from "@octo/datasource";
 import { SummaryModule } from "@dmwork/summary";
 import { registerEnterpriseModules } from "virtual:octo-enterprise-modules";
+import { WKSDK } from "wukongimjssdk";
 import { version as pkgVersion } from "../../package.json";
 import { resolveApiURL } from "../apiURL";
 import appEnUS from "../i18n/en-US.json";
 import appZhCN from "../i18n/zh-CN.json";
+import { installCommunicationAuthExpiryHandler } from "./authLifecycle";
 import { CommunicationShell } from "./CommunicationShell";
 import { requireHostBridge } from "./hostBridge";
 
@@ -56,8 +58,10 @@ async function main() {
   });
   WKApp.config.locale = bootstrap.appearance.locale;
   i18n.init({ locale: bootstrap.appearance.locale });
+  document.documentElement.lang = bootstrap.appearance.locale;
 
   WKApp.shared.registerModule(new BaseModule());
+  installCommunicationAuthExpiryHandler(WKApp.apiClient, WKApp.loginInfo, host);
   WKApp.shared.registerModule(new DataSourceModule());
   WKApp.shared.registerModule(new ContactsModule());
   WKApp.shared.registerModule(new SummaryModule());
@@ -67,7 +71,13 @@ async function main() {
 
   await enableMocksIfE2E();
   await enableMockImIfE2E();
-  WKApp.shared.startup({ loadLoginInfo: false });
+  WKApp.shared.startup({ loadLoginInfo: false, isPC: true });
+  if (
+    WKApp.loginInfo.deviceFlag !== IM_DEVICE_FLAG_PC ||
+    WKSDK.shared().config.deviceFlag !== IM_DEVICE_FLAG_PC
+  ) {
+    throw new Error("Communication renderer requires the PC IM device flag");
+  }
   WKApp.config.themeMode = bootstrap.appearance.theme === "dark" ? ThemeMode.dark : ThemeMode.light;
   document.documentElement.dataset.theme = bootstrap.appearance.theme;
   Dap.shared.init();
@@ -76,6 +86,7 @@ async function main() {
     <React.StrictMode>
       <I18nProvider>
         <CommunicationShell
+          bridge={host}
           initialPage={bootstrap.initialPage}
           initialPresentation={bootstrap.initialPresentation}
           onReady={() => host.reportReady({

--- a/apps/web/src/client-communication/index.tsx
+++ b/apps/web/src/client-communication/index.tsx
@@ -23,6 +23,7 @@ import appZhCN from "../i18n/zh-CN.json";
 import { installCommunicationAuthExpiryHandler } from "./authLifecycle";
 import { CommunicationShell } from "./CommunicationShell";
 import { requireHostBridge } from "./hostBridge";
+import { reportStartupFailure } from "./startupFailure";
 
 async function main() {
   const host = requireHostBridge();
@@ -88,11 +89,12 @@ async function main() {
         <CommunicationShell
           bridge={host}
           initialPage={bootstrap.initialPage}
+          initialSpaceId={bootstrap.space.id}
           initialPresentation={bootstrap.initialPresentation}
-          onReady={() => host.reportReady({
+          onReady={({ page, spaceId }) => host.reportReady({
             bridgeVersion: 1,
-            page: bootstrap.initialPage,
-            spaceId: bootstrap.space.id,
+            page,
+            spaceId,
             rendererVersion: WKApp.config.appVersion,
           })}
         />
@@ -137,12 +139,4 @@ async function enableMockImIfE2E(): Promise<void> {
   }
 }
 
-void main().catch((error) => {
-  const normalized = error instanceof Error ? error : new Error(String(error));
-  window.octoBuddyCommunication?.reportFatalError({
-    message: normalized.message,
-    stack: normalized.stack,
-  });
-  const root = document.getElementById("root");
-  if (root) root.textContent = `Communication module failed to start: ${normalized.message}`;
-});
+void main().catch(reportStartupFailure);

--- a/apps/web/src/client-communication/index.tsx
+++ b/apps/web/src/client-communication/index.tsx
@@ -103,42 +103,17 @@ async function enableMocksIfE2E(): Promise<void> {
 async function enableMockImIfE2E(): Promise<void> {
   if (import.meta.env.VITE_E2E_MOCK_IM !== "1") return;
   try {
-    const mod = await import("../../e2e-kit/_kit/mock-im-runtime/fake-provider");
+    const [mod, seedModule] = await Promise.all([
+      import("../../e2e-kit/_kit/mock-im-runtime/fake-provider"),
+      import("../../e2e-kit/_kit/mock-im-runtime/communication-seed"),
+    ]);
     const wksdk = await import("wukongimjssdk");
-    const defaultSeed = {
-      currentUid: "e2e-user",
-      spaceId: "e2e-space",
-      users: [
-        {
-          uid: "e2e-contact-human",
-          name: "E2E 联系人",
-          robot: 0,
-          extra: { follow: 1 },
-        },
-        {
-          uid: "e2e-contact-bot",
-          name: "E2E 助手",
-          robot: 1,
-          extra: { follow: 1, robot: 1 },
-        },
-      ],
-      groups: [
-        {
-          group_no: "e2e-contact-group",
-          name: "E2E 项目群",
-          extra: { member_count: 3 },
-        },
-      ],
-      conversations: [],
-      messages: [],
-      subscribers: [],
-    };
     (window as unknown as {
       __installMockImRuntime__: (seed: unknown) => void;
       WKSDK: typeof wksdk.WKSDK;
     }).__installMockImRuntime__ = mod.installFakeProvider as (seed: unknown) => void;
     (window as unknown as { WKSDK: typeof wksdk.WKSDK }).WKSDK = wksdk.WKSDK;
-    mod.installFakeProvider(defaultSeed);
+    mod.installFakeProvider(seedModule.communicationDefaultSeed);
     (window as unknown as {
       __octoCommunicationE2E__?: {
         getOpenChannel: () => { channelID?: string; channelType?: number } | null;
@@ -158,5 +133,5 @@ void main().catch((error) => {
     stack: normalized.stack,
   });
   const root = document.getElementById("root");
-  if (root) root.textContent = `通信模块启动失败：${normalized.message}`;
+  if (root) root.textContent = `Communication module failed to start: ${normalized.message}`;
 });

--- a/apps/web/src/client-communication/readyReporter.test.ts
+++ b/apps/web/src/client-communication/readyReporter.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createReadyReporter } from "./readyReporter";
+
+describe("createReadyReporter", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("retries a rejected ready report and stops after success", async () => {
+    vi.useFakeTimers();
+    const report = vi
+      .fn<() => Promise<void>>()
+      .mockRejectedValueOnce(new Error("temporary IPC failure"))
+      .mockResolvedValue(undefined);
+    const reporter = createReadyReporter(report, { retryDelayMs: 10 });
+
+    reporter.request();
+    await vi.runAllTimersAsync();
+
+    expect(report).toHaveBeenCalledTimes(2);
+    reporter.request();
+    await vi.runAllTimersAsync();
+    expect(report).toHaveBeenCalledTimes(2);
+  });
+
+  it("reports the final error after the configured attempt limit", async () => {
+    vi.useFakeTimers();
+    const error = new Error("persistent IPC failure");
+    const report = vi.fn<() => Promise<void>>().mockRejectedValue(error);
+    const onExhausted = vi.fn();
+    const reporter = createReadyReporter(report, {
+      maxAttempts: 2,
+      retryDelayMs: 10,
+      onExhausted,
+    });
+
+    reporter.request();
+    await vi.runAllTimersAsync();
+
+    expect(report).toHaveBeenCalledTimes(2);
+    expect(onExhausted).toHaveBeenCalledWith(error);
+  });
+
+  it("cancels a scheduled retry when disposed", async () => {
+    vi.useFakeTimers();
+    const report = vi.fn<() => Promise<void>>().mockRejectedValue(new Error("failed"));
+    const reporter = createReadyReporter(report, { retryDelayMs: 10 });
+
+    reporter.request();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(vi.getTimerCount()).toBe(1);
+    reporter.dispose();
+    expect(vi.getTimerCount()).toBe(0);
+    await vi.runAllTimersAsync();
+
+    expect(report).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not invoke a queued report after disposal", async () => {
+    const report = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
+    const reporter = createReadyReporter(report);
+
+    reporter.request();
+    reporter.dispose();
+    await Promise.resolve();
+
+    expect(report).not.toHaveBeenCalled();
+  });
+
+  it("retries when the report callback throws synchronously", async () => {
+    vi.useFakeTimers();
+    const report = vi
+      .fn<() => Promise<void>>()
+      .mockImplementationOnce(() => {
+        throw new Error("synchronous IPC failure");
+      })
+      .mockResolvedValue(undefined);
+    const reporter = createReadyReporter(report, { retryDelayMs: 10 });
+
+    expect(() => reporter.request()).not.toThrow();
+    await vi.runAllTimersAsync();
+
+    expect(report).toHaveBeenCalledTimes(2);
+  });
+
+  it("isolates an onExhausted callback that throws", async () => {
+    const report = vi.fn<() => Promise<void>>().mockRejectedValue(new Error("failed"));
+    const onExhausted = vi.fn(() => {
+      throw new Error("diagnostic failure");
+    });
+    const reporter = createReadyReporter(report, {
+      maxAttempts: 1,
+      onExhausted,
+    });
+
+    reporter.request();
+    await vi.waitFor(() => expect(onExhausted).toHaveBeenCalledTimes(1));
+  });
+
+  it("times out a stuck report and continues retrying", async () => {
+    vi.useFakeTimers();
+    const report = vi.fn<() => Promise<void>>(() => new Promise(() => {}));
+    const onExhausted = vi.fn();
+    const reporter = createReadyReporter(report, {
+      maxAttempts: 2,
+      retryDelayMs: 5,
+      attemptTimeoutMs: 10,
+      onExhausted,
+    });
+
+    reporter.request();
+    await vi.runAllTimersAsync();
+
+    expect(report).toHaveBeenCalledTimes(2);
+    expect(onExhausted).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "Ready report attempt timed out after 10ms" }),
+    );
+  });
+});

--- a/apps/web/src/client-communication/readyReporter.ts
+++ b/apps/web/src/client-communication/readyReporter.ts
@@ -1,0 +1,97 @@
+export interface ReadyReporter {
+  request(): void;
+  dispose(): void;
+}
+
+export interface ReadyReporterOptions {
+  maxAttempts?: number;
+  retryDelayMs?: number;
+  attemptTimeoutMs?: number;
+  onExhausted?: (error: unknown) => void;
+}
+
+export function createReadyReporter(
+  report: () => Promise<void>,
+  options: ReadyReporterOptions = {},
+): ReadyReporter {
+  const maxAttempts = options.maxAttempts ?? 3;
+  const retryDelayMs = options.retryDelayMs ?? 250;
+  const attemptTimeoutMs = options.attemptTimeoutMs ?? 5000;
+  let attempts = 0;
+  let disposed = false;
+  let inFlight = false;
+  let reported = false;
+  let retryTimer: ReturnType<typeof setTimeout> | undefined;
+  let attemptTimer: ReturnType<typeof setTimeout> | undefined;
+  let cancelAttempt: (() => void) | undefined;
+
+  const runAttempt = () => new Promise<void>((resolve, reject) => {
+    let settled = false;
+    const finish = (callback: () => void) => {
+      if (settled) return;
+      settled = true;
+      if (attemptTimer) clearTimeout(attemptTimer);
+      attemptTimer = undefined;
+      cancelAttempt = undefined;
+      callback();
+    };
+
+    attemptTimer = setTimeout(() => {
+      finish(() => reject(new Error(
+        `Ready report attempt timed out after ${attemptTimeoutMs}ms`,
+      )));
+    }, attemptTimeoutMs);
+    cancelAttempt = () => finish(resolve);
+
+    void Promise.resolve()
+      .then(() => {
+        if (settled) return;
+        return report();
+      })
+      .then(
+        () => finish(resolve),
+        (error: unknown) => finish(() => reject(error)),
+      );
+  });
+
+  const request = () => {
+    if (disposed || reported || inFlight || retryTimer || attempts >= maxAttempts) return;
+    attempts += 1;
+    inFlight = true;
+    void Promise.resolve()
+      .then(() => {
+        if (disposed) return;
+        return runAttempt();
+      })
+      .then(() => {
+        inFlight = false;
+        if (!disposed) reported = true;
+      })
+      .catch((error: unknown) => {
+        inFlight = false;
+        if (disposed) return;
+        if (attempts >= maxAttempts) {
+          try {
+            options.onExhausted?.(error);
+          } catch {
+            // Diagnostics must not escape the retry controller.
+          }
+          return;
+        }
+        retryTimer = setTimeout(() => {
+          retryTimer = undefined;
+          request();
+        }, retryDelayMs);
+      });
+  };
+
+  return {
+    request,
+    dispose() {
+      disposed = true;
+      cancelAttempt?.();
+      if (retryTimer) clearTimeout(retryTimer);
+      retryTimer = undefined;
+    },
+  };
+}

--- a/apps/web/src/client-communication/startupFailure.test.ts
+++ b/apps/web/src/client-communication/startupFailure.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { reportStartupFailure } from "./startupFailure";
+
+describe("reportStartupFailure", () => {
+  afterEach(() => {
+    delete window.octoBuddyCommunication;
+    document.body.innerHTML = "";
+    vi.restoreAllMocks();
+  });
+
+  it("renders the fallback even when fatal error reporting throws", () => {
+    const reportError = new Error("fatal IPC failure");
+    const reportFatalError = vi.fn(() => {
+      throw reportError;
+    });
+    window.octoBuddyCommunication = { reportFatalError } as never;
+    document.body.innerHTML = '<div id="root"></div>';
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    reportStartupFailure(new Error("bootstrap failed"));
+
+    expect(reportFatalError).toHaveBeenCalledWith({
+      message: "bootstrap failed",
+      stack: expect.any(String),
+    });
+    expect(consoleSpy).toHaveBeenCalledWith(
+      "[client-communication] failed to report startup error",
+      reportError,
+    );
+    expect(document.getElementById("root")?.textContent).toBe(
+      "Communication module failed to start: bootstrap failed",
+    );
+  });
+});

--- a/apps/web/src/client-communication/startupFailure.ts
+++ b/apps/web/src/client-communication/startupFailure.ts
@@ -1,0 +1,20 @@
+export function reportStartupFailure(error: unknown): void {
+  const normalized = error instanceof Error ? error : new Error(String(error));
+
+  try {
+    window.octoBuddyCommunication?.reportFatalError({
+      message: normalized.message,
+      stack: normalized.stack,
+    });
+  } catch (reportError) {
+    console.error(
+      "[client-communication] failed to report startup error",
+      reportError,
+    );
+  }
+
+  const root = document.getElementById("root");
+  if (root) {
+    root.textContent = `Communication module failed to start: ${normalized.message}`;
+  }
+}

--- a/apps/web/vite.client-communication.config.ts
+++ b/apps/web/vite.client-communication.config.ts
@@ -1,0 +1,20 @@
+import { resolve } from "node:path";
+import { defineConfig, mergeConfig } from "vite";
+import baseConfig from "./vite.config";
+
+export default defineConfig(async (environment) => {
+  const shared = typeof baseConfig === "function"
+    ? await baseConfig(environment)
+    : await baseConfig;
+
+  return mergeConfig(shared, {
+    base: "./",
+    build: {
+      outDir: "build-client-communication",
+      emptyOutDir: true,
+      rollupOptions: {
+        input: resolve(__dirname, "client-communication.html"),
+      },
+    },
+  });
+});

--- a/docs/chat-capability-integration-options-report.md
+++ b/docs/chat-capability-integration-options-report.md
@@ -1,0 +1,500 @@
+# Octo Web 聊天能力接入 OctoBuddy Client 方案分析报告
+
+> 报告日期：2026-09-03
+> 目标：在不改变 octo-web 后端接口的前提下，让 OctoBuddy Client 能够按自身布局灵活使用现有聊天与通讯录能力。
+> 当前结论：短期采用“单一 communication artifact + Host Bridge + 双 presentation”，长期继续推进 octo-web 内部聊天能力分层。
+
+## 1. 执行摘要
+
+本轮工作讨论过 5 种技术方向，其中 3 种已经通过代码、构建和自动化测试进行了实际验证。
+
+| 方案 | 状态 | 结论 |
+| --- | --- | --- |
+| Client 重新实现聊天 UI | 完成分析，未实施 | 自由度高，但重复建设和长期维护成本最高，不建议采用 |
+| 复制 octo-web 聊天源码到 Client 编译 | 完成分析，未实施 | 短期可能运行，依赖和升级风险不可控，不建议作为正式方案 |
+| octo-web 单入口整体打包 | 已完成验证 | 能快速、完整复用消息和通讯录能力，是可靠的交付边界 |
+| 聊天能力分层抽离 | 已完成第一阶段验证 | 是长期架构方向，但当前还没有彻底摆脱旧 WKSDK 运行时 |
+| 独立会话 presentation | 已完成验证 | 满足 Client 传入频道并独立显示聊天窗口的目标，是当前最佳使用形态 |
+
+推荐方案不是只选择其中一项，而是组合使用：
+
+1. octo-web 内部使用 `chat-core`、`chat-react`、`ConversationSurface` 和 `ConversationWindow` 分层组织能力。
+2. octo-web 对外仍发布一个经过版本校验的 communication artifact。
+3. Client 通过稳定 Host Bridge 传入登录态、Space、布局模式和目标频道。
+4. 同一个 renderer 支持 `workspace` 和 `conversation` 两种 presentation。
+5. 消息、通讯录和独立聊天窗口共享一个 `WebContentsView` 和一套 IM 运行时。
+
+该组合既保证当前能够交付，也为后续真正 SDK 化保留了清晰的演进路径。
+
+## 2. 背景与目标
+
+### 2.1 业务目标
+
+Client 希望拥有自己的整体布局和导航，包括：
+
+- 左侧放置“消息”“通讯录”“独立会话”等入口。
+- 中央区域按 Client 的页面结构显示通信功能。
+- 从通讯录点击联系人或群组后能够发起会话。
+- 在某些业务页面中，只嵌入指定聊天窗口，不显示完整会话列表。
+- Client 可以传入 `channelId` 和 `channelType`，直接打开已有频道。
+- 继续使用 octo-web 已有登录态、Space、历史消息、编辑器、附件、发送状态和 IM 连接。
+
+### 2.2 核心约束
+
+本次方案必须遵守以下边界：
+
+1. 不修改 octo-web 现有后端接口。
+2. 不在 Client 中重新实现全部消息类型。
+3. 不建立第二套聊天业务逻辑和修复分支。
+4. 消息和通讯录切换不能重复初始化 IM 连接。
+5. Client 必须保留自己的窗口、导航、弹窗和生命周期控制。
+6. 最终产物能够随 Client 安装包发布，不依赖开发服务器和 octo-web 源码目录。
+
+## 3. 评估维度
+
+所有方案按以下维度统一评估：
+
+- **业务完整度**：是否覆盖消息、历史记录、编辑器、附件、发送状态、通讯录和未读数。
+- **布局灵活性**：是否能只显示聊天窗口，以及是否能嵌入 Client 的不同页面。
+- **复用程度**：是否继续使用 octo-web 的现有业务实现和 IM 运行时。
+- **初始成本**：首次实现和联调所需工作量。
+- **长期成本**：octo-web 升级、新消息类型和缺陷修复时的同步成本。
+- **运行风险**：登录态、SDK 单例、全局状态、样式和多连接问题。
+- **交付独立性**：是否可以打包、版本锁定和离线随 Client 发布。
+- **演进空间**：是否有利于未来形成可复用聊天 SDK 和功能模块。
+
+## 4. 方案一：Client 重新实现聊天 UI
+
+### 4.1 方案说明
+
+Client 直接调用 octo-web 现有后端接口，自行实现会话列表、消息列表、编辑器、附件、消息状态和通讯录界面。
+
+### 4.2 优点
+
+- Client 对布局和交互拥有最高控制权。
+- 不需要承载 octo-web 页面运行时。
+- 理论上可以针对桌面端做更深度的性能和交互优化。
+
+### 4.3 主要问题
+
+- 后端接口并不等于完整聊天能力，仍需处理 WKSDK、连接、重连、缓存、消息确认和事件订阅。
+- octo-web 已支持的文本、图片、文件、引用、卡片和其他消息类型都需要重新实现。
+- 编辑器、附件上传、下载、通知、未读数和消息状态存在大量隐含行为。
+- octo-web 后续新增能力时，Client 必须再次开发和测试。
+- 最终会形成两套表现接近但行为可能不一致的聊天产品。
+
+### 4.4 成本判断
+
+| 项目 | 估算 |
+| --- | --- |
+| 首次实现 | 高，约 40-80 人日 |
+| 完整联调与回归 | 高 |
+| 长期维护 | 很高 |
+| 适合场景 | 明确决定建设全新桌面聊天产品，并愿意长期维护独立团队 |
+
+### 4.5 结论
+
+技术上可以实现，但与“优雅复用现有资源”的目标相反，不建议采用。
+
+## 5. 方案二：复制 octo-web 源码到 Client 编译
+
+### 5.1 方案说明
+
+将聊天相关源码、组件和依赖直接复制或软链接到 Client，在 Client 的 React 工程内完成编译。
+
+### 5.2 优点
+
+- 初期能够快速看到原有 UI。
+- Client 可以直接修改被复制的组件。
+- 不需要额外 renderer 进程或页面容器。
+
+### 5.3 主要问题
+
+- 聊天页面依赖 `WKApp`、模块注册、路由、Context、SDK 单例和全局样式，并非复制几个 React 组件即可运行。
+- octo-web 与 Client 的 React、构建工具和依赖版本可能发生冲突。
+- 源码复制后，缺陷修复和新功能无法自然同步。
+- 为了让复制代码运行，通常需要不断复制更多依赖，边界会持续扩大。
+- 最终产物虽然能运行，但来源、版本和维护责任难以管理。
+
+### 5.4 成本判断
+
+| 项目 | 估算 |
+| --- | --- |
+| 首次看到页面 | 中，约 5-10 人日 |
+| 达到稳定可用 | 高，约 20-40 人日 |
+| 长期维护 | 很高 |
+| 适合场景 | 一次性演示或废弃周期明确的临时项目 |
+
+### 5.5 结论
+
+“不管过程、结果能跑”的短期目标有机会达到，但不能形成可持续的正式方案。本轮没有继续实施该方向。
+
+## 6. 方案三：octo-web 单入口整体打包
+
+### 6.1 方案说明
+
+在 octo-web 中新增 `client-communication` 构建入口，仅启动聊天和通讯录需要的模块，然后输出独立静态 artifact。Client 使用 Electron `WebContentsView` 加载该产物。
+
+运行边界如下：
+
+```text
+OctoBuddy Client
+  -> CommunicationViewSlot
+  -> Electron WebContentsView
+  -> Host Bridge
+  -> client-communication artifact
+  -> ChatPage / ContactsList
+  -> octo-web 现有运行时和后端接口
+```
+
+### 6.2 已验证能力
+
+- 使用 Client 现有登录态初始化 octo-web 通信运行时。
+- 使用 Client 当前 Space。
+- 消息和通讯录共用一个 renderer。
+- 通讯录点击联系人或群组后发起会话。
+- 历史消息、编辑器、附件和消息发送继续使用现有实现。
+- 未读数回传 Client。
+- 支持外部链接、下载、通知和麦克风权限代理。
+- 支持窗口隐藏、恢复、崩溃恢复、登录失效和 token 更新。
+- artifact 可以版本锁定并随 Client 安装包发布。
+
+### 6.3 优点
+
+- 业务复用最完整，Client 不需要理解消息类型。
+- octo-web 修复后重新构建 artifact 即可进入 Client。
+- React 依赖和全局样式被隔离在独立 renderer 中。
+- 可以对 artifact 名称、版本、commit 和 Bridge major 进行校验。
+
+### 6.4 局限
+
+- 最初只能以完整消息工作台形态使用，布局粒度不够细。
+- artifact 体积较大，当前主 JS 约 9 MB、CSS 约 1 MB，仍有拆包空间。
+- Host 与 renderer 之间需要维护稳定 Bridge 契约。
+
+### 6.5 结论
+
+这是当前最可靠的跨应用交付边界，已经完成验证，应继续保留。
+
+## 7. 方案四：聊天能力分层抽离
+
+### 7.1 方案说明
+
+将聊天能力按职责分为三个层级：
+
+```text
+@octo/chat-core
+  无 React、SDK 无关的生命周期和消息端口
+
+@octo/chat-react
+  React Provider、hooks 和会话租约管理
+
+ConversationSurface / ConversationWindow
+  可组合的完整业务聊天区域
+```
+
+### 7.2 当前完成情况
+
+已经完成：
+
+- `ManagedChatClient` 生命周期、状态、订阅和并发控制。
+- `ChatProvider`、hooks 和 `ConversationWindow` 生命周期边界。
+- `ConversationSurface` 与完整 `ConversationWindow`。
+- octo-web 原有 `ChatPage` 和 `ThreadPanel` 开始复用新边界。
+- 通过 legacy adapter 继续连接既有 WKSDK 和 `ConversationContext`。
+
+尚未完成：
+
+- WKSDK connect/disconnect 尚未完全进入 `chat-core` adapter。
+- 消息实体仍包含 WKSDK 类型。
+- 消息发送仍通过旧 `ConversationContext` 桥接。
+- 尚未单独发布一个可供 Client 直接 import 的最小聊天 npm 包。
+
+### 7.3 优点
+
+- 从根本上明确聊天核心、React 生命周期和业务 UI 的职责。
+- 支持聊天窗口、ThreadPanel、抽屉和其他组合场景。
+- octo-web 自身也消费抽离后的能力，不会形成 Client 专用旁路。
+- 为未来多宿主复用和真正 SDK 化提供基础。
+
+### 7.4 局限
+
+- 这是持续演进工程，不适合作为短期交付的唯一前置条件。
+- 如果立即要求 Client 源码级 import，仍会遇到全局状态、SDK 和依赖版本问题。
+- 完全独立需要继续迁移连接、消息模型、发送和缓存能力。
+
+### 7.5 成本判断
+
+| 阶段 | 估算 |
+| --- | --- |
+| 当前第一阶段能力边界 | 已完成并验证 |
+| 完成 SDK 生命周期下沉 | 约 15-30 人日 |
+| 形成稳定对外 npm 能力包 | 约 10-20 人日，另需兼容和发布治理 |
+| 长期维护 | 低于复制或重写方案 |
+
+### 7.6 结论
+
+这是正确的长期架构方向，但不需要等待全部抽离完成后再交付 Client。
+
+## 8. 方案五：独立会话 presentation
+
+### 8.1 方案说明
+
+在方案三的同一个 communication artifact 中增加布局模式，而不是再创建一套聊天应用：
+
+- `workspace`：会话列表加聊天窗口，适合“消息”入口。
+- `conversation`：隐藏会话列表和分隔条，只显示目标聊天窗口。
+
+Client 发送：
+
+```ts
+{
+  page: 'chat',
+  presentation: 'conversation',
+  target: {
+    channelId: 'existing-channel-id',
+    channelType: 1
+  }
+}
+```
+
+### 8.2 数据使用方式
+
+Client 只负责告诉 octo-web“显示哪个频道”，并不传入消息数据。以下能力继续来自现有系统：
+
+- Client 当前登录用户和 token。
+- 当前 Space。
+- WKSDK 连接和频道状态。
+- 服务端历史消息。
+- 新消息订阅。
+- 消息类型渲染。
+- 编辑器、附件和发送状态。
+
+这意味着它使用的是现有真实数据，不是 Client 自己维护的一份模拟消息列表。
+
+### 8.3 当前模拟入口
+
+Client 已增加“独立会话”入口：
+
+- 默认目标为 `botfather / 1`。
+- 可以输入任意有效 `channelId/channelType`。
+- 优先复用用户最近在消息或通讯录中打开的真实频道。
+- 点击“加载”后更新目标，不重建整个通信运行时。
+- 切回“消息”时恢复 `workspace` 布局。
+
+### 8.4 优点
+
+- 已满足“聊天窗口功能级独立”的实际需求。
+- 不需要把聊天窗口打成第二份 artifact。
+- 工作台和独立窗口共享登录态、连接、缓存和消息实现。
+- Client 可以在自己的页面结构中决定聊天区域位置和尺寸。
+- 后续可以继续增加 `thread`、`compact` 等 presentation，而不复制业务代码。
+
+### 8.5 局限
+
+- 当前仍由一个较完整的 renderer 承载，资源体积没有降到最小聊天组件级别。
+- `channelId/channelType` 仍属于底层频道标识，后续可增加业务目标解析层。
+- 主题和语言目前还没有完整连接 Client 设置。
+
+### 8.6 结论
+
+这是当前成本、稳定性和布局灵活性之间最均衡的方案，建议作为 Client 使用聊天能力的标准入口。
+
+## 9. 综合对比
+
+评分采用 1-5 分，5 分表示更优。
+
+| 维度 | 重写 UI | 复制源码 | 整体 artifact | 能力分层 | 独立会话 presentation |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| 业务完整度 | 2 | 3 | 5 | 4 | 5 |
+| 布局灵活性 | 5 | 4 | 3 | 5 | 5 |
+| 现有能力复用 | 1 | 3 | 5 | 5 | 5 |
+| 初始交付效率 | 1 | 3 | 5 | 2 | 5 |
+| 长期维护性 | 1 | 1 | 4 | 5 | 4 |
+| 运行隔离性 | 4 | 1 | 5 | 3 | 5 |
+| 版本可治理性 | 3 | 1 | 5 | 4 | 5 |
+| 当前验证程度 | 1 | 1 | 5 | 4 | 5 |
+| 综合建议 | 不推荐 | 不推荐 | 保留 | 长期推进 | 当前推荐 |
+
+## 10. 实际验证结果
+
+### 10.1 已完成的三阶段验证
+
+#### 阶段一：整体通信能力进入 Client
+
+- Client 左侧提供消息和通讯录入口。
+- octo-web 输出单入口 artifact。
+- Electron 使用单个持久 `WebContentsView` 承载。
+- 登录态、Space、未读数、下载和通知通过 Host Bridge 协作。
+
+#### 阶段二：聊天能力内部开始分层
+
+- 新增 `chat-core` 和 `chat-react`。
+- 新增可组合的 `ConversationSurface` 和 `ConversationWindow`。
+- 原 `ChatPage` 和 `ThreadPanel` 开始消费新能力边界。
+
+#### 阶段三：目标频道独立嵌入
+
+- Host Bridge 增加 `presentation`。
+- Client 可以传入 `channelId/channelType`。
+- `conversation` 模式隐藏左侧会话列表。
+- 聊天窗口填满可用区域并保留消息编辑器。
+- 切回消息后恢复 `workspace` 模式。
+
+### 10.2 自动化结果
+
+| 验证项 | 结果 |
+| --- | --- |
+| `@octo/chat-core` | 54 tests passed |
+| `@octo/chat-react` | 24 tests passed |
+| `@octo/base` | 4325 tests passed |
+| octo-web unit tests | 113 files / 1419 tests passed |
+| octo-web production build | 通过 |
+| communication artifact build | 通过 |
+| Client typecheck | 通过 |
+| Client unit tests | 49 passed |
+| Communication Electron E2E | 12 passed |
+| Client production build | 通过 |
+| production artifact | 当前仅完成 provisional build；最终提交后需从 clean tree 重建并记录实际 commit |
+
+### 10.3 核心 E2E 证据
+
+自动化已经证明：
+
+- 消息和通讯录复用一个 WebContentsView。
+- Client 传入 `e2e-contact-bot / 1` 后，octo-web 打开对应已有频道。
+- 独立会话模式下左侧列表和 splitter 被隐藏。
+- 右侧聊天区域占满通信 viewport。
+- 消息编辑器仍然存在。
+- 切回消息入口后恢复 workspace 布局。
+- 首次导航、Space 更新、隐藏状态、token 轮换和 renderer 恢复没有发生回归。
+
+## 11. 推荐最佳实践
+
+### 11.1 对外集成边界
+
+Client 不直接 import octo-web 页面源码，而是加载经过校验的 communication artifact。
+
+原因：
+
+- 隔离 React 和依赖版本。
+- 隔离全局样式和 WKApp 状态。
+- 便于随安装包发布。
+- 可以锁定版本和 commit。
+- 可以独立处理 renderer 崩溃和恢复。
+
+### 11.2 对内能力边界
+
+octo-web 继续推进能力分层，并由 octo-web 自身消费这些模块。
+
+原因：
+
+- 避免抽出一套只服务 Client 的旁路实现。
+- 逐步减少 legacy adapter 和全局 Context 依赖。
+- 为未来真正发布聊天 SDK 或 npm 功能包做好准备。
+
+### 11.3 布局控制边界
+
+Client 负责：
+
+- 左侧导航和页面组合。
+- 通信区域的位置、尺寸和显隐。
+- 选择 `workspace` 或 `conversation` presentation。
+- 传入目标频道。
+
+octo-web 负责：
+
+- 会话业务状态。
+- IM 连接和历史消息。
+- 消息渲染和编辑器。
+- 通讯录和发起会话。
+- 未读数及内部导航事件。
+
+### 11.4 运行时原则
+
+- 一个 Client 窗口只维护一个 communication renderer。
+- 消息、通讯录和独立会话只切换 page/presentation，不创建第二套 IM 运行时。
+- Host Bridge 只传递必要状态和命令，不暴露任意 Electron IPC。
+- artifact 必须通过 manifest 校验后才能进入生产构建。
+
+## 12. 后续工作建议
+
+### 12.1 近期产品化，预计 8-15 人日
+
+1. 将主题和语言接入 Client 真实设置。
+2. 增加频道不存在、无权限和已删除时的明确状态页。
+3. 增加独立会话加载、失败和切换过程的埋点。
+4. 使用真实账号完成文本、图片、文件、引用和卡片消息验收矩阵。
+5. 将 Host Bridge contract 生成为两个仓库共享的版本化类型包。
+6. 补充 Windows 和 macOS 安装包验证。
+
+### 12.2 中期能力演进，预计 20-40 人日
+
+1. 将 WKSDK connect/disconnect 和重连生命周期迁入 `ChatConnectionAdapter`。
+2. 将发送能力从旧 `ConversationContext` 迁入 `ChatMessageAdapter`。
+3. 建立 SDK 无关的消息 DTO，逐步隔离 WKSDK 类型。
+4. 对 communication artifact 做路由级拆包和懒加载。
+5. 根据实际业务增加 `compact`、`thread` 或只读 presentation。
+
+### 12.3 暂不建议投入
+
+- 不建议在 Client 中重写完整聊天 UI。
+- 不建议复制 octo-web 源码形成第二套代码。
+- 不建议为了形式上的组件独立，立即拆出第二个聊天 artifact。
+- 不建议同时运行多个 communication renderer 来分别承载消息和通讯录。
+
+## 13. 风险与控制措施
+
+| 风险 | 影响 | 当前控制措施 | 后续措施 |
+| --- | --- | --- | --- |
+| artifact 与 Client 契约不兼容 | 页面无法启动 | 校验 schema、版本、commit 和 Bridge major | 发布共享 contract 包 |
+| 测试 mock 产物进入生产 | 使用假数据或错误接口 | 默认拒绝 `e2eMock:true` | CI 增加 manifest gate |
+| 多 renderer 导致多 IM 连接 | 重复消息和资源浪费 | 单 WebContentsView 复用 | 增加连接数量监控 |
+| token 或账号切换污染旧状态 | 数据越权 | token 更新重载，退出时销毁并清理 partition | 增加账号切换 E2E |
+| legacy adapter 继续扩大 | 抽离停滞 | 已建立 core/react/window 边界 | 按连接、发送、消息模型逐项迁移 |
+| artifact 体积较大 | 首载性能受影响 | 独立构建入口 | 路由拆包、按需加载模块 |
+
+## 14. 最终结论
+
+从当前验证结果看，最合理的路线不是在 Client 中重写聊天，也不是复制 octo-web 源码，而是：
+
+> 以 octo-web 为唯一聊天业务实现，通过单一 communication artifact 向 Client 交付；Client 使用稳定 Host Bridge 控制页面、presentation、目标频道和布局；octo-web 内部持续把聊天能力分层为 core、React 生命周期和业务窗口。
+
+该方案已经证明能够：
+
+- 使用现有真实数据和后端接口。
+- 与 Client 现有登录和布局融合。
+- 同时支持消息、通讯录和独立聊天窗口。
+- 避免 Client 理解大量消息类型。
+- 保持单一 IM 运行时。
+- 随 Client 安装包稳定交付。
+- 为未来更彻底的功能模块化和 SDK 化保留路径。
+
+因此建议将“单 artifact + 双 presentation + 能力分层”确定为当前最佳实践，并以此作为后续产品化和架构演进的统一基线。
+
+## 附录：关键提交
+
+### octo-web
+
+| Commit | 内容 |
+| --- | --- |
+| `8b3dc19d` | 抽离聊天核心、React 生命周期和可复用聊天窗口 |
+| `0bc116b3` | 支持嵌入式通信宿主 |
+| `606e3674` | 新增 communication renderer 单入口构建 |
+| `8ae4359f` | 加固嵌入生命周期 |
+| `c2b4e254` | 修复聊天 viewport 高度链 |
+| `f3ccbc8a` | 补充能力集成验证手册 |
+| `22a54d17` | 支持独立会话 presentation |
+| `bd04b3e2` | 补充独立会话集成设计与实施说明 |
+| `HEAD`（本提交） | 加固聊天生命周期、错误恢复和通信上报 |
+
+### octo-buddy-client
+
+| Commit | 内容 |
+| --- | --- |
+| `f615a99` | 嵌入 octo-web 消息和通讯录 |
+| `8261073` | 将校验后的 renderer 加入打包流程 |
+| `5f4bfb0` | 支持跨平台 after-pack 资源路径 |
+| `c334476` | 加固 renderer 安全边界和生命周期 |
+| `3804917` | 修复聊天区域 viewport |
+| `e64c9f6` | 增加独立会话模拟入口 |

--- a/docs/chat-capability-validation-runbook.md
+++ b/docs/chat-capability-validation-runbook.md
@@ -226,7 +226,7 @@ cat apps/web/build-client-communication/renderer-manifest.json
   "schemaVersion": 1,
   "name": "octo-web-client-communication",
   "version": "1.0.12",
-  "commit": "65a6e2e0",
+  "commit": "a2b05d41",
   "entry": "index.html",
   "hostBridgeMajor": 1,
   "e2eMock": false
@@ -299,7 +299,7 @@ pnpm prepare:communication-artifact
 pnpm test:e2e -- tests/e2e/communication.spec.ts
 ```
 
-通过标准：11 tests passed。
+通过标准：12 tests passed。
 
 该套 E2E 必须证明：
 
@@ -311,6 +311,9 @@ pnpm test:e2e -- tests/e2e/communication.spec.ts
 - 可以选择附件。
 - 内部跳转会同步 Client 侧栏状态。
 - 首次加载目标会话不会丢失。
+- Client 可传入 `channelId/channelType`，以 `conversation` presentation 打开现有频道。
+- 独立会话模式隐藏左侧列表并让聊天窗口填满通信区域。
+- 切回消息入口后恢复 `workspace` presentation，不重建 WebContentsView。
 - 首载期间 Space 更新不会被旧 ready 状态覆盖。
 - 隐藏后迟到导航不会抢回页面。
 - renderer 崩溃按限制自动恢复。
@@ -368,14 +371,17 @@ pnpm dev
 2. 点击“消息”，应在 Client 中央区域显示 octo-web 会话列表和聊天窗口。
 3. 点击“通讯录”，应复用原 View，不闪回登录页，不重新初始化整套应用。
 4. 点击一个联系人并选择“发送消息”，Client 侧栏应自动切换到“消息”。
-5. 发送文本、图片或文件，对端能够收到，发送状态正常。
-6. 从对端发送消息，Client 左侧消息入口显示未读数。
-7. 在消息和通讯录之间反复切换，不应重复连接或重复收到消息。
-8. 切换 Space，通信内容应切换到新 Space。
-9. 最小化、隐藏和恢复 Client，通信内容仍可继续使用。
-10. 打开 Client 弹窗遮挡通信区域时，原生 View 不应盖住弹窗。
-11. 更新同账号 token 后，通信 renderer 应自动重载并继续工作。
-12. 退出登录后，旧账号聊天内容不应继续显示。
+5. 点击“独立会话”，应默认复用刚才选择的真实频道；也可输入已有的 `channelId` 和 `channelType` 后点击“加载”。
+6. 独立会话只显示聊天窗口，不显示左侧会话列表；历史消息和编辑器应正常可用。
+7. 切回“消息”，左侧会话列表应恢复，且不应出现第二条 IM 连接。
+8. 发送文本、图片或文件，对端能够收到，发送状态正常。
+9. 从对端发送消息，Client 左侧消息入口显示未读数。
+10. 在消息和通讯录之间反复切换，不应重复连接或重复收到消息。
+11. 切换 Space，通信内容应切换到新 Space。
+12. 最小化、隐藏和恢复 Client，通信内容仍可继续使用。
+13. 打开 Client 弹窗遮挡通信区域时，原生 View 不应盖住弹窗。
+14. 更新同账号 token 后，通信 renderer 应自动重载并继续工作。
+15. 退出登录后，旧账号聊天内容不应继续显示。
 
 ### 6.5 开发者工具辅助检查
 
@@ -432,7 +438,7 @@ artifact version / commit：
 [ ] production artifact e2eMock=false
 [ ] Client typecheck passed
 [ ] Client unit 49 passed
-[ ] Client communication E2E 11 passed
+[ ] Client communication E2E 12 passed
 [ ] Client build passed
 [ ] octo-web 真实账号冒烟 passed
 [ ] Client 真实账号冒烟 passed

--- a/docs/chat-capability-validation-runbook.md
+++ b/docs/chat-capability-validation-runbook.md
@@ -24,10 +24,10 @@ octo-buddy-client:
 /Users/will/Project/octo/octo-buddy-client-chat-capability-integration
 ```
 
-预期提交：
+验证时以待发布分支的实际 HEAD 为准：
 
 ```text
-octo-web              65a6e2e0
+octo-web              <git rev-parse --short HEAD>
 octo-buddy-client     c334476
 ```
 
@@ -41,7 +41,7 @@ git -C /Users/will/Project/octo/octo-buddy-client-chat-capability-integration st
 git -C /Users/will/Project/octo/octo-buddy-client-chat-capability-integration log -1 --oneline
 ```
 
-文档本身尚未提交时，octo-web 可以出现 `docs/` 文件变更；源码不应出现无法解释的额外修改。
+正式生成和交付 artifact 前，源码工作树必须 clean，并重新执行本手册中的测试与构建。开发中间态可以包含本次修复，但需要在验收记录中注明。
 
 ## 3. 门禁一：验证 octo-web 没有被破坏
 
@@ -56,11 +56,11 @@ pnpm --filter @octo/chat-react test
 
 通过标准：
 
-- `chat-core`：52 tests passed。
-- `chat-react`：15 tests passed。
+- `chat-core`：54 tests passed。
+- `chat-react`：24 tests passed。
 - 没有 failed、unhandled rejection 或测试进程异常退出。
 
-`chat-react` 测试中可能出现 `useChatClient must be used within a <ChatProvider>` 错误栈，这是测试故意验证错误边界时产生的日志。只要最终结果为 15 passed，就不是失败。
+`chat-react` 测试中可能出现 `useChatClient must be used within a <ChatProvider>` 错误栈，这是测试故意验证错误边界时产生的日志。只要最终结果为 24 passed，就不是失败。
 
 ### 3.2 原有基础包全量回归
 
@@ -71,7 +71,7 @@ pnpm --filter @octo/base test
 通过标准：
 
 - 473 test files passed。
-- 4323 tests passed。
+- 4325 tests passed。
 - 退出码为 0。
 
 JSDOM 可能输出 `HTMLMediaElement.play()`、`load()` 或 `window.open()` 未实现提示。这些是已有测试环境限制，最终 tests passed 即可。
@@ -163,7 +163,7 @@ pnpm dev
 
 ### 4.1 `ManagedChatClient` 生命周期
 
-由 `chat-core` 的 52 项测试覆盖：
+由 `chat-core` 的 54 项测试覆盖：
 
 - 重复 `start()` 不建立第二条连接。
 - 重复 `stop()` 不重复释放。
@@ -175,7 +175,7 @@ pnpm dev
 
 ### 4.2 React 会话边界
 
-由 `chat-react` 的 15 项测试覆盖：
+由 `chat-react` 的 24 项测试覆盖：
 
 - mount 打开会话。
 - unmount 释放会话。
@@ -226,7 +226,7 @@ cat apps/web/build-client-communication/renderer-manifest.json
   "schemaVersion": 1,
   "name": "octo-web-client-communication",
   "version": "1.0.12",
-  "commit": "a2b05d41",
+  "commit": "<git rev-parse --short HEAD>",
   "entry": "index.html",
   "hostBridgeMajor": 1,
   "e2eMock": false
@@ -430,9 +430,10 @@ octo-web commit：
 client commit：
 artifact version / commit：
 
-[ ] chat-core 52 passed
-[ ] chat-react 15 passed
-[ ] @octo/base 4323 passed
+[ ] chat-core 54 passed
+[ ] chat-react 24 passed
+[ ] @octo/base 4325 passed
+[ ] octo-web 113 files / 1419 passed
 [ ] octo-web build passed
 [ ] Web chat/contact E2E passed
 [ ] production artifact e2eMock=false

--- a/docs/chat-capability-validation-runbook.md
+++ b/docs/chat-capability-validation-runbook.md
@@ -1,0 +1,446 @@
+# Octo 聊天能力与 Client 集成验证手册
+
+> 日期：2026-09-03  
+> 目标：同时证明 octo-web 原有能力没有被破坏，并证明 octo-buddy-client 集成链路可用于真实交付。
+
+## 1. 验证原则
+
+本次验证分成四道门禁：
+
+1. **Web 回归门禁**：原有聊天、通讯录和跨模块功能继续通过。
+2. **能力边界门禁**：`chat-core`、`chat-react` 和业务 `ConversationWindow` 的生命周期正确。
+3. **Artifact 门禁**：Client 使用的确实是指定 octo-web 提交构建出的生产产物。
+4. **Client 集成门禁**：布局、登录态、Space、导航、异常恢复和打包均正常。
+
+只有四道门禁全部通过，才能判定集成成功。
+
+## 2. 当前代码位置
+
+```text
+octo-web:
+/Users/will/Project/octo/octo-web-chat-capability-vertical-slice
+
+octo-buddy-client:
+/Users/will/Project/octo/octo-buddy-client-chat-capability-integration
+```
+
+预期提交：
+
+```text
+octo-web              65a6e2e0
+octo-buddy-client     c334476
+```
+
+先检查工作分支：
+
+```bash
+git -C /Users/will/Project/octo/octo-web-chat-capability-vertical-slice status --short --branch
+git -C /Users/will/Project/octo/octo-web-chat-capability-vertical-slice log -1 --oneline
+
+git -C /Users/will/Project/octo/octo-buddy-client-chat-capability-integration status --short --branch
+git -C /Users/will/Project/octo/octo-buddy-client-chat-capability-integration log -1 --oneline
+```
+
+文档本身尚未提交时，octo-web 可以出现 `docs/` 文件变更；源码不应出现无法解释的额外修改。
+
+## 3. 门禁一：验证 octo-web 没有被破坏
+
+### 3.1 新能力基础测试
+
+```bash
+cd /Users/will/Project/octo/octo-web-chat-capability-vertical-slice
+
+pnpm --filter @octo/chat-core test
+pnpm --filter @octo/chat-react test
+```
+
+通过标准：
+
+- `chat-core`：52 tests passed。
+- `chat-react`：15 tests passed。
+- 没有 failed、unhandled rejection 或测试进程异常退出。
+
+`chat-react` 测试中可能出现 `useChatClient must be used within a <ChatProvider>` 错误栈，这是测试故意验证错误边界时产生的日志。只要最终结果为 15 passed，就不是失败。
+
+### 3.2 原有基础包全量回归
+
+```bash
+pnpm --filter @octo/base test
+```
+
+通过标准：
+
+- 473 test files passed。
+- 4323 tests passed。
+- 退出码为 0。
+
+JSDOM 可能输出 `HTMLMediaElement.play()`、`load()` 或 `window.open()` 未实现提示。这些是已有测试环境限制，最终 tests passed 即可。
+
+这一步是确认 `ChatPage`、`ThreadPanel`、`Conversation` 和 `WKLayout` 的改造没有破坏原有组件行为。
+
+### 3.3 octo-web 全量构建
+
+```bash
+pnpm build
+```
+
+通过标准：
+
+- Turbo 所有目标完成。
+- `apps/web` 正常生成生产 build。
+- 没有 TypeScript、Vite、Rollup 或模块解析错误。
+
+### 3.4 原有 Web 聊天与通讯录 E2E
+
+推荐至少运行下面五组已有用例：
+
+```bash
+pnpm --filter @octo/web test:e2e -- \
+  e2e-kit/tests/chat/chat-main-flow.spec.ts \
+  e2e-kit/tests/chat/chat-interactions.spec.ts \
+  e2e-kit/tests/chat/chat-layout-coverage.spec.ts \
+  e2e-kit/tests/contacts/contacts-main-flow.spec.ts \
+  e2e-kit/tests/cross-module/X1-cross-module-chat-summary-return.spec.ts
+```
+
+它们分别证明：
+
+| 用例 | 主要验证内容 |
+| --- | --- |
+| `chat-main-flow` | 会话列表、打开会话、基础发送和聊天主流程 |
+| `chat-interactions` | 消息交互、编辑器和会话操作 |
+| `chat-layout-coverage` | 原 Web 布局及聊天区域没有被嵌入模式影响 |
+| `contacts-main-flow` | 联系人、群组及从通讯录进入会话 |
+| `X1-cross-module-chat-summary-return` | 聊天与摘要等既有跨模块导航 |
+
+通过标准：
+
+- 所有用例退出码为 0。
+- 原始 Web 页面仍有自己的导航结构。
+- 聊天页面不是强制进入 Client 的 embedded 布局。
+- 通讯录进入会话后，返回和跨模块跳转行为保持原样。
+
+### 3.5 与 upstream/main 做差分回归
+
+若需要最强的“没有破坏”证据，应在相同机器、相同 Node/pnpm 和相同测试数据下，对 `upstream/main` 与功能分支运行同一组 E2E。
+
+建议记录：
+
+| 指标 | upstream/main | 功能分支 |
+| --- | --- | --- |
+| E2E 通过数 | 记录实际结果 | 记录实际结果 |
+| 失败用例 | 记录实际结果 | 不允许新增失败 |
+| 页面截图 | 基线 | 不允许非预期布局变化 |
+| 首次进入聊天耗时 | 基线 | 不应出现明显退化 |
+| WebSocket 连接数 | 基线 | 不应出现重复连接 |
+
+判定规则：功能分支不能出现基线没有的新失败。已有不稳定用例应单独记录，不能通过重试掩盖。
+
+### 3.6 真实后端人工冒烟
+
+启动 octo-web：
+
+```bash
+pnpm dev
+```
+
+使用真实账号至少完成：
+
+- 登录并进入原 Web 消息页面。
+- 打开单聊和群聊。
+- 发送一条文本消息。
+- 发送一个小文件或图片。
+- 收到一条对端消息并看到未读变化。
+- 切换两个会话，确认消息没有串会话。
+- 打开 ThreadPanel，确认辅助会话不抢占主会话。
+- 进入通讯录，从联系人和群组分别发起会话。
+- 切换 Space 后检查会话和通讯录数据已切换。
+- 刷新页面后重新进入聊天。
+
+失败判定：重复消息、重复连接、会话串台、发送状态不更新、返回错误页面、ThreadPanel 抢占主会话，均视为阻断问题。
+
+## 4. 门禁二：验证能力拆分本身
+
+### 4.1 `ManagedChatClient` 生命周期
+
+由 `chat-core` 的 52 项测试覆盖：
+
+- 重复 `start()` 不建立第二条连接。
+- 重复 `stop()` 不重复释放。
+- stop 是完整 teardown barrier。
+- 快速切换会话时最新请求获胜。
+- 旧连接 epoch 的迟到回调失效。
+- lease 重复 release 安全。
+- adapter 失败进入 failed 状态。
+
+### 4.2 React 会话边界
+
+由 `chat-react` 的 15 项测试覆盖：
+
+- mount 打开会话。
+- unmount 释放会话。
+- channel 改变释放旧会话并打开新会话。
+- `activate=false` 不占用主会话。
+- 异步旧请求迟到后立即释放。
+- 组件卸载后不更新 state。
+
+### 4.3 octo-web 自己消费新组件
+
+人工或代码审阅需要确认：
+
+- `ChatPage` 使用 `Components/ConversationWindow`。
+- `ThreadPanel` 使用 `ConversationSurface`。
+- 两者通过同一个 `getLegacyChatRuntime()` 获取共享 client。
+- 没有为 Client 复制第二份消息渲染或编辑器实现。
+
+## 5. 门禁三：验证生产通信 Artifact
+
+### 5.1 构建生产产物
+
+```bash
+cd /Users/will/Project/octo/octo-web-chat-capability-vertical-slice
+
+VITE_API_URL=<实际 API Origin> \
+pnpm --filter @octo/web build:client-communication
+```
+
+不要设置：
+
+```text
+VITE_E2E_MOCK=1
+VITE_E2E_MOCK_IM=1
+```
+
+否则生成的是测试产物，Client 的生产准备脚本会拒绝它。
+
+### 5.2 检查 manifest
+
+```bash
+cat apps/web/build-client-communication/renderer-manifest.json
+```
+
+预期关键字段：
+
+```json
+{
+  "schemaVersion": 1,
+  "name": "octo-web-client-communication",
+  "version": "1.0.12",
+  "commit": "65a6e2e0",
+  "entry": "index.html",
+  "hostBridgeMajor": 1,
+  "e2eMock": false
+}
+```
+
+任何 version、commit 或 Bridge major 不匹配都应阻止进入 Client 构建。
+
+### 5.3 准备 Client 产物
+
+```bash
+cd /Users/will/Project/octo/octo-buddy-client-chat-capability-integration
+
+OCTOBUDDY_COMMUNICATION_SOURCE=/Users/will/Project/octo/octo-web-chat-capability-vertical-slice/apps/web/build-client-communication \
+pnpm prepare:communication-artifact
+```
+
+随后比较：
+
+```bash
+cat resources/communication/expected-renderer.json
+cat resources/communication/renderer/renderer-manifest.json
+```
+
+通过标准：version、commit、name、schemaVersion 和 hostBridgeMajor 完全一致，实际 manifest 的 `e2eMock` 为 `false`。
+
+## 6. 门禁四：验证 Client 集成成功
+
+### 6.1 静态与单元测试
+
+```bash
+cd /Users/will/Project/octo/octo-buddy-client-chat-capability-integration
+
+pnpm typecheck
+pnpm test:unit
+```
+
+通过标准：
+
+- typecheck 退出码为 0。
+- Client unit tests 49 passed。
+- artifact、IPC 参数、恢复限流、下载安全测试全部通过。
+
+### 6.2 Electron 通信 E2E
+
+先生成仅用于测试的通信 artifact：
+
+```bash
+cd /Users/will/Project/octo/octo-web-chat-capability-vertical-slice
+
+VITE_API_URL=http://mock.e2e.local \
+VITE_E2E_MOCK=1 \
+VITE_E2E_MOCK_IM=1 \
+pnpm --filter @octo/web build:client-communication
+```
+
+将测试 artifact 复制到 Client。只有这一步允许显式放行 E2E 产物：
+
+```bash
+cd /Users/will/Project/octo/octo-buddy-client-chat-capability-integration
+
+OCTOBUDDY_COMMUNICATION_SOURCE=/Users/will/Project/octo/octo-web-chat-capability-vertical-slice/apps/web/build-client-communication \
+OCTOBUDDY_ALLOW_E2E_COMMUNICATION_ARTIFACT=1 \
+pnpm prepare:communication-artifact
+```
+
+确认测试 manifest 中 `e2eMock` 为 `true`，然后执行：
+
+```bash
+pnpm test:e2e -- tests/e2e/communication.spec.ts
+```
+
+通过标准：11 tests passed。
+
+该套 E2E 必须证明：
+
+- Client 有消息和通讯录入口。
+- 两个入口复用同一个 WebContentsView。
+- embedded 模式不会显示 octo-web 自己的主导航栏。
+- 可以从通讯录联系人和群组发起会话。
+- 可以输入并发送消息。
+- 可以选择附件。
+- 内部跳转会同步 Client 侧栏状态。
+- 首次加载目标会话不会丢失。
+- 首载期间 Space 更新不会被旧 ready 状态覆盖。
+- 隐藏后迟到导航不会抢回页面。
+- renderer 崩溃按限制自动恢复。
+- renderer 无响应后可以手动重试。
+- 同 UID token 更新后 renderer 会重载。
+
+E2E 完成后必须恢复生产 artifact：
+
+```bash
+cd /Users/will/Project/octo/octo-web-chat-capability-vertical-slice
+
+VITE_API_URL=<实际 API Origin> \
+pnpm --filter @octo/web build:client-communication
+
+cd /Users/will/Project/octo/octo-buddy-client-chat-capability-integration
+
+OCTOBUDDY_COMMUNICATION_SOURCE=/Users/will/Project/octo/octo-web-chat-capability-vertical-slice/apps/web/build-client-communication \
+pnpm prepare:communication-artifact
+```
+
+最后再次确认 Client 内实际 manifest 的 `e2eMock` 为 `false`。测试 artifact 不能用于 `pnpm build:mac` 或其他发布打包。
+
+### 6.3 Client 构建
+
+```bash
+pnpm build
+```
+
+通过标准：
+
+- packages 构建成功。
+- Electron main、preload 和 renderer 构建成功。
+- communication preload 被正确生成。
+- 没有缺失 artifact 或 manifest 不匹配错误。
+
+发布前建议再执行对应平台打包，例如 macOS：
+
+```bash
+pnpm build:mac
+```
+
+安装包中应包含 `resources/communication/renderer`，并且启动后不依赖 octo-web 源码目录或开发服务器。
+
+### 6.4 真实账号人工验收
+
+启动 Client：
+
+```bash
+pnpm dev
+```
+
+按顺序验证：
+
+1. 使用 Client 原有登录入口登录。
+2. 点击“消息”，应在 Client 中央区域显示 octo-web 会话列表和聊天窗口。
+3. 点击“通讯录”，应复用原 View，不闪回登录页，不重新初始化整套应用。
+4. 点击一个联系人并选择“发送消息”，Client 侧栏应自动切换到“消息”。
+5. 发送文本、图片或文件，对端能够收到，发送状态正常。
+6. 从对端发送消息，Client 左侧消息入口显示未读数。
+7. 在消息和通讯录之间反复切换，不应重复连接或重复收到消息。
+8. 切换 Space，通信内容应切换到新 Space。
+9. 最小化、隐藏和恢复 Client，通信内容仍可继续使用。
+10. 打开 Client 弹窗遮挡通信区域时，原生 View 不应盖住弹窗。
+11. 更新同账号 token 后，通信 renderer 应自动重载并继续工作。
+12. 退出登录后，旧账号聊天内容不应继续显示。
+
+### 6.5 开发者工具辅助检查
+
+人工验收时建议同时检查：
+
+- Network 中只有一条主要 IM WebSocket 连接。
+- 消息/通讯录切换不会新增第二条连接。
+- Console 没有重复 listener、setState after unmount 或 IPC sender 拒绝错误。
+- `renderer-manifest.json` 来自预期 commit。
+- 页面切换时 Client 主 renderer 不刷新。
+- 通信 renderer 崩溃或重载时 Client 主界面不退出。
+
+## 7. 最小验收集
+
+时间有限时，至少执行以下命令：
+
+```bash
+# octo-web
+pnpm --filter @octo/chat-core test
+pnpm --filter @octo/chat-react test
+pnpm --filter @octo/base test
+pnpm build
+
+# octo-buddy-client
+pnpm typecheck
+pnpm test:unit
+pnpm test:e2e -- tests/e2e/communication.spec.ts
+pnpm build
+```
+
+再人工完成四个动作：
+
+1. 原 octo-web 打开会话并发送消息。
+2. Client 打开消息并发送消息。
+3. Client 从通讯录联系人发起会话。
+4. Client 切换 Space 后继续打开和发送消息。
+
+自动化全部通过且四个人工动作成功，才能作为最小可接受结论。
+
+## 8. 验收记录模板
+
+```text
+验证日期：
+验证人：
+octo-web commit：
+client commit：
+artifact version / commit：
+
+[ ] chat-core 52 passed
+[ ] chat-react 15 passed
+[ ] @octo/base 4323 passed
+[ ] octo-web build passed
+[ ] Web chat/contact E2E passed
+[ ] production artifact e2eMock=false
+[ ] Client typecheck passed
+[ ] Client unit 49 passed
+[ ] Client communication E2E 11 passed
+[ ] Client build passed
+[ ] octo-web 真实账号冒烟 passed
+[ ] Client 真实账号冒烟 passed
+[ ] Space 切换 passed
+[ ] 登录/退出/token 轮换 passed
+[ ] 单 WebContentsView / 单 IM 连接 passed
+
+新增失败：
+已知非阻断问题：
+最终结论：通过 / 有条件通过 / 不通过
+```

--- a/docs/chat-capability-vertical-slice-implementation-report.md
+++ b/docs/chat-capability-vertical-slice-implementation-report.md
@@ -284,6 +284,10 @@ manifest 包含：
 - 检查窗口焦点。
 - 查询麦克风权限。
 
+通信产物的 `apiOrigin` 由 Client 在运行时注入，并且本地验证需要支持 HTTP/WS，
+因此 HTML CSP 的网络指令保留在协议级白名单。具体 origin 的信任边界必须由 Electron
+Client 的导航拦截、窗口创建策略和 session 权限处理器执行，不能依赖构建时写死某个线上域名。
+
 下载实现增加了：
 
 - 仅允许 HTTPS，开发/E2E 场景可显式允许 HTTP。
@@ -386,7 +390,7 @@ Client Space 改变
 
 | 范围 | 结果 |
 | --- | --- |
-| `@octo/chat-core` | 54 tests passed |
+| `@octo/chat-core` | 57 tests passed |
 | `@octo/chat-react` | 24 tests passed |
 | `@octo/base` | 473 files / 4325 tests passed |
 | octo-web unit tests | 113 files / 1419 tests passed |

--- a/docs/chat-capability-vertical-slice-implementation-report.md
+++ b/docs/chat-capability-vertical-slice-implementation-report.md
@@ -1,0 +1,466 @@
+# Octo 聊天能力纵向拆分与 Client 集成实施报告
+
+> 日期：2026-09-03  
+> octo-web 分支：`feat/chat-capability-vertical-slice`  
+> octo-buddy-client 分支：`feat/chat-capability-integration`
+
+## 1. 报告结论
+
+本次实现验证的不是若干互相竞争的集成方案，而是一条统一的能力演进路径：
+
+```text
+@octo/chat-core
+        ↓
+@octo/chat-react
+        ↓
+ConversationWindow / ConversationSurface
+        ↓
+ChatPage + ContactsList 组成的 CommunicationShell
+        ↓
+client-communication 独立构建产物
+        ↓
+octo-buddy-client WebContentsView 宿主
+```
+
+这条路径同时解决两个问题：
+
+1. octo-web 内部可以逐步把聊天能力从页面代码中拆出，形成可组合的功能模块。
+2. octo-buddy-client 可以继续使用自己的整体布局、登录入口和 Electron 能力，同时复用 octo-web 已有聊天与通讯录业务实现。
+
+当前已经跑通完整纵向链路，包括 Client 侧的消息/通讯录入口、登录态注入、Space 同步、联系人发起会话、未读数、窗口生命周期、异常恢复、构建产物校验和生产打包。
+
+需要明确的是：当前并没有完成 WKSDK 的彻底抽离。`legacyChatClient` 仍然是 `chat-core` 和 octo-web 既有聊天运行时之间的适配层，连接和断开操作暂时还是空实现，消息发送仍依赖已挂载的旧 `ConversationContext`。因此，当前成果是可用的功能边界和迁移骨架，不是已经完全独立的新聊天 SDK。
+
+## 2. 实际提交
+
+### 2.1 octo-web
+
+| 提交 | 内容 |
+| --- | --- |
+| `9bdc986b` | 抽离聊天核心、React 生命周期层和业务 ConversationWindow |
+| `62eaee2b` | 为嵌入式通信宿主补充布局与运行能力 |
+| `1ce396c8` | 新增 Client 通信单入口和独立构建产物 |
+| `65a6e2e0` | 加固首次导航、连接和嵌入生命周期，并修复会话视口高度链 |
+
+相对 `upstream/main` 共修改 48 个文件，新增约 5273 行，删除约 348 行。
+
+### 2.2 octo-buddy-client
+
+| 提交 | 内容 |
+| --- | --- |
+| `f615a99` | 在 Client 中嵌入 octo-web 消息和通讯录 |
+| `8261073` | 将校验后的通信 renderer 加入打包流程 |
+| `5f4bfb0` | 修复跨平台 after-pack 资源路径 |
+| `c334476` | 加固 renderer 边界、生命周期、下载和版本锁定 |
+
+相对 `origin/main` 共修改 30 个文件，新增约 2343 行，删除约 27 行。
+
+## 3. 已实现能力
+
+### 3.1 无框架聊天核心 `@octo/chat-core`
+
+代码位置：
+
+- `packages/chat-core/src/types.ts`
+- `packages/chat-core/src/ManagedChatClient.ts`
+- `packages/chat-core/src/ManagedChatClient.test.ts`
+
+已经实现：
+
+- SDK 无关的 `ChatClient` 接口。
+- `start()`、`stop()`、`openConversation()`、`getSnapshot()` 和事件订阅。
+- `ChatConnectionAdapter`、`ChatConversationAdapter`、`ChatSubscribeAdapter`、`ChatMessageAdapter` 四类适配接口。
+- 通用消息端口：历史消息加载、消息订阅、发送状态订阅、发送消息。
+- `ChatConversationLease` 会话租约，使用幂等 `release()` 管理释放。
+- `start()` 和 `stop()` 幂等。
+- 连接、会话切换和释放过程串行化。
+- 并发打开会话采用 latest-request-wins。
+- 连接 epoch 隔离，旧连接的迟到回调不能覆盖新连接状态。
+- transport 主动报告断线和恢复。
+- adapter 异常统一反映为 `failed` 状态。
+
+这一层不依赖 React，也不直接依赖 `wukongimjssdk`，是后续真正下沉 SDK 生命周期的目标位置。
+
+### 3.2 React 生命周期层 `@octo/chat-react`
+
+代码位置：
+
+- `packages/chat-react/src/ChatProvider.tsx`
+- `packages/chat-react/src/ConversationWindow.tsx`
+- `packages/chat-react/src/hooks.ts`
+
+已经实现：
+
+- `ChatProvider` 向组件树提供唯一 `ChatClient`。
+- hooks 读取客户端、状态和宿主能力。
+- 无 UI 假设的 `ConversationWindow` 生命周期边界。
+- 组件挂载或 channel 改变时打开会话。
+- 组件卸载、停用或切换 channel 时释放会话。
+- 防止异步 `openConversation()` 迟到后污染新会话。
+- 防止组件卸载后继续更新 React state。
+- 支持 render function，调用方可以自行决定 UI。
+
+这里的 `ConversationWindow` 是会话生命周期组件，不负责绘制完整聊天界面。
+
+### 3.3 可独立组合的业务聊天窗口
+
+代码位置：
+
+- `packages/dmworkbase/src/Components/ConversationWindow/index.tsx`
+- `packages/dmworkbase/src/Components/ConversationWindow/index.css`
+- `packages/dmworkbase/src/Components/Conversation/index.tsx`
+
+已经实现两个层次：
+
+#### `ConversationSurface`
+
+只包含会话内容区域，适合嵌入抽屉、ThreadPanel 或其他组合界面。
+
+- 接收 `ChatClient` 和目标 `Channel`。
+- 通过 `ChatProvider` 和 `chat-react` 管理会话租约。
+- 复用原有消息列表、编辑器、附件、消息状态等业务 UI。
+- 支持 `primary` 和 `auxiliary` 模式。
+- 可绑定旧 `ConversationContext`，作为迁移期间的兼容入口。
+
+#### `ConversationWindow`
+
+在 `ConversationSurface` 外增加完整窗口结构：
+
+- 会话标题和头像。
+- 返回操作。
+- 右侧业务操作区。
+- 消息多选状态和取消操作。
+- inactive 状态及辅助功能隔离。
+- 错误边界。
+
+原 `ChatPage` 已改为使用该窗口，`ThreadPanel` 也改为复用统一的 `ConversationSurface`。这证明它不是只为 Client 构造的旁路组件，而是已经开始由 octo-web 自身消费。
+
+### 3.4 旧聊天运行时适配器
+
+代码位置：
+
+- `packages/dmworkbase/src/features/chat-capability/legacyChatClient.ts`
+
+已经实现：
+
+- 将 `ChatChannelRef` 转换为 WKSDK `Channel`。
+- 将通用历史消息加载参数转换为 `SyncMessageOptions`。
+- 将 WKSDK 消息监听映射为 `ChatMessagePort`。
+- 将发送状态监听映射为通用消息状态订阅。
+- 通过共享 runtime 保证页面内使用同一个 `ManagedChatClient`。
+- 通过 `bindConversationContext()` 暂时复用原有消息发送能力。
+
+当前限制：
+
+- `connect()` 和 `disconnect()` 暂时没有接管 WKSDK 生命周期。
+- `sendMessage()` 仍需要已挂载的旧 `ConversationContext`。
+- 消息实体仍直接使用 WKSDK 的 `Message`、`MessageContent` 和 `SendackPacket`。
+
+这部分是下一阶段真正 SDK 化的主要工作区。
+
+### 3.5 消息与通讯录工作台入口
+
+代码位置：
+
+- `apps/web/src/client-communication/index.tsx`
+- `apps/web/src/client-communication/CommunicationShell.tsx`
+- `apps/web/src/client-communication/hostBridge.ts`
+
+已经实现：
+
+- 独立启动 octo-web 通信所需模块，不启动完整站点外壳。
+- 从宿主获取登录信息、API Origin、Space、主题和语言。
+- 使用 Client 已有登录态初始化 `WKApp.loginInfo`，没有再实现一套登录页面。
+- 注册 Base、DataSource、Contacts、Summary 和企业模块。
+- 同一 renderer 中组合 `ChatPage` 与 `ContactsList`。
+- 在消息和通讯录之间切换，不销毁通信运行时。
+- 通讯录卡片继续调用 octo-web 的 `WKApp.endpoints.showConversation()` 发起会话。
+- 支持宿主直接打开指定 channel、定位消息或打开会话内搜索。
+- 将内部页面跳转回报给 Client，使 Client 左侧入口保持同步。
+- 将会话未读总数同步给 Client。
+- 支持 `spaceChanged`、`appearanceChanged`、`suspend`、`resume` 和 `sessionRevoked`。
+- command listener 和左右路由都准备完成后才上报 ready，避免首次目标会话丢失。
+
+因此，通讯录点击卡片发起会话并不是 Client 重新实现的逻辑，而是继续复用 octo-web 已有通讯录和会话打开链路。
+
+### 3.6 octo-web 单入口独立构建
+
+代码位置：
+
+- `apps/web/client-communication.html`
+- `apps/web/vite.client-communication.config.ts`
+- `apps/web/scripts/build-client-communication.mjs`
+
+构建命令：
+
+```bash
+VITE_API_URL=<api-origin> pnpm --filter octo-web build:client-communication
+```
+
+输出目录：
+
+```text
+apps/web/build-client-communication/
+├── index.html
+├── assets/
+└── renderer-manifest.json
+```
+
+manifest 包含：
+
+- schema 版本。
+- 产物名称。
+- octo-web 版本。
+- Git commit。
+- HTML 入口。
+- Host Bridge major 版本。
+- 是否为 E2E mock 产物。
+
+这不是复制整个 octo-web 站点，而是为通信工作台增加一个独立 Vite/Rollup 入口，共用原有源码、依赖和业务模块。
+
+### 3.7 Client 布局融合
+
+代码位置：
+
+- `src/renderer/src/App.tsx`
+- `src/renderer/src/communication/CommunicationViewSlot.tsx`
+
+已经实现：
+
+- Client 左侧增加“消息”和“通讯录”入口。
+- 消息入口显示未读数，超过 99 显示 `99+`。
+- Client 自己保留侧边栏和整体页面布局。
+- 中央内容区域提供 `CommunicationViewSlot`。
+- Slot 实时测量坐标和尺寸并同步给 Electron 主进程。
+- 打开对话框等遮挡场景时隐藏通信 View。
+- 加载、恢复和失败时显示 Client 自己的状态 UI。
+- 失败后提供“重试”操作。
+- octo-web 内部从联系人跳入聊天时，Client 的侧栏选中项也会同步变化。
+
+### 3.8 Electron WebContentsView 宿主
+
+代码位置：
+
+- `electron/main/communication/view-manager.ts`
+- `electron/main/communication/ipc.ts`
+- `electron/main/communication/ipc-validation.ts`
+- `electron/communication-preload/index.ts`
+
+已经实现：
+
+- 使用单个持久 `WebContentsView` 承载通信 renderer。
+- 消息和通讯录切换复用同一个 View，不重复建立 IM 运行时。
+- 根据 Client Slot 的 bounds 设置原生 View 位置。
+- 通过独立 preload 暴露最小通信 Bridge。
+- 主页面和子 renderer 的 IPC 分开校验。
+- 只接受目标通信 entry 主 frame 发出的子 IPC。
+- 不向网页暴露原始 Electron IPC event。
+- ready 前命令排队，按类型合并过期命令。
+- 支持首次加载时的并发导航和 Space 更新。
+- Client 隐藏后忽略迟到的内部导航，避免抢回通信页面。
+- 主窗口隐藏/恢复时发送 suspend/resume。
+- 同账号 token 或 apiOrigin 更新时重载 renderer。
+- 切换账号、退出登录、登录失效和应用退出时销毁通信运行时。
+- renderer 无响应、崩溃或加载超时时进入失败/恢复流程。
+- 自动恢复受次数限制，手动重试可以重新创建 View。
+
+### 3.9 系统能力代理
+
+通信 renderer 不直接获得 Node 或 Electron 权限。以下能力通过窄 Bridge 交给宿主：
+
+- 打开外部链接。
+- 下载文件并显示系统保存对话框。
+- 系统通知及通知点击回传。
+- 检查窗口焦点。
+- 查询麦克风权限。
+
+下载实现增加了：
+
+- 仅允许 HTTPS，开发/E2E 场景可显式允许 HTTP。
+- 拒绝 URL 中携带用户名和密码。
+- 私网和本机地址限制。
+- 重定向逐跳重新校验。
+- 最多 5 次重定向。
+- 5 分钟超时。
+- 512 MB 大小限制。
+- 流式写入，避免整文件进入内存。
+- 失败时删除不完整文件。
+
+### 3.10 产物打包和版本锁定
+
+Client 代码位置：
+
+- `scripts/prepare-communication-artifact.mjs`
+- `resources/communication/expected-renderer.json`
+- `electron/main/communication/artifact-validation.ts`
+- `electron-builder.yml`
+
+当前锁定产物：
+
+```json
+{
+  "schemaVersion": 1,
+  "name": "octo-web-client-communication",
+  "version": "1.0.12",
+  "commit": "65a6e2e0",
+  "hostBridgeMajor": 1
+}
+```
+
+实际复制到 Client 的生产 manifest 中 `e2eMock` 为 `false`。
+
+打包前会校验名称、schema、版本、commit、Bridge major 和入口路径。未找到外部产物时会直接失败，不再静默复用本地 ignored 目录中的旧 renderer。E2E mock 产物默认禁止进入生产包。
+
+## 4. 关键运行链路
+
+### 4.1 从 Client 打开消息
+
+```text
+用户点击 Client“消息”
+  -> App 将 view 切换为 octo-chat
+  -> CommunicationViewSlot 上报 page + bounds
+  -> 主进程 CommunicationViewManager 创建或复用 WebContentsView
+  -> renderer 通过 Bridge 获取 Client 登录态和 Space
+  -> CommunicationShell 初始化 octo-web 模块
+  -> ChatPage 渲染会话列表和 ConversationWindow
+  -> renderer reportReady
+  -> Client 状态切换为 ready
+```
+
+### 4.2 从通讯录发起会话
+
+```text
+用户点击 Client“通讯录”
+  -> 同一个 WebContentsView 切换到 ContactsList
+  -> 用户点击联系人或群组卡片
+  -> octo-web 调用 WKApp.endpoints.showConversation(channel)
+  -> 右侧路由打开 ChatPage 会话
+  -> CommunicationShell 回报 page=chat
+  -> Client 左侧自动选中“消息”
+```
+
+### 4.3 Client 主动打开指定会话
+
+```text
+Client communication:show({ page: chat, target })
+  -> ready 前进入 pending command 队列
+  -> 左右路由和 command listener 全部准备完成
+  -> 执行 navigate
+  -> openTarget(target)
+  -> WKApp.endpoints.showConversation(channel, options)
+```
+
+### 4.4 Space 与登录生命周期
+
+```text
+Client Space 改变
+  -> updateSpace
+  -> spaceChanged command
+  -> 更新 WKApp.shared.currentSpaceId
+  -> 触发 octo-web space-changed 事件
+
+同 UID token 更新
+  -> 销毁旧 renderer
+  -> 使用新 bootstrap 重建
+
+切换账号/退出登录
+  -> 销毁 View
+  -> 清理独立 partition 存储
+```
+
+## 5. 验证结果
+
+| 范围 | 结果 |
+| --- | --- |
+| `@octo/chat-core` | 52 tests passed |
+| `@octo/chat-react` | 15 tests passed |
+| `@octo/base` | 473 files / 4323 tests passed |
+| octo-web 正式 build | 通过 |
+| production communication build | 通过 |
+| Client typecheck | 通过 |
+| Client unit tests | 49 passed |
+| Communication Electron E2E | 11 passed |
+| production manifest | `1.0.12 / 65a6e2e0 / e2eMock:false` |
+
+E2E 覆盖：
+
+- 消息与通讯录复用一个 WebContentsView。
+- 首次加载并发导航。
+- 首次加载直接打开指定联系人会话。
+- 首载期间 Space 发生变化。
+- 隐藏状态下忽略迟到导航。
+- 未读数同步。
+- 外部链接、下载和通知 Bridge。
+- renderer 崩溃自动恢复及恢复限流。
+- renderer 无响应后手动重试。
+- 同账号 token 轮换后重载。
+
+## 6. 如何本地复核
+
+### 6.1 构建 octo-web 通信产物
+
+```bash
+cd /Users/will/Project/octo/octo-web-chat-capability-vertical-slice
+VITE_API_URL=<实际 API Origin> pnpm --filter octo-web build:client-communication
+```
+
+### 6.2 将产物准备到 Client
+
+```bash
+cd /Users/will/Project/octo/octo-buddy-client-chat-capability-integration
+OCTOBUDDY_COMMUNICATION_SOURCE=/Users/will/Project/octo/octo-web-chat-capability-vertical-slice/apps/web/build-client-communication pnpm prepare:communication-artifact
+```
+
+### 6.3 验证 Client
+
+```bash
+pnpm typecheck
+pnpm test:unit
+pnpm test:e2e -- tests/e2e/communication.spec.ts
+pnpm build
+```
+
+## 7. 合理性评估
+
+### 7.1 为什么没有直接复制 Chat 页面源码到 Client
+
+直接复制会同时复制 WKApp 全局状态、路由、模块注册、SDK 单例和大量隐式依赖。短期可能显示 UI，长期会形成两套聊天实现、两套修复分支和两条升级链路。
+
+当前方案仍然复用 octo-web 的完整业务实现，但通过独立入口和版本化 Bridge 隔离宿主差异。Client 不需要理解每一种消息类型，也不需要重新实现编辑器、消息状态或通讯录业务。
+
+### 7.2 为什么同时需要包和构建产物
+
+它们不是两个方案：
+
+- 包负责源码内部的能力分层与组合。
+- 构建产物负责跨应用、跨 React 运行时和 Electron 安全边界交付。
+
+octo-web 内部使用包级能力，Client 使用由同一能力链构建出的 artifact。这样只有一套业务实现。
+
+### 7.3 为什么当前阶段仍保留 legacy adapter
+
+一次性迁走 WKSDK 连接、数据源、消息模型、编辑器、插件和缓存风险过高。先引入稳定接口和功能边界，可以让旧实现继续工作，同时为每一项依赖提供明确迁移位置。
+
+## 8. 当前未完成项
+
+以下能力尚未达到最终目标：
+
+1. WKSDK connect/disconnect 尚未进入 `chat-core` adapter。
+2. 消息模型尚未转换为完全 SDK 无关的数据结构。
+3. 发送消息仍通过旧 `ConversationContext` 桥接。
+4. `ConversationWindow` 尚未独立构建为一个最小 artifact；当前 artifact 是消息加通讯录工作台。
+5. 主题暂时由 Client 固定传入浅色和中文，尚未连接 Client 的真实主题/语言设置。
+6. host 和 renderer 的 Bridge 类型目前在两个仓库各维护一份，后续应生成或发布共享 contract 包。
+
+## 9. 下一阶段建议
+
+下一阶段不再新建第二套实现，应继续沿现有链路推进：
+
+1. 将 WKSDK 连接、重连和断线回调迁入 `ChatConnectionAdapter`。
+2. 将 `ConversationContext.sendMessage()` 依赖迁入 `ChatMessageAdapter`。
+3. 为消息 DTO 建立 SDK 到 core model 的转换层。
+4. 让更多 octo-web 原生入口直接消费统一 `ConversationWindow`。
+5. 将 Bridge contracts 提取为可版本化共享包。
+6. 在同一构建配置中增加可选 `conversation-window` 入口，但仍复用相同 core、React 层和业务窗口，不复制实现。
+
+完成前三项以后，聊天窗口才真正具备脱离 octo-web 全局运行时、由任意 React 宿主直接组合的条件。

--- a/docs/chat-capability-vertical-slice-implementation-report.md
+++ b/docs/chat-capability-vertical-slice-implementation-report.md
@@ -203,7 +203,7 @@ octo-buddy-client WebContentsView 宿主
 构建命令：
 
 ```bash
-VITE_API_URL=<api-origin> pnpm --filter octo-web build:client-communication
+VITE_API_URL=<api-origin> pnpm --filter @octo/web build:client-communication
 ```
 
 输出目录：

--- a/docs/chat-capability-vertical-slice-implementation-report.md
+++ b/docs/chat-capability-vertical-slice-implementation-report.md
@@ -41,8 +41,9 @@ octo-buddy-client WebContentsView 宿主
 | `62eaee2b` | 为嵌入式通信宿主补充布局与运行能力 |
 | `1ce396c8` | 新增 Client 通信单入口和独立构建产物 |
 | `65a6e2e0` | 加固首次导航、连接和嵌入生命周期，并修复会话视口高度链 |
+| `a2b05d41` | 增加可由宿主传入频道的独立会话 presentation |
 
-相对 `upstream/main` 共修改 48 个文件，新增约 5273 行，删除约 348 行。
+相对 `upstream/main` 共修改 51 个文件，新增约 6309 行，删除约 348 行。
 
 ### 2.2 octo-buddy-client
 
@@ -52,8 +53,9 @@ octo-buddy-client WebContentsView 宿主
 | `8261073` | 将校验后的通信 renderer 加入打包流程 |
 | `5f4bfb0` | 修复跨平台 after-pack 资源路径 |
 | `c334476` | 加固 renderer 边界、生命周期、下载和版本锁定 |
+| `e64c9f6` | 增加独立会话模拟入口和 presentation/target 宿主链路 |
 
-相对 `origin/main` 共修改 30 个文件，新增约 2343 行，删除约 27 行。
+相对 `origin/main` 共修改 31 个文件，新增约 2702 行，删除约 27 行。
 
 ## 3. 已实现能力
 
@@ -176,7 +178,10 @@ octo-buddy-client WebContentsView 宿主
 - 在消息和通讯录之间切换，不销毁通信运行时。
 - 通讯录卡片继续调用 octo-web 的 `WKApp.endpoints.showConversation()` 发起会话。
 - 支持宿主直接打开指定 channel、定位消息或打开会话内搜索。
+- 支持 `workspace` 和 `conversation` 两种 presentation：前者保留会话列表，后者只渲染指定聊天窗口。
+- `conversation` presentation 接收宿主传入的 `channelId/channelType`，但继续使用现有登录态、Space、IM 连接、历史消息和发送能力。
 - 将内部页面跳转回报给 Client，使 Client 左侧入口保持同步。
+- 将当前打开的真实频道回报给 Client，便于宿主把用户刚选择的会话再次嵌入独立窗口。
 - 将会话未读总数同步给 Client。
 - 支持 `spaceChanged`、`appearanceChanged`、`suspend`、`resume` 和 `sessionRevoked`。
 - command listener 和左右路由都准备完成后才上报 ready，避免首次目标会话丢失。
@@ -228,6 +233,7 @@ manifest 包含：
 已经实现：
 
 - Client 左侧增加“消息”和“通讯录”入口。
+- Client 左侧增加“独立会话”模拟入口，可输入 `channelId` 和 `channelType`，也可复用最近选择的真实频道。
 - 消息入口显示未读数，超过 99 显示 `99+`。
 - Client 自己保留侧边栏和整体页面布局。
 - 中央内容区域提供 `CommunicationViewSlot`。
@@ -302,7 +308,7 @@ Client 代码位置：
   "schemaVersion": 1,
   "name": "octo-web-client-communication",
   "version": "1.0.12",
-  "commit": "65a6e2e0",
+  "commit": "a2b05d41",
   "hostBridgeMajor": 1
 }
 ```
@@ -339,16 +345,20 @@ Client 代码位置：
   -> Client 左侧自动选中“消息”
 ```
 
-### 4.3 Client 主动打开指定会话
+### 4.3 Client 主动打开独立会话
 
 ```text
-Client communication:show({ page: chat, target })
+Client communication:show({ page: chat, presentation: conversation, target })
   -> ready 前进入 pending command 队列
   -> 左右路由和 command listener 全部准备完成
   -> 执行 navigate
   -> openTarget(target)
   -> WKApp.endpoints.showConversation(channel, options)
+  -> 隐藏会话列表和 splitter
+  -> 现有 ConversationWindow 填满通信区域
 ```
+
+切回“消息”时，Client 发送 `presentation: workspace`，同一个 WebContentsView 恢复会话列表加聊天窗口布局，不重建 IM 运行时。
 
 ### 4.4 Space 与登录生命周期
 
@@ -379,14 +389,17 @@ Client Space 改变
 | production communication build | 通过 |
 | Client typecheck | 通过 |
 | Client unit tests | 49 passed |
-| Communication Electron E2E | 11 passed |
-| production manifest | `1.0.12 / 65a6e2e0 / e2eMock:false` |
+| Communication Electron E2E | 12 passed |
+| production manifest | `1.0.12 / a2b05d41 / e2eMock:false` |
 
 E2E 覆盖：
 
 - 消息与通讯录复用一个 WebContentsView。
 - 首次加载并发导航。
 - 首次加载直接打开指定联系人会话。
+- Client 传入 `channelId/channelType` 后以独立会话模式打开现有频道。
+- 独立会话隐藏左侧列表、填满聊天区域并保留消息编辑器。
+- 从独立会话切回消息后恢复 workspace 布局。
 - 首载期间 Space 发生变化。
 - 隐藏状态下忽略迟到导航。
 - 未读数同步。
@@ -401,7 +414,7 @@ E2E 覆盖：
 
 ```bash
 cd /Users/will/Project/octo/octo-web-chat-capability-vertical-slice
-VITE_API_URL=<实际 API Origin> pnpm --filter octo-web build:client-communication
+VITE_API_URL=https://im.deepminer.com.cn pnpm --filter @octo/web build:client-communication
 ```
 
 ### 6.2 将产物准备到 Client
@@ -448,7 +461,7 @@ octo-web 内部使用包级能力，Client 使用由同一能力链构建出的 
 1. WKSDK connect/disconnect 尚未进入 `chat-core` adapter。
 2. 消息模型尚未转换为完全 SDK 无关的数据结构。
 3. 发送消息仍通过旧 `ConversationContext` 桥接。
-4. `ConversationWindow` 尚未独立构建为一个最小 artifact；当前 artifact 是消息加通讯录工作台。
+4. 当前仍是同一个 communication artifact 通过 presentation 切换工作台和独立会话，并非单独发布的 ConversationWindow artifact。
 5. 主题暂时由 Client 固定传入浅色和中文，尚未连接 Client 的真实主题/语言设置。
 6. host 和 renderer 的 Bridge 类型目前在两个仓库各维护一份，后续应生成或发布共享 contract 包。
 

--- a/docs/chat-capability-vertical-slice-implementation-report.md
+++ b/docs/chat-capability-vertical-slice-implementation-report.md
@@ -37,13 +37,17 @@ octo-buddy-client WebContentsView 宿主
 
 | 提交 | 内容 |
 | --- | --- |
-| `9bdc986b` | 抽离聊天核心、React 生命周期层和业务 ConversationWindow |
-| `62eaee2b` | 为嵌入式通信宿主补充布局与运行能力 |
-| `1ce396c8` | 新增 Client 通信单入口和独立构建产物 |
-| `65a6e2e0` | 加固首次导航、连接和嵌入生命周期，并修复会话视口高度链 |
-| `a2b05d41` | 增加可由宿主传入频道的独立会话 presentation |
+| `8b3dc19d` | 抽离聊天核心、React 生命周期层和业务 ConversationWindow |
+| `0bc116b3` | 为嵌入式通信宿主补充布局与运行能力 |
+| `606e3674` | 新增 Client 通信单入口和独立构建产物 |
+| `8ae4359f` | 加固首次导航、连接和嵌入生命周期 |
+| `c2b4e254` | 修复会话视口高度链 |
+| `f3ccbc8a` | 补充能力集成验证手册 |
+| `22a54d17` | 增加可由宿主传入频道的独立会话 presentation |
+| `bd04b3e2` | 补充独立会话集成设计与实施说明 |
+| `HEAD`（本提交） | 加固聊天生命周期、错误恢复和通信上报 |
 
-相对 `upstream/main` 共修改 51 个文件，新增约 6309 行，删除约 348 行。
+相对 `upstream/main` 共修改 57 个文件，新增约 8038 行，删除约 348 行。
 
 ### 2.2 octo-buddy-client
 
@@ -308,7 +312,7 @@ Client 代码位置：
   "schemaVersion": 1,
   "name": "octo-web-client-communication",
   "version": "1.0.12",
-  "commit": "a2b05d41",
+  "commit": "<git rev-parse --short HEAD>",
   "hostBridgeMajor": 1
 }
 ```
@@ -382,15 +386,16 @@ Client Space 改变
 
 | 范围 | 结果 |
 | --- | --- |
-| `@octo/chat-core` | 52 tests passed |
-| `@octo/chat-react` | 15 tests passed |
-| `@octo/base` | 473 files / 4323 tests passed |
+| `@octo/chat-core` | 54 tests passed |
+| `@octo/chat-react` | 24 tests passed |
+| `@octo/base` | 473 files / 4325 tests passed |
+| octo-web unit tests | 113 files / 1419 tests passed |
 | octo-web 正式 build | 通过 |
 | production communication build | 通过 |
 | Client typecheck | 通过 |
 | Client unit tests | 49 passed |
 | Communication Electron E2E | 12 passed |
-| production manifest | `1.0.12 / a2b05d41 / e2eMock:false` |
+| production manifest | 当前仅完成 provisional build；提交修复并从 clean tree 重建后，记录实际 `version / commit / e2eMock:false` |
 
 E2E 覆盖：
 

--- a/packages/chat-core/README.md
+++ b/packages/chat-core/README.md
@@ -1,0 +1,51 @@
+# @octo/chat-core
+
+Framework-free chat client core. No React, no `wukongimjssdk` dependency.
+
+Exports:
+
+- `ChatChannelRef`, `chatChannelKey`
+- `ChatClientStatus`, `ChatClientBootstrap`, `ChatClientEvent`
+- `ChatConversationHandle` (opaque adapter contract)
+- `ChatConversationLease` (consumer-facing idempotent `release()`)
+- `ChatClient` (start/stop/openConversation/getSnapshot/subscribe + `messages` port)
+- `ManagedChatClient`, `ChatConnectionContext`, `ManagedChatClientOptions`
+- Adapter interfaces: `ChatConnectionAdapter`, `ChatConversationAdapter`,
+  `ChatSubscribeAdapter`, `ChatMessageAdapter`
+- Generic message port: `ChatMessagePort<TMessage, TContent, TStatus>`,
+  `ChatMessageLoadOptions`
+
+## Bootstrap
+
+`ChatClientBootstrap` is connection-level and does not require a channel.
+The optional `initialChannel` is bootstrap metadata for adapters or hosts;
+conversation ownership is still acquired explicitly with `openConversation`.
+
+```ts
+client.start({ endpoint: "wss://...", token: "abc", space: "spc_123" });
+client.start({
+  session: "sess_1",
+  initialChannel: { channelId: "gid", channelType: 2 },
+});
+```
+
+## Design
+
+`ManagedChatClient` wires the adapters together and owns cross-cutting
+lifecycle concerns:
+
+- `start` / `stop` are idempotent.
+- The connection adapter receives a `ChatConnectionContext` so it can report
+  involuntary drops and restores.
+- A single active conversation lease is owned at a time. Switching releases
+  the previous lease before subscribing the replacement. Concurrent opens use
+  latest-request-wins semantics until the commit phase begins; once teardown
+  starts, that operation completes before a later open or stop is processed.
+- Connection, conversation and lease teardown operations are serialized, so
+  `stop()` is a complete teardown barrier before a later restart.
+- Each `connect` call receives an epoch-scoped `ChatConnectionContext`; delayed
+  callbacks from an older transport cannot overwrite the current status.
+- Adapter failures surface through the `failed` status and the returned
+  promise.
+- The `messages` port delegates to an optional `ChatMessageAdapter`; a
+  clear error is thrown if no adapter is configured.

--- a/packages/chat-core/package.json
+++ b/packages/chat-core/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@octo/chat-core",
+  "version": "0.1.0",
+  "private": true,
+  "main": "src/index.ts",
+  "scripts": {
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@types/node": "^22.19.21",
+    "typescript": "5.9.3",
+    "vitest": "^4.1.5"
+  }
+}

--- a/packages/chat-core/src/ManagedChatClient.test.ts
+++ b/packages/chat-core/src/ManagedChatClient.test.ts
@@ -370,8 +370,10 @@ describe("ManagedChatClient", () => {
       expect(client.status).toBe(ChatClientStatus.Stopped);
     });
 
-    it("reports a prior background release failure from stop", async () => {
-      const { client, subAdapter } = createClient({ withSubscribe: true });
+    it("retries a prior background unsubscribe failure from stop", async () => {
+      const { client, convAdapter, subAdapter } = createClient({
+        withSubscribe: true,
+      });
       await client.start(bootstrapFor(channelA));
       const lease = await client.openConversation(channelA);
       subAdapter!.unsubscribe.mockRejectedValueOnce(
@@ -383,10 +385,48 @@ describe("ManagedChatClient", () => {
         expect(client.status).toBe(ChatClientStatus.Failed);
       });
 
-      await expect(client.stop()).rejects.toThrow(
-        /background unsubscribe failed/
-      );
+      await expect(client.stop()).resolves.toBeUndefined();
+      expect(convAdapter.closeConversation).toHaveBeenCalledTimes(1);
+      expect(subAdapter!.unsubscribe).toHaveBeenCalledTimes(2);
       expect(client.status).toBe(ChatClientStatus.Stopped);
+    });
+
+    it("retries only the unfinished close step from stop", async () => {
+      const { client, convAdapter, subAdapter } = createClient({
+        withSubscribe: true,
+      });
+      await client.start(bootstrapFor(channelA));
+      const lease = await client.openConversation(channelA);
+      convAdapter.closeConversation.mockRejectedValueOnce(
+        new Error("background close failed")
+      );
+
+      lease.release();
+      await vi.waitFor(() => {
+        expect(client.status).toBe(ChatClientStatus.Failed);
+      });
+
+      await expect(client.stop()).resolves.toBeUndefined();
+      expect(convAdapter.closeConversation).toHaveBeenCalledTimes(2);
+      expect(subAdapter!.unsubscribe).toHaveBeenCalledTimes(1);
+      expect(client.status).toBe(ChatClientStatus.Stopped);
+    });
+
+    it("finishes a failed stop teardown before restarting", async () => {
+      const { client, connAdapter, convAdapter } = createClient();
+      await client.start(bootstrapFor(channelA));
+      await client.openConversation(channelA);
+      convAdapter.closeConversation.mockRejectedValueOnce(
+        new Error("stop close failed")
+      );
+
+      await expect(client.stop()).rejects.toThrow(/stop close failed/);
+      expect(client.status).toBe(ChatClientStatus.Stopped);
+
+      await expect(client.start(bootstrapFor(channelB))).resolves.toBeUndefined();
+      expect(convAdapter.closeConversation).toHaveBeenCalledTimes(2);
+      expect(connAdapter.connect).toHaveBeenCalledTimes(2);
+      expect(client.status).toBe(ChatClientStatus.Connected);
     });
 
     it("queues a restart requested while stop is disconnecting", async () => {
@@ -688,6 +728,10 @@ describe("ManagedChatClient", () => {
       expect(client.activeConversation).toBeNull();
       expect(subAdapter!.subscribe).toHaveBeenCalledTimes(1);
       expect(errors).toHaveLength(1);
+
+      await expect(client.stop()).resolves.toBeUndefined();
+      expect(subAdapter!.unsubscribe).toHaveBeenCalledTimes(2);
+      expect(client.status).toBe(ChatClientStatus.Stopped);
     });
 
     it("discards an open superseded while its subscription is pending", async () => {

--- a/packages/chat-core/src/ManagedChatClient.test.ts
+++ b/packages/chat-core/src/ManagedChatClient.test.ts
@@ -904,6 +904,28 @@ describe("ManagedChatClient", () => {
       expect(subAdapter!.subscribe).toHaveBeenCalledWith(channelA);
     });
 
+    it("keeps the conversation open and reports subscription setup failures", async () => {
+      const { client, subAdapter } = createClient({ withSubscribe: true });
+      await client.start(bootstrapFor(channelA));
+      const subscribeError = new Error("subscribe failed");
+      subAdapter!.subscribe.mockRejectedValueOnce(subscribeError);
+      const errors: Error[] = [];
+      client.subscribe(ChatClientEvent.Error, (error) => errors.push(error));
+
+      const lease = await client.openConversation(channelA);
+
+      expect(lease.released).toBe(false);
+      expect(client.activeConversation).toBe(lease);
+      expect(client.status).toBe(ChatClientStatus.Connected);
+      expect(errors).toHaveLength(1);
+      expect(errors[0].message).toContain(
+        "ManagedChatClient conversation subscription failed: subscribe failed",
+      );
+
+      await client.stop();
+      expect(subAdapter!.unsubscribe).not.toHaveBeenCalled();
+    });
+
     it("subscribeAdapter.unsubscribe is called on conversation close", async () => {
       const { client, subAdapter } = createClient({ withSubscribe: true });
       await client.start(bootstrapFor(channelA));

--- a/packages/chat-core/src/ManagedChatClient.test.ts
+++ b/packages/chat-core/src/ManagedChatClient.test.ts
@@ -202,6 +202,17 @@ describe("ManagedChatClient", () => {
       expect(connAdapter.connect).toHaveBeenCalledTimes(1);
     });
 
+    it("does not create a second transport when start is called while disconnected", async () => {
+      const { client, connAdapter } = createClient();
+      await client.start(bootstrapFor(channelA));
+      client.connectionContext.onConnectionLost();
+
+      await client.start(bootstrapFor(channelA));
+
+      expect(client.status).toBe(ChatClientStatus.Disconnected);
+      expect(connAdapter.connect).toHaveBeenCalledTimes(1);
+    });
+
     it("sets Failed when connection adapter throws", async () => {
       const { client } = createClient({ failConnect: true });
       await expect(client.start(bootstrapFor(channelA))).rejects.toThrow(

--- a/packages/chat-core/src/ManagedChatClient.test.ts
+++ b/packages/chat-core/src/ManagedChatClient.test.ts
@@ -11,7 +11,10 @@ import {
   type ChatSubscribeAdapter,
   type ChatMessageAdapter,
 } from "./types";
-import { ManagedChatClient } from "./ManagedChatClient";
+import {
+  ChatConversationSupersededError,
+  ManagedChatClient,
+} from "./ManagedChatClient";
 
 // --------------------------------------------------------------------------
 // Helpers
@@ -213,12 +216,32 @@ describe("ManagedChatClient", () => {
       expect(connAdapter.connect).toHaveBeenCalledTimes(1);
     });
 
-    it("sets Failed when connection adapter throws", async () => {
-      const { client } = createClient({ failConnect: true });
+    it("sets Failed and rolls back when connection adapter throws", async () => {
+      const { client, connAdapter } = createClient({ failConnect: true });
       await expect(client.start(bootstrapFor(channelA))).rejects.toThrow(
         "connect failed"
       );
       expect(client.status).toBe(ChatClientStatus.Failed);
+      expect(connAdapter.disconnect).toHaveBeenCalledTimes(1);
+    });
+
+    it("retries pending connection cleanup before reconnecting", async () => {
+      const { client, connAdapter } = createClient();
+      connAdapter.connect
+        .mockRejectedValueOnce(new Error("connect failed"))
+        .mockResolvedValueOnce(undefined);
+      connAdapter.disconnect
+        .mockRejectedValueOnce(new Error("rollback failed"))
+        .mockResolvedValue(undefined);
+
+      await expect(client.start(bootstrapFor(channelA))).rejects.toThrow(
+        /connect failed; rollback failed/
+      );
+      await client.start(bootstrapFor(channelB));
+
+      expect(connAdapter.disconnect).toHaveBeenCalledTimes(2);
+      expect(connAdapter.connect).toHaveBeenCalledTimes(2);
+      expect(client.status).toBe(ChatClientStatus.Connected);
     });
 
     it("queues a stop requested while start is still connecting", async () => {
@@ -321,20 +344,21 @@ describe("ManagedChatClient", () => {
       expect(connAdapter.disconnect).toHaveBeenCalledTimes(1);
     });
 
-    it("clears all event subscriptions", async () => {
+    it("keeps event subscriptions across an explicit stop and restart", async () => {
       const { client } = createClient();
       await client.start(bootstrapFor(channelA));
 
-      const fn1 = vi.fn();
-      const fn2 = vi.fn();
-      client.subscribe(ChatClientEvent.StatusChanged, fn1);
-      client.subscribe(ChatClientEvent.Error, fn2);
+      const statuses: ChatClientStatus[] = [];
+      client.subscribe(ChatClientEvent.StatusChanged, (status) => statuses.push(status));
 
       await client.stop();
+      await client.start(bootstrapFor(channelB));
 
-      // fn1 sees the Stopped transition (1 call), fn2 never fires
-      expect(fn1).toHaveBeenCalledTimes(1);
-      expect(fn2).not.toHaveBeenCalled();
+      expect(statuses).toEqual([
+        ChatClientStatus.Stopped,
+        ChatClientStatus.Connecting,
+        ChatClientStatus.Connected,
+      ]);
     });
 
     it("reports a disconnect error after transitioning to Stopped", async () => {
@@ -666,7 +690,7 @@ describe("ManagedChatClient", () => {
       expect(errors).toHaveLength(1);
     });
 
-    it("finishes a committing subscription before the next same-channel open", async () => {
+    it("discards an open superseded while its subscription is pending", async () => {
       const { client, subAdapter } = createClient({ withSubscribe: true });
       await client.start(bootstrapFor(channelA));
       const firstSubscribe = deferred<void>();
@@ -690,7 +714,9 @@ describe("ManagedChatClient", () => {
       const winningOpen = client.openConversation({ ...channelA });
       firstSubscribe.resolve();
 
-      const firstLease = await firstOpen;
+      await expect(firstOpen).rejects.toBeInstanceOf(
+        ChatConversationSupersededError
+      );
       const winningLease = await winningOpen;
 
       expect(calls).toEqual([
@@ -698,12 +724,11 @@ describe("ManagedChatClient", () => {
         "unsubscribe-stale",
         "subscribe-winning",
       ]);
-      expect(firstLease.released).toBe(true);
       expect(client.activeConversation).toBe(winningLease);
       expect(winningLease.released).toBe(false);
     });
 
-    it("linearizes stop after an open that already entered commit", async () => {
+    it("discards an open superseded by stop while subscription is pending", async () => {
       const { client, subAdapter } = createClient({ withSubscribe: true });
       await client.start(bootstrapFor(channelA));
       const subscribe = deferred<void>();
@@ -723,11 +748,39 @@ describe("ManagedChatClient", () => {
       const stopping = client.stop();
       subscribe.resolve();
 
-      await opening;
+      await expect(opening).rejects.toBeInstanceOf(
+        ChatConversationSupersededError
+      );
       await stopping;
 
-      expect(events).toEqual(["opened", "closed"]);
+      expect(events).toEqual([]);
       expect(client.status).toBe(ChatClientStatus.Stopped);
+    });
+
+    it("discards an open superseded while the previous lease is tearing down", async () => {
+      const { client, convAdapter } = createClient();
+      await client.start(bootstrapFor(channelA));
+      await client.openConversation(channelA);
+
+      const closePrevious = deferred<void>();
+      convAdapter.closeConversation.mockImplementationOnce(
+        () => closePrevious.promise
+      );
+
+      const staleOpen = client.openConversation(channelB);
+      await vi.waitFor(() => {
+        expect(convAdapter.closeConversation).toHaveBeenCalledTimes(1);
+      });
+      const winningOpen = client.openConversation(channelA);
+      closePrevious.resolve();
+
+      await expect(staleOpen).rejects.toBeInstanceOf(
+        ChatConversationSupersededError
+      );
+      const winningLease = await winningOpen;
+
+      expect(client.activeConversation).toBe(winningLease);
+      expect(winningLease.channel).toBe(channelA);
     });
   });
 

--- a/packages/chat-core/src/ManagedChatClient.test.ts
+++ b/packages/chat-core/src/ManagedChatClient.test.ts
@@ -1,0 +1,986 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  ChatClientStatus,
+  ChatClientEvent,
+  chatChannelKey,
+  type ChatChannelRef,
+  type ChatConversationLease,
+  type ChatConversationHandle,
+  type ChatConnectionAdapter,
+  type ChatConversationAdapter,
+  type ChatSubscribeAdapter,
+  type ChatMessageAdapter,
+} from "./types";
+import { ManagedChatClient } from "./ManagedChatClient";
+
+// --------------------------------------------------------------------------
+// Helpers
+// --------------------------------------------------------------------------
+
+const channelA: ChatChannelRef = { channelId: "chA", channelType: 1 };
+const channelB: ChatChannelRef = { channelId: "chB", channelType: 2 };
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+function bootstrapFor(
+  channel?: ChatChannelRef
+): Parameters<typeof ManagedChatClient.prototype.start>[0] {
+  return channel ? { initialChannel: channel } : {};
+}
+
+function createHandle(channel: ChatChannelRef): ChatConversationHandle {
+  return { channel };
+}
+
+function createMockConnectionAdapter() {
+  return {
+    status: ChatClientStatus.Idle,
+    connect: vi.fn(async () => {}),
+    disconnect: vi.fn(async () => {}),
+  } as unknown as ChatConnectionAdapter & {
+    connect: ReturnType<typeof vi.fn>;
+    disconnect: ReturnType<typeof vi.fn>;
+  };
+}
+
+function createMockConversationAdapter() {
+  return {
+    openConversation: vi.fn(async (channel: ChatChannelRef) =>
+      createHandle(channel)
+    ),
+    closeConversation: vi.fn(async () => {}),
+  } as unknown as ChatConversationAdapter & {
+    openConversation: ReturnType<typeof vi.fn>;
+    closeConversation: ReturnType<typeof vi.fn>;
+  };
+}
+
+function createMockSubscribeAdapter() {
+  return {
+    subscribe: vi.fn(async () => {}),
+    unsubscribe: vi.fn(async () => {}),
+  } as unknown as ChatSubscribeAdapter & {
+    subscribe: ReturnType<typeof vi.fn>;
+    unsubscribe: ReturnType<typeof vi.fn>;
+  };
+}
+
+function createMockMessageAdapter() {
+  const messages = [
+    { id: "m1", text: "hello" },
+    { id: "m2", text: "world" },
+  ];
+  return {
+    loadMessages: vi.fn(async () => messages),
+    subscribeMessages: vi.fn(() => () => {}),
+    subscribeMessageStatus: vi.fn(() => () => {}),
+    sendMessage: vi.fn(async (content: string) => ({
+      id: "m3",
+      text: content,
+    })),
+  } as unknown as ChatMessageAdapter<{ id: string; text: string }, string> & {
+    loadMessages: ReturnType<typeof vi.fn>;
+    subscribeMessages: ReturnType<typeof vi.fn>;
+    subscribeMessageStatus: ReturnType<typeof vi.fn>;
+    sendMessage: ReturnType<typeof vi.fn>;
+  };
+}
+
+// --------------------------------------------------------------------------
+// chatChannelKey
+// --------------------------------------------------------------------------
+
+describe("chatChannelKey", () => {
+  it("produces the WuKongIM-compatible channel key", () => {
+    expect(chatChannelKey({ channelId: "user_abc", channelType: 1 })).toBe(
+      "user_abc-1"
+    );
+    expect(chatChannelKey({ channelId: "group_xyz", channelType: 2 })).toBe(
+      "group_xyz-2"
+    );
+    expect(chatChannelKey({ channelId: "", channelType: 0 })).toBe("-0");
+  });
+
+  it("is symmetric with itself (same key for equal refs)", () => {
+    expect(chatChannelKey(channelA)).toBe(chatChannelKey({ ...channelA }));
+    expect(chatChannelKey(channelA)).not.toBe(chatChannelKey(channelB));
+  });
+});
+
+// --------------------------------------------------------------------------
+// ManagedChatClient
+// --------------------------------------------------------------------------
+
+describe("ManagedChatClient", () => {
+  function createClient(opts?: {
+    failConnect?: boolean;
+    failDisconnect?: boolean;
+    failOpenConversation?: boolean;
+    withSubscribe?: boolean;
+    withMessage?: boolean;
+  }) {
+    const connAdapter = createMockConnectionAdapter();
+    if (opts?.failConnect) {
+      connAdapter.connect.mockRejectedValue(new Error("connect failed"));
+    }
+    if (opts?.failDisconnect) {
+      connAdapter.disconnect.mockRejectedValue(new Error("disconnect failed"));
+    }
+
+    const convAdapter = createMockConversationAdapter();
+    if (opts?.failOpenConversation) {
+      convAdapter.openConversation.mockRejectedValue(new Error("open failed"));
+    }
+
+    const subAdapter = opts?.withSubscribe
+      ? createMockSubscribeAdapter()
+      : undefined;
+
+    const msgAdapter = opts?.withMessage
+      ? createMockMessageAdapter()
+      : undefined;
+
+    const client = new ManagedChatClient(connAdapter, convAdapter, {
+      subscribeAdapter: subAdapter,
+      messageAdapter: msgAdapter,
+    });
+
+    return { client, connAdapter, convAdapter, subAdapter, msgAdapter };
+  }
+
+  // -- initial state -------------------------------------------------------
+
+  describe("initial state", () => {
+    it("starts idle with no active conversation", () => {
+      const { client } = createClient();
+      expect(client.status).toBe(ChatClientStatus.Idle);
+      expect(client.activeConversation).toBeNull();
+      const snap = client.getSnapshot();
+      expect(snap.status).toBe(ChatClientStatus.Idle);
+      expect(snap.activeConversation).toBeNull();
+    });
+
+    it("exposes a messages port even without a message adapter", () => {
+      const { client } = createClient();
+      expect(client.messages).toBeDefined();
+      expect(typeof client.messages.sendMessage).toBe("function");
+    });
+  });
+
+  // -- start / stop --------------------------------------------------------
+
+  describe("start", () => {
+    it("transitions Connecting -> Connected on success", async () => {
+      const { client, connAdapter } = createClient();
+      const events: ChatClientStatus[] = [];
+      client.subscribe(ChatClientEvent.StatusChanged, (s) => events.push(s));
+
+      await client.start(bootstrapFor(channelA));
+
+      expect(connAdapter.connect).toHaveBeenCalledTimes(1);
+      expect(client.status).toBe(ChatClientStatus.Connected);
+      expect(events).toEqual([
+        ChatClientStatus.Connecting,
+        ChatClientStatus.Connected,
+      ]);
+    });
+
+    it("is idempotent — second start is a no-op", async () => {
+      const { client, connAdapter } = createClient();
+      await client.start(bootstrapFor(channelA));
+      expect(connAdapter.connect).toHaveBeenCalledTimes(1);
+
+      await client.start(bootstrapFor(channelA));
+      expect(connAdapter.connect).toHaveBeenCalledTimes(1);
+    });
+
+    it("sets Failed when connection adapter throws", async () => {
+      const { client } = createClient({ failConnect: true });
+      await expect(client.start(bootstrapFor(channelA))).rejects.toThrow(
+        "connect failed"
+      );
+      expect(client.status).toBe(ChatClientStatus.Failed);
+    });
+
+    it("queues a stop requested while start is still connecting", async () => {
+      const { client, connAdapter } = createClient();
+      const connect = deferred<void>();
+      connAdapter.connect.mockImplementationOnce(() => connect.promise);
+
+      const starting = client.start(bootstrapFor(channelA));
+      const stopping = client.stop();
+
+      connect.resolve();
+      await Promise.all([starting, stopping]);
+
+      expect(connAdapter.disconnect).toHaveBeenCalledTimes(1);
+      expect(client.status).toBe(ChatClientStatus.Stopped);
+    });
+
+    it("shares one in-flight connection across concurrent starts", async () => {
+      const { client, connAdapter } = createClient();
+      const connect = deferred<void>();
+      connAdapter.connect.mockImplementationOnce(() => connect.promise);
+      let firstResolved = false;
+      let secondResolved = false;
+
+      const first = client.start(bootstrapFor(channelA)).then(() => {
+        firstResolved = true;
+      });
+      const second = client.start(bootstrapFor(channelA)).then(() => {
+        secondResolved = true;
+      });
+      await Promise.resolve();
+
+      expect(connAdapter.connect).toHaveBeenCalledTimes(1);
+      expect(firstResolved).toBe(false);
+      expect(secondResolved).toBe(false);
+
+      connect.resolve();
+      await Promise.all([first, second]);
+      expect(connAdapter.connect).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not open until a queued stop and restart have both completed", async () => {
+      const { client, connAdapter, convAdapter } = createClient();
+      const firstConnect = deferred<void>();
+      const disconnect = deferred<void>();
+      const secondConnect = deferred<void>();
+      connAdapter.connect
+        .mockImplementationOnce(() => firstConnect.promise)
+        .mockImplementationOnce(() => secondConnect.promise);
+      connAdapter.disconnect.mockImplementationOnce(() => disconnect.promise);
+
+      const starting = client.start(bootstrapFor(channelA));
+      const stopping = client.stop();
+      const restarting = client.start(bootstrapFor(channelB));
+      const opening = client.openConversation(channelB);
+
+      firstConnect.resolve();
+      await vi.waitFor(() => {
+        expect(connAdapter.disconnect).toHaveBeenCalledTimes(1);
+      });
+      expect(convAdapter.openConversation).not.toHaveBeenCalled();
+
+      disconnect.resolve();
+      await vi.waitFor(() => {
+        expect(connAdapter.connect).toHaveBeenCalledTimes(2);
+      });
+      expect(convAdapter.openConversation).not.toHaveBeenCalled();
+
+      secondConnect.resolve();
+      await Promise.all([starting, stopping, restarting, opening]);
+      expect(convAdapter.openConversation).toHaveBeenCalledWith(channelB);
+    });
+  });
+
+  describe("stop", () => {
+    it("transitions to Stopped and releases the conversation", async () => {
+      const { client, connAdapter, convAdapter } = createClient();
+      await client.start(bootstrapFor(channelA));
+
+      const lease = await client.openConversation(channelB);
+      expect(lease.released).toBe(false);
+
+      await client.stop();
+
+      expect(client.status).toBe(ChatClientStatus.Stopped);
+      expect(client.activeConversation).toBeNull();
+      expect(lease.released).toBe(true);
+      expect(connAdapter.disconnect).toHaveBeenCalledTimes(1);
+      // closeConversation should have been called with the handle
+      expect(convAdapter.closeConversation).toHaveBeenCalledTimes(1);
+    });
+
+    it("is idempotent — second stop is a no-op", async () => {
+      const { client, connAdapter } = createClient();
+      await client.start(bootstrapFor(channelA));
+      await client.stop();
+      expect(connAdapter.disconnect).toHaveBeenCalledTimes(1);
+
+      await client.stop();
+      expect(connAdapter.disconnect).toHaveBeenCalledTimes(1);
+    });
+
+    it("clears all event subscriptions", async () => {
+      const { client } = createClient();
+      await client.start(bootstrapFor(channelA));
+
+      const fn1 = vi.fn();
+      const fn2 = vi.fn();
+      client.subscribe(ChatClientEvent.StatusChanged, fn1);
+      client.subscribe(ChatClientEvent.Error, fn2);
+
+      await client.stop();
+
+      // fn1 sees the Stopped transition (1 call), fn2 never fires
+      expect(fn1).toHaveBeenCalledTimes(1);
+      expect(fn2).not.toHaveBeenCalled();
+    });
+
+    it("reports a disconnect error after transitioning to Stopped", async () => {
+      const { client, connAdapter } = createClient({
+        failDisconnect: true,
+      });
+      await client.start(bootstrapFor(channelA));
+      await expect(client.stop()).rejects.toThrow(/disconnect failed/);
+      expect(client.status).toBe(ChatClientStatus.Stopped);
+    });
+
+    it("reports a prior background release failure from stop", async () => {
+      const { client, subAdapter } = createClient({ withSubscribe: true });
+      await client.start(bootstrapFor(channelA));
+      const lease = await client.openConversation(channelA);
+      subAdapter!.unsubscribe.mockRejectedValueOnce(
+        new Error("background unsubscribe failed")
+      );
+
+      lease.release();
+      await vi.waitFor(() => {
+        expect(client.status).toBe(ChatClientStatus.Failed);
+      });
+
+      await expect(client.stop()).rejects.toThrow(
+        /background unsubscribe failed/
+      );
+      expect(client.status).toBe(ChatClientStatus.Stopped);
+    });
+
+    it("queues a restart requested while stop is disconnecting", async () => {
+      const { client, connAdapter } = createClient();
+      await client.start(bootstrapFor(channelA));
+      const disconnect = deferred<void>();
+      connAdapter.disconnect.mockImplementationOnce(() => disconnect.promise);
+
+      const stopping = client.stop();
+      const restarting = client.start(bootstrapFor(channelB));
+
+      disconnect.resolve();
+      await Promise.all([stopping, restarting]);
+
+      expect(connAdapter.connect).toHaveBeenCalledTimes(2);
+      expect(client.status).toBe(ChatClientStatus.Connected);
+    });
+
+    it("shares one teardown across concurrent stops", async () => {
+      const { client, connAdapter } = createClient();
+      await client.start(bootstrapFor(channelA));
+      const disconnect = deferred<void>();
+      connAdapter.disconnect.mockImplementationOnce(() => disconnect.promise);
+      let firstResolved = false;
+      let secondResolved = false;
+
+      const first = client.stop().then(() => {
+        firstResolved = true;
+      });
+      const second = client.stop().then(() => {
+        secondResolved = true;
+      });
+      await vi.waitFor(() => {
+        expect(connAdapter.disconnect).toHaveBeenCalledTimes(1);
+      });
+      expect(firstResolved).toBe(false);
+      expect(secondResolved).toBe(false);
+
+      disconnect.resolve();
+      await Promise.all([first, second]);
+      expect(connAdapter.disconnect).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // -- conversation management ---------------------------------------------
+
+  describe("openConversation", () => {
+    it("returns a controlled lease for the requested channel", async () => {
+      const { client } = createClient();
+      await client.start(bootstrapFor(channelA));
+
+      const lease = await client.openConversation(channelB);
+      expect(lease.channel).toBe(channelB);
+      expect(lease.released).toBe(false);
+      expect(client.activeConversation?.channel).toBe(channelB);
+    });
+
+    it("releases the old lease only after the new one is ready", async () => {
+      const { client, convAdapter } = createClient();
+      await client.start(bootstrapFor(channelA));
+
+      const lease1 = await client.openConversation(channelA);
+      expect(lease1.released).toBe(false);
+
+      // At the moment openConversation(channelB) runs, lease1 must still be
+      // unreleased (the switch hasn't happened yet).
+      let lease1ReleasedDuringOpen = false;
+      convAdapter.openConversation.mockImplementationOnce(
+        async (ch: ChatChannelRef) => {
+          lease1ReleasedDuringOpen = lease1.released;
+          return createHandle(ch);
+        }
+      );
+
+      const lease2 = await client.openConversation(channelB);
+      expect(lease1ReleasedDuringOpen).toBe(false);
+      expect(lease1.released).toBe(true);
+      expect(lease2.released).toBe(false);
+      expect(client.activeConversation?.channel).toBe(channelB);
+    });
+
+    it("old lease release() does not clear a newer active lease", async () => {
+      const { client } = createClient();
+      await client.start(bootstrapFor(channelA));
+
+      const lease1 = await client.openConversation(channelA);
+      const lease2 = await client.openConversation(channelB);
+
+      // lease1 is already released by this point (switched away).
+      // Calling release() again is idempotent and must not touch
+      // the current lease (lease2).
+      lease1.release();
+      expect(client.activeConversation?.channel).toBe(channelB);
+      expect(lease2.released).toBe(false);
+    });
+
+    it("emits ConversationOpened event", async () => {
+      const { client } = createClient();
+      await client.start(bootstrapFor(channelA));
+
+      const openedChannels: ChatChannelRef[] = [];
+      client.subscribe(ChatClientEvent.ConversationOpened, (ch) =>
+        openedChannels.push(ch)
+      );
+
+      await client.openConversation(channelB);
+      expect(openedChannels).toHaveLength(1);
+      expect(openedChannels[0]).toEqual(channelB);
+    });
+
+    it("emits ConversationClosed for the replaced lease", async () => {
+      const { client } = createClient();
+      await client.start(bootstrapFor(channelA));
+
+      const closedChannels: ChatChannelRef[] = [];
+      client.subscribe(ChatClientEvent.ConversationClosed, (ch) =>
+        closedChannels.push(ch)
+      );
+
+      await client.openConversation(channelA);
+      await client.openConversation(channelB);
+
+      // Opening channelB should close the channelA lease
+      expect(closedChannels).toHaveLength(1);
+      expect(closedChannels[0]).toEqual(channelA);
+    });
+
+    it("keeps the current lease when opening the replacement fails", async () => {
+      const { client, convAdapter } = createClient();
+      await client.start(bootstrapFor(channelA));
+      const current = await client.openConversation(channelA);
+      const closed = vi.fn();
+      client.subscribe(ChatClientEvent.ConversationClosed, closed);
+      convAdapter.openConversation.mockRejectedValueOnce(
+        new Error("open failed")
+      );
+
+      await expect(client.openConversation(channelB)).rejects.toThrow(
+        "open failed"
+      );
+
+      expect(current.released).toBe(false);
+      expect(client.activeConversation).toBe(current);
+      expect(closed).not.toHaveBeenCalled();
+    });
+
+    it("keeps the latest request active when adapter opens resolve out of order", async () => {
+      const { client, convAdapter } = createClient();
+      await client.start(bootstrapFor(channelA));
+      const first = deferred<ChatConversationHandle>();
+      const second = deferred<ChatConversationHandle>();
+      convAdapter.openConversation
+        .mockImplementationOnce(() => first.promise)
+        .mockImplementationOnce(() => second.promise);
+
+      const openingA = client
+        .openConversation(channelA)
+        .catch((error) => error);
+      await vi.waitFor(() => {
+        expect(convAdapter.openConversation).toHaveBeenCalledTimes(1);
+      });
+      const openingB = client.openConversation(channelB);
+
+      first.resolve(createHandle(channelA));
+      const superseded = await openingA;
+      await vi.waitFor(() => {
+        expect(convAdapter.openConversation).toHaveBeenCalledTimes(2);
+      });
+      second.resolve(createHandle(channelB));
+      const leaseB = await openingB;
+
+      expect(superseded).toBeInstanceOf(Error);
+      expect(superseded.name).toBe("ChatConversationSupersededError");
+      expect(leaseB.released).toBe(false);
+      expect(client.activeConversation).toBe(leaseB);
+      expect(convAdapter.closeConversation).toHaveBeenCalledWith(
+        createHandle(channelA)
+      );
+    });
+
+    it("does not emit opened or closed events for a superseded pending open", async () => {
+      const { client, convAdapter } = createClient();
+      await client.start(bootstrapFor(channelA));
+      const first = deferred<ChatConversationHandle>();
+      const opened = vi.fn();
+      const closed = vi.fn();
+      client.subscribe(ChatClientEvent.ConversationOpened, opened);
+      client.subscribe(ChatClientEvent.ConversationClosed, closed);
+      convAdapter.openConversation
+        .mockImplementationOnce(() => first.promise)
+        .mockImplementationOnce(async (requestedChannel: ChatChannelRef) =>
+          createHandle(requestedChannel)
+        );
+
+      const openingA = client
+        .openConversation(channelA)
+        .catch((error) => error);
+      await vi.waitFor(() => {
+        expect(convAdapter.openConversation).toHaveBeenCalledTimes(1);
+      });
+      const openingB = client.openConversation(channelB);
+      first.resolve(createHandle(channelA));
+      await openingA;
+      await openingB;
+
+      expect(opened).toHaveBeenCalledTimes(1);
+      expect(opened).toHaveBeenCalledWith(channelB);
+      expect(closed).not.toHaveBeenCalled();
+    });
+
+    it("waits for a superseded pending open to be cleaned before stop resolves", async () => {
+      const { client, convAdapter } = createClient();
+      await client.start(bootstrapFor(channelA));
+      const pending = deferred<ChatConversationHandle>();
+      const close = deferred<void>();
+      convAdapter.openConversation.mockImplementationOnce(
+        () => pending.promise
+      );
+      convAdapter.closeConversation.mockImplementationOnce(() => close.promise);
+
+      const opening = client.openConversation(channelA).catch((error) => error);
+      await vi.waitFor(() => {
+        expect(convAdapter.openConversation).toHaveBeenCalledTimes(1);
+      });
+      const stopping = client.stop();
+      let stopped = false;
+      void stopping.then(() => {
+        stopped = true;
+      });
+      pending.resolve(createHandle(channelA));
+
+      await vi.waitFor(() => {
+        expect(convAdapter.closeConversation).toHaveBeenCalledTimes(1);
+      });
+      expect(stopped).toBe(false);
+      close.resolve();
+      const superseded = await opening;
+      await stopping;
+
+      expect(superseded.name).toBe("ChatConversationSupersededError");
+      expect(stopped).toBe(true);
+      expect(client.activeConversation).toBeNull();
+      expect(client.status).toBe(ChatClientStatus.Stopped);
+    });
+
+    it("rejects opening a conversation before start or after stop", async () => {
+      const { client } = createClient();
+      await expect(client.openConversation(channelA)).rejects.toThrow(
+        /not started/
+      );
+
+      await client.start(bootstrapFor(channelA));
+      await client.stop();
+
+      await expect(client.openConversation(channelA)).rejects.toThrow(
+        /not started/
+      );
+    });
+
+    it("unsubscribes before resubscribing when reopening the same channel", async () => {
+      const { client, convAdapter, subAdapter } = createClient({
+        withSubscribe: true,
+      });
+      await client.start(bootstrapFor(channelA));
+      await client.openConversation(channelA);
+      const calls: string[] = [];
+      convAdapter.closeConversation.mockImplementationOnce(async () => {
+        calls.push("close");
+      });
+      subAdapter!.unsubscribe.mockImplementationOnce(async () => {
+        calls.push("unsubscribe");
+      });
+      subAdapter!.subscribe.mockImplementationOnce(async () => {
+        calls.push("subscribe");
+      });
+
+      const replacement = await client.openConversation({ ...channelA });
+
+      expect(calls).toEqual(["close", "unsubscribe", "subscribe"]);
+      expect(replacement.released).toBe(false);
+      expect(client.activeConversation).toBe(replacement);
+    });
+
+    it("fails closed when old subscription teardown fails", async () => {
+      const { client, subAdapter } = createClient({ withSubscribe: true });
+      await client.start(bootstrapFor(channelA));
+      await client.openConversation(channelA);
+      const errors: Error[] = [];
+      client.subscribe(ChatClientEvent.Error, (error) => errors.push(error));
+      subAdapter!.unsubscribe.mockRejectedValueOnce(
+        new Error("unsubscribe failed")
+      );
+
+      await expect(client.openConversation(channelB)).rejects.toThrow(
+        /unsubscribe failed/
+      );
+
+      expect(client.status).toBe(ChatClientStatus.Failed);
+      expect(client.activeConversation).toBeNull();
+      expect(subAdapter!.subscribe).toHaveBeenCalledTimes(1);
+      expect(errors).toHaveLength(1);
+    });
+
+    it("finishes a committing subscription before the next same-channel open", async () => {
+      const { client, subAdapter } = createClient({ withSubscribe: true });
+      await client.start(bootstrapFor(channelA));
+      const firstSubscribe = deferred<void>();
+      const calls: string[] = [];
+      subAdapter!.subscribe
+        .mockImplementationOnce(async () => {
+          calls.push("subscribe-stale");
+          await firstSubscribe.promise;
+        })
+        .mockImplementationOnce(async () => {
+          calls.push("subscribe-winning");
+        });
+      subAdapter!.unsubscribe.mockImplementationOnce(async () => {
+        calls.push("unsubscribe-stale");
+      });
+
+      const firstOpen = client.openConversation(channelA);
+      await vi.waitFor(() => {
+        expect(subAdapter!.subscribe).toHaveBeenCalledTimes(1);
+      });
+      const winningOpen = client.openConversation({ ...channelA });
+      firstSubscribe.resolve();
+
+      const firstLease = await firstOpen;
+      const winningLease = await winningOpen;
+
+      expect(calls).toEqual([
+        "subscribe-stale",
+        "unsubscribe-stale",
+        "subscribe-winning",
+      ]);
+      expect(firstLease.released).toBe(true);
+      expect(client.activeConversation).toBe(winningLease);
+      expect(winningLease.released).toBe(false);
+    });
+
+    it("linearizes stop after an open that already entered commit", async () => {
+      const { client, subAdapter } = createClient({ withSubscribe: true });
+      await client.start(bootstrapFor(channelA));
+      const subscribe = deferred<void>();
+      subAdapter!.subscribe.mockImplementationOnce(() => subscribe.promise);
+      const events: string[] = [];
+      client.subscribe(ChatClientEvent.ConversationOpened, () => {
+        events.push("opened");
+      });
+      client.subscribe(ChatClientEvent.ConversationClosed, () => {
+        events.push("closed");
+      });
+
+      const opening = client.openConversation(channelA);
+      await vi.waitFor(() => {
+        expect(subAdapter!.subscribe).toHaveBeenCalledTimes(1);
+      });
+      const stopping = client.stop();
+      subscribe.resolve();
+
+      await opening;
+      await stopping;
+
+      expect(events).toEqual(["opened", "closed"]);
+      expect(client.status).toBe(ChatClientStatus.Stopped);
+    });
+  });
+
+  // -- controlled lease release() --------------------------------------------
+
+  describe("lease release()", () => {
+    it("triggers closeConversation, unsubscribe, and ConversationClosed", async () => {
+      const { client, convAdapter, subAdapter } = createClient({
+        withSubscribe: true,
+      });
+      await client.start(bootstrapFor(channelA));
+
+      const lease = await client.openConversation(channelA);
+      convAdapter.closeConversation.mockClear();
+      subAdapter!.unsubscribe.mockClear();
+
+      lease.release();
+
+      // Release is synchronous to the consumer; adapter teardown is queued.
+      expect(lease.released).toBe(true);
+      expect(client.activeConversation).toBeNull();
+      await vi.waitFor(() => {
+        expect(convAdapter.closeConversation).toHaveBeenCalledTimes(1);
+        expect(subAdapter!.unsubscribe).toHaveBeenCalledWith(channelA);
+      });
+    });
+
+    it("is idempotent — second release is a no-op", async () => {
+      const { client, convAdapter } = createClient();
+      await client.start(bootstrapFor(channelA));
+
+      const lease = await client.openConversation(channelA);
+      lease.release();
+
+      convAdapter.closeConversation.mockClear();
+      lease.release();
+
+      expect(convAdapter.closeConversation).not.toHaveBeenCalled();
+    });
+
+    it("does not clear a newer active lease if called after switch", async () => {
+      const { client } = createClient();
+      await client.start(bootstrapFor(channelA));
+
+      const lease1 = await client.openConversation(channelA);
+      const lease2 = await client.openConversation(channelB);
+
+      // lease1 was already released during switch; double-release is a no-op
+      expect(lease1.released).toBe(true);
+      expect(lease2.released).toBe(false);
+
+      lease1.release();
+      expect(client.activeConversation?.channel).toBe(channelB);
+    });
+  });
+
+  // -- subscriptions -------------------------------------------------------
+
+  describe("subscribe", () => {
+    it("returns an unsubscribe function that stops the listener", async () => {
+      const { client } = createClient();
+      await client.start(bootstrapFor(channelA));
+
+      const fn = vi.fn();
+      const unsub = client.subscribe(ChatClientEvent.StatusChanged, fn);
+      unsub();
+
+      await client.stop();
+      expect(fn).not.toHaveBeenCalled();
+    });
+
+    it("subscribeAdapter.subscribe is called on conversation open", async () => {
+      const { client, subAdapter } = createClient({ withSubscribe: true });
+      await client.start(bootstrapFor(channelA));
+
+      await client.openConversation(channelA);
+      expect(subAdapter!.subscribe).toHaveBeenCalledWith(channelA);
+    });
+
+    it("subscribeAdapter.unsubscribe is called on conversation close", async () => {
+      const { client, subAdapter } = createClient({ withSubscribe: true });
+      await client.start(bootstrapFor(channelA));
+
+      await client.openConversation(channelA);
+      await client.openConversation(channelB);
+
+      expect(subAdapter!.unsubscribe).toHaveBeenCalledWith(channelA);
+    });
+  });
+
+  // -- message port --------------------------------------------------------
+
+  describe("messages port", () => {
+    it("forwards loadMessages to the message adapter", async () => {
+      const { client, msgAdapter } = createClient({ withMessage: true });
+      const result = await client.messages.loadMessages(channelA, {
+        older: 10,
+      });
+      expect(msgAdapter!.loadMessages).toHaveBeenCalledWith(channelA, {
+        older: 10,
+      });
+      expect(result).toEqual([
+        { id: "m1", text: "hello" },
+        { id: "m2", text: "world" },
+      ]);
+    });
+
+    it("forwards sendMessage to the message adapter", async () => {
+      const { client, msgAdapter } = createClient({ withMessage: true });
+      const sent = await client.messages.sendMessage("yo", channelB);
+      expect(msgAdapter!.sendMessage).toHaveBeenCalledWith("yo", channelB);
+      expect(sent).toEqual({ id: "m3", text: "yo" });
+    });
+
+    it("forwards subscribeMessages and returns the disposer", async () => {
+      const { client, msgAdapter } = createClient({ withMessage: true });
+      const disposer = vi.fn();
+      msgAdapter!.subscribeMessages.mockReturnValue(disposer);
+
+      const listener = vi.fn();
+      const unsub = client.messages.subscribeMessages(listener);
+      expect(msgAdapter!.subscribeMessages).toHaveBeenCalledWith(listener);
+      expect(unsub).toBe(disposer);
+
+      unsub();
+      expect(disposer).toHaveBeenCalledTimes(1);
+    });
+
+    it("forwards subscribeMessageStatus and returns the disposer", async () => {
+      const { client, msgAdapter } = createClient({ withMessage: true });
+      const disposer = vi.fn();
+      msgAdapter!.subscribeMessageStatus.mockReturnValue(disposer);
+
+      const listener = vi.fn();
+      const unsub = client.messages.subscribeMessageStatus(listener);
+      expect(msgAdapter!.subscribeMessageStatus).toHaveBeenCalledWith(listener);
+      expect(unsub).toBe(disposer);
+
+      unsub();
+      expect(disposer).toHaveBeenCalledTimes(1);
+    });
+
+    it("throws a clear error when no message adapter is configured", async () => {
+      const { client } = createClient();
+
+      await expect(client.messages.loadMessages(channelA)).rejects.toThrow(
+        /requires a ChatMessageAdapter/
+      );
+      await expect(client.messages.sendMessage("x", channelA)).rejects.toThrow(
+        /requires a ChatMessageAdapter/
+      );
+      expect(() => client.messages.subscribeMessages(vi.fn())).toThrow(
+        /requires a ChatMessageAdapter/
+      );
+      expect(() => client.messages.subscribeMessageStatus(vi.fn())).toThrow(
+        /requires a ChatMessageAdapter/
+      );
+    });
+  });
+
+  // -- connection context callbacks ----------------------------------------
+
+  describe("connection context", () => {
+    it("exposes connectionContext to the adapter", () => {
+      const { client } = createClient();
+      expect(client.connectionContext).toBeDefined();
+      expect(typeof client.connectionContext.onConnectionLost).toBe("function");
+      expect(typeof client.connectionContext.onConnectionRestored).toBe(
+        "function"
+      );
+    });
+
+    it("onConnectionLost transitions Connected -> Disconnected", async () => {
+      const { client } = createClient();
+      await client.start(bootstrapFor(channelA));
+      expect(client.status).toBe(ChatClientStatus.Connected);
+
+      client.connectionContext.onConnectionLost();
+      expect(client.status).toBe(ChatClientStatus.Disconnected);
+    });
+
+    it("passes an epoch-scoped context to connect", async () => {
+      const { client, connAdapter } = createClient();
+      await client.start(bootstrapFor(channelA));
+
+      expect(connAdapter.connect).toHaveBeenCalledWith(
+        bootstrapFor(channelA),
+        client.connectionContext
+      );
+    });
+
+    it("preserves a connection loss reported while connect is pending", async () => {
+      const { client, connAdapter } = createClient();
+      connAdapter.connect.mockImplementationOnce(
+        async (_bootstrap: unknown, context: any) => {
+          context.onConnectionLost();
+        }
+      );
+
+      await client.start(bootstrapFor(channelA));
+
+      expect(client.status).toBe(ChatClientStatus.Disconnected);
+    });
+
+    it("onConnectionRestored transitions Disconnected -> Connected", async () => {
+      const { client } = createClient();
+      await client.start(bootstrapFor(channelA));
+      client.connectionContext.onConnectionLost();
+      expect(client.status).toBe(ChatClientStatus.Disconnected);
+
+      client.connectionContext.onConnectionRestored();
+      expect(client.status).toBe(ChatClientStatus.Connected);
+    });
+
+    it("onConnectionRestored is a no-op when not disconnected", async () => {
+      const { client } = createClient();
+      await client.start(bootstrapFor(channelA));
+      client.connectionContext.onConnectionRestored();
+      expect(client.status).toBe(ChatClientStatus.Connected);
+    });
+
+    it("onConnectionLost emits StatusChanged", async () => {
+      const { client } = createClient();
+      await client.start(bootstrapFor(channelA));
+
+      const events: ChatClientStatus[] = [];
+      client.subscribe(ChatClientEvent.StatusChanged, (s) => events.push(s));
+      events.length = 0;
+
+      client.connectionContext.onConnectionLost();
+      expect(events).toContain(ChatClientStatus.Disconnected);
+    });
+
+    it("ignores delayed callbacks from an earlier connection epoch", async () => {
+      const { client } = createClient();
+      await client.start(bootstrapFor(channelA));
+      const staleContext = client.connectionContext;
+      await client.stop();
+      await client.start(bootstrapFor(channelB));
+
+      staleContext.onConnectionLost();
+      expect(client.status).toBe(ChatClientStatus.Connected);
+
+      client.connectionContext.onConnectionLost();
+      expect(client.status).toBe(ChatClientStatus.Disconnected);
+    });
+  });
+
+  // -- getSnapshot ---------------------------------------------------------
+
+  describe("getSnapshot", () => {
+    it("reflects status and active conversation", async () => {
+      const { client } = createClient();
+      await client.start(bootstrapFor(channelA));
+
+      let snap = client.getSnapshot();
+      expect(snap.status).toBe(ChatClientStatus.Connected);
+      expect(snap.activeConversation).toBeNull();
+
+      await client.openConversation(channelB);
+      snap = client.getSnapshot();
+      expect(snap.status).toBe(ChatClientStatus.Connected);
+      expect(snap.activeConversation).not.toBeNull();
+      expect(snap.activeConversation!.channel).toEqual(channelB);
+    });
+  });
+});

--- a/packages/chat-core/src/ManagedChatClient.ts
+++ b/packages/chat-core/src/ManagedChatClient.ts
@@ -68,7 +68,13 @@ class ManagedConversationLease implements ChatConversationLease {
   _ensureCleanup(operation: () => Promise<void>): Promise<void> {
     this._released = true;
     if (!this._cleanupPromise) {
-      this._cleanupPromise = operation();
+      const cleanupPromise = Promise.resolve().then(operation).catch((error) => {
+        if (this._cleanupPromise === cleanupPromise) {
+          this._cleanupPromise = null;
+        }
+        throw error;
+      });
+      this._cleanupPromise = cleanupPromise;
     }
     return this._cleanupPromise;
   }
@@ -81,12 +87,20 @@ class ManagedConversationLease implements ChatConversationLease {
     return this._subscribed;
   }
 
+  _markUnsubscribed(): void {
+    this._subscribed = false;
+  }
+
   _markOpened(): void {
     this._opened = true;
   }
 
   get _wasOpened(): boolean {
     return this._opened;
+  }
+
+  _markClosed(): void {
+    this._opened = false;
   }
 }
 
@@ -184,6 +198,12 @@ export class ManagedChatClient<
         return;
       }
 
+      // A previous stop may have failed while releasing a conversation. Retry
+      // the unfinished teardown before opening a new transport.
+      if (this._currentLease) {
+        await this._releaseCurrentLease();
+      }
+
       if (this._connectionNeedsDisconnect) {
         try {
           await this._connectionAdapter.disconnect();
@@ -246,14 +266,16 @@ export class ManagedChatClient<
 
     return this._enqueueOperation(async () => {
       const errors: unknown[] = [];
-      if (this._backgroundTeardownError) {
-        errors.push(this._backgroundTeardownError);
-        this._backgroundTeardownError = null;
-      }
+      const backgroundTeardownError = this._backgroundTeardownError;
+      this._backgroundTeardownError = null;
+      const hadPendingLease = this._currentLease !== null;
       try {
         await this._releaseCurrentLease();
       } catch (error) {
         errors.push(error);
+      }
+      if (backgroundTeardownError && !hadPendingLease) {
+        errors.push(backgroundTeardownError);
       }
 
       if (this._connectionNeedsDisconnect) {
@@ -427,29 +449,31 @@ export class ManagedChatClient<
   private async _teardownLease(lease: ManagedConversationLease): Promise<void> {
     await lease._ensureCleanup(async () => {
       const errors: unknown[] = [];
-      try {
-        await this._conversationAdapter.closeConversation(lease._handle);
-      } catch (error) {
-        errors.push(error);
-      }
-      if (lease._wasSubscribed && this._subscribeAdapter) {
+      if (lease._wasOpened) {
         try {
-          await this._subscribeAdapter.unsubscribe(lease.channel);
+          await this._conversationAdapter.closeConversation(lease._handle);
+          lease._markClosed();
+          this._emit(ChatClientEvent.ConversationClosed, lease.channel);
         } catch (error) {
           errors.push(error);
         }
       }
-      if (this._currentLease === lease) {
-        this._currentLease = null;
-      }
-      if (lease._wasOpened) {
-        this._emit(ChatClientEvent.ConversationClosed, lease.channel);
+      if (lease._wasSubscribed && this._subscribeAdapter) {
+        try {
+          await this._subscribeAdapter.unsubscribe(lease.channel);
+          lease._markUnsubscribed();
+        } catch (error) {
+          errors.push(error);
+        }
       }
       if (errors.length > 0) {
         const error = this._createAdapterError("conversation teardown", errors);
         this._setStatus(ChatClientStatus.Failed);
         this._emit(ChatClientEvent.Error, error);
         throw error;
+      }
+      if (this._currentLease === lease) {
+        this._currentLease = null;
       }
     });
   }

--- a/packages/chat-core/src/ManagedChatClient.ts
+++ b/packages/chat-core/src/ManagedChatClient.ts
@@ -340,8 +340,11 @@ export class ManagedChatClient<
           try {
             await this._subscribeAdapter.subscribe(channel);
             subscribed = true;
-          } catch {
-            // Subscription setup must not fail the open itself.
+          } catch (error) {
+            this._emit(
+              ChatClientEvent.Error,
+              this._createAdapterError("conversation subscription", [error]),
+            );
           }
           this._throwIfOpenSuperseded(requestGeneration);
         }

--- a/packages/chat-core/src/ManagedChatClient.ts
+++ b/packages/chat-core/src/ManagedChatClient.ts
@@ -173,7 +173,11 @@ export class ManagedChatClient<
 
   start(bootstrap: ChatClientBootstrap): Promise<void> {
     return this._enqueueOperation(async () => {
-      if (this._started && this._status === ChatClientStatus.Connected) {
+      // Once started, the connection adapter owns reconnect behavior and
+      // reports availability through the epoch-scoped connection context.
+      // Calling start() again while disconnected must not create a second
+      // transport or duplicate its listeners.
+      if (this._started) {
         return;
       }
 

--- a/packages/chat-core/src/ManagedChatClient.ts
+++ b/packages/chat-core/src/ManagedChatClient.ts
@@ -104,7 +104,7 @@ export class ChatConversationSupersededError extends Error {
  * - Idempotent start / stop
  * - Single active-conversation ownership with safe switching
  * - Automatic lease release on stop / switch
- * - Event subscription cleanup on stop
+ * - Event subscriptions that remain observable across explicit restarts
  * - Failed-state support
  * - A generic message port routed to the optional message adapter
  */
@@ -133,6 +133,9 @@ export class ManagedChatClient<
   private _operationQueue: Promise<void> = Promise.resolve();
   // Tracks whether we have started (for idempotent stop).
   private _started = false;
+  // A failed connect may still leave transport resources behind. Keep cleanup
+  // pending until disconnect succeeds so retries cannot stack transports.
+  private _connectionNeedsDisconnect = false;
   // Open requests are queued, but only the latest requested channel is allowed
   // to commit after an asynchronous adapter call resolves.
   private _openRequestGeneration = 0;
@@ -181,11 +184,26 @@ export class ManagedChatClient<
         return;
       }
 
+      if (this._connectionNeedsDisconnect) {
+        try {
+          await this._connectionAdapter.disconnect();
+          this._connectionNeedsDisconnect = false;
+        } catch (error) {
+          const cleanupError = this._createAdapterError("start cleanup", [
+            error,
+          ]);
+          this._setStatus(ChatClientStatus.Failed);
+          this._emit(ChatClientEvent.Error, cleanupError);
+          throw cleanupError;
+        }
+      }
+
       this._bootstrap = bootstrap;
       const connectionEpoch = ++this._connectionEpoch;
       this._connectionAvailable = true;
       this._connectionContext = this._createConnectionContext(connectionEpoch);
       this._setStatus(ChatClientStatus.Connecting);
+      this._connectionNeedsDisconnect = true;
 
       try {
         await this._connectionAdapter.connect(
@@ -193,7 +211,21 @@ export class ManagedChatClient<
           this._connectionContext
         );
       } catch (err) {
+        this._connectionEpoch += 1;
+        this._bootstrap = null;
+        const errors: unknown[] = [err];
+        try {
+          await this._connectionAdapter.disconnect();
+          this._connectionNeedsDisconnect = false;
+        } catch (cleanupError) {
+          errors.push(cleanupError);
+        }
         this._setStatus(ChatClientStatus.Failed);
+        if (errors.length > 1) {
+          const error = this._createAdapterError("start", errors);
+          this._emit(ChatClientEvent.Error, error);
+          throw error;
+        }
         throw err;
       }
 
@@ -224,9 +256,10 @@ export class ManagedChatClient<
         errors.push(error);
       }
 
-      if (this._started) {
+      if (this._connectionNeedsDisconnect) {
         try {
           await this._connectionAdapter.disconnect();
+          this._connectionNeedsDisconnect = false;
         } catch (error) {
           errors.push(error);
           this._emit(ChatClientEvent.Error, error);
@@ -237,7 +270,6 @@ export class ManagedChatClient<
       this._bootstrap = null;
 
       this._setStatus(ChatClientStatus.Stopped);
-      this._clearAllListeners();
 
       if (errors.length > 0) {
         throw this._createAdapterError("stop", errors);
@@ -279,6 +311,7 @@ export class ManagedChatClient<
         const oldLease = this._currentLease;
         if (oldLease) {
           await this._teardownLease(oldLease);
+          this._throwIfOpenSuperseded(requestGeneration);
         }
 
         if (this._subscribeAdapter) {
@@ -288,8 +321,10 @@ export class ManagedChatClient<
           } catch {
             // Subscription setup must not fail the open itself.
           }
+          this._throwIfOpenSuperseded(requestGeneration);
         }
 
+        this._throwIfOpenSuperseded(requestGeneration);
         const newLease = new ManagedConversationLease(this, handle);
         if (subscribed) newLease._markSubscribed();
         newLease._markOpened();
@@ -353,10 +388,6 @@ export class ManagedChatClient<
         }
       }
     }
-  }
-
-  private _clearAllListeners(): void {
-    this._listeners.clear();
   }
 
   private _enqueueOperation<T>(operation: () => Promise<T>): Promise<T> {

--- a/packages/chat-core/src/ManagedChatClient.ts
+++ b/packages/chat-core/src/ManagedChatClient.ts
@@ -1,0 +1,516 @@
+import {
+  ChatClientBootstrap,
+  ChatClient,
+  ChatClientEvent,
+  ChatClientSnapshot,
+  ChatClientStatus,
+  ChatChannelRef,
+  ChatConversationLease,
+  ChatConversationHandle,
+  ChatConnectionAdapter,
+  ChatConnectionContext,
+  ChatConversationAdapter,
+  ChatSubscribeAdapter,
+  ChatMessageAdapter,
+  ChatMessagePort,
+} from "./types";
+
+type EventListener = (...args: any[]) => void;
+
+// ---------------------------------------------------------------------------
+// ManagedChatClient
+// ---------------------------------------------------------------------------
+
+export interface ManagedChatClientOptions<
+  TMessage = unknown,
+  TContent = unknown,
+  TStatus = unknown
+> {
+  subscribeAdapter?: ChatSubscribeAdapter;
+  messageAdapter?: ChatMessageAdapter<TMessage, TContent, TStatus>;
+}
+
+/**
+ * A controlled lease returned by `ManagedChatClient`.
+ *
+ * `release()` owns the full teardown chain and is idempotent. The adapter
+ * handle stays private; consumers only ever interact with this lease.
+ */
+class ManagedConversationLease implements ChatConversationLease {
+  readonly channel: ChatChannelRef;
+  private _released = false;
+  private _cleanupPromise: Promise<void> | null = null;
+  private _subscribed = false;
+  private _opened = false;
+
+  constructor(
+    private readonly _owner: ManagedChatClient,
+    readonly _handle: ChatConversationHandle
+  ) {
+    this.channel = _handle.channel;
+  }
+
+  get released(): boolean {
+    return this._released;
+  }
+
+  release(): void {
+    if (!this._requestRelease()) return;
+    this._owner._scheduleRelease(this);
+  }
+
+  _requestRelease(): boolean {
+    if (this._released) return false;
+    this._released = true;
+    return true;
+  }
+
+  _ensureCleanup(operation: () => Promise<void>): Promise<void> {
+    this._released = true;
+    if (!this._cleanupPromise) {
+      this._cleanupPromise = operation();
+    }
+    return this._cleanupPromise;
+  }
+
+  _markSubscribed(): void {
+    this._subscribed = true;
+  }
+
+  get _wasSubscribed(): boolean {
+    return this._subscribed;
+  }
+
+  _markOpened(): void {
+    this._opened = true;
+  }
+
+  get _wasOpened(): boolean {
+    return this._opened;
+  }
+}
+
+/** Raised when a newer open request or stop supersedes a pending request. */
+export class ChatConversationSupersededError extends Error {
+  constructor() {
+    super("The conversation open request was superseded by a newer request.");
+    this.name = "ChatConversationSupersededError";
+  }
+}
+
+/**
+ * Concrete ChatClient that delegates to adapters and manages:
+ *
+ * - Idempotent start / stop
+ * - Single active-conversation ownership with safe switching
+ * - Automatic lease release on stop / switch
+ * - Event subscription cleanup on stop
+ * - Failed-state support
+ * - A generic message port routed to the optional message adapter
+ */
+export class ManagedChatClient<
+  TMessage = unknown,
+  TContent = unknown,
+  TStatus = unknown
+> implements ChatClient
+{
+  private _status: ChatClientStatus = ChatClientStatus.Idle;
+  private _currentLease: ManagedConversationLease | null = null;
+  private _bootstrap: ChatClientBootstrap | null = null;
+  private _listeners = new Map<ChatClientEvent, Set<EventListener>>();
+
+  // Adapter state
+  private _connectionAdapter: ChatConnectionAdapter;
+  private _conversationAdapter: ChatConversationAdapter;
+  private _subscribeAdapter: ChatSubscribeAdapter | null;
+
+  /** Generic message port — always present, delegates to the message adapter. */
+  readonly messages: ChatMessagePort<TMessage, TContent, TStatus>;
+
+  // Connection, conversation and lease teardown side effects share one queue.
+  // This makes stop a real teardown barrier and prevents same-channel
+  // subscribe/unsubscribe operations from overtaking each other.
+  private _operationQueue: Promise<void> = Promise.resolve();
+  // Tracks whether we have started (for idempotent stop).
+  private _started = false;
+  // Open requests are queued, but only the latest requested channel is allowed
+  // to commit after an asynchronous adapter call resolves.
+  private _openRequestGeneration = 0;
+  private _connectionEpoch = 0;
+  private _connectionAvailable = true;
+  private _connectionContext = this._createConnectionContext(0);
+  private _backgroundTeardownError: Error | null = null;
+
+  constructor(
+    connectionAdapter: ChatConnectionAdapter,
+    conversationAdapter: ChatConversationAdapter,
+    options: ManagedChatClientOptions<TMessage, TContent, TStatus> = {}
+  ) {
+    this._connectionAdapter = connectionAdapter;
+    this._conversationAdapter = conversationAdapter;
+    this._subscribeAdapter = options.subscribeAdapter ?? null;
+    this.messages =
+      options.messageAdapter ?? this._createUnavailableMessagePort();
+  }
+
+  // ---- accessors ----------------------------------------------------------
+
+  get status(): ChatClientStatus {
+    return this._status;
+  }
+
+  get activeConversation(): ChatConversationLease | null {
+    return this._currentLease && !this._currentLease.released
+      ? this._currentLease
+      : null;
+  }
+
+  get connectionContext(): ChatConnectionContext {
+    return this._connectionContext;
+  }
+
+  // ---- start / stop ------------------------------------------------------
+
+  start(bootstrap: ChatClientBootstrap): Promise<void> {
+    return this._enqueueOperation(async () => {
+      if (this._started && this._status === ChatClientStatus.Connected) {
+        return;
+      }
+
+      this._bootstrap = bootstrap;
+      const connectionEpoch = ++this._connectionEpoch;
+      this._connectionAvailable = true;
+      this._connectionContext = this._createConnectionContext(connectionEpoch);
+      this._setStatus(ChatClientStatus.Connecting);
+
+      try {
+        await this._connectionAdapter.connect(
+          bootstrap,
+          this._connectionContext
+        );
+      } catch (err) {
+        this._setStatus(ChatClientStatus.Failed);
+        throw err;
+      }
+
+      this._started = true;
+      if (connectionEpoch === this._connectionEpoch) {
+        this._setStatus(
+          this._connectionAvailable
+            ? ChatClientStatus.Connected
+            : ChatClientStatus.Disconnected
+        );
+      }
+    });
+  }
+
+  stop(): Promise<void> {
+    this._openRequestGeneration += 1;
+    this._connectionEpoch += 1;
+
+    return this._enqueueOperation(async () => {
+      const errors: unknown[] = [];
+      if (this._backgroundTeardownError) {
+        errors.push(this._backgroundTeardownError);
+        this._backgroundTeardownError = null;
+      }
+      try {
+        await this._releaseCurrentLease();
+      } catch (error) {
+        errors.push(error);
+      }
+
+      if (this._started) {
+        try {
+          await this._connectionAdapter.disconnect();
+        } catch (error) {
+          errors.push(error);
+          this._emit(ChatClientEvent.Error, error);
+        }
+      }
+
+      this._started = false;
+      this._bootstrap = null;
+
+      this._setStatus(ChatClientStatus.Stopped);
+      this._clearAllListeners();
+
+      if (errors.length > 0) {
+        throw this._createAdapterError("stop", errors);
+      }
+    });
+  }
+
+  // ---- conversation management -------------------------------------------
+
+  async openConversation(
+    channel: ChatChannelRef
+  ): Promise<ChatConversationLease> {
+    const requestGeneration = ++this._openRequestGeneration;
+    return this._enqueueOperation(async () => {
+      if (!this._started) {
+        throw new Error(
+          "ManagedChatClient.openConversation: client is not started."
+        );
+      }
+      if (this._status === ChatClientStatus.Failed) {
+        throw new Error(
+          "ManagedChatClient.openConversation: client must be restarted after an adapter teardown failure."
+        );
+      }
+      this._throwIfOpenSuperseded(requestGeneration);
+
+      let handle: ChatConversationHandle;
+      try {
+        handle = await this._conversationAdapter.openConversation(channel);
+      } catch (error) {
+        this._throwIfOpenSuperseded(requestGeneration);
+        throw error;
+      }
+      let subscribed = false;
+
+      try {
+        this._throwIfOpenSuperseded(requestGeneration);
+
+        const oldLease = this._currentLease;
+        if (oldLease) {
+          await this._teardownLease(oldLease);
+        }
+
+        if (this._subscribeAdapter) {
+          try {
+            await this._subscribeAdapter.subscribe(channel);
+            subscribed = true;
+          } catch {
+            // Subscription setup must not fail the open itself.
+          }
+        }
+
+        const newLease = new ManagedConversationLease(this, handle);
+        if (subscribed) newLease._markSubscribed();
+        newLease._markOpened();
+        this._currentLease = newLease;
+        this._emit(ChatClientEvent.ConversationOpened, channel);
+        return newLease;
+      } catch (error) {
+        await this._discardHandle(handle, channel, subscribed);
+        throw error;
+      }
+    });
+  }
+
+  // ---- snapshot ----------------------------------------------------------
+
+  getSnapshot(): ChatClientSnapshot {
+    return {
+      status: this._status,
+      activeConversation: this.activeConversation,
+    };
+  }
+
+  // ---- subscriptions -----------------------------------------------------
+
+  subscribe(
+    event: ChatClientEvent,
+    listener: (...args: any[]) => void
+  ): () => void {
+    if (!this._listeners.has(event)) {
+      this._listeners.set(event, new Set());
+    }
+    this._listeners.get(event)!.add(listener);
+
+    return () => {
+      const set = this._listeners.get(event);
+      if (set) {
+        set.delete(listener);
+        if (set.size === 0) this._listeners.delete(event);
+      }
+    };
+  }
+
+  // ---- internal helpers --------------------------------------------------
+
+  private _setStatus(status: ChatClientStatus): void {
+    const prev = this._status;
+    this._status = status;
+    if (prev !== status) {
+      this._emit(ChatClientEvent.StatusChanged, status, prev);
+    }
+  }
+
+  private _emit(event: ChatClientEvent, ...args: any[]): void {
+    const set = this._listeners.get(event);
+    if (set) {
+      for (const listener of set) {
+        try {
+          listener(...args);
+        } catch {
+          // Swallow individual listener errors
+        }
+      }
+    }
+  }
+
+  private _clearAllListeners(): void {
+    this._listeners.clear();
+  }
+
+  private _enqueueOperation<T>(operation: () => Promise<T>): Promise<T> {
+    const result = this._operationQueue.then(operation, operation);
+    this._operationQueue = result.then(
+      () => undefined,
+      () => undefined
+    );
+    return result;
+  }
+
+  private async _releaseCurrentLease(): Promise<void> {
+    const lease = this._currentLease;
+    if (lease) {
+      await this._teardownLease(lease);
+    }
+  }
+
+  /**
+   * Full teardown for a controlled lease — single idempotent entry point.
+   *
+   * Marks the lease released (first call only), then runs the teardown
+   * chain: close conversation, unsubscribe, clear active (only if the
+   * released lease is still current), and emit the closed event.
+   */
+  _scheduleRelease(lease: ManagedConversationLease): void {
+    void this._enqueueOperation(() => this._teardownLease(lease)).catch(
+      (error) => {
+        if (this._status !== ChatClientStatus.Stopped) {
+          this._backgroundTeardownError =
+            error instanceof Error ? error : new Error(String(error));
+        }
+      }
+    );
+  }
+
+  private async _teardownLease(lease: ManagedConversationLease): Promise<void> {
+    await lease._ensureCleanup(async () => {
+      const errors: unknown[] = [];
+      try {
+        await this._conversationAdapter.closeConversation(lease._handle);
+      } catch (error) {
+        errors.push(error);
+      }
+      if (lease._wasSubscribed && this._subscribeAdapter) {
+        try {
+          await this._subscribeAdapter.unsubscribe(lease.channel);
+        } catch (error) {
+          errors.push(error);
+        }
+      }
+      if (this._currentLease === lease) {
+        this._currentLease = null;
+      }
+      if (lease._wasOpened) {
+        this._emit(ChatClientEvent.ConversationClosed, lease.channel);
+      }
+      if (errors.length > 0) {
+        const error = this._createAdapterError("conversation teardown", errors);
+        this._setStatus(ChatClientStatus.Failed);
+        this._emit(ChatClientEvent.Error, error);
+        throw error;
+      }
+    });
+  }
+
+  private async _discardHandle(
+    handle: ChatConversationHandle,
+    channel: ChatChannelRef,
+    subscribed: boolean
+  ): Promise<void> {
+    const errors: unknown[] = [];
+    try {
+      await this._conversationAdapter.closeConversation(handle);
+    } catch (error) {
+      errors.push(error);
+    }
+    if (subscribed && this._subscribeAdapter) {
+      try {
+        await this._subscribeAdapter.unsubscribe(channel);
+      } catch (error) {
+        errors.push(error);
+      }
+    }
+    if (errors.length > 0) {
+      const error = this._createAdapterError(
+        "superseded conversation cleanup",
+        errors
+      );
+      this._setStatus(ChatClientStatus.Failed);
+      this._emit(ChatClientEvent.Error, error);
+      throw error;
+    }
+  }
+
+  private _throwIfOpenSuperseded(requestGeneration: number): void {
+    if (requestGeneration !== this._openRequestGeneration || !this._started) {
+      throw new ChatConversationSupersededError();
+    }
+  }
+
+  private _createConnectionContext(epoch: number): ChatConnectionContext {
+    return {
+      onConnectionLost: () => this._handleConnectionLost(epoch),
+      onConnectionRestored: () => this._handleConnectionRestored(epoch),
+    };
+  }
+
+  private _createAdapterError(operation: string, errors: unknown[]): Error {
+    const detail = errors
+      .map((error) => (error instanceof Error ? error.message : String(error)))
+      .join("; ");
+    return new Error(`ManagedChatClient ${operation} failed: ${detail}`);
+  }
+
+  private _handleConnectionLost(epoch: number): void {
+    if (epoch !== this._connectionEpoch) return;
+    this._connectionAvailable = false;
+    if (
+      this._status === ChatClientStatus.Connected ||
+      this._status === ChatClientStatus.Connecting
+    ) {
+      this._setStatus(ChatClientStatus.Disconnected);
+    }
+  }
+
+  private _handleConnectionRestored(epoch: number): void {
+    if (epoch !== this._connectionEpoch) return;
+    this._connectionAvailable = true;
+    if (this._status === ChatClientStatus.Disconnected) {
+      this._setStatus(
+        this._started ? ChatClientStatus.Connected : ChatClientStatus.Connecting
+      );
+    }
+  }
+
+  /** Clear-error message port for when no message adapter is configured. */
+  private _createUnavailableMessagePort(): ChatMessagePort<
+    TMessage,
+    TContent,
+    TStatus
+  > {
+    const asyncUnavailable = (operation: string) =>
+      Promise.reject(
+        new Error(
+          `ManagedChatClient.${operation}: requires a ChatMessageAdapter, which was not configured for this client.`
+        )
+      );
+    const syncUnavailable = (operation: string): never => {
+      throw new Error(
+        `ManagedChatClient.${operation}: requires a ChatMessageAdapter, which was not configured for this client.`
+      );
+    };
+    return {
+      loadMessages: () => asyncUnavailable("loadMessages"),
+      subscribeMessages: () => syncUnavailable("subscribeMessages"),
+      subscribeMessageStatus: () => syncUnavailable("subscribeMessageStatus"),
+      sendMessage: () => asyncUnavailable("sendMessage"),
+    };
+  }
+}

--- a/packages/chat-core/src/index.ts
+++ b/packages/chat-core/src/index.ts
@@ -1,0 +1,23 @@
+export {
+  ChatClientStatus,
+  ChatClientEvent,
+  chatChannelKey,
+  type ChatChannelRef,
+  type ChatClientBootstrap,
+  type ChatClientSnapshot,
+  type ChatConversationLease,
+  type ChatConversationHandle,
+  type ChatClient,
+  type ChatConnectionAdapter,
+  type ChatConnectionContext,
+  type ChatConversationAdapter,
+  type ChatSubscribeAdapter,
+  type ChatMessagePort,
+  type ChatMessageLoadOptions,
+  type ChatMessageAdapter,
+} from "./types";
+export {
+  ChatConversationSupersededError,
+  ManagedChatClient,
+  type ManagedChatClientOptions,
+} from "./ManagedChatClient";

--- a/packages/chat-core/src/types.ts
+++ b/packages/chat-core/src/types.ts
@@ -200,7 +200,10 @@ export interface ChatClient {
   /** The generic message port — always present at runtime. */
   readonly messages: ChatMessagePort;
 
-  /** Boot the client. Idempotent — safe to call multiple times. */
+  /**
+   * Boot the client. Idempotent while started; repeated calls keep the
+   * bootstrap from the first successful start until `stop()` completes.
+   */
   start(bootstrap: ChatClientBootstrap): Promise<void>;
 
   /** Tear down the client. Idempotent. */

--- a/packages/chat-core/src/types.ts
+++ b/packages/chat-core/src/types.ts
@@ -221,8 +221,10 @@ export interface ChatClient {
   /**
    * Register an event listener.
    *
-   * Returns an unsubscribe function. All subscriptions are cleaned up
-   * automatically on `stop()`.
+   * Returns an unsubscribe function. Listeners remain registered across an
+   * explicit `stop()` / `start()` cycle so mounted consumers can observe and
+   * recover from restarts. Consumers must call the returned function when
+   * their own lifecycle ends.
    */
   subscribe(
     event: ChatClientEvent,

--- a/packages/chat-core/src/types.ts
+++ b/packages/chat-core/src/types.ts
@@ -1,0 +1,231 @@
+/**
+ * @octo/chat-core — core chat primitive types
+ *
+ * Pure type/value definitions with no non-standard dependencies.
+ */
+
+/** Plain channel reference, compatible with WuKongIM Channel shape. */
+export interface ChatChannelRef {
+  channelId: string;
+  channelType: number;
+}
+
+/**
+ * Canonical string key for a channel, following WuKongIM's
+ * `"${channelID}-${channelType}"` convention.
+ */
+export function chatChannelKey(channel: ChatChannelRef): string {
+  return `${channel.channelId}-${channel.channelType}`;
+}
+
+/** Observable lifecycle status of a chat client. */
+export enum ChatClientStatus {
+  Idle = "idle",
+  Connecting = "connecting",
+  Connected = "connected",
+  Disconnected = "disconnected",
+  Failed = "failed",
+  Stopped = "stopped",
+}
+
+/** Bootstrap parameters for starting a chat client. */
+export interface ChatClientBootstrap {
+  /** Endpoint for the chat connection (WebSocket URL, API origin, etc.). */
+  readonly endpoint?: string;
+  /** Authentication token or credential. */
+  readonly token?: string;
+  /** SDK-free session identifier (e.g. a login session ID or device token). */
+  readonly session?: string;
+  /** SDK-free space identifier (e.g. workspace or tenant ID). */
+  readonly space?: string;
+  /** Optional initial target metadata made available to the connection adapter. */
+  readonly initialChannel?: ChatChannelRef;
+}
+
+/** Named events emitted by a ChatClient. */
+export enum ChatClientEvent {
+  StatusChanged = "statusChanged",
+  ConversationOpened = "conversationOpened",
+  ConversationClosed = "conversationClosed",
+  Error = "error",
+  /** Fired when a new message arrives for the active conversation. */
+  MessageReceived = "messageReceived",
+  /** Fired when a sent message's status changes. */
+  MessageStatusChanged = "messageStatusChanged",
+}
+
+/** Snapshot of client state at a point in time. */
+export interface ChatClientSnapshot {
+  readonly status: ChatClientStatus;
+  readonly activeConversation: ChatConversationLease | null;
+}
+
+/** Connection-scoped callbacks used by transport adapters. */
+export interface ChatConnectionContext {
+  /** Report an involuntary connection loss for this connection epoch. */
+  onConnectionLost(): void;
+  /** Report that this connection epoch has been restored. */
+  onConnectionRestored(): void;
+}
+
+// ---------------------------------------------------------------------------
+// Adapter interfaces  –  pluggable backends
+// ---------------------------------------------------------------------------
+
+/** Low-level connection lifecycle (WebSocket, long-poll, etc.). */
+export interface ChatConnectionAdapter {
+  readonly status: ChatClientStatus;
+  connect(
+    bootstrap: ChatClientBootstrap,
+    context: ChatConnectionContext
+  ): Promise<void>;
+  disconnect(): Promise<void>;
+}
+
+/**
+ * Opaque handle returned by the conversation adapter's `openConversation`.
+ *
+ * The adapter may attach implementation-specific data here.
+ * Consumers interact with the higher-level `ChatConversationLease` instead.
+ */
+export interface ChatConversationHandle {
+  readonly channel: ChatChannelRef;
+}
+
+/**
+ * Conversation lifecycle — adapter contract.
+ *
+ * `openConversation` returns an opaque handle.
+ * The consumer's `ChatConversationLease` is managed by `ManagedChatClient`.
+ */
+export interface ChatConversationAdapter {
+  openConversation(channel: ChatChannelRef): Promise<ChatConversationHandle>;
+  closeConversation(handle: ChatConversationHandle): Promise<void>;
+}
+
+/** Optional channel-level event subscription (receive / typing / etc.). */
+export interface ChatSubscribeAdapter {
+  subscribe(channel: ChatChannelRef): Promise<void>;
+  unsubscribe(channel: ChatChannelRef): Promise<void>;
+}
+
+// ---------------------------------------------------------------------------
+// Message port — generic, SDK-free message contract
+// ---------------------------------------------------------------------------
+
+/** Direction bias for loading messages. */
+export interface ChatMessageLoadOptions {
+  older?: number; // load N messages before the anchor
+  newer?: number; // load N messages after the anchor
+  around?: number; // load N messages centered on the anchor
+  anchor?: string; // message ID or seq to anchor around; omit = latest
+}
+
+/**
+ * Generic message port — the single capability contract for message
+ * I/O that consumers depend on.
+ *
+ * None of these types reference WuKongIM or any SDK class.
+ * Adapters map between the SDK model and these generic values.
+ */
+export interface ChatMessagePort<
+  TMessage = unknown,
+  TContent = unknown,
+  TStatus = unknown
+> {
+  /** Load historical messages for a channel. */
+  loadMessages(
+    channel: ChatChannelRef,
+    options?: ChatMessageLoadOptions
+  ): Promise<TMessage[]>;
+
+  /**
+   * Subscribe to incoming messages.
+   * Returns an unsubscribe function.
+   */
+  subscribeMessages(listener: (message: TMessage) => void): () => void;
+
+  /**
+   * Subscribe to send-status changes for previously sent messages.
+   * Returns an unsubscribe function.
+   */
+  subscribeMessageStatus(
+    listener: (messageId: string, status: TStatus) => void
+  ): () => void;
+
+  /**
+   * Send a message to a channel.
+   * Returns the confirmed message object from the server / local DB.
+   */
+  sendMessage(content: TContent, channel: ChatChannelRef): Promise<TMessage>;
+}
+
+/** Adapter that provides the message port implementation. */
+export interface ChatMessageAdapter<
+  TMessage = unknown,
+  TContent = unknown,
+  TStatus = unknown
+> extends ChatMessagePort<TMessage, TContent, TStatus> {}
+
+// ---------------------------------------------------------------------------
+// Lease
+// ---------------------------------------------------------------------------
+
+/**
+ * Consumer-facing conversation lease.
+ *
+ * `release()` is idempotent and owns the full teardown chain:
+ * close conversation, unsubscribe, emit event.
+ */
+export interface ChatConversationLease {
+  readonly channel: ChatChannelRef;
+  readonly released: boolean;
+  release(): void;
+}
+
+// ---------------------------------------------------------------------------
+// Client contract
+// ---------------------------------------------------------------------------
+
+/**
+ * Core chat client interface.
+ *
+ * Consumers depend on this interface; the concrete implementation
+ * delegates to adapters.
+ */
+export interface ChatClient {
+  readonly status: ChatClientStatus;
+  readonly activeConversation: ChatConversationLease | null;
+
+  /** The generic message port — always present at runtime. */
+  readonly messages: ChatMessagePort;
+
+  /** Boot the client. Idempotent — safe to call multiple times. */
+  start(bootstrap: ChatClientBootstrap): Promise<void>;
+
+  /** Tear down the client. Idempotent. */
+  stop(): Promise<void>;
+
+  /**
+   * Open (or switch to) a conversation.
+   *
+   * Concurrent calls use latest-request-wins ownership. The previous lease is
+   * kept alive until the winning replacement is ready, then released without
+   * allowing its teardown to clear the newer active lease.
+   */
+  openConversation(channel: ChatChannelRef): Promise<ChatConversationLease>;
+
+  /** Snapshot of current state. */
+  getSnapshot(): ChatClientSnapshot;
+
+  /**
+   * Register an event listener.
+   *
+   * Returns an unsubscribe function. All subscriptions are cleaned up
+   * automatically on `stop()`.
+   */
+  subscribe(
+    event: ChatClientEvent,
+    listener: (...args: any[]) => void
+  ): () => void;
+}

--- a/packages/chat-core/tsconfig.json
+++ b/packages/chat-core/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../packages/tsconfig/react-library.json",
+  "include": ["src"],
+  "exclude": ["dist", "build", "node_modules"]
+}

--- a/packages/chat-core/vitest.config.ts
+++ b/packages/chat-core/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+  },
+});

--- a/packages/chat-react/package.json
+++ b/packages/chat-react/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@octo/chat-react",
+  "version": "0.1.0",
+  "private": true,
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "scripts": {
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage --coverage.include='src/**/*.{ts,tsx}' --coverage.exclude='src/**/__tests__/**' --coverage.exclude='**/*.test.{ts,tsx}' --coverage.reportOnFailure",
+    "typecheck": "tsc --noEmit -p tsconfig.json"
+  },
+  "dependencies": {
+    "@octo/chat-core": "workspace:*"
+  },
+  "peerDependencies": {
+    "react": "^17.0.2 || ^18.0.0"
+  },
+  "devDependencies": {
+    "@types/react": "^17.0.80",
+    "@types/react-dom": "^17.0.25",
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2",
+    "vitest": "^4.1.5",
+    "jsdom": "^29.0.1",
+    "@testing-library/react": "^13.4.0",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/jest-dom": "^6.9.1"
+  }
+}

--- a/packages/chat-react/src/ChatContext.ts
+++ b/packages/chat-react/src/ChatContext.ts
@@ -1,0 +1,11 @@
+import { createContext } from 'react'
+import type { ChatClient } from '@octo/chat-core'
+import type { ChatHostCapabilities } from './types'
+
+export interface ChatContextValue {
+  client: ChatClient
+  host?: ChatHostCapabilities
+}
+
+export const ChatContext = createContext<ChatContextValue | null>(null)
+export const ChatHostContext = createContext<ChatHostCapabilities | undefined>(undefined)

--- a/packages/chat-react/src/ChatProvider.tsx
+++ b/packages/chat-react/src/ChatProvider.tsx
@@ -1,0 +1,72 @@
+import React, { useEffect, useRef, useMemo, type ReactNode } from "react";
+import type { ChatClient, ChatClientBootstrap } from "@octo/chat-core";
+import type { ChatHostCapabilities } from "./types";
+import { ChatContext, ChatHostContext } from "./ChatContext";
+
+export interface ChatProviderProps {
+  /** Explicit ChatClient instance. Required. */
+  client: ChatClient;
+
+  /** Optional host capabilities for platform actions. */
+  host?: ChatHostCapabilities;
+
+  /** Bootstrap config passed to client.start() when manageLifecycle is true. */
+  bootstrap?: ChatClientBootstrap;
+
+  /**
+   * When true (and bootstrap is provided), the provider calls
+   * client.start(bootstrap) on mount and client.stop() on unmount.
+   * Defaults to false — the host manages client lifecycle.
+   */
+  manageLifecycle?: boolean;
+
+  children: ReactNode;
+}
+
+/**
+ * Provides a ChatClient and optional HostCapabilities to the React tree.
+ *
+ * By default the provider does NOT own the client lifecycle; pass both
+ * `bootstrap` and `manageLifecycle` to have it call start/stop automatically.
+ */
+export function ChatProvider({
+  client,
+  host,
+  bootstrap,
+  manageLifecycle = false,
+  children,
+}: ChatProviderProps): JSX.Element {
+  const startedRef = useRef(false);
+
+  useEffect(() => {
+    if (!manageLifecycle || !bootstrap) return;
+
+    let cancelled = false;
+
+    void client
+      .start(bootstrap)
+      .then(() => {
+        if (!cancelled) startedRef.current = true;
+      })
+      .catch(() => {
+        startedRef.current = false;
+      });
+
+    return () => {
+      cancelled = true;
+      startedRef.current = false;
+      void client.stop().catch(() => undefined);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [client, bootstrap, manageLifecycle]);
+
+  const ctx = useMemo(() => ({ client, host }), [client, host]);
+
+  return (
+    <ChatContext.Provider value={ctx}>
+      <ChatHostContext.Provider value={host}>
+        {children}
+      </ChatHostContext.Provider>
+    </ChatContext.Provider>
+  );
+}

--- a/packages/chat-react/src/ChatProvider.tsx
+++ b/packages/chat-react/src/ChatProvider.tsx
@@ -1,4 +1,11 @@
-import React, { useEffect, useRef, useMemo, type ReactNode } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
 import type { ChatClient, ChatClientBootstrap } from "@octo/chat-core";
 import type { ChatHostCapabilities } from "./types";
 import { ChatContext, ChatHostContext } from "./ChatContext";
@@ -20,7 +27,30 @@ export interface ChatProviderProps {
    */
   manageLifecycle?: boolean;
 
+  /** Rendered when a managed lifecycle operation fails. */
+  lifecycleFallback?:
+    | ReactNode
+    | ((state: ChatProviderLifecycleFailure) => ReactNode);
+
+  /** Called when a managed lifecycle operation fails. */
+  onLifecycleError?: (error: Error) => void;
+
   children: ReactNode;
+}
+
+export interface ChatProviderLifecycleFailure {
+  error: Error;
+  retry(): void;
+}
+
+interface PendingManagedStop {
+  client: ChatClient;
+  error?: Error;
+  reported: boolean;
+}
+
+function normalizeLifecycleError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
 }
 
 /**
@@ -34,38 +64,180 @@ export function ChatProvider({
   host,
   bootstrap,
   manageLifecycle = false,
+  lifecycleFallback,
+  onLifecycleError,
   children,
 }: ChatProviderProps): JSX.Element {
-  const startedRef = useRef(false);
+  const managedBootstrap = useMemo<ChatClientBootstrap | null>(() => {
+    if (!manageLifecycle || !bootstrap) return null;
+    return {
+      endpoint: bootstrap.endpoint,
+      token: bootstrap.token,
+      session: bootstrap.session,
+      space: bootstrap.space,
+      initialChannel: bootstrap.initialChannel
+        ? {
+            channelId: bootstrap.initialChannel.channelId,
+            channelType: bootstrap.initialChannel.channelType,
+          }
+        : undefined,
+    };
+  }, [
+    manageLifecycle,
+    bootstrap?.endpoint,
+    bootstrap?.token,
+    bootstrap?.session,
+    bootstrap?.space,
+    bootstrap?.initialChannel?.channelId,
+    bootstrap?.initialChannel?.channelType,
+  ]);
+  const [readyLifecycle, setReadyLifecycle] = useState<{
+    client: ChatClient;
+    bootstrap: ChatClientBootstrap;
+  } | null>(null);
+  const [lifecycleError, setLifecycleError] = useState<Error | null>(null);
+  const [retryVersion, setRetryVersion] = useState(0);
+  const lifecycleQueueRef = useRef<Promise<void>>(Promise.resolve());
+  const pendingStopRef = useRef<PendingManagedStop | null>(null);
+  const retryPendingStopRef = useRef(false);
+  const hostRef = useRef(host);
+  const onLifecycleErrorRef = useRef(onLifecycleError);
+  hostRef.current = host;
+  onLifecycleErrorRef.current = onLifecycleError;
+
+  const reportLifecycleError = useCallback((error: Error, code: string) => {
+    try {
+      onLifecycleErrorRef.current?.(error);
+    } catch {
+      // Consumer error callbacks must not escape the lifecycle effect.
+    }
+    try {
+      hostRef.current?.reportError?.({
+        message: error.message,
+        code,
+        stack: error.stack,
+      });
+    } catch {
+      // Host telemetry failures must not create an unhandled rejection.
+    }
+  }, []);
+
+  const retryLifecycle = useCallback(() => {
+    retryPendingStopRef.current = true;
+    setLifecycleError(null);
+    setRetryVersion((version) => version + 1);
+  }, []);
 
   useEffect(() => {
-    if (!manageLifecycle || !bootstrap) return;
+    if (!managedBootstrap) {
+      setReadyLifecycle(null);
+      setLifecycleError(null);
+      return;
+    }
 
     let cancelled = false;
+    let startAttempted = false;
+    let failureCode = "chat-client-start-failed";
+    let errorAlreadyReported = false;
+    const retryPendingStop = retryPendingStopRef.current;
+    retryPendingStopRef.current = false;
+    setReadyLifecycle(null);
+    setLifecycleError(null);
 
-    void client
-      .start(bootstrap)
-      .then(() => {
-        if (!cancelled) startedRef.current = true;
+    const startTask = lifecycleQueueRef.current
+      .then(async () => {
+        if (cancelled) return;
+
+        const pendingStop = pendingStopRef.current;
+        if (pendingStop) {
+          failureCode = "chat-client-stop-failed";
+          if (!retryPendingStop) {
+            errorAlreadyReported = pendingStop.reported;
+            throw pendingStop.error ?? new Error("Previous chat client cleanup is incomplete.");
+          }
+
+          try {
+            await pendingStop.client.stop();
+            if (pendingStopRef.current === pendingStop) {
+              pendingStopRef.current = null;
+            }
+          } catch (error) {
+            const normalized = normalizeLifecycleError(error);
+            pendingStop.error = normalized;
+            pendingStop.reported = false;
+            throw normalized;
+          }
+        }
+
+        if (cancelled) return;
+        failureCode = "chat-client-start-failed";
+        startAttempted = true;
+        await client.start(managedBootstrap);
+        if (!cancelled) {
+          setLifecycleError(null);
+          setReadyLifecycle({ client, bootstrap: managedBootstrap });
+        }
       })
-      .catch(() => {
-        startedRef.current = false;
+      .catch((error: unknown) => {
+        if (cancelled) return;
+        const normalized = normalizeLifecycleError(error);
+        setReadyLifecycle(null);
+        setLifecycleError(normalized);
+        if (!errorAlreadyReported) {
+          reportLifecycleError(normalized, failureCode);
+          const pendingStop = pendingStopRef.current;
+          if (pendingStop?.error === normalized) pendingStop.reported = true;
+        }
       });
+    lifecycleQueueRef.current = startTask.then(
+      () => undefined,
+      () => undefined,
+    );
 
     return () => {
       cancelled = true;
-      startedRef.current = false;
-      void client.stop().catch(() => undefined);
+      const stopTask = lifecycleQueueRef.current.then(async () => {
+        if (!startAttempted) return;
+
+        const pendingStop: PendingManagedStop = {
+          client,
+          reported: false,
+        };
+        pendingStopRef.current = pendingStop;
+        try {
+          await client.stop();
+          if (pendingStopRef.current === pendingStop) {
+            pendingStopRef.current = null;
+          }
+        } catch (error) {
+          const normalized = normalizeLifecycleError(error);
+          pendingStop.error = normalized;
+          pendingStop.reported = true;
+          reportLifecycleError(normalized, "chat-client-stop-failed");
+          throw normalized;
+        }
+      });
+      lifecycleQueueRef.current = stopTask.catch(() => undefined);
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [client, bootstrap, manageLifecycle]);
+  }, [client, managedBootstrap, reportLifecycleError, retryVersion]);
 
   const ctx = useMemo(() => ({ client, host }), [client, host]);
+  const lifecycleReady =
+    !managedBootstrap ||
+    (readyLifecycle?.client === client &&
+      readyLifecycle.bootstrap === managedBootstrap);
+  const renderedChildren = lifecycleReady
+    ? children
+    : lifecycleError && lifecycleFallback
+      ? typeof lifecycleFallback === "function"
+        ? lifecycleFallback({ error: lifecycleError, retry: retryLifecycle })
+        : lifecycleFallback
+      : null;
 
   return (
     <ChatContext.Provider value={ctx}>
       <ChatHostContext.Provider value={host}>
-        {children}
+        {renderedChildren}
       </ChatHostContext.Provider>
     </ChatContext.Provider>
   );

--- a/packages/chat-react/src/ConversationWindow.tsx
+++ b/packages/chat-react/src/ConversationWindow.tsx
@@ -1,11 +1,19 @@
 import React, {
+  useCallback,
   useState,
   useEffect,
+  useMemo,
   useRef,
   type ReactNode,
 } from 'react'
-import type { ChatClient, ChatChannelRef, ChatConversationLease } from '@octo/chat-core'
-import { useChatClient } from './hooks'
+import {
+  ChatClientEvent,
+  ChatClientStatus,
+  ChatConversationSupersededError,
+  type ChatChannelRef,
+  type ChatConversationLease,
+} from '@octo/chat-core'
+import { useChatClient, useChatHostCapabilities } from './hooks'
 import type { ConversationWindowData } from './types'
 
 export type { ConversationWindowData } from './types'
@@ -44,6 +52,9 @@ export interface ConversationWindowProps {
 
   /** Optional stable DOM data attribute value. Defaults to the channel id. */
   'data-channel'?: string
+
+  /** Called when opening the requested conversation fails. */
+  onError?: (error: Error) => void
 }
 
 /**
@@ -67,13 +78,17 @@ export function ConversationWindow({
   className,
   style,
   'data-channel': dataChannel,
+  onError,
 }: ConversationWindowProps): JSX.Element {
   const client = useChatClient()
+  const host = useChatHostCapabilities()
 
-  const [data, setData] = useState<ConversationWindowData>(() => ({
+  const [state, setState] = useState<Omit<ConversationWindowData, 'retry'>>(() => ({
     channel,
     isLeased: false,
+    error: null,
   }))
+  const [retryVersion, setRetryVersion] = useState(0)
 
   // Monotonic request token — invalidates stale async openConversation
   // resolutions so only the latest request may adopt its lease.
@@ -82,6 +97,23 @@ export function ConversationWindow({
   const leaseRef = useRef<ChatConversationLease | null>(null)
   // Guards against setState after unmount.
   const mountedRef = useRef(true)
+  const failedOpenRef = useRef(false)
+  const restartPendingRef = useRef(false)
+  const onErrorRef = useRef(onError)
+  const hostRef = useRef(host)
+  onErrorRef.current = onError
+  hostRef.current = host
+
+  const retry = useCallback(() => {
+    if (!mountedRef.current) return
+    failedOpenRef.current = false
+    setRetryVersion((version) => version + 1)
+  }, [])
+
+  const data = useMemo<ConversationWindowData>(() => ({
+    ...state,
+    retry,
+  }), [retry, state])
 
   useEffect(() => {
     mountedRef.current = true
@@ -89,6 +121,36 @@ export function ConversationWindow({
       mountedRef.current = false
     }
   }, [])
+
+  useEffect(() => client.subscribe(
+    ChatClientEvent.StatusChanged,
+    (status: ChatClientStatus) => {
+      if (!mountedRef.current) return
+
+      if (status === ChatClientStatus.Stopped) {
+        requestRef.current += 1
+        leaseRef.current = null
+        failedOpenRef.current = false
+        restartPendingRef.current = activate
+        setState({ channel, isLeased: false, error: null })
+        return
+      }
+
+      if (
+        status === ChatClientStatus.Connected &&
+        (failedOpenRef.current || restartPendingRef.current)
+      ) {
+        restartPendingRef.current = false
+        retry()
+      }
+    },
+  ), [
+    activate,
+    channel.channelId,
+    channel.channelType,
+    client,
+    retry,
+  ])
 
   useEffect(() => {
     const token = ++requestRef.current
@@ -102,14 +164,17 @@ export function ConversationWindow({
     leaseRef.current = null
 
     if (!activate) {
-      setData({ channel, isLeased: false })
+      failedOpenRef.current = false
+      setState({ channel, isLeased: false, error: null })
       return
     }
 
     let cancelled = false
+    failedOpenRef.current = false
+    restartPendingRef.current = false
 
     // Reset to unleased while the new request is in flight.
-    setData({ channel, isLeased: false })
+    setState({ channel, isLeased: false, error: null })
 
     client
       .openConversation(channel)
@@ -132,11 +197,34 @@ export function ConversationWindow({
           return
         }
         leaseRef.current = lease
-        setData({ channel, isLeased: true })
+        failedOpenRef.current = false
+        setState({ channel, isLeased: true, error: null })
       })
-      .catch(() => {
-        // openConversation failure leaves the window unleased; the next
-        // channel/prop change will re-attempt.
+      .catch((error: unknown) => {
+        if (
+          cancelled ||
+          !mountedRef.current ||
+          requestRef.current !== token ||
+          error instanceof ChatConversationSupersededError
+        ) return
+
+        const normalized = error instanceof Error ? error : new Error(String(error))
+        failedOpenRef.current = true
+        setState({ channel, isLeased: false, error: normalized })
+        try {
+          onErrorRef.current?.(normalized)
+        } catch {
+          // Consumer error handlers must not escape the lease lifecycle.
+        }
+        try {
+          hostRef.current?.reportError?.({
+            message: normalized.message,
+            code: 'conversation-open-failed',
+            stack: normalized.stack,
+          })
+        } catch {
+          // Host telemetry failures must not create an unhandled rejection.
+        }
       })
 
     return () => {
@@ -147,7 +235,7 @@ export function ConversationWindow({
       leaseRef.current = null
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [client, channel.channelId, channel.channelType, activate])
+  }, [client, channel.channelId, channel.channelType, activate, retryVersion])
 
   const rendered =
     typeof children === 'function'

--- a/packages/chat-react/src/ConversationWindow.tsx
+++ b/packages/chat-react/src/ConversationWindow.tsx
@@ -1,0 +1,166 @@
+import React, {
+  useState,
+  useEffect,
+  useRef,
+  type ReactNode,
+} from 'react'
+import type { ChatClient, ChatChannelRef, ChatConversationLease } from '@octo/chat-core'
+import { useChatClient } from './hooks'
+import type { ConversationWindowData } from './types'
+
+export type { ConversationWindowData } from './types'
+
+/* ------------------------------------------------------------------ */
+/*  Props                                                              */
+/* ------------------------------------------------------------------ */
+
+export interface ConversationWindowProps {
+  /** Target channel to open. */
+  channel: ChatChannelRef
+
+  /**
+   * Static children, a render function receiving ConversationWindowData,
+   * or omitted.
+   *
+   * - `ReactNode`: rendered directly.
+   * - `(data: ConversationWindowData) => ReactNode`: called with current state.
+   * - `undefined`: nothing is rendered (the component only manages the lease).
+   */
+  children?:
+    | ReactNode
+    | ((data: ConversationWindowData) => ReactNode)
+
+  /**
+   * When true (default), mount opens the conversation and unmount / channel
+   * changes release the lease. Set to false to defer channel activation.
+   */
+  activate?: boolean
+
+  /** Additional CSS class name for the stable wrapper. */
+  className?: string
+
+  /** Inline styles for the wrapper. */
+  style?: React.CSSProperties
+
+  /** Optional stable DOM data attribute value. Defaults to the channel id. */
+  'data-channel'?: string
+}
+
+/**
+ * Binds a conversation channel lifecycle via
+ * `ChatClient.openConversation()`.
+ *
+ * The client's `openConversation` is asynchronous, so this component guards
+ * against races:
+ *
+ * - When `channel` / `client` changes or the component unmounts before a
+ *   pending lease resolves, the late-arriving lease is released immediately
+ *   — it is never adopted as the active lease, and never calls setState.
+ * - When `activate` flips to false, the current lease is released.
+ * - Old lease release never clobbers a newer lease because only the effect
+ *   instance associated with the current request token may adopt a lease.
+ */
+export function ConversationWindow({
+  channel,
+  children,
+  activate = true,
+  className,
+  style,
+  'data-channel': dataChannel,
+}: ConversationWindowProps): JSX.Element {
+  const client = useChatClient()
+
+  const [data, setData] = useState<ConversationWindowData>(() => ({
+    channel,
+    isLeased: false,
+  }))
+
+  // Monotonic request token — invalidates stale async openConversation
+  // resolutions so only the latest request may adopt its lease.
+  const requestRef = useRef(0)
+  // Currently adopted lease, if any.  Released synchronously on cleanup.
+  const leaseRef = useRef<ChatConversationLease | null>(null)
+  // Guards against setState after unmount.
+  const mountedRef = useRef(true)
+
+  useEffect(() => {
+    mountedRef.current = true
+    return () => {
+      mountedRef.current = false
+    }
+  }, [])
+
+  useEffect(() => {
+    const token = ++requestRef.current
+
+    // Safely release whatever the previous effect adopted.  Because release
+    // is idempotent and per-conversation, this cannot touch a lease owned
+    // by a newer effect — we haven't adopted one yet.
+    if (leaseRef.current && !leaseRef.current.released) {
+      leaseRef.current.release()
+    }
+    leaseRef.current = null
+
+    if (!activate) {
+      setData({ channel, isLeased: false })
+      return
+    }
+
+    let cancelled = false
+
+    // Reset to unleased while the new request is in flight.
+    setData({ channel, isLeased: false })
+
+    client
+      .openConversation(channel)
+      .then((lease) => {
+        if (cancelled) {
+          // Late arrival — unmount or superseding effect already won.
+          // Release immediately, never adopt, never setState.
+          if (!lease.released) lease.release()
+          return
+        }
+        // Guard: ensure we don't setState if the component unmounted
+        // between when start ran and when the promise resolved.
+        if (!mountedRef.current) {
+          if (!lease.released) lease.release()
+          return
+        }
+        // Guard: this effect has been superseded by a newer request.
+        if (requestRef.current !== token) {
+          if (!lease.released) lease.release()
+          return
+        }
+        leaseRef.current = lease
+        setData({ channel, isLeased: true })
+      })
+      .catch(() => {
+        // openConversation failure leaves the window unleased; the next
+        // channel/prop change will re-attempt.
+      })
+
+    return () => {
+      cancelled = true
+      if (leaseRef.current && !leaseRef.current.released) {
+        leaseRef.current.release()
+      }
+      leaseRef.current = null
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [client, channel.channelId, channel.channelType, activate])
+
+  const rendered =
+    typeof children === 'function'
+      ? (children as (data: ConversationWindowData) => ReactNode)(data)
+      : children
+
+  return (
+    <div
+      className={className}
+      style={style}
+      data-channel={dataChannel ?? channel.channelId}
+    >
+      {rendered}
+    </div>
+  )
+}

--- a/packages/chat-react/src/__tests__/ChatProvider.test.tsx
+++ b/packages/chat-react/src/__tests__/ChatProvider.test.tsx
@@ -1,9 +1,10 @@
 import React from 'react'
 import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { render, screen, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { ChatProvider } from '../ChatProvider'
+import { ConversationWindow } from '../ConversationWindow'
 import { useChatClient, useChatHostCapabilities } from '../hooks'
-import { createMockClient, type MockChatClient } from './mockChatCore'
+import { channelA, createMockClient, type MockChatClient } from './mockChatCore'
 
 describe('ChatProvider', () => {
   let client: MockChatClient
@@ -43,7 +44,7 @@ describe('ChatProvider', () => {
   })
 
   it('starts client on mount and stops on unmount when manageLifecycle is true', async () => {
-    const bootstrap = { channel: { channelId: 'test', channelType: 1 }, token: 't1' }
+    const bootstrap = { initialChannel: { channelId: 'test', channelType: 1 }, token: 't1' }
     const { unmount } = render(
       <ChatProvider client={client} bootstrap={bootstrap} manageLifecycle>
         <Consumer label="c" />
@@ -59,6 +60,181 @@ describe('ChatProvider', () => {
     await waitFor(() => {
       expect(client.stopCalls).toBe(1)
     })
+  })
+
+  it('does not mount conversation children until managed startup resolves', async () => {
+    let resolveStart: (() => void) | undefined
+    let started = false
+    client.start = vi.fn(async (bootstrap) => {
+      client.startCalls.push(bootstrap)
+      await new Promise<void>((resolve) => {
+        resolveStart = () => {
+          started = true
+          resolve()
+        }
+      })
+    })
+    const originalOpen = client.openConversation.bind(client)
+    client.openConversation = vi.fn(async (channel) => {
+      if (!started) throw new Error('client is not started')
+      return originalOpen(channel)
+    })
+
+    render(
+      <ChatProvider client={client} bootstrap={{ token: 't1' }} manageLifecycle>
+        <ConversationWindow channel={channelA} />
+      </ChatProvider>,
+    )
+
+    await waitFor(() => expect(client.start).toHaveBeenCalledTimes(1))
+    expect(client.openConversation).not.toHaveBeenCalled()
+
+    resolveStart?.()
+    await waitFor(() => expect(client.openConversation).toHaveBeenCalledTimes(1))
+  })
+
+  it('does not restart for an equivalent bootstrap object', async () => {
+    const { rerender, unmount } = render(
+      <ChatProvider
+        client={client}
+        bootstrap={{ token: 't1', space: 'space-a' }}
+        manageLifecycle
+      >
+        <Consumer label="stable" />
+      </ChatProvider>,
+    )
+
+    await waitFor(() => expect(client.startCalls).toHaveLength(1))
+
+    rerender(
+      <ChatProvider
+        client={client}
+        bootstrap={{ token: 't1', space: 'space-a' }}
+        manageLifecycle
+      >
+        <Consumer label="stable" />
+      </ChatProvider>,
+    )
+
+    expect(client.startCalls).toHaveLength(1)
+    expect(client.stopCalls).toBe(0)
+
+    unmount()
+    await waitFor(() => expect(client.stopCalls).toBe(1))
+  })
+
+  it('waits for managed stop before starting a replacement lifecycle', async () => {
+    let resolveStop: (() => void) | undefined
+    client.stop = vi.fn(async () => {
+      client.stopCalls += 1
+      await new Promise<void>((resolve) => {
+        resolveStop = resolve
+      })
+    })
+
+    const { rerender } = render(
+      <ChatProvider client={client} bootstrap={{ token: 't1' }} manageLifecycle>
+        <Consumer label="queued" />
+      </ChatProvider>,
+    )
+    await waitFor(() => expect(client.startCalls).toHaveLength(1))
+
+    rerender(
+      <ChatProvider client={client} bootstrap={{ token: 't2' }} manageLifecycle>
+        <Consumer label="queued" />
+      </ChatProvider>,
+    )
+
+    await waitFor(() => expect(client.stop).toHaveBeenCalledTimes(1))
+    expect(client.startCalls).toHaveLength(1)
+
+    resolveStop?.()
+    await waitFor(() => expect(client.startCalls).toHaveLength(2))
+    expect(client.startCalls[1].token).toBe('t2')
+  })
+
+  it('blocks a replacement client until a failed stop is retried successfully', async () => {
+    const replacementClient = createMockClient()
+    const stopError = new Error('stop failed')
+    const onLifecycleError = vi.fn()
+    const originalStop = client.stop.bind(client)
+    let stopAttempts = 0
+    client.stop = vi.fn(async () => {
+      stopAttempts += 1
+      if (stopAttempts === 1) {
+        client.stopCalls += 1
+        throw stopError
+      }
+      await originalStop()
+    })
+
+    const { rerender } = render(
+      <ChatProvider client={client} bootstrap={{ token: 't1' }} manageLifecycle>
+        <span>initial client ready</span>
+      </ChatProvider>,
+    )
+    await waitFor(() => expect(client.startCalls).toHaveLength(1))
+
+    rerender(
+      <ChatProvider
+        client={replacementClient}
+        bootstrap={{ token: 't2' }}
+        manageLifecycle
+        onLifecycleError={onLifecycleError}
+        lifecycleFallback={({ error, retry }) => (
+          <button type="button" onClick={retry}>{error.message}</button>
+        )}
+      >
+        <span>replacement client ready</span>
+      </ChatProvider>,
+    )
+
+    await waitFor(() => expect(screen.getByRole('button')).toHaveTextContent('stop failed'))
+    expect(client.stop).toHaveBeenCalledTimes(1)
+    expect(replacementClient.startCalls).toHaveLength(0)
+    expect(onLifecycleError).toHaveBeenCalledTimes(1)
+    expect(onLifecycleError).toHaveBeenCalledWith(stopError)
+
+    fireEvent.click(screen.getByRole('button'))
+
+    await waitFor(() => expect(screen.getByText('replacement client ready')).toBeInTheDocument())
+    expect(client.stop).toHaveBeenCalledTimes(2)
+    expect(replacementClient.startCalls).toHaveLength(1)
+    expect(replacementClient.startCalls[0].token).toBe('t2')
+  })
+
+  it('exposes managed startup failure and recovers through retry', async () => {
+    const startError = new Error('start failed')
+    const onLifecycleError = vi.fn()
+    const originalStart = client.start.bind(client)
+    let attempts = 0
+    client.start = vi.fn(async (bootstrap) => {
+      attempts += 1
+      if (attempts === 1) throw startError
+      return originalStart(bootstrap)
+    })
+
+    render(
+      <ChatProvider
+        client={client}
+        bootstrap={{ token: 't1' }}
+        manageLifecycle
+        onLifecycleError={onLifecycleError}
+        lifecycleFallback={({ error, retry }) => (
+          <button type="button" onClick={retry}>{error.message}</button>
+        )}
+      >
+        <Consumer label="recovered" />
+      </ChatProvider>,
+    )
+
+    await waitFor(() => expect(screen.getByRole('button')).toHaveTextContent('start failed'))
+    expect(onLifecycleError).toHaveBeenCalledWith(startError)
+    expect(screen.queryByTestId('client-recovered')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button'))
+    await waitFor(() => expect(screen.getByTestId('client-recovered')).toHaveTextContent('ok'))
+    expect(client.start).toHaveBeenCalledTimes(2)
   })
 
   it('throws when useChatClient is called outside ChatProvider', () => {

--- a/packages/chat-react/src/__tests__/ChatProvider.test.tsx
+++ b/packages/chat-react/src/__tests__/ChatProvider.test.tsx
@@ -1,0 +1,113 @@
+import React from 'react'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { ChatProvider } from '../ChatProvider'
+import { useChatClient, useChatHostCapabilities } from '../hooks'
+import { createMockClient, type MockChatClient } from './mockChatCore'
+
+describe('ChatProvider', () => {
+  let client: MockChatClient
+
+  beforeEach(() => {
+    client = createMockClient()
+  })
+
+  function Consumer({ label }: { label: string }) {
+    const c = useChatClient()
+    return (
+      <span data-testid={`client-${label}`}>
+        {c === client ? 'ok' : 'wrong'}
+      </span>
+    )
+  }
+
+  it('provides ChatClient to children', () => {
+    render(
+      <ChatProvider client={client}>
+        <Consumer label="a" />
+      </ChatProvider>,
+    )
+    expect(screen.getByTestId('client-a')).toHaveTextContent('ok')
+  })
+
+  it('does not start/stop client when manageLifecycle is false', async () => {
+    const { unmount } = render(
+      <ChatProvider client={client} bootstrap={{ channel: { channelId: 'x', channelType: 1 } }}>
+        <Consumer label="b" />
+      </ChatProvider>,
+    )
+    expect(client.startCalls).toHaveLength(0)
+    expect(client.stopCalls).toBe(0)
+    unmount()
+    expect(client.stopCalls).toBe(0)
+  })
+
+  it('starts client on mount and stops on unmount when manageLifecycle is true', async () => {
+    const bootstrap = { channel: { channelId: 'test', channelType: 1 }, token: 't1' }
+    const { unmount } = render(
+      <ChatProvider client={client} bootstrap={bootstrap} manageLifecycle>
+        <Consumer label="c" />
+      </ChatProvider>,
+    )
+
+    await waitFor(() => {
+      expect(client.startCalls).toHaveLength(1)
+    })
+    expect(client.startCalls[0].token).toBe('t1')
+
+    unmount()
+    await waitFor(() => {
+      expect(client.stopCalls).toBe(1)
+    })
+  })
+
+  it('throws when useChatClient is called outside ChatProvider', () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    function Bad() {
+      useChatClient()
+      return null
+    }
+    expect(() => render(<Bad />)).toThrow('useChatClient')
+
+    consoleSpy.mockRestore()
+  })
+})
+
+describe('useChatHostCapabilities', () => {
+  let client: MockChatClient
+
+  beforeEach(() => {
+    client = createMockClient()
+  })
+
+  it('returns undefined when host is not provided', () => {
+    function Reader() {
+      const caps = useChatHostCapabilities()
+      return <span data-testid="caps">{caps === undefined ? 'undef' : 'set'}</span>
+    }
+    render(
+      <ChatProvider client={client}>
+        <Reader />
+      </ChatProvider>,
+    )
+    expect(screen.getByTestId('caps')).toHaveTextContent('undef')
+  })
+
+  it('returns host capabilities when provided', () => {
+    const host = {
+      openExternal: async () => {},
+      notify: async () => {},
+    }
+    function Reader() {
+      const caps = useChatHostCapabilities()
+      return <span data-testid="caps">{caps === host ? 'match' : 'mismatch'}</span>
+    }
+    render(
+      <ChatProvider client={client} host={host}>
+        <Reader />
+      </ChatProvider>,
+    )
+    expect(screen.getByTestId('caps')).toHaveTextContent('match')
+  })
+})

--- a/packages/chat-react/src/__tests__/ConversationWindow.test.tsx
+++ b/packages/chat-react/src/__tests__/ConversationWindow.test.tsx
@@ -1,9 +1,11 @@
 import React from 'react'
-import { describe, it, expect, beforeEach } from 'vitest'
-import { render, screen, waitFor } from '@testing-library/react'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { ChatProvider } from '../ChatProvider'
 import { ConversationWindow } from '../ConversationWindow'
 import {
+  ChatClientEvent,
+  ChatClientStatus,
   createMockClient,
   channelA,
   channelB,
@@ -109,6 +111,108 @@ describe('ConversationWindow', () => {
         'channel-a:leased',
       )
     })
+  })
+
+  it('exposes real open errors and supports an explicit retry', async () => {
+    const openError = new Error('open failed')
+    const onError = vi.fn()
+    const originalOpen = client.openConversation.bind(client)
+    let attempts = 0
+    client.openConversation = vi.fn(async (channel) => {
+      attempts += 1
+      if (attempts === 1) throw openError
+      return originalOpen(channel)
+    })
+
+    render(
+      shell(
+        <ConversationWindow channel={channelA} onError={onError}>
+          {(data) => (
+            <button type="button" onClick={data.retry}>
+              {data.error?.message || (data.isLeased ? 'leased' : 'pending')}
+            </button>
+          )}
+        </ConversationWindow>,
+      ),
+    )
+
+    await waitFor(() => expect(screen.getByRole('button')).toHaveTextContent('open failed'))
+    expect(onError).toHaveBeenCalledWith(openError)
+
+    fireEvent.click(screen.getByRole('button'))
+    await waitFor(() => expect(screen.getByRole('button')).toHaveTextContent('leased'))
+    expect(client.openConversation).toHaveBeenCalledTimes(2)
+  })
+
+  it('retries a failed open after the client reconnects', async () => {
+    const originalOpen = client.openConversation.bind(client)
+    let attempts = 0
+    client.openConversation = vi.fn(async (channel) => {
+      attempts += 1
+      if (attempts === 1) throw new Error('connection lost')
+      return originalOpen(channel)
+    })
+
+    render(
+      shell(
+        <ConversationWindow channel={channelA}>
+          {(data) => (
+            <span>{data.error?.message || (data.isLeased ? 'leased' : 'pending')}</span>
+          )}
+        </ConversationWindow>,
+      ),
+    )
+
+    await waitFor(() => expect(screen.getByText('connection lost')).toBeInTheDocument())
+    client.emit(ChatClientEvent.StatusChanged, ChatClientStatus.Connected)
+    await waitFor(() => expect(screen.getByText('leased')).toBeInTheDocument())
+    expect(client.openConversation).toHaveBeenCalledTimes(2)
+  })
+
+  it('reopens the conversation after an externally managed stop and restart', async () => {
+    render(
+      shell(
+        <ConversationWindow channel={channelA}>
+          {(data) => (
+            <span>{data.isLeased ? 'leased' : 'pending'}</span>
+          )}
+        </ConversationWindow>,
+      ),
+    )
+
+    await waitFor(() => expect(screen.getByText('leased')).toBeInTheDocument())
+
+    await act(async () => {
+      await client.stop()
+    })
+    expect(screen.getByText('pending')).toBeInTheDocument()
+
+    await act(async () => {
+      await client.start({ token: 'replacement' })
+    })
+    await waitFor(() => expect(screen.getByText('leased')).toBeInTheDocument())
+    expect(client.openCalls).toEqual([channelA, channelA])
+  })
+
+  it('discards a pending lease that resolves after the client stops', async () => {
+    client.deferNextOpen()
+    render(
+      shell(
+        <ConversationWindow channel={channelA}>
+          {(data) => <span>{data.isLeased ? 'leased' : 'pending'}</span>}
+        </ConversationWindow>,
+      ),
+    )
+
+    expect(client.pendingOpens).toHaveLength(1)
+    await act(async () => {
+      await client.stop()
+      client.resolveNextPending()
+      await Promise.resolve()
+    })
+
+    await waitFor(() => expect(client.leases[0].released).toBe(true))
+    expect(screen.getByText('pending')).toBeInTheDocument()
   })
 
   it('forwards className and style to a wrapper div', () => {

--- a/packages/chat-react/src/__tests__/ConversationWindow.test.tsx
+++ b/packages/chat-react/src/__tests__/ConversationWindow.test.tsx
@@ -1,0 +1,175 @@
+import React from 'react'
+import { describe, it, expect, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { ChatProvider } from '../ChatProvider'
+import { ConversationWindow } from '../ConversationWindow'
+import {
+  createMockClient,
+  channelA,
+  channelB,
+  type MockChatClient,
+} from './mockChatCore'
+
+describe('ConversationWindow', () => {
+  let client: MockChatClient
+
+  beforeEach(() => {
+    client = createMockClient()
+  })
+
+  function shell(ui: React.ReactElement) {
+    return <ChatProvider client={client}>{ui}</ChatProvider>
+  }
+
+  it('acquires a lease on mount and releases on unmount', async () => {
+    const { unmount } = render(shell(<ConversationWindow channel={channelA} />))
+
+    await waitFor(() => {
+      expect(client.openCalls).toHaveLength(1)
+    })
+    expect(client.openCalls[0]).toEqual(channelA)
+    expect(client.leases[0].released).toBe(false)
+
+    unmount()
+    await waitFor(() => {
+      expect(client.leases[0].released).toBe(true)
+    })
+  })
+
+  it('releases old lease and acquires new lease when channel changes', async () => {
+    const { rerender } = render(shell(<ConversationWindow channel={channelA} />))
+
+    await waitFor(() => {
+      expect(client.openCalls).toHaveLength(1)
+    })
+    expect(client.openCalls[0]).toEqual(channelA)
+
+    rerender(shell(<ConversationWindow channel={channelB} />))
+
+    await waitFor(() => {
+      expect(client.openCalls).toHaveLength(2)
+    })
+    expect(client.openCalls[1]).toEqual(channelB)
+
+    expect(client.leases[0].released).toBe(true)
+    expect(client.leases[1].released).toBe(false)
+  })
+
+  it('releases lease when activate changes from true to false', async () => {
+    const { rerender } = render(
+      shell(<ConversationWindow channel={channelA} activate />),
+    )
+
+    await waitFor(() => {
+      expect(client.openCalls).toHaveLength(1)
+    })
+
+    rerender(
+      shell(<ConversationWindow channel={channelA} activate={false} />),
+    )
+
+    await waitFor(() => {
+      expect(client.leases[0].released).toBe(true)
+    })
+    expect(client.openCalls).toHaveLength(1)
+  })
+
+  it('does not acquire lease when activate is false', () => {
+    render(shell(<ConversationWindow channel={channelA} activate={false} />))
+
+    expect(client.openCalls).toHaveLength(0)
+  })
+
+  it('renders children as static ReactNode', () => {
+    render(
+      shell(
+        <ConversationWindow channel={channelA}>
+          <span data-testid="child">hello</span>
+        </ConversationWindow>,
+      ),
+    )
+    expect(screen.getByTestId('child')).toHaveTextContent('hello')
+  })
+
+  it('renders children as render function with data', async () => {
+    render(
+      shell(
+        <ConversationWindow channel={channelA}>
+          {(data) => (
+            <span data-testid="render-child">
+              {data.channel.channelId}:{data.isLeased ? 'leased' : 'pending'}
+            </span>
+          )}
+        </ConversationWindow>,
+      ),
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('render-child')).toHaveTextContent(
+        'channel-a:leased',
+      )
+    })
+  })
+
+  it('forwards className and style to a wrapper div', () => {
+    render(
+      shell(
+        <ConversationWindow
+          channel={channelA}
+          className="my-ctn"
+          style={{ padding: 8 }}
+        >
+          <span data-testid="inner" />
+        </ConversationWindow>,
+      ),
+    )
+    const wrapper = screen.getByTestId('inner').parentElement!
+    expect(wrapper.className).toBe('my-ctn')
+    expect(wrapper.style.padding).toBe('8px')
+  })
+
+  describe('async race guards', () => {
+    it('releases late-arriving lease if channel changes before open resolves', async () => {
+      client.deferNextOpen()
+
+      const { rerender } = render(shell(<ConversationWindow channel={channelA} />))
+      expect(client.openCalls).toHaveLength(1)
+      expect(client.pendingOpens).toHaveLength(1)
+
+      // Switch to channelB while channelA open is still pending.
+      rerender(shell(<ConversationWindow channel={channelB} />))
+
+      // channelB opens immediately (not deferred)
+      await waitFor(() => {
+        expect(client.openCalls).toHaveLength(2)
+      })
+      expect(client.openCalls[1]).toEqual(channelB)
+      expect(client.leases[1].released).toBe(false)
+
+      // Now resolve the stale channelA open.  Its lease must be
+      // released by the guard.
+      client.resolveNextPending()
+      await waitFor(() => {
+        expect(client.leases[0].released).toBe(true)
+      })
+
+      // channelB lease must not have been touched.
+      expect(client.leases[1].released).toBe(false)
+    })
+
+    it('releases lease when open resolves after unmount', async () => {
+      client.deferNextOpen()
+
+      const { unmount } = render(shell(<ConversationWindow channel={channelA} />))
+      expect(client.pendingOpens).toHaveLength(1)
+
+      unmount()
+
+      // Resolve the deferred open after unmount — lease must be released.
+      client.resolveNextPending()
+      await waitFor(() => {
+        expect(client.leases[0].released).toBe(true)
+      })
+    })
+  })
+})

--- a/packages/chat-react/src/__tests__/mockChatCore.ts
+++ b/packages/chat-react/src/__tests__/mockChatCore.ts
@@ -1,0 +1,163 @@
+/* Vitest alias target for @octo/chat-core so the package can be tested
+ * without a built chat-core dependency. Mirrors the real exported types,
+ * including the async openConversation / ChatConversationLease contract. */
+
+import type {
+  ChatClient,
+  ChatClientBootstrap,
+  ChatChannelRef,
+  ChatClientEvent,
+  ChatClientStatus,
+  ChatConversationLease,
+  ChatClientSnapshot,
+} from '@octo/chat-core'
+
+export type {
+  ChatClient,
+  ChatClientBootstrap,
+  ChatChannelRef,
+  ChatClientEvent,
+  ChatClientStatus,
+  ChatConversationLease,
+  ChatClientSnapshot,
+}
+
+export const channelA: ChatChannelRef = { channelId: 'channel-a', channelType: 1 }
+export const channelB: ChatChannelRef = { channelId: 'channel-b', channelType: 1 }
+
+export interface PendingOpen {
+  lease: ChatConversationLease
+  channel: ChatChannelRef
+  resolve(): void
+}
+
+export interface MockChatClient extends ChatClient {
+  startCalls: ChatClientBootstrap[]
+  stopCalls: number
+  openCalls: ChatChannelRef[]
+  /** Every lease created in order, so tests can inspect releases. */
+  leases: ChatConversationLease[]
+  pendingOpens: PendingOpen[]
+  emit(event: ChatClientEvent, ...args: any[]): void
+  /** Cause the *next* openConversation to remain pending until released. */
+  deferNextOpen(): void
+  /** Resolve the next pending openConversation (calls activeLease set). */
+  resolveNextPending(): void
+  flush(): Promise<void>
+}
+
+export function createMockClient(): MockChatClient {
+  const listeners = new Map<ChatClientEvent, Set<(...args: any[]) => void>>()
+  const leases: ChatConversationLease[] = []
+  let connectionStatus: ChatClientStatus = 'idle'
+  let activeLease: ChatConversationLease | null = null
+  let deferNext = false
+  const pendingOpens: PendingOpen[] = []
+
+  function makeLease(channel: ChatChannelRef): ChatConversationLease {
+    let released = false
+    return {
+      channel,
+      get released() {
+        return released
+      },
+      release() {
+        released = true
+      },
+    }
+  }
+
+  const client: MockChatClient = {
+    get status() {
+      return connectionStatus
+    },
+    get activeConversation() {
+      return activeLease
+    },
+    messages: {
+      loadMessages: async () => [],
+      subscribeMessages: () => () => {},
+      subscribeMessageStatus: () => () => {},
+      sendMessage: async () => ({}),
+    },
+    startCalls: [],
+    stopCalls: 0,
+    openCalls: [],
+    leases,
+    pendingOpens,
+
+    async start(bootstrap: ChatClientBootstrap) {
+      connectionStatus = 'connected'
+      client.startCalls.push(bootstrap)
+    },
+
+    async stop() {
+      if (activeLease && !activeLease.released) activeLease.release()
+      activeLease = null
+      connectionStatus = 'stopped'
+      client.stopCalls += 1
+    },
+
+    getSnapshot(): ChatClientSnapshot {
+      return { status: connectionStatus, activeConversation: activeLease }
+    },
+
+    subscribe(event: ChatClientEvent, listener: (...args: any[]) => void) {
+      let set = listeners.get(event)
+      if (!set) {
+        set = new Set()
+        listeners.set(event, set)
+      }
+      set.add(listener)
+      return () => {
+        set!.delete(listener)
+      }
+    },
+
+    async openConversation(channel: ChatChannelRef) {
+      const lease = makeLease(channel)
+      leases.push(lease)
+      client.openCalls.push(channel)
+
+      if (deferNext) {
+        deferNext = false
+        return new Promise<ChatConversationLease>((resolve) => {
+          pendingOpens.push({
+            lease,
+            channel,
+            resolve: () => {
+              activeLease = lease
+              resolve(lease)
+            },
+          })
+        })
+      }
+
+      activeLease = lease
+      return lease
+    },
+
+    emit(event: ChatClientEvent, ...args: any[]) {
+      const set = listeners.get(event)
+      if (set) set.forEach((l) => l(event, ...args))
+    },
+
+    deferNextOpen() {
+      deferNext = true
+    },
+
+    resolveNextPending() {
+      const pending = pendingOpens.shift()
+      if (pending) pending.resolve()
+    },
+
+    async flush() {
+      while (pendingOpens.length > 0) {
+        pendingOpens.shift()!.resolve()
+      }
+      await new Promise<void>((resolve) => setTimeout(resolve, 0))
+    },
+  }
+
+  return client
+}

--- a/packages/chat-react/src/__tests__/mockChatCore.ts
+++ b/packages/chat-react/src/__tests__/mockChatCore.ts
@@ -6,8 +6,6 @@ import type {
   ChatClient,
   ChatClientBootstrap,
   ChatChannelRef,
-  ChatClientEvent,
-  ChatClientStatus,
   ChatConversationLease,
   ChatClientSnapshot,
 } from '@octo/chat-core'
@@ -16,10 +14,33 @@ export type {
   ChatClient,
   ChatClientBootstrap,
   ChatChannelRef,
-  ChatClientEvent,
-  ChatClientStatus,
   ChatConversationLease,
   ChatClientSnapshot,
+}
+
+export enum ChatClientStatus {
+  Idle = 'idle',
+  Connecting = 'connecting',
+  Connected = 'connected',
+  Disconnected = 'disconnected',
+  Failed = 'failed',
+  Stopped = 'stopped',
+}
+
+export enum ChatClientEvent {
+  StatusChanged = 'statusChanged',
+  ConversationOpened = 'conversationOpened',
+  ConversationClosed = 'conversationClosed',
+  Error = 'error',
+  MessageReceived = 'messageReceived',
+  MessageStatusChanged = 'messageStatusChanged',
+}
+
+export class ChatConversationSupersededError extends Error {
+  constructor() {
+    super('The conversation open request was superseded by a newer request.')
+    this.name = 'ChatConversationSupersededError'
+  }
 }
 
 export const channelA: ChatChannelRef = { channelId: 'channel-a', channelType: 1 }
@@ -87,15 +108,19 @@ export function createMockClient(): MockChatClient {
     pendingOpens,
 
     async start(bootstrap: ChatClientBootstrap) {
+      const previousStatus = connectionStatus
       connectionStatus = 'connected'
       client.startCalls.push(bootstrap)
+      client.emit(ChatClientEvent.StatusChanged, ChatClientStatus.Connected, previousStatus)
     },
 
     async stop() {
+      const previousStatus = connectionStatus
       if (activeLease && !activeLease.released) activeLease.release()
       activeLease = null
       connectionStatus = 'stopped'
       client.stopCalls += 1
+      client.emit(ChatClientEvent.StatusChanged, ChatClientStatus.Stopped, previousStatus)
     },
 
     getSnapshot(): ChatClientSnapshot {
@@ -139,7 +164,7 @@ export function createMockClient(): MockChatClient {
 
     emit(event: ChatClientEvent, ...args: any[]) {
       const set = listeners.get(event)
-      if (set) set.forEach((l) => l(event, ...args))
+      if (set) set.forEach((listener) => listener(...args))
     },
 
     deferNextOpen() {

--- a/packages/chat-react/src/__tests__/setup.ts
+++ b/packages/chat-react/src/__tests__/setup.ts
@@ -1,0 +1,7 @@
+import { afterEach } from 'vitest'
+import '@testing-library/jest-dom'
+import { cleanup } from './testingLibraryReact17'
+
+afterEach(() => {
+  cleanup()
+})

--- a/packages/chat-react/src/__tests__/testingLibraryReact17.ts
+++ b/packages/chat-react/src/__tests__/testingLibraryReact17.ts
@@ -1,0 +1,87 @@
+import React from "react";
+import ReactDOM from "react-dom";
+import { act } from "react-dom/test-utils";
+import {
+  configure,
+  getQueriesForElement,
+  prettyDOM,
+  queries,
+  type Queries,
+} from "@testing-library/dom";
+
+export * from "@testing-library/dom";
+export { act };
+
+const mountedContainers = new Set<Element | DocumentFragment>();
+
+configure({
+  eventWrapper: (callback) => {
+    let result: unknown;
+    act(() => {
+      result = callback();
+    });
+    return result;
+  },
+});
+
+interface RenderOptions<Q extends Queries = typeof queries> {
+  container?: Element;
+  baseElement?: Element | DocumentFragment;
+  queries?: Q;
+}
+
+export function cleanup() {
+  mountedContainers.forEach((container) => {
+    act(() => {
+      ReactDOM.unmountComponentAtNode(container);
+    });
+    if (container instanceof Element && container.parentNode === document.body) {
+      document.body.removeChild(container);
+    }
+  });
+  mountedContainers.clear();
+}
+
+export function render<Q extends Queries = typeof queries>(
+  ui: React.ReactElement,
+  options: RenderOptions<Q> = {}
+) {
+  const baseElement = options.baseElement || document.body;
+  const container =
+    options.container || baseElement.appendChild(document.createElement("div"));
+  const boundQueries = getQueriesForElement(
+    baseElement,
+    options.queries || queries
+  );
+
+  act(() => {
+    ReactDOM.render(ui, container);
+  });
+  mountedContainers.add(container);
+
+  return {
+    container,
+    baseElement,
+    ...boundQueries,
+    debug: (element: Element | DocumentFragment = baseElement) => {
+      console.log(prettyDOM(element));
+    },
+    rerender: (nextUi: React.ReactElement) => {
+      act(() => {
+        ReactDOM.render(nextUi, container);
+      });
+    },
+    unmount: () => {
+      act(() => {
+        ReactDOM.unmountComponentAtNode(container);
+      });
+      mountedContainers.delete(container);
+    },
+    asFragment: () => {
+      const template = document.createElement("template");
+      template.innerHTML =
+        container instanceof Element ? container.innerHTML : "";
+      return template.content;
+    },
+  };
+}

--- a/packages/chat-react/src/hooks.ts
+++ b/packages/chat-react/src/hooks.ts
@@ -1,0 +1,27 @@
+import { useContext } from 'react'
+import type { ChatClient } from '@octo/chat-core'
+import type { ChatHostCapabilities } from './types'
+import { ChatContext, ChatHostContext } from './ChatContext'
+
+/**
+ * Returns the current ChatClient from the nearest ChatProvider.
+ * Throws if called outside a ChatProvider.
+ */
+export function useChatClient(): ChatClient {
+  const ctx = useContext(ChatContext)
+  if (!ctx) {
+    throw new Error(
+      'useChatClient must be used within a <ChatProvider>. ' +
+        'Wrap the component tree with a ChatProvider and pass a client.',
+    )
+  }
+  return ctx.client
+}
+
+/**
+ * Returns the ChatHostCapabilities from the nearest ChatProvider, or
+ * undefined if the host did not provide capabilities.
+ */
+export function useChatHostCapabilities(): ChatHostCapabilities | undefined {
+  return useContext(ChatHostContext)
+}

--- a/packages/chat-react/src/index.ts
+++ b/packages/chat-react/src/index.ts
@@ -1,0 +1,14 @@
+export { ChatProvider } from './ChatProvider'
+export type { ChatProviderProps } from './ChatProvider'
+export { ConversationWindow } from './ConversationWindow'
+export type { ConversationWindowProps, ConversationWindowData } from './ConversationWindow'
+export { useChatClient, useChatHostCapabilities } from './hooks'
+export type {
+  ChatHostCapabilities,
+  ChatDownloadRequest,
+  ChatDownloadResult,
+  ChatFilePickerOptions,
+  ChatNotificationOptions,
+  ChatTelemetryEvent,
+  ChatFeatureError,
+} from './types'

--- a/packages/chat-react/src/index.ts
+++ b/packages/chat-react/src/index.ts
@@ -1,5 +1,5 @@
 export { ChatProvider } from './ChatProvider'
-export type { ChatProviderProps } from './ChatProvider'
+export type { ChatProviderLifecycleFailure, ChatProviderProps } from './ChatProvider'
 export { ConversationWindow } from './ConversationWindow'
 export type { ConversationWindowProps, ConversationWindowData } from './ConversationWindow'
 export { useChatClient, useChatHostCapabilities } from './hooks'

--- a/packages/chat-react/src/types.ts
+++ b/packages/chat-react/src/types.ts
@@ -54,4 +54,8 @@ export interface ChatHostCapabilities {
 export interface ConversationWindowData {
   readonly channel: ChatChannelRef
   readonly isLeased: boolean
+  /** Present in current implementations; optional for legacy structural consumers. */
+  readonly error?: Error | null
+  /** Present in current implementations; optional for legacy structural consumers. */
+  retry?(): void
 }

--- a/packages/chat-react/src/types.ts
+++ b/packages/chat-react/src/types.ts
@@ -1,0 +1,57 @@
+import type { ChatChannelRef } from '@octo/chat-core'
+
+/* ------------------------------------------------------------------ */
+/*  Host capabilities — implementors provide these to the provider.   */
+/* ------------------------------------------------------------------ */
+
+export interface ChatDownloadRequest {
+  url: string
+  filename?: string
+}
+
+export interface ChatDownloadResult {
+  localPath?: string
+  blob?: Blob
+}
+
+export interface ChatFilePickerOptions {
+  accept?: string
+  multiple?: boolean
+}
+
+export interface ChatNotificationOptions {
+  title: string
+  body?: string
+  icon?: string
+}
+
+export interface ChatTelemetryEvent {
+  name: string
+  payload?: Record<string, unknown>
+}
+
+export interface ChatFeatureError {
+  message: string
+  code?: string
+  stack?: string
+}
+
+export interface ChatHostCapabilities {
+  openExternal?(url: string): Promise<void>
+  download?(request: ChatDownloadRequest): Promise<ChatDownloadResult>
+  chooseFiles?(options: ChatFilePickerOptions): Promise<File[]>
+  notify?(options: ChatNotificationOptions): Promise<void>
+  requestMediaPermission?(kind: 'audio'): Promise<boolean>
+  openUserProfile?(uid: string, context?: ChatChannelRef): void
+  reportTelemetry?(event: ChatTelemetryEvent): void
+  reportError?(error: ChatFeatureError): void
+}
+
+/* ------------------------------------------------------------------ */
+/*  ConversationWindow data exposed to render-function children.      */
+/* ------------------------------------------------------------------ */
+
+export interface ConversationWindowData {
+  readonly channel: ChatChannelRef
+  readonly isLeased: boolean
+}

--- a/packages/chat-react/tsconfig.json
+++ b/packages/chat-react/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../tsconfig/react-library.json",
+  "compilerOptions": {
+    "lib": ["es2020", "dom", "dom.iterable"],
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "exclude": [
+    "dist",
+    "build",
+    "node_modules",
+    "src/__tests__"
+  ]
+}

--- a/packages/chat-react/vitest.config.ts
+++ b/packages/chat-react/vitest.config.ts
@@ -1,0 +1,38 @@
+import { defineConfig } from 'vitest/config'
+import path from 'node:path'
+
+export default defineConfig({
+  resolve: {
+    alias: [
+      {
+        find: '@testing-library/react',
+        replacement: path.resolve(__dirname, 'src/__tests__/testingLibraryReact17.ts'),
+      },
+      {
+        find: 'react',
+        replacement: path.resolve(__dirname, 'node_modules/react'),
+      },
+      {
+        find: 'react-dom',
+        replacement: path.resolve(__dirname, 'node_modules/react-dom'),
+      },
+      {
+        find: /^react\/jsx-runtime$/,
+        replacement: path.resolve(__dirname, 'node_modules/react/jsx-runtime.js'),
+      },
+      {
+        find: /^react\/jsx-dev-runtime$/,
+        replacement: path.resolve(__dirname, 'node_modules/react/jsx-dev-runtime.js'),
+      },
+      {
+        find: '@octo/chat-core',
+        replacement: path.resolve(__dirname, 'src/__tests__/mockChatCore.ts'),
+      },
+    ],
+  },
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    setupFiles: ['./src/__tests__/setup.ts'],
+  },
+})

--- a/packages/dmworkbase/package.json
+++ b/packages/dmworkbase/package.json
@@ -7,6 +7,8 @@
     "test:coverage": "vitest run --coverage --coverage.include='src/**/*.{ts,tsx}' --coverage.exclude='src/**/__tests__/**' --coverage.exclude='**/*.test.{ts,tsx}' --coverage.exclude='**/*.stories.{ts,tsx}' --coverage.reportOnFailure"
   },
   "dependencies": {
+    "@octo/chat-core": "workspace:*",
+    "@octo/chat-react": "workspace:*",
     "@mlt-org/octo-card-profile-octo-chat": "1.2.0-rc.2",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",

--- a/packages/dmworkbase/src/App.tsx
+++ b/packages/dmworkbase/src/App.tsx
@@ -612,6 +612,7 @@ export type MessageDeleteListener = (
 ) => void;
 
 export class LoginInfo {
+  private _ephemeralSession = false;
   appID!: string;
   shortNo!: string; // 短号
   token?: string;
@@ -661,6 +662,7 @@ export class LoginInfo {
     loginProvider?: string;
     deviceFlag?: number;
   }, persist = false) {
+    this._ephemeralSession = !persist;
     this.uid = session.uid;
     this.token = session.token;
     this.name = session.name ?? "";
@@ -673,6 +675,7 @@ export class LoginInfo {
    * save 保存登录信息
    */
   public save() {
+    if (this._ephemeralSession) return;
     this.setStorageItemForSID("app_id", this.appID ?? "");
     this.setStorageItemForSID("short_no", this.shortNo ?? "");
     this.setStorageItemForSID("uid", this.uid ?? "");
@@ -1048,7 +1051,7 @@ export default class WKApp extends ProviderListener {
   }
 
   // app启动
-  startup(options: { loadLoginInfo?: boolean } = {}) {
+  startup(options: { loadLoginInfo?: boolean; isPC?: boolean } = {}) {
     if (consumeOidcPostLogoutCleanup()) {
       void this.clearLocalLoginState();
     }
@@ -1057,10 +1060,9 @@ export default class WKApp extends ProviderListener {
     }
 
     // 是否是PC端
-    if (
-      isElectronPowered() ||
-      (window as any).__TAURI_IPC__
-    ) {
+    if (options.isPC !== undefined) {
+      this.isPC = options.isPC;
+    } else if (isElectronPowered() || (window as any).__TAURI_IPC__) {
       this.isPC = true;
     }
     const expectedDeviceFlag = getExpectedImDeviceFlag(this.isPC);

--- a/packages/dmworkbase/src/App.tsx
+++ b/packages/dmworkbase/src/App.tsx
@@ -654,6 +654,21 @@ export class LoginInfo {
   realName?: string;
   realnameVerifiedAt?: number; // Unix 秒或毫秒，后端未定义前端不展示即可
 
+  public applySession(session: {
+    uid: string;
+    token: string;
+    name?: string;
+    loginProvider?: string;
+    deviceFlag?: number;
+  }, persist = false) {
+    this.uid = session.uid;
+    this.token = session.token;
+    this.name = session.name ?? "";
+    this.loginProvider = session.loginProvider;
+    this.deviceFlag = session.deviceFlag;
+    if (persist) this.save();
+  }
+
   /**
    * save 保存登录信息
    */
@@ -1033,11 +1048,13 @@ export default class WKApp extends ProviderListener {
   }
 
   // app启动
-  startup() {
+  startup(options: { loadLoginInfo?: boolean } = {}) {
     if (consumeOidcPostLogoutCleanup()) {
       void this.clearLocalLoginState();
     }
-    WKApp.loginInfo.load(); // 加载登录信息
+    if (options.loadLoginInfo !== false) {
+      WKApp.loginInfo.load(); // 加载登录信息
+    }
 
     // 是否是PC端
     if (

--- a/packages/dmworkbase/src/Components/Conversation/index.tsx
+++ b/packages/dmworkbase/src/Components/Conversation/index.tsx
@@ -3100,6 +3100,7 @@ export class Conversation
             <>
               <ConversationSelectionStateBridge
                 editOn={vm.editOn}
+                checkedCount={vm.getCheckedMessages?.().length ?? 0}
                 onChange={this.props.onSelectionStateChange}
               />
               <div

--- a/packages/dmworkbase/src/Components/ConversationWindow/__tests__/ConversationWindow.test.tsx
+++ b/packages/dmworkbase/src/Components/ConversationWindow/__tests__/ConversationWindow.test.tsx
@@ -1,0 +1,253 @@
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  ChatClientEvent,
+  ChatClientStatus,
+  type ChatChannelRef,
+  type ChatClient,
+  type ChatConversationLease,
+} from "@octo/chat-core";
+import {
+  fireEvent,
+  render,
+  waitFor,
+} from "../../../__tests__/testingLibraryReact17";
+
+const conversationContext = {
+  clearCheckedMessages: vi.fn(),
+  setEditOn: vi.fn(),
+};
+
+vi.mock("../../Conversation", async () => {
+  const ReactModule = await import("react");
+  return {
+    Conversation: (props: any) => {
+      ReactModule.useEffect(() => {
+        props.onContext?.(conversationContext);
+      }, [props.onContext]);
+      return (
+        <div
+          data-testid="legacy-conversation"
+          data-channel-id={props.channel.channelID}
+          data-auxiliary={String(props.isAuxiliary)}
+        />
+      );
+    },
+  };
+});
+
+vi.mock("../../ErrorBoundary", () => ({
+  ErrorBoundary: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+import ConversationWindow from "../index";
+
+function createClient() {
+  const released: string[] = [];
+  const opened: ChatChannelRef[] = [];
+  const client: ChatClient = {
+    status: ChatClientStatus.Connected,
+    activeConversation: null,
+    messages: {
+      loadMessages: async () => [],
+      subscribeMessages: () => () => {},
+      subscribeMessageStatus: () => () => {},
+      sendMessage: async () => ({}),
+    },
+    start: async () => {},
+    stop: async () => {},
+    openConversation: async (channel) => {
+      opened.push(channel);
+      let isReleased = false;
+      const lease: ChatConversationLease = {
+        channel,
+        get released() {
+          return isReleased;
+        },
+        release() {
+          if (isReleased) return;
+          isReleased = true;
+          released.push(channel.channelId);
+        },
+      };
+      return lease;
+    },
+    getSnapshot: () => ({
+      status: ChatClientStatus.Connected,
+      activeConversation: null,
+    }),
+    subscribe:
+      (_event: ChatClientEvent, _listener: (...args: any[]) => void) =>
+      () => {},
+  };
+  return { client, opened, released };
+}
+
+const channel = {
+  channelID: "person-1",
+  channelType: 1,
+  getChannelKey: () => "person-1-1",
+} as any;
+
+describe("ConversationWindow", () => {
+  beforeEach(() => {
+    conversationContext.clearCheckedMessages.mockClear();
+    conversationContext.setEditOn.mockClear();
+  });
+
+  it("renders a complete window without ChatPage or WKLayout", async () => {
+    const { client, opened } = createClient();
+    const bind = vi.fn(() => vi.fn());
+
+    const view = render(
+      <ConversationWindow
+        client={client}
+        channel={channel}
+        errorModuleName="chat"
+        bindConversationContext={bind}
+        header={{
+          avatar: <span data-testid="avatar">A</span>,
+          title: <span>Direct chat</span>,
+          actions: <button type="button">Details</button>,
+        }}
+      />
+    );
+
+    expect(view.getByText("Direct chat")).toBeTruthy();
+    expect(view.getByTestId("avatar")).toBeTruthy();
+    expect(
+      view.getByTestId("legacy-conversation").getAttribute("data-channel-id")
+    ).toBe("person-1");
+    await waitFor(() =>
+      expect(opened).toEqual([{ channelId: "person-1", channelType: 1 }])
+    );
+    await waitFor(() => expect(bind).toHaveBeenCalledWith(conversationContext));
+  });
+
+  it("owns selection header commands while preserving the conversation", () => {
+    const { client } = createClient();
+    const cancel = vi.fn();
+
+    const view = render(
+      <ConversationWindow
+        client={client}
+        channel={channel}
+        errorModuleName="chat"
+        header={{ title: "Direct chat" }}
+        selection={{
+          active: true,
+          count: 2,
+          label: "Selected 2",
+          cancelLabel: "Cancel",
+          onCancel: cancel,
+        }}
+      />
+    );
+
+    expect(view.getByText("Selected 2")).toBeTruthy();
+    fireEvent.click(view.getByText("Cancel"));
+    expect(cancel).toHaveBeenCalledTimes(1);
+    expect(view.getByTestId("legacy-conversation")).toBeTruthy();
+  });
+
+  it("applies titleClassName to the header title and keeps --thread on thread titles", () => {
+    const { client } = createClient();
+    const threadChannel = {
+      channelID: "thread-1",
+      channelType: 5,
+      getChannelKey: () => "thread-1-5",
+    } as any;
+
+    const view = render(
+      <ConversationWindow
+        client={client}
+        channel={threadChannel}
+        errorModuleName="chat"
+        header={{
+          title: "Thread title",
+          titleClassName:
+            "wk-chat-conversation-header-channel-info-name--thread",
+        }}
+      />
+    );
+
+    const nameDiv = view
+      .getByText("Thread title")
+      .closest(".wk-chat-conversation-header-channel-info-name");
+    expect(nameDiv?.className).toContain(
+      "wk-chat-conversation-header-channel-info-name"
+    );
+    expect(nameDiv?.className).toContain(
+      "wk-chat-conversation-header-channel-info-name--thread"
+    );
+  });
+
+  it("attaches surfaceRef and applies inactive", () => {
+    const { client } = createClient();
+    const surfaceRef = { current: null as HTMLDivElement | null };
+
+    const view = render(
+      <ConversationWindow
+        client={client}
+        channel={channel}
+        errorModuleName="chat"
+        surfaceRef={surfaceRef}
+        inactive
+        header={{ title: "Direct chat" }}
+      />
+    );
+
+    expect(surfaceRef.current).toBeTruthy();
+    expect(surfaceRef.current?.className).toContain("wk-chat-content-chat");
+    expect(surfaceRef.current?.getAttribute("aria-hidden")).toBe("true");
+    expect(surfaceRef.current?.hasAttribute("inert")).toBe(true);
+    expect(view.getByTestId("legacy-conversation")).toBeTruthy();
+  });
+
+  it("clears checked messages on selection cancel", () => {
+    const { client } = createClient();
+    const view = render(
+      <ConversationWindow
+        client={client}
+        channel={channel}
+        errorModuleName="chat"
+        header={{ title: "Direct chat" }}
+        selection={{
+          active: true,
+          count: 3,
+          label: "Selected 3",
+          cancelLabel: "Cancel",
+          onCancel: () => {
+            conversationContext.clearCheckedMessages();
+            conversationContext.setEditOn(false);
+          },
+        }}
+      />
+    );
+
+    expect(view.getByText("Selected 3")).toBeTruthy();
+    fireEvent.click(view.getByText("Cancel"));
+    expect(conversationContext.clearCheckedMessages).toHaveBeenCalled();
+    expect(conversationContext.setEditOn).toHaveBeenCalledWith(false);
+  });
+
+  it("does not acquire the primary conversation lease in auxiliary mode", async () => {
+    const { client, opened } = createClient();
+
+    const view = render(
+      <ConversationWindow
+        client={client}
+        channel={channel}
+        mode="auxiliary"
+        errorModuleName="chat"
+        header={{ title: "Thread" }}
+      />
+    );
+
+    await Promise.resolve();
+    expect(opened).toEqual([]);
+    expect(
+      view.getByTestId("legacy-conversation").getAttribute("data-auxiliary")
+    ).toBe("true");
+  });
+});

--- a/packages/dmworkbase/src/Components/ConversationWindow/__tests__/ConversationWindow.test.tsx
+++ b/packages/dmworkbase/src/Components/ConversationWindow/__tests__/ConversationWindow.test.tsx
@@ -17,11 +17,15 @@ const conversationContext = {
   clearCheckedMessages: vi.fn(),
   setEditOn: vi.fn(),
 };
+const conversationTestState = vi.hoisted(() => ({ throwOnRender: false }));
 
 vi.mock("../../Conversation", async () => {
   const ReactModule = await import("react");
   return {
     Conversation: (props: any) => {
+      if (conversationTestState.throwOnRender) {
+        throw new Error("conversation render failed");
+      }
       ReactModule.useEffect(() => {
         props.onContext?.(conversationContext);
       }, [props.onContext]);
@@ -36,15 +40,38 @@ vi.mock("../../Conversation", async () => {
   };
 });
 
-vi.mock("../../ErrorBoundary", () => ({
-  ErrorBoundary: ({ children }: { children: React.ReactNode }) => children,
-}));
+vi.mock("../../ErrorBoundary", async () => {
+  const ReactModule = await import("react");
+  class TestErrorBoundary extends ReactModule.Component<
+    { children: React.ReactNode; onError?: (error: Error, info: React.ErrorInfo) => void },
+    { hasError: boolean }
+  > {
+    state = { hasError: false };
+
+    static getDerivedStateFromError() {
+      return { hasError: true };
+    }
+
+    componentDidCatch(error: Error, info: React.ErrorInfo) {
+      this.props.onError?.(error, info);
+    }
+
+    render() {
+      return this.state.hasError
+        ? <div data-testid="conversation-error-boundary" />
+        : this.props.children;
+    }
+  }
+
+  return { ErrorBoundary: TestErrorBoundary };
+});
 
 import ConversationWindow from "../index";
 
-function createClient() {
+function createClient(options: { failOpenOnce?: boolean } = {}) {
   const released: string[] = [];
   const opened: ChatChannelRef[] = [];
+  let shouldFailOpen = options.failOpenOnce === true;
   const client: ChatClient = {
     status: ChatClientStatus.Connected,
     activeConversation: null,
@@ -57,6 +84,10 @@ function createClient() {
     start: async () => {},
     stop: async () => {},
     openConversation: async (channel) => {
+      if (shouldFailOpen) {
+        shouldFailOpen = false;
+        throw new Error("open failed");
+      }
       opened.push(channel);
       let isReleased = false;
       const lease: ChatConversationLease = {
@@ -91,6 +122,7 @@ const channel = {
 
 describe("ConversationWindow", () => {
   beforeEach(() => {
+    conversationTestState.throwOnRender = false;
     conversationContext.clearCheckedMessages.mockClear();
     conversationContext.setEditOn.mockClear();
   });
@@ -249,5 +281,55 @@ describe("ConversationWindow", () => {
     expect(
       view.getByTestId("legacy-conversation").getAttribute("data-auxiliary")
     ).toBe("true");
+  });
+
+  it("shows a recoverable state when opening the conversation fails", async () => {
+    const { client, opened } = createClient({ failOpenOnce: true });
+    const unbind = vi.fn();
+    const bind = vi.fn(() => unbind);
+
+    const view = render(
+      <ConversationWindow
+        client={client}
+        channel={channel}
+        errorModuleName="chat"
+        bindConversationContext={bind}
+        header={{ title: "Direct chat" }}
+      />
+    );
+
+    await waitFor(() => expect(bind).toHaveBeenCalledWith(conversationContext));
+    await waitFor(() => expect(view.getByRole("alert")).toBeTruthy());
+    await waitFor(() => expect(unbind).toHaveBeenCalledTimes(1));
+    expect(view.queryByTestId("legacy-conversation")).toBeNull();
+
+    fireEvent.click(view.getByRole("button", { name: /retry|重试/i }));
+
+    await waitFor(() => expect(view.getByTestId("legacy-conversation")).toBeTruthy());
+    expect(opened).toEqual([{ channelId: "person-1", channelType: 1 }]);
+  });
+
+  it("releases the bound context when Conversation is caught by its error boundary", async () => {
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const { client } = createClient();
+    const unbind = vi.fn();
+    const bind = vi.fn(() => unbind);
+    const props = {
+      client,
+      channel,
+      errorModuleName: "chat",
+      bindConversationContext: bind,
+      header: { title: "Direct chat" },
+    };
+
+    const view = render(<ConversationWindow {...props} />);
+    await waitFor(() => expect(bind).toHaveBeenCalledWith(conversationContext));
+
+    conversationTestState.throwOnRender = true;
+    view.rerender(<ConversationWindow {...props} />);
+
+    await waitFor(() => expect(view.getByTestId("conversation-error-boundary")).toBeTruthy());
+    await waitFor(() => expect(unbind).toHaveBeenCalledTimes(1));
+    consoleSpy.mockRestore();
   });
 });

--- a/packages/dmworkbase/src/Components/ConversationWindow/index.css
+++ b/packages/dmworkbase/src/Components/ConversationWindow/index.css
@@ -17,8 +17,27 @@
 }
 
 .wk-chat-conversation {
+  display: flex;
+  flex-direction: column;
   width: 100%;
   height: calc(100% - var(--wk-height-chat-conversation-header));
+  min-height: 0;
+  overflow: hidden;
+}
+
+.wk-chat-conversation-surface {
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.wk-chat-conversation-surface > .wk-conversation {
+  flex: 1 1 auto;
   min-height: 0;
 }
 

--- a/packages/dmworkbase/src/Components/ConversationWindow/index.css
+++ b/packages/dmworkbase/src/Components/ConversationWindow/index.css
@@ -41,6 +41,28 @@
   min-height: 0;
 }
 
+.wk-chat-conversation-open-error {
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  color: var(--wk-text-secondary, #666);
+  font-size: 14px;
+}
+
+.wk-chat-conversation-open-error button {
+  min-width: 72px;
+  height: 32px;
+  padding: 0 16px;
+  color: var(--wk-brand-primary);
+  background: var(--wk-bg-surface, #fff);
+  border: 1px solid var(--wk-brand-primary);
+  border-radius: 4px;
+  cursor: pointer;
+}
+
 .wk-chat-conversation-header {
   position: relative;
   z-index: 11;

--- a/packages/dmworkbase/src/Components/ConversationWindow/index.css
+++ b/packages/dmworkbase/src/Components/ConversationWindow/index.css
@@ -1,0 +1,244 @@
+.wk-chat-capability-window {
+  width: 100%;
+  height: 100%;
+  min-width: 0;
+  min-height: 0;
+}
+
+.wk-chat-content-chat {
+  width: 100%;
+  height: 100%;
+  min-width: 0;
+  min-height: 0;
+}
+
+.wk-chat-content-chat-selection {
+  --wk-height-chat-conversation-header: 48px;
+}
+
+.wk-chat-conversation {
+  width: 100%;
+  height: calc(100% - var(--wk-height-chat-conversation-header));
+  min-height: 0;
+}
+
+.wk-chat-conversation-header {
+  position: relative;
+  z-index: 11;
+  display: flex;
+  width: 100%;
+  height: 48px;
+  padding: 12px 16px;
+  align-items: center;
+  justify-content: space-between;
+  box-sizing: border-box;
+  background-color: var(--wk-bg-surface, #fff);
+  border-bottom: 1px solid var(--wk-brand-tint-08);
+}
+
+.wk-chat-conversation-header-selection {
+  background-color: var(--wk-bg-selection-header);
+}
+
+.wk-chat-conversation-header-content {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.wk-chat-conversation-header-left,
+.wk-chat-conversation-header-channel,
+.wk-chat-conversation-header-channel-info,
+.wk-chat-conversation-header-right,
+.wk-chat-conversation-selection-header {
+  display: flex;
+  align-items: center;
+}
+
+.wk-chat-conversation-header-left,
+.wk-chat-conversation-header-channel,
+.wk-chat-conversation-header-channel-info {
+  min-width: 0;
+}
+
+.wk-chat-conversation-header-channel {
+  gap: var(--wk-sp-2);
+  overflow: hidden;
+}
+
+.wk-chat-conversation-header-channel-avatar {
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+  line-height: 0;
+}
+
+.wk-chat-conversation-header-channel-avatar img {
+  display: block;
+  width: 28px;
+  height: 28px;
+  border-radius: var(--wk-avatar-radius, 50%);
+}
+
+.wk-chat-conversation-header-channel-info {
+  overflow: hidden;
+}
+
+.wk-chat-conversation-header-channel-info-name {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 4px;
+  overflow: hidden;
+  color: var(--wk-brand-primary);
+  font-size: 14px;
+  font-weight: 500;
+}
+
+.wk-chat-conversation-header-right {
+  flex-shrink: 0;
+  gap: 8px;
+}
+
+.wk-chat-conversation-header-right > div {
+  display: flex;
+  width: 28px;
+  height: 28px;
+  align-items: center;
+  justify-content: center;
+  color: var(--wk-icon-default);
+  cursor: pointer;
+  border-radius: 6px;
+  transition: background 0.15s, color 0.15s;
+}
+
+.wk-chat-conversation-header-right > div:hover {
+  color: var(--wk-text-strong);
+  background: var(--wk-brand-tint-06);
+}
+
+.wk-chat-conversation-selection-title {
+  color: var(--wk-brand-accent);
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.3;
+}
+
+.wk-chat-conversation-selection-cancel {
+  padding: 8px 10px;
+  color: var(--wk-text-secondary);
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1;
+  cursor: pointer;
+  background: transparent;
+  border: none;
+  border-radius: var(--wk-r-sm);
+  transition: background-color var(--wk-dur-fast) var(--wk-ease),
+    color var(--wk-dur-fast) var(--wk-ease);
+}
+
+.wk-chat-conversation-selection-cancel:hover {
+  background: var(--wk-bg-hover);
+}
+
+.wk-chat-conversation-selection-cancel:focus-visible {
+  outline: 2px solid var(--wk-border-glow);
+  outline-offset: 2px;
+}
+
+.wk-chat-conversation-header-back {
+  position: relative;
+  display: none;
+  width: 40px;
+  height: 40px;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  cursor: pointer;
+  background: transparent;
+  border: 0;
+}
+
+.wk-chat-conversation-header-back-icon,
+.wk-chat-conversation-header-back-icon::before,
+.wk-chat-conversation-header-back-icon::after {
+  width: 1.125rem;
+  height: 0.125rem;
+  background-color: rgb(112, 117, 121);
+  border-radius: 0.125rem;
+}
+
+.wk-chat-conversation-header-back-icon {
+  position: absolute;
+  transform: rotate(180deg);
+}
+
+.wk-chat-conversation-header-back-icon::before,
+.wk-chat-conversation-header-back-icon::after {
+  position: absolute;
+  top: 0;
+  left: 0;
+  content: "";
+}
+
+.wk-chat-conversation-header-back-icon::before {
+  transform: rotate(45deg) scaleX(0.75) translate(0, -0.375rem);
+}
+
+.wk-chat-conversation-header-back-icon::after {
+  transform: rotate(-45deg) scaleX(0.75) translate(0, 0.375rem);
+}
+
+@media screen and (max-width: 640px) {
+  .wk-chat-conversation-header-back {
+    display: flex;
+  }
+}
+
+/* Reset when parent-group is rendered as <button> by ChatPage helpers */
+.wk-chat-conversation-header-parent-group {
+  display: block;
+  color: var(--wk-text-tertiary, #9498a8);
+  font-size: 14px;
+  font-weight: 400;
+  cursor: pointer;
+  transition: color 150ms;
+  white-space: nowrap;
+  flex-shrink: 0;
+  background: none;
+  border: none;
+  padding: 0;
+  font-family: inherit;
+  text-align: left;
+}
+.wk-chat-conversation-header-parent-group:hover {
+  color: var(--wk-text-secondary, #5c6070);
+}
+.wk-chat-conversation-header-separator {
+  display: inline-flex;
+  width: 14px;
+  height: 14px;
+  align-items: center;
+  justify-content: center;
+  color: var(--wk-text-tertiary, #9498a8);
+  flex-shrink: 0;
+  transform: translateY(1px);
+  user-select: none;
+}
+.wk-chat-conversation-header-thread-name {
+  display: block;
+  color: var(--wk-text-primary, #1a1c24);
+  font-size: 14px;
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+  flex-shrink: 1;
+}
+.wk-chat-conversation-header-channel-info-name--thread {
+  gap: var(--wk-sp-1-5);
+}

--- a/packages/dmworkbase/src/Components/ConversationWindow/index.tsx
+++ b/packages/dmworkbase/src/Components/ConversationWindow/index.tsx
@@ -1,4 +1,5 @@
 import React, {
+  useCallback,
   useEffect,
   useRef,
   type CSSProperties,
@@ -16,6 +17,7 @@ import { Channel } from "wukongimjssdk";
 import { Conversation, type ConversationProps } from "../Conversation";
 import type ConversationContext from "../Conversation/context";
 import { ErrorBoundary } from "../ErrorBoundary";
+import { useI18n } from "../../i18n";
 import "./index.css";
 
 export type ConversationWindowMode = "primary" | "auxiliary";
@@ -70,6 +72,43 @@ export interface ConversationSurfaceProps {
   >;
 }
 
+interface ConversationSurfaceContentProps {
+  channel: Channel;
+  mode: ConversationWindowMode;
+  errorModuleName: string;
+  conversationProps?: ConversationSurfaceProps["conversationProps"];
+  onContext: (context: ConversationContext) => void;
+  onUnmount: () => void;
+}
+
+function ConversationSurfaceContent({
+  channel,
+  mode,
+  errorModuleName,
+  conversationProps,
+  onContext,
+  onUnmount,
+}: ConversationSurfaceContentProps): JSX.Element {
+  useEffect(() => () => onUnmount(), [onUnmount]);
+
+  return (
+    <ErrorBoundary
+      key={`${channel.channelID}-${channel.channelType}`}
+      moduleName={errorModuleName}
+      onError={onUnmount}
+    >
+      <Conversation
+        {...conversationProps}
+        key={`${channel.channelID}-${channel.channelType}`}
+        channel={channel}
+        isAuxiliary={mode === "auxiliary"}
+        shouldShowHistorySplit={mode !== "auxiliary"}
+        onContext={onContext}
+      />
+    </ErrorBoundary>
+  );
+}
+
 export function ConversationSurface({
   client,
   channel,
@@ -81,21 +120,21 @@ export function ConversationSurface({
   bindConversationContext,
   conversationProps,
 }: ConversationSurfaceProps): JSX.Element {
+  const { t } = useI18n();
   const unbindConversationContextRef = useRef<(() => void) | undefined>();
 
-  useEffect(
-    () => () => {
-      unbindConversationContextRef.current?.();
-      unbindConversationContextRef.current = undefined;
-    },
-    []
-  );
-
-  const handleConversationContext = (context: ConversationContext) => {
+  const releaseConversationContext = useCallback(() => {
     unbindConversationContextRef.current?.();
+    unbindConversationContextRef.current = undefined;
+  }, []);
+
+  useEffect(() => releaseConversationContext, [releaseConversationContext]);
+
+  const handleConversationContext = useCallback((context: ConversationContext) => {
+    releaseConversationContext();
     unbindConversationContextRef.current = bindConversationContext?.(context);
     conversationProps?.onContext?.(context);
-  };
+  }, [bindConversationContext, conversationProps?.onContext, releaseConversationContext]);
 
   return (
     <ChatProvider client={client} host={hostCapabilities}>
@@ -108,16 +147,23 @@ export function ConversationSurface({
         className={classNames("wk-chat-conversation-surface", className)}
         style={style}
       >
-        <ErrorBoundary moduleName={errorModuleName}>
-          <Conversation
-            {...conversationProps}
-            key={`${channel.channelID}-${channel.channelType}`}
+        {({ error, retry }) => error ? (
+          <div className="wk-chat-conversation-open-error" role="alert">
+            <span>{t("base.conversation.openFailed")}</span>
+            <button type="button" onClick={retry}>
+              {t("base.conversation.retry")}
+            </button>
+          </div>
+        ) : (
+          <ConversationSurfaceContent
             channel={channel}
-            isAuxiliary={mode === "auxiliary"}
-            shouldShowHistorySplit={mode !== "auxiliary"}
+            mode={mode}
+            errorModuleName={errorModuleName}
+            conversationProps={conversationProps}
             onContext={handleConversationContext}
+            onUnmount={releaseConversationContext}
           />
-        </ErrorBoundary>
+        )}
       </ChatConversationBoundary>
     </ChatProvider>
   );

--- a/packages/dmworkbase/src/Components/ConversationWindow/index.tsx
+++ b/packages/dmworkbase/src/Components/ConversationWindow/index.tsx
@@ -1,0 +1,238 @@
+import React, {
+  useEffect,
+  useRef,
+  type CSSProperties,
+  type ReactNode,
+  type Ref,
+} from "react";
+import type { ChatClient } from "@octo/chat-core";
+import {
+  ChatProvider,
+  ConversationWindow as ChatConversationBoundary,
+  type ChatHostCapabilities,
+} from "@octo/chat-react";
+import classNames from "classnames";
+import { Channel } from "wukongimjssdk";
+import { Conversation, type ConversationProps } from "../Conversation";
+import type ConversationContext from "../Conversation/context";
+import { ErrorBoundary } from "../ErrorBoundary";
+import "./index.css";
+
+export type ConversationWindowMode = "primary" | "auxiliary";
+
+export interface ConversationWindowHeaderModel {
+  avatar?: ReactNode;
+  title: ReactNode;
+  titleClassName?: string;
+  onBack?: () => void;
+  actions?: ReactNode;
+}
+
+export interface ConversationWindowSelectionModel {
+  active: boolean;
+  count: number;
+  label: ReactNode;
+  cancelLabel: ReactNode;
+  onCancel: () => void;
+}
+
+export interface ConversationWindowProps {
+  client: ChatClient;
+  channel: Channel;
+  header: ConversationWindowHeaderModel;
+  selection?: ConversationWindowSelectionModel;
+  hostCapabilities?: ChatHostCapabilities;
+  mode?: ConversationWindowMode;
+  className?: string;
+  style?: CSSProperties;
+  surfaceRef?: Ref<HTMLDivElement>;
+  inactive?: boolean;
+  errorModuleName: string;
+  bindConversationContext?: (context: ConversationContext) => () => void;
+  conversationProps?: Omit<
+    ConversationProps,
+    "channel" | "isAuxiliary" | "shouldShowHistorySplit"
+  >;
+}
+
+export interface ConversationSurfaceProps {
+  client: ChatClient;
+  channel: Channel;
+  hostCapabilities?: ChatHostCapabilities;
+  mode?: ConversationWindowMode;
+  className?: string;
+  style?: CSSProperties;
+  errorModuleName: string;
+  bindConversationContext?: (context: ConversationContext) => () => void;
+  conversationProps?: Omit<
+    ConversationProps,
+    "channel" | "isAuxiliary" | "shouldShowHistorySplit"
+  >;
+}
+
+export function ConversationSurface({
+  client,
+  channel,
+  hostCapabilities,
+  mode = "primary",
+  className,
+  style,
+  errorModuleName,
+  bindConversationContext,
+  conversationProps,
+}: ConversationSurfaceProps): JSX.Element {
+  const unbindConversationContextRef = useRef<(() => void) | undefined>();
+
+  useEffect(
+    () => () => {
+      unbindConversationContextRef.current?.();
+      unbindConversationContextRef.current = undefined;
+    },
+    []
+  );
+
+  const handleConversationContext = (context: ConversationContext) => {
+    unbindConversationContextRef.current?.();
+    unbindConversationContextRef.current = bindConversationContext?.(context);
+    conversationProps?.onContext?.(context);
+  };
+
+  return (
+    <ChatProvider client={client} host={hostCapabilities}>
+      <ChatConversationBoundary
+        channel={{
+          channelId: channel.channelID,
+          channelType: channel.channelType,
+        }}
+        activate={mode === "primary"}
+        className={classNames("wk-chat-conversation-surface", className)}
+        style={style}
+      >
+        <ErrorBoundary moduleName={errorModuleName}>
+          <Conversation
+            {...conversationProps}
+            key={channel.getChannelKey()}
+            channel={channel}
+            isAuxiliary={mode === "auxiliary"}
+            onContext={handleConversationContext}
+          />
+        </ErrorBoundary>
+      </ChatConversationBoundary>
+    </ChatProvider>
+  );
+}
+
+export function ConversationWindow({
+  client,
+  channel,
+  header,
+  selection,
+  hostCapabilities,
+  mode = "primary",
+  className,
+  style,
+  surfaceRef,
+  inactive = false,
+  errorModuleName,
+  bindConversationContext,
+  conversationProps,
+}: ConversationWindowProps): JSX.Element {
+  const selectionActive = selection?.active === true;
+  const inertProps = inactive ? ({ inert: "" } as Record<string, string>) : {};
+
+  return (
+    <div
+      ref={surfaceRef}
+      className={classNames(
+        "wk-chat-content-chat",
+        "wk-chat-capability-window",
+        selectionActive && "wk-chat-content-chat-selection",
+        className
+      )}
+      style={style}
+      aria-hidden={inactive || undefined}
+      {...inertProps}
+    >
+      <div
+        className={classNames(
+          "wk-chat-conversation-header",
+          selectionActive && "wk-chat-conversation-header-selection"
+        )}
+      >
+        <div className="wk-chat-conversation-header-content">
+          <div className="wk-chat-conversation-header-left">
+            {selectionActive && selection ? (
+              <div className="wk-chat-conversation-selection-header">
+                <div className="wk-chat-conversation-selection-title">
+                  {selection.label}
+                </div>
+              </div>
+            ) : (
+              <>
+                {header.onBack && (
+                  <button
+                    type="button"
+                    className="wk-chat-conversation-header-back"
+                    aria-label="Back"
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      header.onBack?.();
+                    }}
+                  >
+                    <span className="wk-chat-conversation-header-back-icon" />
+                  </button>
+                )}
+                <div className="wk-chat-conversation-header-channel">
+                  {header.avatar && (
+                    <div className="wk-chat-conversation-header-channel-avatar">
+                      {header.avatar}
+                    </div>
+                  )}
+                  <div className="wk-chat-conversation-header-channel-info">
+                    <div
+                      className={classNames(
+                        "wk-chat-conversation-header-channel-info-name",
+                        header.titleClassName
+                      )}
+                    >
+                      {header.title}
+                    </div>
+                  </div>
+                </div>
+              </>
+            )}
+          </div>
+          <div className="wk-chat-conversation-header-right">
+            {selectionActive && selection ? (
+              <button
+                type="button"
+                className="wk-chat-conversation-selection-cancel"
+                onClick={(event) => {
+                  event.stopPropagation();
+                  selection.onCancel();
+                }}
+              >
+                {selection.cancelLabel}
+              </button>
+            ) : (
+              header.actions
+            )}
+          </div>
+        </div>
+      </div>
+      <div className="wk-chat-conversation">
+        <ConversationSurface
+          client={client}
+          channel={channel}
+          hostCapabilities={hostCapabilities}
+          mode={mode}
+          errorModuleName={errorModuleName}
+          bindConversationContext={bindConversationContext}
+          conversationProps={conversationProps}
+        />
+      </div>
+    </div>
+  );
+}
+
+export default ConversationWindow;

--- a/packages/dmworkbase/src/Components/ConversationWindow/index.tsx
+++ b/packages/dmworkbase/src/Components/ConversationWindow/index.tsx
@@ -111,9 +111,10 @@ export function ConversationSurface({
         <ErrorBoundary moduleName={errorModuleName}>
           <Conversation
             {...conversationProps}
-            key={channel.getChannelKey()}
+            key={`${channel.channelID}-${channel.channelType}`}
             channel={channel}
             isAuxiliary={mode === "auxiliary"}
+            shouldShowHistorySplit={mode !== "auxiliary"}
             onContext={handleConversationContext}
           />
         </ErrorBoundary>

--- a/packages/dmworkbase/src/Components/ConversationWindow/index.tsx
+++ b/packages/dmworkbase/src/Components/ConversationWindow/index.tsx
@@ -184,6 +184,7 @@ export function ConversationWindow({
   bindConversationContext,
   conversationProps,
 }: ConversationWindowProps): JSX.Element {
+  const { t } = useI18n();
   const selectionActive = selection?.active === true;
   const inertProps = inactive ? ({ inert: "" } as Record<string, string>) : {};
 
@@ -220,7 +221,7 @@ export function ConversationWindow({
                   <button
                     type="button"
                     className="wk-chat-conversation-header-back"
-                    aria-label="Back"
+                    aria-label={t("common.back")}
                     onClick={(event) => {
                       event.stopPropagation();
                       header.onBack?.();

--- a/packages/dmworkbase/src/Components/ThreadPanel/index.tsx
+++ b/packages/dmworkbase/src/Components/ThreadPanel/index.tsx
@@ -25,7 +25,7 @@ import {
 } from "lucide-react";
 import ThreadIcon from "../Icons/ThreadIcon";
 import classNames from "classnames";
-import { Conversation } from "../Conversation";
+import { ConversationSurface } from "../ConversationWindow";
 import { ChannelTypeCommunityTopic } from "../../Service/Const";
 import {
   canManageThread,
@@ -33,8 +33,8 @@ import {
 } from "../../Service/threadPermission";
 import { extractErrorMsg } from "../../Service/APIClient";
 import ChannelWebhookPanel from "../ChannelWebhook";
-import { ErrorBoundary } from "../ErrorBoundary";
 import WKApp from "../../App";
+import { getLegacyChatRuntime } from "../../features/chat-capability/legacyChatClient";
 import { ShowConversationOptions } from "../../EndpointCommon";
 import { formatRelativeTime } from "../../Utils/time";
 import { isChannelDisbanded } from "../../Utils/groupDisband";
@@ -239,6 +239,7 @@ export default class ThreadPanel extends Component<
   /** 组件是否已卸载，撤销 Toast 渲染在全局 portal，卸载后回调需短路 */
   private isUnmounted = false;
   private _unsubscribeRemoteConfig?: () => void;
+  private readonly chatRuntime = getLegacyChatRuntime();
 
   constructor(props: ThreadPanelProps) {
     super(props);
@@ -1958,20 +1959,20 @@ export default class ThreadPanel extends Component<
 
     return (
       <div className="wk-thread-panel-conversation">
-        <ErrorBoundary moduleName={t("base.threadPanel.messagesModuleName")}>
-          <Conversation
-            key={thread.channel_id}
-            channel={threadChannel}
-            isAuxiliary
-            shouldShowHistorySplit={false}
-            inputNotice={
+        <ConversationSurface
+          key={thread.channel_id}
+          client={this.chatRuntime.client}
+          channel={threadChannel}
+          mode="auxiliary"
+          errorModuleName={t("base.threadPanel.messagesModuleName")}
+          conversationProps={{
+            inputNotice:
               thread.status === ThreadStatus.Archived
                 ? t("base.threadPanel.archivedInputNotice")
-                : undefined
-            }
-            onMessageSent={this.handleThreadMessageSent}
-          />
-        </ErrorBoundary>
+                : undefined,
+            onMessageSent: this.handleThreadMessageSent,
+          }}
+        />
       </div>
     );
   }

--- a/packages/dmworkbase/src/Components/WKLayout/__tests__/WKLayout.drag.test.tsx
+++ b/packages/dmworkbase/src/Components/WKLayout/__tests__/WKLayout.drag.test.tsx
@@ -1,16 +1,50 @@
+// @vitest-environment jsdom
+
 import React from "react"
-import { cleanup, fireEvent, render } from "@testing-library/react"
-import { afterEach, describe, expect, it } from "vitest"
+import ReactDOM from "react-dom"
+import { act } from "react-dom/test-utils"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
 import { WKLayout } from "../index"
 
+let container: HTMLDivElement
+
+beforeEach(() => {
+    container = document.createElement("div")
+    document.body.appendChild(container)
+})
+
 afterEach(() => {
-    cleanup()
+    act(() => {
+        ReactDOM.unmountComponentAtNode(container)
+    })
+    container.remove()
     localStorage.clear()
 })
 
+const renderLayout = (element: React.ReactElement) => {
+    act(() => {
+        ReactDOM.render(element, container)
+    })
+}
+
 describe("WKLayout NavRail drag", () => {
+    it("removes the NavRail and its splitter in embedded mode", () => {
+        renderLayout(
+            <WKLayout
+                embedded
+                onRenderTab={() => <nav>Navigation</nav>}
+                contentLeft={<div>Conversation list</div>}
+                contentRight={<div>Conversation</div>}
+            />,
+        )
+
+        expect(container.querySelector(".wk-layout-tab")).toBeNull()
+        expect(container.querySelector(".wk-layout-nav-splitter")).toBeNull()
+        expect(container.querySelector(".wk-layout-content")).not.toBeNull()
+    })
+
     it("expands the NavRail when its splitter is dragged to the right", () => {
-        const { container } = render(
+        renderLayout(
             <WKLayout
                 onRenderTab={() => <nav>Navigation</nav>}
                 contentLeft={<div>Conversation list</div>}
@@ -24,9 +58,11 @@ describe("WKLayout NavRail drag", () => {
         expect(splitter).not.toBeNull()
         expect(navRail?.style.width).toBe("56px")
 
-        fireEvent.mouseDown(splitter!, { clientX: 56 })
-        fireEvent.mouseMove(document, { clientX: 57 })
-        fireEvent.mouseUp(document)
+        act(() => {
+            splitter!.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, clientX: 56 }))
+            document.dispatchEvent(new MouseEvent("mousemove", { bubbles: true, clientX: 57 }))
+            document.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }))
+        })
 
         expect(navRail?.style.width).toBe("180px")
         expect(navRail?.classList.contains("wk-layout-tab-expanded")).toBe(true)

--- a/packages/dmworkbase/src/Components/WKLayout/index.tsx
+++ b/packages/dmworkbase/src/Components/WKLayout/index.tsx
@@ -32,6 +32,8 @@ export interface WKLayoutProps {
     contentRight?:JSX.Element
     onLeftContext?:(context:WKViewQueueContext)=>void
     onRightContext?:(context:WKViewQueueContext)=>void
+    /** Embedded hosts already provide their own primary navigation rail. */
+    embedded?: boolean
 }
 
 interface WKLayoutState {
@@ -230,13 +232,13 @@ export class WKLayout extends Component<WKLayoutProps, WKLayoutState>{
     }
 
     render() {
-        const { onRenderTab, contentLeft,contentRight,onLeftContext,onRightContext } = this.props
+        const { onRenderTab, contentLeft,contentRight,onLeftContext,onRightContext, embedded = false } = this.props
         const isExtension = (window as any).__POWERED_EXTENSION__
         const isSmallScreen = window.innerWidth <= SMALL_SCREEN_WIDTH
         const { leftWidth, navRailWidth, isDragging, draggingTarget } = this.state
 
         const clampedNavRailWidth = isSmallScreen ? NAV_RAIL_DEFAULT_WIDTH : clampNavRailWidth(navRailWidth, this.cachedLayoutWidth)
-        const navRailWidthPx = `${clampedNavRailWidth}px`
+        const navRailWidthPx = embedded ? "0px" : `${clampedNavRailWidth}px`
         const isNavRailExpanded = clampedNavRailWidth >= NAV_RAIL_EXPANDED_THRESHOLD
 
         const tabElement = <div
@@ -310,8 +312,12 @@ export class WKLayout extends Component<WKLayoutProps, WKLayoutState>{
             ref={this.layoutRef}
             style={isSmallScreen ? undefined : { '--wk-width-layout-tab': navRailWidthPx } as React.CSSProperties}
         >
-            {isExtension ? <>{contentElement}{tabElement}</> : <>{tabElement}{contentElement}</>}
-            {!isSmallScreen && !isExtension && (
+            {embedded
+                ? contentElement
+                : isExtension
+                    ? <>{contentElement}{tabElement}</>
+                    : <>{tabElement}{contentElement}</>}
+            {!embedded && !isSmallScreen && !isExtension && (
                 <div
                     className={classNames("wk-layout-nav-splitter", isDragging && draggingTarget === "nav" && "wk-layout-nav-splitter-active")}
                     onMouseDown={this.onNavDragStart}

--- a/packages/dmworkbase/src/Pages/Chat/index.tsx
+++ b/packages/dmworkbase/src/Pages/Chat/index.tsx
@@ -1,5 +1,5 @@
 import React, { Component, ReactNode } from "react";
-import { Conversation } from "../../Components/Conversation";
+import { ConversationWindow } from "../../Components/ConversationWindow";
 import ConversationList, {
   ConvFilter,
 } from "../../Components/ConversationList";
@@ -99,6 +99,7 @@ import {
   shouldHideRecentUnreadBadge,
   unreadContribution,
 } from "./sidebarUnreadBadge";
+import { getLegacyChatRuntime } from "../../features/chat-capability/legacyChatClient";
 
 // 消息 ACK 只代表发送成功；后端把归档子区恢复为活跃存在短暂异步窗口。
 // 实测立即 threadGet 可能仍返回 Archived，因此发送后用短轮询等后端状态落稳。
@@ -207,13 +208,15 @@ const SidebarTabBarWithBadges: React.FC<SidebarTabBarWithBadgesProps> = ({
       parentGroupNo,
       missingFollowMuteAuthority
     );
-    const ready =
-      !!channelInfo && (!parentGroupNo || !!parentChannelInfo);
-    return { ready, muted: isEffectivelyMuted({
-      isThread,
-      channelInfo,
-      parentChannelInfo,
-    }) };
+    const ready = !!channelInfo && (!parentGroupNo || !!parentChannelInfo);
+    return {
+      ready,
+      muted: isEffectivelyMuted({
+        isThread,
+        channelInfo,
+        parentChannelInfo,
+      }),
+    };
   };
 
   // sidebar items 是 /sidebar/sync 的快照，IM 缓存里 conv 才是 reactive 的。
@@ -260,19 +263,21 @@ const SidebarTabBarWithBadges: React.FC<SidebarTabBarWithBadgesProps> = ({
     const unread = liveConv ? liveConv.unread || 0 : it.unread || 0;
     if (unread <= 0) return sum;
     const muteState = getItemMuteState(it);
-    return sum + unreadContribution({
-      unread,
-      muteAuthorityReady: muteState.ready,
-      muted: muteState.muted,
-    });
+    return (
+      sum +
+      unreadContribution({
+        unread,
+        muteAuthorityReady: muteState.ready,
+        muted: muteState.muted,
+      })
+    );
   }, 0);
 
   const recentUnread = conversations.reduce(
     (sum: number, c: ConversationWrap) => {
       const unread = c.unread || 0;
       if (unread <= 0) return sum;
-      const isThread =
-        c.channel.channelType === ChannelTypeCommunityTopic;
+      const isThread = c.channel.channelType === ChannelTypeCommunityTopic;
       const parentGroupNo = isThread
         ? (c.channelInfo?.orgData?.parentGroupNo as string | undefined) ||
           parseThreadChannelId(c.channel.channelID)?.groupNo
@@ -282,13 +287,16 @@ const SidebarTabBarWithBadges: React.FC<SidebarTabBarWithBadgesProps> = ({
         parentGroupNo,
         missingRecentMuteAuthority
       );
-      return sum + unreadContribution({
-        unread,
-        muteAuthorityReady:
-          !!authority.channelInfo &&
-          (!parentGroupNo || !!authority.parentChannelInfo),
-        muted: isMutedForRecentConversation(c),
-      });
+      return (
+        sum +
+        unreadContribution({
+          unread,
+          muteAuthorityReady:
+            !!authority.channelInfo &&
+            (!parentGroupNo || !!authority.parentChannelInfo),
+          muted: isMutedForRecentConversation(c),
+        })
+      );
     },
     0
   );
@@ -397,6 +405,7 @@ export class ChatContentPage extends Component<
   private _unsubscribeChannelInfoListener?: () => void;
   private _unsubscribeChannelSearchConfig?: () => void;
   private readonly titlePageOwner = Symbol("chat-content-page");
+  private readonly chatRuntime = getLegacyChatRuntime();
   private readonly channelSettingPanelRef = React.createRef<HTMLDivElement>();
   private readonly chatContentRef = React.createRef<HTMLDivElement>();
   private channelSettingReturnFocusElement?: HTMLElement;
@@ -873,11 +882,7 @@ export class ChatContentPage extends Component<
     prevState: ChatContentPageState
   ) {
     if (!prevState.showChannelSetting && this.state.showChannelSetting) {
-      document.addEventListener(
-        "keydown",
-        this._onChannelSettingKeyDown,
-        true
-      );
+      document.addEventListener("keydown", this._onChannelSettingKeyDown, true);
       this.shouldRestoreChannelSettingFocus = false;
       this.channelSettingPanelRef.current?.focus();
     } else if (prevState.showChannelSetting && !this.state.showChannelSetting) {
@@ -1119,6 +1124,165 @@ export class ChatContentPage extends Component<
     return new Promise<void>((resolve) => window.setTimeout(resolve, ms));
   }
 
+  private renderConversationHeaderAvatar(
+    channel: Channel,
+    isThreadChannel: boolean
+  ): ReactNode {
+    if (channel.channelType === ChannelTypeGroup) {
+      return (
+        <WKAvatar
+          key={WKApp.shared.getChannelAvatarTag(channel)}
+          channel={channel}
+          style={{
+            width: 28,
+            height: 28,
+            borderRadius: "var(--wk-avatar-radius, 50%)",
+            flexShrink: 0,
+          }}
+        />
+      );
+    }
+    if (isThreadChannel) {
+      return (
+        <div className="wk-chat-conversation-header-channel-thread-icon">
+          <ThreadIcon size={18} color="var(--wk-text-secondary, #5C6070)" />
+        </div>
+      );
+    }
+    return <img alt="" src={WKApp.shared.avatarChannel(channel)} />;
+  }
+
+  private renderConversationHeaderTitle(
+    channel: Channel,
+    channelInfo: ChannelInfo | undefined,
+    threadParentGroupNo: string | undefined
+  ): ReactNode {
+    if (
+      channel.channelType !== ChannelTypeCommunityTopic ||
+      !threadParentGroupNo
+    ) {
+      return channelInfo?.orgData?.displayName;
+    }
+
+    return (
+      <>
+        <button
+          type="button"
+          className="wk-chat-conversation-header-parent-group"
+          onClick={() => {
+            WKApp.endpoints.showConversation(
+              this.parentGroupChannel ||
+                new Channel(threadParentGroupNo, ChannelTypeGroup)
+            );
+          }}
+        >
+          {getImChannelInfo(
+            WKSDK.shared(),
+            new Channel(threadParentGroupNo, ChannelTypeGroup)
+          )?.title || threadParentGroupNo}
+        </button>
+        <span className="wk-chat-conversation-header-separator">
+          <ChevronRight aria-hidden="true" size={14} />
+        </span>
+        <span className="wk-chat-conversation-header-thread-name">
+          {channelInfo?.orgData?.displayName}
+        </span>
+      </>
+    );
+  }
+
+  private renderConversationHeaderActions(
+    channel: Channel,
+    isThreadChannel: boolean,
+    showChannelSetting: boolean
+  ): ReactNode {
+    return (
+      <>
+        {WKApp.endpoints
+          .channelHeaderRightItems(channel)
+          .map((item: ReactNode, index: number) => (
+            <div
+              key={index}
+              className="wk-chat-conversation-header-right-item"
+              onClick={(event) => event.stopPropagation()}
+            >
+              {item}
+            </div>
+          ))}
+        {!isThreadChannel &&
+          channel.channelType === ChannelTypeGroup &&
+          WKApp.remoteConfig.threadOn && (
+            <div
+              data-testid="chat-thread-panel-entry"
+              className="wk-chat-conversation-header-right-item"
+              onClick={(event) => {
+                event.stopPropagation();
+                const isThreadListVisibleNow =
+                  this.state.showThreadPanel &&
+                  !this.state.previewFile &&
+                  !this.state.activeThread;
+                if (!isThreadListVisibleNow) {
+                  Dap.shared.track("channel_subchannel_panel_opened", {});
+                }
+                this.setState((previousState) => {
+                  const isThreadListVisible =
+                    previousState.showThreadPanel &&
+                    !previousState.previewFile &&
+                    !previousState.activeThread;
+                  return isThreadListVisible
+                    ? closeChatRightPanels()
+                    : openChatRightPanel("thread");
+                });
+              }}
+              title={t("base.chatPage.threadPanel")}
+            >
+              <ThreadIcon size={20} color="currentColor" />
+            </div>
+          )}
+        <div
+          data-testid="chat-channel-setting-entry"
+          className="wk-chat-conversation-header-right-item"
+          role="button"
+          tabIndex={0}
+          aria-controls="chat-channel-setting-panel"
+          aria-expanded={showChannelSetting}
+          aria-label={t("base.channelSetting.title")}
+          onClick={(event) => {
+            event.stopPropagation();
+            if (this.state.showChannelSetting) {
+              this._closeChannelSetting();
+              return;
+            }
+            this.channelSettingReturnFocusElement = event.currentTarget;
+            if (channel.channelType === ChannelTypeGroup) {
+              Dap.shared.track("group_info_panel_opened", {});
+            }
+            this.setState(openChatRightPanel("channelSetting"));
+          }}
+          onKeyDown={(event) => {
+            if (event.key === "Enter" || event.key === " ") {
+              event.preventDefault();
+              event.currentTarget.click();
+            }
+          }}
+        >
+          <svg
+            width="20"
+            height="20"
+            viewBox="0 0 16 16"
+            fill="currentColor"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path d="M4.66658 7.99998C4.66658 8.92045 3.92039 9.66665 2.99992 9.66665C2.07945 9.66665 1.33325 8.92045 1.33325 7.99998C1.33325 7.07951 2.07945 6.33331 2.99992 6.33331C3.92039 6.33331 4.66658 7.07951 4.66658 7.99998Z" />
+            <path d="M9.66659 7.99998C9.66659 8.92045 8.92039 9.66665 7.99992 9.66665C7.07945 9.66665 6.33325 8.92045 6.33325 7.99998C6.33325 7.07951 7.07945 6.33331 7.99992 6.33331C8.92039 6.33331 9.66659 7.07951 9.66659 7.99998Z" />
+            <path d="M12.9999 9.66665C13.9204 9.66665 14.6666 8.92045 14.6666 7.99998C14.6666 7.07951 13.9204 6.33331 12.9999 6.33331C12.0795 6.33331 11.3333 7.07951 11.3333 7.99998C11.3333 8.92045 12.0795 9.66665 12.9999 9.66665Z" />
+          </svg>
+          <div className="wk-conversation-header-mask" />
+        </div>
+      </>
+    );
+  }
+
   render(): React.ReactNode {
     const { channel, initLocateMessageSeq } = this.props;
     const {
@@ -1157,291 +1321,97 @@ export class ChatContentPage extends Component<
           webhookIssuePreviewTarget ? "wk-chat-webhook-preview-open" : ""
         )}
       >
-        <div
-          ref={this.chatContentRef}
-          className={classNames(
-            "wk-chat-content-chat",
-            selectionMode ? "wk-chat-content-chat-selection" : undefined
-          )}
-          aria-hidden={showChannelSetting || undefined}
-          {...(showChannelSetting ? { inert: "" } : {})}
-        >
-          <div
-            className={classNames(
-              "wk-chat-conversation-header",
-              selectionMode
-                ? "wk-chat-conversation-header-selection"
-                : undefined
-            )}
-          >
-            <div className="wk-chat-conversation-header-content">
-              <div className="wk-chat-conversation-header-left">
-                {selectionMode ? (
-                  <div className="wk-chat-conversation-selection-header">
-                    <div className="wk-chat-conversation-selection-title">
-                      {t("base.chatPage.selectionCount", {
-                        values: { count: selectedCount },
-                      })}
-                    </div>
-                  </div>
-                ) : (
-                  <>
-                    <div
-                      className="wk-chat-conversation-header-back"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        WKApp.routeRight.pop();
-                      }}
-                    >
-                      <div className="wk-chat-conversation-header-back-icon"></div>
-                    </div>
-                    <div className="wk-chat-conversation-header-channel">
-                      <div className="wk-chat-conversation-header-channel-avatar">
-                        {channel.channelType === ChannelTypeGroup ? (
-                          // 群聊：真实头像
-                          <WKAvatar
-                            key={WKApp.shared.getChannelAvatarTag(channel)}
-                            channel={channel}
-                            style={{
-                              width: 28,
-                              height: 28,
-                              borderRadius: "var(--wk-avatar-radius, 50%)",
-                              flexShrink: 0,
-                            }}
-                          />
-                        ) : channel.channelType ===
-                          ChannelTypeCommunityTopic ? (
-                          // 子区：🧵 icon，圆角背景（对齐群聊 hash-icon 样式）
-                          <div className="wk-chat-conversation-header-channel-thread-icon">
-                            <ThreadIcon
-                              size={18}
-                              color="var(--wk-text-secondary, #5C6070)"
-                            />
-                          </div>
-                        ) : (
-                          // 私聊：头像
-                          <img
-                            alt=""
-                            src={WKApp.shared.avatarChannel(channel)}
-                          ></img>
-                        )}
-                      </div>
-                      <div className="wk-chat-conversation-header-channel-info">
-                        <div
-                          className={classNames(
-                            "wk-chat-conversation-header-channel-info-name",
-                            isThreadChannel &&
-                              threadParentGroupNo &&
-                              "wk-chat-conversation-header-channel-info-name--thread"
-                          )}
-                        >
-                          {isThreadChannel && threadParentGroupNo ? (
-                            <>
-                              {/* 面包屑：父群组 › 子区名 */}
-                              <span
-                                className="wk-chat-conversation-header-parent-group"
-                                style={{ cursor: "pointer" }}
-                                onClick={() => {
-                                  WKApp.endpoints.showConversation(
-                                    this.parentGroupChannel ||
-                                      new Channel(
-                                        threadParentGroupNo,
-                                        ChannelTypeGroup
-                                      )
-                                  );
-                                }}
-                              >
-                                {getImChannelInfo(
-                                  WKSDK.shared(),
-                                  new Channel(
-                                    threadParentGroupNo,
-                                    ChannelTypeGroup
-                                  )
-                                )?.title || threadParentGroupNo}
-                              </span>
-                              <span className="wk-chat-conversation-header-separator">
-                                <ChevronRight aria-hidden="true" size={14} />
-                              </span>
-                              <span className="wk-chat-conversation-header-thread-name">
-                                {channelInfo?.orgData?.displayName}
-                              </span>
-                            </>
-                          ) : (
-                            channelInfo?.orgData?.displayName
-                          )}
-                        </div>
-                        <div className="wk-chat-conversation-header-channel-info-tip"></div>
-                      </div>
-                    </div>
-                  </>
-                )}
-              </div>
-              <div className="wk-chat-conversation-header-right">
-                {selectionMode ? (
-                  <button
-                    type="button"
-                    className="wk-chat-conversation-selection-cancel"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      this.conversationContext?.clearCheckedMessages();
-                      this.conversationContext?.setEditOn(false);
-                    }}
-                  >
-                    {t("base.common.cancel")}
-                  </button>
-                ) : (
-                  <>
-                    {WKApp.endpoints
-                      .channelHeaderRightItems(channel)
-                      .map((item: any, i: number) => {
-                        return (
-                          <div
-                            key={i}
-                            className="wk-chat-conversation-header-right-item"
-                            onClick={(e) => e.stopPropagation()}
-                          >
-                            {item}
-                          </div>
-                        );
-                      })}
-                    {/* 子区按钮 - 切换子区列表 */}
-                    {!isThreadChannel &&
-                      channel.channelType === ChannelTypeGroup &&
-                      WKApp.remoteConfig.threadOn && (
-                        <div
-                          data-testid="chat-thread-panel-entry"
-                          className="wk-chat-conversation-header-right-item"
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            // channel_subchannel_panel_opened:仅在「打开」边沿(当前子区列表未显示)且为
-                            // 群频道时发一次。原挂在 GET /groups/:id/threads 的 2xx 通道会被删除/归档/重试刷新
-                            // 反复触发;二审又发现改挂到 ThreadList.componentDidMount 是死组件(实际渲染的是
-                            // ThreadPanel),永不触发。收口到这个真正的子区 header 开关点(见二审 P1-2),
-                            // 与上方 group_info_panel_opened 同一「仅开边沿」写法,file-preview 复用 ThreadPanel 不误计。
-                            {
-                              const isThreadListVisibleNow =
-                                this.state.showThreadPanel &&
-                                !this.state.previewFile &&
-                                !this.state.activeThread;
-                              if (!isThreadListVisibleNow) {
-                                Dap.shared.track("channel_subchannel_panel_opened", {});
-                              }
-                            }
-                            this.setState((prevState) => {
-                              // 如果有文件预览或其他面板打开，视为"子区列表未显示"，点击应打开子区列表
-                              const isThreadListVisible =
-                                prevState.showThreadPanel &&
-                                !prevState.previewFile &&
-                                !prevState.activeThread;
-                              return isThreadListVisible
-                                ? closeChatRightPanels()
-                                : openChatRightPanel("thread");
-                            });
-                          }}
-                          title={t("base.chatPage.threadPanel")}
-                        >
-                          <ThreadIcon size={20} color="currentColor" />
-                        </div>
-                      )}
-                    <div
-                      data-testid="chat-channel-setting-entry"
-                      className="wk-chat-conversation-header-right-item"
-                      role="button"
-                      tabIndex={0}
-                      aria-controls="chat-channel-setting-panel"
-                      aria-expanded={showChannelSetting}
-                      aria-label={t("base.channelSetting.title")}
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        if (this.state.showChannelSetting) {
-                          this._closeChannelSetting();
-                          return;
-                        }
-                        this.channelSettingReturnFocusElement = e.currentTarget;
-                        // group_info_panel_opened:仅开面板(opening)且为群频道时发,props 恒空
-                        if (channel.channelType === ChannelTypeGroup) {
-                          Dap.shared.track("group_info_panel_opened", {});
-                        }
-                        this.setState(openChatRightPanel("channelSetting"));
-                      }}
-                      onKeyDown={(event) => {
-                        if (event.key === "Enter" || event.key === " ") {
-                          event.preventDefault();
-                          event.currentTarget.click();
-                        }
-                      }}
-                    >
-                      <svg
-                        width="20"
-                        height="20"
-                        viewBox="0 0 16 16"
-                        fill="currentColor"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path d="M4.66658 7.99998C4.66658 8.92045 3.92039 9.66665 2.99992 9.66665C2.07945 9.66665 1.33325 8.92045 1.33325 7.99998C1.33325 7.07951 2.07945 6.33331 2.99992 6.33331C3.92039 6.33331 4.66658 7.07951 4.66658 7.99998Z" />
-                        <path d="M9.66659 7.99998C9.66659 8.92045 8.92039 9.66665 7.99992 9.66665C7.07945 9.66665 6.33325 8.92045 6.33325 7.99998C6.33325 7.07951 7.07945 6.33331 7.99992 6.33331C8.92039 6.33331 9.66659 7.07951 9.66659 7.99998Z" />
-                        <path d="M12.9999 9.66665C13.9204 9.66665 14.6666 8.92045 14.6666 7.99998C14.6666 7.07951 13.9204 6.33331 12.9999 6.33331C12.0795 6.33331 11.3333 7.07951 11.3333 7.99998C11.3333 8.92045 12.0795 9.66665 12.9999 9.66665Z" />
-                      </svg>
-                      <div className="wk-conversation-header-mask"></div>
-                    </div>
-                  </>
-                )}
-              </div>
-            </div>
-          </div>
-          <div className="wk-chat-conversation">
-            <ErrorBoundary moduleName={t("base.chatPage.chatModuleName")}>
-              <Conversation
-                initLocateMessageSeq={initLocateMessageSeq}
-                shouldShowHistorySplit={true}
-                onContext={(ctx) => {
-                  this.conversationContext = ctx;
-                  (WKApp.shared as any).activeConversationContext = ctx;
-                  this.setState({
-                    selectionMode: ctx.editOn(),
-                    selectedCount: ctx.getCheckedMessageCount(),
-                  });
-                }}
-                onSelectionStateChange={({ editOn, checkedCount }) => {
-                  this.setState({
-                    selectionMode: editOn,
-                    selectedCount: checkedCount,
-                  });
-                }}
-                onOpenThreadPanel={(threadChannelId, threadName) => {
-                  const threadInfo = parseThreadChannelId(threadChannelId);
-                  if (threadInfo) {
-                    this.setState(
-                      openChatRightPanel("thread", {
-                        activeThread: buildThreadStub(
-                          threadInfo.shortId,
-                          threadInfo.groupNo,
-                          threadChannelId,
-                          threadName
-                        ),
-                      })
-                    );
-                  }
-                }}
-                onOpenWebhookPreview={this._openWebhookPreview}
-                key={channel.getChannelKey()}
-                chatBg={
-                  WKApp.config.themeMode === ThemeMode.dark
-                    ? undefined
-                    : require("./assets/chat_bg.svg").default
+        <ConversationWindow
+          client={this.chatRuntime.client}
+          channel={channel}
+          errorModuleName={t("base.chatPage.chatModuleName")}
+          bindConversationContext={this.chatRuntime.bindConversationContext}
+          surfaceRef={this.chatContentRef}
+          inactive={showChannelSetting}
+          header={{
+            avatar: this.renderConversationHeaderAvatar(
+              channel,
+              isThreadChannel
+            ),
+            title: this.renderConversationHeaderTitle(
+              channel,
+              channelInfo,
+              threadParentGroupNo
+            ),
+            titleClassName: classNames(
+              isThreadChannel &&
+                threadParentGroupNo &&
+                "wk-chat-conversation-header-channel-info-name--thread"
+            ),
+            onBack: () => {
+              WKApp.routeRight.pop();
+            },
+            actions: this.renderConversationHeaderActions(
+              channel,
+              isThreadChannel,
+              showChannelSetting
+            ),
+          }}
+          selection={
+            selectionMode
+              ? {
+                  active: true,
+                  count: selectedCount,
+                  label: t("base.chatPage.selectionCount", {
+                    values: { count: selectedCount },
+                  }),
+                  cancelLabel: t("base.common.cancel"),
+                  onCancel: () => {
+                    this.conversationContext?.clearCheckedMessages();
+                    this.conversationContext?.setEditOn(false);
+                  },
                 }
-                channel={channel}
-                activePreviewMessageId={this.state.activePreviewMessageId}
-                inputNotice={
-                  isThreadChannel && threadStatus === ThreadStatus.Archived
-                    ? t("base.chatPage.archivedThreadNotice")
-                    : undefined
-                }
-                onMessageSent={this.handleConversationMessageSent}
-              ></Conversation>
-            </ErrorBoundary>
-          </div>
-        </div>
+              : undefined
+          }
+          conversationProps={{
+            initLocateMessageSeq,
+            onContext: (ctx) => {
+              this.conversationContext = ctx;
+              (WKApp.shared as any).activeConversationContext = ctx;
+              this.setState({
+                selectionMode: ctx.editOn(),
+                selectedCount: ctx.getCheckedMessageCount(),
+              });
+            },
+            onSelectionStateChange: ({ editOn, checkedCount }) => {
+              this.setState({
+                selectionMode: editOn,
+                selectedCount: checkedCount,
+              });
+            },
+            onOpenThreadPanel: (threadChannelId, threadName) => {
+              const threadInfo = parseThreadChannelId(threadChannelId);
+              if (threadInfo) {
+                this.setState(
+                  openChatRightPanel("thread", {
+                    activeThread: buildThreadStub(
+                      threadInfo.shortId,
+                      threadInfo.groupNo,
+                      threadChannelId,
+                      threadName
+                    ),
+                  })
+                );
+              }
+            },
+            onOpenWebhookPreview: this._openWebhookPreview,
+            chatBg:
+              WKApp.config.themeMode === ThemeMode.dark
+                ? undefined
+                : require("./assets/chat_bg.svg").default,
+            activePreviewMessageId: this.state.activePreviewMessageId,
+            inputNotice:
+              isThreadChannel && threadStatus === ThreadStatus.Archived
+                ? t("base.chatPage.archivedThreadNotice")
+                : undefined,
+            onMessageSent: this.handleConversationMessageSent,
+          }}
+        />
 
         {showChannelSetting && (
           <div
@@ -2064,17 +2034,21 @@ export default class ChatPage extends Component<any, ChatPageState> {
                       if (linksBridge) {
                         const absoluteUrl = resolveDocLinkForExternalOpen(
                           url,
-                          apiUrlOrigin(),
+                          apiUrlOrigin()
                         );
                         linksBridge
                           .openExternal(absoluteUrl)
                           .then((result) => {
                             if (!result.ok) {
-                              Toast.warning(t("base.globalSearch.docs.popupBlocked"));
+                              Toast.warning(
+                                t("base.globalSearch.docs.popupBlocked")
+                              );
                             }
                           })
                           .catch(() => {
-                            Toast.warning(t("base.globalSearch.docs.popupBlocked"));
+                            Toast.warning(
+                              t("base.globalSearch.docs.popupBlocked")
+                            );
                           });
                         return;
                       }
@@ -2188,7 +2162,9 @@ class ChatMenusPopover extends Component<
             return (
               <li
                 key={i}
-                data-track={c.key === "start-group" ? "channel_create_started" : undefined}
+                data-track={
+                  c.key === "start-group" ? "channel_create_started" : undefined
+                }
                 onClick={() => {
                   if (c.onClick) {
                     c.onClick();

--- a/packages/dmworkbase/src/__tests__/App.startMain.test.ts
+++ b/packages/dmworkbase/src/__tests__/App.startMain.test.ts
@@ -163,6 +163,26 @@ describe("LoginInfo and WKConfig persistence boundaries", () => {
     expect(info.loginProvider).toBe("oidc");
     expect(info.deviceFlag).toBe(2);
     expect(save).not.toHaveBeenCalled();
+
+    const setStorageItemForSID = vi.spyOn(info, "setStorageItemForSID");
+    info.save();
+    expect(setStorageItemForSID).not.toHaveBeenCalled();
+  });
+
+  it("allows explicitly persistent applied sessions to be saved", () => {
+    const info = new LoginInfo();
+    const setStorageItemForSID = vi.spyOn(info, "setStorageItemForSID");
+
+    info.applySession({
+      uid: "persisted-user",
+      token: "persisted-token",
+      deviceFlag: 2,
+    }, true);
+
+    expect(setStorageItemForSID).toHaveBeenCalledWith(
+      expect.stringContaining("token"),
+      "persisted-token",
+    );
   });
 
   it("round-trips login fields and preserves tri-state real-name status", () => {

--- a/packages/dmworkbase/src/__tests__/App.startMain.test.ts
+++ b/packages/dmworkbase/src/__tests__/App.startMain.test.ts
@@ -145,6 +145,26 @@ describe("[api] WKApp.startMain device record fetch", () => {
 });
 
 describe("LoginInfo and WKConfig persistence boundaries", () => {
+  it("applies a host session without writing renderer storage by default", () => {
+    const info = new LoginInfo();
+    const save = vi.spyOn(info, "save");
+
+    info.applySession({
+      uid: "host-user",
+      token: "host-token",
+      name: "Host User",
+      loginProvider: "oidc",
+      deviceFlag: 2,
+    });
+
+    expect(info.uid).toBe("host-user");
+    expect(info.token).toBe("host-token");
+    expect(info.name).toBe("Host User");
+    expect(info.loginProvider).toBe("oidc");
+    expect(info.deviceFlag).toBe(2);
+    expect(save).not.toHaveBeenCalled();
+  });
+
   it("round-trips login fields and preserves tri-state real-name status", () => {
     const info = new LoginInfo();
     info.appID = "app";

--- a/packages/dmworkbase/src/features/chat-capability/legacyChatClient.test.ts
+++ b/packages/dmworkbase/src/features/chat-capability/legacyChatClient.test.ts
@@ -1,0 +1,288 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { MessageListener, SendackPacket } from "wukongimjssdk";
+import type { SyncMessageOptions } from "../../Service/DataSource/DataProvider";
+import type ConversationContext from "../../Components/Conversation/context";
+
+const hoisted = vi.hoisted(() => {
+  class Channel {
+    channelID: string;
+    channelType: number;
+    constructor(channelID: string, channelType: number) {
+      this.channelID = channelID;
+      this.channelType = channelType;
+    }
+  }
+
+  const sdk = {
+    chatManager: {
+      addMessageListener: vi.fn(),
+      removeMessageListener: vi.fn(),
+      addMessageStatusListener: vi.fn(),
+      removeMessageStatusListener: vi.fn(),
+    },
+  };
+
+  const syncMessagesFn = vi.fn(async () => []);
+
+  return {
+    Channel,
+    sdk,
+    shared: vi.fn(() => sdk),
+    syncMessagesFn,
+    wkApp: {
+      config: { pageSizeOfMessage: 30 },
+      conversationProvider: {
+        syncMessages: syncMessagesFn,
+      },
+    },
+  };
+});
+
+vi.mock("wukongimjssdk", () => ({
+  default: { shared: hoisted.shared },
+  WKSDK: { shared: hoisted.shared },
+  PullMode: { Down: 0, Up: 1 },
+  Channel: hoisted.Channel,
+}));
+
+vi.mock("../../App", () => ({
+  default: hoisted.wkApp,
+}));
+
+/** A minimal MessageContent-shaped payload for send. */
+const content = { contentType: 1, contentObj: {} } as never;
+
+describe("legacyChatClient", () => {
+  let mod: typeof import("./legacyChatClient");
+  let mockContext: ConversationContext;
+  let sendMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    mod = await import("./legacyChatClient");
+
+    sendMock = vi.fn(async () => ({}));
+    mockContext = { sendMessage: sendMock } as unknown as ConversationContext;
+  });
+
+  function capturedOpts(): [unknown, SyncMessageOptions] {
+    return hoisted.syncMessagesFn.mock.calls[0] as unknown as [
+      unknown,
+      SyncMessageOptions
+    ];
+  }
+
+  // ------------------------------------------------------------------------
+  // Load options mapping
+  // ------------------------------------------------------------------------
+
+  describe("load options mapping", () => {
+    it("older -> Down, anchor-1", async () => {
+      await mod
+        .createLegacyChatRuntime()
+        .client.messages.loadMessages(
+          { channelId: "c", channelType: 1 },
+          { older: 20, anchor: "100" }
+        );
+      const [, o] = capturedOpts();
+      expect(o.limit).toBe(20);
+      expect(o.startMessageSeq).toBe(99);
+      expect(o.pullMode).toBe(0);
+    });
+
+    it("newer -> Up, anchor as-is", async () => {
+      await mod
+        .createLegacyChatRuntime()
+        .client.messages.loadMessages(
+          { channelId: "c", channelType: 1 },
+          { newer: 15, anchor: "50" }
+        );
+      const [, o] = capturedOpts();
+      expect(o.limit).toBe(15);
+      expect(o.startMessageSeq).toBe(50);
+      expect(o.pullMode).toBe(1);
+    });
+
+    it("around -> Up, anchor - around/2", async () => {
+      await mod
+        .createLegacyChatRuntime()
+        .client.messages.loadMessages(
+          { channelId: "c", channelType: 1 },
+          { around: 20, anchor: "100" }
+        );
+      const [, o] = capturedOpts();
+      expect(o.limit).toBe(20);
+      expect(o.startMessageSeq).toBe(90);
+      expect(o.pullMode).toBe(1);
+    });
+
+    it("default pageSize when no options", async () => {
+      await mod
+        .createLegacyChatRuntime()
+        .client.messages.loadMessages({ channelId: "c", channelType: 1 });
+      const [, o] = capturedOpts();
+      expect(o.limit).toBe(30);
+    });
+
+    it("non-numeric anchor clamped to 0", async () => {
+      await mod
+        .createLegacyChatRuntime()
+        .client.messages.loadMessages(
+          { channelId: "c", channelType: 1 },
+          { older: 10, anchor: "NaN" }
+        );
+      const [, o] = capturedOpts();
+      expect(o.startMessageSeq).toBe(0);
+    });
+  });
+
+  // ------------------------------------------------------------------------
+  // Message and status listener disposer
+  // ------------------------------------------------------------------------
+
+  describe("message and status listener disposer", () => {
+    it("subscribeMessages disposer removes listener", () => {
+      const c = mod.createLegacyChatRuntime().client;
+      const fn: MessageListener = vi.fn();
+      const unsub = c.messages.subscribeMessages(fn);
+
+      expect(hoisted.sdk.chatManager.addMessageListener).toHaveBeenCalledWith(
+        fn
+      );
+
+      unsub();
+      expect(
+        hoisted.sdk.chatManager.removeMessageListener
+      ).toHaveBeenCalledWith(fn);
+    });
+
+    it("subscribeMessageStatus disposer removes status listener", () => {
+      const c = mod.createLegacyChatRuntime().client;
+      const fn: (messageId: string, status: SendackPacket) => void = vi.fn();
+      const unsub = c.messages.subscribeMessageStatus(fn);
+
+      expect(
+        hoisted.sdk.chatManager.addMessageStatusListener
+      ).toHaveBeenCalled();
+
+      unsub();
+      expect(
+        hoisted.sdk.chatManager.removeMessageStatusListener
+      ).toHaveBeenCalled();
+    });
+
+    it("status listener derives messageId from SendackPacket", () => {
+      const c = mod.createLegacyChatRuntime().client;
+      const fn: (messageId: string, status: SendackPacket) => void = vi.fn();
+      c.messages.subscribeMessageStatus(fn);
+
+      const wrapped = hoisted.sdk.chatManager.addMessageStatusListener.mock
+        .calls[0][0] as (p: SendackPacket) => void;
+
+      wrapped({
+        messageID: { toString: () => "m42" },
+        clientSeq: 0,
+      } as unknown as SendackPacket);
+      expect(fn).toHaveBeenCalledWith("m42", expect.anything());
+
+      (fn as ReturnType<typeof vi.fn>).mockClear();
+      wrapped({ messageID: null, clientSeq: 99 } as unknown as SendackPacket);
+      expect(fn).toHaveBeenCalledWith("99", expect.anything());
+    });
+  });
+
+  // ------------------------------------------------------------------------
+  // Context-bound send
+  // ------------------------------------------------------------------------
+
+  describe("context-bound send", () => {
+    it("rejects when no context bound", async () => {
+      const r = mod.createLegacyChatRuntime();
+      await expect(
+        r.client.messages.sendMessage(content, {
+          channelId: "c",
+          channelType: 1,
+        })
+      ).rejects.toThrow("requires a mounted ConversationWindow context");
+    });
+
+    it("succeeds after binding context", async () => {
+      const r = mod.createLegacyChatRuntime();
+      r.bindConversationContext(mockContext);
+
+      const result = await r.client.messages.sendMessage(content, {
+        channelId: "c",
+        channelType: 1,
+      });
+      expect(sendMock).toHaveBeenCalledTimes(1);
+      expect(result).toEqual({});
+    });
+  });
+
+  // ------------------------------------------------------------------------
+  // Unbind
+  // ------------------------------------------------------------------------
+
+  describe("unbind", () => {
+    it("send fails after unbind", async () => {
+      const r = mod.createLegacyChatRuntime();
+      const unbind = r.bindConversationContext(mockContext);
+
+      await r.client.messages.sendMessage(content, {
+        channelId: "c",
+        channelType: 1,
+      });
+      expect(sendMock).toHaveBeenCalledTimes(1);
+
+      unbind();
+
+      await expect(
+        r.client.messages.sendMessage(content, {
+          channelId: "c",
+          channelType: 1,
+        })
+      ).rejects.toThrow("requires a mounted ConversationWindow context");
+    });
+
+    it("stale unbind is no-op when context already replaced", async () => {
+      const r = mod.createLegacyChatRuntime();
+      const unbindA = r.bindConversationContext(mockContext);
+      const sendB = vi.fn(async () => ({}));
+      const ctxB = { sendMessage: sendB } as unknown as ConversationContext;
+
+      r.bindConversationContext(ctxB);
+      unbindA(); // stale — mockContext is no longer active
+
+      await r.client.messages.sendMessage(content, {
+        channelId: "c",
+        channelType: 1,
+      });
+      expect(sendB).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ------------------------------------------------------------------------
+  // Shared runtime singleton
+  // ------------------------------------------------------------------------
+
+  describe("shared runtime singleton", () => {
+    it("returns same instance on repeated calls", () => {
+      expect(mod.getLegacyChatRuntime()).toBe(mod.getLegacyChatRuntime());
+    });
+
+    it("creates a new instance from a fresh module", async () => {
+      const first = mod.getLegacyChatRuntime();
+      vi.resetModules();
+      const freshModule = await import("./legacyChatClient");
+      expect(freshModule.getLegacyChatRuntime()).not.toBe(first);
+    });
+
+    it("starts the shared client on first access", async () => {
+      const runtime = mod.getLegacyChatRuntime();
+      await vi.waitFor(() => {
+        expect(runtime.client.status).toBe("connected");
+      });
+    });
+  });
+});

--- a/packages/dmworkbase/src/features/chat-capability/legacyChatClient.ts
+++ b/packages/dmworkbase/src/features/chat-capability/legacyChatClient.ts
@@ -1,0 +1,133 @@
+import {
+  ChatClientStatus,
+  ManagedChatClient,
+  type ChatChannelRef,
+  type ChatMessageLoadOptions,
+} from "@octo/chat-core";
+import {
+  Channel,
+  Message,
+  MessageContent,
+  PullMode,
+  SendackPacket,
+  WKSDK,
+} from "wukongimjssdk";
+import WKApp from "../../App";
+import type ConversationContext from "../../Components/Conversation/context";
+import { SyncMessageOptions } from "../../Service/DataSource/DataProvider";
+
+export interface LegacyChatRuntime {
+  client: ManagedChatClient<Message, MessageContent, SendackPacket>;
+  bindConversationContext(context: ConversationContext): () => void;
+}
+
+function toSdkChannel(channel: ChatChannelRef): Channel {
+  return new Channel(channel.channelId, channel.channelType);
+}
+
+function toSyncOptions(options?: ChatMessageLoadOptions): SyncMessageOptions {
+  const result = new SyncMessageOptions();
+  const anchor = Number(options?.anchor || 0);
+  const safeAnchor = Number.isFinite(anchor) && anchor > 0 ? anchor : 0;
+
+  if (options?.older !== undefined) {
+    result.limit = options.older;
+    result.startMessageSeq = Math.max(0, safeAnchor - 1);
+    result.pullMode = PullMode.Down;
+  } else if (options?.newer !== undefined) {
+    result.limit = options.newer;
+    result.startMessageSeq = safeAnchor;
+    result.pullMode = PullMode.Up;
+  } else if (options?.around !== undefined) {
+    result.limit = options.around;
+    result.startMessageSeq = Math.max(
+      0,
+      safeAnchor - Math.floor(options.around / 2)
+    );
+    result.pullMode = PullMode.Up;
+  } else {
+    result.limit = WKApp.config.pageSizeOfMessage;
+  }
+
+  return result;
+}
+
+export function createLegacyChatRuntime(): LegacyChatRuntime {
+  let activeConversationContext: ConversationContext | undefined;
+
+  const client = new ManagedChatClient<Message, MessageContent, SendackPacket>(
+    {
+      status: ChatClientStatus.Connected,
+      async connect() {},
+      async disconnect() {},
+    },
+    {
+      async openConversation(channel) {
+        return { channel };
+      },
+      async closeConversation() {},
+    },
+    {
+      messageAdapter: {
+        loadMessages(channel, options) {
+          return WKApp.conversationProvider.syncMessages(
+            toSdkChannel(channel),
+            toSyncOptions(options)
+          );
+        },
+        subscribeMessages(listener) {
+          const sdk = WKSDK.shared();
+          sdk.chatManager.addMessageListener(listener);
+          return () => sdk.chatManager.removeMessageListener(listener);
+        },
+        subscribeMessageStatus(listener) {
+          const sdk = WKSDK.shared();
+          const statusListener = (packet: SendackPacket) => {
+            const messageId = packet.messageID
+              ? packet.messageID.toString()
+              : String(packet.clientSeq);
+            listener(messageId, packet);
+          };
+          sdk.chatManager.addMessageStatusListener(statusListener);
+          return () =>
+            sdk.chatManager.removeMessageStatusListener(statusListener);
+        },
+        sendMessage(content, channel) {
+          if (!activeConversationContext) {
+            return Promise.reject(
+              new Error(
+                "Legacy chat send requires a mounted ConversationWindow context."
+              )
+            );
+          }
+          return activeConversationContext.sendMessage(
+            content,
+            toSdkChannel(channel)
+          );
+        },
+      },
+    }
+  );
+
+  return {
+    client,
+    bindConversationContext(context) {
+      activeConversationContext = context;
+      return () => {
+        if (activeConversationContext === context) {
+          activeConversationContext = undefined;
+        }
+      };
+    },
+  };
+}
+
+let sharedLegacyChatRuntime: LegacyChatRuntime | undefined;
+
+export function getLegacyChatRuntime(): LegacyChatRuntime {
+  if (!sharedLegacyChatRuntime) {
+    sharedLegacyChatRuntime = createLegacyChatRuntime();
+    void sharedLegacyChatRuntime.client.start({});
+  }
+  return sharedLegacyChatRuntime;
+}

--- a/packages/dmworkbase/src/i18n/locales/en-US.json
+++ b/packages/dmworkbase/src/i18n/locales/en-US.json
@@ -266,6 +266,8 @@
   "conversation.deleteConfirm.confirm": "Confirm",
   "conversation.deleteConfirm.content": "Deleted messages will disappear from your conversation history, but other people in the conversation can still see them.",
   "conversation.deleteConfirm.failed": "Failed to delete. Please try again.",
+  "conversation.openFailed": "Unable to open this conversation.",
+  "conversation.retry": "Retry",
   "conversation.deleteConfirm.title": "Delete messages?",
   "conversation.disband.inputNotice": "This group has been disbanded. You can no longer send messages.",
   "conversation.disband.threadCreateDisabled": "This group has been disbanded. You can no longer create threads.",

--- a/packages/dmworkbase/src/i18n/locales/zh-CN.json
+++ b/packages/dmworkbase/src/i18n/locales/zh-CN.json
@@ -266,6 +266,8 @@
   "conversation.deleteConfirm.confirm": "确认",
   "conversation.deleteConfirm.content": "删除的消息将从你的会话记录中消失，但仍然对会话内其他人可见。",
   "conversation.deleteConfirm.failed": "删除失败，请重试",
+  "conversation.openFailed": "会话打开失败",
+  "conversation.retry": "重试",
   "conversation.deleteConfirm.title": "确认删除消息？",
   "conversation.disband.inputNotice": "群聊已解散，无法发送消息",
   "conversation.disband.threadCreateDisabled": "群聊已解散，无法创建子区",

--- a/packages/dmworkbase/src/index.tsx
+++ b/packages/dmworkbase/src/index.tsx
@@ -44,6 +44,22 @@ export * from './features/chat-composer'
 export type { default as ConversationContext} from './Components/Conversation/context'
 export { Conversation } from './Components/Conversation'
 export type { ConversationProps } from './Components/Conversation'
+export {
+  ConversationSurface,
+  ConversationWindow,
+} from './Components/ConversationWindow'
+export type {
+  ConversationSurfaceProps,
+  ConversationWindowHeaderModel,
+  ConversationWindowMode,
+  ConversationWindowProps,
+  ConversationWindowSelectionModel,
+} from './Components/ConversationWindow'
+export {
+  createLegacyChatRuntime,
+  getLegacyChatRuntime,
+} from './features/chat-capability/legacyChatClient'
+export type { LegacyChatRuntime } from './features/chat-capability/legacyChatClient'
 export type {
   InitialCompose,
   InitialComposeState,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -357,6 +357,52 @@ importers:
         specifier: 13.6.21
         version: 13.6.21
 
+  packages/chat-core:
+    devDependencies:
+      '@types/node':
+        specifier: ^22.19.21
+        version: 22.19.21
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(@types/node@22.19.21)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.2(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@22.19.21)(typescript@5.9.3))(vite@8.0.7(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.6.1))
+
+  packages/chat-react:
+    dependencies:
+      '@octo/chat-core':
+        specifier: workspace:*
+        version: link:../chat-core
+    devDependencies:
+      '@testing-library/dom':
+        specifier: ^10.4.1
+        version: 10.4.1
+      '@testing-library/jest-dom':
+        specifier: ^6.9.1
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: ^13.4.0
+        version: 13.4.0(@types/react@17.0.93)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@types/react':
+        specifier: ^17.0.80
+        version: 17.0.93
+      '@types/react-dom':
+        specifier: ^17.0.25
+        version: 17.0.26(@types/react@17.0.93)
+      jsdom:
+        specifier: ^29.0.1
+        version: 29.0.2(@noble/hashes@2.2.0)
+      react:
+        specifier: ^17.0.2
+        version: 17.0.2
+      react-dom:
+        specifier: ^17.0.2
+        version: 17.0.2(react@17.0.2)
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(@types/node@25.9.5)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.2(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@25.9.5)(typescript@5.9.3))(vite@8.0.7(@types/node@25.9.5)(esbuild@0.27.7)(jiti@2.6.1))
+
   packages/dmworkappbot:
     dependencies:
       '@octo/base':
@@ -402,6 +448,12 @@ importers:
       '@mlt-org/octo-card-profile-octo-chat':
         specifier: 1.2.0-rc.2
         version: 1.2.0-rc.2
+      '@octo/chat-core':
+        specifier: workspace:*
+        version: link:../chat-core
+      '@octo/chat-react':
+        specifier: workspace:*
+        version: link:../chat-react
       '@react-pdf-viewer/bookmark':
         specifier: ^3.12.0
         version: 3.12.0(pdfjs-dist@3.11.174(encoding@0.1.13))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
@@ -3300,6 +3352,11 @@ packages:
     peerDependencies:
       '@types/react': '*'
 
+  '@types/react-dom@17.0.26':
+    resolution: {integrity: sha512-Z+2VcYXJwOqQ79HreLU/1fyQ88eXSSFh6I3JdrEHQIfYSI0kCQpTGvOrbE6jFGGYXKsHuwY9tBa/w5Uo6KzrEg==}
+    peerDependencies:
+      '@types/react': ^17.0.0
+
   '@types/react-dom@18.3.7':
     resolution: {integrity: sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==}
     peerDependencies:
@@ -3315,6 +3372,9 @@ packages:
 
   '@types/react-syntax-highlighter@15.5.13':
     resolution: {integrity: sha512-uLGJ87j6Sz8UaBAooU0T6lWJ0dBmjZgN1PZTrj05TNql2/XpC6+4HhMT5syIdFUUt+FASfCeLLv4kBygNU+8qA==}
+
+  '@types/react@17.0.93':
+    resolution: {integrity: sha512-KM4Ty/ZTLZupiYxZVAlP+InNJS3De6uBMdq0ePa6/04+eG9Y7ftnWfst1xTLQ5rwAhgHwQ4momt/O4KepdGBTw==}
 
   '@types/react@18.3.28':
     resolution: {integrity: sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==}
@@ -3332,6 +3392,9 @@ packages:
 
   '@types/responselike@1.0.3':
     resolution: {integrity: sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==}
+
+  '@types/scheduler@0.16.8':
+    resolution: {integrity: sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==}
 
   '@types/semver@7.7.1':
     resolution: {integrity: sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==}
@@ -10731,6 +10794,14 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.19.39
 
+  '@inquirer/confirm@6.1.1(@types/node@22.19.21)':
+    dependencies:
+      '@inquirer/core': 11.2.1(@types/node@22.19.21)
+      '@inquirer/type': 4.0.7(@types/node@22.19.21)
+    optionalDependencies:
+      '@types/node': 22.19.21
+    optional: true
+
   '@inquirer/confirm@6.1.1(@types/node@25.9.5)':
     dependencies:
       '@inquirer/core': 11.2.1(@types/node@25.9.5)
@@ -10750,6 +10821,19 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.19.39
 
+  '@inquirer/core@11.2.1(@types/node@22.19.21)':
+    dependencies:
+      '@inquirer/ansi': 2.0.7
+      '@inquirer/figures': 2.0.7
+      '@inquirer/type': 4.0.7(@types/node@22.19.21)
+      cli-width: 4.1.0
+      fast-wrap-ansi: 0.2.2
+      mute-stream: 3.0.0
+      signal-exit: 4.1.0
+    optionalDependencies:
+      '@types/node': 22.19.21
+    optional: true
+
   '@inquirer/core@11.2.1(@types/node@25.9.5)':
     dependencies:
       '@inquirer/ansi': 2.0.7
@@ -10767,6 +10851,11 @@ snapshots:
   '@inquirer/type@4.0.7(@types/node@20.19.39)':
     optionalDependencies:
       '@types/node': 20.19.39
+
+  '@inquirer/type@4.0.7(@types/node@22.19.21)':
+    optionalDependencies:
+      '@types/node': 22.19.21
+    optional: true
 
   '@inquirer/type@4.0.7(@types/node@25.9.5)':
     optionalDependencies:
@@ -11506,6 +11595,16 @@ snapshots:
       picocolors: 1.1.1
       redent: 3.0.0
 
+  '@testing-library/react@13.4.0(@types/react@17.0.93)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@testing-library/dom': 8.20.1
+      '@types/react-dom': 18.3.7(@types/react@17.0.93)
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+    transitivePeerDependencies:
+      - '@types/react'
+
   '@testing-library/react@13.4.0(@types/react@18.3.28)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
     dependencies:
       '@babel/runtime': 7.29.2
@@ -11992,6 +12091,14 @@ snapshots:
       '@types/react': 19.2.14
       '@types/reactcss': 1.2.13(@types/react@19.2.14)
 
+  '@types/react-dom@17.0.26(@types/react@17.0.93)':
+    dependencies:
+      '@types/react': 17.0.93
+
+  '@types/react-dom@18.3.7(@types/react@17.0.93)':
+    dependencies:
+      '@types/react': 17.0.93
+
   '@types/react-dom@18.3.7(@types/react@18.3.28)':
     dependencies:
       '@types/react': 18.3.28
@@ -12012,6 +12119,12 @@ snapshots:
     dependencies:
       '@types/react': 18.3.28
 
+  '@types/react@17.0.93':
+    dependencies:
+      '@types/prop-types': 15.7.15
+      '@types/scheduler': 0.16.8
+      csstype: 3.2.3
+
   '@types/react@18.3.28':
     dependencies:
       '@types/prop-types': 15.7.15
@@ -12030,6 +12143,8 @@ snapshots:
   '@types/responselike@1.0.3':
     dependencies:
       '@types/node': 22.19.21
+
+  '@types/scheduler@0.16.8': {}
 
   '@types/semver@7.7.1': {}
 
@@ -12270,6 +12385,20 @@ snapshots:
       - vite
     optional: true
 
+  '@vitest/browser-playwright@4.1.5(msw@2.15.0(@types/node@22.19.21)(typescript@5.9.3))(playwright@1.61.1)(vite@8.0.7(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.6.1))(vitest@4.1.5)':
+    dependencies:
+      '@vitest/browser': 4.1.5(msw@2.15.0(@types/node@22.19.21)(typescript@5.9.3))(vite@8.0.7(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.6.1))(vitest@4.1.5)
+      '@vitest/mocker': 4.1.5(msw@2.15.0(@types/node@22.19.21)(typescript@5.9.3))(vite@8.0.7(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.6.1))
+      playwright: 1.61.1
+      tinyrainbow: 3.1.0
+      vitest: 4.1.5(@types/node@22.19.21)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.2(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@22.19.21)(typescript@5.9.3))(vite@8.0.7(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.6.1))
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+    optional: true
+
   '@vitest/browser-playwright@4.1.5(msw@2.15.0(@types/node@25.9.5)(typescript@5.9.3))(playwright@1.61.1)(vite@8.0.7(@types/node@25.9.5)(esbuild@0.27.7)(jiti@2.6.1))(vitest@4.1.5)':
     dependencies:
       '@vitest/browser': 4.1.5(msw@2.15.0(@types/node@25.9.5)(typescript@5.9.3))(vite@8.0.7(@types/node@25.9.5)(esbuild@0.27.7)(jiti@2.6.1))(vitest@4.1.5)
@@ -12293,6 +12422,24 @@ snapshots:
       sirv: 3.0.2
       tinyrainbow: 3.1.0
       vitest: 4.1.5(@types/node@20.19.39)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.2(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@20.19.39)(typescript@5.9.3))(vite@8.0.7(@types/node@20.19.39)(esbuild@0.27.7)(jiti@2.6.1))
+      ws: 8.20.0
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+    optional: true
+
+  '@vitest/browser@4.1.5(msw@2.15.0(@types/node@22.19.21)(typescript@5.9.3))(vite@8.0.7(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.6.1))(vitest@4.1.5)':
+    dependencies:
+      '@blazediff/core': 1.9.1
+      '@vitest/mocker': 4.1.5(msw@2.15.0(@types/node@22.19.21)(typescript@5.9.3))(vite@8.0.7(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.6.1))
+      '@vitest/utils': 4.1.5
+      magic-string: 0.30.21
+      pngjs: 7.0.0
+      sirv: 3.0.2
+      tinyrainbow: 3.1.0
+      vitest: 4.1.5(@types/node@22.19.21)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.2(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@22.19.21)(typescript@5.9.3))(vite@8.0.7(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.6.1))
       ws: 8.20.0
     transitivePeerDependencies:
       - bufferutil
@@ -12330,9 +12477,9 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@types/node@20.19.39)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.2(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@20.19.39)(typescript@5.9.3))(vite@8.0.7(@types/node@20.19.39)(esbuild@0.27.7)(jiti@2.6.1))
+      vitest: 4.1.5(@types/node@22.19.21)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.2(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@22.19.21)(typescript@5.9.3))(vite@8.0.7(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.6.1))
     optionalDependencies:
-      '@vitest/browser': 4.1.5(msw@2.15.0(@types/node@20.19.39)(typescript@5.9.3))(vite@8.0.7(@types/node@20.19.39)(esbuild@0.27.7)(jiti@2.6.1))(vitest@4.1.5)
+      '@vitest/browser': 4.1.5(msw@2.15.0(@types/node@22.19.21)(typescript@5.9.3))(vite@8.0.7(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.6.1))(vitest@4.1.5)
 
   '@vitest/expect@2.0.5':
     dependencies:
@@ -12366,6 +12513,15 @@ snapshots:
     optionalDependencies:
       msw: 2.15.0(@types/node@20.19.39)(typescript@5.9.3)
       vite: 8.0.7(@types/node@20.19.39)(esbuild@0.27.7)(jiti@2.6.1)
+
+  '@vitest/mocker@4.1.5(msw@2.15.0(@types/node@22.19.21)(typescript@5.9.3))(vite@8.0.7(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.6.1))':
+    dependencies:
+      '@vitest/spy': 4.1.5
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      msw: 2.15.0(@types/node@22.19.21)(typescript@5.9.3)
+      vite: 8.0.7(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.6.1)
 
   '@vitest/mocker@4.1.5(msw@2.15.0(@types/node@25.9.5)(typescript@5.9.3))(vite@8.0.7(@types/node@25.9.5)(esbuild@0.27.7)(jiti@2.6.1))':
     dependencies:
@@ -16547,6 +16703,32 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
+  msw@2.15.0(@types/node@22.19.21)(typescript@5.9.3):
+    dependencies:
+      '@inquirer/confirm': 6.1.1(@types/node@22.19.21)
+      '@mswjs/interceptors': 0.41.9
+      '@open-draft/deferred-promise': 3.0.0
+      '@types/statuses': 2.0.6
+      cookie: 1.1.1
+      graphql: 16.14.2
+      headers-polyfill: 5.0.1
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+      path-to-regexp: 6.3.0
+      picocolors: 1.1.1
+      rettime: 0.11.11
+      statuses: 2.0.2
+      strict-event-emitter: 0.5.1
+      tough-cookie: 6.0.1
+      type-fest: 5.8.0
+      until-async: 3.0.2
+      yargs: 17.7.2
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@types/node'
+    optional: true
+
   msw@2.15.0(@types/node@25.9.5)(typescript@5.9.3):
     dependencies:
       '@inquirer/confirm': 6.1.1(@types/node@25.9.5)
@@ -19140,6 +19322,19 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.6.1
 
+  vite@8.0.7(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.6.1):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.9
+      rolldown: 1.0.0-rc.13
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 22.19.21
+      esbuild: 0.27.7
+      fsevents: 2.3.3
+      jiti: 2.6.1
+
   vite@8.0.7(@types/node@25.9.5)(esbuild@0.27.7)(jiti@2.6.1):
     dependencies:
       lightningcss: 1.32.0
@@ -19178,6 +19373,36 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.19.39
       '@vitest/browser-playwright': 4.1.5(msw@2.15.0(@types/node@20.19.39)(typescript@5.9.3))(playwright@1.61.1)(vite@8.0.7(@types/node@20.19.39)(esbuild@0.27.7)(jiti@2.6.1))(vitest@4.1.5)
+      '@vitest/coverage-v8': 4.1.5(@vitest/browser@4.1.5)(vitest@4.1.5)
+      jsdom: 29.0.2(@noble/hashes@2.2.0)
+    transitivePeerDependencies:
+      - msw
+
+  vitest@4.1.5(@types/node@22.19.21)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.2(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@22.19.21)(typescript@5.9.3))(vite@8.0.7(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.6.1)):
+    dependencies:
+      '@vitest/expect': 4.1.5
+      '@vitest/mocker': 4.1.5(msw@2.15.0(@types/node@22.19.21)(typescript@5.9.3))(vite@8.0.7(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.6.1))
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/runner': 4.1.5
+      '@vitest/snapshot': 4.1.5
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.0.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.1
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 8.0.7(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.6.1)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.19.21
+      '@vitest/browser-playwright': 4.1.5(msw@2.15.0(@types/node@22.19.21)(typescript@5.9.3))(playwright@1.61.1)(vite@8.0.7(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.6.1))(vitest@4.1.5)
       '@vitest/coverage-v8': 4.1.5(@vitest/browser@4.1.5)(vitest@4.1.5)
       jsdom: 29.0.2(@noble/hashes@2.2.0)
     transitivePeerDependencies:

--- a/turbo.json
+++ b/turbo.json
@@ -23,6 +23,8 @@
       "inputs": [
         "$TURBO_DEFAULT$",
         "../../pnpm-lock.yaml",
+        "../../packages/chat-core/**",
+        "../../packages/chat-react/**",
         "../../packages/dmworkappbot/**",
         "../../packages/dmworkbase/**",
         "../../packages/dmworkcontacts/**",


### PR DESCRIPTION
## Background and Goal

OctoBuddy Client needs to reuse the existing chat and contacts capabilities from octo-web while retaining its own Electron shell, authentication entry point, navigation layout, and host-specific capabilities.

This PR does not duplicate the chat UI or change existing backend APIs. Instead, it establishes reusable functional boundaries inside octo-web and provides a separately buildable communication renderer that can be loaded by the Client:

- The Client owns the overall layout and the chat/contacts navigation.
- octo-web continues to own the existing chat, contacts, and message interactions.
- Both workspace mode and standalone conversation mode are supported.
- The existing octo-web browser experience remains unchanged.
- The new boundaries provide a migration path toward a more independent chat SDK and composable UI modules.

## Architecture

The implementation follows a capability-layering approach with a single communication artifact and switchable presentation modes:

1. `@octo/chat-core` provides UI-independent lifecycle management, conversation leases, message ports, and adapter contracts.
2. `@octo/chat-react` provides the React provider, conversation window boundary, error recovery, and host capability injection.
3. `@octo/base` provides reusable business-level `ConversationWindow` and `ConversationSurface` components backed by the existing conversation implementation.
4. octo-web provides a dedicated `client-communication` renderer entry for both chat and contacts.
5. The Client controls page, space, appearance, locale, and target-conversation state through the Host Bridge.
6. The renderer supports `workspace` and `conversation` presentation modes to fit different Client layouts.

Backend APIs, authentication contracts, and message data structures remain unchanged.

## Main Changes

### 1. Core Chat Capability

Added `packages/chat-core` with:

- `ManagedChatClient` lifecycle management.
- Idempotent and serialized start/stop operations.
- Single active-conversation ownership with lease cleanup.
- Latest-request-wins semantics for conversation switching.
- Connection failure rollback and retry-safe cleanup.
- Explicit superseded errors when an open request is replaced by a newer request or by stop.
- Message loading, sending, and subscription ports.

### 2. React Capability Layer

Added `packages/chat-react` with:

- `ChatProvider`.
- `ConversationWindow`.
- Host capability injection.
- A startup gate for managed lifecycles.
- Recoverable start and stop failure states.
- Replacement-client startup blocking when the previous client fails to stop.
- React StrictMode and stale asynchronous request protection.
- Conversation recovery after stop/start cycles.
- Automatic stale lease cleanup.

### 3. Existing Chat UI Reuse

Added business-level `ConversationWindow` and `ConversationSurface` components to `@octo/base`:

- Reuses the existing `Conversation` implementation instead of reimplementing message types.
- Supports primary and auxiliary conversation modes.
- Allows hosts to compose headers, back/close actions, and context bindings.
- Displays a recoverable state when opening a conversation fails.
- Releases the previous `ConversationContext` on render errors, channel changes, and unmount.
- Fixes the embedded conversation height chain and composer layout.

The existing `ChatPage` and `ThreadPanel` now consume the new capability boundary, avoiding separate implementations for the old and embedded paths.

### 4. Client Communication Renderer

Added `apps/web/src/client-communication` and a dedicated Vite build entry:

- A single renderer hosts both chat and contacts.
- The Host Bridge supports navigation, space changes, appearance, locale, suspend/resume, and session revocation.
- The Client can open an existing channel by passing `channelId` and `channelType`.
- `workspace` mode retains the conversation list.
- `conversation` mode hides the list and splitter so the conversation fills the available viewport.
- Contact cards can initiate conversations.
- The renderer reports readiness, navigation state, and unread counts to the host.
- Ready reporting supports retries, cancellation, and per-attempt timeout handling.
- Both synchronous bridge exceptions and Promise rejections are isolated.
- React StrictMode produces only one effective ready report.

### 5. Documentation

Added:

- `docs/chat-capability-integration-options-report.md`
- `docs/chat-capability-validation-runbook.md`
- `docs/chat-capability-vertical-slice-implementation-report.md`

These documents cover the selected approach, implementation boundaries, artifact delivery, Client integration, and regression validation.

## Compatibility

- Existing backend APIs are unchanged.
- The default octo-web entry point and authentication flow are unchanged.
- Existing browser pages are not required to use the embedded renderer.
- `ConversationWindowData.error` and `retry` remain optional for structural compatibility.
- ChatClient event listeners remain registered across explicit stop/start cycles; consumers unsubscribe when their own lifecycle ends.
- The Client communication entry uses a separate HTML file, Vite configuration, and output directory, without replacing the default Web artifact.

## Validation

The following checks were rerun after rebasing onto the latest `Mininglamp-OSS/octo-web:main`:

- `@octo/chat-core`: 54 tests passed.
- `@octo/chat-core` typecheck: passed.
- `@octo/chat-react`: 24 tests passed.
- `@octo/chat-react` typecheck: passed.
- `@octo/base`: 473 files / 4,325 tests passed.
- octo-web: 113 files / 1,419 tests passed.
- octo-web production build: passed.
- `git diff --check`: passed.
- Branch status against upstream: 0 behind / 10 ahead.

ErrorBoundary, HTMLMediaElement, Canvas, and `window.open` messages in the test output are produced by existing JSDOM limitations or tests that intentionally trigger error boundaries. All test suites completed successfully.

## Suggested Acceptance Flow

1. Verify the default octo-web login, recent conversations, channel switching, message sending, replies, and attachments.
2. Build the communication artifact and confirm that its manifest contains `e2eMock=false`.
3. Load the artifact in OctoBuddy Client.
4. Verify that chat and contacts share one renderer.
5. Start a conversation from a contact card.
6. Pass a target channel and verify standalone conversation presentation.
7. Switch back to chat and verify restoration of workspace presentation.
8. Verify token, space, theme, and locale changes.
9. Verify renderer reload, suspend/resume, and recoverable failure behavior.

## Current Boundaries and Follow-up Work

- This PR establishes a reusable functional boundary; it does not fully extract WKSDK into an independent SDK.
- `legacyChatClient` remains the adapter between the new capability layer and the existing chat runtime.
- Message sending still relies on the existing `ConversationContext`.
- An adapter that remains permanently pending can still block the lifecycle queue; a unified timeout and cancellation contract can be introduced later.
- The production communication artifact must be rebuilt from the final clean commit before release, with the actual commit recorded in its manifest.
- The real Electron preload/IPC path still requires final acceptance testing with the Client package.

