### PR TITLE
feat(main): send space admin entry to /admin/space with current spaceId

### DIFF
--- a/apps/web/src/Pages/Main/index.tsx
+++ b/apps/web/src/Pages/Main/index.tsx
@@ -22,6 +22,7 @@ import {
     resolveInitialSpaceForUser,
 } from "../../features/spacePreference";
 import { requestGuardedMenuChange, requestProgrammaticMenuChange } from "./menuChange";
+import { buildSpaceAdminUrl } from "./spaceAdminUrl";
 import { requestMailWorkspaceSwitch } from "@octo/mail";
 
 // ─── MainContentLeft：纯路由渲染区（Sidebar + 内容） ───────────────────────
@@ -280,11 +281,7 @@ export class MainPage extends Component<{}, MainPageState> {
                                         onCreateSpace={() => this.setState({ showCreateSpace: true })}
                                         canManageSpace={canManageSpace}
                                         onSpaceManagement={() => {
-                                            // 带上当前 Space id，让管理后台默认落到用户正在使用的空间，
-                                            // 而不是可管理列表里的第一个（用户可能同时管理多个空间）。
-                                            window.location.href = currentSpaceId
-                                                ? `/space?spaceId=${encodeURIComponent(currentSpaceId)}`
-                                                : "/space";
+                                            window.location.href = buildSpaceAdminUrl(currentSpaceId);
                                         }}
                                         // 菜单
                                         menusList={vm.menusList}

--- a/apps/web/src/Pages/Main/index.tsx
+++ b/apps/web/src/Pages/Main/index.tsx
@@ -281,7 +281,9 @@ export class MainPage extends Component<{}, MainPageState> {
                                         onCreateSpace={() => this.setState({ showCreateSpace: true })}
                                         canManageSpace={canManageSpace}
                                         onSpaceManagement={() => {
-                                            window.location.href = buildSpaceAdminUrl(currentSpaceId);
+                                            // 点击时再读，避免在 applySpaceSelection 的 getMySpaces 失败分支
+                                            // (只弹 toast、不 re-render) 后短暂窗口内用到 render 时闭包捕获的旧 id。
+                                            window.location.href = buildSpaceAdminUrl(WKApp.shared.currentSpaceId);
                                         }}
                                         // 菜单
                                         menusList={vm.menusList}

--- a/apps/web/src/Pages/Main/index.tsx
+++ b/apps/web/src/Pages/Main/index.tsx
@@ -279,7 +279,13 @@ export class MainPage extends Component<{}, MainPageState> {
                                         onJoinSpace={() => this.setState({ showJoinSpace: true })}
                                         onCreateSpace={() => this.setState({ showCreateSpace: true })}
                                         canManageSpace={canManageSpace}
-                                        onSpaceManagement={() => { window.location.href = "/space"; }}
+                                        onSpaceManagement={() => {
+                                            // 带上当前 Space id，让管理后台默认落到用户正在使用的空间，
+                                            // 而不是可管理列表里的第一个（用户可能同时管理多个空间）。
+                                            window.location.href = currentSpaceId
+                                                ? `/space?spaceId=${encodeURIComponent(currentSpaceId)}`
+                                                : "/space";
+                                        }}
                                         // 菜单
                                         menusList={vm.menusList}
                                         currentMenus={vm.currentMenus}

--- a/apps/web/src/Pages/Main/spaceAdminUrl.ts
+++ b/apps/web/src/Pages/Main/spaceAdminUrl.ts
@@ -1,0 +1,14 @@
+// 主站「空间管理」入口跳转 URL 的构造。
+//
+// 直接指向管理后台 SPA 的实际路径 `/admin/space`,而不是走 `/space` 短链 301——
+// nginx 的 `return 301` 默认不会带上原始 query,`?spaceId=` 会在这一跳被丢掉;
+// `/admin/space` 由 `/admin/` 的 try_files 直接落到 SPA index.html,浏览器 URL
+// 上的 query 原样保留,SpaceEntry 里 `readRequestedSpaceId()` 才能读到。
+//
+// 带上当前 Space id 是为了让管理后台默认落到用户正在使用的空间,而不是可管理
+// 列表里的第一个(用户可能同时管理多个空间)。currentSpaceId 缺失时回退到不带
+// 参数的路径,后台按原有默认(当前 / 列表第一个)处理。
+export function buildSpaceAdminUrl(currentSpaceId: string | undefined | null): string {
+  if (!currentSpaceId) return '/admin/space'
+  return `/admin/space?spaceId=${encodeURIComponent(currentSpaceId)}`
+}

--- a/apps/web/src/Pages/Main/spaceAdminUrl.ts
+++ b/apps/web/src/Pages/Main/spaceAdminUrl.ts
@@ -13,6 +13,6 @@
 // `/admin/` 由 try_files 落到 SPA index.html,浏览器 URL 上的 query 原样保留,
 // SpaceEntry 的 `readRequestedSpaceId()` 才读得到。
 export function buildSpaceAdminUrl(currentSpaceId: string | undefined | null): string {
-  if (!currentSpaceId) return '/admin/space'
-  return `/admin/space?spaceId=${encodeURIComponent(currentSpaceId)}`
+  if (!currentSpaceId) return "/admin/space";
+  return `/admin/space?spaceId=${encodeURIComponent(currentSpaceId)}`;
 }

--- a/apps/web/src/Pages/Main/spaceAdminUrl.ts
+++ b/apps/web/src/Pages/Main/spaceAdminUrl.ts
@@ -1,13 +1,17 @@
 // 主站「空间管理」入口跳转 URL 的构造。
 //
-// 直接指向管理后台 SPA 的实际路径 `/admin/space`,而不是走 `/space` 短链 301——
-// nginx 的 `return 301` 默认不会带上原始 query,`?spaceId=` 会在这一跳被丢掉;
-// `/admin/space` 由 `/admin/` 的 try_files 直接落到 SPA index.html,浏览器 URL
-// 上的 query 原样保留,SpaceEntry 里 `readRequestedSpaceId()` 才能读到。
-//
 // 带上当前 Space id 是为了让管理后台默认落到用户正在使用的空间,而不是可管理
 // 列表里的第一个(用户可能同时管理多个空间)。currentSpaceId 缺失时回退到不带
 // 参数的路径,后台按原有默认(当前 / 列表第一个)处理。
+//
+// 直接指向管理后台 SPA 的实际路径 `/admin/space`,而不是 `/space` 短链:这样
+// query 不依赖任何一层重定向去转发它,少一跳,且在没有前置代理、直连 admin
+// 容器的拓扑下同样成立 —— 那一层的 `location = /space` 用的是不带 args 的
+// `return 301 /admin/space`,会把 `?spaceId=` 丢掉。
+// (注:标准部署的前置 nginx 用 `return 301 /admin/space$1$is_args$args`,是会
+//  保留 query 的,所以走短链在那个拓扑下也能工作 —— 直连路径只是更稳。)
+// `/admin/` 由 try_files 落到 SPA index.html,浏览器 URL 上的 query 原样保留,
+// SpaceEntry 的 `readRequestedSpaceId()` 才读得到。
 export function buildSpaceAdminUrl(currentSpaceId: string | undefined | null): string {
   if (!currentSpaceId) return '/admin/space'
   return `/admin/space?spaceId=${encodeURIComponent(currentSpaceId)}`

--- a/apps/web/src/__tests__/spaceAdminEntryWiring.test.ts
+++ b/apps/web/src/__tests__/spaceAdminEntryWiring.test.ts
@@ -7,39 +7,40 @@
  * WKApp.shared.currentSpaceId,但它的 getMySpaces() 失败分支只弹 toast、不触发
  * re-render,于是切换空间后若刷新列表失败,render 闭包捕获的就是上一个空间 id。
  *
- * 这里沿用本仓 layoutPendingInviteToast.test.ts 的做法:读源码断言调用形状,
- * 这样将来把它改回 render 闭包会立刻失败,而不是静默回归。
+ * 这里沿用本仓 layoutPendingInviteToast.test.ts 的做法:读源码断言调用形状。
+ * 断言的是「点击时从 WKApp.shared 取值」这个语义,而不是某一种写法 —— 先把值
+ * 存进局部变量再传给 buildSpaceAdminUrl 同样正确,不应该被判失败。
  */
 import * as fs from 'fs';
 import * as path from 'path';
 
 describe('Main nav 空间管理入口的接线', () => {
     let source: string;
-    let handlerBody: string;
+    let handlerCode: string;
 
     beforeAll(() => {
         source = fs.readFileSync(
             path.join(__dirname, '../Pages/Main/index.tsx'), 'utf-8');
-        // 取 onSpaceManagement={...} 到下一个 prop 之前的这段,只针对 handler 断言,
-        // 避免匹配到文件里别处对 currentSpaceId 的合法使用(如 NavRail 的高亮 prop)。
-        const match = source.match(/onSpaceManagement=\{([\s\S]*?)\n\s{40}\/\//);
-        expect(match).not.toBeNull();
-        handlerBody = match![1];
+        // 锚定到下一个 prop(menusList)而不是缩进宽度或某条注释:重新格式化、
+        // 调整缩进、改写注释都不该让这个测试失效。
+        const match = source.match(/onSpaceManagement=\{([\s\S]*?)\n\s*menusList=/);
+        expect(match, 'onSpaceManagement handler not found in Main/index.tsx').not.toBeNull();
+        // 去掉注释后再断言,避免被注释里的文字（或被注释掉的旧代码）影响判断。
+        handlerCode = match![1]
+            .replace(/\/\*[\s\S]*?\*\//g, '')
+            .replace(/\/\/[^\n]*/g, '');
     });
 
-    it('handler 内部直接从 WKApp.shared 读当前空间,不依赖 render 作用域的变量', () => {
-        expect(handlerBody).toMatch(/buildSpaceAdminUrl\(\s*WKApp\.shared\.currentSpaceId\s*\)/);
+    it('点击时从 WKApp.shared 读当前空间,而不是 render 作用域捕获的值', () => {
+        // 关键回归点。回退成 buildSpaceAdminUrl(currentSpaceId)(render 闭包)时,
+        // handler 体里就不再出现这个符号,本用例失败。
+        expect(handlerCode).toMatch(/WKApp\.shared\.currentSpaceId/);
     });
 
-    it('handler 没有把 render 作用域的 currentSpaceId 传进 buildSpaceAdminUrl', () => {
-        // 关键回归点:buildSpaceAdminUrl(currentSpaceId) 这种裸变量形式必须不出现。
-        expect(handlerBody).not.toMatch(/buildSpaceAdminUrl\(\s*currentSpaceId\s*\)/);
-    });
-
-    it('导航目标来自 buildSpaceAdminUrl,没有绕过它硬编码路径', () => {
-        expect(handlerBody).toMatch(/window\.location\.href\s*=\s*buildSpaceAdminUrl\(/);
-        expect(handlerBody).not.toMatch(/["'`]\/space["'`]/);
-        expect(handlerBody).not.toMatch(/["'`]\/admin\/space/);
+    it('导航目标由 buildSpaceAdminUrl 生成,没有绕过它硬编码路径', () => {
+        expect(handlerCode).toMatch(/window\.location\.href\s*=\s*buildSpaceAdminUrl\(/);
+        expect(handlerCode).not.toMatch(/["'`]\/space["'`]/);
+        expect(handlerCode).not.toMatch(/["'`]\/admin\/space/);
     });
 
     it('buildSpaceAdminUrl 是从本地模块导入的', () => {

--- a/apps/web/src/__tests__/spaceAdminEntryWiring.test.ts
+++ b/apps/web/src/__tests__/spaceAdminEntryWiring.test.ts
@@ -1,0 +1,49 @@
+/**
+ * 锁住「空间管理」入口的接线方式,而不只是 URL 构造的结果。
+ *
+ * buildSpaceAdminUrl 本身有单测(spaceAdminUrl.test.ts),但那些用例无法区分
+ * handler 是在 *点击时* 读 WKApp.shared.currentSpaceId,还是用了 render 作用域里
+ * 那个同名局部变量。后者是个真实的过期读问题:applySpaceSelection 会同步写
+ * WKApp.shared.currentSpaceId,但它的 getMySpaces() 失败分支只弹 toast、不触发
+ * re-render,于是切换空间后若刷新列表失败,render 闭包捕获的就是上一个空间 id。
+ *
+ * 这里沿用本仓 layoutPendingInviteToast.test.ts 的做法:读源码断言调用形状,
+ * 这样将来把它改回 render 闭包会立刻失败,而不是静默回归。
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+
+describe('Main nav 空间管理入口的接线', () => {
+    let source: string;
+    let handlerBody: string;
+
+    beforeAll(() => {
+        source = fs.readFileSync(
+            path.join(__dirname, '../Pages/Main/index.tsx'), 'utf-8');
+        // 取 onSpaceManagement={...} 到下一个 prop 之前的这段,只针对 handler 断言,
+        // 避免匹配到文件里别处对 currentSpaceId 的合法使用(如 NavRail 的高亮 prop)。
+        const match = source.match(/onSpaceManagement=\{([\s\S]*?)\n\s{40}\/\//);
+        expect(match).not.toBeNull();
+        handlerBody = match![1];
+    });
+
+    it('handler 内部直接从 WKApp.shared 读当前空间,不依赖 render 作用域的变量', () => {
+        expect(handlerBody).toMatch(/buildSpaceAdminUrl\(\s*WKApp\.shared\.currentSpaceId\s*\)/);
+    });
+
+    it('handler 没有把 render 作用域的 currentSpaceId 传进 buildSpaceAdminUrl', () => {
+        // 关键回归点:buildSpaceAdminUrl(currentSpaceId) 这种裸变量形式必须不出现。
+        expect(handlerBody).not.toMatch(/buildSpaceAdminUrl\(\s*currentSpaceId\s*\)/);
+    });
+
+    it('导航目标来自 buildSpaceAdminUrl,没有绕过它硬编码路径', () => {
+        expect(handlerBody).toMatch(/window\.location\.href\s*=\s*buildSpaceAdminUrl\(/);
+        expect(handlerBody).not.toMatch(/["'`]\/space["'`]/);
+        expect(handlerBody).not.toMatch(/["'`]\/admin\/space/);
+    });
+
+    it('buildSpaceAdminUrl 是从本地模块导入的', () => {
+        expect(source).toMatch(
+            /import\s*\{\s*buildSpaceAdminUrl\s*\}\s*from\s*["']\.\/spaceAdminUrl["']/);
+    });
+});

--- a/apps/web/src/__tests__/spaceAdminUrl.test.ts
+++ b/apps/web/src/__tests__/spaceAdminUrl.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest'
+import { buildSpaceAdminUrl } from '../Pages/Main/spaceAdminUrl'
+
+describe('buildSpaceAdminUrl', () => {
+  it('有当前空间时,带上 ?spaceId=', () => {
+    expect(buildSpaceAdminUrl('abc123')).toBe('/admin/space?spaceId=abc123')
+  })
+
+  it('空串 / undefined / null 时,回退到不带参数的 /admin/space,由后台走默认逻辑', () => {
+    expect(buildSpaceAdminUrl('')).toBe('/admin/space')
+    expect(buildSpaceAdminUrl(undefined)).toBe('/admin/space')
+    expect(buildSpaceAdminUrl(null)).toBe('/admin/space')
+  })
+
+  it('包含需要编码字符的 id 会被 encodeURIComponent 处理,避免破坏 URL', () => {
+    expect(buildSpaceAdminUrl('a b&c=d')).toBe('/admin/space?spaceId=a%20b%26c%3Dd')
+  })
+
+  it('目标是管理后台的 SPA 实际路径 /admin/space,不走 /space 短链 301 以避免 query 丢失', () => {
+    expect(buildSpaceAdminUrl('x')).toMatch(/^\/admin\/space(\?|$)/)
+    expect(buildSpaceAdminUrl(null)).toMatch(/^\/admin\/space(\?|$)/)
+  })
+})

--- a/apps/web/src/__tests__/spaceAdminUrl.test.ts
+++ b/apps/web/src/__tests__/spaceAdminUrl.test.ts
@@ -1,23 +1,27 @@
-import { describe, it, expect } from 'vitest'
-import { buildSpaceAdminUrl } from '../Pages/Main/spaceAdminUrl'
+import { describe, it, expect } from 'vitest';
+import { buildSpaceAdminUrl } from '../Pages/Main/spaceAdminUrl';
 
 describe('buildSpaceAdminUrl', () => {
-  it('有当前空间时,带上 ?spaceId=', () => {
-    expect(buildSpaceAdminUrl('abc123')).toBe('/admin/space?spaceId=abc123')
-  })
+    it('有当前空间时,带上 ?spaceId=', () => {
+        expect(buildSpaceAdminUrl('abc123')).toBe('/admin/space?spaceId=abc123');
+    });
 
-  it('空串 / undefined / null 时,回退到不带参数的 /admin/space,由后台走默认逻辑', () => {
-    expect(buildSpaceAdminUrl('')).toBe('/admin/space')
-    expect(buildSpaceAdminUrl(undefined)).toBe('/admin/space')
-    expect(buildSpaceAdminUrl(null)).toBe('/admin/space')
-  })
+    it('空串 / undefined / null 时,回退到不带参数的 /admin/space,由后台走默认逻辑', () => {
+        expect(buildSpaceAdminUrl('')).toBe('/admin/space');
+        expect(buildSpaceAdminUrl(undefined)).toBe('/admin/space');
+        expect(buildSpaceAdminUrl(null)).toBe('/admin/space');
+    });
 
-  it('包含需要编码字符的 id 会被 encodeURIComponent 处理,避免破坏 URL', () => {
-    expect(buildSpaceAdminUrl('a b&c=d')).toBe('/admin/space?spaceId=a%20b%26c%3Dd')
-  })
+    it('包含需要编码字符的 id 会被 encodeURIComponent 处理,避免破坏 URL', () => {
+        expect(buildSpaceAdminUrl('a b&c=d')).toBe('/admin/space?spaceId=a%20b%26c%3Dd');
+    });
 
-  it('目标是管理后台的 SPA 实际路径 /admin/space,不走 /space 短链 301 以避免 query 丢失', () => {
-    expect(buildSpaceAdminUrl('x')).toMatch(/^\/admin\/space(\?|$)/)
-    expect(buildSpaceAdminUrl(null)).toMatch(/^\/admin\/space(\?|$)/)
-  })
-})
+    it('不会被恶意 id 带出 /admin/space 这个前缀', () => {
+        // 开放重定向 / 路径逃逸的形状:编码后都只能落在 query 里。
+        // eslint-disable-next-line no-script-url -- 这里是被测的输入数据,不是真的当 URL 用
+        for (const evil of ['//evil.com', '../../etc/passwd', 'javascript:alert(1)']) {
+            expect(buildSpaceAdminUrl(evil)).toMatch(/^\/admin\/space\?spaceId=/);
+            expect(buildSpaceAdminUrl(evil)).not.toContain('//evil.com');
+        }
+    });
+});


### PR DESCRIPTION
## Summary

The space-management entry in the main nav used to jump to `/space` with no context, so users who manage multiple spaces always landed on the admin's `managed[0]` and had to switch by hand. This PR passes the current space id via `?spaceId=` and points the entry straight at the admin SPA path `/admin/space`, so the admin backend opens the space the user is actually in.

The consumer, [Mininglamp-OSS/octo-admin#161](https://github.com/Mininglamp-OSS/octo-admin/pull/161), **merged on 2026-09-03**, so the feature takes effect as soon as this lands rather than waiting on anything else.

## Related Issue

<!-- none -->

## Changes

- `apps/web/src/Pages/Main/index.tsx` — the `onSpaceManagement` handler navigates to `buildSpaceAdminUrl(WKApp.shared.currentSpaceId)`, reading the singleton at click time rather than capturing it in render scope.
- `apps/web/src/Pages/Main/spaceAdminUrl.ts` (new) — pure helper returning `/admin/space?spaceId=<encoded>` when a current space is known, `/admin/space` otherwise. Targets the admin SPA path directly rather than the `/space` short link so the query does not depend on any redirect layer forwarding it, which also keeps it correct when the admin container is reached without the edge proxy.
- `apps/web/src/__tests__/spaceAdminUrl.test.ts` (new) — encoded / empty / null / undefined branches plus open-redirect and path-escape shapes.
- `apps/web/src/__tests__/spaceAdminEntryWiring.test.ts` (new) — source-level assertion that the handler reads `WKApp.shared.currentSpaceId` inside the callback, so the stale-closure bug cannot silently return.

## Review follow-ups

Every round of feedback is addressed on this branch:

- **Stale render closure** 🟡: the handler captured `currentSpaceId` at render time. `applySpaceSelection`'s `getMySpaces()` failure branch only toasts without re-rendering, so a switch followed by a failed refresh left a window where the click carried the previous space id. Now read at click time (`e2ab008`).
- **Inaccurate nginx rationale**: the original comment claimed `return 301` loses the query. That is false for the front-door nginx, which uses `return 301 /admin/space$1$is_args$args`; query loss only occurs at the admin container's own `location = /space`. Comment corrected to state the real reason (`5a7318e`).
- **Untested wiring**: added the source-level assertion above (`5a7318e`).
- **Wiring test was pinned to formatting, and over-fitted** (`c1c9834`): it anchored on `\n\s{40}//`, so one `prettier --write` or any reflow of this nested JSX would have broken it with an unhelpful message; and its negative assertion rejected a *correct* refactor that reads the singleton into a local first. Now anchored on the following `menusList=` prop, comments stripped before asserting, and the check restated positively as "the handler body reads `WKApp.shared.currentSpaceId`". Also unified quoting/semicolons with the sibling modules and between the two test files.

## Architecture / Module Boundary

- Affected module(s): `apps/web` Main nav (space management entry only)
- New or changed user-visible entry point: no (the existing entry's behavior is refined; still one entry, still labeled 空间管理)
- Shared layer touched: none — the URL helper lives under `Pages/Main` alongside its only caller
- If shared code changed, impact scope: n/a
- Duplicate entry point checked: yes — the replaced line was the only `/space` navigation in the repo

## Testing

- **Unit tests: 1416 passed across 113 files** (`vitest run` in `apps/web`). The count moved 1417 → 1416 because the over-fitted negative assertion was removed, not because anything regressed.
- **ESLint clean** on all changed files (repo-pinned v7.32.0).
- **`vite build` succeeds.**
- **Mutation-verified**, covering all three concerns raised in review:
  - revert to the render closure → **fails** (the regression is still caught)
  - refactor to a click-time local variable → **passes** (no longer over-fitted)
  - reindent and drop the trailing comment → **passes** (formatting-resilient)
- End-to-end manual check (open main app → click 空间管理 while in a non-first managed space → confirm the admin opens on that space) still pending a staging environment.

- [x] Unit tests added/updated
- [ ] Manually verified

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes
- [ ] Updated documentation — n/a (no user-facing copy or docs affected)
- [x] Ran `pnpm i18n:check` or confirmed the change does not affect UI copy — no copy changes
- [x] Confirmed the change follows module ownership and does not add duplicate user-visible entry points
- [x] Described impact scope when shared components, messages, bridge, or services are changed — n/a, no shared layer touched
- [x] Followed commit message conventions (Conventional Commits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fm1wJX7SoAXUh5cdwPXSes