### PR TITLE
docs(i18n): add Copy Length Budgets & Constrained Layouts section

### DIFF
--- a/docs/i18n-agent-guide.md
+++ b/docs/i18n-agent-guide.md
@@ -177,12 +177,12 @@ For Octo, source strings are usually Chinese, not English. Chinese → English e
 
 ### Constrained Container Inventory & Budgets
 
-The following containers in Octo Web have fixed or narrow width constraints. When adding or migrating a translation key rendered in one of these containers, the translated string in **any** locale must fit the budget below. Budgets are conservative maxes derived from the current CSS; measure again if the layout changes.
+The following containers in Octo Web have fixed or narrow width constraints. When adding or migrating a translation key rendered in one of these containers, the translated string in **any** locale must fit the budget below. Budgets are conservative maxes derived from the current CSS and the current formatter outputs; measure again if the layout changes.
 
 | Container | Component / consumer | Character budget | Notes |
 |---|---|---|---|
-| NavRail label — collapsed rail | `packages/dmworkbase/src/Components/NavRail/NavItem.tsx` + `.wk-navrail__item` / `.wk-navrail__item-label` in `packages/dmworkbase/src/Components/NavRail/index.css` | ≤ 8 chars | Applies only to the collapsed rail (item 56×54, icon 20×20, label padding-inline 4px → usable label ~44px at font-size `--wk-text-size-tiny`). Expanded rail (`.wk-layout-tab-expanded .wk-navrail__item`, row layout with `width: 100%`) is not budget-limited here. |
-| Chat list date column | `packages/dmworkbase/src/Components/ConversationList/index.tsx` (`.wk-conversationlist-item-time`) rendering `getTimeStringAutoShort2` from `packages/dmworkbase/src/Utils/time.ts` | ≤ 12 chars | Cell shares the row header line with the conversation name; must not truncate time digits. The English key `time.dayBeforeYesterday` = "The day before yesterday" is currently rendered here and overflows — long forms like this need a shorter locale form or a numeric/date fallback (see Design Layer 3). |
+| NavRail label — collapsed rail | `packages/dmworkbase/src/Components/NavRail/NavItem.tsx` + `.wk-navrail__item` / `.wk-navrail__item-label` in `packages/dmworkbase/src/Components/NavRail/index.css` | ≤ 8 chars | **Deliberate design carve-out**: the collapsed rail is a fixed 56 px icon-first grid (item 56×54, icon 20×20, label padding-inline 4px → usable label ~44px at font-size `--wk-text-size-tiny`). Design layer 1 ("reserve space in layout") does **not** apply here — the whole point of the collapsed rail is a constant grid; extra chars are absorbed by editing copy or by dropping to icon-only. The expanded rail (`.wk-layout-tab-expanded .wk-navrail__item`, row layout with `width: 100%`) is not budget-limited here. |
+| Chat list date column | `packages/dmworkbase/src/Components/ConversationList/index.tsx` (`.wk-conversationlist-item-time`) rendering `getTimeStringAutoShort2` from `packages/dmworkbase/src/Utils/time.ts` | ≤ 16 chars | Cell is `flex-shrink: 0` and shares the header line with a `flex: 1; min-width: 0` conversation title, so an oversized time string does **not** truncate itself — it hogs the row and forces the title to truncate more. Budget covers realistic worst-case outputs the formatter already produces: `Yesterday 21:34` (15), `2026-09-06 10:00` (16), `Wed 10:30` (9). The current English `time.dayBeforeYesterday` value ("The day before yesterday") plus a time suffix reaches ~30 chars in this cell and blows the budget — see Design Layer 3 for the fix. |
 | Tab title | Tabs / SegmentedControl surfaces | ≤ 12 chars | Verify per usage — some tab rows scroll horizontally and need no budget. |
 | Primary button (fixed-width toolbar) | Toolbar / ActionBar surfaces with hard `width` on the button | ≤ 18 chars | Skip if the toolbar uses `width: max-content`. |
 | Table column header (fixed-width) | Table headers with hard `width` | ≤ 14 chars | Skip if the table auto-sizes columns. |
@@ -191,43 +191,67 @@ Add rows to this table when a new narrow container is discovered. Do not delete 
 
 ### Design Layers (in order of preference)
 
-1. **Reserve space in layout, not in copy.** Layout containers use `min-width` + `width: max-content` + `max-width: 100%`, not `width: <fixed-px>`. Reserve for source × 2 as a rule of thumb.
-2. **Short-variant keys (proposed convention).** When a base translation exceeds the budget in any locale, add a sibling `.short` key. Call sites in constrained containers resolve the short form first and fall back to the base key. There is currently no dedicated helper for this; use the existing `defaultValue` option on `t()`:
+1. **Reserve space in layout, not in copy.** Layout containers use `min-width` + `width: max-content` + `max-width: 100%`, not `width: <fixed-px>`. Reserve for source × 2 as a rule of thumb. Deliberate design-constraint carve-outs (e.g. the fixed-grid collapsed NavRail above) are the exception, not the rule; those cases skip straight to layers 2/3.
 
-   ```ts
-   // Proposed convention for constrained-container call sites.
-   const label = t(`${key}.short`, { defaultValue: t(key) });
-   ```
+2. **Short-variant keys (proposed convention, `.short` suffix).** When a base translation exceeds a budget in any locale, add a sibling `.short` key **atomically in every locale file at the same time**. This is a hard requirement, not a nice-to-have — see below for why.
 
-   Example keys: `nav.summary` = `AI Summary` (full), `nav.summary.short` = `Summary` (fits collapsed NavRail budget). When you add a `.short`, add it in **every** locale file — English-only `.short` variants leave zh-CN (and any future locale) still overflowing.
+   **Why not "fall back at the call site":** `t()`'s resolution order (see `packages/dmworkbase/src/i18n/I18nService.ts`) is:
 
-3. **Locale-sensitive short formats for dates/times/numbers.** Dates, times, relative times, and numbers in constrained containers must go through `format.dateTime` / `format.time` / `format.relativeTime` / `format.number` from `@octo/base`, not through translated phrase keys. Never hand-translate `"the day before yesterday"` (`time.dayBeforeYesterday`); render the underlying timestamp through a formatter that produces a fixed-width output. The current `format.relativeTime` wraps `Intl.RelativeTimeFormat` with `numeric: "auto"` and takes only `(value, unit)` — there is no short-mode option today. Constrained chat/list surfaces that need `HH:mm` / weekday-abbrev / `MMM d` / `M/d/yy` should build those via `format.dateTime` / `format.time` with explicit `Intl.DateTimeFormatOptions`, not by adding phrase translations.
+   1. `messages[activeLocale][key]`
+   2. `messages[defaultLocale][key]` (`defaultLocale` is `zh-CN`)
+   3. `options.defaultValue`
+   4. `key` (raw)
+
+   So `t(\`${key}.short\`, { defaultValue: t(key) })` is **unsafe**: if only zh-CN adds `foo.short` and en-US does not, an active en-US user gets the zh-CN short string via step 2 (Chinese leaks into the English UI) and never reaches the `defaultValue`. A missing `.short` never falls back to the base key of the same locale. The safe recipe is therefore:
+
+   - Add `foo.short` to **every** locale JSON at the same time, or don't add it in any.
+   - Callers pick the key explicitly by container, not by fallback:
+
+     ```ts
+     // Constrained container:
+     const label = t(narrowSurface ? `${key}.short` : key);
+     ```
+
+   - `pnpm i18n:check` should assert atomic locale coverage for any key with a `.short` sibling (any locale has `foo.short` ⇒ every locale has `foo.short`). Wire this in when the length-assertion pass lands.
+
+   **Go-forward vs. grandfathered.** A different suffix convention already exists in the codebase — camelCase `Short` (e.g. `conversationList.minutesAgoShort`, `filePreview.pdf.noBookmarksShort`, `globalSearch.aggregated.messagesShort`, `subscribers.minutesAgoShort`, `dmworkskillmarket:reuploadShort`). Those keys are **grandfathered**; do not migrate them just to change the suffix. For **new** constrained-container keys, prefer the dotted `.short` sibling because it groups with its base in flat JSON and is trivial for `i18n:check` to pair up. Whichever convention a caller uses, the atomic-locale-coverage rule above still applies.
+
+3. **Locale-sensitive short formats for dates/times/numbers.** Dates, times, relative times, and numbers in constrained containers must go through `format.dateTime` / `format.time` / `format.relativeTime` / `format.number` from `@octo/base`, **not** through translated phrase keys — this rule and the "shorter locale form" note on the date column are the same rule. If a shorter phrasing is needed (e.g. the current `Yesterday HH:mm` composition or a locale-native "yesterday" produced by `Intl.RelativeTimeFormat`), it should come from the formatter, not from a translation key. If a truly custom short form is unavoidable, add it as a helper on the formatter, not as a new phrase key in the resource files.
+
+   The current `format.relativeTime` wraps `Intl.RelativeTimeFormat` with `numeric: "auto"` and takes only `(value, unit)` — there is no short-mode option today. Constrained chat/list surfaces that need `HH:mm` / weekday-abbrev / `MMM d` / `M/d/yy` should build those via `format.dateTime` / `format.time` with explicit `Intl.DateTimeFormatOptions`.
 
    Reference ladder to aim for in constrained rows (implement per surface, do not hard-code phrasing):
 
    - Today → `HH:mm`
-   - Yesterday → `format.relativeTime(-1, "day")` (locale-native short form; do not hand-translate)
-   - This week → weekday abbrev via `format.dateTime(t, { weekday: "short" })`
-   - This year → `format.dateTime(t, { month: "short", day: "numeric" })`
-   - Prior years → `format.dateTime(t, { year: "2-digit", month: "numeric", day: "numeric" })`
+   - Yesterday → `format.relativeTime(-1, "day")` (locale-native short form; do not hand-translate) or `format.time(ts)` for a pure `HH:mm`
+   - This week → weekday abbrev via `format.dateTime(ts, { weekday: "short" })`
+   - This year → `format.dateTime(ts, { month: "short", day: "numeric" })`
+   - Prior years → `format.dateTime(ts, { year: "2-digit", month: "numeric", day: "numeric" })`
 
-4. **Truncation + tooltip (last resort).** `text-overflow: ellipsis` + `title` attribute (or `aria-label`) so users can hover to see the full copy. Ellipsis without a tooltip is an accessibility bug (W3C WAI, Baymard).
+4. **Truncation + tooltip (last resort).** `text-overflow: ellipsis` on the element that clips, plus **both** of the following (they are not interchangeable):
+
+   - `title="{full text}"` for the **visible hover tooltip** — sighted mouse users need this to read the truncated content on hover; screen readers may or may not surface it depending on platform.
+   - `aria-label="{full text}"` (or the equivalent accessible name via visually-hidden text) for the **accessible name** — required for keyboard-only and AT users; `title` alone is not a reliable accessible name in every AT.
+
+   Ellipsis with neither is a hard accessibility bug (W3C WAI, Baymard). Ellipsis with only one covers only half the audience.
 
 ### Anti-patterns
 
 - ❌ Direct translation of a phrase that exceeds the budget (`The day before yesterday`, `AI Summary` in a collapsed NavRail label).
-- ❌ Ellipsis without `title` / `aria-label` fallback.
-- ❌ Fixed pixel widths on layout containers holding translatable copy.
+- ❌ Ellipsis without both a `title` and an accessible name — see Layer 4.
+- ❌ Fixed pixel widths on layout containers holding translatable copy (outside a deliberate design-constraint carve-out).
 - ❌ Reducing font-size to fit — accessibility regression.
-- ❌ Adding a `.short` variant in English only, leaving zh-CN and future locales unaddressed.
-- ❌ Hard-coded date/time phrases in place of `format.dateTime` / `format.time` / `format.relativeTime`.
+- ❌ Adding a `.short` (or grandfathered `Short`) variant in one locale only — it silently leaks the other locale's short string into the un-updated locale via `t()`'s default-locale fallback.
+- ❌ Using `defaultValue` as a `.short → base` fallback at the call site — see Layer 2 for why this is unsafe.
+- ❌ Hard-coded date/time phrases in place of `format.dateTime` / `format.time` / `format.relativeTime`, whether via `t()` or inline literals.
 
 ### Verification Checklist (for PRs touching constrained layouts)
 
 - [ ] `pnpm i18n:check` passes.
-- [ ] Every locale file (`zh-CN`, `en-US`, and any future locales) carries the `.short` variant for keys rendered in constrained containers.
+- [ ] Every locale file (`zh-CN`, `en-US`, and any future locales) carries the `.short` (or grandfathered `Short`) sibling atomically — no locale is missing it if any locale has it.
+- [ ] Call sites in constrained containers select the short/base key explicitly, not via a `t(..., { defaultValue: t(base) })` fallback (which leaks zh-CN into en-US when only one locale has the sibling).
 - [ ] Manual browser verification in both `zh-CN` and `en-US` for the touched screens.
-- [ ] Ellipsis-truncated elements have `title` or `aria-label`.
+- [ ] Ellipsis-truncated elements have **both** `title` (visible hover tooltip) and an accessible name (`aria-label` or equivalent).
 - [ ] Date / time / number rendering goes through `format.*` (or an explicit `Intl.*` call), not a translated phrase.
 
 ### References

--- a/docs/i18n-agent-guide.md
+++ b/docs/i18n-agent-guide.md
@@ -154,11 +154,11 @@ When excluding a source file from hardcoded Chinese checks, record the reason in
 
 ## Copy Length Budgets & Constrained Layouts
 
-Constrained layouts — nav labels, tabs, buttons, date columns, table cells with fixed widths — are where localization most often fails. English source strings are typically the shortest form; other languages expand significantly, and the shorter the source, the higher the expansion ratio. Octo uses Chinese as the primary source, which magnifies the effect: short Chinese labels can grow by an order of magnitude when translated to English.
+Constrained layouts — nav labels, tabs, buttons, date columns, table cells with fixed widths — are where localization most often fails. Short source strings expand the most when translated, and Octo uses Chinese as the primary source; short Chinese labels can grow by an order of magnitude when rendered in English.
 
 ### Reference Expansion Ratios (W3C / IBM)
 
-Source: W3C "Text size in translation" (citing IBM Guidelines to Design Global Solutions).
+Source: W3C "Text size in translation" (citing IBM Guidelines to Design Global Solutions). The figures are **English-source** averages across common target locales.
 
 | English source length | Average expansion |
 |---|---|
@@ -166,58 +166,69 @@ Source: W3C "Text size in translation" (citing IBM Guidelines to Design Global S
 | 11-20 | 180-200% |
 | 21-30 | 160-180% |
 | 31-50 | 140-160% |
+| 51-70 | 130-140% |
 | > 70 | ~130% |
 
-Chinese → English expansion for short strings is often even larger than the table above. Real examples from Octo Web:
+For Octo, source strings are usually Chinese, not English. Chinese → English expansion is generally **larger** than the table above; treat these numbers as a lower bound when the source is Chinese and design for the worst-case locale, not the source locale. Real examples from Octo Web:
 
 - `智能总结` (4 chars) → `AI Summary` (10 chars, 2.5×)
 - `前天` (2 chars) → `The day before yesterday` (24 chars, 12×)
 - `昨天` (2 chars) → `Yesterday` (9 chars, 4.5×)
 
-Design for the worst-case locale, not the source locale.
-
 ### Constrained Container Inventory & Budgets
 
-The following containers in Octo Web have fixed or narrow width constraints. When adding or migrating a translation key rendered in one of these containers, the translated string in **any** locale must fit the budget below.
+The following containers in Octo Web have fixed or narrow width constraints. When adding or migrating a translation key rendered in one of these containers, the translated string in **any** locale must fit the budget below. Budgets are conservative maxes derived from the current CSS; measure again if the layout changes.
 
-| Container | Component | Character budget | Notes |
+| Container | Component / consumer | Character budget | Notes |
 |---|---|---|---|
-| NavRail label (top-level menu) | `packages/dmworkbase/src/Components/NavRail/NavItem.tsx` | ≤ 10 chars | Icon 40px + label area ~60-80px; use `.short` variant for longer copy |
-| Chat list date column | ChannelList row (locate during WS-216) | ≤ 12 chars | Must not truncate time digits; go through `format.relativeTime` short mode |
-| Tab title | Tabs / SegmentedControl surfaces | ≤ 12 chars | |
-| Primary button (fixed-width toolbar) | Toolbar / ActionBar | ≤ 18 chars | |
-| Table column header (fixed-width) | Table headers with hard `width` | ≤ 14 chars | |
+| NavRail label — collapsed rail | `packages/dmworkbase/src/Components/NavRail/NavItem.tsx` + `.wk-navrail__item` / `.wk-navrail__item-label` in `packages/dmworkbase/src/Components/NavRail/index.css` | ≤ 8 chars | Applies only to the collapsed rail (item 56×54, icon 20×20, label padding-inline 4px → usable label ~44px at font-size `--wk-text-size-tiny`). Expanded rail (`.wk-layout-tab-expanded .wk-navrail__item`, row layout with `width: 100%`) is not budget-limited here. |
+| Chat list date column | `packages/dmworkbase/src/Components/ConversationList/index.tsx` (`.wk-conversationlist-item-time`) rendering `getTimeStringAutoShort2` from `packages/dmworkbase/src/Utils/time.ts` | ≤ 12 chars | Cell shares the row header line with the conversation name; must not truncate time digits. The English key `time.dayBeforeYesterday` = "The day before yesterday" is currently rendered here and overflows — long forms like this need a shorter locale form or a numeric/date fallback (see Design Layer 3). |
+| Tab title | Tabs / SegmentedControl surfaces | ≤ 12 chars | Verify per usage — some tab rows scroll horizontally and need no budget. |
+| Primary button (fixed-width toolbar) | Toolbar / ActionBar surfaces with hard `width` on the button | ≤ 18 chars | Skip if the toolbar uses `width: max-content`. |
+| Table column header (fixed-width) | Table headers with hard `width` | ≤ 14 chars | Skip if the table auto-sizes columns. |
 
 Add rows to this table when a new narrow container is discovered. Do not delete rows without evidence the container is no longer constrained.
 
 ### Design Layers (in order of preference)
 
 1. **Reserve space in layout, not in copy.** Layout containers use `min-width` + `width: max-content` + `max-width: 100%`, not `width: <fixed-px>`. Reserve for source × 2 as a rule of thumb.
-2. **Short-variant keys.** When a base translation exceeds the budget in any locale, add a `.short` variant key. Consumers in constrained containers resolve `<key>.short` first, fall back to `<key>`. Example: `nav.summary` = `AI Summary` (full), `nav.summary.short` = `Summary` (fits NavRail budget). When you add a `.short`, add it in **every** locale file — English-only `.short` variants leave zh-CN (and any future locale) still overflowing.
-3. **Locale-sensitive short formats for dates/times/numbers.** Dates, times, relative times, and numbers in constrained containers must go through `format.relativeTime` / `format.dateTime` / `format.number`. Never hand-translate `"the day before yesterday"`. Reference short-format ladder for relative time:
+2. **Short-variant keys (proposed convention).** When a base translation exceeds the budget in any locale, add a sibling `.short` key. Call sites in constrained containers resolve the short form first and fall back to the base key. There is currently no dedicated helper for this; use the existing `defaultValue` option on `t()`:
+
+   ```ts
+   // Proposed convention for constrained-container call sites.
+   const label = t(`${key}.short`, { defaultValue: t(key) });
+   ```
+
+   Example keys: `nav.summary` = `AI Summary` (full), `nav.summary.short` = `Summary` (fits collapsed NavRail budget). When you add a `.short`, add it in **every** locale file — English-only `.short` variants leave zh-CN (and any future locale) still overflowing.
+
+3. **Locale-sensitive short formats for dates/times/numbers.** Dates, times, relative times, and numbers in constrained containers must go through `format.dateTime` / `format.time` / `format.relativeTime` / `format.number` from `@octo/base`, not through translated phrase keys. Never hand-translate `"the day before yesterday"` (`time.dayBeforeYesterday`); render the underlying timestamp through a formatter that produces a fixed-width output. The current `format.relativeTime` wraps `Intl.RelativeTimeFormat` with `numeric: "auto"` and takes only `(value, unit)` — there is no short-mode option today. Constrained chat/list surfaces that need `HH:mm` / weekday-abbrev / `MMM d` / `M/d/yy` should build those via `format.dateTime` / `format.time` with explicit `Intl.DateTimeFormatOptions`, not by adding phrase translations.
+
+   Reference ladder to aim for in constrained rows (implement per surface, do not hard-code phrasing):
+
    - Today → `HH:mm`
-   - Yesterday → `Yesterday` / `1d ago`
-   - This week → weekday abbrev (`Wed`) or `2d ago`
-   - This year → `MMM d` (`Sep 4`)
-   - Prior years → `M/d/yy` or `MMM d, yyyy`
+   - Yesterday → `format.relativeTime(-1, "day")` (locale-native short form; do not hand-translate)
+   - This week → weekday abbrev via `format.dateTime(t, { weekday: "short" })`
+   - This year → `format.dateTime(t, { month: "short", day: "numeric" })`
+   - Prior years → `format.dateTime(t, { year: "2-digit", month: "numeric", day: "numeric" })`
+
 4. **Truncation + tooltip (last resort).** `text-overflow: ellipsis` + `title` attribute (or `aria-label`) so users can hover to see the full copy. Ellipsis without a tooltip is an accessibility bug (W3C WAI, Baymard).
 
 ### Anti-patterns
 
-- ❌ Direct translation of a phrase that exceeds the budget (`The day before yesterday`, `AI Summary` in NavRail).
+- ❌ Direct translation of a phrase that exceeds the budget (`The day before yesterday`, `AI Summary` in a collapsed NavRail label).
 - ❌ Ellipsis without `title` / `aria-label` fallback.
 - ❌ Fixed pixel widths on layout containers holding translatable copy.
 - ❌ Reducing font-size to fit — accessibility regression.
 - ❌ Adding a `.short` variant in English only, leaving zh-CN and future locales unaddressed.
-- ❌ Hard-coded date/time phrases in place of `format.relativeTime` / `format.dateTime`.
+- ❌ Hard-coded date/time phrases in place of `format.dateTime` / `format.time` / `format.relativeTime`.
 
 ### Verification Checklist (for PRs touching constrained layouts)
 
-- [ ] `pnpm i18n:check` passes, including length assertions once WS-218 lands.
+- [ ] `pnpm i18n:check` passes.
 - [ ] Every locale file (`zh-CN`, `en-US`, and any future locales) carries the `.short` variant for keys rendered in constrained containers.
 - [ ] Manual browser verification in both `zh-CN` and `en-US` for the touched screens.
 - [ ] Ellipsis-truncated elements have `title` or `aria-label`.
-- [ ] Date / time / number rendering goes through `format.*`, not a translated string.
+- [ ] Date / time / number rendering goes through `format.*` (or an explicit `Intl.*` call), not a translated phrase.
 
 ### References
 

--- a/docs/i18n-agent-guide.md
+++ b/docs/i18n-agent-guide.md
@@ -152,6 +152,81 @@ Do not translate:
 
 When excluding a source file from hardcoded Chinese checks, record the reason in `.i18n/scan-config.json`. Do not add broad ignores without a concrete non-UI reason.
 
+## Copy Length Budgets & Constrained Layouts
+
+Constrained layouts — nav labels, tabs, buttons, date columns, table cells with fixed widths — are where localization most often fails. English source strings are typically the shortest form; other languages expand significantly, and the shorter the source, the higher the expansion ratio. Octo uses Chinese as the primary source, which magnifies the effect: short Chinese labels can grow by an order of magnitude when translated to English.
+
+### Reference Expansion Ratios (W3C / IBM)
+
+Source: W3C "Text size in translation" (citing IBM Guidelines to Design Global Solutions).
+
+| English source length | Average expansion |
+|---|---|
+| ≤ 10 chars | 200-300% |
+| 11-20 | 180-200% |
+| 21-30 | 160-180% |
+| 31-50 | 140-160% |
+| > 70 | ~130% |
+
+Chinese → English expansion for short strings is often even larger than the table above. Real examples from Octo Web:
+
+- `智能总结` (4 chars) → `AI Summary` (10 chars, 2.5×)
+- `前天` (2 chars) → `The day before yesterday` (24 chars, 12×)
+- `昨天` (2 chars) → `Yesterday` (9 chars, 4.5×)
+
+Design for the worst-case locale, not the source locale.
+
+### Constrained Container Inventory & Budgets
+
+The following containers in Octo Web have fixed or narrow width constraints. When adding or migrating a translation key rendered in one of these containers, the translated string in **any** locale must fit the budget below.
+
+| Container | Component | Character budget | Notes |
+|---|---|---|---|
+| NavRail label (top-level menu) | `packages/dmworkbase/src/Components/NavRail/NavItem.tsx` | ≤ 10 chars | Icon 40px + label area ~60-80px; use `.short` variant for longer copy |
+| Chat list date column | ChannelList row (locate during WS-216) | ≤ 12 chars | Must not truncate time digits; go through `format.relativeTime` short mode |
+| Tab title | Tabs / SegmentedControl surfaces | ≤ 12 chars | |
+| Primary button (fixed-width toolbar) | Toolbar / ActionBar | ≤ 18 chars | |
+| Table column header (fixed-width) | Table headers with hard `width` | ≤ 14 chars | |
+
+Add rows to this table when a new narrow container is discovered. Do not delete rows without evidence the container is no longer constrained.
+
+### Design Layers (in order of preference)
+
+1. **Reserve space in layout, not in copy.** Layout containers use `min-width` + `width: max-content` + `max-width: 100%`, not `width: <fixed-px>`. Reserve for source × 2 as a rule of thumb.
+2. **Short-variant keys.** When a base translation exceeds the budget in any locale, add a `.short` variant key. Consumers in constrained containers resolve `<key>.short` first, fall back to `<key>`. Example: `nav.summary` = `AI Summary` (full), `nav.summary.short` = `Summary` (fits NavRail budget). When you add a `.short`, add it in **every** locale file — English-only `.short` variants leave zh-CN (and any future locale) still overflowing.
+3. **Locale-sensitive short formats for dates/times/numbers.** Dates, times, relative times, and numbers in constrained containers must go through `format.relativeTime` / `format.dateTime` / `format.number`. Never hand-translate `"the day before yesterday"`. Reference short-format ladder for relative time:
+   - Today → `HH:mm`
+   - Yesterday → `Yesterday` / `1d ago`
+   - This week → weekday abbrev (`Wed`) or `2d ago`
+   - This year → `MMM d` (`Sep 4`)
+   - Prior years → `M/d/yy` or `MMM d, yyyy`
+4. **Truncation + tooltip (last resort).** `text-overflow: ellipsis` + `title` attribute (or `aria-label`) so users can hover to see the full copy. Ellipsis without a tooltip is an accessibility bug (W3C WAI, Baymard).
+
+### Anti-patterns
+
+- ❌ Direct translation of a phrase that exceeds the budget (`The day before yesterday`, `AI Summary` in NavRail).
+- ❌ Ellipsis without `title` / `aria-label` fallback.
+- ❌ Fixed pixel widths on layout containers holding translatable copy.
+- ❌ Reducing font-size to fit — accessibility regression.
+- ❌ Adding a `.short` variant in English only, leaving zh-CN and future locales unaddressed.
+- ❌ Hard-coded date/time phrases in place of `format.relativeTime` / `format.dateTime`.
+
+### Verification Checklist (for PRs touching constrained layouts)
+
+- [ ] `pnpm i18n:check` passes, including length assertions once WS-218 lands.
+- [ ] Every locale file (`zh-CN`, `en-US`, and any future locales) carries the `.short` variant for keys rendered in constrained containers.
+- [ ] Manual browser verification in both `zh-CN` and `en-US` for the touched screens.
+- [ ] Ellipsis-truncated elements have `title` or `aria-label`.
+- [ ] Date / time / number rendering goes through `format.*`, not a translated string.
+
+### References
+
+- W3C "Text size in translation": https://www.w3.org/International/articles/article-text-size.en
+- IBM Globalization — Guidelines to design global solutions
+- Material Design 3 Navigation Bar (accessibility): https://m3.material.io/components/navigation-bar/accessibility
+- Apple Human Interface Guidelines — Localization: https://developer.apple.com/localization/
+- SimpleLocalize — Text expansion in UI localization: https://simplelocalize.io/blog/posts/text-expansion-ui-localization/
+
 ## Adding New Copy
 
 For new user-visible copy:

--- a/docs/i18n-agent-guide.md
+++ b/docs/i18n-agent-guide.md
@@ -182,7 +182,7 @@ The following containers in Octo Web have fixed or narrow width constraints. Whe
 | Container | Component / consumer | Character budget | Notes |
 |---|---|---|---|
 | NavRail label — collapsed rail | `packages/dmworkbase/src/Components/NavRail/NavItem.tsx` + `.wk-navrail__item` / `.wk-navrail__item-label` in `packages/dmworkbase/src/Components/NavRail/index.css` | ≤ 8 chars | **Deliberate design carve-out**: the collapsed rail is a fixed 56 px icon-first grid (item 56×54, icon 20×20, label padding-inline 4px → usable label ~44px at font-size `--wk-text-size-tiny`). Design layer 1 ("reserve space in layout") does **not** apply here — the whole point of the collapsed rail is a constant grid; extra chars are absorbed by editing copy or by dropping to icon-only. The expanded rail (`.wk-layout-tab-expanded .wk-navrail__item`, row layout with `width: 100%`) is not budget-limited here. |
-| Chat list date column | `packages/dmworkbase/src/Components/ConversationList/index.tsx` (`.wk-conversationlist-item-time`) rendering `getTimeStringAutoShort2` from `packages/dmworkbase/src/Utils/time.ts` | ≤ 16 chars | Cell is `flex-shrink: 0` and shares the header line with a `flex: 1; min-width: 0` conversation title, so an oversized time string does **not** truncate itself — it hogs the row and forces the title to truncate more. Budget covers realistic worst-case outputs the formatter already produces: `Yesterday 21:34` (15), `2026-09-06 10:00` (16), `Wed 10:30` (9). The current English `time.dayBeforeYesterday` value ("The day before yesterday") plus a time suffix reaches ~30 chars in this cell and blows the budget — see Design Layer 3 for the fix. |
+| Chat list date column | `packages/dmworkbase/src/Components/ConversationList/index.tsx` (`.wk-conversationlist-item-time`) rendering `getTimeStringAutoShort2` from `packages/dmworkbase/src/Utils/time.ts` | ≤ 16 chars | Cell is `flex-shrink: 0` and shares the header line with a `flex: 1; min-width: 0` conversation title, so an oversized time string does **not** truncate itself — it hogs the row and forces the title to truncate more. Budget covers realistic worst-case outputs the formatter already produces (`getTimeStringAutoShort2` uses `Intl` `weekday: "long"` and formats cross-year as `yyyy/M/d`): `Yesterday 21:34` (15), `2026/12/26 10:00` (16), `Wednesday 10:30` (15). The current English `time.dayBeforeYesterday` value ("The day before yesterday") plus a time suffix reaches ~30 chars in this cell and blows the budget — see Design Layer 3 for the fix. |
 | Tab title | Tabs / SegmentedControl surfaces | ≤ 12 chars | Verify per usage — some tab rows scroll horizontally and need no budget. |
 | Primary button (fixed-width toolbar) | Toolbar / ActionBar surfaces with hard `width` on the button | ≤ 18 chars | Skip if the toolbar uses `width: max-content`. |
 | Table column header (fixed-width) | Table headers with hard `width` | ≤ 14 chars | Skip if the table auto-sizes columns. |
@@ -202,7 +202,7 @@ Add rows to this table when a new narrow container is discovered. Do not delete 
    3. `options.defaultValue`
    4. `key` (raw)
 
-   So `t(\`${key}.short\`, { defaultValue: t(key) })` is **unsafe**: if only zh-CN adds `foo.short` and en-US does not, an active en-US user gets the zh-CN short string via step 2 (Chinese leaks into the English UI) and never reaches the `defaultValue`. A missing `.short` never falls back to the base key of the same locale. The safe recipe is therefore:
+   So ``t(`${key}.short`, { defaultValue: t(key) })`` is **unsafe**: if only zh-CN adds `foo.short` and en-US does not, an active en-US user gets the zh-CN short string via step 2 (Chinese leaks into the English UI) and never reaches the `defaultValue`. A missing `.short` never falls back to the base key of the same locale. The safe recipe is therefore:
 
    - Add `foo.short` to **every** locale JSON at the same time, or don't add it in any.
    - Callers pick the key explicitly by container, not by fallback:
@@ -212,7 +212,7 @@ Add rows to this table when a new narrow container is discovered. Do not delete 
      const label = t(narrowSurface ? `${key}.short` : key);
      ```
 
-   - `pnpm i18n:check` should assert atomic locale coverage for any key with a `.short` sibling (any locale has `foo.short` ⇒ every locale has `foo.short`). Wire this in when the length-assertion pass lands.
+   - `pnpm i18n:check` **already enforces this**: its `missing-key` rule (see `scripts/i18n-scan.mjs`, function `checkLocaleResources`) flags any key present in one locale but absent from another and fails the check. Do not rely on a future length-assertion pass to catch the mismatch — the atomic-coverage rule is enforced today via `missing-key`. A separate length-assertion pass is only about *budget* enforcement, not coverage.
 
    **Go-forward vs. grandfathered.** A different suffix convention already exists in the codebase — camelCase `Short` (e.g. `conversationList.minutesAgoShort`, `filePreview.pdf.noBookmarksShort`, `globalSearch.aggregated.messagesShort`, `subscribers.minutesAgoShort`, `dmworkskillmarket:reuploadShort`). Those keys are **grandfathered**; do not migrate them just to change the suffix. For **new** constrained-container keys, prefer the dotted `.short` sibling because it groups with its base in flat JSON and is trivial for `i18n:check` to pair up. Whichever convention a caller uses, the atomic-locale-coverage rule above still applies.
 
@@ -247,8 +247,8 @@ Add rows to this table when a new narrow container is discovered. Do not delete 
 
 ### Verification Checklist (for PRs touching constrained layouts)
 
-- [ ] `pnpm i18n:check` passes.
-- [ ] Every locale file (`zh-CN`, `en-US`, and any future locales) carries the `.short` (or grandfathered `Short`) sibling atomically — no locale is missing it if any locale has it.
+- [ ] `pnpm i18n:check` passes — this already enforces atomic locale coverage via its `missing-key` rule.
+- [ ] Every locale file (`zh-CN`, `en-US`, and any future locales) carries the `.short` (or grandfathered `Short`) sibling atomically — no locale is missing it if any locale has it. (Enforced by `pnpm i18n:check` above; the manual bullet is a reminder.)
 - [ ] Call sites in constrained containers select the short/base key explicitly, not via a `t(..., { defaultValue: t(base) })` fallback (which leaks zh-CN into en-US when only one locale has the sibling).
 - [ ] Manual browser verification in both `zh-CN` and `en-US` for the touched screens.
 - [ ] Ellipsis-truncated elements have **both** `title` (visible hover tooltip) and an accessible name (`aria-label` or equivalent).


### PR DESCRIPTION
## Summary

Adds a `Copy Length Budgets & Constrained Layouts` section to `docs/i18n-agent-guide.md` — the missing layer between "translate copy" and "verify layout". Existing guide only says *"verify both languages if layout may be affected"*; there was no budget table, no constrained-container inventory, no expansion-ratio reference.

Closes #1631
WS-217

## What's new in the guide

- **Expansion-ratio table** — W3C / IBM figures (marked English-source; treated as a lower bound for zh-source) + real Octo examples (`前天` → `The day before yesterday`, 12× expansion; `智能总结` → `AI Summary`, 2.5×).
- **Constrained container inventory** — starter table with character budgets, derived from current CSS and current formatter outputs:
  - NavRail label (**collapsed rail**) — **≤ 8 chars**, called out as a deliberate design carve-out (fixed 56 px icon-first grid).
  - Chat list date column — **≤ 16 chars**, sized to cover realistic outputs from `getTimeStringAutoShort2` (`Yesterday 21:34`, `2026/12/26 10:00`, `Wednesday 10:30`).
  - Tab title ≤ 12; primary button (fixed-width toolbar) ≤ 18; fixed-width table header ≤ 14.
  - Meant to grow as new narrow containers are discovered.
- **Four design layers**, in preference order:
  1. Reserve space in the layout (with deliberate carve-outs like the collapsed NavRail explicitly noted).
  2. **`.short` variant keys — proposed convention**, not an existing helper. Layer 2 documents the actual `t()` fallback chain (active locale → default locale `zh-CN` → `defaultValue` → raw key), forbids the `t(..., { defaultValue: t(base) })` fallback recipe (which silently leaks zh-CN into en-US when only one locale has the sibling), and **hard-requires atomic locale coverage** (any locale has `foo.short` ⇒ every locale has `foo.short`). Callers pick the short/base key explicitly at the call site by container. Atomic coverage is already enforced today by `pnpm i18n:check`'s `missing-key` rule. Existing camelCase `Short` keys (`conversationList.minutesAgoShort`, etc.) are grandfathered — same atomicity rule applies.
  3. Locale-sensitive short formats for dates/times/numbers via `format.*` / `Intl`, never via translated phrase keys.
  4. Truncation + tooltip as last resort, with `title` (visible hover tooltip) and `aria-label` (accessible name) both required — they are not interchangeable.
- **Anti-patterns** and **PR verification checklist** for changes touching constrained layouts.
- **References**: W3C, IBM Globalization, Material Design 3, Apple HIG, SimpleLocalize.

## Scope guard

Docs-only change; **no code, no i18n resources, no CI changes**. Bug fixes for the existing NavRail / date-column truncation, CI length assertions, and the full-site audit are tracked as separate tasks and are intentionally out of scope here.

## Verification

- No build / test / lint impact (single-file docs edit).
- Rendered locally; MD renders correctly with tables and reference links.
