### PR TITLE
fix(conversation-list): resolve stale mentions and bubble collapsed threads

### DIFF
--- a/packages/dmworkbase/src/Components/CategoryHeader/__tests__/CategoryHeader.test.tsx
+++ b/packages/dmworkbase/src/Components/CategoryHeader/__tests__/CategoryHeader.test.tsx
@@ -70,6 +70,32 @@ describe("CategoryHeader drag handle", () => {
   });
 });
 
+describe("CategoryHeader collapsed badges", () => {
+  it("shows an unresolved mention even when unread is zero", () => {
+    act(() => {
+      ReactDOM.render(
+        <CategoryHeader
+          name="研发"
+          unreadCount={0}
+          hasMention
+          isCollapsed
+          onToggle={vi.fn()}
+        />,
+        container
+      );
+    });
+
+    expect(
+      container.querySelector(".wk-category-header__badge--mention")
+    ).not.toBeNull();
+    expect(
+      container.querySelector(
+        ".wk-category-header__badge:not(.wk-category-header__badge--mention)"
+      )
+    ).toBeNull();
+  });
+});
+
 describe("CategoryHeader management menu", () => {
   it("renders an accessible MoreHorizontal button only when an action is available", () => {
     const onToggle = vi.fn();

--- a/packages/dmworkbase/src/Components/CategoryHeader/index.tsx
+++ b/packages/dmworkbase/src/Components/CategoryHeader/index.tsx
@@ -160,11 +160,13 @@ const CategoryHeader: React.FC<CategoryHeaderProps> = ({
                 ) : null}
             </span>
             {/* 分组折叠时才显示角标，展开时隐藏 */}
-            {isCollapsed && !isEmpty && !!unreadCount && unreadCount > 0 && (
+            {isCollapsed && !isEmpty && ((unreadCount ?? 0) > 0 || hasMention) && (
                 <span className="wk-category-header__badges">
-                    <span className="wk-category-header__badge">
-                        {unreadCount > 99 ? "99+" : unreadCount}
-                    </span>
+                    {(unreadCount ?? 0) > 0 && (
+                        <span className="wk-category-header__badge">
+                            {(unreadCount ?? 0) > 99 ? "99+" : unreadCount}
+                        </span>
+                    )}
                     {hasMention && (
                         <span className="wk-category-header__badge wk-category-header__badge--mention">@</span>
                     )}

--- a/packages/dmworkbase/src/Components/Conversation/__tests__/messageOrder.test.ts
+++ b/packages/dmworkbase/src/Components/Conversation/__tests__/messageOrder.test.ts
@@ -1322,7 +1322,10 @@ describe("ConversationVM message ordering", () => {
         vm.browseToMessageSeq = 3
         sdkState.conversationListener(conversation, "update")
         expect(conversation.unread).toBe(0)
-        expect(conversation.isMentionMe).toBe(false)
+        // 已读到底不再主动清 SDK 的 isMentionMe（WS-213 方案 A）：
+        // 权威源是 ConversationWrap.isMentionMe getter（reminders + lastMessage.mention.uids），
+        // 前端不再重复覆盖 SDK 内的 field。
+        expect(conversation.isMentionMe).toBe(true)
 
         const base: any = { channel: new Channel("u1", 1), header: {}, contentType: 1, send: false, fromUID: "u2", clientMsgNo: "new" }
         sdkState.messageListener({ ...base, channel: new Channel("other", 1) })

--- a/packages/dmworkbase/src/Components/Conversation/__tests__/messageOrder.test.ts
+++ b/packages/dmworkbase/src/Components/Conversation/__tests__/messageOrder.test.ts
@@ -1316,16 +1316,20 @@ describe("ConversationVM message ordering", () => {
         vm.browseToMessageSeq = 1
         vm.didMount()
 
-        const conversation: any = { channel: new Channel("u1", 1), unread: 3, isMentionMe: true }
+        let mentionWrites = 0
+        const conversation: any = { channel: new Channel("u1", 1), unread: 3 }
+        Object.defineProperty(conversation, "isMentionMe", {
+            configurable: true,
+            get: () => true,
+            set: () => { mentionWrites += 1 },
+        })
         sdkState.conversationListener(conversation, "update")
         expect(vm.unreadCount).toBe(3)
         vm.browseToMessageSeq = 3
         sdkState.conversationListener(conversation, "update")
         expect(conversation.unread).toBe(0)
-        // 已读到底不再主动清 SDK 的 isMentionMe（WS-213 方案 A）：
-        // 权威源是 ConversationWrap.isMentionMe getter（reminders + lastMessage.mention.uids），
-        // 前端不再重复覆盖 SDK 内的 field。
-        expect(conversation.isMentionMe).toBe(true)
+        // 已读到底不再写 SDK 的 isMentionMe；权威源是 ConversationWrap getter。
+        expect(mentionWrites).toBe(0)
 
         const base: any = { channel: new Channel("u1", 1), header: {}, contentType: 1, send: false, fromUID: "u2", clientMsgNo: "new" }
         sdkState.messageListener({ ...base, channel: new Channel("other", 1) })

--- a/packages/dmworkbase/src/Components/Conversation/vm.ts
+++ b/packages/dmworkbase/src/Components/Conversation/vm.ts
@@ -950,8 +950,6 @@ export default class ConversationVM extends ProviderListener {
                         // 确保 SDK 缓存的 Conversation 对象与本地已读状态保持一致
                         conversation.unread = 0
                     }
-                    // 用户已读到底，同步清 SDK 的 isMentionMe，防止新消息到来时角标误显示
-                    conversation.isMentionMe = false
                 }
                 this.unreadCount = conversation.unread
             }

--- a/packages/dmworkbase/src/Components/ConversationList/__tests__/layout.test.tsx
+++ b/packages/dmworkbase/src/Components/ConversationList/__tests__/layout.test.tsx
@@ -359,7 +359,7 @@ describe("ConversationList unread indicators", () => {
     ).toBe("14");
   });
 
-  it("renders mention and muted unread count together", () => {
+  it("hides the mention marker in a muted conversation but keeps the muted unread count", () => {
     act(() => {
       ReactDOM.render(
         <ConversationList
@@ -375,9 +375,8 @@ describe("ConversationList unread indicators", () => {
       ".wk-conversationlist-item-indicators"
     );
 
-    expect(indicators?.querySelector(".wk-mention")?.textContent).toBe(
-      "base.conversationList.mentionMarker"
-    );
+    // WS-213 方案 A + 对齐 category header：免打扰群不亮 @我 标签
+    expect(indicators?.querySelector(".wk-mention")).toBeNull();
     expect(
       indicators?.querySelector(".wk-conv-unread-num--muted")?.textContent
     ).toBe("5");

--- a/packages/dmworkbase/src/Components/ConversationList/__tests__/layout.test.tsx
+++ b/packages/dmworkbase/src/Components/ConversationList/__tests__/layout.test.tsx
@@ -239,8 +239,13 @@ function makeConversation(options: {
   unread: number;
   mention?: boolean;
   mute?: boolean;
+  channelType?: number;
+  channelID?: string;
 }) {
-  const channel = makeChannel("alice");
+  const channel = makeChannel(
+    options.channelID ?? "alice",
+    options.channelType ?? 1
+  );
   return {
     channel,
     channelInfo: {
@@ -250,7 +255,7 @@ function makeConversation(options: {
       lastOffline: 0,
       top: false,
       orgData: {
-        displayName: "Alice",
+        displayName: options.channelID ?? "Alice",
       },
     },
     unread: options.unread,
@@ -375,11 +380,65 @@ describe("ConversationList unread indicators", () => {
       ".wk-conversationlist-item-indicators"
     );
 
-    // WS-213 方案 A + 对齐 category header：免打扰群不亮 @我 标签
-    expect(indicators?.querySelector(".wk-mention")).toBeNull();
+    // WS-213 review 反馈 P1-2：mute 语义反转需要产品拍板，暂保持既有行为——
+    // 免打扰群里的直接 @我 仍然点亮 marker（与 v1 shipped 行为一致）。
+    expect(indicators?.querySelector(".wk-mention")?.textContent).toBe(
+      "base.conversationList.mentionMarker"
+    );
     expect(
       indicators?.querySelector(".wk-conv-unread-num--muted")?.textContent
     ).toBe("5");
+  });
+
+  it("keeps the mention marker after unread has been cleared (WS-213 core)", () => {
+    // 回归 WS-213 主 case：thread 里 @我 → 读到底（unread=0）→ 返回列表 → 仍显示 @我
+    act(() => {
+      ReactDOM.render(
+        <ConversationList
+          conversations={
+            [makeConversation({ unread: 0, mention: true })] as any
+          }
+        />,
+        container
+      );
+    });
+
+    const indicators = container.querySelector(
+      ".wk-conversationlist-item-indicators"
+    );
+
+    expect(indicators?.querySelector(".wk-mention")?.textContent).toBe(
+      "base.conversationList.mentionMarker"
+    );
+  });
+
+  it("renders the mention marker on a group channel with cleared unread", () => {
+    // 群聊是 WS-213 的主要目标。previous fixtures 都是 Person，缺少 group 覆盖。
+    act(() => {
+      ReactDOM.render(
+        <ConversationList
+          conversations={
+            [
+              makeConversation({
+                unread: 0,
+                mention: true,
+                channelType: 2,
+                channelID: "team-room",
+              }),
+            ] as any
+          }
+        />,
+        container
+      );
+    });
+
+    const indicators = container.querySelector(
+      ".wk-conversationlist-item-indicators"
+    );
+
+    expect(indicators?.querySelector(".wk-mention")?.textContent).toBe(
+      "base.conversationList.mentionMarker"
+    );
   });
 
   it("renders the 1v1 unread-priority marker for an unread DM without mention", () => {

--- a/packages/dmworkbase/src/Components/ConversationList/__tests__/layout.test.tsx
+++ b/packages/dmworkbase/src/Components/ConversationList/__tests__/layout.test.tsx
@@ -270,7 +270,8 @@ function makeConversation(options: {
 function makeCompactConversation(
   channelID: string,
   channelType: number,
-  parentGroupNo?: string
+  parentGroupNo?: string,
+  options: { isMentionMe?: boolean; unread?: number } = {}
 ) {
   const channel = makeChannel(channelID, channelType);
   return {
@@ -284,8 +285,8 @@ function makeCompactConversation(
         parentGroupNo,
       },
     },
-    unread: 0,
-    isMentionMe: false,
+    unread: options.unread ?? 0,
+    isMentionMe: !!options.isMentionMe,
     simpleReminders: [],
     remoteExtra: {},
     timestamp: 1,
@@ -364,7 +365,7 @@ describe("ConversationList unread indicators", () => {
     ).toBe("14");
   });
 
-  it("hides the mention marker in a muted conversation but keeps the muted unread count", () => {
+  it("keeps the mention marker in a muted conversation alongside the muted unread count", () => {
     act(() => {
       ReactDOM.render(
         <ConversationList
@@ -580,6 +581,90 @@ describe("ConversationList unread indicators", () => {
         ".wk-conv-compact-item--thread .wk-conv-compact-drag-handle"
       )
     ).toBeNull();
+  });
+
+  it("bubbles @我 from a collapsed thread onto the parent group row (WS-213 rev 3, P2-2)", () => {
+    // 折叠态：thread 行不显示，父群行应通过 collapsedThreadHasMention 冒泡出 @我 marker。
+    // 覆盖 renderItem → conversationItem → CompactGroupItem 的整条 wiring，
+    // 而不只是 unread.ts 里的 helper 单测。
+    const parent = makeCompactConversation("group-a", 2);
+    const thread = makeCompactConversation("thread-a", 3, "group-a", {
+      isMentionMe: true,
+    });
+
+    act(() => {
+      ReactDOM.render(
+        <ConversationList
+          conversations={[parent, thread] as any}
+          compact
+          disablePinSplit
+        />,
+        container
+      );
+    });
+
+    // 强制进入 collapsed：如果当前是 expanded，点一下 toggle 收起。
+    const toggle = container.querySelector(
+      ".wk-conv-compact-thread-tag"
+    ) as HTMLElement;
+    expect(toggle).not.toBeNull();
+    if (toggle.querySelector(".lucide-chevron-down")) {
+      act(() => {
+        toggle.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      });
+    }
+
+    expect(
+      container.querySelectorAll(".wk-conv-compact-item--thread")
+    ).toHaveLength(0);
+
+    const parentRow = container.querySelector(
+      ".wk-conv-compact-item--has-threads"
+    );
+    expect(parentRow).not.toBeNull();
+    expect(parentRow?.querySelector(".wk-conv-compact-mention")).not.toBeNull();
+  });
+
+  it("does not double-light @我 when the thread is expanded (WS-213 rev 3, P2-2)", () => {
+    // 展开态：thread 行自己亮 @我，父群行不应再冒泡（否则同一 mention 亮两次）。
+    const parent = makeCompactConversation("group-a", 2);
+    const thread = makeCompactConversation("thread-a", 3, "group-a", {
+      isMentionMe: true,
+    });
+
+    act(() => {
+      ReactDOM.render(
+        <ConversationList
+          conversations={[parent, thread] as any}
+          compact
+          disablePinSplit
+        />,
+        container
+      );
+    });
+
+    // 强制进入 expanded：如果当前 collapsed，点一下 toggle 展开。
+    const toggle = container.querySelector(
+      ".wk-conv-compact-thread-tag"
+    ) as HTMLElement;
+    expect(toggle).not.toBeNull();
+    if (toggle.querySelector(".lucide-chevron-right")) {
+      act(() => {
+        toggle.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      });
+    }
+
+    expect(
+      container.querySelectorAll(".wk-conv-compact-item--thread")
+    ).toHaveLength(1);
+
+    const parentRow = container.querySelector(
+      ".wk-conv-compact-item--has-threads"
+    );
+    expect(parentRow?.querySelector(".wk-conv-compact-mention")).toBeNull();
+
+    const threadRow = container.querySelector(".wk-conv-compact-item--thread");
+    expect(threadRow?.querySelector(".wk-conv-compact-mention")).not.toBeNull();
   });
 });
 

--- a/packages/dmworkbase/src/Components/ConversationList/__tests__/layout.test.tsx
+++ b/packages/dmworkbase/src/Components/ConversationList/__tests__/layout.test.tsx
@@ -391,8 +391,10 @@ describe("ConversationList unread indicators", () => {
     ).toBe("5");
   });
 
-  it("keeps the mention marker after unread has been cleared (WS-213 core)", () => {
-    // 回归 WS-213 主 case：thread 里 @我 → 读到底（unread=0）→ 返回列表 → 仍显示 @我
+  it("renders an authoritative mention signal independently of the row unread count", () => {
+    // 这里只验证渲染层契约：上游已经判定 isMentionMe=true 时，不再由行级 unread
+    // 二次屏蔽。读到底后该信号是否仍为 true，由 ConversationWrap 的 reminder/
+    // read-watermark 规则决定并在 Model.test.ts 中覆盖。
     act(() => {
       ReactDOM.render(
         <ConversationList
@@ -413,8 +415,8 @@ describe("ConversationList unread indicators", () => {
     );
   });
 
-  it("renders the mention marker on a group channel with cleared unread", () => {
-    // 群聊是 WS-213 的主要目标。previous fixtures 都是 Person，缺少 group 覆盖。
+  it("renders an authoritative mention signal on a group row with zero unread", () => {
+    // 群聊是 WS-213 的主要目标；本用例只验证行组件消费已解析 mention 信号的行为。
     act(() => {
       ReactDOM.render(
         <ConversationList
@@ -623,6 +625,49 @@ describe("ConversationList unread indicators", () => {
     );
     expect(parentRow).not.toBeNull();
     expect(parentRow?.querySelector(".wk-conv-compact-mention")).not.toBeNull();
+  });
+
+  it("does not revive an acknowledged parent mention from ordinary collapsed thread unread (#1625)", () => {
+    // Model 层已将父群的历史 mention 解析为 false；子区只有普通未读。
+    // 折叠后父群应聚合 unread，但不能把该 unread 与父群历史 mention 重新组合。
+    const parent = makeCompactConversation("group-read", 2, undefined, {
+      isMentionMe: false,
+      unread: 0,
+    });
+    const thread = makeCompactConversation("thread-plain", 3, "group-read", {
+      isMentionMe: false,
+      unread: 1,
+    });
+
+    act(() => {
+      ReactDOM.render(
+        <ConversationList
+          conversations={[parent, thread] as any}
+          compact
+          disablePinSplit
+        />,
+        container
+      );
+    });
+
+    const toggle = container.querySelector(
+      ".wk-conv-compact-thread-tag"
+    ) as HTMLElement;
+    expect(toggle).not.toBeNull();
+    if (toggle.querySelector(".lucide-chevron-down")) {
+      act(() => {
+        toggle.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      });
+    }
+
+    const parentRow = container.querySelector(
+      ".wk-conv-compact-item--has-threads"
+    );
+    expect(parentRow).not.toBeNull();
+    expect(parentRow?.querySelector(".wk-conv-compact-mention")).toBeNull();
+    expect(parentRow?.querySelector(".wk-conv-compact-badge")?.textContent).toBe(
+      "1"
+    );
   });
 
   it("does not double-light @我 when the thread is expanded (WS-213 rev 3, P2-2)", () => {

--- a/packages/dmworkbase/src/Components/ConversationList/__tests__/layout.test.tsx
+++ b/packages/dmworkbase/src/Components/ConversationList/__tests__/layout.test.tsx
@@ -16,6 +16,9 @@ import {
 } from "vitest";
 
 let ConversationList: typeof import("../index").default;
+let ActualConversationWrap: typeof import(
+  "../../../Service/Model"
+).ConversationWrap;
 let container: HTMLDivElement;
 const apiPut = vi.fn();
 const toastError = vi.fn();
@@ -47,6 +50,7 @@ beforeAll(async () => {
   vi.doMock("wukongimjssdk", () => {
     const sdk = {
       shared: () => ({
+        config: { uid: "u1" },
         channelManager: {
           addListener: vi.fn(),
           removeListener: vi.fn(),
@@ -128,10 +132,15 @@ beforeAll(async () => {
     },
   }));
 
-  vi.doMock("../../../Service/Const", () => ({
-    ChannelTypeCommunityTopic: 3,
-    EndpointID: {},
-  }));
+  vi.doMock("../../../Service/Const", async () => {
+    const actual = await vi.importActual<
+      typeof import("../../../Service/Const")
+    >("../../../Service/Const");
+    return {
+      ...actual,
+      ChannelTypeCommunityTopic: 3,
+    };
+  });
 
   vi.doMock("../../../Service/Thread", async () => {
     const actual = await vi.importActual<typeof import("../../../Service/Thread")>(
@@ -166,6 +175,23 @@ beforeAll(async () => {
     muteChannelSetting: vi.fn(() => Promise.resolve()),
     topChannelSetting,
   }));
+
+  vi.doMock("../../../Service/EmojiService", () => ({
+    DefaultEmojiService: {
+      shared: { emojiRegExp: () => /(?!)/ },
+    },
+  }));
+
+  vi.doMock("../../../Service/SpaceService", () => ({
+    getSpaceFilteredLastMessage: (conversation: any) =>
+      conversation.lastMessage,
+    SYSTEM_BOTS: new Set(),
+  }));
+
+  const actualModel = await vi.importActual<
+    typeof import("../../../Service/Model")
+  >("../../../Service/Model");
+  ActualConversationWrap = actualModel.ConversationWrap;
 
   vi.doMock("../../../Service/Model", () => ({
     MessageWrap: class {},
@@ -292,6 +318,18 @@ function makeCompactConversation(
     timestamp: 1,
     lastMessage: undefined,
   };
+}
+
+function makeReadMentionConversation(channelID: string) {
+  const raw = makeCompactConversation(channelID, 2, undefined, { unread: 0 });
+  return new ActualConversationWrap({
+    ...raw,
+    reminders: [],
+    lastMessage: {
+      channel: raw.channel,
+      content: { mention: { uids: ["u1"] } },
+    },
+  } as any);
 }
 
 function openContextMenu(selector: string) {
@@ -628,12 +666,9 @@ describe("ConversationList unread indicators", () => {
   });
 
   it("does not revive an acknowledged parent mention from ordinary collapsed thread unread (#1625)", () => {
-    // Model 层已将父群的历史 mention 解析为 false；子区只有普通未读。
-    // 折叠后父群应聚合 unread，但不能把该 unread 与父群历史 mention 重新组合。
-    const parent = makeCompactConversation("group-read", 2, undefined, {
-      isMentionMe: false,
-      unread: 0,
-    });
+    // 父群最后一条消息仍然 @我，但 unread 已清零且 reminder 重载后为空。
+    // 这里使用真实 ConversationWrap getter，确保子区普通未读不能重新暴露历史 mention。
+    const parent = makeReadMentionConversation("group-read");
     const thread = makeCompactConversation("thread-plain", 3, "group-read", {
       isMentionMe: false,
       unread: 1,
@@ -660,6 +695,9 @@ describe("ConversationList unread indicators", () => {
       });
     }
 
+    expect(
+      container.querySelectorAll(".wk-conv-compact-item--thread")
+    ).toHaveLength(0);
     const parentRow = container.querySelector(
       ".wk-conv-compact-item--has-threads"
     );

--- a/packages/dmworkbase/src/Components/ConversationList/__tests__/layout.test.tsx
+++ b/packages/dmworkbase/src/Components/ConversationList/__tests__/layout.test.tsx
@@ -23,6 +23,9 @@ let container: HTMLDivElement;
 const apiPut = vi.fn();
 const toastError = vi.fn();
 const notifyConversationListeners = vi.fn();
+const reminderDone = vi.fn(() => Promise.resolve());
+const mittEmit = vi.fn();
+const browserUnreadPublish = vi.fn();
 const topChannelSetting = vi.fn(() => Promise.resolve());
 
 class MockChannel {
@@ -59,6 +62,9 @@ beforeAll(async () => {
         },
         conversationManager: {
           notifyConversationListeners,
+        },
+        reminderManager: {
+          done: reminderDone,
         },
       }),
     };
@@ -129,7 +135,14 @@ beforeAll(async () => {
       },
       apiClient: { put: apiPut },
       conversationProvider: { deleteConversation: vi.fn() },
+      mittBus: { emit: mittEmit },
     },
+  }));
+
+  vi.doMock("../../../features/documentTitle", () => ({
+    getBrowserUnreadConversationSync: () => ({
+      publish: browserUnreadPublish,
+    }),
   }));
 
   vi.doMock("../../../Service/Const", async () => {
@@ -863,9 +876,13 @@ describe("ConversationList context-menu matrix", () => {
   });
 
   it("keeps unread state and reports an error when clear-unread fails", async () => {
+    const reminders = [
+      { reminderID: 7, messageSeq: 10, reminderType: 1, done: false },
+    ];
     const conversation = {
       ...makeConversation({ unread: 5 }),
-      conversation: { unread: 5, extra: {} },
+      reminders,
+      conversation: { unread: 5, extra: {}, reminders },
     };
     const error = new Error("clear failed");
     apiPut.mockRejectedValueOnce(error);
@@ -892,6 +909,40 @@ describe("ConversationList context-menu matrix", () => {
       unread: 0,
     });
     expect(conversation.conversation.unread).toBe(5);
+    expect(reminderDone).not.toHaveBeenCalled();
     expect(toastError).toHaveBeenCalledWith("base.conversationList.error.clearUnreadFailed");
+  });
+
+  it("marks unresolved mention reminders done when marking a conversation as read", async () => {
+    const reminders = [
+      { reminderID: 7, messageSeq: 10, reminderType: 1, done: false },
+      { reminderID: 8, messageSeq: 9, reminderType: 1, done: true },
+      { reminderID: 9, messageSeq: 8, reminderType: 2, done: false },
+    ];
+    const conversation = {
+      ...makeConversation({ unread: 5, mention: true }),
+      reminders,
+      conversation: { unread: 5, extra: {}, reminders },
+    };
+    apiPut.mockResolvedValueOnce({});
+
+    act(() => {
+      ReactDOM.render(
+        <ConversationList conversations={[conversation] as any} />,
+        container
+      );
+    });
+    openContextMenu(".wk-conversationlist-item");
+
+    await act(async () => {
+      (container.querySelector(
+        '[data-menu-title="base.conversationList.context.markAsRead"]'
+      ) as HTMLElement).click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(conversation.conversation.unread).toBe(0);
+    expect(reminderDone).toHaveBeenCalledWith([7]);
   });
 });

--- a/packages/dmworkbase/src/Components/ConversationList/__tests__/unread.test.ts
+++ b/packages/dmworkbase/src/Components/ConversationList/__tests__/unread.test.ts
@@ -1,11 +1,25 @@
 import { describe, expect, it } from "vitest"
-import { collapsedThreadUnread } from "../unread"
+import { collapsedThreadHasMention, collapsedThreadUnread } from "../unread"
 
 const thread = (
   unread: number,
   mute?: number | null
 ) => ({
   unread,
+  channelInfo: {
+    orgData: {
+      thread: {
+        mute,
+      },
+    },
+  },
+})
+
+const mentionThread = (
+  isMentionMe: boolean,
+  mute?: number | null
+) => ({
+  isMentionMe,
   channelInfo: {
     orgData: {
       thread: {
@@ -30,5 +44,53 @@ describe("collapsedThreadUnread", () => {
 
   it("keeps all Threads muted when their parent is muted", () => {
     expect(collapsedThreadUnread([thread(3), thread(2, 0)], true, true)).toBe(0)
+  })
+})
+
+describe("collapsedThreadHasMention", () => {
+  it("returns false for empty thread list", () => {
+    expect(collapsedThreadHasMention([], false, true)).toBe(false)
+  })
+
+  it("returns false when includeCollapsed is disabled", () => {
+    expect(
+      collapsedThreadHasMention([mentionThread(true)], false, false)
+    ).toBe(false)
+  })
+
+  it("returns true when any unmuted thread has @我", () => {
+    expect(
+      collapsedThreadHasMention(
+        [mentionThread(false), mentionThread(true)],
+        false,
+        true
+      )
+    ).toBe(true)
+  })
+
+  it("ignores mentions inside muted threads", () => {
+    expect(
+      collapsedThreadHasMention([mentionThread(true, 1)], false, true)
+    ).toBe(false)
+  })
+
+  it("ignores mentions when parent group is muted (parent mute cascades)", () => {
+    expect(
+      collapsedThreadHasMention(
+        [mentionThread(true), mentionThread(true, 0)],
+        true,
+        true
+      )
+    ).toBe(false)
+  })
+
+  it("returns false when no thread carries @我", () => {
+    expect(
+      collapsedThreadHasMention(
+        [mentionThread(false), mentionThread(false)],
+        false,
+        true
+      )
+    ).toBe(false)
   })
 })

--- a/packages/dmworkbase/src/Components/ConversationList/__tests__/unread.test.ts
+++ b/packages/dmworkbase/src/Components/ConversationList/__tests__/unread.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from "vitest"
 import {
   collapsedThreadHasMention,
   collapsedThreadUnread,
-  hasMentionForRow,
 } from "../unread"
 
 const thread = (
@@ -81,24 +80,5 @@ describe("collapsedThreadHasMention", () => {
         true
       )
     ).toBe(false)
-  })
-})
-
-describe("hasMentionForRow", () => {
-  it("returns true if the row itself is @我", () => {
-    expect(hasMentionForRow(true, false)).toBe(true)
-  })
-
-  it("returns true if a collapsed thread bubbles @我", () => {
-    expect(hasMentionForRow(false, true)).toBe(true)
-  })
-
-  it("returns false when neither source is active", () => {
-    expect(hasMentionForRow(false, false)).toBe(false)
-  })
-
-  it("does not couple to unread — bubbles mention with zero unread", () => {
-    // 回归 WS-213：读到底后 unread=0，@我 仍要显示。行为已完全解耦。
-    expect(hasMentionForRow(true, false)).toBe(true)
   })
 })

--- a/packages/dmworkbase/src/Components/ConversationList/__tests__/unread.test.ts
+++ b/packages/dmworkbase/src/Components/ConversationList/__tests__/unread.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest"
-import { collapsedThreadHasMention, collapsedThreadUnread } from "../unread"
+import {
+  collapsedThreadHasMention,
+  collapsedThreadUnread,
+  hasMentionForRow,
+} from "../unread"
 
 const thread = (
   unread: number,
@@ -49,48 +53,52 @@ describe("collapsedThreadUnread", () => {
 
 describe("collapsedThreadHasMention", () => {
   it("returns false for empty thread list", () => {
-    expect(collapsedThreadHasMention([], false, true)).toBe(false)
+    expect(collapsedThreadHasMention([], true)).toBe(false)
   })
 
   it("returns false when includeCollapsed is disabled", () => {
-    expect(
-      collapsedThreadHasMention([mentionThread(true)], false, false)
-    ).toBe(false)
+    expect(collapsedThreadHasMention([mentionThread(true)], false)).toBe(false)
   })
 
-  it("returns true when any unmuted thread has @我", () => {
+  it("returns true when any thread has @我", () => {
     expect(
       collapsedThreadHasMention(
         [mentionThread(false), mentionThread(true)],
-        false,
         true
       )
     ).toBe(true)
   })
 
-  it("ignores mentions inside muted threads", () => {
-    expect(
-      collapsedThreadHasMention([mentionThread(true, 1)], false, true)
-    ).toBe(false)
-  })
-
-  it("ignores mentions when parent group is muted (parent mute cascades)", () => {
-    expect(
-      collapsedThreadHasMention(
-        [mentionThread(true), mentionThread(true, 0)],
-        true,
-        true
-      )
-    ).toBe(false)
+  it("still bubbles mention from a muted thread (mute is not filtered)", () => {
+    // 行为对齐父群行 hasMention：mute 不抑制 @我 marker
+    expect(collapsedThreadHasMention([mentionThread(true, 1)], true)).toBe(true)
   })
 
   it("returns false when no thread carries @我", () => {
     expect(
       collapsedThreadHasMention(
         [mentionThread(false), mentionThread(false)],
-        false,
         true
       )
     ).toBe(false)
+  })
+})
+
+describe("hasMentionForRow", () => {
+  it("returns true if the row itself is @我", () => {
+    expect(hasMentionForRow(true, false)).toBe(true)
+  })
+
+  it("returns true if a collapsed thread bubbles @我", () => {
+    expect(hasMentionForRow(false, true)).toBe(true)
+  })
+
+  it("returns false when neither source is active", () => {
+    expect(hasMentionForRow(false, false)).toBe(false)
+  })
+
+  it("does not couple to unread — bubbles mention with zero unread", () => {
+    // 回归 WS-213：读到底后 unread=0，@我 仍要显示。行为已完全解耦。
+    expect(hasMentionForRow(true, false)).toBe(true)
   })
 })

--- a/packages/dmworkbase/src/Components/ConversationList/index.tsx
+++ b/packages/dmworkbase/src/Components/ConversationList/index.tsx
@@ -51,7 +51,7 @@ import AiBadge from "../AiBadge";
 import ConversationVM from "../Conversation/vm";
 import { I18nContext, t, useI18n } from "../../i18n";
 import { formatDraftPreview } from "../../Utils/draftPreview";
-import { collapsedThreadUnread } from "./unread";
+import { collapsedThreadHasMention, collapsedThreadUnread } from "./unread";
 import { shouldShowExternalBadge } from "./externalBadge";
 import {
   addImChannelInfoListener,
@@ -129,6 +129,8 @@ interface CompactGroupItemProps {
   onToggleThreads?: (e: React.MouseEvent) => void;
   /** 折叠时子区的未读数（展开时为 0） */
   threadUnread?: number;
+  /** 折叠时子区是否有 @我（展开时为 false），用于父群行冒泡显示 @我 标签 */
+  threadHasMention?: boolean;
 }
 
 const CompactGroupItem: React.FC<CompactGroupItemProps> = ({
@@ -142,10 +144,10 @@ const CompactGroupItem: React.FC<CompactGroupItemProps> = ({
   threadsExpanded,
   onToggleThreads,
   threadUnread = 0,
+  threadHasMention = false,
 }) => {
   const { t } = useI18n();
   const totalUnread = conversationWrap.unread + threadUnread;
-  const hasMention = conversationWrap.isMentionMe && totalUnread > 0;
   const channelInfo = conversationWrap.channelInfo;
   // channelInfo 未加载时主动拉取，加载完触发 re-render
   React.useEffect(() => {
@@ -183,6 +185,10 @@ const CompactGroupItem: React.FC<CompactGroupItemProps> = ({
     channelInfo,
     parentChannelInfo,
   });
+  // @我 标签：解绑「必须有未读」的旧规则，只跟随权威 mention 状态 + 静音语义。
+  // reminders 或 lastMessage.mention.uids 命中都算；折叠子区里的 @我 冒泡到父群行。
+  const hasMention =
+    (conversationWrap.isMentionMe || threadHasMention) && !effectiveMute;
 
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
     useSortable({
@@ -704,7 +710,8 @@ export default class ConversationList extends Component<
   conversationItem(
     conversationWrap: ConversationWrap,
     hasThreads = false,
-    threadUnread = 0
+    threadUnread = 0,
+    threadHasMention = false
   ) {
     let channelInfo = conversationWrap.channelInfo;
     if (!channelInfo) {
@@ -751,6 +758,7 @@ export default class ConversationList extends Component<
               : false
           }
           threadUnread={threadUnread}
+          threadHasMention={threadHasMention}
           onClick={() => {
             this._trackChannelOpened(conversationWrap);
             if (this.props.onClick) this.props.onClick(conversationWrap);
@@ -788,15 +796,16 @@ export default class ConversationList extends Component<
     // parent item receives the collapsed unread count. Recent mode renders
     // threads as independent rows and must keep parent unread independent.
     const totalUnread = conversationWrap.unread + threadUnread;
-    const hasMention = conversationWrap.isMentionMe && totalUnread > 0;
-    const visibleSimpleReminders = conversationWrap.simpleReminders?.filter(
-      (r) => !r.done && r.reminderType !== ReminderType.ReminderTypeMentionMe
-    );
     const effectiveMute = isEffectivelyMuted({
       isThread,
       channelInfo,
       parentChannelInfo,
     });
+    const hasMention =
+      (conversationWrap.isMentionMe || threadHasMention) && !effectiveMute;
+    const visibleSimpleReminders = conversationWrap.simpleReminders?.filter(
+      (r) => !r.done && r.reminderType !== ReminderType.ReminderTypeMentionMe
+    );
     // 非 compact 下子区按 design v3.1 走扁平时间序，左侧用父频道头像，
     // 不再套 .wk-conversationlist-item-thread（避免缩进 + 树形连接线视觉嵌套）。
     const avatarChannel = isThread && parentChannel ? parentChannel : conversationWrap.channel;
@@ -1402,7 +1411,19 @@ export default class ConversationList extends Component<
         );
         return collapsedThreadUnread(threads, !!parentInfo?.mute, !!compact);
       })();
-      return this.conversationItem(conv, hasThreads, threadUnread);
+      // 折叠子区里的 @我 冒泡到父群行，避免子区折叠时用户看不到 @我 信号。
+      // 展开态下子区自己会亮 @我，父群行返回 false 避免同一 mention 亮两次。
+      const threadHasMention = (() => {
+        if (!hasThreads) return false;
+        if (this._isThreadExpanded(conv.channel.channelID)) return false;
+        const threads = threadsByParent.get(conv.channel.channelID) ?? [];
+        const parentInfo = getImChannelInfo(
+          WKSDK.shared(),
+          new Channel(conv.channel.channelID, ChannelTypeGroup)
+        );
+        return collapsedThreadHasMention(threads, !!parentInfo?.mute, !!compact);
+      })();
+      return this.conversationItem(conv, hasThreads, threadUnread, threadHasMention);
     };
 
     return (

--- a/packages/dmworkbase/src/Components/ConversationList/index.tsx
+++ b/packages/dmworkbase/src/Components/ConversationList/index.tsx
@@ -54,7 +54,6 @@ import { formatDraftPreview } from "../../Utils/draftPreview";
 import {
   collapsedThreadHasMention,
   collapsedThreadUnread,
-  hasMentionForRow,
 } from "./unread";
 import { shouldShowExternalBadge } from "./externalBadge";
 import {
@@ -191,11 +190,8 @@ const CompactGroupItem: React.FC<CompactGroupItemProps> = ({
   });
   // @我 标签只跟随权威 mention 源（reminders + lastMessage 兜底），不再和未读数耦合，
   // 也不做 mute 过滤——免打扰群里的直接 @我 仍然点亮（保持既有行为）。折叠子区里的 @我
-  // 通过 threadHasMention 冒泡到父群行。规则集中在 hasMentionForRow，避免多点漂移。
-  const hasMention = hasMentionForRow(
-    conversationWrap.isMentionMe,
-    threadHasMention
-  );
+  // 通过 threadHasMention 冒泡到父群行。
+  const hasMention = conversationWrap.isMentionMe || threadHasMention;
 
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
     useSortable({
@@ -808,10 +804,7 @@ export default class ConversationList extends Component<
       channelInfo,
       parentChannelInfo,
     });
-    const hasMention = hasMentionForRow(
-      conversationWrap.isMentionMe,
-      threadHasMention
-    );
+    const hasMention = conversationWrap.isMentionMe || threadHasMention;
     const visibleSimpleReminders = conversationWrap.simpleReminders?.filter(
       (r) => !r.done && r.reminderType !== ReminderType.ReminderTypeMentionMe
     );

--- a/packages/dmworkbase/src/Components/ConversationList/index.tsx
+++ b/packages/dmworkbase/src/Components/ConversationList/index.tsx
@@ -51,7 +51,11 @@ import AiBadge from "../AiBadge";
 import ConversationVM from "../Conversation/vm";
 import { I18nContext, t, useI18n } from "../../i18n";
 import { formatDraftPreview } from "../../Utils/draftPreview";
-import { collapsedThreadHasMention, collapsedThreadUnread } from "./unread";
+import {
+  collapsedThreadHasMention,
+  collapsedThreadUnread,
+  hasMentionForRow,
+} from "./unread";
 import { shouldShowExternalBadge } from "./externalBadge";
 import {
   addImChannelInfoListener,
@@ -185,10 +189,13 @@ const CompactGroupItem: React.FC<CompactGroupItemProps> = ({
     channelInfo,
     parentChannelInfo,
   });
-  // @我 标签：解绑「必须有未读」的旧规则，只跟随权威 mention 状态 + 静音语义。
-  // reminders 或 lastMessage.mention.uids 命中都算；折叠子区里的 @我 冒泡到父群行。
-  const hasMention =
-    (conversationWrap.isMentionMe || threadHasMention) && !effectiveMute;
+  // @我 标签只跟随权威 mention 源（reminders + lastMessage 兜底），不再和未读数耦合，
+  // 也不做 mute 过滤——免打扰群里的直接 @我 仍然点亮（保持既有行为）。折叠子区里的 @我
+  // 通过 threadHasMention 冒泡到父群行。规则集中在 hasMentionForRow，避免多点漂移。
+  const hasMention = hasMentionForRow(
+    conversationWrap.isMentionMe,
+    threadHasMention
+  );
 
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
     useSortable({
@@ -801,8 +808,10 @@ export default class ConversationList extends Component<
       channelInfo,
       parentChannelInfo,
     });
-    const hasMention =
-      (conversationWrap.isMentionMe || threadHasMention) && !effectiveMute;
+    const hasMention = hasMentionForRow(
+      conversationWrap.isMentionMe,
+      threadHasMention
+    );
     const visibleSimpleReminders = conversationWrap.simpleReminders?.filter(
       (r) => !r.done && r.reminderType !== ReminderType.ReminderTypeMentionMe
     );
@@ -1401,28 +1410,28 @@ export default class ConversationList extends Component<
       const hasThreads =
         conv.channel.channelType === ChannelTypeGroup &&
         threadsByParent.has(conv.channel.channelID);
-      const threadUnread = (() => {
-        if (!hasThreads) return 0;
-        if (this._isThreadExpanded(conv.channel.channelID)) return 0;
-        const threads = threadsByParent.get(conv.channel.channelID) ?? [];
-        const parentInfo = getImChannelInfo(
-          WKSDK.shared(),
-          new Channel(conv.channel.channelID, ChannelTypeGroup)
-        );
-        return collapsedThreadUnread(threads, !!parentInfo?.mute, !!compact);
-      })();
-      // 折叠子区里的 @我 冒泡到父群行，避免子区折叠时用户看不到 @我 信号。
-      // 展开态下子区自己会亮 @我，父群行返回 false 避免同一 mention 亮两次。
-      const threadHasMention = (() => {
-        if (!hasThreads) return false;
-        if (this._isThreadExpanded(conv.channel.channelID)) return false;
-        const threads = threadsByParent.get(conv.channel.channelID) ?? [];
-        const parentInfo = getImChannelInfo(
-          WKSDK.shared(),
-          new Channel(conv.channel.channelID, ChannelTypeGroup)
-        );
-        return collapsedThreadHasMention(threads, !!parentInfo?.mute, !!compact);
-      })();
+      const collapsedThreads =
+        hasThreads && !this._isThreadExpanded(conv.channel.channelID)
+          ? threadsByParent.get(conv.channel.channelID) ?? []
+          : [];
+      const parentInfoForCollapsed =
+        collapsedThreads.length > 0
+          ? getImChannelInfo(
+              WKSDK.shared(),
+              new Channel(conv.channel.channelID, ChannelTypeGroup)
+            )
+          : undefined;
+      const threadUnread = collapsedThreadUnread(
+        collapsedThreads,
+        !!parentInfoForCollapsed?.mute,
+        !!compact
+      );
+      // 折叠子区里的 @我 冒泡到父群行。展开态下 collapsedThreads=[]，返回 false，
+      // 避免子区自己那一行和父群同时亮 @我。mute 不做过滤——与父群行的 hasMention 语义一致。
+      const threadHasMention = collapsedThreadHasMention(
+        collapsedThreads,
+        !!compact
+      );
       return this.conversationItem(conv, hasThreads, threadUnread, threadHasMention);
     };
 

--- a/packages/dmworkbase/src/Components/ConversationList/index.tsx
+++ b/packages/dmworkbase/src/Components/ConversationList/index.tsx
@@ -51,6 +51,7 @@ import AiBadge from "../AiBadge";
 import ConversationVM from "../Conversation/vm";
 import { I18nContext, t, useI18n } from "../../i18n";
 import { formatDraftPreview } from "../../Utils/draftPreview";
+import { selectDoneReminderIDs } from "../Conversation/reminderDone";
 import {
   collapsedThreadHasMention,
   collapsedThreadUnread,
@@ -797,17 +798,18 @@ export default class ConversationList extends Component<
     const selected = select && select.isEqual(conversationWrap.channel);
     // compact mode nests collapsed threads under the parent group, so the
     // parent item receives the collapsed unread count. Recent mode renders
-    // threads as independent rows and must keep parent unread independent.
+    // threads as independent rows and must keep both parent unread and mention
+    // state independent from their child threads.
     const totalUnread = conversationWrap.unread + threadUnread;
+    const hasMention = conversationWrap.isMentionMe;
+    const visibleSimpleReminders = conversationWrap.simpleReminders?.filter(
+      (r) => !r.done && r.reminderType !== ReminderType.ReminderTypeMentionMe
+    );
     const effectiveMute = isEffectivelyMuted({
       isThread,
       channelInfo,
       parentChannelInfo,
     });
-    const hasMention = conversationWrap.isMentionMe || threadHasMention;
-    const visibleSimpleReminders = conversationWrap.simpleReminders?.filter(
-      (r) => !r.done && r.reminderType !== ReminderType.ReminderTypeMentionMe
-    );
     // 非 compact 下子区按 design v3.1 走扁平时间序，左侧用父频道头像，
     // 不再套 .wk-conversationlist-item-thread（避免缩进 + 树形连接线视觉嵌套）。
     const avatarChannel = isThread && parentChannel ? parentChannel : conversationWrap.channel;
@@ -1476,6 +1478,13 @@ export default class ConversationList extends Component<
                 icon: BrushCleaning,
                 onClick: () => {
                   if (!channel) return;
+                  const doneMentionReminderIDs = selectDoneReminderIDs(
+                    conv.reminders,
+                    {
+                      scrolledToBottom: true,
+                      isVisible: () => false,
+                    }
+                  );
                   void WKApp.apiClient
                     .put("conversation/clearUnread", {
                       channel_id: channel.channelID,
@@ -1508,6 +1517,11 @@ export default class ConversationList extends Component<
                         unread: 0,
                       });
                       WKApp.mittBus.emit("sidebar-reload" as any);
+                      if (doneMentionReminderIDs.length > 0) {
+                        return WKSDK.shared().reminderManager.done(
+                          doneMentionReminderIDs
+                        );
+                      }
                     })
                     .catch((err) => {
                       Toast.error(

--- a/packages/dmworkbase/src/Components/ConversationList/unread.ts
+++ b/packages/dmworkbase/src/Components/ConversationList/unread.ts
@@ -36,18 +36,25 @@ export function collapsedThreadUnread(
   }, 0)
 }
 
-// 折叠子区里的 @我 上浮到父群行。签名与 collapsedThreadUnread 对齐，静音语义共用
-// isThreadUnreadMuted（父群静音时 thread 不能单独打破，逻辑与未读聚合一致）。
+// 折叠子区里的 @我 上浮到父群行。仅判断 mention 有无，不做 mute 过滤——
+// 与父群行自己 hasMention 的语义保持一致（免打扰群里的直接 @我 仍然点亮 marker，
+// 这是产品行为，若要收紧到 mute-suppress 需要产品明确拍板并同时改动 category header）。
 // 注意：传入元素需暴露与 ConversationWrap 一致的 isMentionMe getter，
 // 才能读到 reminders + lastMessage.mention.uids 的权威源。
 export function collapsedThreadHasMention(
   threads: ThreadRowSource[],
-  parentMuted: boolean,
   includeCollapsed: boolean
 ): boolean {
   if (!includeCollapsed) return false
-  return threads.some((thread) => {
-    if (isThreadUnreadMuted(thread, parentMuted)) return false
-    return !!thread.isMentionMe
-  })
+  return threads.some((thread) => !!thread.isMentionMe)
+}
+
+// 行级 @我 展示规则的唯一定义。两个 render 路径（compact / recent）共用，
+// 避免 review 反复出现的"改一处漏一处"。参数取 ConversationWrap 的 isMentionMe
+// 与 collapsedThreadHasMention 的返回值。
+export function hasMentionForRow(
+  wrapIsMentionMe: boolean,
+  threadHasMention: boolean
+): boolean {
+  return wrapIsMentionMe || threadHasMention
 }

--- a/packages/dmworkbase/src/Components/ConversationList/unread.ts
+++ b/packages/dmworkbase/src/Components/ConversationList/unread.ts
@@ -1,7 +1,8 @@
 import { isEffectivelyMuted } from "../../Service/Thread"
 
-interface ThreadUnreadSource {
+interface ThreadRowSource {
   unread?: number
+  isMentionMe?: boolean
   channelInfo?: {
     orgData?: {
       thread?: {
@@ -12,7 +13,7 @@ interface ThreadUnreadSource {
 }
 
 export function isThreadUnreadMuted(
-  thread: ThreadUnreadSource,
+  thread: ThreadRowSource,
   parentMuted: boolean
 ): boolean {
   return isEffectivelyMuted({
@@ -23,7 +24,7 @@ export function isThreadUnreadMuted(
 }
 
 export function collapsedThreadUnread(
-  threads: ThreadUnreadSource[],
+  threads: ThreadRowSource[],
   parentMuted: boolean,
   includeCollapsedThreadUnread: boolean
 ): number {
@@ -33,4 +34,20 @@ export function collapsedThreadUnread(
     if (isThreadUnreadMuted(thread, parentMuted)) return sum
     return sum + (thread.unread || 0)
   }, 0)
+}
+
+// 折叠子区里的 @我 上浮到父群行。签名与 collapsedThreadUnread 对齐，静音语义共用
+// isThreadUnreadMuted（父群静音时 thread 不能单独打破，逻辑与未读聚合一致）。
+// 注意：传入元素需暴露与 ConversationWrap 一致的 isMentionMe getter，
+// 才能读到 reminders + lastMessage.mention.uids 的权威源。
+export function collapsedThreadHasMention(
+  threads: ThreadRowSource[],
+  parentMuted: boolean,
+  includeCollapsed: boolean
+): boolean {
+  if (!includeCollapsed) return false
+  return threads.some((thread) => {
+    if (isThreadUnreadMuted(thread, parentMuted)) return false
+    return !!thread.isMentionMe
+  })
 }

--- a/packages/dmworkbase/src/Components/ConversationList/unread.ts
+++ b/packages/dmworkbase/src/Components/ConversationList/unread.ts
@@ -48,13 +48,3 @@ export function collapsedThreadHasMention(
   if (!includeCollapsed) return false
   return threads.some((thread) => !!thread.isMentionMe)
 }
-
-// 行级 @我 展示规则的唯一定义。两个 render 路径（compact / recent）共用，
-// 避免 review 反复出现的"改一处漏一处"。参数取 ConversationWrap 的 isMentionMe
-// 与 collapsedThreadHasMention 的返回值。
-export function hasMentionForRow(
-  wrapIsMentionMe: boolean,
-  threadHasMention: boolean
-): boolean {
-  return wrapIsMentionMe || threadHasMention
-}

--- a/packages/dmworkbase/src/Components/ConversationListGrouped/__tests__/ConversationListGrouped.archived.test.tsx
+++ b/packages/dmworkbase/src/Components/ConversationListGrouped/__tests__/ConversationListGrouped.archived.test.tsx
@@ -154,13 +154,13 @@ afterEach(() => {
     container.remove()
 })
 
-function groupConv(groupNo: string) {
+function groupConv(groupNo: string, options: { unread?: number; isMentionMe?: boolean } = {}) {
     return {
         channel: { channelID: groupNo, channelType: ChannelTypeGroup },
         channelInfo: { orgData: {} },
         timestamp: 100,
-        unread: 0,
-        isMentionMe: false,
+        unread: options.unread ?? 0,
+        isMentionMe: options.isMentionMe ?? false,
     }
 }
 
@@ -262,6 +262,28 @@ describe("ConversationListGrouped — 归档子区过滤 (issue #345)", () => {
         })
 
         expect(container.textContent || "").toContain("grpA____tUnknown")
+    })
+
+    it("does not combine an acknowledged mention from one group with another group's unread (#1625)", () => {
+        const twoGroupCategories = [{
+            ...categories[0],
+            groups: [{ group_no: "grpA" }, { group_no: "grpB" }],
+        }]
+        const conversations = [
+            // ConversationWrap 已根据 reminder/read watermark 将历史 mention 解析为 false。
+            groupConv("grpA", { unread: 0, isMentionMe: false }),
+            // 同分类另一个群只有普通未读。
+            groupConv("grpB", { unread: 1, isMentionMe: false }),
+        ]
+
+        renderGrouped({
+            conversations: conversations as any,
+            categories: twoGroupCategories as any,
+        })
+
+        const category = lastCategoryProps.categories.find((item: any) => item.id === "cat-a")
+        expect(category.unreadCount).toBe(1)
+        expect(category.hasMention).toBe(false)
     })
 
     it("renders loading/error/empty fallbacks and accepts drag lifecycle events", () => {

--- a/packages/dmworkbase/src/Components/ConversationListGrouped/__tests__/ConversationListGrouped.archived.test.tsx
+++ b/packages/dmworkbase/src/Components/ConversationListGrouped/__tests__/ConversationListGrouped.archived.test.tsx
@@ -5,6 +5,7 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vite
 import { ThreadStatus } from "../../../Service/Thread"
 
 let ConversationListGrouped: typeof import("../index").default
+let ActualConversationWrap: typeof import("../../../Service/Model").ConversationWrap
 let container: HTMLDivElement
 let lastDndProps: any
 let lastCategoryProps: any
@@ -17,6 +18,7 @@ beforeAll(async () => {
     vi.doMock("wukongimjssdk", () => ({
         default: {
             shared: () => ({
+                config: { uid: "me" },
                 channelManager: {
                     getChannelInfo: () => undefined,
                 },
@@ -35,15 +37,30 @@ beforeAll(async () => {
         Conversation: class {},
         WKSDK: {
             shared: () => ({
+                config: { uid: "me" },
                 channelManager: {
                     getChannelInfo: () => undefined,
                 },
             }),
         },
+        ReminderType: { ReminderTypeMentionMe: 1 },
     }))
 
-    vi.doMock("../../../Service/Const", () => ({
-        ChannelTypeCommunityTopic,
+    vi.doMock("../../../Service/Const", async () => {
+        const actual = await vi.importActual<typeof import("../../../Service/Const")>("../../../Service/Const")
+        return { ...actual, ChannelTypeCommunityTopic }
+    })
+
+    vi.doMock("../../../App", () => ({
+        default: {
+            loginInfo: { uid: "me" },
+            shared: {
+                currentSpaceId: "",
+                avatarChannel: () => "avatar",
+                getChannelAvatarTag: () => "tag",
+            },
+            dataSource: { commonDataSource: { getImageURL: (url: string) => url } },
+        },
     }))
 
     vi.doMock("../../../Service/Thread", () => ({
@@ -58,6 +75,22 @@ beforeAll(async () => {
     vi.doMock("../../../Service/FollowService", () => ({ default: {} }))
 
     vi.doMock("../../../Service/SidebarService", () => ({ default: {} }))
+
+    vi.doMock("../../../Service/EmojiService", () => ({
+        DefaultEmojiService: { shared: { emojiRegExp: () => /(?!)/ } },
+    }))
+
+    vi.doMock("../../../Service/TypingManager", () => ({
+        TypingManager: { shared: { getFakeTypingMessage: () => undefined } },
+    }))
+
+    vi.doMock("../../../Service/SpaceService", () => ({
+        getSpaceFilteredLastMessage: (conversation: any) => conversation.lastMessage,
+        SYSTEM_BOTS: new Set(),
+    }))
+
+    const actualModel = await vi.importActual<typeof import("../../../Service/Model")>("../../../Service/Model")
+    ActualConversationWrap = actualModel.ConversationWrap
 
     vi.doMock("../../../Service/Model", () => ({
         ConversationWrap: class {
@@ -162,6 +195,20 @@ function groupConv(groupNo: string, options: { unread?: number; isMentionMe?: bo
         unread: options.unread ?? 0,
         isMentionMe: options.isMentionMe ?? false,
     }
+}
+
+function readMentionGroupConv(groupNo: string) {
+    const raw = groupConv(groupNo, { unread: 0 })
+    return new ActualConversationWrap({
+        ...raw,
+        reminders: [],
+        simpleReminders: [],
+        remoteExtra: {},
+        lastMessage: {
+            channel: raw.channel,
+            content: { mention: { uids: ["me"] } },
+        },
+    } as any)
 }
 
 function threadConv(channelID: string, parentGroupNo: string, status?: number) {
@@ -270,8 +317,8 @@ describe("ConversationListGrouped — 归档子区过滤 (issue #345)", () => {
             groups: [{ group_no: "grpA" }, { group_no: "grpB" }],
         }]
         const conversations = [
-            // ConversationWrap 已根据 reminder/read watermark 将历史 mention 解析为 false。
-            groupConv("grpA", { unread: 0, isMentionMe: false }),
+            // 使用真实 ConversationWrap：grpA 的最后一条消息仍 @我，但已读且 reminder 为空。
+            readMentionGroupConv("grpA"),
             // 同分类另一个群只有普通未读。
             groupConv("grpB", { unread: 1, isMentionMe: false }),
         ]

--- a/packages/dmworkbase/src/Service/Model.tsx
+++ b/packages/dmworkbase/src/Service/Model.tsx
@@ -117,28 +117,52 @@ export class ConversationWrap {
     }
 
     public get isMentionMe(): boolean {
-        // 权威来源：server-side reminders（Plan X 下 ais-only 不建 reminder，
-        // 且 filterChannelLevelByPublisher 已排除 sender 自通知）
+        // WS-213 rev 3 结算规则（yujiawei review P1-1 / P1-2）：
+        //   1) 任一未 done 的 mention reminder → true（reminder 是权威 unresolved 信号）。
+        //   2) 全部 done → 用 messageSeq 判断 reminder 是否覆盖当前 lastMessage：
+        //      - 覆盖（reminder.messageSeq >= lastSeq）→ 用户已确认，false；
+        //      - 未覆盖（有更新的 mention 但 reminder 还没同步 / 或从未建 reminder 的
+        //        channel 如 Person）→ 走 lastMessage 兜底。
+        //   3) lastMessage 兜底命中时，用 unread > 0 作为本地"未确认"水位——
+        //      对于永远不走 reminder sync 的 Person 频道（reminders.ts:16-23），
+        //      这是唯一的清除信号，与旧行为兼容。
+        // 单次遍历同时收集"是否有 undone"与"最大 covered seq"，避免 P2-4 提到的
+        // 每 render 一次的中间数组分配。
         const reminders = this.conversation.reminders
-        const mentionReminders = reminders?.filter(
-            r => r.reminderType === ReminderType.ReminderTypeMentionMe
-        )
-        if (mentionReminders && mentionReminders.length > 0) {
-            // reminder 记录已存在 → 完全以其 done 状态为准；lastMessage 兜底不再介入，
-            // 否则读到底把 reminder done 之后 lastMessage 仍是 @我，marker 永远清不掉（WS-213 review）。
-            return mentionReminders.some(r => !r.done)
+        let hasUndoneMention = false
+        let maxCoveredSeq = 0
+        let sawMentionReminder = false
+        if (reminders) {
+            for (const r of reminders) {
+                if (r.reminderType !== ReminderType.ReminderTypeMentionMe) continue
+                sawMentionReminder = true
+                if (!r.done) hasUndoneMention = true
+                const seq = r.messageSeq ?? 0
+                if (seq > maxCoveredSeq) maxCoveredSeq = seq
+            }
         }
+        if (hasUndoneMention) return true
 
-        // 实时兜底：reminder 还没同步下来时，只信 per-uid mention（不信 SDK 的 broadcast 判断）。
-        // Plan X: mention.all=1 不再代表人类通知，SDK 的 isMentionMe 对 broadcast 不可靠。
-        // 走 this.lastMessage（Space-filtered），避免跨 Space 的 mention 污染 person 频道。
-        const mention = this.lastMessage?.content?.mention
+        // lastMessage 兜底：走 Space-filtered getter，避免跨 Space mention 污染 person 频道。
+        // Plan X 下 mention.all=1 不代表人类通知，只信 per-uid mention。
+        const lastMessage = this.lastMessage
+        const mention = lastMessage?.content?.mention
         const myUid = WKSDK.shared().config.uid
-        if (mention?.uids && Array.isArray(mention.uids) && myUid && mention.uids.includes(myUid)) {
-            return true
-        }
+        const lastMentionsMe = !!(
+            mention?.uids &&
+            Array.isArray(mention.uids) &&
+            myUid &&
+            mention.uids.includes(myUid)
+        )
+        if (!lastMentionsMe) return false
 
-        return false
+        // done 的 reminder 覆盖当前 lastMessage → 用户已确认，marker 应清。
+        const lastSeq = lastMessage?.messageSeq ?? 0
+        if (sawMentionReminder && lastSeq <= maxCoveredSeq) return false
+
+        // reminder 未覆盖（Person 无 reminder，或 group 新 mention reminder 还没同步）：
+        // unread=0 视作用户已越过此消息（对 Person 尤其重要，否则永远清不掉）。
+        return this.conversation.unread > 0
     }
 
     public set isMentionMe(isMentionMe: boolean | undefined) {

--- a/packages/dmworkbase/src/Service/Model.tsx
+++ b/packages/dmworkbase/src/Service/Model.tsx
@@ -161,8 +161,11 @@ export class ConversationWrap {
         if (sawMentionReminder && lastSeq <= maxCoveredSeq) return false
 
         // reminder 未覆盖（Person 无 reminder，或 group 新 mention reminder 还没同步）：
-        // unread=0 视作用户已越过此消息（对 Person 尤其重要，否则永远清不掉）。
-        return this.conversation.unread > 0
+        // 用 Space-aware `this.unread` 而不是 raw `conversation.unread`——Person-in-Space
+        // 的行 badge / read state 走 spaceUnread；raw unread 可能来自别的 Space，与当前
+        // Space 的 lastMessage / 展示语义不一致（Jerry-Xin rev 3 addendum）。unread=0
+        // 视作用户已越过此消息（对 Person 尤其重要，否则永远清不掉）。
+        return this.unread > 0
     }
 
     public set isMentionMe(isMentionMe: boolean | undefined) {

--- a/packages/dmworkbase/src/Service/Model.tsx
+++ b/packages/dmworkbase/src/Service/Model.tsx
@@ -119,13 +119,20 @@ export class ConversationWrap {
     public get isMentionMe(): boolean {
         // 权威来源：server-side reminders（Plan X 下 ais-only 不建 reminder，
         // 且 filterChannelLevelByPublisher 已排除 sender 自通知）
-        const hasReminderMention = (this.conversation.reminders?.length ?? 0) > 0
-            && this.conversation.reminders!.some(r => r.reminderType === ReminderType.ReminderTypeMentionMe && !r.done)
-        if (hasReminderMention) return true
+        const reminders = this.conversation.reminders
+        const mentionReminders = reminders?.filter(
+            r => r.reminderType === ReminderType.ReminderTypeMentionMe
+        )
+        if (mentionReminders && mentionReminders.length > 0) {
+            // reminder 记录已存在 → 完全以其 done 状态为准；lastMessage 兜底不再介入，
+            // 否则读到底把 reminder done 之后 lastMessage 仍是 @我，marker 永远清不掉（WS-213 review）。
+            return mentionReminders.some(r => !r.done)
+        }
 
-        // 实时兜底：只信 per-uid mention（不信 SDK 的 broadcast 判断）
-        // Plan X: mention.all=1 不再代表人类通知，SDK 的 isMentionMe 对 broadcast 不可靠
-        const mention = this.conversation.lastMessage?.content?.mention
+        // 实时兜底：reminder 还没同步下来时，只信 per-uid mention（不信 SDK 的 broadcast 判断）。
+        // Plan X: mention.all=1 不再代表人类通知，SDK 的 isMentionMe 对 broadcast 不可靠。
+        // 走 this.lastMessage（Space-filtered），避免跨 Space 的 mention 污染 person 频道。
+        const mention = this.lastMessage?.content?.mention
         const myUid = WKSDK.shared().config.uid
         if (mention?.uids && Array.isArray(mention.uids) && myUid && mention.uids.includes(myUid)) {
             return true

--- a/packages/dmworkbase/src/Service/Model.tsx
+++ b/packages/dmworkbase/src/Service/Model.tsx
@@ -158,7 +158,13 @@ export class ConversationWrap {
 
         // done 的 reminder 覆盖当前 lastMessage → 用户已确认，marker 应清。
         const lastSeq = lastMessage?.messageSeq ?? 0
-        if (sawMentionReminder && lastSeq <= maxCoveredSeq) return false
+        // 缺失/未落盘的 seq 不能证明覆盖关系；此时继续走 unread 水位兜底。
+        if (
+            sawMentionReminder
+            && lastSeq > 0
+            && maxCoveredSeq > 0
+            && lastSeq <= maxCoveredSeq
+        ) return false
 
         // reminder 未覆盖（Person 无 reminder，或 group 新 mention reminder 还没同步）：
         // 用 Space-aware `this.unread` 而不是 raw `conversation.unread`——Person-in-Space

--- a/packages/dmworkbase/src/Service/__tests__/Model.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/Model.test.ts
@@ -256,6 +256,39 @@ describe("ConversationWrap", () => {
     expect(wrap.isMentionMe).toBe(false)
   })
 
+  it("retires the marker once every mention reminder is done, even if lastMessage still mentions me", () => {
+    // WS-213 review 反馈 P1-1：reminder 一旦存在，就以其 done 状态为唯一权威，
+    // lastMessage 兜底不再介入——否则读到底后 lastMessage 不变，marker 永远清不掉。
+    const wrap = new ConversationWrap(conversation({
+      unread: 0,
+      reminders: [
+        { reminderType: 1, done: true },
+      ],
+      lastMessage: message({ content: { mention: { uids: ["me"] } } }),
+    }))
+    expect(wrap.isMentionMe).toBe(false)
+  })
+
+  it("keeps the marker on when at least one mention reminder is still undone", () => {
+    const wrap = new ConversationWrap(conversation({
+      reminders: [
+        { reminderType: 1, done: true },
+        { reminderType: 1, done: false },
+      ],
+      lastMessage: message({ content: {} }),
+    }))
+    expect(wrap.isMentionMe).toBe(true)
+  })
+
+  it("uses lastMessage fallback only when no mention reminder record exists (pre-sync window)", () => {
+    // reminder 还没同步下来时，前端凭 lastMessage.mention.uids 先亮 marker
+    const wrap = new ConversationWrap(conversation({
+      reminders: [],
+      lastMessage: message({ content: { mention: { uids: ["me"] } } }),
+    }))
+    expect(wrap.isMentionMe).toBe(true)
+  })
+
   it("initializes extras and delegates identity and reload operations", () => {
     const raw = conversation({ extra: undefined })
     const wrap = new ConversationWrap(raw)

--- a/packages/dmworkbase/src/Service/__tests__/Model.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/Model.test.ts
@@ -256,15 +256,15 @@ describe("ConversationWrap", () => {
     expect(wrap.isMentionMe).toBe(false)
   })
 
-  it("retires the marker once every mention reminder is done, even if lastMessage still mentions me", () => {
-    // WS-213 review 反馈 P1-1：reminder 一旦存在，就以其 done 状态为唯一权威，
-    // lastMessage 兜底不再介入——否则读到底后 lastMessage 不变，marker 永远清不掉。
+  it("retires the marker once every mention reminder covers the lastMessage (WS-213 rev 3)", () => {
+    // 读到底后所有 mention reminder done + reminder.messageSeq 覆盖 lastMessage.messageSeq
+    // → 用户已确认 → false（reminder 权威语义）。
     const wrap = new ConversationWrap(conversation({
       unread: 0,
       reminders: [
-        { reminderType: 1, done: true },
+        { reminderType: 1, done: true, messageSeq: 42 },
       ],
-      lastMessage: message({ content: { mention: { uids: ["me"] } } }),
+      lastMessage: message({ messageSeq: 42, content: { mention: { uids: ["me"] } } }),
     }))
     expect(wrap.isMentionMe).toBe(false)
   })
@@ -272,17 +272,53 @@ describe("ConversationWrap", () => {
   it("keeps the marker on when at least one mention reminder is still undone", () => {
     const wrap = new ConversationWrap(conversation({
       reminders: [
-        { reminderType: 1, done: true },
-        { reminderType: 1, done: false },
+        { reminderType: 1, done: true, messageSeq: 10 },
+        { reminderType: 1, done: false, messageSeq: 20 },
       ],
-      lastMessage: message({ content: {} }),
+      lastMessage: message({ messageSeq: 20, content: {} }),
     }))
     expect(wrap.isMentionMe).toBe(true)
   })
 
   it("uses lastMessage fallback only when no mention reminder record exists (pre-sync window)", () => {
-    // reminder 还没同步下来时，前端凭 lastMessage.mention.uids 先亮 marker
+    // reminder 还没同步下来时，前端凭 lastMessage.mention.uids + unread>0 先亮 marker
     const wrap = new ConversationWrap(conversation({
+      unread: 3,
+      reminders: [],
+      lastMessage: message({ content: { mention: { uids: ["me"] } } }),
+    }))
+    expect(wrap.isMentionMe).toBe(true)
+  })
+
+  it("lights up when a newer mentioning lastMessage postdates every done reminder (P1-1)", () => {
+    // 老的 done reminder（seq=10）不应屏蔽 seq=500 的新 @我：
+    // ReminderManager.reminders 从不删除，新 mention 的 reminder 未同步前，走 fallback。
+    const wrap = new ConversationWrap(conversation({
+      unread: 1,
+      reminders: [
+        { reminderType: 1, done: true, messageSeq: 10 },
+      ],
+      lastMessage: message({ messageSeq: 500, content: { mention: { uids: ["me"] } } }),
+    }))
+    expect(wrap.isMentionMe).toBe(true)
+  })
+
+  it("clears the marker on a Person channel once unread reaches zero (P1-2)", () => {
+    // 1:1 频道不走 reminder sync（reminders.ts:16-23 只处理 group / community topic），
+    // 所以 fallback 必须能凭 unread=0 清除，否则 DM 里的 @我 永远显示。
+    const wrap = new ConversationWrap(conversation({
+      channel: { channelID: "peer", channelType: 1 },
+      unread: 0,
+      reminders: [],
+      lastMessage: message({ content: { mention: { uids: ["me"] } } }),
+    }))
+    expect(wrap.isMentionMe).toBe(false)
+  })
+
+  it("keeps the marker on a Person channel while unread is nonzero (P1-2 counterpart)", () => {
+    const wrap = new ConversationWrap(conversation({
+      channel: { channelID: "peer", channelType: 1 },
+      unread: 2,
       reminders: [],
       lastMessage: message({ content: { mention: { uids: ["me"] } } }),
     }))

--- a/packages/dmworkbase/src/Service/__tests__/Model.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/Model.test.ts
@@ -325,6 +325,56 @@ describe("ConversationWrap", () => {
     expect(wrap.isMentionMe).toBe(true)
   })
 
+  it("uses Space-aware unread on a Person channel where raw unread and spaceUnread diverge (Jerry-Xin rev 3 addendum)", () => {
+    // Person-in-Space：当前 Space 已读完（spaceUnread=0），但 raw unread 因为别的
+    // Space 仍有值 > 0。行的 badge / read state 走 spaceUnread，marker fallback
+    // 必须同源 —— 否则 spaceLastMessage.mention.uids 命中会长期误亮。
+    const originalSpaceId = WKApp.shared.currentSpaceId
+    WKApp.shared.currentSpaceId = "space-1"
+    try {
+      const spaceMsg = message({
+        messageID: "space-mention",
+        content: { mention: { uids: ["me"] } },
+      })
+      const wrap = new ConversationWrap(conversation({
+        channel: { channelID: "peer", channelType: 1 },
+        unread: 3, // raw unread from other Spaces
+        reminders: [],
+        extra: { spaceUnread: 0, spaceLastMessage: spaceMsg },
+        lastMessage: message({ content: {} }),
+      }))
+      // Sanity checks: sibling getters are Space-aware
+      expect(wrap.unread).toBe(0)
+      expect(wrap.lastMessage).toBe(spaceMsg)
+      // Marker gate must agree with the displayed row state
+      expect(wrap.isMentionMe).toBe(false)
+    } finally {
+      WKApp.shared.currentSpaceId = originalSpaceId
+    }
+  })
+
+  it("lights the marker on a Person-in-Space channel while spaceUnread is nonzero", () => {
+    const originalSpaceId = WKApp.shared.currentSpaceId
+    WKApp.shared.currentSpaceId = "space-1"
+    try {
+      const spaceMsg = message({
+        messageID: "space-mention",
+        content: { mention: { uids: ["me"] } },
+      })
+      const wrap = new ConversationWrap(conversation({
+        channel: { channelID: "peer", channelType: 1 },
+        unread: 0,
+        reminders: [],
+        extra: { spaceUnread: 2, spaceLastMessage: spaceMsg },
+        lastMessage: message({ content: {} }),
+      }))
+      expect(wrap.unread).toBe(2)
+      expect(wrap.isMentionMe).toBe(true)
+    } finally {
+      WKApp.shared.currentSpaceId = originalSpaceId
+    }
+  })
+
   it("initializes extras and delegates identity and reload operations", () => {
     const raw = conversation({ extra: undefined })
     const wrap = new ConversationWrap(raw)

--- a/packages/dmworkbase/src/Service/__tests__/Model.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/Model.test.ts
@@ -278,7 +278,6 @@ describe("ConversationWrap", () => {
       reminders: [],
       lastMessage: message({
         channel: { channelID: "group-read", channelType: 2 },
-        messageSeq: 42,
         content: { mention: { uids: ["me"] } },
       }),
     }))

--- a/packages/dmworkbase/src/Service/__tests__/Model.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/Model.test.ts
@@ -269,6 +269,23 @@ describe("ConversationWrap", () => {
     expect(wrap.isMentionMe).toBe(false)
   })
 
+  it("does not revive a read group mention from lastMessage after reminder reload (#1625)", () => {
+    // 已读 reminder 在全量重载后可能不再返回。即使最后一条消息仍然 @我，
+    // 群聊自身 unread=0 也必须作为已读水位，不能让其他会话/子区的未读重新点亮它。
+    const wrap = new ConversationWrap(conversation({
+      channel: { channelID: "group-read", channelType: 2 },
+      unread: 0,
+      reminders: [],
+      lastMessage: message({
+        channel: { channelID: "group-read", channelType: 2 },
+        messageSeq: 42,
+        content: { mention: { uids: ["me"] } },
+      }),
+    }))
+
+    expect(wrap.isMentionMe).toBe(false)
+  })
+
   it("keeps the marker on when at least one mention reminder is still undone", () => {
     const wrap = new ConversationWrap(conversation({
       reminders: [

--- a/packages/dmworkbase/src/Service/__tests__/Model.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/Model.test.ts
@@ -319,6 +319,32 @@ describe("ConversationWrap", () => {
     expect(wrap.isMentionMe).toBe(true)
   })
 
+  it("falls back to unread when reminder coverage lacks a usable messageSeq", () => {
+    const withoutEitherSeq = new ConversationWrap(conversation({
+      unread: 2,
+      reminders: [
+        { reminderType: 1, done: true, messageSeq: undefined },
+      ],
+      lastMessage: message({
+        messageSeq: undefined,
+        content: { mention: { uids: ["me"] } },
+      }),
+    }))
+    expect(withoutEitherSeq.isMentionMe).toBe(true)
+
+    const withoutLastMessageSeq = new ConversationWrap(conversation({
+      unread: 2,
+      reminders: [
+        { reminderType: 1, done: true, messageSeq: 10 },
+      ],
+      lastMessage: message({
+        messageSeq: undefined,
+        content: { mention: { uids: ["me"] } },
+      }),
+    }))
+    expect(withoutLastMessageSeq.isMentionMe).toBe(true)
+  })
+
   it("clears the marker on a Person channel once unread reaches zero (P1-2)", () => {
     // 1:1 频道不走 reminder sync（reminders.ts:16-23 只处理 group / community topic），
     // 所以 fallback 必须能凭 unread=0 清除，否则 DM 里的 @我 永远显示。


### PR DESCRIPTION
## Summary

This PR fixes the mention-marker lifecycle and collapsed-thread bubbling as a complete replacement for #1622, while adding end-to-end regression coverage for the stale-mention scenarios reported in #1625.

The shared rule is that `isMentionMe` represents an unresolved mention, not merely a historical last message that once mentioned the current user:

- A real unresolved mention in a collapsed thread bubbles to its parent group row.
- A mention that has already been acknowledged stays cleared after reminder reload.
- Ordinary unread messages from a collapsed thread or another conversation cannot revive an acknowledged mention.

Refs #1621.
Refs #1625.

| State or action | Unread | Mention state | Expected UI |
| --- | ---: | --- | --- |
| New direct mention | Positive | Unresolved | Show unread and `@me` |
| Open and read to latest | Zero | Acknowledged | Clear `@me` |
| Use **Mark as read** | Zero | Acknowledged | Clear `@me` |
| Zero unread with a still-unresolved reminder | Zero | Unresolved | Show `@me` on both the row and a collapsed category header |

## Production changes

- Make `ConversationWrap.isMentionMe` reminder-aware and compare reminder coverage with `lastMessage.messageSeq`.
- Use the Space-aware unread value as the fallback acknowledgement watermark.
- Decouple row-level mention rendering from the unread count.
- Bubble unresolved mentions from collapsed threads to their parent group in compact mode without double-lighting expanded threads.
- Preserve the existing behavior where a direct mention can appear in a muted conversation.
- Stop mutating the raw SDK `conversation.isMentionMe` field when reading to the bottom; `ConversationWrap` is the authoritative source.
- Make the conversation-list **Mark as read** action acknowledge unresolved mention reminders as well as clearing unread.
- Render a collapsed category's mention badge independently from its unread-count badge.
- Treat missing or zero `messageSeq` values as insufficient proof that a done reminder covers the current last message.

## Regression coverage

- A read group does not revive a historical `lastMessage` mention after its completed reminder disappears from a full reload.
- A collapsed thread with ordinary unread increments the parent unread badge without reviving the parent's acknowledged mention.
- Ordinary unread in another conversation in the same category cannot activate an acknowledged mention.
- The two UI scenarios use the real `ConversationWrap.isMentionMe` getter rather than pre-resolved boolean fixtures.
- Existing coverage also verifies reminder sequencing, Person conversations, Space-aware unread, collapsed-thread bubbling, expanded-thread behavior, and mute semantics.
- Marking a conversation as read completes only its unresolved mention reminders and does not do so when clearing unread fails.
- A collapsed category keeps its `@` badge when an unresolved mention exists at zero unread.

## Verification

```text
Test Files  471 passed (471)
Tests       4323 passed (4323)
```

A mutation run restored the four production files to their `main` versions while keeping the new tests. All three `#1625` tests failed, confirming that the Model, collapsed-thread, and category cases detect the unfixed behavior.

## Follow-up scope

- #1621 remains open to track the product decision for muted mentions. This PR preserves the existing row behavior instead of changing mute semantics without product confirmation.
- #1625 remains open to track reminder persistence reliability, including failed `message/reminder/done` requests and out-of-order reminder sync responses.

## Relationship to #1622 and attribution

This PR supersedes #1622 as the merge vehicle. The production implementation originated in #1622 and is preserved here together with the additional #1625 regression coverage. If this PR is merged, #1622 should not be merged separately.

Please preserve the original author's credit in the final squash commit:

```text
Co-authored-by: pkuWMH <201708361+pkuWMH@users.noreply.github.com>
```
