### PR TITLE
fix(message): avoid premature header truncation

### DIFF
--- a/packages/dmworkbase/src/Components/GlobalSearch/item-contacts.css
+++ b/packages/dmworkbase/src/Components/GlobalSearch/item-contacts.css
@@ -22,7 +22,7 @@ body[theme-mode=dark] .wk-item-contacts:hover {
     font-size: 14px;
     font-weight: 500;
     /* 用 flex 让 .wk-search-result-item-space 的
-       text-overflow: ellipsis + max-width 在同一行水平收敛生效。
+       text-overflow: ellipsis 在同一行按可用空间收敛生效。
        baseline 对齐保证 @SpaceName 后缀与姓名底部对齐，避免视觉错位。 */
     display: flex;
     align-items: baseline;
@@ -48,9 +48,9 @@ mark {
     font-weight: 400;
     color: var(--wk-text-secondary);
     line-height: 1.3;
+    min-width: 0;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-    max-width: 12rem;
-    flex-shrink: 1;
+    flex: 0 1 auto;
 }

--- a/packages/dmworkbase/src/Components/Subscribers/list.css
+++ b/packages/dmworkbase/src/Components/Subscribers/list.css
@@ -162,11 +162,11 @@
     font-weight: 400;
     color: var(--wk-text-secondary);
     line-height: 1.3;
+    min-width: 0;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-    max-width: 12rem;
-    flex-shrink: 1;
+    flex: 0 1 auto;
 }
 
 .wk-subscrierlist-item-content {

--- a/packages/dmworkbase/src/Messages/Base/index.css
+++ b/packages/dmworkbase/src/Messages/Base/index.css
@@ -103,7 +103,7 @@
 }
 
 .wk-msg-head-name {
-    flex: 1 1 auto;
+    flex: 0 1 auto;
     min-width: 0;
     font-weight: 600;
     font-size: 13px;

--- a/packages/dmworkbase/src/Messages/Base/index.css
+++ b/packages/dmworkbase/src/Messages/Base/index.css
@@ -103,13 +103,14 @@
 }
 
 .wk-msg-head-name {
+    flex: 1 1 auto;
+    min-width: 0;
     font-weight: 600;
     font-size: 13px;
     line-height: 1.3;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-    max-width: 200px;
 }
 
 .wk-msg-head-time {
@@ -127,15 +128,15 @@
 
 /* 消息气泡头部「@SpaceName」后缀，紧随昵称展示，小字次要色 */
 .wk-msg-head-space {
+    flex: 0 1 auto;
+    min-width: 0;
     font-size: 12px;
     font-weight: var(--wk-font-regular, 400);
     color: var(--semi-color-text-2, var(--wk-text-secondary, rgba(9, 30, 66, 0.6)));
     line-height: 1.3;
-    max-width: 180px;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-    flex-shrink: 1;
 }
 
 /* ── Bubble box ── */

--- a/packages/dmworkbase/src/ui/message/MessageRow/MessageRow.stories.tsx
+++ b/packages/dmworkbase/src/ui/message/MessageRow/MessageRow.stories.tsx
@@ -194,10 +194,10 @@ export const HeaderLayoutRegression: Story = {
           isSelected={false}
           showAvatar={false}
           avatarUrl=""
-          senderName="这是一个足够长但在宽容器中应该完整显示的发送者名称"
+          senderName="宽容器中可完整显示的发送者名称"
           timestamp="10:30"
           isExternal
-          sourceSpaceName="这是一个足够长但在宽容器中应该完整显示的来源空间名称"
+          sourceSpaceName="宽容器中可完整显示的来源空间名称"
         >
           <Bubble position="single" isSend={false}>
             宽容器布局回归检查

--- a/packages/dmworkbase/src/ui/message/MessageRow/MessageRow.stories.tsx
+++ b/packages/dmworkbase/src/ui/message/MessageRow/MessageRow.stories.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import type { Meta, StoryObj } from '@storybook/react'
+import { expect } from '@storybook/test'
 import MessageRow from './index'
 import Bubble from '../Bubble'
 
@@ -144,7 +145,7 @@ export const Conversation: Story = {
           大家早，昨天提的新需求我整理了一下
         </Bubble>
       </MessageRow>
-      
+
       {/* 接收方连续消息 */}
       <MessageRow
         isSend={false}
@@ -159,7 +160,7 @@ export const Conversation: Story = {
           主要有三点：用户分组、Thread 功能、消息搜索优化
         </Bubble>
       </MessageRow>
-      
+
       {/* 发送方回复 */}
       <MessageRow
         isSend={true}
@@ -176,6 +177,91 @@ export const Conversation: Story = {
       </MessageRow>
     </div>
   ),
+}
+
+/**
+ * Chromium layout regression guard for the sender / source-space header.
+ * This intentionally checks rendered geometry because jsdom does not perform
+ * flex layout or calculate ellipsis metrics.
+ */
+export const HeaderLayoutRegression: Story = {
+  render: () => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '24px' }}>
+      <div data-testid="wide-message-row" style={{ width: '760px' }}>
+        <MessageRow
+          isSend={false}
+          isContinue={false}
+          isSelected={false}
+          showAvatar={false}
+          avatarUrl=""
+          senderName="这是一个足够长但在宽容器中应该完整显示的发送者名称"
+          timestamp="10:30"
+          isExternal
+          sourceSpaceName="这是一个足够长但在宽容器中应该完整显示的来源空间名称"
+        >
+          <Bubble position="single" isSend={false}>
+            宽容器布局回归检查
+          </Bubble>
+        </MessageRow>
+      </div>
+      <div data-testid="narrow-message-row" style={{ width: '380px' }}>
+        <MessageRow
+          isSend={false}
+          isContinue={false}
+          isSelected={false}
+          showAvatar={false}
+          avatarUrl=""
+          senderName="这是一个在窄容器中需要省略的超长发送者名称"
+          timestamp="10:30"
+          isExternal
+          sourceSpaceName="这是一个在窄容器中需要省略的超长来源空间名称"
+        >
+          <Bubble position="single" isSend={false}>
+            窄容器布局回归检查
+          </Bubble>
+        </MessageRow>
+      </div>
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const wide = canvasElement.querySelector('[data-testid="wide-message-row"]')
+    const narrow = canvasElement.querySelector(
+      '[data-testid="narrow-message-row"]'
+    )
+    expect(wide).not.toBeNull()
+    expect(narrow).not.toBeNull()
+
+    const wideName = wide!.querySelector('.wk-msg-row-sender') as HTMLElement
+    const wideSpace = wide!.querySelector(
+      '.wk-msg-row-sender-space'
+    ) as HTMLElement
+    const wideTime = wide!.querySelector('.wk-msg-row-timestamp') as HTMLElement
+    expect(wideName.scrollWidth).toBeLessThanOrEqual(wideName.clientWidth)
+    expect(wideSpace.scrollWidth).toBeLessThanOrEqual(wideSpace.clientWidth)
+    expect(wideTime.getBoundingClientRect().right).toBeLessThanOrEqual(
+      wide!.querySelector('.wk-msg-row')!.getBoundingClientRect().right
+    )
+    expect(
+      wideSpace.getBoundingClientRect().left -
+        wideName.getBoundingClientRect().right
+    ).toBeCloseTo(8, 0)
+
+    const narrowName = narrow!.querySelector(
+      '.wk-msg-row-sender'
+    ) as HTMLElement
+    const narrowSpace = narrow!.querySelector(
+      '.wk-msg-row-sender-space'
+    ) as HTMLElement
+    const narrowTime = narrow!.querySelector(
+      '.wk-msg-row-timestamp'
+    ) as HTMLElement
+    expect(narrowName.scrollWidth).toBeGreaterThan(narrowName.clientWidth)
+    expect(narrowSpace.scrollWidth).toBeGreaterThan(narrowSpace.clientWidth)
+    expect(narrowTime.scrollWidth).toBe(narrowTime.clientWidth)
+    expect(
+      narrow!.querySelector('.wk-msg-row')!.scrollWidth
+    ).toBeLessThanOrEqual(narrow!.querySelector('.wk-msg-row')!.clientWidth)
+  },
 }
 
 /**

--- a/packages/dmworkbase/src/ui/message/MessageRow/index.css
+++ b/packages/dmworkbase/src/ui/message/MessageRow/index.css
@@ -138,6 +138,11 @@
 }
 
 .wk-msg-row-sender {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 0 1 auto;
   font-size: 15px;
   font-weight: 600;
   color: var(--wk-text-primary);
@@ -153,16 +158,18 @@
   font-weight: var(--wk-font-regular, 400);
   color: var(--semi-color-text-2, var(--wk-text-secondary, rgba(9, 30, 66, 0.6)));
   line-height: 1.3;
-  max-width: 180px;
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  flex-shrink: 1;
+  flex: 0 1 auto;
 }
 
 .wk-msg-row-timestamp {
   font-size: 12px;
   color: var(--wk-text-legacy-tertiary);
+  white-space: nowrap;
+  flex-shrink: 0;
 }
 
 .wk-msg-row-edited {

--- a/packages/dmworkbase/src/ui/message/ReplyBlock/index.css
+++ b/packages/dmworkbase/src/ui/message/ReplyBlock/index.css
@@ -62,8 +62,8 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  max-width: 140px;
-  flex-shrink: 1;
+  min-width: 0;
+  flex: 0 1 auto;
 }
 
 .wk-reply-block__digest {


### PR DESCRIPTION
## Summary
Fix premature truncation of message sender names and source space names when the message header still has available width.

## Related Issue
Fixes #1643

## Changes
- Remove fixed max-width limits from `.wk-msg-head-name` and `.wk-msg-head-space`.
- Use flex sizing with `min-width: 0` so text uses available header space and ellipsizes only when necessary.
- Preserve the non-shrinking timestamp behavior.

## Architecture / Module Boundary
- Affected module(s): Messages/Base
- New or changed user-visible entry point: no
- Shared layer touched: Messages
- Impact scope: Message header layout only
- Duplicate entry point checked: not applicable

## Testing
- `pnpm exec vitest run src/Messages/Base/__tests__/MessageBase.test.tsx`
- `pnpm exec vitest run src/ui/message/MessageRow/__tests__/MessageRow.test.tsx`
- CSS validation and `git diff --check` passed.

## Checklist
- [x] I have read CONTRIBUTING.md
- [x] PR description is in English
- [x] Ran `pnpm i18n:check` or confirmed the change does not affect UI copy
- [x] Confirmed the change follows module ownership and does not add duplicate user-visible entry points
- [x] Described impact scope when shared components, messages, bridge, or services are changed
- [x] Followed commit message conventions (Conventional Commits)