### PR TITLE
fix(docs): support embedded previews, forwarding and rich-text voice hosts

### DIFF
--- a/apps/web/scripts/build-client-communication.mjs
+++ b/apps/web/scripts/build-client-communication.mjs
@@ -8,6 +8,7 @@ void buildClientFeature({
   sourceEntry: "client-communication.html",
   outputDirectory: "build-client-communication",
   contractRevision: 3,
+  documentForwardVersion: 1,
   includeImMock: true,
 }).catch((error) => {
   console.error(`[build-client-communication] failed: ${error.message}`);

--- a/apps/web/scripts/client-feature-build.mjs
+++ b/apps/web/scripts/client-feature-build.mjs
@@ -34,11 +34,14 @@ export async function buildClientFeature({
   sourceEntry,
   outputDirectory,
   contractRevision = 1,
+  documentForwardVersion,
   includeImMock = false,
 }) {
   const scriptDir = path.dirname(fileURLToPath(scriptUrl));
   const appDir = path.resolve(scriptDir, "..");
-  const outputDir = path.join(appDir, outputDirectory);
+  const outputDir = process.env.OCTO_CLIENT_ARTIFACT_OUT_DIR
+    ? path.resolve(process.env.OCTO_CLIENT_ARTIFACT_OUT_DIR)
+    : path.join(appDir, outputDirectory);
   const viteEnv = loadEnv("production", appDir, "VITE_");
   const buildEnv = resolveClientFeatureBuildEnv(process.env, viteEnv);
   if (!buildEnv.apiURL) {
@@ -71,7 +74,7 @@ export async function buildClientFeature({
     "bin",
     "vite.js"
   );
-  await run(process.execPath, [viteBin, "build", "--config", configFile], {
+  await run(process.execPath, [viteBin, "build", "--config", configFile, "--outDir", outputDir], {
     cwd: appDir,
     env: {
       ...process.env,
@@ -119,6 +122,7 @@ export async function buildClientFeature({
     entry: "index.html",
     hostBridgeMajor: 1,
     contractRevision,
+    ...(documentForwardVersion === undefined ? {} : { documentForwardVersion }),
     sourceDirty,
     e2eMock: buildEnv.e2eMock || (includeImMock && buildEnv.e2eMockIm),
     mockFlags: {

--- a/apps/web/src/client-communication/CommunicationShell.tsx
+++ b/apps/web/src/client-communication/CommunicationShell.tsx
@@ -33,6 +33,7 @@ import {
 import { createReadyReporter } from "./readyReporter";
 import { Toast } from "@douyinfe/semi-ui";
 import { installSummaryNavigation } from "./summaryNavigation";
+import { installDocumentForward } from "./documentForward";
 import "./index.css";
 
 function bindLeftRoute(context: WKViewQueueContext) {
@@ -137,6 +138,10 @@ export function CommunicationShell({
   useEffect(() => installSummaryNavigation(bridge, (error) => {
     console.error("[client-communication] failed to open summary", error);
     Toast.error(t("summary.common.operationFailed"));
+  }), [bridge]);
+  useEffect(() => installDocumentForward(bridge, {
+    getSpaceId: () => spaceIdRef.current,
+    getContext: () => WKApp.shared.baseContext,
   }), [bridge]);
 
   const reportReadyWhenPrepared = useCallback(() => {

--- a/apps/web/src/client-communication/documentForward.test.ts
+++ b/apps/web/src/client-communication/documentForward.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it, vi } from "vitest";
+import { installDocumentForward, supportsDocumentForward } from "./documentForward";
+import type { OctoBuddyCommunicationBridge, DocumentForwardRequest } from "./hostBridge";
+import type { WKBaseContext } from "@octo/base/src/Components/WKBase";
+import type { DocForwardOpen } from "@octo/base/src/Components/ForwardModal/grant";
+
+function fixture() {
+  const listeners = new Map<string, Function>();
+  const subscribe = (key: string) => (fn: Function) => { listeners.set(key, fn); return () => { listeners.delete(key); }; };
+  const closed = vi.fn();
+  let forward: DocForwardOpen;
+  const context = {
+    showConversationSelect: vi.fn((_callback, _title, input: DocForwardOpen) => { forward = input; return closed; }),
+  } as unknown as WKBaseContext;
+  const bridge = {
+    onDocumentForward: subscribe("request"), onDocumentForwardCancel: subscribe("cancel"), onCommand: subscribe("command"),
+    grantDocumentForward: vi.fn(async () => ({ granted: 1, failed: 0 })),
+    authorizeDocumentForward: vi.fn(async () => {}),
+    respondDocumentForward: vi.fn(),
+  } as unknown as OctoBuddyCommunicationBridge;
+  const state = { space: "sender-space" };
+  const dispose = installDocumentForward(bridge, { getSpaceId: () => state.space, getContext: () => context });
+  const request: DocumentForwardRequest = {
+    requestId: "main-request", spaceId: state.space,
+    input: { docId: "doc-a", title: "Title", link: "https://docs.test/d/doc-a#instruction",
+      spaceId: "document-home", canGrant: true, shareAsCard: false },
+  };
+  return { bridge, listeners, closed, dispose, state, context,
+    open: () => listeners.get("request")!(request),
+    get forward() { return forward!; },
+  };
+}
+
+describe("Docs communication artifact adapter", () => {
+  it("does nothing for an older host", () => {
+    const bridge = {} as OctoBuddyCommunicationBridge;
+    expect(supportsDocumentForward(bridge)).toBe(false);
+    expect(() => installDocumentForward(bridge, {} as never)()).not.toThrow();
+  });
+  it("preserves card/text semantics and document space, delegates grant and authorizes every send", async () => {
+    const f = fixture();
+    f.open();
+    expect(f.forward).toMatchObject({ docId: "doc-a", spaceId: "document-home", shareAsCard: false,
+      link: "https://docs.test/d/doc-a#instruction" });
+    await f.forward.grantAccess!(["recipient"], "writer");
+    expect(f.bridge.grantDocumentForward).toHaveBeenCalledWith({ requestId: "main-request", uids: ["recipient"], role: "writer" });
+    await f.forward.beforeSend!();
+    await f.forward.beforeSend!();
+    expect(f.bridge.authorizeDocumentForward).toHaveBeenCalledTimes(2);
+    f.forward.onResult!({ sent: 2, failed: 0 });
+    f.forward.onResult!({ sent: 2, failed: 0 });
+    expect(f.bridge.respondDocumentForward).toHaveBeenCalledTimes(1);
+    f.dispose();
+  });
+  it("source cancellation closes only its picker and rejects any late grant/send", async () => {
+    const f = fixture();
+    f.open();
+    f.listeners.get("cancel")!({ requestId: "unknown" });
+    expect(f.closed).not.toHaveBeenCalled();
+    f.listeners.get("cancel")!({ requestId: "main-request" });
+    expect(f.closed).toHaveBeenCalledTimes(1);
+    await expect(f.forward.beforeSend!()).rejects.toThrow();
+    await expect(f.forward.grantAccess!(["u"], "reader")).rejects.toThrow();
+    expect(f.bridge.authorizeDocumentForward).not.toHaveBeenCalled();
+    f.dispose();
+  });
+  it("rechecks context after asynchronous grant and send authorization", async () => {
+    const f = fixture();
+    let finish: () => void = () => {};
+    vi.mocked(f.bridge.authorizeDocumentForward!).mockImplementation(() => new Promise((resolve) => { finish = resolve; }));
+    f.open();
+    const send = f.forward.beforeSend!();
+    f.state.space = "new-space";
+    finish();
+    await expect(send).rejects.toThrow();
+    f.dispose();
+  });
+  it("preserves the picker across layout suspension and same-space updates", () => {
+    const f = fixture();
+    f.open();
+    for (const type of ["suspend", "resume", "hostVisibilityChanged"]) f.listeners.get("command")!({ type });
+    f.listeners.get("command")!({ type: "spaceChanged", space: { id: f.state.space } });
+    expect(f.forward.isActive!()).toBe(true);
+    expect(f.closed).not.toHaveBeenCalled();
+    expect(f.bridge.respondDocumentForward).not.toHaveBeenCalled();
+    f.dispose();
+  });
+  it.each(["sessionRevoked", "spaceChanged"])("cancels on %s and removes listeners on cleanup", (type) => {
+    const f = fixture();
+    f.open();
+    f.listeners.get("command")!({ type, space: { id: "different-space" } });
+    expect(f.forward.isActive!()).toBe(false);
+    expect(f.closed).toHaveBeenCalledTimes(1);
+    f.dispose();
+    expect(f.listeners.size).toBe(0);
+  });
+});

--- a/apps/web/src/client-communication/documentForward.ts
+++ b/apps/web/src/client-communication/documentForward.ts
@@ -1,0 +1,89 @@
+import type { WKBaseContext } from "@octo/base/src/Components/WKBase";
+import type { OctoBuddyCommunicationBridge } from "./hostBridge";
+
+export function supportsDocumentForward(bridge: OctoBuddyCommunicationBridge): boolean {
+  return [
+    bridge.onDocumentForward, bridge.onDocumentForwardCancel, bridge.grantDocumentForward,
+    bridge.authorizeDocumentForward, bridge.respondDocumentForward,
+  ].every((method) => typeof method === "function");
+}
+
+/** No Docs dependency or API routes: the originating artifact owns document grants. */
+export function installDocumentForward(
+  bridge: OctoBuddyCommunicationBridge,
+  host: { getSpaceId(): string; getContext(): WKBaseContext },
+): () => void {
+  if (!supportsDocumentForward(bridge)) return () => {};
+  let disposed = false;
+  const operations = new Map<string, () => void>();
+  const offRequest = bridge.onDocumentForward!((request) => {
+    let active = true;
+    let closePicker: (() => void) | void;
+    const isActive = () => !disposed && active && request.spaceId === host.getSpaceId();
+    const respond = (response: { ok: boolean; result?: unknown; error?: string }) => {
+      if (!active) return;
+      active = false;
+      operations.delete(request.requestId);
+      bridge.respondDocumentForward!({ requestId: request.requestId, ...response });
+    };
+    const cancel = () => {
+      if (!active) return;
+      respond({ ok: true, result: null });
+      closePicker?.();
+    };
+    operations.set(request.requestId, cancel);
+    try {
+      if (!isActive()) throw new Error("Document forward context expired");
+      const input = request.input;
+      closePicker = host.getContext().showConversationSelect(undefined, input.modalTitle, {
+        messageTitle: input.title,
+        link: input.link,
+        shareAsCard: input.shareAsCard,
+        docId: input.docId,
+        spaceId: input.spaceId,
+        kind: input.kind,
+        ownerName: input.ownerName,
+        updatedAt: input.updatedAt,
+        canGrant: input.canGrant,
+        disabledReason: input.disabledReason,
+        defaultRole: input.defaultRole,
+        isActive,
+        beforeSend: async () => {
+          if (!isActive()) throw new Error("Document forward context expired");
+          await bridge.authorizeDocumentForward!({ requestId: request.requestId });
+          if (!isActive()) throw new Error("Document forward context expired");
+        },
+        grantAccess: input.canGrant ? async (uids, role) => {
+          if (!isActive()) throw new Error("Document forward context expired");
+          const result = await bridge.grantDocumentForward!({ requestId: request.requestId, uids, role });
+          if (!isActive()) throw new Error("Document forward context expired");
+          return result;
+        } : undefined,
+        onResult: (result) => {
+          if (!isActive()) respond({ ok: false, error: "Document forward context expired" });
+          else respond({ ok: true, result });
+        },
+        onError: () => respond({ ok: false, error: "Document forwarding failed" }),
+      }, cancel);
+    } catch {
+      respond({ ok: false, error: "Document forwarding unavailable" });
+    }
+  });
+  const cancelAll = () => {
+    for (const cancel of [...operations.values()]) cancel();
+  };
+  const offCancel = bridge.onDocumentForwardCancel!(({ requestId }) => operations.get(requestId)?.());
+  const offCommand = bridge.onCommand((command) => {
+    // Host layout changes may hide and restore the same view. The originating Docs
+    // runtime owns cancellation; visibility alone must not dismiss its picker.
+    if (command.type === "sessionRevoked" ||
+        (command.type === "spaceChanged" && command.space.id !== host.getSpaceId())) cancelAll();
+  });
+  return () => {
+    disposed = true;
+    cancelAll();
+    offRequest();
+    offCancel();
+    offCommand();
+  };
+}

--- a/apps/web/src/client-communication/documentPreview.test.ts
+++ b/apps/web/src/client-communication/documentPreview.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  getDocumentPreviewBody,
+} from "@octo/base/src/Service/DocumentPreviewService";
+import type { DocumentPreviewResponse } from "@octo/base/src/Service/DocumentPreviewService";
+import { installHostDocumentPreview } from "./documentPreview";
+import type { HostCommand, OctoBuddyCommunicationBridge } from "./hostBridge";
+
+vi.mock("@octo/base/src/Messages/DocumentShareCard/preview", () => ({
+  resetDocPreviewCache: vi.fn(),
+}));
+
+import { resetDocPreviewCache } from "@octo/base/src/Messages/DocumentShareCard/preview";
+
+let dispose: (() => void) | undefined;
+afterEach(() => {
+  dispose?.();
+  dispose = undefined;
+  vi.clearAllMocks();
+});
+
+function fixture() {
+  let onCommand: (command: HostCommand) => void = () => {};
+  const bridge = {
+    getDocumentPreview: vi.fn(async (): Promise<DocumentPreviewResponse> => ({
+      ok: true, body: { preview: {} },
+    })),
+    reportAuthExpired: vi.fn(),
+    onCommand: vi.fn((callback: typeof onCommand) => {
+      onCommand = callback;
+      return vi.fn();
+    }),
+  };
+  dispose = installHostDocumentPreview(bridge as unknown as OctoBuddyCommunicationBridge, "space-a");
+  return { bridge, command: (command: HostCommand) => onCommand(command) };
+}
+
+describe("communication document preview adapter", () => {
+  it("supports an older host without registering a transport", () => {
+    expect(() => installHostDocumentPreview({} as OctoBuddyCommunicationBridge, "space-a")()).not.toThrow();
+    expect(resetDocPreviewCache).not.toHaveBeenCalled();
+  });
+
+  it("passes document identity to the host without message-supplied space", async () => {
+    const f = fixture();
+    await getDocumentPreviewBody({ docId: "d_1", kind: "html" }, "untrusted-space");
+    expect(f.bridge.getDocumentPreview).toHaveBeenCalledWith({ docId: "d_1", kind: "html" });
+  });
+
+  it("reports an expired current session instead of hiding authentication failure", async () => {
+    const f = fixture();
+    f.bridge.getDocumentPreview.mockResolvedValue({ ok: false, status: 401 });
+    await expect(getDocumentPreviewBody({ docId: "d_1", kind: "doc" }, ""))
+      .rejects.toMatchObject({ status: 401 });
+    expect(f.bridge.reportAuthExpired).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not invalidate cached status for same-space or visibility updates", async () => {
+    const f = fixture();
+    f.command({ type: "spaceChanged", space: { id: "space-a", name: "A" } });
+    f.command({ type: "hostVisibilityChanged", visible: false });
+    expect(resetDocPreviewCache).toHaveBeenCalledTimes(1);
+    await expect(getDocumentPreviewBody({ docId: "d_1", kind: "doc" }, ""))
+      .resolves.toEqual({ preview: {} });
+  });
+
+  it("does not issue new preview requests after session revocation", async () => {
+    const f = fixture();
+    f.command({ type: "sessionRevoked" });
+    await expect(getDocumentPreviewBody({ docId: "d_1", kind: "doc" }, "")).rejects.toThrow();
+    expect(f.bridge.getDocumentPreview).not.toHaveBeenCalled();
+  });
+
+  it.each(["spaceChanged", "sessionRevoked", "dispose"] as const)(
+    "rejects stale completion after %s and clears the preview cache", async (type) => {
+      const f = fixture();
+      let resolve: (result: DocumentPreviewResponse) => void = () => {};
+      f.bridge.getDocumentPreview.mockImplementation(() => new Promise((done) => { resolve = done; }));
+      const pending = getDocumentPreviewBody({ docId: "d_1", kind: "doc" }, "");
+      const assertion = expect(pending).rejects.toMatchObject({ status: undefined });
+      if (type === "dispose") dispose!();
+      else if (type === "spaceChanged") f.command({ type, space: { id: "new", name: "New" } });
+      else f.command({ type });
+      resolve({ ok: false, status: 401 });
+      await assertion;
+      expect(f.bridge.reportAuthExpired).not.toHaveBeenCalled();
+      expect(resetDocPreviewCache).toHaveBeenCalledTimes(2);
+    },
+  );
+});

--- a/apps/web/src/client-communication/documentPreview.ts
+++ b/apps/web/src/client-communication/documentPreview.ts
@@ -1,0 +1,45 @@
+import {
+  installDocumentPreviewTransport,
+} from "@octo/base/src/Service/DocumentPreviewService";
+import { resetDocPreviewCache } from "@octo/base/src/Messages/DocumentShareCard/preview";
+import type { OctoBuddyCommunicationBridge } from "./hostBridge";
+
+export function installHostDocumentPreview(
+  bridge: OctoBuddyCommunicationBridge,
+  initialSpaceId: string,
+): () => void {
+  if (!bridge.getDocumentPreview) return () => {};
+  let revision = 0;
+  let active = true;
+  let spaceId = initialSpaceId;
+  const getPreview = bridge.getDocumentPreview.bind(bridge);
+  const uninstall = installDocumentPreviewTransport(async (input) => {
+    if (!active) return { ok: false };
+    const captured = revision;
+    const result = await getPreview(input);
+    if (!active || captured !== revision) return { ok: false };
+    if (!result.ok && result.status === 401) {
+      bridge.reportAuthExpired("Document preview session expired");
+    }
+    return result;
+  });
+  resetDocPreviewCache();
+  const offCommand = bridge.onCommand((command) => {
+    if (command.type === "spaceChanged") {
+      if (command.space.id === spaceId) return;
+      spaceId = command.space.id;
+    }
+    if (command.type === "spaceChanged" || command.type === "sessionRevoked") {
+      revision++;
+      resetDocPreviewCache();
+      if (command.type === "sessionRevoked") active = false;
+    }
+  });
+  return () => {
+    active = false;
+    revision++;
+    offCommand();
+    uninstall();
+    resetDocPreviewCache();
+  };
+}

--- a/apps/web/src/client-communication/hostBridge.ts
+++ b/apps/web/src/client-communication/hostBridge.ts
@@ -72,7 +72,29 @@ export interface SummaryCapabilityResponse {
   error?: string;
 }
 
+export interface DocumentForwardInput {
+  docId: string;
+  title: string;
+  link: string;
+  shareAsCard?: boolean;
+  spaceId?: string;
+  kind?: "doc" | "board" | "sheet" | "html";
+  ownerName?: string;
+  updatedAt?: string;
+  canGrant: boolean;
+  disabledReason?: string;
+  defaultRole?: "reader" | "commenter" | "writer";
+  modalTitle?: string;
+}
+
+export interface DocumentForwardRequest {
+  requestId: string;
+  spaceId: string;
+  input: DocumentForwardInput;
+}
+
 export interface OctoBuddyCommunicationBridge {
+  getDocumentPreview?: import("@octo/base/src/Service/DocumentPreviewService").DocumentPreviewTransport;
   openSummary(request: {
     route: import("@dmwork/summary").SummaryWorkspaceRoute;
     spaceId: string;
@@ -84,6 +106,7 @@ export interface OctoBuddyCommunicationBridge {
     page: CommunicationPage;
     spaceId: string;
     rendererVersion: string;
+    documentForwardVersion?: 1;
   }): Promise<void>;
   reportNavigation(state: NavigationReport): Promise<void>;
   reportUnread(count: number): void;
@@ -93,6 +116,15 @@ export interface OctoBuddyCommunicationBridge {
   onSummaryRequest?(
     callback: (request: SummaryCapabilityRequest) => void
   ): () => void;
+  onDocumentForward?(callback: (request: DocumentForwardRequest) => void): () => void;
+  onDocumentForwardCancel?(callback: (request: { requestId: string }) => void): () => void;
+  grantDocumentForward?(request: {
+    requestId: string;
+    uids: string[];
+    role: "reader" | "commenter" | "writer";
+  }): Promise<{ granted: number; failed: number; failures?: string[]; rejected?: string[] }>;
+  authorizeDocumentForward?(request: { requestId: string }): Promise<void>;
+  respondDocumentForward?(response: SummaryCapabilityResponse): void;
   onCommand(callback: (command: HostCommand) => void): () => void;
 }
 

--- a/apps/web/src/client-communication/index.tsx
+++ b/apps/web/src/client-communication/index.tsx
@@ -26,6 +26,7 @@ import { enableClientFeatureMocks } from "../client-feature/e2eMocks";
 import { CommunicationShell } from "./CommunicationShell";
 import { requireHostBridge } from "./hostBridge";
 import { reportStartupFailure } from "./startupFailure";
+import { installHostDocumentPreview } from "./documentPreview";
 
 async function main() {
   const host = requireHostBridge();
@@ -52,6 +53,7 @@ async function main() {
   });
   WKApp.shared.currentSpaceId = bootstrap.space.id;
   document.documentElement.dataset.spaceId = bootstrap.space.id;
+  installHostDocumentPreview(host, bootstrap.space.id);
 
   i18n.registerNamespace("app", {
     "zh-CN": appZhCN,
@@ -96,6 +98,7 @@ async function main() {
             page,
             spaceId,
             rendererVersion: WKApp.config.appVersion,
+            documentForwardVersion: 1,
           })}
         />
       </I18nProvider>

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -233,7 +233,7 @@ export default defineConfig(({ mode }) => {
     ],
     resolve: {
       extensions: [".mjs", ".js", ".mts", ".ts", ".jsx", ".tsx", ".json"],
-      dedupe: ["react", "react-dom"],
+      dedupe: ["react", "react-dom", "@octo/base"],
     },
     build: {
       outDir: "build",

--- a/docs/docs-client-forward-bridge.md
+++ b/docs/docs-client-forward-bridge.md
@@ -1,0 +1,67 @@
+# Docs Client Forward Bridge
+
+## Behavior List
+
+- Reuse the existing Docs "forward to chat" entry and the communication artifact's
+  conversation picker. Do not initialize a second IM connection in the Docs artifact.
+- Docs owns document metadata, the canonical link, permission checks and the
+  existing forward-grant batch API. Communication owns target/member selection,
+  opt-in grants, type-18 cards or instruction text, sending and result feedback.
+- The Client carries typed requests between isolated renderers. It binds every
+  operation to the originating document, authenticated principal and selected
+  organization. Document home space is metadata, never an authorization override.
+- A cancelled, closed or revoked source must not authorize or send later. Ordinary
+  grant failures remain nonfatal, as in Web; invalidated operations are different
+  and must stop before further side effects.
+- Host visibility is not source validity. Page transitions, layout remounts and
+  overlays may suspend/resume the same communication view without cancelling its
+  picker. Explicit cancellation, source teardown, changed account/organization
+  and actual communication disposal still invalidate it.
+- The existing Web entry remains supported without Client bridge methods. A Docs
+  artifact without a compatible host must not expose its local, disconnected
+  conversation picker as a usable forwarding capability.
+
+## File Map
+
+- `packages/dmworkbase/src/Components/ForwardModal/grant.ts`: optional scoped
+  forwarding lifecycle hooks on the existing contract.
+- `packages/dmworkbase/src/Components/WKBase/index.tsx`: reuse existing selection
+  and send orchestration, with scoped cancellation and side-effect checks.
+- `apps/web/src/client-communication/*`: typed Docs request adapter, grant
+  round trips, cancellation and capability reporting.
+- Client `electron/main/docs/*` and `electron/main/communication/*`: validate
+  payloads, bind source identity, manage pending requests and forward grants.
+- Client preloads and embedded feature controller: expose only explicit bridge
+  operations and present the existing communication view.
+- Docs `src/client-docs/*` and `src/octoweb/index.ts`: opt-in host adapter;
+  ordinary Web fallback remains unchanged.
+- Tests beside each boundary: execute production implementations with isolated
+  transport dependencies, not duplicated implementations of the tested logic.
+
+## PR Scope
+
+The change completes forwarding from the extracted Docs workspace. It does not
+change backend endpoints, document authorization rules, the Web navigation
+model, editor engines or release publishing. Shared changes are limited to the
+existing conversation picker and document-forward lifecycle, with regression
+tests for ordinary Web callers.
+
+This note is a development plan, not an assertion of completed integration.
+The Web baseline is `2a41ee1d` (upstream #1640); pre-existing voice compatibility
+changes remain separate and must be preserved.
+
+## Verification Plan
+
+- Web: actual WKBase/forward tests for ordinary callers, cancel/replacement,
+  async grant invalidation, per-target send guard, and card/text behavior.
+- Docs: actual bridge/runtime tests for unavailable host, read-only policy,
+  request/result/grant lifecycle and revoked sessions.
+- Client: trusted sender, immutable document target, source teardown, login and
+  organization changes, timeout, rejected grant, and pending request cleanup.
+- Build new real communication and Docs artifacts into isolated directories.
+  Never claim a newly added bridge works with an old artifact.
+- Run real Electron integration against local HTTP/IM fixtures. Grant opt-in,
+  cancel and card delivery must be observable. This does not replace authorized
+  online collaboration acceptance.
+- Do not restart the user's live Client or write to production documents while
+  running these checks.

--- a/docs/docs-voice-host-compatibility.md
+++ b/docs/docs-voice-host-compatibility.md
@@ -1,0 +1,48 @@
+# Docs Voice Host Compatibility
+
+## Behavior List
+
+- Keep native input/textarea voice capture, selection replacement, configured shortcuts,
+  settings gating and offline behavior unchanged.
+- Allow rich-text hosts to omit `inputRef` and insert transcription via the existing callback.
+- Ref-less shortcut activation requires an explicit `isHotkeyActive` callback. An unfocused
+  rich-text editor, or one without that callback, must not capture global shortcuts.
+- A supplied ref whose element is still null remains unavailable.
+- No new menu, route, backend interface, permission or navigation behavior.
+
+## File Map
+
+- `packages/dmworkbase/src/Components/VoiceInputButton/index.tsx`: optional rich-text
+  host contract, availability and shortcut focus.
+- `packages/dmworkbase/src/Components/VoiceInputButton/useTextareaVoice.ts`: preserve
+  native selection handling and support callback-only insertion.
+- Tests in the same directory: native regressions, ref-less rendering and voice delivery.
+- `apps/web/vite.config.ts`: deduplicate `@octo/base` so externally sourced enterprise
+  modules share the host's login, module registry and public components.
+- The Docs artifact build selects this worktree explicitly; it must not silently use
+  an unrelated checkout or claim a dirty local artifact is a fixed release.
+
+## PR Scope
+
+This is a backward-compatible shared voice-input correction. Docs' existing
+`MentionComposer` already omits `inputRef` and supplies `isHotkeyActive`; its local type
+shim and component mock accepted that contract, but the current real base crashed on
+`inputRef.current`. Normal HTML document loading reproduced this in the production
+artifact, while terminal error-page smoke tests did not.
+
+No Docs implementation is copied into OSS Web. No visual redesign, general SDK
+extraction or backend change is included. The primary Web checkout stays unchanged.
+An external Docs worktree resolves its own linked base without Vite deduplication;
+that can load a second base singleton and bypass the host compatibility correction.
+Keep one base instance for the shell and its enterprise modules.
+
+## Verification Plan
+
+- Run the existing and added `VoiceInputButton` / `useTextareaVoice` tests.
+- Exercise both real component and real hook, replacing only the lower voice-service
+  boundary where possible; a mocked hook alone does not prove ref-less capture works.
+- Rebuild the Docs artifact against this checkout, then run the Client Electron
+  successful-document test with network fixtures and the original error-page smoke test.
+- Rebuild Web with its existing enterprise Docs entry. Run shared voice/composer
+  regressions; a successful build does not prove logged-in Web visual or audio behavior.
+- Record real microphone, live backend and manual Web checks separately from fixtures.

--- a/packages/dmworkbase/src/Components/ForwardModal/grant.ts
+++ b/packages/dmworkbase/src/Components/ForwardModal/grant.ts
@@ -137,8 +137,8 @@ export interface DocForwardOpen {
   docId?: string
   /** The doc's space id (deep-link + preview both need it). */
   spaceId?: string
-  /** Resource kind — doc/board/sheet — drives the card icon + which preview endpoint the cell calls. */
-  kind?: "doc" | "board" | "sheet"
+  /** Resource kind — doc/board/sheet/html — drives the card icon + which preview endpoint the cell calls. */
+  kind?: "doc" | "board" | "sheet" | "html"
   /** Pre-resolved owner display name for the card eyebrow (optional). */
   ownerName?: string
   /** Pre-formatted "updated at" string for the card eyebrow (optional). */
@@ -151,6 +151,29 @@ export interface DocForwardOpen {
   defaultRole?: ForwardGrantRole
   /** docs-injected executor; host awaits it BEFORE sending (先授权后发). */
   grantAccess?(uids: string[], role: ForwardGrantRole): Promise<ForwardGrantResult>
+  /**
+   * Optional liveness check for the originating source. When present and returning false at
+   * any lifecycle checkpoint, the whole forward is aborted via `onError` without further
+   * side effects (no grant, no send, no onResult). The Client bridge uses this to reject
+   * a forward from a revoked document session, a changed principal, or an invalidated
+   * scoped picker. Ordinary Web callers omit it — behaviour is unchanged.
+   */
+  isActive?(): boolean
+  /**
+   * Called when the forward lifecycle is invalidated mid-flight — the source became inactive
+   * (`isActive` false), the cancellation handle was invoked after confirmation, the source
+   * space changed between selection and send, or `beforeSend` observes a revoked state.
+   * Unlike a grant failure (nonfatal — the message is still sent), invalidation stops the
+   * entire flow with no further side effects.
+   */
+  onError?(error: unknown): void
+  /**
+   * Optional per-target authorization gate. Awaited before EVERY actual SDK send through
+   * ForwardService, together with an `isActive` check before and after. The Client bridge
+   * uses it to run a host IPC authorization check per target; ordinary Web omits it.
+   * Null/undefined return means the target is cleared to send.
+   */
+  beforeSend?(): Promise<void>
   /** Optional outcome callback (host already toasts; docs may use this for extra UI). */
   onResult?(result: {
     sent: number

--- a/packages/dmworkbase/src/Components/VoiceInputButton/VoiceInputButton.test.tsx
+++ b/packages/dmworkbase/src/Components/VoiceInputButton/VoiceInputButton.test.tsx
@@ -4,29 +4,71 @@ import ReactDOM from "react-dom";
 import { act } from "react-dom/test-utils";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+// ---------------------------------------------------------------------------
+// These tests run the REAL VoiceInputButton with the REAL useTextareaVoice.
+// Only the lower useVoiceInput adapter is replaced so no microphone or backend
+// is touched. The adapter's onTranscribed option (the real useTextareaVoice
+// handler that computes replaceMode + selection) is preserved and invoked so
+// transcript delivery through the real hook is covered.
+// ---------------------------------------------------------------------------
+
 const mocks = vi.hoisted(() => ({
+  adapterOnTranscribed: undefined as undefined | ((text: string) => void),
+  rawStartRecording: vi.fn(),
+  rawStopRecording: vi.fn(),
+  rawCancelRecording: vi.fn(),
+  isRecording: false,
+  isTranscribing: false,
   isVoiceEnabled: true,
-  settingsEnabled: false,
+  localAvailable: false,
   toastWarning: vi.fn(),
-  startRecording: vi.fn(),
-  stopRecording: vi.fn(),
-  cancelRecording: vi.fn(),
+  toastError: vi.fn(),
   shortcut: "alt-right" as "alt-right" | "shift-right" | "shift-left",
   speakingMode: "toggle" as "toggle" | "hold",
-  isRecording: false,
+  settingsEnabled: true,
+  // Simulates the async window where the real adapter's startRecording is
+  // pending before useVoiceInput flips isRecording to true.
+  deferStart: false,
+  pendingStart: null as null | (() => void),
 }));
 
-vi.mock("./useTextareaVoice", () => ({
-  default: () => {
-    const [isRecording, setIsRecording] = React.useState(mocks.isRecording);
+vi.mock("../../features/chat-composer/voice", () => ({
+  useVoiceInput: (options: { onTranscribed?: (text: string) => void }) => {
+    mocks.adapterOnTranscribed = options.onTranscribed;
+    const [recording, setRecording] = React.useState(mocks.isRecording);
+    const [transcribing, setTranscribing] = React.useState(mocks.isTranscribing);
     return {
-    isRecording,
-    isTranscribing: false,
-    isVoiceEnabled: mocks.isVoiceEnabled,
-    localAvailable: false,
-    startRecording: (...args: unknown[]) => { mocks.isRecording = true; setIsRecording(true); mocks.startRecording(...args); },
-    stopRecordingAndTranscribe: (...args: unknown[]) => { mocks.isRecording = false; setIsRecording(false); mocks.stopRecording(...args); },
-    cancelRecording: mocks.cancelRecording,
+      isRecording: recording,
+      isTranscribing: transcribing,
+      startRecording: (...args: unknown[]) => {
+        mocks.rawStartRecording(...args);
+        if (mocks.deferStart) {
+          mocks.pendingStart = () => {
+            mocks.isRecording = true;
+            setRecording(true);
+          };
+        } else {
+          mocks.isRecording = true;
+          setRecording(true);
+        }
+      },
+      stopRecordingAndTranscribe: (contextText?: string) => {
+        mocks.rawStopRecording(contextText);
+        mocks.adapterOnTranscribed?.("transcribed text");
+        mocks.isRecording = false;
+        mocks.isTranscribing = false;
+        setRecording(false);
+        setTranscribing(false);
+      },
+      cancelRecording: (...args: unknown[]) => {
+        mocks.isRecording = false;
+        setRecording(false);
+        mocks.rawCancelRecording(...args);
+      },
+      isVoiceEnabled: mocks.isVoiceEnabled,
+      localAvailable: mocks.localAvailable,
+      currentMode: "append_only" as const,
+      currentUtteranceId: "utt-1",
     };
   },
 }));
@@ -35,91 +77,400 @@ vi.mock("../../Service/VoiceSettingsStore", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../../Service/VoiceSettingsStore")>()),
   getVoiceShortcut: () => mocks.shortcut,
   voiceSettingsStore: {
-    get: () => ({ enabled: mocks.settingsEnabled, speakingMode: mocks.speakingMode, shortcutWindows: mocks.shortcut, shortcutMacos: mocks.shortcut }),
+    get: () => ({
+      enabled: mocks.settingsEnabled,
+      speakingMode: mocks.speakingMode,
+      shortcutWindows: mocks.shortcut,
+      shortcutMacos: mocks.shortcut,
+    }),
     subscribe: () => () => {},
   },
 }));
 
-vi.mock("../../App", () => ({ default: { shared: { currentSpaceId: "space-a" }, mittBus: { on: vi.fn(), off: vi.fn() } } }));
+vi.mock("../../App", () => ({
+  default: {
+    shared: { currentSpaceId: "space-a" },
+    mittBus: { on: vi.fn(), off: vi.fn() },
+  },
+}));
 vi.mock("../../i18n", () => ({ useI18n: () => ({ t: (key: string) => key }) }));
 vi.mock("lucide-react", () => ({ Mic: () => <span /> }));
 vi.mock("@douyinfe/semi-ui", () => ({
-  Toast: { warning: (...args: unknown[]) => mocks.toastWarning(...args), error: vi.fn() },
+  Toast: {
+    warning: (...args: unknown[]) => mocks.toastWarning(...args),
+    error: (...args: unknown[]) => mocks.toastError(...args),
+  },
   Dropdown: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
 
 import VoiceInputButton from "./index";
 
 let container: HTMLDivElement;
-let input: HTMLTextAreaElement;
+let textarea: HTMLTextAreaElement;
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mocks.isRecording = false;
+  mocks.isTranscribing = false;
   mocks.isVoiceEnabled = true;
-  mocks.settingsEnabled = false;
+  mocks.localAvailable = false;
+  mocks.settingsEnabled = true;
   mocks.shortcut = "alt-right";
   mocks.speakingMode = "toggle";
-  mocks.isRecording = false;
-  mocks.startRecording.mockReset();
-  mocks.stopRecording.mockReset();
+  mocks.deferStart = false;
+  mocks.pendingStart = null;
+  mocks.rawStartRecording.mockReset();
+  mocks.rawStopRecording.mockReset();
+  mocks.rawCancelRecording.mockReset();
   Object.defineProperty(navigator, "onLine", { configurable: true, value: true });
   container = document.createElement("div");
-  input = document.createElement("textarea");
-  document.body.appendChild(input);
+  textarea = document.createElement("textarea");
+  textarea.value = "existing content";
+  document.body.appendChild(textarea);
   document.body.appendChild(container);
 });
 
 afterEach(() => {
-  act(() => ReactDOM.unmountComponentAtNode(container));
-  input.remove();
+  act(() => { ReactDOM.unmountComponentAtNode(container); });
+  textarea.remove();
   container.remove();
 });
 
+const clickButton = () =>
+  act(() => {
+    (container.querySelector(".wk-vib__btn") as HTMLElement).click();
+  });
+
+// ======================================================
+// Availability + settings gating (with real hook)
+// ======================================================
 describe("VoiceInputButton availability", () => {
   it("renders nothing when the voice service is unavailable", () => {
     mocks.isVoiceEnabled = false;
-    act(() => ReactDOM.render(<VoiceInputButton inputRef={{ current: input }} onTranscribed={() => undefined} />, container));
+    act(() => {
+      ReactDOM.render(
+        <VoiceInputButton inputRef={{ current: textarea }} onTranscribed={() => undefined} />,
+        container,
+      );
+    });
     expect(container.querySelector(".wk-vib")).toBeNull();
   });
 
   it("shows the disabled toast when voice input is not enabled in settings", () => {
-    act(() => ReactDOM.render(<VoiceInputButton inputRef={{ current: input }} onTranscribed={() => undefined} />, container));
-    act(() => (container.querySelector(".wk-vib__btn") as HTMLElement).click());
+    mocks.settingsEnabled = false;
+    act(() => {
+      ReactDOM.render(
+        <VoiceInputButton inputRef={{ current: textarea }} onTranscribed={() => undefined} />,
+        container,
+      );
+    });
+    clickButton();
     expect(mocks.toastWarning).toHaveBeenCalledWith("base.voiceInput.error.unavailable");
   });
 
-  it("starts and stops toggle mode for the configured shortcut", () => {
-    mocks.settingsEnabled = true;
-    input.focus();
-    act(() => ReactDOM.render(<VoiceInputButton inputRef={{ current: input }} onTranscribed={() => undefined} />, container));
-    act(() => window.dispatchEvent(new KeyboardEvent("keydown", { code: "AltRight" })));
-    act(() => window.dispatchEvent(new KeyboardEvent("keydown", { code: "AltRight" })));
-    expect(mocks.startRecording).toHaveBeenCalledWith("append_only");
-    expect(mocks.stopRecording).toHaveBeenCalled();
-  });
-
-  it("recognizes both configurable Shift shortcuts in hold mode", () => {
+  it("recognizes the configured Shift shortcut in hold mode", () => {
     vi.useFakeTimers();
-    mocks.settingsEnabled = true;
     mocks.speakingMode = "hold";
     mocks.shortcut = "shift-right";
-    input.focus();
-    act(() => ReactDOM.render(<VoiceInputButton inputRef={{ current: input }} onTranscribed={() => undefined} />, container));
-    act(() => window.dispatchEvent(new KeyboardEvent("keydown", { code: "ShiftRight" })));
-    act(() => vi.advanceTimersByTime(500));
-    expect(mocks.startRecording).toHaveBeenCalledWith("append_only");
-    act(() => window.dispatchEvent(new KeyboardEvent("keyup", { code: "ShiftRight", key: "Shift" })));
-    expect(mocks.stopRecording).toHaveBeenCalled();
+    textarea.focus();
+    act(() => {
+      ReactDOM.render(
+        <VoiceInputButton inputRef={{ current: textarea }} onTranscribed={() => undefined} />,
+        container,
+      );
+    });
+    act(() => { window.dispatchEvent(new KeyboardEvent("keydown", { code: "ShiftRight" })); });
+    act(() => { vi.advanceTimersByTime(500); });
+    expect(mocks.rawStartRecording).toHaveBeenCalledWith("append_only");
+    act(() => { window.dispatchEvent(new KeyboardEvent("keyup", { code: "ShiftRight", key: "Shift" })); });
+    expect(mocks.rawStopRecording).toHaveBeenCalled();
     vi.useRealTimers();
   });
 
   it("does not treat AltGraph as the Alt shortcut", () => {
-    mocks.settingsEnabled = true;
-    input.focus();
-    act(() => ReactDOM.render(<VoiceInputButton inputRef={{ current: input }} onTranscribed={() => undefined} />, container));
+    textarea.focus();
+    act(() => {
+      ReactDOM.render(
+        <VoiceInputButton inputRef={{ current: textarea }} onTranscribed={() => undefined} />,
+        container,
+      );
+    });
     const event = new KeyboardEvent("keydown", { code: "AltRight", altKey: true });
     Object.defineProperty(event, "getModifierState", { value: (key: string) => key === "AltGraph" });
-    act(() => window.dispatchEvent(event));
-    expect(mocks.startRecording).not.toHaveBeenCalled();
+    act(() => { window.dispatchEvent(event); });
+    expect(mocks.rawStartRecording).not.toHaveBeenCalled();
+  });
+});
+
+// ======================================================
+// Ref-supplied mode: native behavior preserved
+// ======================================================
+describe("ref-supplied mode", () => {
+  it("keyboard shortcut fires when the input is focused", () => {
+    textarea.focus();
+    act(() => {
+      ReactDOM.render(
+        <VoiceInputButton inputRef={{ current: textarea }} onTranscribed={() => undefined} />,
+        container,
+      );
+    });
+    act(() => { window.dispatchEvent(new KeyboardEvent("keydown", { code: "AltRight" })); });
+    expect(mocks.rawStartRecording).toHaveBeenCalledWith("append_only");
+  });
+
+  it("keyboard shortcut is blocked when the input is not focused", () => {
+    act(() => {
+      ReactDOM.render(
+        <VoiceInputButton inputRef={{ current: textarea }} onTranscribed={() => undefined} />,
+        container,
+      );
+    });
+    act(() => { window.dispatchEvent(new KeyboardEvent("keydown", { code: "AltRight" })); });
+    expect(mocks.rawStartRecording).not.toHaveBeenCalled();
+  });
+
+  it("mouse click captures and preserves native selection", () => {
+    textarea.setSelectionRange(2, 7);
+    const onTranscribed = vi.fn();
+    act(() => {
+      ReactDOM.render(
+        <VoiceInputButton inputRef={{ current: textarea }} onTranscribed={onTranscribed} />,
+        container,
+      );
+    });
+    clickButton();
+    clickButton();
+    expect(onTranscribed).toHaveBeenCalledWith("transcribed text", "insert", { from: 2, to: 7 });
+  });
+
+  it("a supplied ref whose element is null stays disabled", () => {
+    act(() => {
+      ReactDOM.render(
+        <VoiceInputButton inputRef={{ current: null }} onTranscribed={() => undefined} />,
+        container,
+      );
+    });
+    clickButton();
+    expect(mocks.rawStartRecording).not.toHaveBeenCalled();
+    const btn = container.querySelector(".wk-vib__btn") as HTMLElement;
+    expect(btn.classList.contains("wk-vib__btn--disabled")).toBe(true);
+  });
+
+  it("keyboard shortcut is blocked when the ref element is null even with a hotkey callback", () => {
+    act(() => {
+      ReactDOM.render(
+        <VoiceInputButton inputRef={{ current: null }} onTranscribed={() => undefined} isHotkeyActive={() => true} />,
+        container,
+      );
+    });
+    act(() => { window.dispatchEvent(new KeyboardEvent("keydown", { code: "AltRight" })); });
+    expect(mocks.rawStartRecording).not.toHaveBeenCalled();
+  });
+});
+
+// ======================================================
+// Ref-less mode: callback-only capture and delivery
+// ======================================================
+describe("ref-less mode", () => {
+  it("renders the button when voice is available and ref is omitted", () => {
+    act(() => { ReactDOM.render(<VoiceInputButton onTranscribed={() => undefined} />, container); });
+    expect(container.querySelector(".wk-vib__btn")).not.toBeNull();
+  });
+
+  it("mouse click captures via the existing callback and delivers transcript", () => {
+    const onTranscribed = vi.fn();
+    act(() => { ReactDOM.render(<VoiceInputButton onTranscribed={onTranscribed} />, container); });
+    clickButton();
+    clickButton();
+    expect(onTranscribed).toHaveBeenCalledWith("transcribed text", "insert", { from: 0, to: 0 });
+  });
+
+  it("keyboard shortcut never globally captures when isHotkeyActive is absent", () => {
+    act(() => { ReactDOM.render(<VoiceInputButton onTranscribed={() => undefined} />, container); });
+    act(() => { window.dispatchEvent(new KeyboardEvent("keydown", { code: "AltRight" })); });
+    expect(mocks.rawStartRecording).not.toHaveBeenCalled();
+  });
+
+  it("keyboard shortcut fires only when isHotkeyActive returns true", () => {
+    act(() => {
+      ReactDOM.render(
+        <VoiceInputButton onTranscribed={() => undefined} isHotkeyActive={() => true} />,
+        container,
+      );
+    });
+    act(() => { window.dispatchEvent(new KeyboardEvent("keydown", { code: "AltRight" })); });
+    expect(mocks.rawStartRecording).toHaveBeenCalledWith("append_only");
+  });
+
+  it("keyboard shortcut is silently skipped when isHotkeyActive returns false", () => {
+    const isHotkeyActive = vi.fn(() => false);
+    act(() => {
+      ReactDOM.render(
+        <VoiceInputButton onTranscribed={() => undefined} isHotkeyActive={isHotkeyActive} />,
+        container,
+      );
+    });
+    act(() => { window.dispatchEvent(new KeyboardEvent("keydown", { code: "AltRight" })); });
+    expect(mocks.rawStartRecording).not.toHaveBeenCalled();
+  });
+
+  it("Escape always cancels ref-less recording even without isHotkeyActive", () => {
+    const onTranscribed = vi.fn();
+    act(() => { ReactDOM.render(<VoiceInputButton onTranscribed={onTranscribed} />, container); });
+    // Start via click
+    clickButton();
+    expect(mocks.rawStartRecording).toHaveBeenCalled();
+    mocks.isRecording = true;
+    // Escape should cancel regardless of isHotkeyActive being absent
+    act(() => { window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" })); });
+    expect(mocks.rawCancelRecording).toHaveBeenCalled();
+  });
+});
+
+// ======================================================
+// Hold mode in ref-less context
+// ======================================================
+describe("ref-less hold mode", () => {
+  it("hold capture fires when isHotkeyActive returns true and key is held", () => {
+    vi.useFakeTimers();
+    mocks.speakingMode = "hold";
+    mocks.shortcut = "shift-right";
+    act(() => {
+      ReactDOM.render(
+        <VoiceInputButton onTranscribed={() => undefined} isHotkeyActive={() => true} />,
+        container,
+      );
+    });
+    act(() => { window.dispatchEvent(new KeyboardEvent("keydown", { code: "ShiftRight" })); });
+    act(() => { vi.advanceTimersByTime(500); });
+    expect(mocks.rawStartRecording).toHaveBeenCalledWith("append_only");
+    act(() => { window.dispatchEvent(new KeyboardEvent("keyup", { code: "ShiftRight", key: "Shift" })); });
+    expect(mocks.rawStopRecording).toHaveBeenCalled();
+    vi.useRealTimers();
+  });
+
+  it("hold capture is blocked before timer fires when isHotkeyActive returns false", () => {
+    vi.useFakeTimers();
+    mocks.speakingMode = "hold";
+    mocks.shortcut = "shift-right";
+    act(() => {
+      ReactDOM.render(
+        <VoiceInputButton onTranscribed={() => undefined} isHotkeyActive={() => false} />,
+        container,
+      );
+    });
+    act(() => { window.dispatchEvent(new KeyboardEvent("keydown", { code: "ShiftRight" })); });
+    act(() => { vi.advanceTimersByTime(500); });
+    expect(mocks.rawStartRecording).not.toHaveBeenCalled();
+    vi.useRealTimers();
+  });
+
+  it("focus loss before hold timer fires prevents capture", () => {
+    vi.useFakeTimers();
+    mocks.speakingMode = "hold";
+    mocks.shortcut = "shift-right";
+    const focusState = { active: true };
+    const isHotkeyActive = vi.fn(() => focusState.active);
+    act(() => {
+      ReactDOM.render(
+        <VoiceInputButton onTranscribed={() => undefined} isHotkeyActive={isHotkeyActive} />,
+        container,
+      );
+    });
+    act(() => { window.dispatchEvent(new KeyboardEvent("keydown", { code: "ShiftRight" })); });
+    // Focus leaves before the timer fires
+    focusState.active = false;
+    act(() => { vi.advanceTimersByTime(500); });
+    expect(mocks.rawStartRecording).not.toHaveBeenCalled();
+    vi.useRealTimers();
+  });
+
+  it("release during a deferred start still sets cancelPendingRef (no stuck recording)", () => {
+    vi.useFakeTimers();
+    mocks.speakingMode = "hold";
+    mocks.shortcut = "shift-right";
+    mocks.deferStart = true;
+    const focusState = { active: true };
+    const isHotkeyActive = vi.fn(() => focusState.active);
+    act(() => {
+      ReactDOM.render(
+        <VoiceInputButton onTranscribed={() => undefined} isHotkeyActive={isHotkeyActive} />,
+        container,
+      );
+    });
+    // Hold fires the timer; async start is now pending so isRecording is false.
+    act(() => { window.dispatchEvent(new KeyboardEvent("keydown", { code: "ShiftRight" })); });
+    act(() => { vi.advanceTimersByTime(500); });
+    expect(mocks.rawStartRecording).toHaveBeenCalledWith("append_only");
+    expect(mocks.rawCancelRecording).not.toHaveBeenCalled();
+    // Focus leaves while the start is still pending, then the key is released.
+    focusState.active = false;
+    act(() => { window.dispatchEvent(new KeyboardEvent("keyup", { code: "ShiftRight", key: "Shift" })); });
+    // Deferred start resolves to isRecording=true; the cancelPending path must
+    // then cancel the session rather than leaving a stuck recording.
+    act(() => { mocks.pendingStart?.(); });
+    expect(mocks.rawCancelRecording).toHaveBeenCalled();
+    vi.useRealTimers();
+  });
+
+  it("focus loss after recording starts still stops on keyup (ownership-based)", () => {
+    vi.useFakeTimers();
+    mocks.speakingMode = "hold";
+    mocks.shortcut = "shift-right";
+    const focusState = { active: true };
+    const isHotkeyActive = vi.fn(() => focusState.active);
+    act(() => {
+      ReactDOM.render(
+        <VoiceInputButton onTranscribed={() => undefined} isHotkeyActive={isHotkeyActive} />,
+        container,
+      );
+    });
+    // Start: keydown fires
+    act(() => { window.dispatchEvent(new KeyboardEvent("keydown", { code: "ShiftRight" })); });
+    act(() => { vi.advanceTimersByTime(500); });
+    expect(mocks.rawStartRecording).toHaveBeenCalledWith("append_only");
+    // Focus leaves while still holding the key
+    focusState.active = false;
+    // keyup should still stop because ownsRecording is true
+    act(() => { window.dispatchEvent(new KeyboardEvent("keyup", { code: "ShiftRight", key: "Shift" })); });
+    expect(mocks.rawStopRecording).toHaveBeenCalled();
+    vi.useRealTimers();
+  });
+
+});
+
+// ======================================================
+// Cancel and blur behavior
+// ======================================================
+describe("cancel and blur", () => {
+  it("Escape during ref-supplied recording triggers cancel", () => {
+    textarea.focus();
+    act(() => {
+      ReactDOM.render(
+        <VoiceInputButton inputRef={{ current: textarea }} onTranscribed={() => undefined} />,
+        container,
+      );
+    });
+    act(() => { window.dispatchEvent(new KeyboardEvent("keydown", { code: "AltRight" })); });
+    expect(mocks.rawStartRecording).toHaveBeenCalled();
+    act(() => { window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" })); });
+    expect(mocks.rawCancelRecording).toHaveBeenCalled();
+  });
+
+  it("window blur event cancels recording", () => {
+    textarea.focus();
+    act(() => {
+      ReactDOM.render(
+        <VoiceInputButton inputRef={{ current: textarea }} onTranscribed={() => undefined} />,
+        container,
+      );
+    });
+    // Start recording
+    act(() => { window.dispatchEvent(new KeyboardEvent("keydown", { code: "AltRight" })); });
+    expect(mocks.rawStartRecording).toHaveBeenCalled();
+    mocks.rawCancelRecording.mockClear();
+    // Dispatch window blur
+    act(() => { window.dispatchEvent(new Event("blur")); });
+    expect(mocks.rawCancelRecording).toHaveBeenCalled();
   });
 });

--- a/packages/dmworkbase/src/Components/VoiceInputButton/index.tsx
+++ b/packages/dmworkbase/src/Components/VoiceInputButton/index.tsx
@@ -31,7 +31,7 @@ const voiceHost = {
 };
 
 export interface VoiceInputButtonProps {
-  inputRef: React.RefObject<HTMLInputElement | HTMLTextAreaElement | null>;
+  inputRef?: React.RefObject<HTMLInputElement | HTMLTextAreaElement | null> | null;
   onTranscribed: (text: string, replaceMode: ReplaceMode, savedSelectionRange?: SelectionRange) => void;
   getCurrentText?: () => string;
   showModeMenu?: boolean;
@@ -40,6 +40,8 @@ export interface VoiceInputButtonProps {
   className?: string;
   /** Called right before recording starts (useful for cancelling pending blur commits) */
   onRecordingStart?: () => void;
+  /** Callback to check if keyboard shortcut is allowed (ref-less mode). If absent, shortcuts never capture globally. */
+  isHotkeyActive?: () => boolean;
 }
 
 export default function VoiceInputButton({
@@ -51,6 +53,7 @@ export default function VoiceInputButton({
   getChatContext,
   className,
   onRecordingStart,
+  isHotkeyActive,
 }: VoiceInputButtonProps) {
   const { t } = useI18n();
   const [showMenu, setShowMenu] = useState(false);
@@ -67,7 +70,7 @@ export default function VoiceInputButton({
     isVoiceEnabled,
     localAvailable,
   } = useTextareaVoice({
-    inputRef,
+    inputRef: inputRef ?? null,
     onTranscribed,
     getCurrentText,
     enableEditMode: showModeMenu,
@@ -92,7 +95,7 @@ export default function VoiceInputButton({
   }, []);
 
   const canRecord = isOnline || localAvailable;
-  const isDisabled = !inputRef.current || !canRecord;
+  const isDisabled = (inputRef ? !inputRef.current : false) || !canRecord;
 
   // Floating indicator position
   const [floatingPosition, setFloatingPosition] = useState<{
@@ -179,6 +182,8 @@ export default function VoiceInputButton({
   isRecordingRef.current = isRecording;
   const isTranscribingRef = useRef(isTranscribing);
   isTranscribingRef.current = isTranscribing;
+  const isHotkeyActiveRef = useRef(isHotkeyActive);
+  isHotkeyActiveRef.current = isHotkeyActive;
 
   const clearShiftTimer = useCallback(() => {
     if (shiftTimerRef.current !== null) {
@@ -208,7 +213,13 @@ export default function VoiceInputButton({
       : !event.altKey && !event.ctrlKey && !event.metaKey;
 
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (!inputRef.current || document.activeElement !== inputRef.current || document.querySelector(".wk-settings-center-modal")) return;
+      // Ref-less mode: require explicit focus via isHotkeyActive callback;
+      // absent callback never captures globally.
+      if (!inputRef) {
+        if (!isHotkeyActiveRef.current || !isHotkeyActiveRef.current()) return;
+      }
+      if (inputRef && (!inputRef.current || document.activeElement !== inputRef.current)) return;
+      if (document.querySelector(".wk-settings-center-modal")) return;
 
       if (
         voiceShortcutMatches(e, configuredShortcut) &&
@@ -241,6 +252,9 @@ export default function VoiceInputButton({
           }, PREPARING_DELAY_MS);
           shiftTimerRef.current = setTimeout(() => {
             shiftTimerRef.current = null;
+            // Ref-less hold capture re-checks focus before starting so a host
+            // whose focus moved while the key stayed down does not begin.
+            if (!inputRef && (!isHotkeyActiveRef.current || !isHotkeyActiveRef.current())) return;
             if (!isOnlineRef.current && !localAvailableRef.current) {
               Toast.warning(t("base.voiceInput.error.networkUnavailable"));
               return;
@@ -274,10 +288,16 @@ export default function VoiceInputButton({
     };
 
     const handleKeyUp = (e: KeyboardEvent) => {
-      if (!inputRef.current) return;
-      const isInputFocused = document.activeElement === inputRef.current;
+      if (inputRef && !inputRef.current) return;
+      const ownsRecording = isRecordingRef.current || shiftRecordingRef.current || shiftTimerRef.current !== null;
+      const isInputFocused = inputRef
+        ? document.activeElement === inputRef.current
+        : (isHotkeyActiveRef.current?.() ?? false);
 
-      if (!isRecordingRef.current && !isInputFocused) return;
+      // Focus gating applies only to START. If this button already owns a
+      // pending hold timer or an active recording, release must still
+      // clear/stop even if the host lost focus.
+      if (!ownsRecording && !isInputFocused) return;
 
       if (voiceShortcutMatches(e, configuredShortcut) && shiftTimerRef.current !== null) {
         clearShiftTimer();
@@ -333,7 +353,7 @@ export default function VoiceInputButton({
       Toast.warning(t("base.voiceInput.error.networkUnavailable"));
       return;
     }
-    if (!inputRef.current) return;
+    if (inputRef && !inputRef.current) return;
     if (!voiceSettings.enabled) {
       Toast.warning(t("base.voiceInput.error.unavailable"));
       return;
@@ -348,7 +368,7 @@ export default function VoiceInputButton({
       Toast.warning(t("base.voiceInput.error.unavailable"));
       return;
     }
-    if (!canRecord || !inputRef.current) return;
+    if (!canRecord || (inputRef && !inputRef.current)) return;
     if (!voiceSettings.enabled) {
       Toast.warning(t("base.voiceInput.error.unavailable"));
       return;
@@ -457,7 +477,7 @@ export default function VoiceInputButton({
           trigger="hover"
           position="topRight"
           render={dropdownMenu}
-          visible={canRecord && !!inputRef.current ? showMenu : false}
+          visible={canRecord && (inputRef ? !!inputRef.current : true) ? showMenu : false}
           onVisibleChange={setShowMenu}
           spacing={4}
         >

--- a/packages/dmworkbase/src/Components/VoiceInputButton/useTextareaVoice.ts
+++ b/packages/dmworkbase/src/Components/VoiceInputButton/useTextareaVoice.ts
@@ -15,7 +15,7 @@ export interface SelectionRange {
 
 export interface UseTextareaVoiceOptions {
   voiceHost: ChatComposerVoiceHost;
-  inputRef: React.RefObject<HTMLInputElement | HTMLTextAreaElement | null>;
+  inputRef?: React.RefObject<HTMLInputElement | HTMLTextAreaElement | null> | null;
   onTranscribed: (text: string, replaceMode: ReplaceMode, savedSelectionRange?: SelectionRange) => void;
   getCurrentText?: () => string;
   enableEditMode?: boolean;
@@ -80,15 +80,23 @@ export default function useTextareaVoice({
 
   const startRecording = useCallback(
     (mode?: VoiceMode) => {
-      if (!inputRef.current) return;
+      const el = inputRef ? inputRef.current : undefined;
+      // A supplied ref whose element has not mounted yet stays unavailable.
+      if (inputRef && !el) return;
 
-      const el = inputRef.current;
-      const selStart = el.selectionStart ?? 0;
-      const selEnd = el.selectionEnd ?? 0;
-      hadSelectionRef.current = selStart !== selEnd;
-      savedSelectionRangeRef.current = { from: selStart, to: selEnd };
-      const selectedText = (selStart !== selEnd) ? el.value.slice(selStart, selEnd) : undefined;
-      savedSelectedTextRef.current = selectedText;
+      if (el) {
+        const selStart = el.selectionStart ?? 0;
+        const selEnd = el.selectionEnd ?? 0;
+        hadSelectionRef.current = selStart !== selEnd;
+        savedSelectionRangeRef.current = { from: selStart, to: selEnd };
+        const selectedText = (selStart !== selEnd) ? el.value.slice(selStart, selEnd) : undefined;
+        savedSelectedTextRef.current = selectedText;
+      } else {
+        // Ref-less host: no DOM selection to capture; fall back to callback insertion.
+        hadSelectionRef.current = false;
+        savedSelectionRangeRef.current = { from: 0, to: 0 };
+        savedSelectedTextRef.current = undefined;
+      }
 
       const effectiveMode = mode ?? "append_only";
       recordingModeRef.current = effectiveMode;

--- a/packages/dmworkbase/src/Components/WKBase/__tests__/WKBase.lifecycle.test.tsx
+++ b/packages/dmworkbase/src/Components/WKBase/__tests__/WKBase.lifecycle.test.tsx
@@ -1,0 +1,378 @@
+// @vitest-environment jsdom
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Toast } from "@douyinfe/semi-ui";
+import { Channel, Message, WKSDK } from "wukongimjssdk";
+import type { DocForwardOpen, ForwardGrant, ForwardGrantResult } from "../../ForwardModal/grant";
+
+const runtime = vi.hoisted(() => ({
+  subscribers: new Map<string, Array<{ uid: string }>>(),
+  disbanded: new Set<string>(),
+  syncSubscribers: vi.fn(async () => {}),
+  currentSpaceId: "sender-space",
+}));
+
+vi.mock("../../ConversationSelect", () => ({ default: () => null }));
+vi.mock("../../WKModal", () => ({ default: () => null }));
+vi.mock("../../UserInfo", () => ({ default: () => null }));
+vi.mock("../../BotDetailModal", () => ({ default: () => null }));
+vi.mock("../../../im-runtime/currentChannelRuntime", () => ({
+  getCurrentImChannelSubscribers: (channel: Channel) => runtime.subscribers.get(channel.channelID) ?? [],
+  syncCurrentImChannelSubscribers: runtime.syncSubscribers,
+}));
+vi.mock("../../../im-runtime/channelRuntime", () => ({
+  getImChannelInfo: () => ({ orgData: { receipt: 1 } }),
+}));
+vi.mock("../../../Utils/groupDisband", () => ({
+  isConversationDisbanded: (channel: Channel) => runtime.disbanded.has(channel.channelID),
+}));
+vi.mock("../../../App", () => ({
+  default: {
+    shared: { get currentSpaceId() { return runtime.currentSpaceId; } },
+    apiClient: { config: { apiURL: "https://test.invalid/api/v1/" } },
+    endpoints: {},
+  },
+}));
+
+import WKBase from "../index";
+import ConversationSelect from "../../ConversationSelect";
+import WKModal from "../../WKModal";
+
+const documentInput: DocForwardOpen = {
+  messageTitle: "Quarterly plan",
+  link: "https://docs.test/d/doc-a",
+  docId: "doc-a",
+  spaceId: "document-home",
+  shareAsCard: true,
+  kind: "html",
+  canGrant: true,
+};
+const recipient = new Channel("peer", 1);
+const group = new Channel("group", 2);
+const grant: ForwardGrant = {
+  role: "writer",
+  principalsByTarget: [{ channelID: "peer", channelType: 1, uids: ["peer"] }],
+};
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((yes, no) => { resolve = yes; reject = no; });
+  return { promise, resolve, reject };
+}
+
+function makeBase(): WKBase {
+  const base = new WKBase({ children: null });
+  base.context = { t: (key: string) => key } as WKBase["context"];
+  base.setState = (update) => {
+    const next = typeof update === "function" ? update(base.state, base.props) : update;
+    if (next) base.state = { ...base.state, ...next };
+  };
+  return base;
+}
+
+function findElement(node: React.ReactNode, type: unknown, className?: string): React.ReactElement {
+  let found: React.ReactElement | undefined;
+  function visit(children: React.ReactNode): void {
+    React.Children.forEach(children, (child) => {
+      if (!React.isValidElement(child)) return;
+      if (child.type === type && (!className || child.props.className === className)) found = child;
+      else visit(child.props.children);
+    });
+  }
+  visit(node);
+  if (!found) throw new Error("Expected forwarding element in the actual WKBase render tree");
+  return found;
+}
+
+// Exercise production render callbacks and ForwardService; only the SDK transport is replaced.
+function picker(base: WKBase) {
+  const tree = base.render();
+  const select = findElement(tree, ConversationSelect);
+  const modal = findElement(tree, WKModal, "wk-base-modal wk-base-modal-forward");
+  return {
+    confirm: select.props.onFinished as (channels: Channel[], grant?: ForwardGrant) => void,
+    cancel: select.props.onCancel as () => void,
+    dismiss: modal.props.onCancel as () => void,
+  };
+}
+
+const flush = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+let send: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  runtime.subscribers.clear();
+  runtime.disbanded.clear();
+  runtime.currentSpaceId = "sender-space";
+  runtime.syncSubscribers.mockReset().mockResolvedValue(undefined);
+  send = vi.spyOn(WKSDK.shared().chatManager, "send").mockImplementation(async (content, channel) => {
+    const message = new Message();
+    message.content = content;
+    message.channel = channel;
+    return message;
+  });
+  vi.spyOn(Toast, "success").mockReturnValue("success");
+  vi.spyOn(Toast, "warning").mockReturnValue("warning");
+  vi.spyOn(Toast, "error").mockReturnValue("error");
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("document forwarding through WKBase render callbacks", () => {
+  it("accepts forwards after React's development lifecycle remount", async () => {
+    const base = makeBase();
+    base.componentDidMount();
+    base.componentWillUnmount();
+    base.componentDidMount();
+    const onResult = vi.fn();
+    base.showConversationSelect(undefined, undefined, { ...documentInput, onResult });
+    picker(base).confirm([group]);
+    await vi.waitFor(() => expect(onResult).toHaveBeenCalledOnce());
+    expect(send).toHaveBeenCalledOnce();
+  });
+
+  it("confirms once, closes the picker and sends an actual type-18 card", async () => {
+    const base = makeBase();
+    const onResult = vi.fn();
+    const cancel = base.showConversationSelect(undefined, "Forward", { ...documentInput, onResult });
+    const ui = picker(base);
+    ui.confirm([group]);
+    ui.confirm([group]);
+    expect(base.state.showConversationSelect).toBe(false);
+    await vi.waitFor(() => expect(onResult).toHaveBeenCalledTimes(1));
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send.mock.calls[0][0].encodeJSON()).toMatchObject({
+      type: 18, doc_id: "doc-a", space_id: "document-home", kind: "html",
+      title: "Quarterly plan", url: documentInput.link, permission: "reader",
+    });
+    expect(send.mock.calls[0][2].receiptEnabled).toBe(true);
+    expect(onResult).toHaveBeenCalledWith(expect.objectContaining({ sent: 1, failed: 0 }));
+    cancel?.();
+    expect(onResult).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps AI instruction forwards as text with the original anchored link", async () => {
+    const base = makeBase();
+    const onResult = vi.fn();
+    const link = "https://docs.test/d/doc-a?instruction=revise#paragraph-3";
+    base.showConversationSelect(undefined, undefined, { ...documentInput, shareAsCard: false, link, onResult });
+    picker(base).confirm([recipient]);
+    await vi.waitFor(() => expect(onResult).toHaveBeenCalledOnce());
+    expect(send.mock.calls[0][0].contentType).toBe(1);
+    expect(send.mock.calls[0][0].encodeJSON()).toMatchObject({
+      content: expect.stringContaining(link), space_id: "sender-space",
+    });
+  });
+
+  it.each(["cancel", "dismiss", "handle"] as const)("cancels via %s once without sending", async (method) => {
+    const base = makeBase();
+    const onCancel = vi.fn();
+    const onError = vi.fn();
+    const cancel = base.showConversationSelect(undefined, undefined, { ...documentInput, onError }, onCancel);
+    const ui = picker(base);
+    if (method === "handle") cancel?.();
+    else ui[method]();
+    ui.cancel();
+    cancel?.();
+    ui.confirm([recipient]);
+    await flush();
+    expect(base.state.showConversationSelect).toBe(false);
+    expect(onCancel).toHaveBeenCalledOnce();
+    expect(onError).not.toHaveBeenCalled();
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("ignores stale confirm/dismiss callbacks without closing a replacement picker", async () => {
+    const base = makeBase();
+    const onCancel = vi.fn();
+    const oldResult = vi.fn();
+    const oldCancel = base.showConversationSelect(undefined, "Old", { ...documentInput, onResult: oldResult }, onCancel);
+    const stale = picker(base);
+    const onResult = vi.fn();
+    base.showConversationSelect(undefined, "New", { ...documentInput, messageTitle: "New", onResult });
+    stale.confirm([recipient]);
+    stale.dismiss();
+    oldCancel?.();
+    expect(base.state.showConversationSelect).toBe(true);
+    expect(base.state.conversationSelectTitle).toBe("New");
+    expect(onCancel).toHaveBeenCalledOnce();
+    expect(send).not.toHaveBeenCalled();
+    picker(base).confirm([group]);
+    await vi.waitFor(() => expect(onResult).toHaveBeenCalledOnce());
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send.mock.calls[0][0].encodeJSON().title).toBe("New");
+    expect(oldResult).not.toHaveBeenCalled();
+  });
+
+  it("preserves the plain selection callback used by existing Web callers", () => {
+    const base = makeBase();
+    const onFinished = vi.fn();
+    const onCancel = vi.fn();
+    const cancel = base.showConversationSelect(onFinished, "Select", undefined, onCancel);
+    const ui = picker(base);
+    ui.confirm([recipient]);
+    ui.confirm([recipient]);
+    cancel?.();
+    expect(onFinished).toHaveBeenCalledExactlyOnceWith([recipient]);
+    expect(onCancel).not.toHaveBeenCalled();
+    expect(base.state.showConversationSelect).toBe(false);
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("waits for opt-in grants before sending and preserves partial grant feedback", async () => {
+    const base = makeBase();
+    const pending = deferred<ForwardGrantResult>();
+    const grantAccess = vi.fn(() => pending.promise);
+    const onResult = vi.fn();
+    base.showConversationSelect(undefined, undefined, { ...documentInput, grantAccess, onResult });
+    picker(base).confirm([recipient], grant);
+    expect(grantAccess).toHaveBeenCalledExactlyOnceWith(["peer"], "writer");
+    expect(send).not.toHaveBeenCalled();
+    pending.resolve({ granted: 0, failed: 1, failures: ["peer"], rejected: ["peer"] });
+    await vi.waitFor(() => expect(onResult).toHaveBeenCalledOnce());
+    expect(send).toHaveBeenCalledOnce();
+    expect(onResult).toHaveBeenCalledWith({ sent: 1, failed: 0, grantFailures: ["peer"], grantRejections: ["peer"] });
+    expect(Toast.warning).toHaveBeenCalledWith("base.forwardModal.grant.grantRejected");
+  });
+
+  it("keeps ordinary grant transport failure nonfatal", async () => {
+    const base = makeBase();
+    const onResult = vi.fn();
+    const onError = vi.fn();
+    base.showConversationSelect(undefined, undefined, {
+      ...documentInput, onResult, onError, grantAccess: async () => { throw new Error("grant unavailable"); },
+    });
+    picker(base).confirm([recipient], grant);
+    await vi.waitFor(() => expect(onResult).toHaveBeenCalledOnce());
+    expect(send).toHaveBeenCalledOnce();
+    expect(Toast.warning).toHaveBeenCalledWith("base.forwardModal.grant.grantFailed");
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it.each(["cancel", "unmount", "space", "inactive"] as const)(
+    "stops after a pending grant when the source is invalidated by %s",
+    async (reason) => {
+      const base = makeBase();
+      const pending = deferred<ForwardGrantResult>();
+      const onResult = vi.fn();
+      const onError = vi.fn();
+      let active = true;
+      const cancel = base.showConversationSelect(undefined, undefined, {
+        ...documentInput, onResult, onError, isActive: () => active, grantAccess: () => pending.promise,
+      });
+      picker(base).confirm([recipient], grant);
+      if (reason === "cancel") cancel?.();
+      if (reason === "unmount") base.componentWillUnmount();
+      if (reason === "space") runtime.currentSpaceId = "other-space";
+      if (reason === "inactive") active = false;
+      pending.resolve({ granted: 1, failed: 0 });
+      await flush();
+      expect(send).not.toHaveBeenCalled();
+      expect(onResult).not.toHaveBeenCalled();
+      expect(onError).toHaveBeenCalledOnce();
+      expect(Toast.success).not.toHaveBeenCalled();
+    },
+  );
+
+  it("cancels before a legacy member lookup resolves without granting access", async () => {
+    const base = makeBase();
+    const pending = deferred<void>();
+    runtime.syncSubscribers.mockImplementation(() => pending.promise);
+    runtime.subscribers.set("group", [{ uid: "peer" }]);
+    const grantAccess = vi.fn(async () => ({ granted: 1, failed: 0 }));
+    const onError = vi.fn();
+    const cancel = base.showConversationSelect(undefined, undefined, { ...documentInput, grantAccess, onError });
+    picker(base).confirm([group], { role: "reader" });
+    cancel?.();
+    pending.resolve();
+    await flush();
+    expect(grantAccess).not.toHaveBeenCalled();
+    expect(send).not.toHaveBeenCalled();
+    expect(onError).toHaveBeenCalledOnce();
+  });
+
+  it("does not cancel a confirmed forward when another picker opens", async () => {
+    const base = makeBase();
+    const pending = deferred<ForwardGrantResult>();
+    const onResult = vi.fn();
+    const cancelFirst = base.showConversationSelect(undefined, undefined, {
+      ...documentInput, onResult, grantAccess: () => pending.promise,
+    });
+    picker(base).confirm([recipient], grant);
+    const onFinished = vi.fn();
+    base.showConversationSelect(onFinished, "Next selection");
+    pending.resolve({ granted: 1, failed: 0 });
+    await vi.waitFor(() => expect(onResult).toHaveBeenCalledOnce());
+    cancelFirst?.();
+    expect(base.state.showConversationSelect).toBe(true);
+    picker(base).confirm([group]);
+    expect(onFinished).toHaveBeenCalledExactlyOnceWith([group]);
+  });
+
+  it("awaits host authorization at every actual SDK send", async () => {
+    const base = makeBase();
+    const authorization = deferred<void>();
+    const beforeSend = vi.fn(() => authorization.promise);
+    const onResult = vi.fn();
+    base.showConversationSelect(undefined, undefined, { ...documentInput, beforeSend, onResult });
+    picker(base).confirm([recipient, group]);
+    expect(beforeSend).toHaveBeenCalledTimes(2);
+    expect(send).not.toHaveBeenCalled();
+    authorization.resolve();
+    await vi.waitFor(() => expect(onResult).toHaveBeenCalledOnce());
+    expect(send).toHaveBeenCalledTimes(2);
+  });
+
+  it.each(["reject", "cancel", "space"] as const)("rejects late send authorization after %s", async (reason) => {
+    const base = makeBase();
+    const authorization = deferred<void>();
+    const onError = vi.fn();
+    const onResult = vi.fn();
+    const cancel = base.showConversationSelect(undefined, undefined, {
+      ...documentInput, onError, onResult, beforeSend: () => authorization.promise,
+    });
+    picker(base).confirm([recipient, group]);
+    if (reason === "reject") authorization.reject(new Error("source revoked"));
+    else {
+      if (reason === "cancel") cancel?.();
+      else runtime.currentSpaceId = "other-space";
+      authorization.resolve();
+    }
+    await flush();
+    expect(send).not.toHaveBeenCalled();
+    expect(onError).toHaveBeenCalledOnce();
+    expect(onResult).not.toHaveBeenCalled();
+    expect(Toast.success).not.toHaveBeenCalled();
+  });
+
+  it("guards later SDK sends after an ordinary Web caller changes space mid-forward", async () => {
+    const base = makeBase();
+    const onError = vi.fn();
+    const onResult = vi.fn();
+    send.mockImplementationOnce(async () => {
+      runtime.currentSpaceId = "other-space";
+      return new Message();
+    });
+    base.showConversationSelect(undefined, undefined, { ...documentInput, onError, onResult });
+    picker(base).confirm([recipient, group]);
+    await flush();
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledOnce();
+    expect(onResult).not.toHaveBeenCalled();
+  });
+
+  it("keeps disbanded and transport-failed targets in ordinary Web result accounting", async () => {
+    const base = makeBase();
+    const onResult = vi.fn();
+    const onError = vi.fn();
+    runtime.disbanded.add("disbanded");
+    send.mockRejectedValueOnce(new Error("transport failure"));
+    base.showConversationSelect(undefined, undefined, { ...documentInput, onResult, onError });
+    picker(base).confirm([recipient, group, new Channel("disbanded", 2)]);
+    await vi.waitFor(() => expect(onResult).toHaveBeenCalledOnce());
+    expect(send).toHaveBeenCalledTimes(2);
+    expect(onResult).toHaveBeenCalledWith(expect.objectContaining({ sent: 1, failed: 2 }));
+    expect(Toast.error).toHaveBeenCalledWith("base.forwardModal.grant.partialSendFailed");
+    expect(onError).not.toHaveBeenCalled();
+  });
+});

--- a/packages/dmworkbase/src/Components/WKBase/index.tsx
+++ b/packages/dmworkbase/src/Components/WKBase/index.tsx
@@ -1,6 +1,6 @@
 import { Modal, Toast } from "@douyinfe/semi-ui";
 import WKModal from "../WKModal";
-import { Channel, ChannelTypePerson, MessageText } from "wukongimjssdk";
+import { Channel, ChannelTypePerson, MessageText, WKSDK } from "wukongimjssdk";
 import React, { Component, HTMLProps, ReactNode } from "react";
 import ConversationSelect from "../ConversationSelect";
 import type { ConversationSelectGrant } from "../ConversationSelect";
@@ -8,7 +8,7 @@ import type { DocForwardOpen, ForwardGrant } from "../ForwardModal/grant";
 import { buildForwardMessageText } from "../ForwardModal/forwardMessageText";
 import { DocumentShareCardContent } from "../../Messages/DocumentShareCard/DocumentShareCardContent";
 import { isConversationDisbanded } from "../../Utils/groupDisband";
-import { ForwardService } from "../../Service/ForwardService";
+import { ForwardService, type ForwardResult, type ForwardSender } from "../../Service/ForwardService";
 import { interpretForwardResult } from "../../Service/forwardResultToast";
 import UserInfo from "../UserInfo";
 import BotDetailModal from "../BotDetailModal";
@@ -134,6 +134,14 @@ export class GlobalModalOptions {
   onCancel?: () => void;
 }
 
+/** A picker and its asynchronous send share one identity until cancellation or completion. */
+interface ForwardOp {
+  settled: boolean
+  confirmed: boolean
+  forward?: DocForwardOpen
+  onCancel?: () => void
+}
+
 export interface WKBaseProps {
   children: React.ReactNode;
   onContext?: (context: WKBaseContext) => void;
@@ -150,7 +158,7 @@ export interface WKBaseContext {
     title?: string,
     forward?: DocForwardOpen,
     onCancel?: () => void
-  ): void;
+  ): (() => void) | void;
 
   // 显示用户信息
   showUserInfo(uid: string, fromChannel?: Channel, vercode?: string): void;
@@ -256,10 +264,11 @@ export default class WKBase
     title?: string,
     forward?: DocForwardOpen,
     onCancel?: () => void
-  ) {
-    // feature #511: stash the forward payload so the finished handler can run the host-side
-    // "先授权后发" orchestration. Cleared on cancel/close so a later plain forward isn't affected.
-    this.docForward = forward;
+  ): (() => void) | void {
+    if (this.currentForwardOp) this.cancelForward(this.currentForwardOp);
+    const op: ForwardOp = { settled: false, confirmed: false, forward, onCancel };
+    this.forwardOps.add(op);
+    this.currentForwardOp = op;
     this.setState((prev) => ({
       showConversationSelect: true,
       conversationSelectFinished: onFinished,
@@ -273,14 +282,34 @@ export default class WKBase
             spaceId: forward.spaceId,
           }
         : undefined,
-      // 每次打开递增 key，强制 ConversationSelect 重新挂载，
-      // 让 useForwardModal 用当前 spaceId 重新拉数据，避免切 Space 后列表陈旧。
       conversationSelectKey: (prev.conversationSelectKey ?? 0) + 1,
     }));
+    return () => this.cancelForward(op);
   }
 
-  /** feature #511: active doc-forward payload (host-side orchestration), null for plain forwards. */
-  private docForward?: DocForwardOpen;
+  private currentForwardOp?: ForwardOp;
+  private readonly forwardOps = new Set<ForwardOp>();
+  private forwardUnmounted = false;
+
+  private hideForwardPicker(op: ForwardOp): void {
+    if (this.currentForwardOp !== op) return;
+    this.currentForwardOp = undefined;
+    if (!this.forwardUnmounted) this.setState({
+      showConversationSelect: false,
+      conversationSelectGrant: undefined,
+      conversationSelectFinished: undefined,
+      conversationSelectCancelled: undefined,
+    });
+  }
+
+  private cancelForward(op: ForwardOp): void {
+    if (op.settled) return;
+    op.settled = true;
+    this.forwardOps.delete(op);
+    this.hideForwardPicker(op);
+    if (op.confirmed) op.forward?.onError?.(new Error("Document forwarding cancelled"));
+    else op.onCancel?.();
+  }
 
   /**
    * Legacy fallback: expand selected targets into a de-duplicated uid snapshot
@@ -317,17 +346,38 @@ export default class WKBase
   private async runDocForward(
     channels: Channel[],
     grant: ForwardGrant | undefined,
-    forward: DocForwardOpen
+    forward: DocForwardOpen,
+    op?: ForwardOp
   ): Promise<void> {
     const { t } = this.context;
+
+    // Capture source space BEFORE any async grant/load, so no send proceeds
+    // under a different currentSpaceId.
+    const sourceSpaceId = WKApp.shared.currentSpaceId;
+
     let grantFailures: string[] | undefined;
     let grantRejections: string[] | undefined;
+    let interrupted = false;
+    const isDead = (): boolean => interrupted || this.forwardUnmounted || op?.settled === true ||
+      WKApp.shared.currentSpaceId !== sourceSpaceId || forward.isActive?.() === false;
+    const reportError = (error: unknown): void => {
+      if (interrupted) return;
+      interrupted = true;
+      if (op?.settled) return;
+      if (op) { op.settled = true; this.forwardOps.delete(op); }
+      forward.onError?.(error);
+    };
+    if (isDead()) {
+      reportError(new Error("Forward source is no longer active"));
+      return;
+    }
 
     // 0) disband guard 提前一次，仅为 grant 阶段决定是否有可授权目标。真正的 send 阶段
     // disband 计入交给 ForwardService（它同样过滤 disband 并计入 failedTargets）。
     const sendable = channels.filter((ch) => !isConversationDisbanded(ch));
     if (sendable.length === 0) {
       Toast.error(t("base.forwardModal.grant.sendFailed"));
+      if (op) { op.settled = true; this.forwardOps.delete(op); }
       forward.onResult?.({
         sent: 0,
         failed: channels.length,
@@ -362,21 +412,30 @@ export default class WKBase
           uids = [...new Set([...humanUids, ...legacyBotUids])];
         }
         if (uids.length > 0) {
+          // Liveness check before granting: cancelled or inactive source must not grant.
+          if (isDead()) {
+            reportError(new Error("Forward source invalidated before grant execution"));
+            return;
+          }
           const res = await forward.grantAccess(uids, grant.role);
           if (res.failed > 0) grantFailures = res.failures;
           if (res.rejected && res.rejected.length > 0)
             grantRejections = res.rejected;
         }
-      } catch {
+      } catch (error) {
+        if (isDead()) { reportError(error); return; }
         // A grant failure must not block sending the message — the receiver can still
         // request access (screen 4c). Surface it as a non-fatal warning.
         Toast.warning(t("base.forwardModal.grant.grantFailed"));
       }
     }
 
-    // 2) send the message to each target via ForwardService (统一 disband 守卫、
-    // space_id / mention 注入、错误隔离)。原先手写的 encodeJSON monkey-patch
-    // 由 wrapSendContentForInjection + opts.spaceId 代替。
+    if (isDead()) {
+      reportError(new Error("Forward source invalidated after grant"));
+      return;
+    }
+
+    // 2) build the content factory.
     //
     // 只有**文档分享转发**（startDocForward，显式 shareAsCard=true）才发文档卡片
     // （DocumentShareCardContent=18）。其它复用同一转发通道但语义不同的流程——尤其
@@ -401,9 +460,38 @@ export default class WKBase
           new MessageText(
             buildForwardMessageText(forward.messageTitle, forward.link)
           );
-    const result = await ForwardService.send(channels, contentFactory, {
-      spaceId: WKApp.shared.currentSpaceId,
-    });
+
+    if (isDead()) {
+      reportError(new Error("Forward source invalidated before send"));
+      return;
+    }
+
+    // ForwardService still owns filtering and accounting. Guard at the actual SDK boundary,
+    // including ordinary Web callers; a Client can additionally revalidate its source in main.
+    const sender: ForwardSender = async (content, channel, setting) => {
+      try {
+        if (isDead()) throw new Error("Forward source is no longer active");
+        if (forward.beforeSend) await forward.beforeSend();
+        if (isDead()) throw new Error("Forward source is no longer active");
+      } catch (error) {
+        reportError(error);
+        throw error;
+      }
+      return WKSDK.shared().chatManager.send(content, channel, setting);
+    };
+
+    const result: ForwardResult = await ForwardService.send(
+      channels, contentFactory,
+      {
+        spaceId: sourceSpaceId,
+        sender,
+      },
+    );
+
+    if (isDead()) {
+      reportError(new Error("Forward invalidated during send"));
+      return;
+    }
 
     // 3) partial-failure Toast (reuse the dmworksummary范式). 分母维度用 targets，
     // 保留旧的用户可见语义（原代码 total=channels.length，即 result.targets）。
@@ -433,6 +521,7 @@ export default class WKBase
     }
 
     const sent = state.total - state.failed;
+    if (op) { op.settled = true; this.forwardOps.delete(op); }
     forward.onResult?.({
       sent,
       failed: state.failed,
@@ -440,7 +529,6 @@ export default class WKBase
       grantRejections,
     });
   }
-
   hideUserInfo() {
     // 与 showUserInfo 对称：主动关闭时也视为一次状态变更，让 router 递增 token
     // 使任何在飞的 fetchChannelInfo 结果都被丢弃，避免关闭后又被晚到的 resolve
@@ -467,6 +555,7 @@ export default class WKBase
   }
 
   componentDidMount() {
+    this.forwardUnmounted = false;
     const { onContext } = this.props;
     if (onContext) {
       onContext(this);
@@ -474,6 +563,8 @@ export default class WKBase
   }
 
   componentWillUnmount() {
+    this.forwardUnmounted = true;
+    for (const op of [...this.forwardOps]) this.cancelForward(op);
     // Stale-guard: router.dispose() marks the router disposed and invalidates
     // the token so any unresolved fetchChannelInfo returning post-unmount is a
     // no-op (no setState-on-unmounted React warning).
@@ -510,7 +601,6 @@ export default class WKBase
       conversationSelectKey,
       conversationSelectGrant,
       conversationSelectFinished,
-      conversationSelectCancelled,
       onAlertOk,
       alertContent,
       alertTitle,
@@ -519,6 +609,7 @@ export default class WKBase
       orgCode,
       orgUid,
     } = this.state;
+    const renderForwardOp = this.currentForwardOp;
     // join_org.html 由后端提供，需要通过 API 路径加载
     // Web 环境：apiURL = "/api/v1/"，replace 后得到 "/api/"，由 Nginx 代理到后端
     // Tauri/Electron 环境：apiURL = "https://host/v1/"，replace 后得到 "https://host/"
@@ -579,48 +670,34 @@ export default class WKBase
           width={625}
           options={{ mask: false }}
           onCancel={() => {
-            const onCancel = conversationSelectCancelled;
-            this.docForward = undefined;
-            this.setState({
-              showConversationSelect: false,
-              conversationSelectGrant: undefined,
-              conversationSelectFinished: undefined,
-              conversationSelectCancelled: undefined,
-            });
-            onCancel?.();
+            if (renderForwardOp) this.cancelForward(renderForwardOp);
           }}
         >
           <ConversationSelect
             key={conversationSelectKey}
             grant={conversationSelectGrant}
             onFinished={(channels: Channel[], grant) => {
-              const forward = this.docForward;
-              this.docForward = undefined;
-              this.setState({
-                showConversationSelect: false,
-                conversationSelectGrant: undefined,
-                conversationSelectFinished: undefined,
-                conversationSelectCancelled: undefined,
-              });
+              if (!renderForwardOp || renderForwardOp !== this.currentForwardOp ||
+                  renderForwardOp.settled || renderForwardOp.confirmed) return;
+              renderForwardOp.confirmed = true;
+              const forward = renderForwardOp.forward;
+              this.hideForwardPicker(renderForwardOp);
               if (forward) {
                 // feature #511: host owns "先授权后发" + send + partial-failure Toast.
-                void this.runDocForward(channels, grant, forward);
+                void this.runDocForward(channels, grant, forward, renderForwardOp).catch((error) => {
+                  if (renderForwardOp.settled) return;
+                  renderForwardOp.settled = true;
+                  this.forwardOps.delete(renderForwardOp);
+                  forward.onError?.(error);
+                });
                 return;
               }
-              if (conversationSelectFinished) {
-                conversationSelectFinished(channels);
-              }
+              renderForwardOp.settled = true;
+              this.forwardOps.delete(renderForwardOp);
+              conversationSelectFinished?.(channels);
             }}
             onCancel={() => {
-              const onCancel = conversationSelectCancelled;
-              this.docForward = undefined;
-              this.setState({
-                showConversationSelect: false,
-                conversationSelectGrant: undefined,
-                conversationSelectFinished: undefined,
-                conversationSelectCancelled: undefined,
-              });
-              onCancel?.();
+              if (renderForwardOp) this.cancelForward(renderForwardOp);
             }}
             title={conversationSelectTitle}
           ></ConversationSelect>

--- a/packages/dmworkbase/src/Messages/DocumentShareCard/__tests__/preview.test.ts
+++ b/packages/dmworkbase/src/Messages/DocumentShareCard/__tests__/preview.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../../../Service/APIClient", () => ({
   default: {
@@ -22,8 +22,15 @@ vi.mock("../../../App", () => ({
 
 import APIClient from "../../../Service/APIClient";
 import { fetchDocPreview, resetDocPreviewCache } from "../preview";
+import { installDocumentPreviewTransport } from "../../../Service/DocumentPreviewService";
 
 const apiGet = APIClient.shared.get as unknown as ReturnType<typeof vi.fn>;
+let disposeTransport: (() => void) | undefined;
+
+afterEach(() => {
+  disposeTransport?.();
+  disposeTransport = undefined;
+});
 
 /**
  * 构造一个和 APIClient 拦截器真实 reject 形状一致的错误对象。
@@ -163,6 +170,51 @@ describe("fetchDocPreview — ACL-safe status mapping (blocker #3 / ACL design)"
   it("empty docId short-circuits to error without a request", async () => {
     const res = await fetchDocPreview("doc", "", "sp_1");
     expect(res.status).toBe("error");
+    expect(apiGet).not.toHaveBeenCalled();
+  });
+});
+
+describe("fetchDocPreview host transport", () => {
+  it("does not cache an old response or remove new inflight work after a context reset", async () => {
+    const pending: Array<(value: unknown) => void> = [];
+    apiGet.mockImplementation(() => new Promise((resolve) => pending.push(resolve)));
+    const old = fetchDocPreview("doc", "d_race", "sp_1");
+    resetDocPreviewCache();
+    const current = fetchDocPreview("doc", "d_race", "sp_1");
+    pending[0]({});
+    expect(await old).toEqual({ status: "error" });
+    const duplicate = fetchDocPreview("doc", "d_race", "sp_1");
+    expect(apiGet).toHaveBeenCalledTimes(2);
+    pending[1]({});
+    expect((await current).status).toBe("ready");
+    expect((await duplicate).status).toBe("ready");
+  });
+
+  it.each([
+    [403, undefined, "denied"],
+    [404, undefined, "unavailable"],
+    [410, undefined, "unavailable"],
+    [409, "unsupported_doc_type", "empty"],
+    [409, "conflict", "unavailable"],
+    [409, "sheet_snapshot_invalid", "error"],
+    [409, "board_snapshot_invalid", "error"],
+    [409, undefined, "error"],
+    [401, undefined, "error"],
+    [500, undefined, "error"],
+  ] as const)("keeps HTTP %s / %s as %s", async (status, code, expected) => {
+    disposeTransport = installDocumentPreviewTransport(async () => ({ ok: false, status, code }));
+    expect(await fetchDocPreview("doc", "d_host", "wire-space")).toEqual({ status: expected });
+    expect(apiGet).not.toHaveBeenCalled();
+  });
+
+  it("renders real preview data supplied through the host", async () => {
+    disposeTransport = installDocumentPreviewTransport(async () => ({
+      ok: true, body: { preview: { heading: "Title", paragraphs: ["Body"] } },
+    }));
+    expect(await fetchDocPreview("html", "d_host", "wire-space")).toEqual({
+      status: "ready",
+      preview: { type: "doc", heading: "Title", paragraphs: ["Body"] },
+    });
     expect(apiGet).not.toHaveBeenCalled();
   });
 });

--- a/packages/dmworkbase/src/Messages/DocumentShareCard/preview.ts
+++ b/packages/dmworkbase/src/Messages/DocumentShareCard/preview.ts
@@ -1,4 +1,7 @@
-import APIClient from "../../Service/APIClient";
+import {
+  DocumentPreviewError,
+  getDocumentPreviewBody,
+} from "../../Service/DocumentPreviewService";
 import WKApp from "../../App";
 import type {
   DocShareKind,
@@ -171,17 +174,6 @@ function adoptHtmlPreview(body: unknown): DocSharePreview | undefined {
   return { type: "doc", heading, paragraphs };
 }
 
-const ENDPOINT: Record<DocShareKind, string> = {
-  doc: "content",
-  board: "scene",
-  sheet: "sheet",
-  // html 有了专属预览端点（docs-backend docHtmlPreview.ts，reader / requireDocRole）：
-  // 服务端抓上游 HTML、抽出 heading + 前几段**纯文本**返回，原始 markup 永不过界。
-  // 它复用 doc 的三段式错误码语义（403 无权限 / 404·410 失效 / 409
-  // `unsupported_doc_type` 该类型无预览 / 409 `conflict` 已归档），所以下面的分派不变。
-  html: "html-preview",
-};
-
 /**
  * 从 APIClient reject 出来的错误里取 docs-backend 的 **wire 错误码**。
  *
@@ -193,6 +185,7 @@ const ENDPOINT: Record<DocShareKind, string> = {
  * 同款先例：dmworkmcp/src/api/mcpService.ts、expertService.ts 的 extractErrorMessage。
  */
 function wireErrorCode(e: unknown): string | undefined {
+  if (e instanceof DocumentPreviewError) return e.code;
   if (!e || typeof e !== "object") return undefined;
   const raw = (e as { error?: unknown }).error;
   if (!raw || typeof raw !== "object") return undefined;
@@ -210,13 +203,7 @@ async function requestPreview(
   spaceId: string,
 ): Promise<DocPreviewResult> {
   try {
-    const body = await APIClient.shared.get<unknown>(
-      `docs/${encodeURIComponent(docId)}/${ENDPOINT[kind]}`,
-      {
-        headers: spaceId ? { "X-Space-Id": spaceId } : undefined,
-        param: spaceId ? { sp: spaceId } : undefined,
-      } as any,
-    );
+    const body = await getDocumentPreviewBody({ kind, docId }, spaceId);
     const preview =
       kind === "doc"
         ? parseDocPreview(body)
@@ -258,9 +245,11 @@ async function requestPreview(
 const PREVIEW_TTL_MS = 30_000;
 const resultCache = new Map<string, { at: number; result: DocPreviewResult }>();
 const inflight = new Map<string, Promise<DocPreviewResult>>();
+let cacheGeneration = 0;
 
 /** 测试用：清空预览结果缓存与在飞表，避免用例间串味。 */
 export function resetDocPreviewCache(): void {
+  cacheGeneration++;
   resultCache.clear();
   inflight.clear();
   cacheOwnerUid = null;
@@ -332,6 +321,7 @@ export async function fetchDocPreview(
   // 的 key 存取，杜绝下一个用户在 TTL 窗口内读到上一个用户的 ready/denied。
   const viewerUid = currentViewerUid();
   if (viewerUid !== cacheOwnerUid) {
+    cacheGeneration++;
     resultCache.clear();
     inflight.clear();
     cacheOwnerUid = viewerUid;
@@ -349,7 +339,13 @@ export async function fetchDocPreview(
   const existing = inflight.get(key);
   if (existing) return existing;
 
+  const generation = cacheGeneration;
   const p = requestPreview(kind, docId, spaceId).then((result) => {
+    // A host organization/session switch must not revive old results or delete
+    // a newer request for the same card after resetDocPreviewCache().
+    if (generation !== cacheGeneration || viewerUid !== currentViewerUid()) {
+      return { status: "error" } as DocPreviewResult;
+    }
     inflight.delete(key);
     if (result.status !== "error") resultCache.set(key, { at: Date.now(), result });
     return result;

--- a/packages/dmworkbase/src/Service/DocumentPreviewService.ts
+++ b/packages/dmworkbase/src/Service/DocumentPreviewService.ts
@@ -1,0 +1,64 @@
+import APIClient from "./APIClient";
+
+export interface DocumentPreviewInput {
+  docId: string;
+  kind: "doc" | "board" | "sheet" | "html";
+}
+
+export type DocumentPreviewResponse =
+  | { ok: true; body: unknown }
+  | { ok: false; status?: number; code?: string };
+
+export type DocumentPreviewTransport = (
+  input: DocumentPreviewInput,
+) => Promise<DocumentPreviewResponse>;
+
+export class DocumentPreviewError extends Error {
+  constructor(public readonly status?: number, public readonly code?: string) {
+    super("Document preview request failed");
+    this.name = "DocumentPreviewError";
+  }
+}
+
+const endpoints: Record<DocumentPreviewInput["kind"], string> = {
+  doc: "content",
+  board: "scene",
+  sheet: "sheet",
+  html: "html-preview",
+};
+
+let hostTransport: DocumentPreviewTransport | undefined;
+
+/** Installed only by an embedded host; ordinary Web keeps its existing HTTP path. */
+export function installDocumentPreviewTransport(
+  transport: DocumentPreviewTransport,
+): () => void {
+  hostTransport = transport;
+  return () => {
+    if (hostTransport === transport) hostTransport = undefined;
+  };
+}
+
+export async function getDocumentPreviewBody(
+  input: DocumentPreviewInput,
+  spaceId: string,
+): Promise<unknown> {
+  if (hostTransport) {
+    // Only identity and kind cross IPC. The host owns credentials and organization.
+    const result = await hostTransport({ docId: input.docId, kind: input.kind });
+    if (!result.ok) throw new DocumentPreviewError(result.status, result.code);
+    return result.body;
+  }
+
+  const path = `docs/${encodeURIComponent(input.docId)}/${endpoints[input.kind]}`;
+  const apiURL = APIClient.shared.config?.apiURL;
+  // Desktop's IM prefix is /v1/, but Docs lives at /api/v1/docs/.
+  // Web's relative /api/v1/ base must retain its dev/reverse proxy.
+  const url = apiURL && /^https?:\/\//i.test(apiURL)
+    ? `${new URL(apiURL).origin}/api/v1/${path}`
+    : path;
+  return APIClient.shared.get<unknown>(url, {
+    headers: spaceId ? { "X-Space-Id": spaceId } : undefined,
+    param: spaceId ? { sp: spaceId } : undefined,
+  });
+}

--- a/packages/dmworkbase/src/Service/__tests__/DocumentPreviewService.test.ts
+++ b/packages/dmworkbase/src/Service/__tests__/DocumentPreviewService.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import axios, { type AxiosRequestConfig } from "axios";
+import APIClient from "../APIClient";
+import {
+  DocumentPreviewError,
+  getDocumentPreviewBody,
+  installDocumentPreviewTransport,
+} from "../DocumentPreviewService";
+
+const client = APIClient.shared;
+const originalAdapter = axios.defaults.adapter;
+const originalApiURL = client.config.apiURL;
+let requests: AxiosRequestConfig[];
+let dispose: (() => void) | undefined;
+
+beforeEach(() => {
+  requests = [];
+  client.config.apiURL = "/api/v1/";
+  client.config.tokenCallback = () => "test-token";
+  client.config.spaceIdCallback = () => "current-space";
+  axios.defaults.adapter = async (config) => {
+    requests.push(config);
+    return { data: { doc: {} }, status: 200, statusText: "OK", headers: {}, config };
+  };
+});
+
+afterEach(() => {
+  dispose?.();
+  dispose = undefined;
+  axios.defaults.adapter = originalAdapter;
+  client.config.apiURL = originalApiURL;
+  client.config.tokenCallback = undefined;
+  client.config.spaceIdCallback = undefined;
+});
+
+describe("document preview HTTP boundary", () => {
+  it.each([
+    ["doc", "content"],
+    ["board", "scene"],
+    ["sheet", "sheet"],
+    ["html", "html-preview"],
+  ] as const)("preserves Web proxy, authentication and explicit space for %s", async (kind, endpoint) => {
+    await expect(getDocumentPreviewBody({ kind, docId: "d_1" }, "doc-space"))
+      .resolves.toEqual({ doc: {} });
+    expect(requests).toHaveLength(1);
+    expect(requests[0]).toMatchObject({
+      url: `docs/d_1/${endpoint}`,
+      baseURL: "/api/v1/",
+      params: { sp: "doc-space" },
+      headers: { token: "test-token", "X-Space-Id": "doc-space" },
+    });
+  });
+
+  it.each(["https://api.test/v1/", "https://api.test/api/v1/"])(
+    "uses the Docs namespace with absolute API base %s", async (apiURL) => {
+      client.config.apiURL = apiURL;
+      await getDocumentPreviewBody({ kind: "html", docId: "d_1" }, "");
+      expect(requests[0].url).toBe("https://api.test/api/v1/docs/d_1/html-preview");
+      expect(client.config.apiURL).toBe(apiURL);
+    },
+  );
+
+  it("encodes document identity as a single path segment", async () => {
+    await getDocumentPreviewBody({ kind: "doc", docId: "a/b?#" }, "");
+    expect(requests[0].url).toBe("docs/a%2Fb%3F%23/content");
+  });
+
+  it("uses host transport without forwarding renderer space or credentials", async () => {
+    const transport = vi.fn().mockResolvedValue({ ok: true, body: { preview: {} } });
+    dispose = installDocumentPreviewTransport(transport);
+    await expect(getDocumentPreviewBody({ kind: "html", docId: "d_1" }, "wire-space"))
+      .resolves.toEqual({ preview: {} });
+    expect(transport).toHaveBeenCalledWith({ kind: "html", docId: "d_1" });
+    expect(requests).toHaveLength(0);
+  });
+
+  it("preserves host error status and wire code without retrying browser HTTP", async () => {
+    dispose = installDocumentPreviewTransport(async () => ({
+      ok: false, status: 409, code: "conflict",
+    }));
+    await expect(getDocumentPreviewBody({ kind: "doc", docId: "d_1" }, ""))
+      .rejects.toEqual(new DocumentPreviewError(409, "conflict"));
+    expect(requests).toHaveLength(0);
+  });
+
+  it("does not retry a rejected host operation through browser HTTP", async () => {
+    dispose = installDocumentPreviewTransport(async () => { throw new Error("offline"); });
+    await expect(getDocumentPreviewBody({ kind: "doc", docId: "d_1" }, ""))
+      .rejects.toThrow("offline");
+    expect(requests).toHaveLength(0);
+  });
+
+  it("restores Web HTTP after disposal without removing a newer transport", async () => {
+    const first = installDocumentPreviewTransport(async () => ({ ok: true, body: "old" }));
+    dispose = installDocumentPreviewTransport(async () => ({ ok: true, body: "new" }));
+    first();
+    await expect(getDocumentPreviewBody({ kind: "doc", docId: "d_1" }, ""))
+      .resolves.toBe("new");
+    dispose();
+    await getDocumentPreviewBody({ kind: "doc", docId: "d_1" }, "");
+    expect(requests).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary

Add the Web-side compatibility needed to reuse document previews, forwarding, and shared voice input from an independently hosted document workspace.

This PR is independently reviewable: it does **not** import or bundle the extracted Docs editor, add a Docs package dependency, change backend contracts, or include Client layout integration. Ordinary Web callers keep their existing entry points and HTTP fallback; cross-renderer capabilities are opt-in.

## Related Issue

No issue is linked. This is the Web compatibility portion of the document workspace extraction.

## Changes

### Document card previews

- Extract preview fetching into `DocumentPreviewService`, retaining the existing content, scene, sheet, and HTML-preview endpoints and error semantics.
- Allow the communication artifact to install a host transport. Only document identity and kind cross the bridge; the host owns authentication and organization context.
- Preserve Web's relative API/proxy path and correct the Docs API path for absolute desktop API origins.
- Invalidate preview caches and in-flight responses on session or organization changes, preventing stale responses from repopulating a cleared cache.

### Forwarding through the communication artifact

- Add optional, typed request/cancel/authorize/grant/result bridge methods and advertise `documentForwardVersion: 1`.
- Reuse the existing conversation picker and `ForwardService`. The originating document feature owns document metadata and grants; communication owns recipient selection and message delivery.
- Track each picker/send operation independently, including cancellation, replacement, unmount, and source invalidation.
- Recheck source validity before grants and each actual SDK send. A cancelled or revoked source cannot continue later side effects.
- Keep ordinary grant failures nonfatal, as in the existing Web flow. Distinguish grant failure from cancellation or revoked authorization, which stops the flow.
- Do not cancel a valid forward merely because the same view is hidden for a layout change or overlay.

### Shared voice input and build compatibility

- Support rich-text hosts that use transcription callbacks without an input/textarea ref; a supplied but unmounted ref remains unavailable.
- Require explicit focus ownership for ref-less shortcuts, recheck focus before delayed recording starts, and stop an owned recording when the shortcut is released after focus loss.
- Deduplicate `@octo/base` alongside React so externally composed modules share the host runtime.
- Support isolated artifact output via `OCTO_CLIENT_ARTIFACT_OUT_DIR`, retaining the existing default output and dirty/mock provenance checks.

## Architecture / Module Boundary

- **Affected modules:** `apps/web/src/client-communication`, `packages/dmworkbase` preview service/message adapter, shared forwarding orchestration, and voice input; Web/artifact build configuration.
- **New user-visible entry point:** none. Existing document cards, conversation selection, and voice controls are reused.
- **Shared layers touched:** `Components`, `Messages`, service, and host bridge.
- **Shared impact:** ordinary Web document preview, picker lifecycle/forwarding, native textarea voice input, and enterprise composition must remain compatible. New lifecycle guards intentionally prevent stale forwarding after cancellation or context changes.
- **Dependency direction:** external Docs consumers may use this shared base; this Web change does not depend on Docs source or an installed Docs renderer. Document preview data still comes from the existing document backend.
- **Full integration:** forwarding from a separately hosted Docs workspace requires compatible source, Client host, and communication bridges. Missing optional bridge methods leave the adapter inactive.
- **Duplicate entry points:** none added; no second IM client or disconnected document-local picker is introduced.
- **Out of scope:** editor engines, document permissions policy, backend changes, Client's new main/layout integration, and release publishing.

## Testing

Fresh local verification on `f15cb8859be633358d23329d4c9cf55a30d7d898`, rebased on `upstream/main`, on September 9, 2026:

| Check | Result |
| --- | --- |
| Shared forwarding, WKBase lifecycle, voice input, card preview and preview-service regressions | 304 passed, 26 files |
| Communication document-forward and preview host adapters | 15 passed, 2 files |
| `pnpm i18n:check` | Passed; locale keys healthy |
| `git diff --check upstream/main...HEAD` | Passed |

Reproduction:

```sh
pnpm --filter @octo/base exec vitest run src/Components/ForwardModal src/Components/WKBase/__tests__/WKBase.lifecycle.test.tsx src/Components/VoiceInputButton src/Messages/DocumentShareCard/__tests__ src/Service/__tests__/DocumentPreviewService.test.ts --maxWorkers=2
pnpm --filter @octo/web exec vitest run src/client-communication/documentForward.test.ts src/client-communication/documentPreview.test.ts --maxWorkers=2
pnpm i18n:check
```

- [x] Unit and component regression tests added/updated.
- [ ] Full CI/build/coverage gates passed on the submitted PR head; pending remote checks.
- [ ] Fresh post-rebase real-service/microphone and full Client integration acceptance; not claimed by these tests.

Earlier extraction work had separate manual and Electron integration verification. Those results are not a substitute for validation of the newly integrated Client main, which remains a separate change.

## Review Focus

1. Preview transport fallback, API path selection, and cache invalidation across identities.
2. Picker operation identity and cancellation during async grants and per-recipient sends.
3. Backward compatibility for ordinary Web picker callers and input/textarea voice hosts.
4. Optional bridge negotiation and shared-base deduplication without importing enterprise Docs.

## Checklist

- [x] Read `CONTRIBUTING.md`.
- [x] PR description is in English.
- [x] Added or updated tests.
- [x] Added architecture and compatibility documentation.
- [x] Ran `pnpm i18n:check`.
- [x] Kept module ownership and existing user-visible entry points.
- [x] Described shared-component, message, bridge, and service impact.
- [x] Followed Conventional Commits.
- [x] No generated renderer artifacts, runtime binaries, or credentials included.

This PR requests review only. It does not request merging, auto-merge, deployment, or a Client release.
