### PR TITLE
fix(market): add scroll pagination and default to skills

### DIFF
--- a/apps/web/e2e-kit/case-specs/experts/EX4-experts-market-truncated-page.md
+++ b/apps/web/e2e-kit/case-specs/experts/EX4-experts-market-truncated-page.md
@@ -1,26 +1,69 @@
 # EX4 Expert market search beyond page 1
 
-- Mode: authenticated real page with local MSW and mock IM.
-- Priority: P1 regression, marketplace issue #81.
-- Tags: `@EX4 @p1 @experts @market @pagination`.
-- Scenario: `expert-market-truncated`, with 112 plugin records and matching
-  names at positions 66 and 112.
+## Metadata
 
-The mock `/market/api/v1/plugins` filters by `q` before applying `page` and
-`page_size`, returning the filtered total. Category and tag handlers supply the
-scoped catalog metadata.
+- Case 类型: feature flow
+- 目标模式: real-page seed
+- 登录状态: authed fixture
+- 优先级: P1 (回归守护)
+- Tags: `@EX4 @p1 @experts @market @pagination`
 
-Run the case in Chinese and English. Initially show 100 of 112 records with a
-tail scroll sentinel. Scrolling the sentinel into view auto-loads page 2, shows
-all 112 and removes the sentinel (no load-more button — parity with the 技能 /
-连接器 catalogs). Searching
-for `数据分析报告` must return both `数据分析报告专家` and `数据分析报告师`.
-Clear the search, then search again from the first 100 records to verify that
-finding the second match does not depend on previously loading page 2.
-Search for `rare-report` in the tag popover: this tag is beyond the initial
-50 suggestions and belongs only to record 112. Selecting it must return that
-record while keeping the keyword active.
+## 目标
 
-Assert cards and counts and save screenshots of pagination/search in both
-locales. No pixel baseline is required. The regression fails if filtering moves
-back to the loaded slice or if paging never exposes records beyond page 1.
+Guard the marketplace issue #81 fix: Experts must remain searchable beyond the
+first page, and scroll pagination must re-arm until every available page is
+loaded. A regression would stop after page 1 or page 2 and silently hide later
+records.
+
+## 前置条件
+
+- fixture: `fixtures-authed` (`E2E_TARGET=local`, mock IM enabled).
+- Per-case MSW handler: `e2e-kit/msw-handlers/expert-market-truncated.ts`.
+  - `GET /market/api/v1/plugins` exposes 212 records, filters by `q` before
+    applying `page` and `page_size`, and returns the filtered total.
+  - Matching names are placed at positions 66 and 112.
+  - Category and tag endpoints return scoped metadata; `rare-report` belongs
+    only to record 112 and is beyond the initial 50 tag suggestions.
+- Run once with `zh-CN` and once with `en-US`.
+
+## 用户操作步骤
+
+1. Open the Experts marketplace and confirm that the first 100 of 212 cards are visible.
+2. Scroll the tail sentinel into view and wait for page 2.
+3. Scroll the re-armed sentinel into view again and wait for page 3.
+4. Search for `数据分析报告`, clear it, then repeat the same search from page 1.
+5. Open Tags, search for `rare-report`, and select it while the keyword remains active.
+
+## 预期结果
+
+- The list advances from 100 to 200 and then to all 212 cards.
+- The tail sentinel disappears only after all 212 cards are visible.
+- Searching `数据分析报告` shows both `数据分析报告专家` and `数据分析报告师`.
+- Repeating the search from page 1 returns the same two server-filtered matches.
+- Selecting `rare-report` narrows the list to `数据分析报告师` without clearing the keyword.
+- No load-more button, load failure, or empty state appears during the flow.
+
+## 反例
+
+- If the observer is not re-armed after page 2, the list remains at 200 / 212
+  and the second sentinel scroll times out.
+- If filtering is performed only on loaded rows, the repeated keyword search
+  misses the record originally placed beyond page 1.
+- If tag suggestions are limited to their initial page, `rare-report` is absent
+  and the option assertion times out.
+
+## 视觉基准
+
+No pixel baseline. Save pagination and search screenshots in both locales and
+use card-count, status-text, role, and visible-name assertions for the contract.
+
+## 摸清依据
+
+- `packages/dmworkmcp/src/pages/ExpertMarketListPage.tsx`: pagination sentinel,
+  loaded-count status, search, and tag-filter UI.
+- `packages/dmworkmcp/src/bridge/useExpertCatalog.ts`: server-side filtering,
+  page state, deduplication, and empty-page termination.
+- `apps/web/e2e-kit/msw-handlers/expert-market-truncated.ts`: 212-record fixture,
+  offset pagination, keyword filtering, categories, and tag suggestions.
+- `apps/web/e2e-kit/tests/experts/EX4-experts-market-truncated-page.spec.ts`:
+  bilingual three-page user flow and UI assertions.

--- a/apps/web/e2e-kit/case-specs/experts/EX4-experts-market-truncated-page.md
+++ b/apps/web/e2e-kit/case-specs/experts/EX4-experts-market-truncated-page.md
@@ -11,7 +11,9 @@ The mock `/market/api/v1/plugins` filters by `q` before applying `page` and
 scoped catalog metadata.
 
 Run the case in Chinese and English. Initially show 100 of 112 records with a
-load-more button. Loading page 2 shows all 112 and removes the button. Searching
+tail scroll sentinel. Scrolling the sentinel into view auto-loads page 2, shows
+all 112 and removes the sentinel (no load-more button — parity with the 技能 /
+连接器 catalogs). Searching
 for `数据分析报告` must return both `数据分析报告专家` and `数据分析报告师`.
 Clear the search, then search again from the first 100 records to verify that
 finding the second match does not depend on previously loading page 2.

--- a/apps/web/e2e-kit/msw-handlers/expert-market-truncated.ts
+++ b/apps/web/e2e-kit/msw-handlers/expert-market-truncated.ts
@@ -37,7 +37,7 @@ const firstPlugin = {
 };
 
 // Production regression: matching names at positions 66 and 112.
-const plugins = Array.from({ length: 112 }, (_, index) => ({
+const plugins = Array.from({ length: 212 }, (_, index) => ({
   ...firstPlugin,
   plugin_id: `catalog-expert-${index + 1}`,
   plugin_name: index === 65 ? "数据分析报告专家" : index === 111 ? "数据分析报告师" : `目录专家${index + 1}`,
@@ -68,7 +68,7 @@ export const expertMarketTruncatedHandlers = [
     if (!enabled()) return undefined;
     return HttpResponse.json({
       data: [
-        { category_id: "dev-tools", name: "研发工具", sort_order: 0, plugin_count: 112 },
+        { category_id: "dev-tools", name: "研发工具", sort_order: 0, plugin_count: 212 },
       ],
     });
   }),

--- a/apps/web/e2e-kit/tests/experts/EX4-experts-market-truncated-page.spec.ts
+++ b/apps/web/e2e-kit/tests/experts/EX4-experts-market-truncated-page.spec.ts
@@ -13,14 +13,16 @@ for (const locale of ["zh-CN", "en-US"]) {
 
     const cards = authedPage.locator(".wk-mcp-expert-grid .wk-mcp-card");
     const pagination = authedPage.locator(".wk-mcp-expert-pagination");
-    const more = authedPage.getByRole("button", { name: en ? "Load more" : "加载更多", exact: true });
+    const sentinel = authedPage.locator(".wk-mcp-expert-sentinel");
     await expect(cards).toHaveCount(100);
     await expect(pagination).toContainText(en ? "Showing 100 of 112" : "已显示 100 / 112 项");
-    await more.scrollIntoViewIfNeeded();
+    await sentinel.scrollIntoViewIfNeeded();
     await authedPage.screenshot({ path: testInfo.outputPath(`pagination-${locale}.png`) });
-    await more.click();
+    // Scrolling the sentinel into view auto-loads the rest — no click needed,
+    // matching the 技能 / 连接器 catalogs.
     await expect(cards).toHaveCount(112);
-    await expect(more).toHaveCount(0);
+    await expect(pagination).toContainText(en ? "Showing 112 of 112" : "已显示 112 / 112 项");
+    await expect(sentinel).toHaveCount(0);
 
     const search = authedPage.getByRole("searchbox", { name: en ? "Search experts" : "搜索专家", exact: true });
     await search.fill("数据分析报告");

--- a/apps/web/e2e-kit/tests/experts/EX4-experts-market-truncated-page.spec.ts
+++ b/apps/web/e2e-kit/tests/experts/EX4-experts-market-truncated-page.spec.ts
@@ -15,13 +15,16 @@ for (const locale of ["zh-CN", "en-US"]) {
     const pagination = authedPage.locator(".wk-mcp-expert-pagination");
     const sentinel = authedPage.locator(".wk-mcp-expert-sentinel");
     await expect(cards).toHaveCount(100);
-    await expect(pagination).toContainText(en ? "Showing 100 of 112" : "已显示 100 / 112 项");
+    await expect(pagination).toContainText(en ? "Showing 100 of 212" : "已显示 100 / 212 项");
     await sentinel.scrollIntoViewIfNeeded();
     await authedPage.screenshot({ path: testInfo.outputPath(`pagination-${locale}.png`) });
     // Scrolling the sentinel into view auto-loads the rest — no click needed,
     // matching the 技能 / 连接器 catalogs.
-    await expect(cards).toHaveCount(112);
-    await expect(pagination).toContainText(en ? "Showing 112 of 112" : "已显示 112 / 112 项");
+    await expect(cards).toHaveCount(200);
+    await expect(pagination).toContainText(en ? "Showing 200 of 212" : "已显示 200 / 212 项");
+    await sentinel.scrollIntoViewIfNeeded();
+    await expect(cards).toHaveCount(212);
+    await expect(pagination).toContainText(en ? "Showing 212 of 212" : "已显示 212 / 212 项");
     await expect(sentinel).toHaveCount(0);
 
     const search = authedPage.getByRole("searchbox", { name: en ? "Search experts" : "搜索专家", exact: true });

--- a/packages/dmworkmcp/src/__tests__/module.marketEntry.test.tsx
+++ b/packages/dmworkmcp/src/__tests__/module.marketEntry.test.tsx
@@ -95,6 +95,7 @@ describe("McpMarketModule market entry", () => {
     )?.[1] as () => { onPress?: (reentry?: boolean) => void };
     menuFactory().onPress?.(false);
 
+    expect(h.popToRoot).not.toHaveBeenCalled();
     expect(h.replaceToRoot).not.toHaveBeenCalled();
     expect(h.syncPath).not.toHaveBeenCalled();
   });

--- a/packages/dmworkmcp/src/__tests__/module.marketEntry.test.tsx
+++ b/packages/dmworkmcp/src/__tests__/module.marketEntry.test.tsx
@@ -1,0 +1,88 @@
+// @vitest-environment jsdom
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const h = vi.hoisted(() => ({
+  registerNamespace: vi.fn(),
+  registerRoute: vi.fn(),
+  registerMenu: vi.fn(),
+  routeGet: vi.fn(),
+  popToRoot: vi.fn(),
+  replaceToRoot: vi.fn(),
+  syncPath: vi.fn(),
+  track: vi.fn(),
+}));
+
+vi.mock("@octo/base", () => ({
+  ChatPage: () => React.createElement("div", { "data-testid": "chat-page" }),
+  I18nProvider: ({ children }: { children: React.ReactNode }) => children,
+  i18n: { registerNamespace: h.registerNamespace },
+  t: (key: string) => key,
+  Dap: { shared: { track: h.track } },
+  Menus: class {
+    onPress?: (reentry?: boolean) => void;
+
+    constructor(
+      public id: string,
+      public routePath: string,
+      public title: string,
+      public icon: React.ReactElement,
+      public selectedIcon: React.ReactElement
+    ) {}
+  },
+  WKApp: {
+    route: {
+      register: h.registerRoute,
+      get: h.routeGet,
+      syncPath: h.syncPath,
+    },
+    routeLeft: { popToRoot: h.popToRoot },
+    routeRight: { replaceToRoot: h.replaceToRoot },
+    menus: { register: h.registerMenu },
+  },
+}));
+
+vi.mock("@dmwork/skillmarket", () => ({
+  SkillListPage: () => React.createElement("div", { "data-testid": "skills-page" }),
+  SpaceReviewPage: () => React.createElement("div", { "data-testid": "review-page" }),
+}));
+vi.mock("../pages/McpMarketListPage", () => ({
+  default: () => React.createElement("div", { "data-testid": "mcp-page" }),
+}));
+vi.mock("../pages/MyAssetsPage", () => ({ default: () => null }));
+vi.mock("../pages/ExpertMarketListPage", () => ({ default: () => null }));
+vi.mock("../components/MarketSidebar", () => ({ default: () => null }));
+
+import { SkillListPage } from "@dmwork/skillmarket";
+import McpMarketListPage from "../pages/McpMarketListPage";
+import { McpMarketModule } from "../module";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.routeGet.mockImplementation((path: string) => {
+    const registration = h.registerRoute.mock.calls.find(([route]) => route === path);
+    return registration?.[1]?.();
+  });
+});
+
+describe("McpMarketModule market entry", () => {
+  it("opens Skills from the top-level menu and keeps the connector deep link", () => {
+    new McpMarketModule().init();
+
+    const menuFactory = h.registerMenu.mock.calls.find(
+      ([id]) => id === "mcp-market"
+    )?.[1] as () => { onPress?: (reentry?: boolean) => void };
+    const menu = menuFactory();
+    menu.onPress?.(false);
+
+    expect(h.routeGet).toHaveBeenCalledWith("/mcp-market/skills");
+    expect(h.replaceToRoot.mock.calls[0][0].type).toBe(SkillListPage);
+    expect(h.syncPath).toHaveBeenCalledWith("/mcp-market/skills");
+    expect(h.track).toHaveBeenCalledWith("market_module_entered", {});
+
+    const connectorFactory = h.registerRoute.mock.calls.find(
+      ([path]) => path === "/mcp-market/mcp"
+    )?.[1] as () => React.ReactElement;
+    expect(connectorFactory().type).toBe(McpMarketListPage);
+  });
+});

--- a/packages/dmworkmcp/src/__tests__/module.marketEntry.test.tsx
+++ b/packages/dmworkmcp/src/__tests__/module.marketEntry.test.tsx
@@ -85,4 +85,17 @@ describe("McpMarketModule market entry", () => {
     )?.[1] as () => React.ReactElement;
     expect(connectorFactory().type).toBe(McpMarketListPage);
   });
+
+  it("does not sync the Skills URL when the route cannot resolve", () => {
+    new McpMarketModule().init();
+    h.routeGet.mockReturnValue(undefined);
+
+    const menuFactory = h.registerMenu.mock.calls.find(
+      ([id]) => id === "mcp-market"
+    )?.[1] as () => { onPress?: (reentry?: boolean) => void };
+    menuFactory().onPress?.(false);
+
+    expect(h.replaceToRoot).not.toHaveBeenCalled();
+    expect(h.syncPath).not.toHaveBeenCalled();
+  });
 });

--- a/packages/dmworkmcp/src/components/MarketSidebar.tsx
+++ b/packages/dmworkmcp/src/components/MarketSidebar.tsx
@@ -66,9 +66,9 @@ interface MarketItem {
 }
 
 // Order below controls the sidebar tab order: 技能 → 连接器 → 专家 → 我的发布
-// → 组织发布管理. The NavRail menu's onPress still boots the right pane into
-// /mcp-market/mcp (see module.tsx), independent of this order; this array only
-// drives the sidebar's visual order + the path-miss fallback.
+// → 组织发布管理. The NavRail menu's onPress boots the right pane into
+// /mcp-market/skills (see module.tsx), which matches this order's first item;
+// this array drives the sidebar's visual order + the path-miss fallback.
 //
 // The array stays a module-level, side-effect-free constant: per-user
 // visibility is expressed as the `visible` / `routable` predicates above and
@@ -321,9 +321,9 @@ export default class MarketSidebar extends Component<{}, MarketSidebarState> {
   private handleNavMenuActivated = ({ menuId }: { menuId: string }) => {
     if (menuId !== "mcp-market") return;
     // Main first activates the top-level `/mcp-market` route, then the menu's
-    // onPress redirects the right pane to MCP. Do not reuse a stale Skills
-    // state during that short interval: the top-level entry always defaults
-    // to MCP, while explicit deep links keep their matching item.
+    // onPress redirects the right pane to Skills. Do not reuse a stale state
+    // during that short interval: the top-level entry always defaults to
+    // Skills, while explicit deep links keep their matching item.
     const { gate } = this.state;
     const item =
       findMarketItemByRoutePath(WKApp.route.currentPath, gate) ??

--- a/packages/dmworkmcp/src/index.css
+++ b/packages/dmworkmcp/src/index.css
@@ -2736,7 +2736,7 @@
    it starts the next page before the user reaches the true bottom. */
 .wk-mcp-expert-sentinel {
   width: 100%;
-  height: 1px;
+  height: var(--wk-sp-0-5);
 }
 
 .wk-mcp-expert-pagination__loading {

--- a/packages/dmworkmcp/src/index.css
+++ b/packages/dmworkmcp/src/index.css
@@ -1590,6 +1590,17 @@
   padding: var(--wk-sp-4) var(--wk-sp-6);
 }
 
+/* Infinite-scroll trigger at the tail of the 全部 list. Kept a little tall so it
+   enters the observer's rootMargin before the user hits the hard bottom, and to
+   give the load-more spinner somewhere to sit. */
+.wk-mcp-mine__all-sentinel {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: var(--wk-sp-6);
+  padding: var(--wk-sp-3) 0;
+}
+
 /* 我的发布's own chrome — the 我的发布 title and the 全部/技能/连接器/专家/专家团 tab
    strip — is not responsive: it stays inset by var(--wk-sp-6) at every width, and
    the panel below it has to keep that left edge or the table visibly steps out
@@ -2719,6 +2730,17 @@
   margin-top: var(--wk-sp-4);
   color: var(--wk-text-tertiary);
   font-size: var(--wk-text-size-sm);
+}
+
+/* Zero-height scroll trigger — invisible, but given the observer's rootMargin
+   it starts the next page before the user reaches the true bottom. */
+.wk-mcp-expert-sentinel {
+  width: 100%;
+  height: 1px;
+}
+
+.wk-mcp-expert-pagination__loading {
+  color: var(--wk-text-tertiary);
 }
 
 .wk-mcp-expert-sort button {

--- a/packages/dmworkmcp/src/module.tsx
+++ b/packages/dmworkmcp/src/module.tsx
@@ -113,7 +113,9 @@ export class McpMarketModule implements IModule {
           <McpMarketIcon />,
           <McpMarketIcon active />
         );
-        // Point the right pane at the MCP market on click.
+        // Point the right pane at the 技能 (Skills) market on click — the
+        // default landing tab, matching MARKET_ITEMS[0] / the sidebar's seeded
+        // activeId so the highlighted row and the mounted pane agree.
         // onPress (apps/web/src/App/index.tsx:154) — Main/index.tsx's default
         // click handler is bypassed when onPress is defined, so we own both
         // the left popToRoot and the right replaceToRoot here.
@@ -123,15 +125,15 @@ export class McpMarketModule implements IModule {
             Dap.shared.track("market_module_entered", {});
           }
           WKApp.routeLeft.popToRoot();
-          const page = WKApp.route.get("/mcp-market/mcp");
+          const page = WKApp.route.get("/mcp-market/skills");
           if (page && React.isValidElement(page)) {
             WKApp.routeRight.replaceToRoot(page);
           }
           // Sync URL so refresh/copy-link/back button land on the same tab.
           // Main/index.tsx#onMenuClick already syncPath's to the menu's
           // `/mcp-market` before firing onPress, but the mounted pane is the
-          // more specific MCP landing route — reflect that.
-          WKApp.route.syncPath("/mcp-market/mcp");
+          // more specific Skills landing route — reflect that.
+          WKApp.route.syncPath("/mcp-market/skills");
         };
         return m;
       },

--- a/packages/dmworkmcp/src/module.tsx
+++ b/packages/dmworkmcp/src/module.tsx
@@ -128,12 +128,13 @@ export class McpMarketModule implements IModule {
           const page = WKApp.route.get("/mcp-market/skills");
           if (page && React.isValidElement(page)) {
             WKApp.routeRight.replaceToRoot(page);
+            // Sync URL so refresh/copy-link/back button land on the same tab.
+            // Main/index.tsx#onMenuClick already syncPath's to the menu's
+            // `/mcp-market` before firing onPress, but the mounted pane is the
+            // more specific Skills landing route — reflect that only after the
+            // pane resolves successfully.
+            WKApp.route.syncPath("/mcp-market/skills");
           }
-          // Sync URL so refresh/copy-link/back button land on the same tab.
-          // Main/index.tsx#onMenuClick already syncPath's to the menu's
-          // `/mcp-market` before firing onPress, but the mounted pane is the
-          // more specific Skills landing route — reflect that.
-          WKApp.route.syncPath("/mcp-market/skills");
         };
         return m;
       },

--- a/packages/dmworkmcp/src/module.tsx
+++ b/packages/dmworkmcp/src/module.tsx
@@ -124,9 +124,9 @@ export class McpMarketModule implements IModule {
           if (!reentry) {
             Dap.shared.track("market_module_entered", {});
           }
-          WKApp.routeLeft.popToRoot();
           const page = WKApp.route.get("/mcp-market/skills");
           if (page && React.isValidElement(page)) {
+            WKApp.routeLeft.popToRoot();
             WKApp.routeRight.replaceToRoot(page);
             // Sync URL so refresh/copy-link/back button land on the same tab.
             // Main/index.tsx#onMenuClick already syncPath's to the menu's

--- a/packages/dmworkmcp/src/pages/AllAssetsList.tsx
+++ b/packages/dmworkmcp/src/pages/AllAssetsList.tsx
@@ -18,33 +18,31 @@ import { getMcpAvatarColor, getMcpAvatarText } from "../utils/mcpAvatar";
 
 const PAGE_SIZE = 50;
 
-/** Keep one observer alive while pagination is available. The callback ref
- * exposes the latest guards/cursor without rebuilding the observer after each
- * appended page. */
+/** Observe the tail until the current cursor loads, then re-arm for the next
+ * cursor so a short appended page that remains in view still advances. */
 function LoadMoreSentinel({
   onLoadMore,
+  rearmKey,
   children,
 }: {
   onLoadMore: () => void;
+  rearmKey: string;
   children?: React.ReactNode;
 }) {
   const ref = useRef<HTMLDivElement | null>(null);
-  const callbackRef = useRef(onLoadMore);
-  callbackRef.current = onLoadMore;
 
   useEffect(() => {
     const node = ref.current;
     if (!node || typeof IntersectionObserver === "undefined") return undefined;
     const observer = new IntersectionObserver(
       (entries) => {
-        if (entries.some((entry) => entry.isIntersecting))
-          callbackRef.current();
+        if (entries.some((entry) => entry.isIntersecting)) onLoadMore();
       },
       { rootMargin: "160px" }
     );
     observer.observe(node);
     return () => observer.disconnect();
-  }, []);
+  }, [onLoadMore, rearmKey]);
 
   return (
     <div ref={ref} className="wk-mcp-mine__all-sentinel">
@@ -101,8 +99,6 @@ export default function AllAssetsList({ onOpenType }: { onOpenType: (type: strin
   // Records which request generation owns the current pagination request. A
   // stale request must not clear the in-flight guard for a newer Space/load.
   const loadingMoreVersionRef = useRef<number | null>(null);
-  cursorRef.current = cursor;
-
   const load = useCallback(async () => {
     const version = ++requestRef.current;
     loadingMoreVersionRef.current = null;
@@ -116,9 +112,13 @@ export default function AllAssetsList({ onOpenType }: { onOpenType: (type: strin
       const page = await getMySkills({ limit: PAGE_SIZE }, { pluginType: "all" });
       if (version !== requestRef.current) return;
       setItems(page.items);
-      setCursor(page.nextCursor);
+      const nextCursor = page.items.length > 0 ? page.nextCursor : null;
+      cursorRef.current = nextCursor;
+      setCursor(nextCursor);
     } catch (err) {
       if (version !== requestRef.current) return;
+      cursorRef.current = null;
+      setCursor(null);
       setError(err instanceof Error ? err.message : t("skillMarket.common.loadFailed"));
     } finally {
       if (version === requestRef.current) {
@@ -151,8 +151,24 @@ export default function AllAssetsList({ onOpenType }: { onOpenType: (type: strin
         { pluginType: "all" }
       );
       if (version !== requestRef.current) return;
-      setItems((prev) => [...prev, ...page.items]);
-      setCursor(page.nextCursor);
+      setItems((prev) => {
+        // The API cursor wraps offset pagination, whose pages can overlap when
+        // another actor mutates the listing between requests. Keep each asset
+        // id once so MineTable never receives duplicate React keys/rows.
+        const seen = new Set(prev.map((item) => item.id));
+        const added = page.items.filter((item) => {
+          if (seen.has(item.id)) return false;
+          seen.add(item.id);
+          return true;
+        });
+        return [...prev, ...added];
+      });
+      const nextCursor =
+        page.items.length > 0 && page.nextCursor !== next
+          ? page.nextCursor
+          : null;
+      cursorRef.current = nextCursor;
+      setCursor(nextCursor);
     } catch {
       if (version !== requestRef.current) return;
       moreErrorRef.current = true;
@@ -163,6 +179,12 @@ export default function AllAssetsList({ onOpenType }: { onOpenType: (type: strin
       if (version === requestRef.current) setLoadingMore(false);
     }
   }, []);
+
+  const handleLoadMoreIntersection = useCallback(() => {
+    // Keep a failed page on explicit retry; repeated observer callbacks must
+    // not turn a backend error into an automatic retry loop.
+    if (!moreErrorRef.current) void loadMore();
+  }, [loadMore]);
 
   useEffect(() => {
     void load();
@@ -189,6 +211,7 @@ export default function AllAssetsList({ onOpenType }: { onOpenType: (type: strin
       // synchronously instead of leaving it live under the new request header.
       requestRef.current += 1;
       setItems([]);
+      cursorRef.current = null;
       setCursor(null);
       setError(null);
       moreErrorRef.current = false;
@@ -343,11 +366,8 @@ export default function AllAssetsList({ onOpenType }: { onOpenType: (type: strin
       <MineTable rows={rows} ariaLabel={t("mcp.mine.allAriaLabel")} />
       {(cursor || loadingMore || moreError) && (
         <LoadMoreSentinel
-          onLoadMore={() => {
-            // Keep a failed page on explicit retry; repeated observer callbacks
-            // must not turn a backend error into an automatic retry loop.
-            if (!moreErrorRef.current) void loadMore();
-          }}
+          onLoadMore={handleLoadMoreIntersection}
+          rearmKey={cursor ?? ""}
         >
           {loadingMore ? (
             <span className="skill-market-review-list--loading">

--- a/packages/dmworkmcp/src/pages/AllAssetsList.tsx
+++ b/packages/dmworkmcp/src/pages/AllAssetsList.tsx
@@ -48,6 +48,7 @@ export default function AllAssetsList({ onOpenType }: { onOpenType: (type: strin
   const [loading, setLoading] = useState(true);
   const [loadingMore, setLoadingMore] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [moreError, setMoreError] = useState(false);
   const [busyId, setBusyId] = useState<string | null>(null);
   const [deleting, setDeleting] = useState<Skill | null>(null);
   // Opaque cursor for the next page, null when the list is exhausted. The 全部
@@ -60,14 +61,19 @@ export default function AllAssetsList({ onOpenType }: { onOpenType: (type: strin
   // The IntersectionObserver callback captures these once at observe time, so
   // the live cursor / in-flight flag are read through refs instead.
   const cursorRef = useRef<string | null>(null);
-  const loadingMoreRef = useRef(false);
+  // Records which request generation owns the current pagination request. A
+  // stale request must not clear the in-flight guard for a newer Space/load.
+  const loadingMoreVersionRef = useRef<number | null>(null);
   const sentinelRef = useRef<HTMLDivElement | null>(null);
   cursorRef.current = cursor;
 
   const load = useCallback(async () => {
     const version = ++requestRef.current;
+    loadingMoreVersionRef.current = null;
     setLoading(true);
+    setLoadingMore(false);
     setError(null);
+    setMoreError(false);
     try {
       const page = await getMySkills({ limit: PAGE_SIZE }, { pluginType: "all" });
       if (version !== requestRef.current) return;
@@ -84,13 +90,14 @@ export default function AllAssetsList({ onOpenType }: { onOpenType: (type: strin
   // Append the next page. Deliberately does NOT bump requestRef — a load-more is
   // a continuation of the current base read, not a new one — but it is voided by
   // any base read or Space switch that bumps the version out from under it. A
-  // failed page is swallowed: the sentinel stays and a later scroll retries it.
+  // failed page leaves the existing rows in place and exposes an explicit retry.
   const loadMore = useCallback(async () => {
     const next = cursorRef.current;
-    if (!next || loadingMoreRef.current) return;
-    loadingMoreRef.current = true;
     const version = requestRef.current;
+    if (!next || loadingMoreVersionRef.current === version) return;
+    loadingMoreVersionRef.current = version;
     setLoadingMore(true);
+    setMoreError(false);
     try {
       const page = await getMySkills(
         { limit: PAGE_SIZE, cursor: next },
@@ -100,9 +107,11 @@ export default function AllAssetsList({ onOpenType }: { onOpenType: (type: strin
       setItems((prev) => [...prev, ...page.items]);
       setCursor(page.nextCursor);
     } catch {
-      // Swallow — retried on the next intersection; the base read owns errors.
+      if (version !== requestRef.current) return;
+      setMoreError(true);
     } finally {
-      loadingMoreRef.current = false;
+      if (loadingMoreVersionRef.current !== version) return;
+      loadingMoreVersionRef.current = null;
       if (version === requestRef.current) setLoadingMore(false);
     }
   }, []);
@@ -111,13 +120,22 @@ export default function AllAssetsList({ onOpenType }: { onOpenType: (type: strin
     void load();
   }, [load]);
 
+  useEffect(
+    () => () => {
+      requestRef.current += 1;
+      loadingMoreVersionRef.current = null;
+    },
+    []
+  );
+
   // Auto-load the next page when the sentinel nears the viewport, so the 全部
   // tab scrolls like the 技能 / 连接器 catalogs instead of stopping at page one.
   // The sentinel only renders once rows exist, so this re-runs as `loading`
   // settles to pick up the node; guarded for jsdom, which has no IO.
   useEffect(() => {
     const node = sentinelRef.current;
-    if (!node || typeof IntersectionObserver === "undefined") return undefined;
+    if (!node || moreError || typeof IntersectionObserver === "undefined")
+      return undefined;
     const observer = new IntersectionObserver(
       (entries) => {
         if (entries.some((entry) => entry.isIntersecting)) void loadMore();
@@ -126,7 +144,7 @@ export default function AllAssetsList({ onOpenType }: { onOpenType: (type: strin
     );
     observer.observe(node);
     return () => observer.disconnect();
-  }, [loadMore, loading, error, items.length]);
+  }, [loadMore, loading, error, moreError, items.length, cursor]);
 
   // Re-read on a Space switch. Every per-type tab (SkillListPage,
   // McpMarketListPage) subscribes; the 全部 tab — which is the default view and
@@ -143,6 +161,7 @@ export default function AllAssetsList({ onOpenType }: { onOpenType: (type: strin
       setItems([]);
       setCursor(null);
       setError(null);
+      setMoreError(false);
       setBusyId(null);
       setDeleting(null);
       void load();
@@ -291,14 +310,23 @@ export default function AllAssetsList({ onOpenType }: { onOpenType: (type: strin
   return (
     <div className="wk-mcp-mine__all">
       <MineTable rows={rows} ariaLabel={t("mcp.mine.allAriaLabel")} />
-      <div ref={sentinelRef} className="wk-mcp-mine__all-sentinel">
-        {loadingMore && (
-          <span className="skill-market-review-list--loading">
-            <RefreshCw size={14} className="skill-market-spin" />
-            {t("skillMarket.common.loading")}
-          </span>
-        )}
-      </div>
+      {(cursor || loadingMore || moreError) && (
+        <div ref={sentinelRef} className="wk-mcp-mine__all-sentinel">
+          {loadingMore ? (
+            <span className="skill-market-review-list--loading">
+              <RefreshCw size={14} className="skill-market-spin" />
+              {t("skillMarket.common.loading")}
+            </span>
+          ) : moreError ? (
+            <>
+              <span role="alert">{t("skillMarket.common.loadFailed")}</span>
+              <WKButton variant="secondary" onClick={() => void loadMore()}>
+                {t("skillMarket.list.retry")}
+              </WKButton>
+            </>
+          ) : null}
+        </div>
+      )}
       <WKModal
         visible={Boolean(deleting)}
         onCancel={() => {

--- a/packages/dmworkmcp/src/pages/AllAssetsList.tsx
+++ b/packages/dmworkmcp/src/pages/AllAssetsList.tsx
@@ -46,11 +46,23 @@ export default function AllAssetsList({ onOpenType }: { onOpenType: (type: strin
   useI18n();
   const [items, setItems] = useState<Skill[]>([]);
   const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [busyId, setBusyId] = useState<string | null>(null);
   const [deleting, setDeleting] = useState<Skill | null>(null);
+  // Opaque cursor for the next page, null when the list is exhausted. The 全部
+  // tab used to fetch a single page and stop, so any owner with more than
+  // PAGE_SIZE assets could never see the rest; it now pages like the per-type
+  // tabs (SkillListPage / McpMarketListPage), just cursor-driven here.
+  const [cursor, setCursor] = useState<string | null>(null);
   // Guards against an out-of-order response overwriting a newer one.
   const requestRef = useRef(0);
+  // The IntersectionObserver callback captures these once at observe time, so
+  // the live cursor / in-flight flag are read through refs instead.
+  const cursorRef = useRef<string | null>(null);
+  const loadingMoreRef = useRef(false);
+  const sentinelRef = useRef<HTMLDivElement | null>(null);
+  cursorRef.current = cursor;
 
   const load = useCallback(async () => {
     const version = ++requestRef.current;
@@ -60,6 +72,7 @@ export default function AllAssetsList({ onOpenType }: { onOpenType: (type: strin
       const page = await getMySkills({ limit: PAGE_SIZE }, { pluginType: "all" });
       if (version !== requestRef.current) return;
       setItems(page.items);
+      setCursor(page.nextCursor);
     } catch (err) {
       if (version !== requestRef.current) return;
       setError(err instanceof Error ? err.message : t("skillMarket.common.loadFailed"));
@@ -68,9 +81,52 @@ export default function AllAssetsList({ onOpenType }: { onOpenType: (type: strin
     }
   }, []);
 
+  // Append the next page. Deliberately does NOT bump requestRef — a load-more is
+  // a continuation of the current base read, not a new one — but it is voided by
+  // any base read or Space switch that bumps the version out from under it. A
+  // failed page is swallowed: the sentinel stays and a later scroll retries it.
+  const loadMore = useCallback(async () => {
+    const next = cursorRef.current;
+    if (!next || loadingMoreRef.current) return;
+    loadingMoreRef.current = true;
+    const version = requestRef.current;
+    setLoadingMore(true);
+    try {
+      const page = await getMySkills(
+        { limit: PAGE_SIZE, cursor: next },
+        { pluginType: "all" }
+      );
+      if (version !== requestRef.current) return;
+      setItems((prev) => [...prev, ...page.items]);
+      setCursor(page.nextCursor);
+    } catch {
+      // Swallow — retried on the next intersection; the base read owns errors.
+    } finally {
+      loadingMoreRef.current = false;
+      if (version === requestRef.current) setLoadingMore(false);
+    }
+  }, []);
+
   useEffect(() => {
     void load();
   }, [load]);
+
+  // Auto-load the next page when the sentinel nears the viewport, so the 全部
+  // tab scrolls like the 技能 / 连接器 catalogs instead of stopping at page one.
+  // The sentinel only renders once rows exist, so this re-runs as `loading`
+  // settles to pick up the node; guarded for jsdom, which has no IO.
+  useEffect(() => {
+    const node = sentinelRef.current;
+    if (!node || typeof IntersectionObserver === "undefined") return undefined;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((entry) => entry.isIntersecting)) void loadMore();
+      },
+      { rootMargin: "160px" }
+    );
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [loadMore, loading, error, items.length]);
 
   // Re-read on a Space switch. Every per-type tab (SkillListPage,
   // McpMarketListPage) subscribes; the 全部 tab — which is the default view and
@@ -85,6 +141,7 @@ export default function AllAssetsList({ onOpenType }: { onOpenType: (type: strin
       // synchronously instead of leaving it live under the new request header.
       requestRef.current += 1;
       setItems([]);
+      setCursor(null);
       setError(null);
       setBusyId(null);
       setDeleting(null);
@@ -234,6 +291,14 @@ export default function AllAssetsList({ onOpenType }: { onOpenType: (type: strin
   return (
     <div className="wk-mcp-mine__all">
       <MineTable rows={rows} ariaLabel={t("mcp.mine.allAriaLabel")} />
+      <div ref={sentinelRef} className="wk-mcp-mine__all-sentinel">
+        {loadingMore && (
+          <span className="skill-market-review-list--loading">
+            <RefreshCw size={14} className="skill-market-spin" />
+            {t("skillMarket.common.loading")}
+          </span>
+        )}
+      </div>
       <WKModal
         visible={Boolean(deleting)}
         onCancel={() => {

--- a/packages/dmworkmcp/src/pages/AllAssetsList.tsx
+++ b/packages/dmworkmcp/src/pages/AllAssetsList.tsx
@@ -18,6 +18,41 @@ import { getMcpAvatarColor, getMcpAvatarText } from "../utils/mcpAvatar";
 
 const PAGE_SIZE = 50;
 
+/** Keep one observer alive while pagination is available. The callback ref
+ * exposes the latest guards/cursor without rebuilding the observer after each
+ * appended page. */
+function LoadMoreSentinel({
+  onLoadMore,
+  children,
+}: {
+  onLoadMore: () => void;
+  children?: React.ReactNode;
+}) {
+  const ref = useRef<HTMLDivElement | null>(null);
+  const callbackRef = useRef(onLoadMore);
+  callbackRef.current = onLoadMore;
+
+  useEffect(() => {
+    const node = ref.current;
+    if (!node || typeof IntersectionObserver === "undefined") return undefined;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((entry) => entry.isIntersecting))
+          callbackRef.current();
+      },
+      { rootMargin: "160px" }
+    );
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <div ref={ref} className="wk-mcp-mine__all-sentinel">
+      {children}
+    </div>
+  );
+}
+
 /** Wire plugin type -> MineTable's local row type. */
 const ROW_TYPE: Record<string, MineAssetType> = {
   skill: "skill",
@@ -59,17 +94,20 @@ export default function AllAssetsList({ onOpenType }: { onOpenType: (type: strin
   // Guards against an out-of-order response overwriting a newer one.
   const requestRef = useRef(0);
   // The IntersectionObserver callback captures these once at observe time, so
-  // the live cursor / in-flight flag are read through refs instead.
+  // live request state is read through refs instead.
   const cursorRef = useRef<string | null>(null);
+  const loadingRef = useRef(true);
+  const moreErrorRef = useRef(false);
   // Records which request generation owns the current pagination request. A
   // stale request must not clear the in-flight guard for a newer Space/load.
   const loadingMoreVersionRef = useRef<number | null>(null);
-  const sentinelRef = useRef<HTMLDivElement | null>(null);
   cursorRef.current = cursor;
 
   const load = useCallback(async () => {
     const version = ++requestRef.current;
     loadingMoreVersionRef.current = null;
+    loadingRef.current = true;
+    moreErrorRef.current = false;
     setLoading(true);
     setLoadingMore(false);
     setError(null);
@@ -83,7 +121,10 @@ export default function AllAssetsList({ onOpenType }: { onOpenType: (type: strin
       if (version !== requestRef.current) return;
       setError(err instanceof Error ? err.message : t("skillMarket.common.loadFailed"));
     } finally {
-      if (version === requestRef.current) setLoading(false);
+      if (version === requestRef.current) {
+        loadingRef.current = false;
+        setLoading(false);
+      }
     }
   }, []);
 
@@ -94,8 +135,14 @@ export default function AllAssetsList({ onOpenType }: { onOpenType: (type: strin
   const loadMore = useCallback(async () => {
     const next = cursorRef.current;
     const version = requestRef.current;
-    if (!next || loadingMoreVersionRef.current === version) return;
+    if (
+      !next ||
+      loadingRef.current ||
+      loadingMoreVersionRef.current === version
+    )
+      return;
     loadingMoreVersionRef.current = version;
+    moreErrorRef.current = false;
     setLoadingMore(true);
     setMoreError(false);
     try {
@@ -108,6 +155,7 @@ export default function AllAssetsList({ onOpenType }: { onOpenType: (type: strin
       setCursor(page.nextCursor);
     } catch {
       if (version !== requestRef.current) return;
+      moreErrorRef.current = true;
       setMoreError(true);
     } finally {
       if (loadingMoreVersionRef.current !== version) return;
@@ -128,24 +176,6 @@ export default function AllAssetsList({ onOpenType }: { onOpenType: (type: strin
     []
   );
 
-  // Auto-load the next page when the sentinel nears the viewport, so the 全部
-  // tab scrolls like the 技能 / 连接器 catalogs instead of stopping at page one.
-  // The sentinel only renders once rows exist, so this re-runs as `loading`
-  // settles to pick up the node; guarded for jsdom, which has no IO.
-  useEffect(() => {
-    const node = sentinelRef.current;
-    if (!node || moreError || typeof IntersectionObserver === "undefined")
-      return undefined;
-    const observer = new IntersectionObserver(
-      (entries) => {
-        if (entries.some((entry) => entry.isIntersecting)) void loadMore();
-      },
-      { rootMargin: "160px" }
-    );
-    observer.observe(node);
-    return () => observer.disconnect();
-  }, [loadMore, loading, error, moreError, items.length, cursor]);
-
   // Re-read on a Space switch. Every per-type tab (SkillListPage,
   // McpMarketListPage) subscribes; the 全部 tab — which is the default view and
   // aggregates all four types — otherwise keeps rendering the previous Space's
@@ -161,6 +191,7 @@ export default function AllAssetsList({ onOpenType }: { onOpenType: (type: strin
       setItems([]);
       setCursor(null);
       setError(null);
+      moreErrorRef.current = false;
       setMoreError(false);
       setBusyId(null);
       setDeleting(null);
@@ -311,7 +342,13 @@ export default function AllAssetsList({ onOpenType }: { onOpenType: (type: strin
     <div className="wk-mcp-mine__all">
       <MineTable rows={rows} ariaLabel={t("mcp.mine.allAriaLabel")} />
       {(cursor || loadingMore || moreError) && (
-        <div ref={sentinelRef} className="wk-mcp-mine__all-sentinel">
+        <LoadMoreSentinel
+          onLoadMore={() => {
+            // Keep a failed page on explicit retry; repeated observer callbacks
+            // must not turn a backend error into an automatic retry loop.
+            if (!moreErrorRef.current) void loadMore();
+          }}
+        >
           {loadingMore ? (
             <span className="skill-market-review-list--loading">
               <RefreshCw size={14} className="skill-market-spin" />
@@ -325,7 +362,7 @@ export default function AllAssetsList({ onOpenType }: { onOpenType: (type: strin
               </WKButton>
             </>
           ) : null}
-        </div>
+        </LoadMoreSentinel>
       )}
       <WKModal
         visible={Boolean(deleting)}

--- a/packages/dmworkmcp/src/pages/ExpertMarketListPage.test.tsx
+++ b/packages/dmworkmcp/src/pages/ExpertMarketListPage.test.tsx
@@ -146,8 +146,6 @@ class MockIntersectionObserver {
     return [];
   }
 }
-(globalThis as unknown as { IntersectionObserver: unknown }).IntersectionObserver =
-  MockIntersectionObserver;
 
 /** Fire "scrolled into view" for sentinels within `parent`, triggering
  *  loadMore. Scoped so a stacked mine view can page one section at a time. */
@@ -168,6 +166,7 @@ function scrollLoadMore(parent: ParentNode = root) {
 
 beforeEach(() => {
   observers.length = 0;
+  vi.stubGlobal("IntersectionObserver", MockIntersectionObserver);
   vi.useFakeTimers();
   vi.resetAllMocks();
   reviews.useReviewRequests.mockReturnValue({ items: [], refresh: reviews.refresh });
@@ -192,6 +191,7 @@ afterEach(() => {
     ReactDOM.unmountComponentAtNode(root);
   });
   root.remove();
+  vi.unstubAllGlobals();
   vi.useRealTimers();
 });
 
@@ -391,6 +391,29 @@ describe("expert catalog server search and pagination", () => {
     expect(api.listExperts).toHaveBeenLastCalledWith(
       expect.objectContaining({ page: 1 })
     );
+  });
+
+  it("re-arms after a short page so a remaining page can load", async () => {
+    api.listExperts
+      .mockResolvedValueOnce({ items: records.slice(0, 100), total: 250 })
+      .mockResolvedValueOnce({ items: records.slice(100), total: 250 })
+      .mockResolvedValueOnce({ items: [], total: 250 });
+
+    await render();
+    const initialObserver = observers[0];
+    scrollLoadMore();
+    await tick();
+
+    expect(itemCount()).toBe(112);
+    expect(observers).toHaveLength(1);
+    expect(observers[0]).not.toBe(initialObserver);
+
+    scrollLoadMore();
+    await tick();
+    expect(api.listExperts).toHaveBeenLastCalledWith(
+      expect.objectContaining({ page: 3 })
+    );
+    expect(observers).toHaveLength(0);
   });
 
   it("filters a category and tags found only beyond page 1, and forwards sort", async () => {

--- a/packages/dmworkmcp/src/pages/ExpertMarketListPage.test.tsx
+++ b/packages/dmworkmcp/src/pages/ExpertMarketListPage.test.tsx
@@ -116,7 +116,58 @@ function serverList(params: ListExpertParams = {}): Promise<ExpertListResult> {
 }
 
 let root: HTMLDivElement;
+
+// Controllable IntersectionObserver: the pagination sentinel auto-loads on
+// intersection now (no 加载更多 button), so tests drive that by firing the
+// observed callbacks through `scrollLoadMore()` instead of clicking.
+interface FakeObserver {
+  cb: IntersectionObserverCallback;
+  elements: Set<Element>;
+}
+const observers: FakeObserver[] = [];
+class MockIntersectionObserver {
+  private entry: FakeObserver;
+  constructor(cb: IntersectionObserverCallback) {
+    this.entry = { cb, elements: new Set() };
+    observers.push(this.entry);
+  }
+  observe(el: Element) {
+    this.entry.elements.add(el);
+  }
+  unobserve(el: Element) {
+    this.entry.elements.delete(el);
+  }
+  disconnect() {
+    this.entry.elements.clear();
+    const i = observers.indexOf(this.entry);
+    if (i >= 0) observers.splice(i, 1);
+  }
+  takeRecords() {
+    return [];
+  }
+}
+(globalThis as unknown as { IntersectionObserver: unknown }).IntersectionObserver =
+  MockIntersectionObserver;
+
+/** Fire "scrolled into view" for sentinels within `parent`, triggering
+ *  loadMore. Scoped so a stacked mine view can page one section at a time. */
+function scrollLoadMore(parent: ParentNode = root) {
+  act(() => {
+    for (const obs of [...observers]) {
+      const targets = Array.from(obs.elements).filter((el) => parent.contains(el));
+      if (targets.length === 0) continue;
+      obs.cb(
+        targets.map(
+          (target) => ({ isIntersecting: true, target } as IntersectionObserverEntry)
+        ),
+        obs as unknown as IntersectionObserver
+      );
+    }
+  });
+}
+
 beforeEach(() => {
+  observers.length = 0;
   vi.useFakeTimers();
   vi.resetAllMocks();
   reviews.useReviewRequests.mockReturnValue({ items: [], refresh: reviews.refresh });
@@ -321,11 +372,9 @@ describe("expert catalog server search and pagination", () => {
 
   it("loads the remaining records once, then resets paging for search and clear", async () => {
     await render();
-    const more = button("mcp.expert.loadMore");
-    act(() => {
-      Simulate.click(more);
-      Simulate.click(more);
-    });
+    // Two intersections in a row must still fetch page 2 only once.
+    scrollLoadMore();
+    scrollLoadMore();
     await tick();
     expect(api.listExperts).toHaveBeenCalledTimes(2);
     expect(api.listExperts).toHaveBeenLastCalledWith(
@@ -375,7 +424,7 @@ describe("expert catalog server search and pagination", () => {
   it("keeps previous rows on a later-page failure and retries the same page", async () => {
     await render();
     api.listExperts.mockRejectedValueOnce(new Error("offline"));
-    click(button("mcp.expert.loadMore"));
+    scrollLoadMore();
     await tick();
     expect(itemCount()).toBe(100);
     expect(root.querySelector('[role="alert"]')).not.toBeNull();
@@ -405,7 +454,7 @@ describe("expert catalog server search and pagination", () => {
     await render();
     const old = deferred<ExpertListResult>();
     api.listExperts.mockReturnValueOnce(old.promise);
-    click(button("mcp.expert.loadMore"));
+    scrollLoadMore();
     search("数据分析报告");
     await tick(250);
     await act(async () => {
@@ -436,7 +485,7 @@ describe("expert catalog server search and pagination", () => {
     await render();
     const old = deferred<ExpertListResult>();
     api.listExperts.mockReturnValueOnce(old.promise);
-    click(button("mcp.expert.loadMore"));
+    scrollLoadMore();
     api.listExperts.mockResolvedValueOnce({ items: [], total: 0 });
     const spaceChanged = bus.on.mock.calls.find(
       ([event]) => event === "space-changed"
@@ -461,11 +510,11 @@ describe("expert catalog server search and pagination", () => {
       items: records.slice(99),
       total: 250,
     });
-    click(button("mcp.expert.loadMore"));
+    scrollLoadMore();
     await tick();
     expect(itemCount()).toBe(112);
     api.listExperts.mockResolvedValueOnce({ items: [], total: 250 });
-    click(button("mcp.expert.loadMore"));
+    scrollLoadMore();
     await tick();
     expect(root.textContent).not.toContain("mcp.expert.loadMore");
   });
@@ -478,7 +527,7 @@ describe("expert catalog server search and pagination", () => {
     expect(api.listExpertTags).toHaveBeenCalledWith("agent", { mine: true });
     expect(api.listExpertTags).toHaveBeenCalledWith("squad", { mine: true });
     const sections = root.querySelectorAll(".wk-mcp-expert-mine-section");
-    click(button("mcp.expert.loadMore", sections[0]));
+    scrollLoadMore(sections[0]);
     await tick();
     expect(sections[0].querySelectorAll("[data-item]")).toHaveLength(112);
     expect(sections[1].querySelectorAll("[data-item]")).toHaveLength(100);
@@ -513,7 +562,7 @@ describe("expert catalog server search and pagination", () => {
       });
       await render({ variant: "mine", mineType });
       expect(reviews.useReviewRequests).toHaveBeenLastCalledWith({ mode: "mine", pageSize: 100, enabled: true });
-      click(button("mcp.expert.loadMore"));
+      scrollLoadMore();
       await tick();
       const pending = root.querySelector('[data-item="expert-101"]')!;
       expect(pending.getAttribute("data-status")).toBe("pending_review");

--- a/packages/dmworkmcp/src/pages/ExpertMarketListPage.tsx
+++ b/packages/dmworkmcp/src/pages/ExpertMarketListPage.tsx
@@ -49,6 +49,34 @@ const SORT_OPTIONS: Array<{ value: ExpertCatalogSort; labelKey: string; descendi
 ];
 
 /**
+ * Tail sentinel that fires `onLoadMore` when it scrolls near the viewport, so
+ * 专家 / 专家团 page in on scroll like the 技能 / 连接器 catalogs instead of
+ * forcing a click on 加载更多. Renders nothing visible — the pagination row
+ * shows the count + a spinner. `loadMore` is self-guarded (a page already in
+ * flight, exhausted, or errored is a no-op), so repeated intersections are
+ * safe. jsdom has no IntersectionObserver; there it degrades to an inert node
+ * and tests drive `loadMore` through a mocked observer.
+ */
+function LoadMoreSentinel({ onLoadMore }: { onLoadMore: () => void }) {
+  const ref = useRef<HTMLDivElement | null>(null);
+  const cbRef = useRef(onLoadMore);
+  cbRef.current = onLoadMore;
+  useEffect(() => {
+    const node = ref.current;
+    if (!node || typeof IntersectionObserver === "undefined") return undefined;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((entry) => entry.isIntersecting)) cbRef.current();
+      },
+      { rootMargin: "160px" }
+    );
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, []);
+  return <div ref={ref} className="wk-mcp-expert-sentinel" aria-hidden="true" />;
+}
+
+/**
  * Rendering variant. "market" (default) = discovery catalog (专家/专家团 tabs).
  * "mine" = personal assets mounted inside MyAssetsPage — forces the mine view,
  * hides the in-page tab strip + hero title. `mineType` narrows the mine view to
@@ -283,16 +311,26 @@ export default function ExpertMarketListPage({
           values: { count: catalog.items.length, total: catalog.total },
         })}
       </span>
-      {catalog.moreErrorKey && <span role="alert">{t(catalog.moreErrorKey)}</span>}
-      {catalog.hasMore && (
-        <WKButton
-          variant="secondary"
-          disabled={catalog.loadingMore}
-          onClick={() => catalog.loadMore()}
-        >
-          {t(catalog.loadingMore ? "mcp.expert.loading" : catalog.moreErrorKey ? "mcp.list.retry" : "mcp.expert.loadMore")}
-        </WKButton>
+      {catalog.loadingMore && (
+        <span className="wk-mcp-expert-pagination__loading" role="status">
+          {t("mcp.expert.loading")}
+        </span>
       )}
+      {catalog.moreErrorKey && <span role="alert">{t(catalog.moreErrorKey)}</span>}
+      {catalog.hasMore &&
+        (catalog.moreErrorKey ? (
+          // A failed page stops the scroll auto-retry loop; the user re-triggers
+          // it explicitly rather than have every intersection re-hit a 5xx.
+          <WKButton
+            variant="secondary"
+            disabled={catalog.loadingMore}
+            onClick={() => catalog.loadMore()}
+          >
+            {t("mcp.list.retry")}
+          </WKButton>
+        ) : (
+          <LoadMoreSentinel onLoadMore={() => catalog.loadMore()} />
+        ))}
     </div>
   );
 

--- a/packages/dmworkmcp/src/pages/ExpertMarketListPage.tsx
+++ b/packages/dmworkmcp/src/pages/ExpertMarketListPage.tsx
@@ -57,13 +57,23 @@ const SORT_OPTIONS: Array<{ value: ExpertCatalogSort; labelKey: string; descendi
  * safe. jsdom has no IntersectionObserver; there it degrades to an inert node
  * and tests drive `loadMore` through a mocked observer.
  */
-function LoadMoreSentinel({ onLoadMore }: { onLoadMore: () => void }) {
+function LoadMoreSentinel({
+  onLoadMore,
+  rearmKey,
+}: {
+  onLoadMore: () => void;
+  rearmKey: number;
+}) {
   const ref = useRef<HTMLDivElement | null>(null);
   const cbRef = useRef(onLoadMore);
-  cbRef.current = onLoadMore;
+  useEffect(() => {
+    cbRef.current = onLoadMore;
+  }, [onLoadMore]);
   useEffect(() => {
     const node = ref.current;
     if (!node || typeof IntersectionObserver === "undefined") return undefined;
+    // Recreating on each committed page re-delivers the current intersection,
+    // so a short page that leaves the sentinel visible can continue loading.
     const observer = new IntersectionObserver(
       (entries) => {
         if (entries.some((entry) => entry.isIntersecting)) cbRef.current();
@@ -72,7 +82,7 @@ function LoadMoreSentinel({ onLoadMore }: { onLoadMore: () => void }) {
     );
     observer.observe(node);
     return () => observer.disconnect();
-  }, []);
+  }, [rearmKey]);
   return <div ref={ref} className="wk-mcp-expert-sentinel" aria-hidden="true" />;
 }
 
@@ -329,7 +339,10 @@ export default function ExpertMarketListPage({
             {t("mcp.list.retry")}
           </WKButton>
         ) : (
-          <LoadMoreSentinel onLoadMore={() => catalog.loadMore()} />
+          <LoadMoreSentinel
+            onLoadMore={() => catalog.loadMore()}
+            rearmKey={catalog.page}
+          />
         ))}
     </div>
   );

--- a/packages/dmworkmcp/src/pages/__tests__/AllAssetsList.test.tsx
+++ b/packages/dmworkmcp/src/pages/__tests__/AllAssetsList.test.tsx
@@ -208,6 +208,7 @@ describe("AllAssetsList pagination", () => {
         container
       );
     });
+    const initialObserver = observers[0];
     scrollLoadMore();
     scrollLoadMore();
 
@@ -217,9 +218,43 @@ describe("AllAssetsList pagination", () => {
       { pluginType: "all" }
     );
 
-    await act(async () => nextPage.resolve(page([asset("b", "Second page")])));
+    await act(async () =>
+      nextPage.resolve(page([asset("b", "Second page")], "third"))
+    );
     expect(container.textContent).toContain("First page");
     expect(container.textContent).toContain("Second page");
+    expect(observers).toHaveLength(1);
+    expect(observers[0]).toBe(initialObserver);
+  });
+
+  it("does not page with the old cursor during a row-action reload", async () => {
+    const reload = deferred<ReturnType<typeof page>>();
+    h.getMySkills
+      .mockResolvedValueOnce(page([asset("a", "Published asset")], "old-next"))
+      .mockReturnValueOnce(reload.promise);
+    h.publishPlugin.mockResolvedValueOnce({ displayStatus: "published" });
+
+    await act(async () => {
+      ReactDOM.render(
+        React.createElement(AllAssetsList, { onOpenType: vi.fn() }),
+        container
+      );
+    });
+    const publish = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent === "publish-Published asset"
+    );
+    await act(async () => publish?.click());
+
+    scrollLoadMore();
+    expect(h.getMySkills).toHaveBeenCalledTimes(2);
+    expect(h.getMySkills).not.toHaveBeenCalledWith(
+      { limit: 50, cursor: "old-next" },
+      { pluginType: "all" }
+    );
+
+    await act(async () =>
+      reload.resolve(page([asset("a", "Published asset")]))
+    );
   });
 
   it("keeps loaded rows and exposes retry when the next page fails", async () => {
@@ -241,6 +276,8 @@ describe("AllAssetsList pagination", () => {
     expect(container.querySelector('[role="alert"]')?.textContent).toBe(
       "skillMarket.common.loadFailed"
     );
+    scrollLoadMore();
+    expect(h.getMySkills).toHaveBeenCalledTimes(2);
 
     const retry = Array.from(container.querySelectorAll("button")).find(
       (button) => button.textContent === "skillMarket.list.retry"

--- a/packages/dmworkmcp/src/pages/__tests__/AllAssetsList.test.tsx
+++ b/packages/dmworkmcp/src/pages/__tests__/AllAssetsList.test.tsx
@@ -18,21 +18,100 @@ function emit(event: string) {
   for (const handler of [...(h.handlers[event] ?? [])]) handler();
 }
 
+interface FakeObserver {
+  callback: IntersectionObserverCallback;
+  elements: Set<Element>;
+}
+
+const observers: FakeObserver[] = [];
+
+class MockIntersectionObserver {
+  private entry: FakeObserver;
+
+  constructor(callback: IntersectionObserverCallback) {
+    this.entry = { callback, elements: new Set() };
+    observers.push(this.entry);
+  }
+
+  observe(element: Element) {
+    this.entry.elements.add(element);
+  }
+
+  unobserve(element: Element) {
+    this.entry.elements.delete(element);
+  }
+
+  disconnect() {
+    this.entry.elements.clear();
+    const index = observers.indexOf(this.entry);
+    if (index >= 0) observers.splice(index, 1);
+  }
+
+  takeRecords() {
+    return [];
+  }
+}
+
+function scrollLoadMore() {
+  act(() => {
+    for (const observer of [...observers]) {
+      const targets = Array.from(observer.elements).filter((element) =>
+        container.contains(element)
+      );
+      if (targets.length === 0) continue;
+      observer.callback(
+        targets.map(
+          (target) =>
+            ({ isIntersecting: true, target } as IntersectionObserverEntry)
+        ),
+        observer as unknown as IntersectionObserver
+      );
+    }
+  });
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: Error) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
 vi.mock("@octo/base", () => ({
   t: (key: string) => key,
   useI18n: () => undefined,
   WKApp: {
     mittBus: {
-      on: (event: string, handler: () => void) => (h.handlers[event] ??= []).push(handler),
+      on: (event: string, handler: () => void) =>
+        (h.handlers[event] ??= []).push(handler),
       off: (event: string, handler: () => void) => {
-        h.handlers[event] = (h.handlers[event] ?? []).filter((entry) => entry !== handler);
+        h.handlers[event] = (h.handlers[event] ?? []).filter(
+          (entry) => entry !== handler
+        );
       },
     },
   },
-  WKButton: ({ children, loading: _loading, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement> & { loading?: boolean }) =>
+  WKButton: ({
+    children,
+    loading: _loading,
+    ...props
+  }: React.ButtonHTMLAttributes<HTMLButtonElement> & { loading?: boolean }) =>
     React.createElement("button", props, children),
-  WKModal: ({ visible, children, footer }: { visible: boolean; children: React.ReactNode; footer: React.ReactNode }) =>
-    visible ? React.createElement("div", { role: "dialog" }, children, footer) : null,
+  WKModal: ({
+    visible,
+    children,
+    footer,
+  }: {
+    visible: boolean;
+    children: React.ReactNode;
+    footer: React.ReactNode;
+  }) =>
+    visible
+      ? React.createElement("div", { role: "dialog" }, children, footer)
+      : null,
 }));
 
 vi.mock("@douyinfe/semi-ui", () => ({
@@ -45,10 +124,27 @@ vi.mock("@dmwork/skillmarket", () => ({
       "div",
       null,
       ...rows.flatMap((row) => [
-        React.createElement("span", { key: `${row.id}-name` }, String(row.name)),
-        row.onPublish ? React.createElement("button", { key: `${row.id}-publish`, onClick: row.onPublish as () => void }, `publish-${row.name}`) : null,
-        React.createElement("button", { key: `${row.id}-delete`, onClick: row.onDelete as () => void }, `delete-${row.name}`),
-      ]),
+        React.createElement(
+          "span",
+          { key: `${row.id}-name` },
+          String(row.name)
+        ),
+        row.onPublish
+          ? React.createElement(
+              "button",
+              {
+                key: `${row.id}-publish`,
+                onClick: row.onPublish as () => void,
+              },
+              `publish-${row.name}`
+            )
+          : null,
+        React.createElement(
+          "button",
+          { key: `${row.id}-delete`, onClick: row.onDelete as () => void },
+          `delete-${row.name}`
+        ),
+      ])
     ),
   getMySkills: (...args: unknown[]) => h.getMySkills(...args),
   publishPlugin: (...args: unknown[]) => h.publishPlugin(...args),
@@ -78,18 +174,125 @@ const asset = (id: string, name: string) => ({
   listingState: "draft",
   displayStatus: "draft",
 });
-const page = (items: unknown[]) => ({ items, nextCursor: null, total: items.length });
+const page = (items: unknown[], nextCursor: string | null = null) => ({
+  items,
+  nextCursor,
+  total: items.length,
+});
 
 let container: HTMLDivElement;
 beforeEach(() => {
   container = document.createElement("div");
   document.body.appendChild(container);
   h.handlers = {};
+  observers.length = 0;
   vi.clearAllMocks();
+  vi.stubGlobal("IntersectionObserver", MockIntersectionObserver);
 });
 afterEach(() => {
   ReactDOM.unmountComponentAtNode(container);
   container.remove();
+  vi.unstubAllGlobals();
+});
+
+describe("AllAssetsList pagination", () => {
+  it("appends the next page once when the tail intersects", async () => {
+    const nextPage = deferred<ReturnType<typeof page>>();
+    h.getMySkills
+      .mockResolvedValueOnce(page([asset("a", "First page")], "next"))
+      .mockReturnValueOnce(nextPage.promise);
+
+    await act(async () => {
+      ReactDOM.render(
+        React.createElement(AllAssetsList, { onOpenType: vi.fn() }),
+        container
+      );
+    });
+    scrollLoadMore();
+    scrollLoadMore();
+
+    expect(h.getMySkills).toHaveBeenCalledTimes(2);
+    expect(h.getMySkills).toHaveBeenLastCalledWith(
+      { limit: 50, cursor: "next" },
+      { pluginType: "all" }
+    );
+
+    await act(async () => nextPage.resolve(page([asset("b", "Second page")])));
+    expect(container.textContent).toContain("First page");
+    expect(container.textContent).toContain("Second page");
+  });
+
+  it("keeps loaded rows and exposes retry when the next page fails", async () => {
+    h.getMySkills
+      .mockResolvedValueOnce(page([asset("a", "First page")], "next"))
+      .mockRejectedValueOnce(new Error("offline"))
+      .mockResolvedValueOnce(page([asset("b", "Retried page")]));
+
+    await act(async () => {
+      ReactDOM.render(
+        React.createElement(AllAssetsList, { onOpenType: vi.fn() }),
+        container
+      );
+    });
+    scrollLoadMore();
+    await act(async () => undefined);
+
+    expect(container.textContent).toContain("First page");
+    expect(container.querySelector('[role="alert"]')?.textContent).toBe(
+      "skillMarket.common.loadFailed"
+    );
+
+    const retry = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent === "skillMarket.list.retry"
+    );
+    await act(async () => retry?.click());
+
+    expect(h.getMySkills).toHaveBeenLastCalledWith(
+      { limit: 50, cursor: "next" },
+      { pluginType: "all" }
+    );
+    expect(container.textContent).toContain("Retried page");
+    expect(container.querySelector('[role="alert"]')).toBeNull();
+  });
+
+  it("lets the new Space paginate while the old Space page is still in flight", async () => {
+    const oldPage = deferred<ReturnType<typeof page>>();
+    h.getMySkills
+      .mockResolvedValueOnce(
+        page([asset("a", "Space A asset")], "space-a-next")
+      )
+      .mockReturnValueOnce(oldPage.promise)
+      .mockResolvedValueOnce(
+        page([asset("b", "Space B asset")], "space-b-next")
+      )
+      .mockResolvedValueOnce(page([asset("c", "Space B second page")]));
+
+    await act(async () => {
+      ReactDOM.render(
+        React.createElement(AllAssetsList, { onOpenType: vi.fn() }),
+        container
+      );
+    });
+    scrollLoadMore();
+    await act(async () => emit("space-changed"));
+
+    expect(container.textContent).toContain("Space B asset");
+    expect(container.textContent).not.toContain("skillMarket.common.loading");
+
+    scrollLoadMore();
+    await act(async () => undefined);
+    expect(h.getMySkills).toHaveBeenLastCalledWith(
+      { limit: 50, cursor: "space-b-next" },
+      { pluginType: "all" }
+    );
+    expect(container.textContent).toContain("Space B second page");
+
+    await act(async () =>
+      oldPage.resolve(page([asset("stale", "Stale Space A row")]))
+    );
+    expect(container.textContent).not.toContain("Stale Space A row");
+    expect(container.textContent).toContain("Space B second page");
+  });
 });
 
 describe("AllAssetsList Space isolation", () => {
@@ -97,13 +300,27 @@ describe("AllAssetsList Space isolation", () => {
     let resolveNew: (value: ReturnType<typeof page>) => void = () => {};
     h.getMySkills
       .mockResolvedValueOnce(page([asset("a", "Space A asset")]))
-      .mockImplementationOnce(() => new Promise((resolve) => { resolveNew = resolve; }));
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveNew = resolve;
+          })
+      );
 
     await act(async () => {
-      ReactDOM.render(React.createElement(AllAssetsList, { onOpenType: vi.fn() }), container);
+      ReactDOM.render(
+        React.createElement(AllAssetsList, { onOpenType: vi.fn() }),
+        container
+      );
     });
     expect(container.textContent).toContain("Space A asset");
-    act(() => (Array.from(container.querySelectorAll("button")).find((button) => button.textContent === "delete-Space A asset") as HTMLButtonElement).click());
+    act(() =>
+      (
+        Array.from(container.querySelectorAll("button")).find(
+          (button) => button.textContent === "delete-Space A asset"
+        ) as HTMLButtonElement
+      ).click()
+    );
     expect(container.querySelector('[role="dialog"]')).not.toBeNull();
 
     act(() => emit("space-changed"));
@@ -120,13 +337,25 @@ describe("AllAssetsList Space isolation", () => {
       .mockResolvedValueOnce(page([asset("a", "Space A asset")]))
       .mockResolvedValueOnce(page([asset("b", "Space B asset")]));
     h.publishPlugin.mockImplementationOnce(
-      () => new Promise((_resolve, reject) => { rejectPublish = reject; }),
+      () =>
+        new Promise((_resolve, reject) => {
+          rejectPublish = reject;
+        })
     );
 
     await act(async () => {
-      ReactDOM.render(React.createElement(AllAssetsList, { onOpenType: vi.fn() }), container);
+      ReactDOM.render(
+        React.createElement(AllAssetsList, { onOpenType: vi.fn() }),
+        container
+      );
     });
-    act(() => (Array.from(container.querySelectorAll("button")).find((button) => button.textContent === "publish-Space A asset") as HTMLButtonElement).click());
+    act(() =>
+      (
+        Array.from(container.querySelectorAll("button")).find(
+          (button) => button.textContent === "publish-Space A asset"
+        ) as HTMLButtonElement
+      ).click()
+    );
     await act(async () => emit("space-changed"));
     expect(container.textContent).toContain("Space B asset");
 

--- a/packages/dmworkmcp/src/pages/__tests__/AllAssetsList.test.tsx
+++ b/packages/dmworkmcp/src/pages/__tests__/AllAssetsList.test.tsx
@@ -196,11 +196,12 @@ afterEach(() => {
 });
 
 describe("AllAssetsList pagination", () => {
-  it("appends the next page once when the tail intersects", async () => {
+  it("re-arms after each page and stops when an empty page has a cursor", async () => {
     const nextPage = deferred<ReturnType<typeof page>>();
     h.getMySkills
       .mockResolvedValueOnce(page([asset("a", "First page")], "next"))
-      .mockReturnValueOnce(nextPage.promise);
+      .mockReturnValueOnce(nextPage.promise)
+      .mockResolvedValueOnce(page([], "fourth"));
 
     await act(async () => {
       ReactDOM.render(
@@ -224,7 +225,45 @@ describe("AllAssetsList pagination", () => {
     expect(container.textContent).toContain("First page");
     expect(container.textContent).toContain("Second page");
     expect(observers).toHaveLength(1);
-    expect(observers[0]).toBe(initialObserver);
+    expect(observers[0]).not.toBe(initialObserver);
+
+    scrollLoadMore();
+    await act(async () => undefined);
+    expect(h.getMySkills).toHaveBeenCalledTimes(3);
+    expect(h.getMySkills).toHaveBeenLastCalledWith(
+      { limit: 50, cursor: "third" },
+      { pluginType: "all" }
+    );
+    expect(observers).toHaveLength(0);
+  });
+
+  it("deduplicates overlapping offset pages by asset id", async () => {
+    h.getMySkills
+      .mockResolvedValueOnce(
+        page(
+          [asset("a", "First asset"), asset("shared", "Shared asset")],
+          "next"
+        )
+      )
+      .mockResolvedValueOnce(
+        page([asset("shared", "Shared asset"), asset("b", "Second asset")])
+      );
+
+    await act(async () => {
+      ReactDOM.render(
+        React.createElement(AllAssetsList, { onOpenType: vi.fn() }),
+        container
+      );
+    });
+    scrollLoadMore();
+    await act(async () => undefined);
+
+    const sharedRows = Array.from(container.querySelectorAll("span")).filter(
+      (element) => element.textContent === "Shared asset"
+    );
+    expect(sharedRows).toHaveLength(1);
+    expect(container.textContent).toContain("First asset");
+    expect(container.textContent).toContain("Second asset");
   });
 
   it("does not page with the old cursor during a row-action reload", async () => {

--- a/packages/dmworkskillmarket/src/api/skillApiReal.test.ts
+++ b/packages/dmworkskillmarket/src/api/skillApiReal.test.ts
@@ -287,6 +287,16 @@ describe("skillApiReal", () => {
     expect(url).toContain("sort=downloads");
   });
 
+  it("stops offset pagination when a page is empty despite a larger total", async () => {
+    mockFetch.mockReturnValueOnce(
+      jsonResponse([], 200, { total: 100, page: 2, page_size: 20 })
+    );
+
+    const result = await getMySkills({ cursor: "2", limit: 20 });
+
+    expect(result).toEqual({ items: [], nextCursor: null, total: 100 });
+  });
+
   it("getSkill maps the plugin detail with package artifacts", async () => {
     mockFetch.mockReturnValueOnce(
       jsonResponse({

--- a/packages/dmworkskillmarket/src/api/skillApiReal.ts
+++ b/packages/dmworkskillmarket/src/api/skillApiReal.ts
@@ -541,7 +541,10 @@ function listPlugins(
       items,
       // Synthesize the legacy opaque cursor from offset pagination: the next
       // cursor is simply the next page number while more rows remain.
-      nextCursor: page * pageSize < total ? String(page + 1) : null,
+      nextCursor:
+        items.length > 0 && page * pageSize < total
+          ? String(page + 1)
+          : null,
       total,
     };
   });

--- a/packages/dmworkskillmarket/src/index.css
+++ b/packages/dmworkskillmarket/src/index.css
@@ -2922,13 +2922,13 @@
      single-line look, vertical padding + line-height let a two-line transition
      wrap inside the background instead of overflowing it. The version tokens
      hold no spaces, so wrapping only ever happens around the arrow. */
-  min-height: 20px;
-  padding: 2px var(--wk-sp-2);
+  min-height: var(--wk-sp-5);
+  padding: var(--wk-sp-0-5) var(--wk-sp-2);
   border-radius: var(--wk-r-sm);
   background: var(--wk-bg-elevated);
   color: var(--wk-text-secondary);
   font-variant-numeric: tabular-nums;
-  line-height: 16px;
+  line-height: var(--wk-sp-4);
   text-align: center;
   vertical-align: middle;
   white-space: normal;
@@ -3604,8 +3604,6 @@
 .skill-market-spin {
   animation: skill-market-spin 900ms linear infinite;
 }
-
-
 /* Inline confirmation that replaces a dialog's footer rather than stacking a
    second dialog over it. It occupies the footer slot, so it inherits the modal's
    footer padding and border; only the layout and the warning tone are set here. */

--- a/packages/dmworkskillmarket/src/index.css
+++ b/packages/dmworkskillmarket/src/index.css
@@ -2914,14 +2914,25 @@
   white-space: nowrap;
 }
 .wk-mine-table__version {
-  display: inline-flex;
-  align-items: center;
-  height: 20px;
-  padding: 0 var(--wk-sp-2);
+  display: inline-block;
+  /* An upgrade renders `v1.0.0 → v1.0.1`, which does not fit the fixed version
+     track and used to wrap out of a height-locked pill, splitting the box. The
+     head and body are separate grids, so the track cannot be content-sized
+     without misaligning — instead the pill grows: min-height keeps the 20px
+     single-line look, vertical padding + line-height let a two-line transition
+     wrap inside the background instead of overflowing it. The version tokens
+     hold no spaces, so wrapping only ever happens around the arrow. */
+  min-height: 20px;
+  padding: 2px var(--wk-sp-2);
   border-radius: var(--wk-r-sm);
   background: var(--wk-bg-elevated);
   color: var(--wk-text-secondary);
   font-variant-numeric: tabular-nums;
+  line-height: 16px;
+  text-align: center;
+  vertical-align: middle;
+  white-space: normal;
+  max-width: 100%;
 }
 .wk-mine-table__vis {
   display: inline-flex;


### PR DESCRIPTION
## Summary

Make marketplace lists consistently load additional records on scroll, keep the UI recoverable when pagination fails, and align the top-level Market entry with the first sidebar item (Skills). The review pass also fixes the review-queue version pill so upgrade versions remain inside the pill.

## Related Issue

Fixes Mininglamp-OSS/octo-marketplace#83

Related to Mininglamp-OSS/octo-marketplace#81 and Mininglamp-OSS/octo-marketplace#85 (pagination and scrolling behavior).

## Changes

- Add cursor-based infinite scrolling to My Publications → All instead of stopping after the first 50 assets.
- Replace the Experts / Expert Teams manual load-more action with a guarded intersection sentinel.
- Preserve already loaded rows and expose an explicit retry after a later-page failure.
- Invalidate stale base and pagination responses after a Space change or component unmount.
- Open Skills when entering Market while preserving explicit Connector deep links.
- Allow review-queue version pills such as `v1.0.0 → v1.0.1` to wrap inside their background.
- Update unit and EX4 Playwright coverage for scrolling, retry, request races, and the default market entry.

## Architecture / Module Boundary

- Affected module(s): `@dmwork/mcp`, `@dmwork/skillmarket`, and the web EX4 marketplace E2E case.
- New or changed user-visible entry point: yes; the existing top-level Market entry now opens the existing Skills route. No additional menu, route, or button entry was introduced.
- Shared layer touched: none. Changes stay within marketplace pages, module registration, package-owned styles, and tests.
- If shared code changed, impact scope: not applicable; no shared `ui/`, `Components/`, `Messages/`, bridge, service, API contract, persistence, authorization, or data-model change.
- Duplicate entry point checked: yes.

## COMPREHENSION

- `AllAssetsList` owns an opaque next-page cursor. Its observer requests one continuation at a time; a base reload changes the request generation so older results cannot update the new Space.
- Expert catalog pagination continues to use the existing catalog hook as its source of truth; only the trigger changes from a button to an observer sentinel. Errors stop automatic retries and retain a manual retry action.
- The Market menu activation now routes, mounts, highlights, and synchronizes the URL to Skills. Direct `/mcp-market/mcp` navigation remains mapped to Connectors.

## Testing

- [x] Unit tests added/updated
- [x] Manually verified
- `CI=true pnpm turbo run test --concurrency=1 --filter=!@octo/base` — 11/11 tasks passed.
- `pnpm --filter @octo/base test:coverage` — 481 files and 4,573 tests passed; 71.57% statements / 63.22% branches / 66.92% functions / 73.26% lines.
- `@dmwork/mcp` suite — 32 files and 374 tests passed.
- `@dmwork/skillmarket` suite — 22 files and 306 tests passed.
- Focused marketplace regression set — 49 tests passed.
- `pnpm i18n:check` — passed.
- `pnpm lint:css` — passed with 1,310 pre-existing repository warnings and no new warning from this diff.
- `pnpm lint` — exited successfully; the current workspace reports no configured executable lint task.
- Web production build and E2E build — passed (existing third-party `eval` and chunk-size warnings only).
- EX4 Playwright scenario — passed in `zh-CN` and `en-US`; screenshots visually checked.
- `git diff --check` — passed.

## Known Warnings / Residual Risk

- Existing test logs include React `act(...)`, jsdom browser-API, and Turbo output-file warnings; all suites still exited successfully and none originate from the changed marketplace paths.
- IntersectionObserver behavior is covered with deterministic unit mocks and the real Playwright page. Remaining risk is limited to browser-specific observer timing near the scroll boundary; in-flight guards prevent duplicate requests, and failures expose retry.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes
- [x] Updated documentation
- [x] Ran `pnpm i18n:check` or confirmed the change does not affect UI copy
- [x] Confirmed the change follows module ownership and does not add duplicate user-visible entry points
- [x] Described impact scope when shared components, messages, bridge, or services are changed
- [x] Followed commit message conventions (Conventional Commits)
