### PR TITLE
fix(market): hide empty category filters

### DIFF
--- a/packages/dmworkmcp/src/api/expertService.listSort.test.ts
+++ b/packages/dmworkmcp/src/api/expertService.listSort.test.ts
@@ -56,7 +56,7 @@ vi.mock("@octo/base", () => ({
   DEFAULT_REQUEST_TIMEOUT_MS: 20000,
 }));
 
-import { listExperts, listSquads, listMyExperts, listMySquads, listExpertTags } from "./expertService";
+import { listExperts, listSquads, listMyExperts, listMySquads, listExpertTags, listExpertCategories } from "./expertService";
 import type { ExpertCatalogSort } from "./expertService";
 import { WKApp } from "@octo/base";
 
@@ -169,6 +169,21 @@ describe("expertService catalog sort wire contract", () => {
       url: "/market/api/v1/plugin_tags",
       params: { plugin_type: "expert_team", scene_code: "default", mode: "mine", q: "rare" },
     });
+  });
+
+  it("omits zero-count expert categories from the filter taxonomy", async () => {
+    mock.instance.get.mockResolvedValue({
+      data: {
+        data: [
+          { name: "Reports", plugin_count: 2 },
+          { name: "Empty", plugin_count: 0 },
+        ],
+      },
+    });
+
+    expect(await listExpertCategories("agent")).toEqual([
+      { name: "Reports", count: 2 },
+    ]);
   });
 });
 

--- a/packages/dmworkmcp/src/api/expertService.ts
+++ b/packages/dmworkmcp/src/api/expertService.ts
@@ -697,7 +697,9 @@ async function listExpertCategoriesReal(
   kind: ExpertKindParam
 ): Promise<ExpertCategoryCount[]> {
   const data = await fetchExpertCategoriesWire(pluginTypeOf(kind));
-  return data.map((c) => ({ name: c.name, count: c.plugin_count ?? 0 }));
+  return data
+    .filter((c) => (c.plugin_count ?? 0) > 0)
+    .map((c) => ({ name: c.name, count: c.plugin_count ?? 0 }));
 }
 
 // ─── Mock implementations (session-local CRUD over module arrays) ───────────
@@ -823,7 +825,7 @@ function listExpertCategoriesMock(
   const categories = EXPERT_CATEGORIES.filter((c) => c !== ALL_CATEGORY).map(
     (name) => ({ name, count: counts.get(name) ?? 0 })
   );
-  return delay(categories);
+  return delay(categories.filter((category) => category.count > 0));
 }
 
 // ─── Public API (the only surface the UI imports) ──────────────────────────

--- a/packages/dmworkmcp/src/api/mcpService.connector.test.ts
+++ b/packages/dmworkmcp/src/api/mcpService.connector.test.ts
@@ -40,6 +40,7 @@ import type { CreateMcpParams } from "../types/mcp";
 
 const CATEGORIES = [
   { category_id: "c-dev", name: "dev", plugin_count: 2, sort_order: 0 },
+  { category_id: "c-empty", name: "empty", plugin_count: 0, sort_order: 1 },
 ];
 
 /** `/plugin_categories` reads flow through get<T>() → resp.data.data. */
@@ -112,6 +113,7 @@ describe("fetchMcpListPath — category resolution fails closed (P1-2)", () => {
     expect(listCalls).toHaveLength(0);
     // Pills are still returned so the user can switch away.
     expect(res.categories.some((c) => c.key === "dev")).toBe(true);
+    expect(res.categories.some((c) => c.key === "empty")).toBe(false);
   });
 
   it("sends the resolved category_id for a known category", async () => {

--- a/packages/dmworkmcp/src/api/mcpService.ts
+++ b/packages/dmworkmcp/src/api/mcpService.ts
@@ -114,10 +114,9 @@ function assertSafeUploadURL(raw: string): void {
 
 // ─── Mock implementations ──────────────────────────────────────────────────
 
-/** Category pill counts over an arbitrary MCP set. Callers pass the same
- *  filtered slice they showed as items, so pill numbers stay coherent with
- *  the visible list — matches the real backend's `/mcp_categories` which
- *  respects `created_by_type` (issue #894 follow-up). */
+/** Category pill counts over the visible catalog scope. Keyword/category/tag
+ *  filters are deliberately excluded so the filter bar does not disappear
+ *  when the current result set is empty. */
 function buildCategories(source: McpListItem[] = MOCK_MCP_LIST): McpCategory[] {
   const counts = new Map<string, number>();
   for (const item of source) {
@@ -127,7 +126,7 @@ function buildCategories(source: McpListItem[] = MOCK_MCP_LIST): McpCategory[] {
     key,
     label: MCP_CATEGORY_LABELS[key] ?? key,
     count: key === "all" ? source.length : counts.get(key) ?? 0,
-  }));
+  })).filter((category) => category.key === "all" || category.count > 0);
 }
 
 async function fetchMcpListMock(
@@ -179,7 +178,7 @@ async function fetchMcpListMockFiltered(
   return delay({
     items,
     total: filtered.length,
-    categories: buildCategories(filtered),
+    categories: buildCategories(source),
   });
 }
 
@@ -768,6 +767,7 @@ async function fetchMcpListPath(
   const categories: McpCategory[] = [
     { key: CATEGORY_KEY_ALL, label: categoryLabel(CATEGORY_KEY_ALL), count: allCount },
     ...[...categoryWire]
+      .filter((c) => (c.plugin_count ?? 0) > 0)
       .sort((a, b) => (a.sort_order ?? 0) - (b.sort_order ?? 0))
       .map((c) => ({ key: c.name, label: c.name, count: c.plugin_count ?? 0 })),
   ];

--- a/packages/dmworkmcp/src/bridge/useExpertCatalog.ts
+++ b/packages/dmworkmcp/src/bridge/useExpertCatalog.ts
@@ -39,6 +39,14 @@ interface CatalogState {
   moreErrorKey: string | null;
 }
 
+interface CatalogMetadataState {
+  key: string;
+  scopeKey: string;
+  categories: ExpertCategoryCount[];
+  loading: boolean;
+  errorKey: string | null;
+}
+
 function emptyState(key: string, loading: boolean): CatalogState {
   return {
     key,
@@ -53,12 +61,13 @@ function emptyState(key: string, loading: boolean): CatalogState {
   };
 }
 
-function emptyMetadata(key: string, loading: boolean) {
+function emptyMetadata(key: string, scopeKey: string, loading: boolean): CatalogMetadataState {
   return {
     key,
+    scopeKey,
     loading,
-    categories: [] as ExpertCategoryCount[],
-    errorKey: null as string | null,
+    categories: [],
+    errorKey: null,
   };
 }
 
@@ -88,6 +97,12 @@ export function useExpertCatalog(options: CatalogOptions) {
     options.scopeRevision,
     revision,
   ]);
+  const metadataScopeKey = JSON.stringify([
+    kind,
+    mine,
+    enabled,
+    options.scopeRevision,
+  ]);
   const tags = useExpertTags({
     kind,
     mine,
@@ -99,7 +114,7 @@ export function useExpertCatalog(options: CatalogOptions) {
     emptyState(key, enabled)
   );
   const [metadata, setMetadata] = useState(() =>
-    emptyMetadata(metadataKey, enabled)
+    emptyMetadata(metadataKey, metadataScopeKey, enabled)
   );
   const generation = useRef(0);
   const paging = useRef(false);
@@ -115,13 +130,18 @@ export function useExpertCatalog(options: CatalogOptions) {
   // or paging so category chips and tag choices do not jump to a partial list.
   useEffect(() => {
     let cancelled = false;
-    setMetadata(emptyMetadata(metadataKey, enabled));
+    setMetadata((previous) =>
+      previous.scopeKey === metadataScopeKey
+        ? { ...previous, key: metadataKey, loading: enabled, errorKey: null }
+        : emptyMetadata(metadataKey, metadataScopeKey, enabled)
+    );
     if (enabled) {
       (mine ? Promise.resolve([]) : listExpertCategories(kind))
         .then((categories) => {
           if (!cancelled)
             setMetadata({
               key: metadataKey,
+              scopeKey: metadataScopeKey,
               categories,
               loading: false,
               errorKey: null,
@@ -129,16 +149,21 @@ export function useExpertCatalog(options: CatalogOptions) {
         })
         .catch((err) => {
           if (!cancelled)
-            setMetadata({
-              ...emptyMetadata(metadataKey, false),
+            setMetadata((previous) => ({
+              ...(previous.scopeKey === metadataScopeKey
+                ? previous
+                : emptyMetadata(metadataKey, metadataScopeKey, false)),
+              key: metadataKey,
+              scopeKey: metadataScopeKey,
+              loading: false,
               errorKey: expertListErrorI18nKey(err),
-            });
+            }));
         });
     }
     return () => {
       cancelled = true;
     };
-  }, [metadataKey, enabled, mine, kind]);
+  }, [metadataKey, metadataScopeKey, enabled, mine, kind]);
 
   useEffect(() => {
     const version = ++generation.current;
@@ -236,12 +261,14 @@ export function useExpertCatalog(options: CatalogOptions) {
   // Never render rows from an earlier Space/filter while the effect is pending.
   const current = state.key === key ? state : emptyState(key, enabled);
   const facets =
-    metadata.key === metadataKey
-      ? metadata
-      : emptyMetadata(metadataKey, enabled);
+    metadata.scopeKey === metadataScopeKey
+      ? { ...metadata, key: metadataKey, loading: metadata.key === metadataKey ? metadata.loading : enabled }
+      : emptyMetadata(metadataKey, metadataScopeKey, enabled);
   return {
     ...current,
     categories: facets.categories,
+    categoriesLoading: facets.loading,
+    categoriesErrorKey: facets.errorKey,
     tags: tags.items,
     tagsLoading: tags.loading,
     tagsErrorKey: tags.errorKey,

--- a/packages/dmworkmcp/src/pages/ExpertMarketListPage.test.tsx
+++ b/packages/dmworkmcp/src/pages/ExpertMarketListPage.test.tsx
@@ -131,6 +131,7 @@ beforeEach(() => {
   api.listExpertCategories.mockResolvedValue([
     { name: "Reports", count: 1 },
     { name: "General", count: 111 },
+    { name: "Empty", count: 0 },
   ]);
   api.listExpertTags.mockResolvedValue(["common", "rare", "analysis"]);
   root = document.createElement("div");
@@ -346,6 +347,7 @@ describe("expert catalog server search and pagination", () => {
 
   it("filters a category and tags found only beyond page 1, and forwards sort", async () => {
     await render();
+    expect(root.textContent).not.toContain("Empty0");
     click(
       Array.from(root.querySelectorAll(".wk-mcp-expert-category")).find(
         (el) => el.textContent === "Reports1"

--- a/packages/dmworkmcp/src/pages/ExpertMarketListPage.test.tsx
+++ b/packages/dmworkmcp/src/pages/ExpertMarketListPage.test.tsx
@@ -4,7 +4,7 @@ import ReactDOM from "react-dom";
 import { act, Simulate } from "react-dom/test-utils";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ExpertItem } from "../mock/expertMock";
-import type { ExpertListResult, ListExpertParams } from "../api/expertService";
+import type { ExpertCategoryCount, ExpertListResult, ListExpertParams } from "../api/expertService";
 import type { MineRow } from "@dmwork/skillmarket";
 
 const api = vi.hoisted(() => ({
@@ -163,6 +163,13 @@ function button(label: string, parent: ParentNode = root) {
     (el) => el.textContent === label
   );
   if (!found) throw new Error(`Missing button: ${label}`);
+  return found;
+}
+function categoryButton(label: string) {
+  const found = Array.from(
+    root.querySelectorAll<HTMLButtonElement>(".wk-mcp-expert-category")
+  ).find((el) => el.textContent?.startsWith(label));
+  if (!found) throw new Error(`Missing category: ${label}`);
   return found;
 }
 function click(el: Element) {
@@ -348,11 +355,7 @@ describe("expert catalog server search and pagination", () => {
   it("filters a category and tags found only beyond page 1, and forwards sort", async () => {
     await render();
     expect(root.textContent).not.toContain("Empty0");
-    click(
-      Array.from(root.querySelectorAll(".wk-mcp-expert-category")).find(
-        (el) => el.textContent === "Reports1"
-      )!
-    );
+    click(categoryButton("Reports"));
     await tick();
     expect(api.listExperts).toHaveBeenLastCalledWith(
       expect.objectContaining({ category: "Reports", page: 1 })
@@ -372,6 +375,36 @@ describe("expert catalog server search and pagination", () => {
     expect(api.listExperts).toHaveBeenLastCalledWith(
       expect.objectContaining({ sort: "installs", page: 1 })
     );
+  });
+
+  it("preserves an active category while retry refetches category metadata", async () => {
+    await render();
+    api.listExperts.mockRejectedValueOnce(new Error("offline"));
+    click(categoryButton("Reports"));
+    await tick();
+    expect(api.listExperts).toHaveBeenLastCalledWith(
+      expect.objectContaining({ category: "Reports", page: 1 })
+    );
+    expect(button("mcp.list.retry")).toBeTruthy();
+
+    const categoryReload = deferred<ExpertCategoryCount[]>();
+    api.listExpertCategories.mockReturnValueOnce(categoryReload.promise);
+    click(button("mcp.list.retry"));
+    await tick();
+
+    expect(api.listExperts).toHaveBeenLastCalledWith(
+      expect.objectContaining({ category: "Reports", page: 1 })
+    );
+    expect(categoryButton("Reports").getAttribute("aria-pressed")).toBe("true");
+
+    await act(async () => {
+      categoryReload.resolve([
+        { name: "Reports", count: 1 },
+        { name: "General", count: 111 },
+      ]);
+    });
+    await tick();
+    expect(categoryButton("Reports").getAttribute("aria-pressed")).toBe("true");
   });
 
   it("keeps previous rows on a later-page failure and retries the same page", async () => {

--- a/packages/dmworkmcp/src/pages/ExpertMarketListPage.tsx
+++ b/packages/dmworkmcp/src/pages/ExpertMarketListPage.tsx
@@ -241,12 +241,23 @@ export default function ExpertMarketListPage({
     };
   }, [tagFilterOpen]);
 
-  // Category chips: 全部 sentinel first, then the fetched category set (or the
-  // static fallback, which already includes 全部).
+  // Category chips: 全部 sentinel first, then the backend category set. Empty
+  // categories are filtered here too so tests/mocks cannot reintroduce zero-count
+  // chips.
   const categoryChips = useMemo(() => {
-    if (categories.length) return [ALL_CATEGORY, ...categories.map((c) => c.name)];
-    return EXPERT_CATEGORIES;
+    return [
+      ALL_CATEGORY,
+      ...categories.filter((c) => c.count > 0).map((c) => c.name),
+    ];
   }, [categories]);
+  useEffect(() => {
+    if (
+      category !== ALL_CATEGORY &&
+      !categories.some((item) => item.count > 0 && item.name === category)
+    ) {
+      setCategory(ALL_CATEGORY);
+    }
+  }, [categories, category]);
 
   // The scoped tag endpoint includes tags on records beyond the loaded page.
   const allTags = useMemo(() => {

--- a/packages/dmworkmcp/src/pages/ExpertMarketListPage.tsx
+++ b/packages/dmworkmcp/src/pages/ExpertMarketListPage.tsx
@@ -252,12 +252,19 @@ export default function ExpertMarketListPage({
   }, [categories]);
   useEffect(() => {
     if (
+      activeCatalog.categoriesLoading ||
+      activeCatalog.categoriesErrorKey ||
+      categories.length === 0
+    ) {
+      return;
+    }
+    if (
       category !== ALL_CATEGORY &&
       !categories.some((item) => item.count > 0 && item.name === category)
     ) {
       setCategory(ALL_CATEGORY);
     }
-  }, [categories, category]);
+  }, [activeCatalog.categoriesLoading, activeCatalog.categoriesErrorKey, categories, category]);
 
   // The scoped tag endpoint includes tags on records beyond the loaded page.
   const allTags = useMemo(() => {

--- a/packages/dmworkmcp/src/pages/McpMarketListPage.tsx
+++ b/packages/dmworkmcp/src/pages/McpMarketListPage.tsx
@@ -24,6 +24,7 @@ import {
   type UseMyReviewStateResult,
 } from "../hooks/useMyReviewState";
 import { isImageIcon } from "../utils/icon";
+import { CATEGORY_KEY_ALL } from "../utils/constants";
 import { getMcpAvatarColor, getMcpAvatarText } from "../utils/mcpAvatar";
 import "../index.css";
 import { parseMcpListQuery, serializeMcpListQuery } from "./mcpListQuery";
@@ -389,9 +390,11 @@ export default class McpMarketListPage extends Component<
         offset: 0,
       });
       if (requestVersion !== this.requestVersion) return;
-      const selectedCategoryMissing = this.state.categoriesSelected.some(
-        (key) => key !== "all" && !resp.categories.some((cat) => cat.key === key)
-      );
+      const selectedCategoryMissing =
+        resp.categories.length > 1 &&
+        this.state.categoriesSelected.some(
+          (key) => key !== CATEGORY_KEY_ALL && !resp.categories.some((cat) => cat.key === key)
+        );
       if (selectedCategoryMissing) {
         this.setState(
           {
@@ -400,7 +403,7 @@ export default class McpMarketListPage extends Component<
             categoriesSelected: [],
             total: 0,
             offset: 0,
-            loading: false,
+            loading: true,
           },
           () => this.loadData()
         );

--- a/packages/dmworkmcp/src/pages/McpMarketListPage.tsx
+++ b/packages/dmworkmcp/src/pages/McpMarketListPage.tsx
@@ -389,6 +389,23 @@ export default class McpMarketListPage extends Component<
         offset: 0,
       });
       if (requestVersion !== this.requestVersion) return;
+      const selectedCategoryMissing = this.state.categoriesSelected.some(
+        (key) => key !== "all" && !resp.categories.some((cat) => cat.key === key)
+      );
+      if (selectedCategoryMissing) {
+        this.setState(
+          {
+            items: [],
+            categories: resp.categories,
+            categoriesSelected: [],
+            total: 0,
+            offset: 0,
+            loading: false,
+          },
+          () => this.loadData()
+        );
+        return;
+      }
       this.setState({
         items: resp.items,
         categories: resp.categories,

--- a/packages/dmworkmcp/src/pages/__tests__/McpMarketListPage.spaceIsolation.test.tsx
+++ b/packages/dmworkmcp/src/pages/__tests__/McpMarketListPage.spaceIsolation.test.tsx
@@ -61,7 +61,13 @@ import McpMarketListPage from "../McpMarketListPage";
 
 type PageInternals = {
   state: Record<string, unknown>;
-  setState: (patch: Record<string, unknown>, callback?: () => void) => void;
+  setState: (
+    patch:
+      | Record<string, unknown>
+      | ((prev: Record<string, unknown>) => Record<string, unknown>),
+    callback?: () => void
+  ) => void;
+  loadData: () => Promise<void>;
   handleEditFromCard: (item: { id: string }) => Promise<void>;
   openPublishVersion: (item: { id: string }) => Promise<void>;
   handleSpaceChanged_: () => void;
@@ -81,10 +87,22 @@ function deferred<T>() {
 
 function createPage(): PageInternals {
   const page = new McpMarketListPage({}) as unknown as PageInternals;
-  page.setState = (patch) => {
-    page.state = { ...page.state, ...patch };
+  page.setState = (patch, callback) => {
+    const next = typeof patch === "function" ? patch(page.state) : patch;
+    page.state = { ...page.state, ...next };
+    callback?.();
   };
   page.componentDidMount();
+  return page;
+}
+
+function createUnmountedPage(): PageInternals {
+  const page = new McpMarketListPage({}) as unknown as PageInternals;
+  page.setState = (patch, callback) => {
+    const next = typeof patch === "function" ? patch(page.state) : patch;
+    page.state = { ...page.state, ...next };
+    callback?.();
+  };
   return page;
 }
 
@@ -94,6 +112,82 @@ const detail = { id: item.id, name: "Space A connector" };
 beforeEach(() => {
   vi.resetAllMocks();
   h.app.currentSpaceId = "space-a";
+  const emptyList = {
+    items: [],
+    categories: [{ key: "all", label: "全部", count: 0 }],
+    total: 0,
+  };
+  h.fetchMcpList.mockResolvedValue(emptyList);
+  h.fetchMcpMine.mockResolvedValue(emptyList);
+  h.fetchMcpTags.mockResolvedValue([]);
+});
+
+describe("McpMarketListPage category reset contract", () => {
+  it("keeps the selected category when taxonomy degrades to the All pill only", async () => {
+    const page = createUnmountedPage();
+    page.state = {
+      ...page.state,
+      mode: "all",
+      categoriesSelected: ["dev"],
+    };
+    h.fetchMcpList.mockResolvedValueOnce({
+      items: [],
+      categories: [{ key: "all", label: "全部", count: 0 }],
+      total: 0,
+    });
+
+    await page.loadData();
+
+    expect(h.fetchMcpList).toHaveBeenCalledOnce();
+    expect(page.state.categoriesSelected).toEqual(["dev"]);
+    expect(page.state.loading).toBe(false);
+  });
+
+  it("resets a selected category only after a resolved taxonomy omits it", async () => {
+    const page = createUnmountedPage();
+    page.state = {
+      ...page.state,
+      mode: "all",
+      categoriesSelected: ["dev"],
+    };
+    const secondLoad = deferred<{
+      items: unknown[];
+      categories: Array<{ key: string; label: string; count: number }>;
+      total: number;
+    }>();
+    h.fetchMcpList
+      .mockResolvedValueOnce({
+        items: [],
+        categories: [
+          { key: "all", label: "全部", count: 1 },
+          { key: "data", label: "Data", count: 1 },
+        ],
+        total: 0,
+      })
+      .mockReturnValueOnce(secondLoad.promise);
+
+    await page.loadData();
+
+    expect(h.fetchMcpList).toHaveBeenCalledTimes(2);
+    expect(h.fetchMcpList.mock.calls.at(-1)?.[0]).toEqual(
+      expect.objectContaining({ categories: [] })
+    );
+    expect(page.state.categoriesSelected).toEqual([]);
+    expect(page.state.loading).toBe(true);
+
+    secondLoad.resolve({
+      items: [{ id: "data-plugin" }],
+      categories: [
+        { key: "all", label: "全部", count: 1 },
+        { key: "data", label: "Data", count: 1 },
+      ],
+      total: 1,
+    });
+    await Promise.resolve();
+
+    expect(page.state.loading).toBe(false);
+    expect(page.state.items).toEqual([{ id: "data-plugin" }]);
+  });
 });
 
 describe("McpMarketListPage detail continuation Space isolation", () => {

--- a/packages/dmworkskillmarket/src/api/skillApi.test.ts
+++ b/packages/dmworkskillmarket/src/api/skillApi.test.ts
@@ -38,6 +38,13 @@ describe("skillApi mock contract", () => {
     ).toBeGreaterThan(5);
   });
 
+  it("keeps category counts independent from search and tag filters", async () => {
+    const all = await getCategories();
+    const filtered = await getCategories({ q: "missing", tags: ["none"] });
+
+    expect(filtered).toEqual(all);
+  });
+
   it("pages skills and returns a cursor for the next batch", async () => {
     const firstPage = await getSkills({ limit: 20 });
     const secondPage = await getSkills({

--- a/packages/dmworkskillmarket/src/api/skillApiMock.ts
+++ b/packages/dmworkskillmarket/src/api/skillApiMock.ts
@@ -113,12 +113,14 @@ function pageSkills(items: Skill[], query: SkillListQuery): PagedResult<Skill> {
   };
 }
 
-export function getCategories(opts?: {
+export function getCategories(_opts?: {
   signal?: AbortSignal;
   q?: string;
   tags?: string[];
 }): Promise<Category[]> {
-  const filtered = applySkillQuery({ q: opts?.q, tags: opts?.tags });
+  // Match the real unified taxonomy endpoint: category visibility/counts are
+  // scoped to the visible catalog, not to the current keyword/tag result set.
+  const filtered = applySkillQuery({});
   const counted = CATEGORY_SEEDS.map((category) => ({
     ...category,
     skillCount:

--- a/packages/dmworkskillmarket/src/components/CategoryChips.tsx
+++ b/packages/dmworkskillmarket/src/components/CategoryChips.tsx
@@ -36,13 +36,13 @@ export default function CategoryChips({ categories, activeId, onChange }: Catego
     };
   }, [moreOpen]);
   const ordered = useMemo(() => {
-    return [...categories].sort((a, b) => {
-      if (a.id === "all") return -1;
-      if (b.id === "all") return 1;
-      if (a.skillCount > 0 && b.skillCount === 0) return -1;
-      if (a.skillCount === 0 && b.skillCount > 0) return 1;
-      return a.sortOrder - b.sortOrder;
-    });
+    return categories
+      .filter((category) => category.id === "all" || category.skillCount > 0)
+      .sort((a, b) => {
+        if (a.id === "all") return -1;
+        if (b.id === "all") return 1;
+        return a.sortOrder - b.sortOrder;
+      });
   }, [categories]);
 
   const mediumBase = ordered.slice(0, MEDIUM_VISIBLE_LIMIT);

--- a/packages/dmworkskillmarket/src/components/__tests__/CategoryChips.test.tsx
+++ b/packages/dmworkskillmarket/src/components/__tests__/CategoryChips.test.tsx
@@ -21,6 +21,7 @@ describe("CategoryChips", () => {
     const buttons = within(list).getAllByRole("button");
     expect(buttons[0]).toHaveTextContent("全部");
     expect(within(list).getByRole("button", { name: /洞察研究/ })).toBeInTheDocument();
+    expect(within(list).queryByRole("button", { name: /空分类/ })).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: /代码质检/ })).toHaveAttribute("aria-pressed", "true");
     expect(screen.getByRole("button", { name: /更多/ })).toBeInTheDocument();
   });
@@ -45,6 +46,7 @@ describe("CategoryChips", () => {
     expect(within(menu).getByRole("menuitem", { name: /办公协作/ })).toBeInTheDocument();
     expect(within(menu).getByRole("menuitem", { name: /洞察研究/ })).toBeInTheDocument();
     expect(within(menu).getByRole("menuitem", { name: /代码质检/ })).toBeInTheDocument();
+    expect(within(menu).queryByRole("menuitem", { name: /空分类/ })).not.toBeInTheDocument();
   });
 
   it("still renders the mobile more menu when desktop has no overflow", () => {

--- a/packages/dmworkskillmarket/src/hooks/useSkills.ts
+++ b/packages/dmworkskillmarket/src/hooks/useSkills.ts
@@ -58,7 +58,7 @@ export function useSkills(options: UseSkillsOptions = {}): UseSkillsResult {
       try {
         const signal = controller.signal;
         const [categoryItems, page] = await Promise.all([
-          getCategories({ q: debouncedQuery, tags: selectedTags, signal }),
+          getCategories({ signal }),
           options.mine
             ? getMySkills(
                 {
@@ -103,9 +103,12 @@ export function useSkills(options: UseSkillsOptions = {}): UseSkillsResult {
           },
           ...categoryItems.filter((category) => category.id !== "all"),
         ];
+        const selectableCategories = normalizedCategories.filter(
+          (category) => category.id === "all" || category.skillCount > 0
+        );
         if (
           categoryId !== "all" &&
-          !normalizedCategories.some((category) => category.id === categoryId)
+          !selectableCategories.some((category) => category.id === categoryId)
         ) {
           setCategoryIdState("all");
         }

--- a/packages/dmworkskillmarket/src/pages/__tests__/SkillListPage.test.tsx
+++ b/packages/dmworkskillmarket/src/pages/__tests__/SkillListPage.test.tsx
@@ -298,8 +298,6 @@ describe("SkillListPage", () => {
 
     expect(api.getCategories).toHaveBeenCalledWith(
       expect.objectContaining({
-        q: "ci",
-        tags: [],
         signal: expect.any(AbortSignal),
       })
     );
@@ -336,8 +334,6 @@ describe("SkillListPage", () => {
     await waitFor(() => {
       expect(api.getCategories).toHaveBeenCalledWith(
         expect.objectContaining({
-          q: "",
-          tags: ["纪要"],
           signal: expect.any(AbortSignal),
         })
       );
@@ -357,8 +353,6 @@ describe("SkillListPage", () => {
       );
       expect(api.getCategories).toHaveBeenCalledWith(
         expect.objectContaining({
-          q: "",
-          tags: [],
           signal: expect.any(AbortSignal),
         })
       );


### PR DESCRIPTION
## Summary

Hide empty category filters across the marketplace list pages so users only see categories that contain at least one visible, displayable item in the current marketplace scope.

## Related Issue

Refs Mininglamp-OSS/octo-marketplace#73

## Changes

- Filter zero-count categories out of Skill, MCP connector, Expert, and Expert Team category filters while keeping the synthetic "All" entry.
- Keep category metadata independent from keyword/tag filters, so an empty search result does not temporarily remove valid category filters.
- Reset stale selected categories back to "All" when a previously selected category is no longer visible.
- Align mocks with the real category-count contract and add/update regression coverage.

## Architecture / Module Boundary

- Affected module(s): `@dmwork/skillmarket`, `@dmwork/mcp`
- New or changed user-visible entry point: no
- Shared layer touched: none
- If shared code changed, impact scope: not applicable
- Duplicate entry point checked: not applicable

## Testing

- [x] Unit tests added/updated
- [ ] Manually verified

Commands run:

```bash
pnpm --filter @dmwork/skillmarket test -- src/components/__tests__/CategoryChips.test.tsx src/pages/__tests__/SkillListPage.test.tsx src/api/skillApiReal.test.ts src/api/skillApi.test.ts
pnpm --filter @dmwork/mcp test -- src/api/mcpService.connector.test.ts src/api/expertService.listSort.test.ts src/api/expertService.categoryFailClosed.test.ts src/pages/ExpertMarketListPage.test.tsx src/pages/McpMarketListPage.spaceIsolation.test.tsx
git diff --check
```

Results:

- `@dmwork/skillmarket`: 22 files passed, 307 tests passed.
- `@dmwork/mcp`: 31 files passed, 371 tests passed.
- `git diff --check`: passed.

Additional check attempted:

```bash
pnpm --filter @dmwork/skillmarket exec tsc -p tsconfig.json --noEmit
pnpm --filter @dmwork/mcp exec tsc -p tsconfig.json --noEmit
```

Both package-level `tsc -p` checks currently fail on pre-existing environment/project type issues outside this change path, including dependency typings in `@douyinfe/semi-foundation`, missing React/lodash/prism declarations, and existing package test/source type errors. The focused Vitest suites above pass.

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes
- [ ] Updated documentation
- [x] Ran `pnpm i18n:check` or confirmed the change does not affect UI copy
- [x] Confirmed the change follows module ownership and does not add duplicate user-visible entry points
- [x] Described impact scope when shared components, messages, bridge, or services are changed
- [x] Followed commit message conventions (Conventional Commits)

## Octo-spec Self Review

- Scope: limited to marketplace category filtering and tests for Skill, MCP connector, Expert, and Expert Team list surfaces.
- Risk review: no auth, tenant boundary, destructive mutation, persistence, migration, or public API schema changes. Category counts continue to come from the existing authenticated marketplace category endpoints.
- Residual risk: manual browser verification was not run in this turn; package-level raw TypeScript checks are blocked by existing project/dependency type noise noted above.
