### PR TITLE
feat(market): align all publication actions

### DIFF
--- a/packages/dmworkmcp/src/api/mcpService.connector.test.ts
+++ b/packages/dmworkmcp/src/api/mcpService.connector.test.ts
@@ -34,7 +34,7 @@ vi.mock("@octo/base", () => ({
   DEFAULT_REQUEST_TIMEOUT_MS: 20000,
 }));
 
-import { createMcp, updateMcp, fetchMcpList } from "./mcpService";
+import { createMcp, updateMcp, fetchMcpList, trackMcpView } from "./mcpService";
 import { WKApp } from "@octo/base";
 import type { CreateMcpParams } from "../types/mcp";
 
@@ -88,11 +88,53 @@ function detailPlugin(overrides: Record<string, unknown> = {}) {
 let spaceCounter = 0;
 
 beforeEach(() => {
+  mock.logout.mockReset();
   mock.instance.get.mockReset();
   mock.instance.post.mockReset();
   mock.instance.delete.mockReset();
   // Bust the per-Space category cache between tests by rotating the Space id.
   WKApp.shared.currentSpaceId = `sp-${spaceCounter++}`;
+});
+
+describe("trackMcpView", () => {
+  it("records a plugin view and remains best-effort on failure", async () => {
+    mock.instance.post.mockResolvedValueOnce({ data: { data: {} } });
+
+    await expect(trackMcpView("connector-1")).resolves.toBeUndefined();
+    expect(mock.instance.post).toHaveBeenCalledWith(
+      "/market/api/v1/metrics/track",
+      {
+        resource_type: "plugin",
+        resource_id: "connector-1",
+        event_type: "view",
+      }
+    );
+
+    mock.instance.post.mockRejectedValueOnce(new Error("metrics unavailable"));
+    await expect(trackMcpView("connector-1")).resolves.toBeUndefined();
+  });
+
+  it("does not log out when only the best-effort metric returns 401", async () => {
+    const rejectResponse = mock.instance.interceptors.response.use.mock.calls[0]?.[1] as (
+      error: unknown
+    ) => Promise<never>;
+
+    await expect(
+      rejectResponse({
+        response: { status: 401 },
+        config: { url: "/market/api/v1/metrics/track" },
+      })
+    ).rejects.toBeDefined();
+    expect(mock.logout).not.toHaveBeenCalled();
+
+    await expect(
+      rejectResponse({
+        response: { status: 401 },
+        config: { url: "/market/api/v1/plugins" },
+      })
+    ).rejects.toBeDefined();
+    expect(mock.logout).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("fetchMcpListPath — category resolution fails closed (P1-2)", () => {

--- a/packages/dmworkmcp/src/api/mcpService.ts
+++ b/packages/dmworkmcp/src/api/mcpService.ts
@@ -60,6 +60,7 @@ import { McpListError, classifyMcpListError, executeMcpListRequest } from "./mcp
 //   fetchMcpList(params)   → list + categories
 //   fetchMcpMine(params)   → list restricted to caller-owned records
 //   fetchMcpDetail(id)     → full detail
+//   trackMcpView(id)       → best-effort view metric
 //   probeMcpTools(req)     → "try connect / fetch tool list" (see LSC-70)
 //   createMcp(params)      → create a new MCP entry
 //   updateMcp(id, params)  → PATCH — owner-only partial update
@@ -188,6 +189,13 @@ async function fetchMcpDetailMock(id: string): Promise<McpDetail> {
     throw new Error(`MCP not found: ${id}`);
   }
   return delay(detail);
+}
+
+async function trackMcpViewMock(id: string): Promise<void> {
+  const detail = MOCK_MCP_DETAILS.find((item) => item.id === id);
+  if (detail) detail.viewCount = (detail.viewCount ?? 0) + 1;
+  const item = MOCK_MCP_LIST.find((entry) => entry.id === id);
+  if (item) item.viewCount = (item.viewCount ?? 0) + 1;
 }
 
 async function probeMcpToolsMock(
@@ -434,7 +442,14 @@ mcpAxios.interceptors.request.use((config) => {
 mcpAxios.interceptors.response.use(
   (resp) => resp,
   (err) => {
-    if (err?.response?.status === 401) {
+    const url = (err?.config?.url as string | undefined) ?? "";
+    if (
+      err?.response?.status === 401 &&
+      // View tracking is fire-and-forget. Its authorization failure must not
+      // tear down an otherwise healthy session; ordinary marketplace reads
+      // remain the authoritative authentication probe.
+      url !== `${BASE}/metrics/track`
+    ) {
       WKApp.shared.logout();
     }
     return Promise.reject(err);
@@ -803,6 +818,20 @@ async function fetchMcpDetailReal(id: string): Promise<McpDetail> {
   return mapDetail(detail.plugin, maps.idToKey);
 }
 
+/** Record one connector detail view. Metrics are deliberately best-effort:
+ * opening the detail must still work when the metrics service is unavailable. */
+async function trackMcpViewReal(id: string): Promise<void> {
+  try {
+    await mcpAxios.post(`${BASE}/metrics/track`, {
+      resource_type: "plugin",
+      resource_id: id,
+      event_type: "view",
+    });
+  } catch {
+    // A lost metric is non-actionable and must not affect the detail UI.
+  }
+}
+
 async function probeMcpToolsReal(
   req: McpProbeRequest
 ): Promise<McpProbeResult> {
@@ -1107,6 +1136,10 @@ export function listConnectorCategories(): Promise<string[]> {
 
 export function fetchMcpDetail(id: string): Promise<McpDetail> {
   return USE_MOCK ? fetchMcpDetailMock(id) : fetchMcpDetailReal(id);
+}
+
+export function trackMcpView(id: string): Promise<void> {
+  return USE_MOCK ? trackMcpViewMock(id) : trackMcpViewReal(id);
 }
 
 /** One tag suggestion in the tag-filter popover (mcp-v1.md §4.8). */

--- a/packages/dmworkmcp/src/components/McpDetailModal.tsx
+++ b/packages/dmworkmcp/src/components/McpDetailModal.tsx
@@ -3,7 +3,7 @@ import { WKModal, WKButton, t, Dap } from "@octo/base";
 import { Toast, Spin } from "@douyinfe/semi-ui";
 import { IconWrenchStroked } from "@douyinfe/semi-icons";
 import { Bot, ShieldCheck, UserRound } from "lucide-react";
-import { deleteMcp, fetchMcpDetail } from "../api/mcpService";
+import { deleteMcp, fetchMcpDetail, trackMcpView } from "../api/mcpService";
 import { buildQuickStartTabs, TOKEN_PLACEHOLDER_RE } from "../api/quickStartTemplates";
 import type { McpDetail, McpQuickStart } from "../types/mcp";
 import { IconGlyph } from "../utils/icon";
@@ -140,6 +140,7 @@ const McpDetailModal: React.FC<McpDetailModalProps> = ({
     setDeleting(false);
     let cancelled = false;
     setLoading(true);
+    void trackMcpView(mcpId);
     fetchMcpDetail(mcpId)
       .then((d) => {
         if (!cancelled) setDetail(d);

--- a/packages/dmworkmcp/src/components/__tests__/McpDetailModal.inlineDelete.test.tsx
+++ b/packages/dmworkmcp/src/components/__tests__/McpDetailModal.inlineDelete.test.tsx
@@ -7,10 +7,12 @@ import { afterEach, describe, it, expect, vi } from "vitest";
 // ── Mocks ──────────────────────────────────────────────────────────────────
 const deleteMcp = vi.fn();
 const fetchMcpDetail = vi.fn();
+const trackMcpView = vi.fn();
 
 vi.mock("../../api/mcpService", () => ({
   deleteMcp: (...a: unknown[]) => deleteMcp(...a),
   fetchMcpDetail: (...a: unknown[]) => fetchMcpDetail(...a),
+  trackMcpView: (...a: unknown[]) => trackMcpView(...a),
 }));
 vi.mock("../../api/quickStartTemplates", () => ({
   buildQuickStartTabs: () => [
@@ -132,6 +134,8 @@ describe("McpDetailModal 就地内联删除确认（方案A）", () => {
     );
     expect(initialBtns).toContain("mcp.detail.delete");
     expect(initialBtns).toContain("mcp.detail.edit");
+    expect(trackMcpView).toHaveBeenCalledTimes(1);
+    expect(trackMcpView).toHaveBeenCalledWith("m1");
 
     // 点「删除」——footer 就地切成确认态；应出现确认提示文案 + 确认删除按钮，
     // 且没有第二个 WKModal（不叠遮罩）。wkConfirm 抛错的 stub 也未触发。

--- a/packages/dmworkmcp/src/components/__tests__/McpOfficialPublisher.test.tsx
+++ b/packages/dmworkmcp/src/components/__tests__/McpOfficialPublisher.test.tsx
@@ -12,6 +12,7 @@ const fetchMcpDetail = vi.fn();
 vi.mock("../../api/mcpService", () => ({
   deleteMcp: vi.fn(),
   fetchMcpDetail: (...args: unknown[]) => fetchMcpDetail(...args),
+  trackMcpView: vi.fn(),
 }));
 vi.mock("../../api/quickStartTemplates", () => ({
   buildQuickStartTabs: () => [],

--- a/packages/dmworkmcp/src/features/mine/MineActionHost.test.tsx
+++ b/packages/dmworkmcp/src/features/mine/MineActionHost.test.tsx
@@ -1,0 +1,368 @@
+// @vitest-environment jsdom
+import React from "react";
+import ReactDOM from "react-dom";
+import { act } from "react-dom/test-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const h = vi.hoisted(() => ({
+  getCategories: vi.fn(),
+  getSkill: vi.fn(),
+  fetchMcpDetail: vi.fn(),
+  getExpert: vi.fn(),
+  getSquad: vi.fn(),
+  loadExpertReviewSnapshot: vi.fn(),
+  toastError: vi.fn(),
+  toastSuccess: vi.fn(),
+  toastWarning: vi.fn(),
+}));
+
+const skill = {
+  id: "skill-1",
+  name: "Skill one",
+  listingState: "draft",
+  visibility: "private",
+  displayStatus: "draft",
+};
+const connector = {
+  id: "connector-1",
+  name: "Connector one",
+  listingState: "published",
+  visibility: "space",
+  displayStatus: "published",
+};
+const expert = {
+  id: "expert-1",
+  name: "Expert one",
+  kind: "agent",
+  version: "1.0.0",
+};
+const squad = {
+  id: "squad-1",
+  name: "Squad one",
+  kind: "squad",
+  version: "1.0.0",
+};
+
+vi.mock("@octo/base", () => ({
+  t: (key: string) => key,
+  useI18n: () => undefined,
+}));
+
+vi.mock("@douyinfe/semi-ui", () => ({
+  Toast: {
+    error: h.toastError,
+    success: h.toastSuccess,
+    warning: h.toastWarning,
+  },
+}));
+
+vi.mock("@dmwork/skillmarket", () => ({
+  getCategories: (...args: unknown[]) => h.getCategories(...args),
+  getSkill: (...args: unknown[]) => h.getSkill(...args),
+  SkillDetailModal: ({
+    skillId,
+    onEdit,
+    onDelete,
+  }: {
+    skillId: string | null;
+    onEdit?: (item: typeof skill) => void;
+    onDelete?: (item: typeof skill) => void;
+  }) =>
+    skillId ? (
+      <div data-testid="skill-detail" data-id={skillId}>
+        <button type="button" onClick={() => onEdit?.(skill)}>
+          detail-edit
+        </button>
+        <button type="button" onClick={() => onDelete?.(skill)}>
+          detail-delete
+        </button>
+      </div>
+    ) : null,
+  EditSkillModal: ({ skill: item }: { skill: typeof skill | null }) =>
+    item ? <div data-testid="skill-edit" data-id={item.id} /> : null,
+  NewSkillModal: ({ visible }: { visible: boolean }) =>
+    visible ? <div data-testid="skill-upgrade" /> : null,
+  DeleteConfirmModal: ({ skill: item }: { skill: typeof skill | null }) =>
+    item ? <div data-testid="skill-delete" data-id={item.id} /> : null,
+}));
+
+vi.mock("../../api/mcpService", () => ({
+  fetchMcpDetail: (...args: unknown[]) => h.fetchMcpDetail(...args),
+}));
+
+vi.mock("../../api/expertService", () => ({
+  getExpert: (...args: unknown[]) => h.getExpert(...args),
+  getSquad: (...args: unknown[]) => h.getSquad(...args),
+  loadExpertReviewSnapshot: (...args: unknown[]) =>
+    h.loadExpertReviewSnapshot(...args),
+}));
+
+vi.mock("../../components/McpCreateModal", () => ({
+  default: ({
+    visible,
+    editing,
+    reviewMode,
+    onSaved,
+    onPublished,
+  }: {
+    visible: boolean;
+    editing: typeof connector | null;
+    reviewMode: boolean;
+    onSaved: () => void;
+    onPublished: () => void;
+  }) =>
+    visible ? (
+      <div
+        data-testid="connector-form"
+        data-id={editing?.id}
+        data-review={String(reviewMode)}
+      >
+        <button
+          type="button"
+          onClick={() => {
+            onSaved();
+            onPublished();
+          }}
+        >
+          connector-saved
+        </button>
+      </div>
+    ) : null,
+}));
+
+vi.mock("../../components/McpDetailModal", () => ({
+  default: ({
+    mcpId,
+    canManage,
+    onEdit,
+  }: {
+    mcpId: string | null;
+    canManage?: boolean;
+    onEdit?: (item: typeof connector) => void;
+  }) =>
+    mcpId ? (
+      <div
+        data-testid="connector-detail"
+        data-id={mcpId}
+        data-manage={String(canManage)}
+      >
+        <button type="button" onClick={() => onEdit?.(connector)}>
+          connector-detail-edit
+        </button>
+      </div>
+    ) : null,
+}));
+
+vi.mock("../../components/ExpertEditModal", () => ({
+  default: ({ item }: { item: typeof expert | null }) =>
+    item ? <div data-testid="expert-edit" data-id={item.id} /> : null,
+}));
+vi.mock("../../components/ExpertDetailModal", () => ({
+  default: ({ item }: { item: typeof expert | typeof squad | null }) =>
+    item ? <div data-testid="expert-detail" data-id={item.id} /> : null,
+}));
+vi.mock("../../components/ExpertBotPublishModal", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/ReviewSubmitModal", () => ({
+  default: ({ target }: { target: { pluginId: string } | null }) =>
+    target ? (
+      <div data-testid="review-submit" data-id={target.pluginId} />
+    ) : null,
+}));
+
+import MineActionHost from "./MineActionHost";
+import type { MineActionRequest } from "@dmwork/skillmarket";
+
+let container: HTMLDivElement;
+
+function renderHost(
+  request: MineActionRequest | null,
+  onClose = vi.fn(),
+  onChanged = vi.fn()
+) {
+  act(() => {
+    ReactDOM.render(
+      <MineActionHost
+        request={request}
+        onClose={onClose}
+        onChanged={onChanged}
+      />,
+      container
+    );
+  });
+  return { onClose, onChanged };
+}
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  vi.clearAllMocks();
+  h.getCategories.mockResolvedValue([]);
+  h.getSkill.mockResolvedValue(skill);
+  h.fetchMcpDetail.mockResolvedValue(connector);
+  h.getExpert.mockResolvedValue(expert);
+  h.getSquad.mockResolvedValue(squad);
+});
+
+afterEach(() => {
+  ReactDOM.unmountComponentAtNode(container);
+  container.remove();
+});
+
+describe("MineActionHost", () => {
+  it("opens each owning flow over the all tab", async () => {
+    renderHost({
+      requestId: 1,
+      pluginId: skill.id,
+      type: "skill",
+      action: "view",
+    });
+    await act(async () => undefined);
+    expect(
+      container
+        .querySelector('[data-testid="skill-detail"]')
+        ?.getAttribute("data-id")
+    ).toBe(skill.id);
+
+    renderHost({
+      requestId: 2,
+      pluginId: connector.id,
+      type: "connector",
+      action: "upgrade",
+    });
+    await act(async () => undefined);
+    expect(
+      container
+        .querySelector('[data-testid="connector-form"]')
+        ?.getAttribute("data-review")
+    ).toBe("true");
+
+    renderHost({
+      requestId: 3,
+      pluginId: expert.id,
+      type: "expert",
+      action: "edit",
+    });
+    await act(async () => undefined);
+    expect(
+      container
+        .querySelector('[data-testid="expert-edit"]')
+        ?.getAttribute("data-id")
+    ).toBe(expert.id);
+
+    renderHost({
+      requestId: 4,
+      pluginId: squad.id,
+      type: "squad",
+      action: "upgrade",
+    });
+    await act(async () => undefined);
+    expect(
+      container
+        .querySelector('[data-testid="review-submit"]')
+        ?.getAttribute("data-id")
+    ).toBe(squad.id);
+  });
+
+  it("keeps owner actions in skill and connector details", async () => {
+    renderHost({
+      requestId: 1,
+      pluginId: skill.id,
+      type: "skill",
+      action: "view",
+    });
+    await act(async () => undefined);
+    act(() => (container.querySelector("button") as HTMLButtonElement).click());
+    expect(
+      container.querySelector('[data-testid="skill-edit"]')
+    ).not.toBeNull();
+
+    renderHost({
+      requestId: 2,
+      pluginId: connector.id,
+      type: "connector",
+      action: "view",
+    });
+    await act(async () => undefined);
+    expect(
+      container
+        .querySelector('[data-testid="connector-detail"]')
+        ?.getAttribute("data-manage")
+    ).toBe("true");
+    act(() => {
+      const button = Array.from(container.querySelectorAll("button")).find(
+        (item) => item.textContent === "connector-detail-edit"
+      ) as HTMLButtonElement;
+      button.click();
+    });
+    expect(
+      container
+        .querySelector('[data-testid="connector-form"]')
+        ?.getAttribute("data-review")
+    ).toBe("true");
+  });
+
+  it("ignores a stale load after a newer action replaces it", async () => {
+    let resolveSkill: (value: typeof skill) => void = () => {};
+    h.getSkill.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveSkill = resolve;
+      })
+    );
+    renderHost({
+      requestId: 1,
+      pluginId: skill.id,
+      type: "skill",
+      action: "edit",
+    });
+
+    renderHost({
+      requestId: 2,
+      pluginId: connector.id,
+      type: "connector",
+      action: "view",
+    });
+    expect(
+      container.querySelector('[data-testid="connector-detail"]')
+    ).not.toBeNull();
+    await act(async () => resolveSkill(skill));
+
+    expect(container.querySelector('[data-testid="skill-edit"]')).toBeNull();
+    expect(
+      container.querySelector('[data-testid="connector-detail"]')
+    ).not.toBeNull();
+  });
+
+  it("refreshes the all list only once when a modal reports multiple success callbacks", async () => {
+    const onChanged = vi.fn();
+    renderHost(
+      {
+        requestId: 1,
+        pluginId: connector.id,
+        type: "connector",
+        action: "edit",
+      },
+      vi.fn(),
+      onChanged
+    );
+    await act(async () => undefined);
+    act(() => (container.querySelector("button") as HTMLButtonElement).click());
+    expect(onChanged).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports a load failure and closes the pending action", async () => {
+    const onClose = vi.fn();
+    h.getExpert.mockRejectedValueOnce(new Error("load failed"));
+
+    renderHost(
+      { requestId: 1, pluginId: expert.id, type: "expert", action: "edit" },
+      onClose
+    );
+    await act(async () => undefined);
+
+    expect(h.toastError).toHaveBeenCalledWith("load failed");
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(container.querySelector('[data-testid="expert-edit"]')).toBeNull();
+  });
+});

--- a/packages/dmworkmcp/src/features/mine/MineActionHost.tsx
+++ b/packages/dmworkmcp/src/features/mine/MineActionHost.tsx
@@ -1,0 +1,284 @@
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import { Toast } from "@douyinfe/semi-ui";
+import { t, useI18n } from "@octo/base";
+import {
+  EditSkillModal,
+  DeleteConfirmModal,
+  getCategories,
+  getSkill,
+  NewSkillModal,
+  SkillDetailModal,
+  type Category,
+  type MineActionRequest,
+  type Skill,
+} from "@dmwork/skillmarket";
+import McpCreateModal from "../../components/McpCreateModal";
+import McpDetailModal from "../../components/McpDetailModal";
+import ExpertBotPublishModal from "../../components/ExpertBotPublishModal";
+import ExpertEditModal from "../../components/ExpertEditModal";
+import ExpertDetailModal from "../../components/ExpertDetailModal";
+import ReviewSubmitModal, {
+  type ReviewSubmitTarget,
+} from "../../components/ReviewSubmitModal";
+import { fetchMcpDetail } from "../../api/mcpService";
+import {
+  getExpert,
+  getSquad,
+  loadExpertReviewSnapshot,
+} from "../../api/expertService";
+import type { ExpertItem } from "../../mock/expertMock";
+import type { McpDetail } from "../../types/mcp";
+
+interface MineActionHostProps {
+  request: MineActionRequest | null;
+  onClose: () => void;
+  onChanged: () => void;
+}
+
+/** Opens the owning detail/edit/upgrade flow over the mixed 全部 list without
+ * navigating away. Each flow remains the same component its type page uses. */
+export default function MineActionHost({
+  request,
+  onClose,
+  onChanged,
+}: MineActionHostProps) {
+  useI18n();
+  const [skill, setSkill] = useState<Skill | null>(null);
+  const [skillFlow, setSkillFlow] = useState<"edit" | "upgrade" | null>(null);
+  const [skillDetailId, setSkillDetailId] = useState<string | null>(null);
+  const [deletingSkill, setDeletingSkill] = useState<Skill | null>(null);
+  const [skillCategories, setSkillCategories] = useState<Category[]>([]);
+  const [connector, setConnector] = useState<McpDetail | null>(null);
+  const [connectorFlow, setConnectorFlow] = useState<"edit" | "upgrade" | null>(
+    null
+  );
+  const [connectorDetailId, setConnectorDetailId] = useState<string | null>(
+    null
+  );
+  const [expert, setExpert] = useState<ExpertItem | null>(null);
+  const [expertDetail, setExpertDetail] = useState<ExpertItem | null>(null);
+  const [reviewTarget, setReviewTarget] = useState<ReviewSubmitTarget | null>(
+    null
+  );
+  const [botTarget, setBotTarget] = useState<ExpertItem | null>(null);
+  const changedRef = useRef(false);
+
+  const clear = useCallback(() => {
+    setSkill(null);
+    setSkillFlow(null);
+    setSkillDetailId(null);
+    setDeletingSkill(null);
+    setSkillCategories([]);
+    setConnector(null);
+    setConnectorFlow(null);
+    setConnectorDetailId(null);
+    setExpert(null);
+    setExpertDetail(null);
+    setReviewTarget(null);
+    setBotTarget(null);
+  }, []);
+
+  const close = useCallback(() => {
+    clear();
+    onClose();
+  }, [clear, onClose]);
+
+  const notifyChanged = useCallback(() => {
+    if (changedRef.current) return;
+    changedRef.current = true;
+    onChanged();
+  }, [onChanged]);
+
+  useEffect(() => {
+    if (!request) {
+      clear();
+      return undefined;
+    }
+    let active = true;
+    changedRef.current = false;
+    clear();
+
+    const load = async () => {
+      if (request.type === "skill") {
+        if (request.action === "view") {
+          const categories = await getCategories();
+          if (!active) return;
+          setSkillCategories(categories);
+          setSkillDetailId(request.pluginId);
+          return;
+        }
+        const [item, categories] = await Promise.all([
+          getSkill(request.pluginId),
+          getCategories(),
+        ]);
+        if (!active) return;
+        setSkillCategories(categories);
+        setSkillFlow(request.action);
+        setSkill(item);
+        return;
+      }
+
+      if (request.type === "connector") {
+        if (request.action === "view") {
+          setConnectorDetailId(request.pluginId);
+          return;
+        }
+        const item = await fetchMcpDetail(request.pluginId);
+        if (active) {
+          setConnectorFlow(request.action);
+          setConnector(item);
+        }
+        return;
+      }
+
+      const item = await (request.type === "squad"
+        ? getSquad(request.pluginId)
+        : getExpert(request.pluginId));
+      if (!active) return;
+      if (request.action === "view") {
+        setExpertDetail(item);
+      } else if (request.action === "edit") {
+        setExpert(item);
+      } else {
+        setReviewTarget({
+          pluginId: item.id,
+          name: item.name,
+          version: item.version,
+          isUpgrade: true,
+          loadSnapshot: () => loadExpertReviewSnapshot(item.id),
+          needs: { relations: true, content: true },
+        });
+      }
+    };
+
+    void load().catch((error) => {
+      if (!active) return;
+      Toast.error(
+        error instanceof Error
+          ? error.message
+          : t("skillMarket.common.loadFailed")
+      );
+      close();
+    });
+    return () => {
+      active = false;
+    };
+  }, [clear, close, request?.requestId]);
+
+  return (
+    <>
+      <SkillDetailModal
+        skillId={skillDetailId}
+        categories={skillCategories}
+        onClose={close}
+        onEdit={(item) => {
+          const pending = item.displayStatus === "pending_review";
+          if (pending) {
+            Toast.warning(t("skillMarket.review.pendingBlocksEdit"));
+            return;
+          }
+          const listedToOrg =
+            item.listingState === "published" && item.visibility === "space";
+          setSkillDetailId(null);
+          setSkillFlow(listedToOrg ? "upgrade" : "edit");
+          setSkill(item);
+        }}
+        onDelete={(item) => setDeletingSkill(item)}
+      />
+      <EditSkillModal
+        skill={skillFlow === "edit" ? skill : null}
+        categories={skillCategories}
+        onClose={close}
+        onUpdated={notifyChanged}
+        onPublished={(message) => {
+          Toast.success(message);
+          notifyChanged();
+        }}
+      />
+      <NewSkillModal
+        visible={Boolean(skill) && skillFlow === "upgrade"}
+        categories={skillCategories}
+        reviewSkill={skill}
+        reviewInitial={null}
+        onClose={close}
+        onCreated={(message) => {
+          Toast.success(message ?? t("skillMarket.review.submittedToast"));
+          notifyChanged();
+        }}
+      />
+      <DeleteConfirmModal
+        skill={deletingSkill}
+        onClose={() => setDeletingSkill(null)}
+        onDeleted={() => {
+          Toast.success(t("skillMarket.list.deleted"));
+          notifyChanged();
+          close();
+        }}
+      />
+      <McpCreateModal
+        visible={Boolean(connector)}
+        editing={connector}
+        reviewMode={connectorFlow === "upgrade"}
+        onClose={close}
+        onSaved={notifyChanged}
+        onPublished={(message) => {
+          Toast.success(message);
+          notifyChanged();
+        }}
+        onReviewSubmitted={(message) => {
+          Toast.success(message);
+          notifyChanged();
+        }}
+      />
+      <McpDetailModal
+        mcpId={connectorDetailId}
+        onClose={close}
+        canManage
+        onEdit={(item) => {
+          if (item.displayStatus === "pending_review") {
+            Toast.warning(t("mcp.review.pendingBlocksEdit"));
+            return;
+          }
+          const listedToOrg =
+            item.listingState === "published" && item.visibility === "space";
+          setConnectorDetailId(null);
+          setConnectorFlow(listedToOrg ? "upgrade" : "edit");
+          setConnector(item);
+        }}
+        onDeleted={() => {
+          notifyChanged();
+          close();
+        }}
+      />
+      <ReviewSubmitModal
+        target={reviewTarget}
+        onClose={close}
+        onSubmitted={(message) => {
+          Toast.success(message);
+          notifyChanged();
+        }}
+      />
+      <ExpertEditModal
+        item={expert}
+        onClose={close}
+        onSaved={(message) => {
+          Toast.success(message);
+          notifyChanged();
+        }}
+        onEditContent={(item) => {
+          setExpert(null);
+          setBotTarget(item);
+        }}
+      />
+      <ExpertDetailModal item={expertDetail} onClose={close} />
+      <ExpertBotPublishModal
+        visible={Boolean(botTarget)}
+        kind={botTarget?.kind === "squad" ? "squad" : "agent"}
+        mode="update"
+        editingId={botTarget?.id}
+        onClose={close}
+        onToast={(message) => Toast.success(message)}
+      />
+    </>
+  );
+}

--- a/packages/dmworkmcp/src/i18n/en-US.json
+++ b/packages/dmworkmcp/src/i18n/en-US.json
@@ -18,6 +18,7 @@
     "pageTitle": "My publications",
     "navAriaLabel": "My asset type",
     "tabAll": "All",
+    "searchPlaceholder": "Search name or description...",
     "emptyAll": "You have not published anything yet",
     "allAriaLabel": "All my publications",
     "deleteTitle": "Delete plugin",

--- a/packages/dmworkmcp/src/i18n/zh-CN.json
+++ b/packages/dmworkmcp/src/i18n/zh-CN.json
@@ -18,6 +18,7 @@
     "pageTitle": "我的发布",
     "navAriaLabel": "我的资产类型",
     "tabAll": "全部",
+    "searchPlaceholder": "搜索名称、描述...",
     "emptyAll": "还没有发布任何内容",
     "allAriaLabel": "我的全部发布",
     "deleteTitle": "删除插件",

--- a/packages/dmworkmcp/src/index.css
+++ b/packages/dmworkmcp/src/index.css
@@ -1493,6 +1493,15 @@
   border-bottom: 1px solid var(--wk-border-strong);
 }
 
+.wk-mcp-mine__hero-actions {
+  position: absolute;
+  z-index: 2;
+  top: var(--wk-sp-4);
+  right: var(--wk-sp-6);
+  display: flex;
+  align-items: center;
+}
+
 .wk-mcp-mine__hero-title h1 {
   margin: 0;
   color: var(--wk-text-strong);

--- a/packages/dmworkmcp/src/pages/AllAssetsList.tsx
+++ b/packages/dmworkmcp/src/pages/AllAssetsList.tsx
@@ -11,6 +11,7 @@ import {
   getSkillAvatarText,
   publishPlugin,
   type MineAssetType,
+  type MineActionRequest,
   type MineRow,
   type Skill,
 } from "@dmwork/skillmarket";
@@ -68,15 +69,23 @@ const ROW_TYPE: Record<string, MineAssetType> = {
  * The backend made this expressible by allowing `plugin_type` to be omitted on
  * the `mode=mine` listing.
  *
- * The actions it offers are exactly the TYPE-AGNOSTIC ones — 发布, 取消审核 and
- * 删除 each go through an endpoint that takes a plugin id and nothing else. 编辑
- * and 升级版本 are absent because they need the owning market's authoring surface
- * (a connector edits through a wizard, an expert through a bot flow), and
- * reproducing that dispatch here would guarantee this tab drifts from the four
- * that own those flows. Clicking a row opens the tab that can do them.
+ * Type-agnostic actions run here. 详情、编辑 and 升级版本 hand the plugin id to
+ * the page-level action host, which opens the owning type's existing modal over
+ * this tab; this keeps the mixed table aligned without duplicating authoring UI.
  */
-export default function AllAssetsList({ onOpenType }: { onOpenType: (type: string) => void }) {
+export default function AllAssetsList({
+  query = "",
+  refreshKey = 0,
+  onOpenType,
+  onRequestAction,
+}: {
+  query?: string;
+  refreshKey?: number;
+  onOpenType: (type: string) => void;
+  onRequestAction?: (request: Omit<MineActionRequest, "requestId">) => void;
+}) {
   useI18n();
+  const [debouncedQuery, setDebouncedQuery] = useState("");
   const [items, setItems] = useState<Skill[]>([]);
   const [loading, setLoading] = useState(true);
   const [loadingMore, setLoadingMore] = useState(false);
@@ -109,7 +118,12 @@ export default function AllAssetsList({ onOpenType }: { onOpenType: (type: strin
     setError(null);
     setMoreError(false);
     try {
-      const page = await getMySkills({ limit: PAGE_SIZE }, { pluginType: "all" });
+      const page = await getMySkills(
+        debouncedQuery
+          ? { limit: PAGE_SIZE, q: debouncedQuery }
+          : { limit: PAGE_SIZE },
+        { pluginType: "all" }
+      );
       if (version !== requestRef.current) return;
       setItems(page.items);
       const nextCursor = page.items.length > 0 ? page.nextCursor : null;
@@ -126,7 +140,7 @@ export default function AllAssetsList({ onOpenType }: { onOpenType: (type: strin
         setLoading(false);
       }
     }
-  }, []);
+  }, [debouncedQuery, refreshKey]);
 
   // Append the next page. Deliberately does NOT bump requestRef — a load-more is
   // a continuation of the current base read, not a new one — but it is voided by
@@ -147,7 +161,9 @@ export default function AllAssetsList({ onOpenType }: { onOpenType: (type: strin
     setMoreError(false);
     try {
       const page = await getMySkills(
-        { limit: PAGE_SIZE, cursor: next },
+        debouncedQuery
+          ? { limit: PAGE_SIZE, cursor: next, q: debouncedQuery }
+          : { limit: PAGE_SIZE, cursor: next },
         { pluginType: "all" }
       );
       if (version !== requestRef.current) return;
@@ -178,7 +194,7 @@ export default function AllAssetsList({ onOpenType }: { onOpenType: (type: strin
       loadingMoreVersionRef.current = null;
       if (version === requestRef.current) setLoadingMore(false);
     }
-  }, []);
+  }, [debouncedQuery]);
 
   const handleLoadMoreIntersection = useCallback(() => {
     // Keep a failed page on explicit retry; repeated observer callbacks must
@@ -189,6 +205,11 @@ export default function AllAssetsList({ onOpenType }: { onOpenType: (type: strin
   useEffect(() => {
     void load();
   }, [load]);
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => setDebouncedQuery(query.trim()), 300);
+    return () => window.clearTimeout(timer);
+  }, [query]);
 
   useEffect(
     () => () => {
@@ -224,9 +245,9 @@ export default function AllAssetsList({ onOpenType }: { onOpenType: (type: strin
     return () => WKApp.mittBus.off("space-changed", handleSpaceChanged);
   }, [load]);
 
-  /** Runs one row action and reloads either way — on a conflict the server
-   *  already knows a state this page does not. The row stays disabled until the
-   *  reload settles so a second click cannot race it. */
+  /** Runs one row action and reloads when its base read is still current. The
+   *  row stays disabled while the mutation is in flight, but a newer list read
+   *  must never retain that action's lock. */
   const run = useCallback(
     async (id: string, action: () => Promise<void>, failKey: string) => {
       const version = requestRef.current;
@@ -237,13 +258,13 @@ export default function AllAssetsList({ onOpenType }: { onOpenType: (type: strin
         if (version !== requestRef.current) return;
         Toast.error(err instanceof Error ? err.message : t(failKey));
       } finally {
+        // The row lock belongs to this action, not to the list request
+        // generation. A search/refresh can supersede the base read while the
+        // mutation is still in flight, but it must not leave the row disabled.
+        setBusyId((current) => (current === id ? null : current));
         if (version !== requestRef.current) return;
         const reload = load();
-        const reloadVersion = requestRef.current;
         await reload;
-        // `load` increments the request version; only clear this action's state
-        // when no Space switch or newer load superseded that reload.
-        if (reloadVersion === requestRef.current) setBusyId(null);
       }
     },
     [load]
@@ -285,11 +306,13 @@ export default function AllAssetsList({ onOpenType }: { onOpenType: (type: strin
 
   const rows: MineRow[] = items.map((item) => {
     const wireType = item.pluginType ?? "skill";
+    const rowType = ROW_TYPE[wireType] ?? "skill";
     const status = item.displayStatus ?? "draft";
     const pending = status === "pending_review";
+    const listedToOrg = item.listingState === "published" && item.visibility === "space";
     return {
       id: item.id,
-      type: ROW_TYPE[wireType] ?? "skill",
+      type: rowType,
       trackItemType: wireType,
       // Each type draws its avatar the way its OWN tab draws it — skills key the
       // tile off the name, the other markets off the id — so the same row does
@@ -316,11 +339,21 @@ export default function AllAssetsList({ onOpenType }: { onOpenType: (type: strin
       version: item.version,
       visibility: item.visibility,
       views: item.viewCount,
-      downloads: item.downloadCount,
+      // Skills are downloaded as packages and do not report a successful local
+      // install. The other plugin types use the backend's install metric, just
+      // like their owning tabs do.
+      downloads: rowType === "skill" ? item.downloadCount : item.installCount,
       status,
       ariaLabel: item.name,
       busy: busyId === item.id,
-      onOpen: () => onOpenType(wireType),
+      onOpen: onRequestAction
+        ? () => onRequestAction({ pluginId: item.id, type: rowType, action: "view" })
+        : () => onOpenType(wireType),
+      onEdit:
+        onRequestAction && !listedToOrg && !pending
+          ? () => onRequestAction({ pluginId: item.id, type: rowType, action: "edit" })
+          : undefined,
+      editAria: t("skillMarket.plugin.ariaEdit", { values: { name: item.name } }),
       onPublish:
         item.listingState !== "published" && !pending
           ? () =>
@@ -343,6 +376,11 @@ export default function AllAssetsList({ onOpenType }: { onOpenType: (type: strin
               )
           : undefined,
       publishAria: t("skillMarket.plugin.ariaPublish", { values: { name: item.name } }),
+      onUpgrade:
+        onRequestAction && listedToOrg && !pending
+          ? () => onRequestAction({ pluginId: item.id, type: rowType, action: "upgrade" })
+          : undefined,
+      upgradeAria: t("skillMarket.plugin.ariaUpgrade", { values: { name: item.name } }),
       onCancelReview:
         pending && item.reviewId
           ? () =>

--- a/packages/dmworkmcp/src/pages/MyAssetsPage.test.tsx
+++ b/packages/dmworkmcp/src/pages/MyAssetsPage.test.tsx
@@ -1,0 +1,183 @@
+// @vitest-environment jsdom
+import React from "react";
+import ReactDOM from "react-dom";
+import { act } from "react-dom/test-utils";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const spaceHandlers = new Set<() => void>();
+
+vi.mock("@octo/base", () => ({
+  t: (key: string) => key,
+  useI18n: () => undefined,
+  WKApp: {
+    mittBus: {
+      on: (_event: string, handler: () => void) => spaceHandlers.add(handler),
+      off: (_event: string, handler: () => void) =>
+        spaceHandlers.delete(handler),
+    },
+  },
+}));
+
+vi.mock("@dmwork/skillmarket", () => ({
+  SearchBar: () => React.createElement("input", { type: "search" }),
+  SkillListPage: () =>
+    React.createElement("div", { "data-testid": "skills-page" }),
+}));
+
+vi.mock("./AllAssetsList", () => ({
+  default: ({
+    onRequestAction,
+  }: {
+    onRequestAction: (request: unknown) => void;
+  }) =>
+    React.createElement(
+      React.Fragment,
+      null,
+      React.createElement(
+        "button",
+        {
+          type: "button",
+          onClick: () =>
+            onRequestAction({
+              pluginId: "skill-1",
+              type: "skill",
+              action: "view",
+            }),
+        },
+        "view from all"
+      ),
+      React.createElement(
+        "button",
+        {
+          type: "button",
+          onClick: () =>
+            onRequestAction({
+              pluginId: "skill-1",
+              type: "skill",
+              action: "edit",
+            }),
+        },
+        "edit from all"
+      ),
+      React.createElement(
+        "button",
+        {
+          type: "button",
+          onClick: () =>
+            onRequestAction({
+              pluginId: "skill-1",
+              type: "skill",
+              action: "upgrade",
+            }),
+        },
+        "upgrade from all"
+      )
+    ),
+}));
+
+vi.mock("../features/mine/MineActionHost", () => ({
+  default: ({
+    request,
+  }: {
+    request: { type: string; action: string } | null;
+  }) =>
+    React.createElement(
+      "div",
+      { "data-testid": "edit-host" },
+      request ? `${request.type}:${request.action}` : "closed"
+    ),
+}));
+
+vi.mock("./McpMarketListPage", () => ({ default: () => null }));
+vi.mock("./ExpertMarketListPage", () => ({ default: () => null }));
+
+import MyAssetsPage from "./MyAssetsPage";
+
+let container: HTMLDivElement;
+
+afterEach(() => {
+  ReactDOM.unmountComponentAtNode(container);
+  container.remove();
+  spaceHandlers.clear();
+});
+
+describe("MyAssetsPage all-tab actions", () => {
+  it("opens details in place while keeping the all tab selected", () => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    act(() => ReactDOM.render(<MyAssetsPage />, container));
+
+    const allTab = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent === "mcp.mine.tabAll"
+    ) as HTMLButtonElement;
+    const view = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent === "view from all"
+    ) as HTMLButtonElement;
+    act(() => view.click());
+
+    expect(allTab.getAttribute("aria-pressed")).toBe("true");
+    expect(
+      container.querySelector('[data-testid="edit-host"]')?.textContent
+    ).toBe("skill:view");
+  });
+
+  it("opens edit in place while keeping the all tab selected", () => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    act(() => ReactDOM.render(<MyAssetsPage />, container));
+
+    const allTab = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent === "mcp.mine.tabAll"
+    ) as HTMLButtonElement;
+    const edit = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent === "edit from all"
+    ) as HTMLButtonElement;
+    act(() => edit.click());
+
+    expect(allTab.getAttribute("aria-pressed")).toBe("true");
+    expect(
+      container.querySelector('[data-testid="edit-host"]')?.textContent
+    ).toBe("skill:edit");
+    expect(container.querySelector('[data-testid="skills-page"]')).toBeNull();
+  });
+
+  it("opens upgrade in place while keeping the all tab selected", () => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    act(() => ReactDOM.render(<MyAssetsPage />, container));
+
+    const allTab = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent === "mcp.mine.tabAll"
+    ) as HTMLButtonElement;
+    const upgrade = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent === "upgrade from all"
+    ) as HTMLButtonElement;
+    act(() => upgrade.click());
+
+    expect(allTab.getAttribute("aria-pressed")).toBe("true");
+    expect(
+      container.querySelector('[data-testid="edit-host"]')?.textContent
+    ).toBe("skill:upgrade");
+  });
+
+  it("closes an all-tab action when the active Space changes", () => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    act(() => ReactDOM.render(<MyAssetsPage />, container));
+
+    const edit = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent === "edit from all"
+    ) as HTMLButtonElement;
+    act(() => edit.click());
+    expect(
+      container.querySelector('[data-testid="edit-host"]')?.textContent
+    ).toBe("skill:edit");
+
+    act(() => {
+      for (const handler of [...spaceHandlers]) handler();
+    });
+    expect(
+      container.querySelector('[data-testid="edit-host"]')?.textContent
+    ).toBe("closed");
+  });
+});

--- a/packages/dmworkmcp/src/pages/MyAssetsPage.tsx
+++ b/packages/dmworkmcp/src/pages/MyAssetsPage.tsx
@@ -1,10 +1,16 @@
-import React, { useState } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import { LayoutGrid, Plug, Sparkles, UserRound, Users } from "lucide-react";
-import { useI18n, t } from "@octo/base";
-import { SkillListPage } from "@dmwork/skillmarket";
+import { useI18n, t, WKApp } from "@octo/base";
+import {
+  SearchBar,
+  SkillListPage,
+  type MineActionRequest,
+  type MineAssetType,
+} from "@dmwork/skillmarket";
 import McpMarketListPage from "./McpMarketListPage";
 import ExpertMarketListPage from "./ExpertMarketListPage";
 import AllAssetsList from "./AllAssetsList";
+import MineActionHost from "../features/mine/MineActionHost";
 import "../index.css";
 
 /** Which personal-asset type the 我的 page is showing. Experts and squads are
@@ -32,6 +38,13 @@ function initialType(): MineType {
   return "all";
 }
 
+function tabForAssetType(type: MineAssetType | string): MineType {
+  if (type === "connector") return "mcp";
+  if (type === "expert") return "experts";
+  if (type === "squad" || type === "expert_team") return "squads";
+  return "skills";
+}
+
 const TYPE_TABS: Array<{
   key: MineType;
   labelKey: string;
@@ -39,11 +52,31 @@ const TYPE_TABS: Array<{
 }> = [
   // 全部 leads: it is the only view that answers "what have I got waiting on
   // review" without visiting four tabs.
-  { key: "all", labelKey: "mcp.mine.tabAll", icon: <LayoutGrid size={15} aria-hidden="true" /> },
-  { key: "skills", labelKey: "skillMarket.plugin.typeSkill", icon: <Sparkles size={15} aria-hidden="true" /> },
-  { key: "mcp", labelKey: "skillMarket.plugin.typeConnector", icon: <Plug size={15} aria-hidden="true" /> },
-  { key: "experts", labelKey: "skillMarket.plugin.typeExpert", icon: <UserRound size={15} aria-hidden="true" /> },
-  { key: "squads", labelKey: "skillMarket.plugin.typeExpertTeam", icon: <Users size={15} aria-hidden="true" /> },
+  {
+    key: "all",
+    labelKey: "mcp.mine.tabAll",
+    icon: <LayoutGrid size={15} aria-hidden="true" />,
+  },
+  {
+    key: "skills",
+    labelKey: "skillMarket.plugin.typeSkill",
+    icon: <Sparkles size={15} aria-hidden="true" />,
+  },
+  {
+    key: "mcp",
+    labelKey: "skillMarket.plugin.typeConnector",
+    icon: <Plug size={15} aria-hidden="true" />,
+  },
+  {
+    key: "experts",
+    labelKey: "skillMarket.plugin.typeExpert",
+    icon: <UserRound size={15} aria-hidden="true" />,
+  },
+  {
+    key: "squads",
+    labelKey: "skillMarket.plugin.typeExpertTeam",
+    icon: <Users size={15} aria-hidden="true" />,
+  },
 ];
 
 /**
@@ -57,21 +90,60 @@ const TYPE_TABS: Array<{
 export default function MyAssetsPage() {
   useI18n();
   const [type, setType] = useState<MineType>(initialType);
+  const [allQuery, setAllQuery] = useState("");
+  const [allRefreshKey, setAllRefreshKey] = useState(0);
+  const [mineActionRequest, setMineActionRequest] =
+    useState<MineActionRequest | null>(null);
+  const requestIdRef = useRef(0);
+  const handleActionRequest = useCallback(
+    (request: Omit<MineActionRequest, "requestId">) => {
+      setMineActionRequest({ ...request, requestId: ++requestIdRef.current });
+    },
+    []
+  );
+  const handleDirectEditClose = useCallback(() => {
+    setMineActionRequest(null);
+  }, []);
+  const handleDirectEditChanged = useCallback(() => {
+    setAllRefreshKey((key) => key + 1);
+  }, []);
+
+  useEffect(() => {
+    const handleSpaceChanged = () => setMineActionRequest(null);
+    WKApp.mittBus.on("space-changed", handleSpaceChanged);
+    return () => WKApp.mittBus.off("space-changed", handleSpaceChanged);
+  }, []);
+
   return (
     <div className="wk-mcp-mine">
       <header className="wk-mcp-mine__hero">
         <div className="wk-mcp-mine__hero-title">
           <h1>{t("mcp.mine.pageTitle")}</h1>
         </div>
+        {type === "all" && (
+          <div className="wk-mcp-mine__hero-actions">
+            <SearchBar
+              value={allQuery}
+              onChange={setAllQuery}
+              placeholder={t("mcp.mine.searchPlaceholder")}
+            />
+          </div>
+        )}
       </header>
-      <nav className="wk-mcp-mine__tabs" aria-label={t("mcp.mine.navAriaLabel")}>
+      <nav
+        className="wk-mcp-mine__tabs"
+        aria-label={t("mcp.mine.navAriaLabel")}
+      >
         {TYPE_TABS.map((tab) => (
           <button
             key={tab.key}
             type="button"
             className={type === tab.key ? "is-active" : ""}
             aria-pressed={type === tab.key}
-            onClick={() => setType(tab.key)}
+            onClick={() => {
+              setMineActionRequest(null);
+              setType(tab.key);
+            }}
           >
             <span className="wk-mcp-mine__tab-icon">{tab.icon}</span>
             {t(tab.labelKey)}
@@ -81,17 +153,13 @@ export default function MyAssetsPage() {
       <div className="wk-mcp-mine__panel">
         {type === "all" && (
           <AllAssetsList
-            onOpenType={(wireType) =>
-              setType(
-                wireType === "connector"
-                  ? "mcp"
-                  : wireType === "expert"
-                    ? "experts"
-                    : wireType === "expert_team"
-                      ? "squads"
-                      : "skills"
-              )
-            }
+            query={allQuery}
+            refreshKey={allRefreshKey}
+            onOpenType={(wireType) => {
+              setMineActionRequest(null);
+              setType(tabForAssetType(wireType));
+            }}
+            onRequestAction={handleActionRequest}
           />
         )}
         {type === "skills" && <SkillListPage variant="mine" />}
@@ -102,6 +170,11 @@ export default function MyAssetsPage() {
           <ExpertMarketListPage variant="mine" mineType="squad" />
         )}
         {type === "mcp" && <McpMarketListPage variant="mine" />}
+        <MineActionHost
+          request={type === "all" ? mineActionRequest : null}
+          onClose={handleDirectEditClose}
+          onChanged={handleDirectEditChanged}
+        />
       </div>
     </div>
   );

--- a/packages/dmworkmcp/src/pages/__tests__/AllAssetsList.test.tsx
+++ b/packages/dmworkmcp/src/pages/__tests__/AllAssetsList.test.tsx
@@ -129,14 +129,40 @@ vi.mock("@dmwork/skillmarket", () => ({
           { key: `${row.id}-name` },
           String(row.name)
         ),
+        React.createElement(
+          "span",
+          { key: `${row.id}-metric`, "data-testid": `metric-${row.id}` },
+          String(row.downloads)
+        ),
         row.onPublish
           ? React.createElement(
               "button",
               {
                 key: `${row.id}-publish`,
+                disabled: Boolean(row.busy),
                 onClick: row.onPublish as () => void,
               },
               `publish-${row.name}`
+            )
+          : null,
+        row.onUpgrade
+          ? React.createElement(
+              "button",
+              {
+                key: `${row.id}-upgrade`,
+                onClick: row.onUpgrade as () => void,
+              },
+              `upgrade-${row.name}`
+            )
+          : null,
+        row.onEdit
+          ? React.createElement(
+              "button",
+              {
+                key: `${row.id}-edit`,
+                onClick: row.onEdit as () => void,
+              },
+              `edit-${row.name}`
             )
           : null,
         React.createElement(
@@ -161,7 +187,7 @@ vi.mock("../../utils/mcpAvatar", () => ({
 
 import AllAssetsList from "../AllAssetsList";
 
-const asset = (id: string, name: string) => ({
+const asset = (id: string, name: string, patch: Record<string, unknown> = {}) => ({
   id,
   name,
   displayName: name,
@@ -170,9 +196,11 @@ const asset = (id: string, name: string) => ({
   visibility: "private",
   version: "1.0.0",
   viewCount: 0,
+  installCount: 0,
   downloadCount: 0,
   listingState: "draft",
   displayStatus: "draft",
+  ...patch,
 });
 const page = (items: unknown[], nextCursor: string | null = null) => ({
   items,
@@ -193,6 +221,160 @@ afterEach(() => {
   ReactDOM.unmountComponentAtNode(container);
   container.remove();
   vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+describe("AllAssetsList parity with type tabs", () => {
+  it("debounces a unified search and sends it to the all-types list", async () => {
+    vi.useFakeTimers();
+    h.getMySkills.mockResolvedValue(page([]));
+
+    await act(async () => {
+      ReactDOM.render(
+        React.createElement(AllAssetsList, {
+          query: "",
+          onOpenType: vi.fn(),
+        }),
+        container
+      );
+    });
+    await act(async () => {
+      ReactDOM.render(
+        React.createElement(AllAssetsList, {
+          query: "report",
+          onOpenType: vi.fn(),
+        }),
+        container
+      );
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(300);
+    });
+
+    expect(h.getMySkills).toHaveBeenLastCalledWith(
+      { limit: 50, q: "report" },
+      { pluginType: "all" }
+    );
+  });
+
+  it("requests edit and upgrade from the page-level modal host", async () => {
+    const onRequestAction = vi.fn();
+    h.getMySkills.mockResolvedValue(
+      page([
+        asset("draft-skill", "Draft skill"),
+        asset("listed-expert", "Listed expert", {
+          pluginType: "expert",
+          visibility: "space",
+          listingState: "published",
+          displayStatus: "published",
+        }),
+      ])
+    );
+
+    await act(async () => {
+      ReactDOM.render(
+        React.createElement(AllAssetsList, {
+          onOpenType: vi.fn(),
+          onRequestAction,
+        }),
+        container
+      );
+    });
+    act(() => {
+      (
+        Array.from(container.querySelectorAll("button")).find(
+          (button) => button.textContent === "edit-Draft skill"
+        ) as HTMLButtonElement
+      ).click();
+      (
+        Array.from(container.querySelectorAll("button")).find(
+          (button) => button.textContent === "upgrade-Listed expert"
+        ) as HTMLButtonElement
+      ).click();
+    });
+
+    expect(onRequestAction).toHaveBeenNthCalledWith(1, {
+      pluginId: "draft-skill",
+      type: "skill",
+      action: "edit",
+    });
+    expect(onRequestAction).toHaveBeenNthCalledWith(2, {
+      pluginId: "listed-expert",
+      type: "expert",
+      action: "upgrade",
+    });
+  });
+
+  it("uses downloads for skills and installs for the other asset types", async () => {
+    h.getMySkills.mockResolvedValue(
+      page([
+        asset("skill", "Skill", { downloadCount: 12, installCount: 1 }),
+        asset("connector", "Connector", {
+          pluginType: "connector",
+          downloadCount: 2,
+          installCount: 34,
+        }),
+      ])
+    );
+
+    await act(async () => {
+      ReactDOM.render(
+        React.createElement(AllAssetsList, { onOpenType: vi.fn() }),
+        container
+      );
+    });
+
+    expect(container.querySelector('[data-testid="metric-skill"]')?.textContent).toBe("12");
+    expect(container.querySelector('[data-testid="metric-connector"]')?.textContent).toBe("34");
+  });
+
+  it("releases a row action lock when a search reload supersedes it", async () => {
+    vi.useFakeTimers();
+    const publish = deferred<{ displayStatus: string }>();
+    h.getMySkills.mockResolvedValue(page([asset("a", "Searchable asset")]));
+    h.publishPlugin.mockReturnValueOnce(publish.promise);
+
+    await act(async () => {
+      ReactDOM.render(
+        React.createElement(AllAssetsList, {
+          query: "",
+          onOpenType: vi.fn(),
+        }),
+        container
+      );
+    });
+    const publishButton = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent === "publish-Searchable asset"
+    ) as HTMLButtonElement;
+
+    act(() => publishButton.click());
+    expect(publishButton.disabled).toBe(true);
+
+    await act(async () => {
+      ReactDOM.render(
+        React.createElement(AllAssetsList, {
+          query: "searchable",
+          onOpenType: vi.fn(),
+        }),
+        container
+      );
+      await vi.advanceTimersByTimeAsync(300);
+    });
+    expect(h.getMySkills).toHaveBeenLastCalledWith(
+      { limit: 50, q: "searchable" },
+      { pluginType: "all" }
+    );
+    expect(publishButton.disabled).toBe(true);
+
+    await act(async () => publish.resolve({ displayStatus: "published" }));
+
+    const refreshedButton = Array.from(
+      container.querySelectorAll("button")
+    ).find(
+      (button) => button.textContent === "publish-Searchable asset"
+    ) as HTMLButtonElement;
+    expect(refreshedButton.disabled).toBe(false);
+  });
 });
 
 describe("AllAssetsList pagination", () => {

--- a/packages/dmworkskillmarket/src/api/skillApiReal.test.ts
+++ b/packages/dmworkskillmarket/src/api/skillApiReal.test.ts
@@ -223,6 +223,7 @@ describe("skillApiReal", () => {
     expect(result.items[0].iconUrl).toBe("https://cdn.example.com/icons/ci.png");
     expect(result.items[0].version).toBe("1.0.2");
     expect(result.items[0].viewCount).toBe(7);
+    expect(result.items[0].installCount).toBe(0);
     expect(result.items[0].downloadCount).toBe(3);
     // 1 * 10 < 42 → the synthesized cursor is the next page number.
     expect(result.nextCursor).toBe("2");

--- a/packages/dmworkskillmarket/src/api/skillApiReal.ts
+++ b/packages/dmworkskillmarket/src/api/skillApiReal.ts
@@ -389,6 +389,7 @@ function mapSkill(raw: PluginListItemWire): Skill {
     fileSize: 0,
     fileSha256: undefined,
     viewCount: raw.view_count ?? 0,
+    installCount: raw.install_count ?? 0,
     downloadCount: raw.download_count ?? 0,
     // Rendered, never derived. The server folds the listing state together with
     // the review entity into `display_status`; recomputing it here from

--- a/packages/dmworkskillmarket/src/components/MineTable.tsx
+++ b/packages/dmworkskillmarket/src/components/MineTable.tsx
@@ -7,12 +7,8 @@ import {
   Globe,
   Lock,
   Pencil,
-  Plug,
-  Sparkles,
   Trash2,
   Upload,
-  UserRound,
-  Users,
   X,
   XCircle,
 } from "lucide-react";
@@ -29,6 +25,14 @@ import { formatCount } from "../utils/format";
 /** The four personal-asset kinds. `squad` is this table's local name for the
  *  `expert_team` wire type. */
 export type MineAssetType = "skill" | "connector" | "expert" | "squad";
+
+/** A one-shot request from the mixed “全部” list to its modal action host. */
+export interface MineActionRequest {
+  requestId: number;
+  pluginId: string;
+  type: MineAssetType;
+  action: "view" | "edit" | "upgrade";
+}
 
 const WIRE_TYPE: Record<MineAssetType, string> = {
   skill: "skill",
@@ -51,8 +55,7 @@ const WIRE_TYPE: Record<MineAssetType, string> = {
 export interface MineRow {
   id: string;
   type: MineAssetType;
-  /** Avatar node (image or color tile) rendered on the left; MineTable overlays
-   *  the type marker on top of it. */
+  /** Avatar node (image or color tile) rendered on the left. */
   icon: React.ReactNode;
   name: string;
   description?: string;
@@ -125,13 +128,6 @@ interface MineTableProps {
   ariaLabel?: string;
 }
 
-const TYPE_MARKERS: Record<MineAssetType, React.ReactElement> = {
-  skill: <Sparkles size={11} aria-hidden="true" />,
-  connector: <Plug size={11} aria-hidden="true" />,
-  expert: <UserRound size={11} aria-hidden="true" />,
-  squad: <Users size={11} aria-hidden="true" />,
-};
-
 /** system/public -> 全平台 globe, private -> lock, space -> org building. */
 function visibilityIcon(key: string): { cls: string; icon: React.ReactElement } {
   const v = key === "public" ? "system" : key;
@@ -196,12 +192,6 @@ export default function MineTable({ rows, ariaLabel }: MineTableProps) {
               >
                 <span className="wk-mine-table__avatar">
                   {r.icon}
-                  <span
-                    className={`wk-mine-table__type wk-mine-table__type--${r.type}`}
-                    aria-hidden="true"
-                  >
-                    {TYPE_MARKERS[r.type]}
-                  </span>
                 </span>
                 <span className="wk-mine-table__namecol">
                   <span className="wk-mine-table__namerow" title={r.name}>

--- a/packages/dmworkskillmarket/src/i18n/en-US.json
+++ b/packages/dmworkskillmarket/src/i18n/en-US.json
@@ -286,7 +286,7 @@
     "actionEdit": "Edit",
     "actionDelete": "Delete",
     "actionUpgrade": "New version",
-    "actionCancelReview": "Cancel review",
+    "actionCancelReview": "Withdraw review",
     "actionDelist": "Delist",
     "actionPublish": "Publish",
     "actionSaveDraft": "Save draft",

--- a/packages/dmworkskillmarket/src/i18n/zh-CN.json
+++ b/packages/dmworkskillmarket/src/i18n/zh-CN.json
@@ -286,7 +286,7 @@
     "actionEdit": "编辑",
     "actionDelete": "删除",
     "actionUpgrade": "升级版本",
-    "actionCancelReview": "取消审核",
+    "actionCancelReview": "撤销审核",
     "actionDelist": "下架",
     "actionPublish": "发布",
     "actionSaveDraft": "保存草稿",

--- a/packages/dmworkskillmarket/src/index.css
+++ b/packages/dmworkskillmarket/src/index.css
@@ -2823,8 +2823,8 @@
   color: var(--wk-text-tertiary);
   font-size: 12px;
 }
-/* name cell — an activatable open-button wrapping avatar (+ type marker) +
-   name/description stack. The button is the flex container so the whole name
+/* name cell — an activatable open-button wrapping avatar + name/description
+   stack. The button is the flex container so the whole name
    area is one keyboard-focusable target. */
 .wk-mine-table__col--name {
   display: flex;
@@ -2873,31 +2873,6 @@
   font-weight: var(--wk-font-semibold);
   font-size: 14px;
   overflow: hidden;
-}
-.wk-mine-table__type {
-  position: absolute;
-  right: -4px;
-  bottom: -4px;
-  width: 18px;
-  height: 18px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: 50%;
-  border: 2px solid var(--wk-bg-surface);
-  color: var(--wk-bg-surface);
-}
-.wk-mine-table__type--skill {
-  background: var(--wk-color-warning);
-}
-.wk-mine-table__type--connector {
-  background: var(--wk-color-info);
-}
-.wk-mine-table__type--expert {
-  background: var(--wk-color-primary);
-}
-.wk-mine-table__type--squad {
-  background: var(--wk-color-success);
 }
 .wk-mine-table__namecol {
   display: flex;

--- a/packages/dmworkskillmarket/src/index.tsx
+++ b/packages/dmworkskillmarket/src/index.tsx
@@ -8,7 +8,13 @@ export {
   default as MineTable,
   type MineRow,
   type MineAssetType,
+  type MineActionRequest,
 } from "./components/MineTable";
+export { default as SearchBar } from "./components/SearchBar";
+export { default as EditSkillModal } from "./components/EditSkillModal";
+export { default as NewSkillModal } from "./components/NewSkillModal";
+export { default as SkillDetailModal } from "./components/SkillDetailModal";
+export { default as DeleteConfirmModal } from "./components/DeleteConfirmModal";
 // "组织审核" — the Space reviewer queue, mounted by dmworkmcp at
 // /mcp-market/review as the sidebar's fifth entry.
 export { default as SpaceReviewPage } from "./pages/SpaceReviewPage";
@@ -57,7 +63,7 @@ export {
 // The 全部 tab of 我的发布 lists every plugin type through the one endpoint that
 // can return them together (`mode=mine` with plugin_type omitted), so dmworkmcp
 // needs the reader and the row type.
-export { getMySkills, deleteSkill } from "./api/skillApi";
+export { getCategories, getMySkills, getSkill, deleteSkill } from "./api/skillApi";
 // Version rules, mirrored from the backend so a form objects before a round trip.
 export {
   isValidVersion,
@@ -69,7 +75,7 @@ export {
 // The 全部 tab renders skills beside connectors and experts, so it needs the
 // skill avatar helpers to draw a skill row the same way the 技能 tab does.
 export { getSkillAvatarColor, getSkillAvatarText } from "./utils/skillAvatar";
-export type { Skill } from "./types/skill";
+export type { Category, Skill } from "./types/skill";
 export type {
   ReviewRequest,
   ReviewStatus,

--- a/packages/dmworkskillmarket/src/pages/__tests__/SkillListPage.test.tsx
+++ b/packages/dmworkskillmarket/src/pages/__tests__/SkillListPage.test.tsx
@@ -154,7 +154,7 @@ describe("SkillListPage", () => {
     expect(container.querySelector(".skill-market-card__action-button")).not.toBeInTheDocument();
     unmount();
 
-    render(<SkillListPage variant="mine" />);
+    const { container: mineContainer } = render(<SkillListPage variant="mine" />);
 
     expect(screen.queryByLabelText(categoryAriaLabel)).not.toBeInTheDocument();
     expect(
@@ -171,6 +171,7 @@ describe("SkillListPage", () => {
     expect(
       screen.getByRole("button", { name: deleteSkillName })
     ).toBeInTheDocument();
+    expect(mineContainer.querySelector(".wk-mine-table__type")).not.toBeInTheDocument();
   });
 
   // 编辑 gating is two-axis now. `visibility` is only the declared intent and

--- a/packages/dmworkskillmarket/src/types/skill.ts
+++ b/packages/dmworkskillmarket/src/types/skill.ts
@@ -68,6 +68,8 @@ export interface Skill {
   fileSize: number;
   fileSha256?: string;
   viewCount?: number;
+  /** Successful installs for non-skill rows returned by the unified plugin API. */
+  installCount?: number;
   downloadCount?: number;
   /** Listing lifecycle and the single status to render. Both are supplied by the
    *  server on the owner (`mode=mine`) listing and on the detail read; they are


### PR DESCRIPTION
## Summary

Aligns the existing "All" view in My publications with the per-type tabs. Search and owner actions now work in place for skills, connectors, experts, and squads, without changing tabs.

## Related Issue

- Refs Mininglamp-OSS/octo-marketplace#90
- Fixes Mininglamp-OSS/octo-marketplace#91

## Behavior List

- Entry: the existing My publications > All tab; no new menu or route.
- Primary path: search the mixed list, then view, edit, publish, upgrade, withdraw review, or delete the owned asset from the current tab.
- Empty/loading/error states: reuse the mixed list states; pagination keeps loaded rows and exposes an explicit retry.
- Permissions/Space: owner affordances mirror the existing type tabs; switching Space closes active dialogs and invalidates stale reads.
- Navigation: view, edit, and upgrade stay on All and reuse the owning type's existing dialogs.

## Changes

- Moves the All-tab search into the page header and keeps the same 360 px search control used by the market surfaces.
- Adds in-place detail, edit, and upgrade flows for all four asset types while preserving owner actions inside skill and connector details.
- Refreshes the mixed list after successful mutations and guards against stale requests, duplicate refreshes, Space changes, and row locks stranded by concurrent reloads.
- Keeps Skill metrics on `download_count`; uses `install_count` for connectors, experts, and squads.
- Tracks connector detail views without allowing a best-effort metrics 401 to log out the user.
- Renames "Cancel review" to "Withdraw review" (with matching zh-CN copy) and removes the avatar corner type badge while retaining the textual type label.

## File Map

- `packages/dmworkmcp/src/pages/MyAssetsPage.tsx`: existing page entry, header search, action request ownership, and Space lifecycle.
- `packages/dmworkmcp/src/pages/AllAssetsList.tsx`: mixed-list search, pagination, action gating, and metric projection.
- `packages/dmworkmcp/src/features/mine/MineActionHost.tsx`: business container adapting mixed rows to existing type-owned dialogs.
- `packages/dmworkmcp/src/api/mcpService.ts`: connector view metric and best-effort authentication handling.
- `packages/dmworkskillmarket/src/components/MineTable.tsx`: shared owner table presentation and badge removal.
- Adjacent tests and locale files: regression coverage and bilingual copy.

## Scope

This PR does:
- Update the existing My publications flow only.
- Reuse current skill, connector, expert, and squad dialogs.
- Change shared MineTable visuals by removing the avatar corner badge.

This PR does not:
- Add version downgrade behavior.
- Change marketplace backend endpoints or persistence.
- Add a second user-visible entry point.
- Redesign the individual type tabs.

## Architecture / Module Boundary

- Affected modules: `@dmwork/mcp`, `@dmwork/skillmarket`.
- New or changed user-visible entry point: no; the existing All tab is enhanced.
- Shared layer touched: MineTable rendering and skillmarket exports/API mapping.
- Shared impact: all MineTable consumers lose the redundant avatar badge; textual type labels remain.
- Duplicate entry point checked: yes.
- Story coverage: not added because no reusable UI component was introduced; the feature container composes existing dialogs and has focused component tests.

## COMPREHENSION / Risk Review

- Authoritative state: backend `listing_state` and `display_status` continue to decide legal actions.
- Async lifecycle: request IDs and active guards discard stale dialog hydration; Space changes clear active requests.
- Mutation consistency: no optimistic state patching; successful actions trigger a server reread, with duplicate callbacks deduplicated.
- Metrics failure: connector view tracking is fire-and-forget and cannot trigger global logout by itself.
- Main regression surface: shared MineTable consumers; covered by both affected package suites and production build.

## Testing

- [x] `pnpm --filter @dmwork/mcp test` - 34 files, 397 tests passed
- [x] `pnpm --filter @dmwork/skillmarket test` - 22 files, 308 tests passed
- [x] `pnpm i18n:check`
- [x] `pnpm lint:css` - passed; repository still reports 3,780 existing warnings
- [x] `pnpm --filter @octo/web build` - passed with existing Vite direct-eval, chunk-size, and dynamic-import warnings
- [x] `git diff --check`
- [ ] Browser walkthrough - intentionally skipped at the requester's direction

A standalone `tsc --noEmit` was also attempted, but the repository currently fails globally on pre-existing React type-version/module-resolution conflicts across unrelated packages. The production build and affected package suites pass.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] PR description is in English
- [x] Added tests for my changes
- [ ] Updated documentation - not required; no public documentation contract changed
- [x] Ran `pnpm i18n:check`
- [x] Confirmed the change follows module ownership and does not add duplicate user-visible entry points
- [x] Described shared impact scope
- [x] Followed Conventional Commits
